### PR TITLE
Fix two bugs in new diff hunk handling

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1040,10 +1040,10 @@ impl SerializableItem for Editor {
             } => window.spawn(cx, |mut cx| {
                 let project = project.clone();
                 async move {
-                    let language = if let Some(language_name) = language {
-                        let language_registry =
-                            project.update(&mut cx, |project, _| project.languages().clone())?;
+                    let language_registry =
+                        project.update(&mut cx, |project, _| project.languages().clone())?;
 
+                    let language = if let Some(language_name) = language {
                         // We don't fail here, because we'd rather not set the language if the name changed
                         // than fail to restore the buffer.
                         language_registry
@@ -1061,6 +1061,7 @@ impl SerializableItem for Editor {
 
                     // Then set the text so that the dirty bit is set correctly
                     buffer.update(&mut cx, |buffer, cx| {
+                        buffer.set_language_registry(language_registry);
                         if let Some(language) = language {
                             buffer.set_language(Some(language), cx);
                         }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3484,7 +3484,8 @@ impl MultiBufferSnapshot {
                 let region = cursor.region()?;
                 let buffer_start = if region.is_main_buffer {
                     let start_overshoot = range.start.saturating_sub(region.range.start.key);
-                    region.buffer_range.start.key + start_overshoot
+                    (region.buffer_range.start.key + start_overshoot)
+                        .min(region.buffer_range.end.key)
                 } else {
                     cursor.main_buffer_position()?.key
                 };

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -2223,7 +2223,9 @@ impl BufferChangeSet {
                         let base_text = cx.background_executor().spawn(snapshot).await;
                         this.update(&mut cx, |this, cx| {
                             this.base_text = Some(base_text);
-                            cx.notify();
+                            cx.emit(BufferChangeSetEvent::DiffChanged {
+                                changed_range: text::Anchor::MIN..text::Anchor::MAX,
+                            });
                         })
                     }));
                 }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/23981

Release Notes:

- Fixed a crash that could happen when expanding certain diff hunks
- Fixed a bug where diff hunks were not syntax highlighted when reopening a project with previously-opened buffers.
