### PR TITLE
Renames: `HighlightedText`->`HighlightedMatch` + `HighlightedEdits`->`HighlightedText`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -96,7 +96,7 @@ use itertools::Itertools;
 use language::{
     language_settings::{self, all_language_settings, language_settings, InlayHintSettings},
     markdown, point_from_lsp, AutoindentMode, BracketPair, Buffer, Capability, CharKind, CodeLabel,
-    CursorShape, Diagnostic, Documentation, EditPreview, HighlightedEdits, IndentKind, IndentSize,
+    CursorShape, Diagnostic, Documentation, EditPreview, HighlightedText, IndentKind, IndentSize,
     Language, OffsetRangeExt, Point, Selection, SelectionGoal, TextObject, TransactionId,
     TreeSitterOptions,
 };
@@ -488,7 +488,7 @@ impl InlineCompletionMenuHint {
 #[derive(Clone, Debug)]
 enum InlineCompletionText {
     Move(SharedString),
-    Edit(HighlightedEdits),
+    Edit(HighlightedText),
 }
 
 pub(crate) enum EditDisplayMode {
@@ -15840,7 +15840,7 @@ fn inline_completion_edit_text(
     edit_preview: &EditPreview,
     include_deletions: bool,
     cx: &App,
-) -> Option<HighlightedEdits> {
+) -> Option<HighlightedText> {
     let edits = edits
         .iter()
         .map(|(anchor, text)| {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -15401,7 +15401,7 @@ async fn assert_highlighted_edits(
     edits: Vec<(Range<Point>, String)>,
     include_deletions: bool,
     cx: &mut TestAppContext,
-    assertion_fn: impl Fn(HighlightedEdits, &App),
+    assertion_fn: impl Fn(HighlightedText, &App),
 ) {
     let window = cx.add_window(|window, cx| {
         let buffer = MultiBuffer::build_simple(text, cx);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -596,7 +596,7 @@ pub struct EditPreview {
 }
 
 #[derive(Default, Clone, Debug)]
-pub struct HighlightedEdits {
+pub struct HighlightedText {
     pub text: SharedString,
     pub highlights: Vec<(Range<usize>, HighlightStyle)>,
 }
@@ -608,9 +608,9 @@ impl EditPreview {
         edits: &[(Range<Anchor>, String)],
         include_deletions: bool,
         cx: &App,
-    ) -> HighlightedEdits {
+    ) -> HighlightedText {
         let Some(visible_range_in_preview_snapshot) = self.compute_visible_range(edits) else {
-            return HighlightedEdits::default();
+            return HighlightedText::default();
         };
 
         let mut text = String::new();
@@ -686,7 +686,7 @@ impl EditPreview {
             cx,
         );
 
-        HighlightedEdits {
+        HighlightedText {
             text: text.into(),
             highlights,
         }

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2739,7 +2739,7 @@ async fn test_preview_edits(cx: &mut TestAppContext) {
         edits: Vec<(Range<Point>, &str)>,
         include_deletions: bool,
         cx: &mut TestAppContext,
-        assert_fn: impl Fn(HighlightedEdits),
+        assert_fn: impl Fn(HighlightedText),
     ) {
         let buffer = cx.new(|cx| Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx));
         let edits = buffer.read_with(cx, |buffer, _| {

--- a/crates/picker/src/highlighted_match_with_paths.rs
+++ b/crates/picker/src/highlighted_match_with_paths.rs
@@ -2,19 +2,19 @@ use ui::{prelude::*, HighlightedLabel};
 
 #[derive(Clone)]
 pub struct HighlightedMatchWithPaths {
-    pub match_label: HighlightedText,
-    pub paths: Vec<HighlightedText>,
+    pub match_label: HighlightedMatch,
+    pub paths: Vec<HighlightedMatch>,
 }
 
 #[derive(Debug, Clone, IntoElement)]
-pub struct HighlightedText {
+pub struct HighlightedMatch {
     pub text: String,
     pub highlight_positions: Vec<usize>,
     pub char_count: usize,
     pub color: Color,
 }
 
-impl HighlightedText {
+impl HighlightedMatch {
     pub fn join(components: impl Iterator<Item = Self>, separator: &str) -> Self {
         let mut char_count = 0;
         let separator_char_count = separator.chars().count();
@@ -48,7 +48,7 @@ impl HighlightedText {
         Self { color, ..self }
     }
 }
-impl RenderOnce for HighlightedText {
+impl RenderOnce for HighlightedMatch {
     fn render(self, _window: &mut Window, _: &mut App) -> impl IntoElement {
         HighlightedLabel::new(self.text, self.highlight_positions).color(self.color)
     }

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -11,7 +11,7 @@ use gpui::{
 };
 use ordered_float::OrderedFloat;
 use picker::{
-    highlighted_match_with_paths::{HighlightedMatchWithPaths, HighlightedText},
+    highlighted_match_with_paths::{HighlightedMatch, HighlightedMatchWithPaths},
     Picker, PickerDelegate,
 };
 pub use remote_servers::RemoteServerProjects;
@@ -386,7 +386,7 @@ impl PickerDelegate for RecentProjectsDelegate {
             .unzip();
 
         let highlighted_match = HighlightedMatchWithPaths {
-            match_label: HighlightedText::join(match_labels.into_iter().flatten(), ", "),
+            match_label: HighlightedMatch::join(match_labels.into_iter().flatten(), ", "),
             paths,
         };
 
@@ -487,7 +487,7 @@ fn highlights_for_path(
     path: &Path,
     match_positions: &Vec<usize>,
     path_start_offset: usize,
-) -> (Option<HighlightedText>, HighlightedText) {
+) -> (Option<HighlightedMatch>, HighlightedMatch) {
     let path_string = path.to_string_lossy();
     let path_char_count = path_string.chars().count();
     // Get the subset of match highlight positions that line up with the given path.
@@ -513,7 +513,7 @@ fn highlights_for_path(
             .take_while(|position| *position < file_name_start + char_count)
             .map(|position| position - file_name_start)
             .collect::<Vec<_>>();
-        HighlightedText {
+        HighlightedMatch {
             text: text.to_string(),
             highlight_positions,
             char_count,
@@ -523,7 +523,7 @@ fn highlights_for_path(
 
     (
         file_name_text_and_positions,
-        HighlightedText {
+        HighlightedMatch {
             text: path_string.to_string(),
             highlight_positions: path_positions,
             char_count: path_char_count,

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -7,7 +7,7 @@ use gpui::{
     Focusable, InteractiveElement, ParentElement, Render, SharedString, Styled, Subscription, Task,
     WeakEntity, Window,
 };
-use picker::{highlighted_match_with_paths::HighlightedText, Picker, PickerDelegate};
+use picker::{highlighted_match_with_paths::HighlightedMatch, Picker, PickerDelegate};
 use project::{task_store::TaskStore, TaskSourceKind};
 use task::{ResolvedTask, RevealTarget, TaskContext, TaskTemplate};
 use ui::{
@@ -356,7 +356,7 @@ impl PickerDelegate for TasksModalDelegate {
             Some(Tooltip::simple(tooltip_label_text, cx))
         };
 
-        let highlighted_location = HighlightedText {
+        let highlighted_location = HighlightedMatch {
             text: hit.string.clone(),
             highlight_positions: hit.positions.clone(),
             char_count: hit.string.chars().count(),


### PR DESCRIPTION
In support of work on https://github.com/zed-industries/zed/tree/new-ui-for-edit-prediction-with-lsp-completions, where we want to be able to extract a range of the buffer as `HighlightedText`.

Release Notes:

- N/A