### PR TITLE
anthropic: Fix license

### DIFF
--- a/crates/anthropic/Cargo.toml
+++ b/crates/anthropic/Cargo.toml
@@ -3,7 +3,7 @@ name = "anthropic"
 version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
-license = "AGPL-3.0-or-later"
+license = "GPL-3.0-or-later"
 
 [features]
 default = []

--- a/crates/anthropic/LICENSE-AGPL
+++ b/crates/anthropic/LICENSE-AGPL
@@ -1,1 +1,0 @@
-../../LICENSE-AGPL

--- a/crates/anthropic/LICENSE-GPL
+++ b/crates/anthropic/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL


### PR DESCRIPTION
This PR fixes the license for the `anthropic` crate.

It was mistakenly licensed as AGPL, despite being used outside of collab. It should be licensed as GPL.

Release Notes:

- N/A
