### PR TITLE
Fix clipping at end of line in vim mode with inlay hints

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1069,12 +1069,9 @@ impl DisplaySnapshot {
     }
 
     pub fn clip_at_line_end(&self, point: DisplayPoint) -> DisplayPoint {
-        let mut point = point.0;
-        if point.column == self.line_len(DisplayRow(point.row)) {
-            point.column = point.column.saturating_sub(1);
-            point = self.block_snapshot.clip_point(point, Bias::Left);
-        }
-        DisplayPoint(point)
+        let mut point = self.display_point_to_point(point, Bias::Left);
+        point.column = point.column.saturating_sub(1);
+        self.point_to_display_point(point, Bias::Left)
     }
 
     pub fn folds_in_range<T>(&self, range: Range<T>) -> impl Iterator<Item = &Fold>

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1068,9 +1068,14 @@ impl DisplaySnapshot {
         DisplayPoint(self.block_snapshot.clip_point(point.0, bias))
     }
 
-    pub fn clip_at_line_end(&self, point: DisplayPoint) -> DisplayPoint {
-        let mut point = self.display_point_to_point(point, Bias::Left);
+    pub fn clip_at_line_end(&self, display_point: DisplayPoint) -> DisplayPoint {
+        let mut point = self.display_point_to_point(display_point, Bias::Left);
+
+        if point.column != self.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+            return display_point;
+        }
         point.column = point.column.saturating_sub(1);
+        point = self.buffer_snapshot.clip_point(point, Bias::Left);
         self.point_to_display_point(point, Bias::Left)
     }
 


### PR DESCRIPTION
Closes #23877

Co-Authored-By: Ben <ben@zed.dev>
Co-Authored-By: Michael <michael@zed.dev>

Release Notes:

- vim: Fix navigating to end of line with inlay hints
