### PR TITLE
Ensure pane where search buttons are clicked is focused before dispatching action

### DIFF
--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -14,7 +14,15 @@ pub(super) fn render_nav_button(
         icon,
     )
     .shape(IconButtonShape::Square)
-    .on_click(|_, window, cx| window.dispatch_action(action.boxed_clone(), cx))
+    .on_click({
+        let focus_handle = focus_handle.clone();
+        move |_, window, cx| {
+            if !focus_handle.is_focused(&window) {
+                window.focus(&focus_handle);
+            }
+            window.dispatch_action(action.boxed_clone(), cx)
+        }
+    })
     .tooltip(move |window, cx| Tooltip::for_action_in(tooltip, action, &focus_handle, window, cx))
     .disabled(!active)
 }


### PR DESCRIPTION
Closes #23906

Note: Changes the focused pane when search UI is interacted with on an unfocused pane rather than leaving the focused pane unchanged as focusing on click is more likely to be the expected behavior

Release Notes:

- Fixes an issue with search actions so that they now execute on the clicked pane rather than the focused pane when using search UI in multiple panes
