### PR TITLE
Improve GitHub issue previews

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -5,10 +5,10 @@ type: "Bug"
 body:
   - type: textarea
     attributes:
-      label: Describe the bug / provide steps to reproduce it
-      description: A one line summary, and detailed reproduction steps
+      label: Summary
+      description: Describe the bug with a one line summary, and provide detailed reproduction steps
       value: |
-        Summary:
+        <!-- Please insert a one line summary of the issue below -->
 
         <!-- Include all steps necessary to reproduce from a clean Zed installation. Be verbose -->
         Steps to trigger the problem:

--- a/.github/ISSUE_TEMPLATE/2_crash_report.yml
+++ b/.github/ISSUE_TEMPLATE/2_crash_report.yml
@@ -4,10 +4,10 @@ type: "Crash"
 body:
   - type: textarea
     attributes:
-      label: Describe the bug / provide steps to reproduce it
-      description: A one line summary, and detailed reproduction steps
+      label: Summary
+      description: Describe the bug with a one line summary, and provide detailed reproduction steps
       value: |
-        Summary:
+        <!-- Please insert a one line summary of the issue below -->
 
         <!-- Include all steps necessary to reproduce from a clean Zed installation. Be verbose -->
         Steps to trigger the problem:


### PR DESCRIPTION
Modify the new issue templates so that the summary of the issue is hopefully at the top and visible in previews/references to the issue

Release Notes:

- N/A 
