### PR TITLE
assistant_context_editor: Don't block `ContextStore` initialization on reloading contexts

### DIFF
--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -144,11 +144,9 @@ impl ContextStore {
                 this.handle_project_changed(project.clone(), cx);
                 this.synchronize_contexts(cx);
                 this.register_context_server_handlers(cx);
+                this.reload(cx).detach_and_log_err(cx);
                 this
             })?;
-            this.update(&mut cx, |this, cx| this.reload(cx))?
-                .await
-                .log_err();
 
             Ok(this)
         })


### PR DESCRIPTION
This PR changes the `ContextStore` constructor to not block on reloading the contexts before we finish initializing it.

I noticed that the Assistant panel was taking a long time to show up in the status bar, and upon further investigation uncovered that with a large number of contexts (I have ~320) it takes a long time to load them all.

Release Notes:

- N/A
