### PR TITLE
lmstudio: Support missing quantization in model metadata

### DIFF
--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -192,7 +192,7 @@ pub struct ModelEntry {
     pub publisher: String,
     pub arch: Option<String>,
     pub compatibility_type: CompatibilityType,
-    pub quantization: String,
+    pub quantization: Option<String>,
     pub state: ModelState,
     pub max_context_length: Option<u32>,
     pub loaded_context_length: Option<u32>,


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/23764

Certain models do not include `quantization` parameter from lm studio rest API.

Release Notes:

- Fixed usage of nonquantized models with LM Studio