### PR TITLE
theme: Properly resolve directory and chevron icons from icon themes

### DIFF
--- a/crates/theme/src/registry.rs
+++ b/crates/theme/src/registry.rs
@@ -255,6 +255,14 @@ impl ThemeRegistry {
     ) -> Result<()> {
         let icon_theme_family = read_icon_theme(icon_theme_path, fs).await?;
 
+        let resolve_icon_path = |path: SharedString| {
+            icons_root_dir
+                .join(path.as_ref())
+                .to_string_lossy()
+                .to_string()
+                .into()
+        };
+
         let mut state = self.state.write();
         for icon_theme in icon_theme_family.themes {
             let icon_theme = IconTheme {
@@ -265,23 +273,21 @@ impl ThemeRegistry {
                     AppearanceContent::Dark => Appearance::Dark,
                 },
                 directory_icons: DirectoryIcons {
-                    collapsed: icon_theme.directory_icons.collapsed,
-                    expanded: icon_theme.directory_icons.expanded,
+                    collapsed: icon_theme.directory_icons.collapsed.map(resolve_icon_path),
+                    expanded: icon_theme.directory_icons.expanded.map(resolve_icon_path),
                 },
                 chevron_icons: ChevronIcons {
-                    collapsed: icon_theme.chevron_icons.collapsed,
-                    expanded: icon_theme.chevron_icons.expanded,
+                    collapsed: icon_theme.chevron_icons.collapsed.map(resolve_icon_path),
+                    expanded: icon_theme.chevron_icons.expanded.map(resolve_icon_path),
                 },
                 file_icons: icon_theme
                     .file_icons
                     .into_iter()
                     .map(|(key, icon)| {
-                        let path = icons_root_dir.join(icon.path.as_ref());
-
                         (
                             key,
                             IconDefinition {
-                                path: path.to_string_lossy().to_string().into(),
+                                path: resolve_icon_path(icon.path),
                             },
                         )
                     })


### PR DESCRIPTION
This PR fixes an issue where we weren't properly resolving directory and chevron icons from icon themes the way we were for file icons.

We need to interpret the icon paths as relative to the extension directory.

Release Notes:

- N/A
