### PR TITLE
docs: Remove lingering docs for `default_dock_anchor`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -515,12 +515,6 @@ List of `string` values
 "cursor_shape": "hollow"
 ```
 
-**Options**
-
-1. Position the dock attached to the bottom of the workspace: `bottom`
-2. Position the dock to the right of the workspace like a side panel: `right`
-3. Position the dock full screen over the entire workspace: `expanded`
-
 ## Editor Scrollbar
 
 - Description: Whether or not to show the editor scrollbar and various elements in it.


### PR DESCRIPTION
This PR removes some lingering docs leftover after `default_dock_anchor` was removed.

These were missed in https://github.com/zed-industries/zed/pull/18210.

Closes https://github.com/zed-industries/zed/issues/24023.

Release Notes:

- N/A
