### PR TITLE
open_ai: Add o3-mini

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -78,6 +78,8 @@ pub enum Model {
     O1Preview,
     #[serde(rename = "o1-mini", alias = "o1-mini")]
     O1Mini,
+    #[serde(rename = "o3-mini", alias = "o3-mini")]
+    O3Mini,
 
     #[serde(rename = "custom")]
     Custom {
@@ -101,6 +103,7 @@ impl Model {
             "o1" => Ok(Self::O1),
             "o1-preview" => Ok(Self::O1Preview),
             "o1-mini" => Ok(Self::O1Mini),
+            "o3-mini" => Ok(Self::O3Mini),
             _ => Err(anyhow!("invalid model id")),
         }
     }
@@ -115,6 +118,7 @@ impl Model {
             Self::O1 => "o1",
             Self::O1Preview => "o1-preview",
             Self::O1Mini => "o1-mini",
+            Self::O3Mini => "o3-mini",
             Self::Custom { name, .. } => name,
         }
     }
@@ -129,6 +133,7 @@ impl Model {
             Self::O1 => "o1",
             Self::O1Preview => "o1-preview",
             Self::O1Mini => "o1-mini",
+            Self::O3Mini => "o3-mini",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name),
@@ -145,6 +150,7 @@ impl Model {
             Self::O1 => 200000,
             Self::O1Preview => 128000,
             Self::O1Mini => 128000,
+            Self::O3Mini => 200000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }


### PR DESCRIPTION
OpenAI added o3-mini with a context window size of 200000 tokens to the API today: https://platform.openai.com/docs/models#o3-mini

Release Notes:

- Added OpenAI o3-mini
