### PR TITLE
Add support for icon themes

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -10,6 +10,7 @@
     "light": "One Light",
     "dark": "One Dark"
   },
+  "icon_theme": "Zed (Default)",
   // The name of a base set of key bindings to use.
   // This setting can take six values, each named after another
   // text editor:

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -319,9 +319,6 @@ pub struct ThemeSettingsContent {
     #[serde(default)]
     pub theme: Option<ThemeSelection>,
     /// The name of the icon theme to use.
-    ///
-    /// Currently not exposed to the user.
-    #[serde(skip)]
     #[serde(default)]
     pub icon_theme: Option<String>,
 


### PR DESCRIPTION
This PR adds support for icon themes.

Closes https://github.com/zed-industries/zed/issues/8843.

Here is Zed with Material Icons:

<img width="1136" alt="Screenshot 2025-01-30 at 7 02 06 PM" src="https://github.com/user-attachments/assets/57d8a0e0-ff38-44d9-8628-af58a60a7c9a" />

### Extensions

Extensions can provide icon themes as well as the icons used in those themes.

Icon themes are defined as JSON files in the `icon_themes` directory, and icons included in the `icons` directory will be packaged up with the extension.

All icon paths within an icon theme are interpreted relative to the root of the extension.

See the [Material Icon Theme](https://github.com/zed-extensions/material-icon-theme) extension for an example.

Release Notes:

- Added support for icon themes.
  - Extensions can now provide icon themes.
  - Use the `icon theme selector: toggle` action to switch between installed icon themes.
