### PR TITLE
gpui: Move generic bounds to a `where` clause for better readability

### DIFF
--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -114,9 +114,9 @@ impl From<Arc<Image>> for ImageSource {
     }
 }
 
-impl<
-        F: Fn(&mut Window, &mut App) -> Option<Result<Arc<RenderImage>, ImageCacheError>> + 'static,
-    > From<F> for ImageSource
+impl<F> From<F> for ImageSource
+where
+    F: Fn(&mut Window, &mut App) -> Option<Result<Arc<RenderImage>, ImageCacheError>> + 'static,
 {
     fn from(value: F) -> Self {
         Self::Custom(Arc::new(value))


### PR DESCRIPTION
This PR moves some generic bounds to a `where` clause to improve the formatting/readability of the associated `impl` block.

Release Notes:

- N/A
