### PR TITLE
WIP: Enforce buffer ordering in multibuffer

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -466,8 +466,7 @@ impl ProjectDiagnosticsEditor {
                             }
 
                             let excerpt_id = excerpts
-                                .insert_excerpts_after(
-                                    prev_excerpt_id,
+                                .push_excerpts(
                                     buffer.clone(),
                                     [ExcerptRange {
                                         context: context_range.clone(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13338,11 +13338,7 @@ impl Editor {
                 refresh_linked_ranges(self, window, cx);
                 telemetry.log_edit_event("editor", is_via_ssh);
             }
-            multi_buffer::Event::ExcerptsAdded {
-                buffer,
-                predecessor,
-                excerpts,
-            } => {
+            multi_buffer::Event::ExcerptsAdded { buffer, excerpts } => {
                 self.tasks_update_task = Some(self.refresh_runnables(window, cx));
                 let buffer_id = buffer.read(cx).remote_id();
                 if self.buffer.read(cx).change_set_for(buffer_id).is_none() {
@@ -13357,7 +13353,6 @@ impl Editor {
                 }
                 cx.emit(EditorEvent::ExcerptsAdded {
                     buffer: buffer.clone(),
-                    predecessor: *predecessor,
                     excerpts: excerpts.clone(),
                 });
                 self.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
@@ -15251,7 +15246,6 @@ pub enum EditorEvent {
     },
     ExcerptsAdded {
         buffer: Entity<Buffer>,
-        predecessor: ExcerptId,
         excerpts: Vec<(ExcerptId, ExcerptRange<language::Anchor>)>,
     },
     ExcerptsRemoved {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10431,8 +10431,7 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
                 ],
                 cx,
             );
-            multibuffer.insert_excerpts_after(
-                excerpt_ids[0],
+            multibuffer.push_excerpts(
                 buffer_2.clone(),
                 [
                     ExcerptRange {

--- a/crates/editor/src/git/project_diff.rs
+++ b/crates/editor/src/git/project_diff.rs
@@ -856,8 +856,7 @@ impl ProjectDiffEditor {
                     for (_, buffer, hunk_ranges) in excerpts_to_add {
                         let buffer_snapshot = buffer.read(cx).snapshot();
                         let max_point = buffer_snapshot.max_point();
-                        let new_excerpts = multi_buffer.insert_excerpts_after(
-                            after_excerpt_id,
+                        let new_excerpts = multi_buffer.push_excerpts(
                             buffer,
                             hunk_ranges.into_iter().map(|range| {
                                 let mut extended_point_range = range.to_point(&buffer_snapshot);

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -255,16 +255,12 @@ impl FollowableItem for Editor {
 
         match update {
             proto::update_view::Variant::Editor(update) => match event {
-                EditorEvent::ExcerptsAdded {
-                    buffer,
-                    predecessor,
-                    excerpts,
-                } => {
+                EditorEvent::ExcerptsAdded { buffer, excerpts } => {
                     let buffer_id = buffer.read(cx).remote_id();
                     let mut excerpts = excerpts.iter();
                     if let Some((id, range)) = excerpts.next() {
                         update.inserted_excerpts.push(proto::ExcerptInsertion {
-                            previous_excerpt_id: Some(predecessor.to_proto()),
+                            previous_excerpt_id: None,
                             excerpt: serialize_excerpt(buffer_id, id, range),
                         });
                         update.inserted_excerpts.extend(excerpts.map(|(id, range)| {
@@ -394,8 +390,7 @@ async fn update_editor_from_message(
                     }
                 });
 
-                multibuffer.insert_excerpts_with_ids_after(
-                    ExcerptId::from_proto(previous_excerpt_id),
+                multibuffer.insert_excerpts_with_ids(
                     buffer,
                     [excerpt]
                         .into_iter()

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -669,10 +669,8 @@ fn test_excerpt_events(cx: &mut App) {
             &leader_multibuffer,
             move |follower, _, event, cx| match event.clone() {
                 Event::ExcerptsAdded {
-                    buffer,
-                    predecessor,
-                    excerpts,
-                } => follower.insert_excerpts_with_ids_after(predecessor, buffer, excerpts, cx),
+                    buffer, excerpts, ..
+                } => follower.insert_excerpts_with_ids(buffer, excerpts, cx),
                 Event::ExcerptsRemoved { ids } => follower.remove_excerpts(ids, cx),
                 Event::Edited { .. } => {
                     *follower_edit_event_count.write() += 1;
@@ -698,8 +696,7 @@ fn test_excerpt_events(cx: &mut App) {
             ],
             cx,
         );
-        leader.insert_excerpts_after(
-            leader.excerpt_ids()[0],
+        leader.push_excerpts(
             buffer_2.clone(),
             [
                 ExcerptRange {
@@ -1155,8 +1152,7 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
     let excerpt_id_5 = multibuffer.update(cx, |multibuffer, cx| {
         multibuffer.remove_excerpts([excerpt_id_3], cx);
         multibuffer
-            .insert_excerpts_after(
-                excerpt_id_2,
+            .push_excerpts(
                 buffer_2.clone(),
                 [ExcerptRange {
                     context: 5..8,
@@ -2249,8 +2245,7 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
 
                 let excerpt_id = multibuffer.update(cx, |multibuffer, cx| {
                     multibuffer
-                        .insert_excerpts_after(
-                            prev_excerpt_id,
+                        .push_excerpts(
                             buffer_handle.clone(),
                             [ExcerptRange {
                                 context: range,


### PR DESCRIPTION
This is an exploration of pushing the excerpt ordering down into the multibuffer.

It seems to mostly work (though the randomized tests are failing because they
assume they can push nonsense in there), but some thought is needed on how to
upgrade collab (probably a breaking change).

If we want to push in this direction I think we should spend some time cleaning up the
implementation to not store quite so many Arc<Path>'s (and fixing randomized tests...)

Release Notes:

- N/A
