### PR TITLE
vim: Add :set wrap and :set nowrap

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -87,6 +87,12 @@ pub struct ToggleComments {
 }
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
+pub struct ToggleSoftWrap {
+    #[serde(default)]
+    pub mode: Option<language::language_settings::SoftWrap>,
+}
+
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
 pub struct FoldAt {
     #[serde(skip)]
     pub buffer_row: MultiBufferRow,
@@ -208,6 +214,7 @@ impl_actions!(
         ShowCompletions,
         ToggleCodeActions,
         ToggleComments,
+        ToggleSoftWrap,
         UnfoldAt,
         FoldAtLevel,
     ]
@@ -381,7 +388,6 @@ gpui::actions!(
         SetMark,
         ToggleRelativeLineNumbers,
         ToggleSelectionMenu,
-        ToggleSoftWrap,
         ToggleTabBar,
         Transpose,
         Undo,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12171,8 +12171,15 @@ impl Editor {
         self.soft_wrap_mode_override = Some(language_settings::SoftWrap::EditorWidth)
     }
 
-    pub fn toggle_soft_wrap(&mut self, _: &ToggleSoftWrap, _: &mut Window, cx: &mut Context<Self>) {
-        if self.soft_wrap_mode_override.is_some() {
+    pub fn toggle_soft_wrap(
+        &mut self,
+        action: &ToggleSoftWrap,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if action.mode.is_some() {
+            self.soft_wrap_mode_override = action.mode;
+        } else if self.soft_wrap_mode_override.is_some() {
             self.soft_wrap_mode_override.take();
         } else {
             let soft_wrap = match self.soft_wrap_mode(cx) {

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -749,6 +749,18 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("e", "dit"), editor::actions::ReloadFile)
             .bang(editor::actions::ReloadFile),
         VimCommand::new(("cpp", "link"), editor::actions::CopyPermalinkToLine).range(act_on_range),
+        VimCommand::new(
+            ("set wrap", ""),
+            editor::actions::ToggleSoftWrap {
+                mode: Some(language::language_settings::SoftWrap::EditorWidth),
+            },
+        ),
+        VimCommand::new(
+            ("set nowrap", ""),
+            editor::actions::ToggleSoftWrap {
+                mode: Some(language::language_settings::SoftWrap::None),
+            },
+        ),
     ]
 }
 


### PR DESCRIPTION
Closes #21147

Hi! This is my first pull request. I found this issue from the vim channel notes, and thought it was an appropriate first contribution, to try and understand things here. I hope I did it all correctly! I didn't find any tests for soft wrapping, so I have not made or edited any.

The original issue requested that `set wrap` _toggle_ the soft wrap state. That's not what Vim does, so that's not what I've done. Instead, I've added separate `:set wrap` and `:set nowrap` commands.

I tried a few different things out here, including adding separate `EnableSoftWrap` and `DisableSoftWrap` actions, and converting `editor::set_soft_wrap_mode()` to an action. In the end I chose an optional parameter to the existing action to be the lowest touch change here.

These are (I think) the first `:set ...` commands added to the Vim mode in Zed, unless I've missed something. If there is a desire for more of these (`number`, `relativenumber`, `shiftwidth`, et al), I would be happy to contribute those as well. And, if this is not the correct way to have added such an option, please also let me know.

Thanks,
Max.

Release Notes:

- Added Vim `:set wrap` and `:set nowrap` to enable and disable `soft_wrap`
