### PR TITLE
edit prediction: Fix popover positioning when placed above edit

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3527,7 +3527,7 @@ impl EditorElement {
                     crate::inline_completion_edit_text(&snapshot, edits, edit_preview, false, cx)
                 })?;
 
-                let line_count = highlighted_edits.text.lines().count() + 1;
+                let line_count = highlighted_edits.text.lines().count();
 
                 let longest_row =
                     editor_snapshot.longest_row_in_range(edit_start.row()..edit_end.row() + 1);


### PR DESCRIPTION
Fixes an off-by-one error when the popover was placed above the edit:
<img width="688" alt="Screenshot 2025-01-30 at 11 59 14" src="https://github.com/user-attachments/assets/938a6626-3f4d-4566-b68c-89b14d48b68d" />


Release Notes:

- N/A
