### PR TITLE
Enable word wrap in feedback modal

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12144,6 +12144,10 @@ impl Editor {
             .update(cx, |map, cx| map.set_wrap_width(width, cx))
     }
 
+    pub fn set_soft_wrap(&mut self) {
+        self.soft_wrap_mode_override = Some(language_settings::SoftWrap::EditorWidth)
+    }
+
     pub fn toggle_soft_wrap(&mut self, _: &ToggleSoftWrap, _: &mut Window, cx: &mut Context<Self>) {
         if self.soft_wrap_mode_override.is_some() {
             self.soft_wrap_mode_override.take();

--- a/crates/feedback/src/feedback_modal.rs
+++ b/crates/feedback/src/feedback_modal.rs
@@ -194,6 +194,7 @@ impl FeedbackModal {
             editor.set_show_inline_completions(Some(false), window, cx);
             editor.set_vertical_scroll_margin(5, cx);
             editor.set_use_modal_editing(false);
+            editor.set_soft_wrap();
             editor
         });
 


### PR DESCRIPTION
https://zed-industries.slack.com/archives/C04S7CZPF4M/p1738151539115169

Release Notes:

- Enable word wrap in the feedback modal
