### PR TITLE
theme_importer: Fix theme JSON schema URL

### DIFF
--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -19,7 +19,7 @@ use theme::{Appearance, AppearanceContent, ThemeFamilyContent};
 use crate::vscode::VsCodeTheme;
 use crate::vscode::VsCodeThemeConverter;
 
-const ZED_THEME_SCHEMA_URL: &str = "https://zed.dev/public/schema/themes/v0.2.0.json";
+const ZED_THEME_SCHEMA_URL: &str = "https://zed.dev/schema/themes/v0.2.0.json";
 
 #[derive(Debug, Deserialize)]
 struct FamilyMetadata {


### PR DESCRIPTION
This PR fixes the URL for the theme JSON schema, as it had an extra path segment.

Release Notes:

- N/A
