### PR TITLE
edit prediction: Do not request a completion if edits can be interpolated

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1349,6 +1349,17 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
             return;
         }
 
+        if let Some(current_completion) = self.current_completion.as_ref() {
+            let snapshot = buffer.read(cx).snapshot();
+            if current_completion
+                .completion
+                .interpolate(&snapshot)
+                .is_some()
+            {
+                return;
+            }
+        }
+
         let pending_completion_id = self.next_pending_completion_id;
         self.next_pending_completion_id += 1;
 


### PR DESCRIPTION
This ensures that we do not fetch a new completion when the edits of the user can be interpolated.
E.g. (suggestions in `[]`):
```rust
s[truct Person {}]
```
Then if i type out `truct` we will not fetch a new completion

Release Notes:

- N/A
