### PR TITLE
vim: Add textobject `e` for entire file

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -421,7 +421,8 @@
       "i": "vim::IndentObj",
       "shift-i": ["vim::IndentObj", { "includeBelow": true }],
       "f": "vim::Method",
-      "c": "vim::Class"
+      "c": "vim::Class",
+      "e": "vim::EntireFile"
     }
   },
   {

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -40,6 +40,7 @@ pub enum Object {
     Method,
     Class,
     Comment,
+    EntireFile,
 }
 
 #[derive(Clone, Deserialize, JsonSchema, PartialEq)]
@@ -83,7 +84,8 @@ actions!(
         Tag,
         Method,
         Class,
-        Comment
+        Comment,
+        EntireFile
     ]
 );
 
@@ -150,6 +152,9 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &Class, window, cx| {
         vim.object(Object::Class, window, cx)
     });
+    Vim::action(editor, cx, |vim, _: &EntireFile, window, cx| {
+        vim.object(Object::EntireFile, window, cx)
+    });
     Vim::action(editor, cx, |vim, _: &Comment, window, cx| {
         if !matches!(vim.active_operator(), Some(Operator::Object { .. })) {
             vim.push_operator(Operator::Object { around: true }, window, cx);
@@ -200,6 +205,7 @@ impl Object {
             | Object::Argument
             | Object::Method
             | Object::Class
+            | Object::EntireFile
             | Object::Comment
             | Object::IndentObj { .. } => true,
         }
@@ -225,6 +231,7 @@ impl Object {
             | Object::Method
             | Object::Class
             | Object::Comment
+            | Object::EntireFile
             | Object::CurlyBrackets
             | Object::AngleBrackets => true,
         }
@@ -262,7 +269,7 @@ impl Object {
                     Mode::Visual
                 }
             }
-            Object::Paragraph => Mode::VisualLine,
+            Object::Paragraph | Object::EntireFile => Mode::VisualLine,
         }
     }
 
@@ -386,6 +393,7 @@ impl Object {
             ),
             Object::Argument => argument(map, relative_to, around),
             Object::IndentObj { include_below } => indent(map, relative_to, around, include_below),
+            Object::EntireFile => entire_file(map),
         }
     }
 
@@ -707,6 +715,10 @@ fn around_next_word(
     });
 
     Some(start..end)
+}
+
+fn entire_file(map: &DisplaySnapshot) -> Option<Range<DisplayPoint>> {
+    Some(DisplayPoint::zero()..map.max_point())
 }
 
 fn text_object(


### PR DESCRIPTION
Co-Authored-By: Thomas Heartman <zed@thomasheartman.com>

Release Notes:

- vim: Add `e` for entire file object. `yae` to copy entire file
