### PR TITLE
extensions_ui: Show the filtered icon theme selector when installing an icon theme

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -444,6 +444,23 @@ impl ExtensionStore {
             .filter_map(|(name, theme)| theme.extension.as_ref().eq(extension_id).then_some(name))
     }
 
+    /// Returns the names of icon themes provided by extensions.
+    pub fn extension_icon_themes<'a>(
+        &'a self,
+        extension_id: &'a str,
+    ) -> impl Iterator<Item = &'a Arc<str>> {
+        self.extension_index
+            .icon_themes
+            .iter()
+            .filter_map(|(name, icon_theme)| {
+                icon_theme
+                    .extension
+                    .as_ref()
+                    .eq(extension_id)
+                    .then_some(name)
+            })
+    }
+
     pub fn fetch_extensions(
         &self,
         search: Option<&str>,

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -295,6 +295,25 @@ impl ExtensionsPage {
                     );
                 })
                 .ok();
+            return;
+        }
+
+        let icon_themes = extension_store
+            .extension_icon_themes(extension_id)
+            .map(|name| name.to_string())
+            .collect::<Vec<_>>();
+        if !icon_themes.is_empty() {
+            workspace
+                .update(cx, |_workspace, cx| {
+                    window.dispatch_action(
+                        zed_actions::icon_theme_selector::Toggle {
+                            themes_filter: Some(icon_themes),
+                        }
+                        .boxed_clone(),
+                        cx,
+                    );
+                })
+                .ok();
         }
     }
 


### PR DESCRIPTION
This PR makes it so when you install an extension with icon themes it will deploy the icon theme selector filtered down to the newly-installed icon themes.

This is similar to what we do when installing an extension with themes.

Because we can only have one picker open at a time, when installing an extension that has _both_ themes and icon themes, the theme selector will take precedence.

Release Notes:

- N/A
