### PR TITLE
Use different commit author for collab project clients

### DIFF
--- a/crates/call/src/cross_platform/room.rs
+++ b/crates/call/src/cross_platform/room.rs
@@ -532,6 +532,10 @@ impl Room {
         &self.local_participant
     }
 
+    pub fn local_participant_user(&self, cx: &App) -> Option<Arc<User>> {
+        self.user_store.read(cx).current_user()
+    }
+
     pub fn remote_participants(&self) -> &BTreeMap<u64, RemoteParticipant> {
         &self.remote_participants
     }

--- a/crates/call/src/macos/room.rs
+++ b/crates/call/src/macos/room.rs
@@ -588,6 +588,10 @@ impl Room {
         &self.local_participant
     }
 
+    pub fn local_participant_user(&self, cx: &App) -> Option<Arc<User>> {
+        self.user_store.read(cx).current_user()
+    }
+
     pub fn remote_participants(&self) -> &BTreeMap<u64, RemoteParticipant> {
         &self.remote_participants
     }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4073,9 +4073,11 @@ impl Project {
         })??;
 
         let commit_message = envelope.payload.message;
+        let name = envelope.payload.name;
+        let email = envelope.payload.email;
         let (err_sender, mut err_receiver) = mpsc::channel(1);
         repository_handle
-            .commit_with_message(commit_message, err_sender)
+            .commit_with_message(commit_message, name.zip(email), err_sender)
             .context("unstaging entries")?;
         if let Some(error) = err_receiver.next().await {
             Err(error.context("error during unstaging"))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4073,8 +4073,8 @@ impl Project {
         })??;
 
         let commit_message = envelope.payload.message;
-        let name = envelope.payload.name;
-        let email = envelope.payload.email;
+        let name = envelope.payload.name.map(SharedString::from);
+        let email = envelope.payload.email.map(SharedString::from);
         let (err_sender, mut err_receiver) = mpsc::channel(1);
         repository_handle
             .commit_with_message(commit_message, name.zip(email), err_sender)

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2656,4 +2656,6 @@ message Commit {
     uint64 worktree_id = 2;
     uint64 work_directory_id = 3;
     string message = 4;
+    optional string name = 5;
+    optional string email = 6;
 }

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -721,9 +721,11 @@ impl HeadlessProject {
         })??;
 
         let commit_message = envelope.payload.message;
+        let name = envelope.payload.name;
+        let email = envelope.payload.email;
         let (err_sender, mut err_receiver) = mpsc::channel(1);
         repository_handle
-            .commit_with_message(commit_message, err_sender)
+            .commit_with_message(commit_message, name.zip(email), err_sender)
             .context("unstaging entries")?;
         if let Some(error) = err_receiver.next().await {
             Err(error.context("error during unstaging"))

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -4,7 +4,7 @@ use extension_host::headless_host::HeadlessExtensionStore;
 use fs::Fs;
 use futures::channel::mpsc;
 use git::repository::RepoPath;
-use gpui::{App, AppContext as _, AsyncApp, Context, Entity, PromptLevel};
+use gpui::{App, AppContext as _, AsyncApp, Context, Entity, PromptLevel, SharedString};
 use http_client::HttpClient;
 use language::{proto::serialize_operation, Buffer, BufferEvent, LanguageRegistry};
 use node_runtime::NodeRuntime;
@@ -721,8 +721,8 @@ impl HeadlessProject {
         })??;
 
         let commit_message = envelope.payload.message;
-        let name = envelope.payload.name;
-        let email = envelope.payload.email;
+        let name = envelope.payload.name.map(SharedString::from);
+        let email = envelope.payload.email.map(SharedString::from);
         let (err_sender, mut err_receiver) = mpsc::channel(1);
         repository_handle
             .commit_with_message(commit_message, name.zip(email), err_sender)


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/23869

* Retrieves user + email for collab project clients and use these when such users commit

Same as in https://github.com/zed-industries/zed/pull/23329, "is it the right user name and e-mail" and "how to override these" questions apply.

* If this data is unavailable, forbid committing to the remote client

* Forbid running related actions in git panel, if committing/writing is not permitted


Release Notes:

- N/A
