### PR TITLE
Unify selection directions when performing `editor: select all matches`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8827,6 +8827,12 @@ impl Editor {
             }
         }
 
+        let reversed = self.selections.oldest::<usize>(cx).reversed;
+
+        for selection in new_selections.iter_mut() {
+            selection.reversed = reversed;
+        }
+
         select_next_state.done = true;
         self.unfold_ranges(
             &new_selections

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5237,7 +5237,7 @@ async fn test_select_all_matches(cx: &mut gpui::TestAppContext) {
 
     let mut cx = EditorTestContext::new(cx).await;
 
-    // Test carrot-only selections
+    // Test caret-only selections
     cx.set_state("abc\nˇabc abc\ndefabc\nabc");
 
     cx.update_editor(|e, window, cx| e.select_all_matches(&SelectAllMatches, window, cx))

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5236,11 +5236,27 @@ async fn test_select_all_matches(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 
     let mut cx = EditorTestContext::new(cx).await;
+
+    // Test carrot-only selections
     cx.set_state("abc\nˇabc abc\ndefabc\nabc");
 
     cx.update_editor(|e, window, cx| e.select_all_matches(&SelectAllMatches, window, cx))
         .unwrap();
     cx.assert_editor_state("«abcˇ»\n«abcˇ» «abcˇ»\ndefabc\n«abcˇ»");
+
+    // Test left-to-right selections
+    cx.set_state("abc\n«abcˇ»\nabc");
+
+    cx.update_editor(|e, window, cx| e.select_all_matches(&SelectAllMatches, window, cx))
+        .unwrap();
+    cx.assert_editor_state("«abcˇ»\n«abcˇ»\n«abcˇ»");
+
+    // Test right-to-left selections
+    cx.set_state("abc\n«ˇabc»\nabc");
+
+    cx.update_editor(|e, window, cx| e.select_all_matches(&SelectAllMatches, window, cx))
+        .unwrap();
+    cx.assert_editor_state("«ˇabc»\n«ˇabc»\n«ˇabc»");
 }
 
 #[gpui::test]


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/19569

Current behavior:

https://github.com/user-attachments/assets/1de764c9-7c62-49ad-b24b-6e85760857db

After PR:

https://github.com/user-attachments/assets/651d8e50-95e2-4513-852b-9557d00d2b62

Release Notes:

- Unified selection directions when performing `editor: select all matches`.
