### PR TITLE
Improve inline_completions.disabled_globs in default.json

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -776,7 +776,7 @@
   "load_direnv": "direct",
   "inline_completions": {
     // A list of globs representing files that inline completions should be disabled for.
-    "disabled_globs": [".env"]
+    "disabled_globs": ["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"]
   },
   // Settings specific to journaling
   "journal": {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -382,11 +382,16 @@ There are two options to choose from:
 - Default:
 
 ```json
-"inline_completions": {
-  "disabled_globs": [
-    ".env"
-  ]
-}
+  "inline_completions": {
+    "disabled_globs": [
+      "**/.env*",
+      "**/*.pem",
+      "**/*.key",
+      "**/*.cert",
+      "**/*.crt",
+      "**/secrets.yml"
+    ]
+  }
 ```
 
 **Options**


### PR DESCRIPTION
Make sure that inline completions (Copilot, etc) are disabled for more secret globs (matches `private_files`)

Release Notes:

- Improved default `inline_completions.disabled_globs` 