### PR TITLE
git_ui: More git panel refinement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13520,7 +13520,6 @@ dependencies = [
  "client",
  "collections",
  "feature_flags",
- "git_ui",
  "gpui",
  "http_client",
  "notifications",

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -927,11 +927,6 @@ impl GitPanel {
                                     )
                                 }
                             })
-                            .key_binding(ui::KeyBinding::for_action_in(
-                                &UnstageAll,
-                                &focus_handle,
-                                window,
-                            ))
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.unstage_all(&UnstageAll, window, cx)
                             }))
@@ -949,11 +944,6 @@ impl GitPanel {
                                     )
                                 }
                             })
-                            .key_binding(ui::KeyBinding::for_action_in(
-                                &StageAll,
-                                &focus_handle,
-                                window,
-                            ))
                             .on_click(cx.listener(move |this, _, window, cx| {
                                 this.stage_all(&StageAll, window, cx)
                             }))

--- a/crates/git_ui/src/repository_selector.rs
+++ b/crates/git_ui/src/repository_selector.rs
@@ -34,7 +34,8 @@ impl RepositorySelector {
         };
 
         let picker = cx.new(|cx| {
-            Picker::uniform_list(delegate, window, cx).max_height(Some(rems(20.).into()))
+            Picker::nonsearchable_uniform_list(delegate, window, cx)
+                .max_height(Some(rems(20.).into()))
         });
 
         let _subscriptions = if let Some(git_state) = git_state {
@@ -234,20 +235,6 @@ impl PickerDelegate for RepositorySelectorDelegate {
                 .spacing(ListItemSpacing::Sparse)
                 .toggle_state(selected)
                 .child(Label::new(display_name)),
-        )
-    }
-
-    fn render_footer(
-        &self,
-        _window: &mut Window,
-        cx: &mut Context<Picker<Self>>,
-    ) -> Option<gpui::AnyElement> {
-        // TODO: Implement footer rendering if needed
-        Some(
-            div()
-                .text_ui_sm(cx)
-                .child("Temporary location for repo selector")
-                .into_any_element(),
         )
     }
 }

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -47,7 +47,6 @@ util.workspace = true
 telemetry.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
-git_ui.workspace = true
 zed_predict_onboarding.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -15,9 +15,7 @@ use crate::platforms::{platform_linux, platform_mac, platform_windows};
 use auto_update::AutoUpdateStatus;
 use call::ActiveCall;
 use client::{Client, UserStore};
-use feature_flags::{FeatureFlagAppExt, GitUiFeatureFlag, ZedPro};
-use git_ui::repository_selector::RepositorySelector;
-use git_ui::repository_selector::RepositorySelectorPopoverMenu;
+use feature_flags::{FeatureFlagAppExt, ZedPro};
 use gpui::{
     actions, div, px, Action, AnyElement, App, Context, Decorations, Element, Entity,
     InteractiveElement, Interactivity, IntoElement, MouseButton, ParentElement, Render, Stateful,
@@ -27,7 +25,6 @@ use project::Project;
 use rpc::proto;
 use settings::Settings as _;
 use smallvec::SmallVec;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use theme::ActiveTheme;
 use ui::{
@@ -105,7 +102,6 @@ pub struct TitleBar {
     platform_style: PlatformStyle,
     content: Stateful<Div>,
     children: SmallVec<[AnyElement; 2]>,
-    repository_selector: Entity<RepositorySelector>,
     project: Entity<Project>,
     user_store: Entity<UserStore>,
     client: Arc<Client>,
@@ -113,7 +109,6 @@ pub struct TitleBar {
     should_move: bool,
     application_menu: Option<Entity<ApplicationMenu>>,
     _subscriptions: Vec<Subscription>,
-    git_ui_enabled: Arc<AtomicBool>,
     zed_predict_banner: Entity<ZedPredictBanner>,
 }
 
@@ -191,7 +186,6 @@ impl Render for TitleBar {
                                         title_bar
                                             .children(self.render_project_host(cx))
                                             .child(self.render_project_name(cx))
-                                            .children(self.render_current_repository(cx))
                                             .children(self.render_project_branch(cx))
                                     })
                             })
@@ -302,14 +296,6 @@ impl TitleBar {
         subscriptions.push(cx.observe_window_activation(window, Self::window_activation_changed));
         subscriptions.push(cx.observe(&user_store, |_, _, cx| cx.notify()));
 
-        let is_git_ui_enabled = Arc::new(AtomicBool::new(false));
-        subscriptions.push(cx.observe_flag::<GitUiFeatureFlag, _>({
-            let is_git_ui_enabled = is_git_ui_enabled.clone();
-            move |enabled, _cx| {
-                is_git_ui_enabled.store(enabled, Ordering::SeqCst);
-            }
-        }));
-
         let zed_predict_banner = cx.new(|cx| {
             ZedPredictBanner::new(
                 workspace.weak_handle(),
@@ -325,14 +311,12 @@ impl TitleBar {
             content: div().id(id.into()),
             children: SmallVec::new(),
             application_menu,
-            repository_selector: cx.new(|cx| RepositorySelector::new(project.clone(), window, cx)),
             workspace: workspace.weak_handle(),
             should_move: false,
             project,
             user_store,
             client,
             _subscriptions: subscriptions,
-            git_ui_enabled: is_git_ui_enabled,
             zed_predict_banner,
         }
     }
@@ -513,41 +497,6 @@ impl TitleBar {
                     cx,
                 );
             }))
-    }
-
-    // NOTE: Not sure we want to keep this in the titlebar, but for while we are working on Git it is helpful in the short term
-    pub fn render_current_repository(&self, cx: &mut Context<Self>) -> Option<impl IntoElement> {
-        if !self.git_ui_enabled.load(Ordering::SeqCst) {
-            return None;
-        }
-
-        let active_repository = self.project.read(cx).active_repository(cx)?;
-        let display_name = active_repository.display_name(self.project.read(cx), cx);
-
-        // TODO: what to render if no active repository?
-        Some(RepositorySelectorPopoverMenu::new(
-            self.repository_selector.clone(),
-            ButtonLike::new("active-repository")
-                .style(ButtonStyle::Subtle)
-                .child(
-                    h_flex().w_full().gap_0p5().child(
-                        div()
-                            .overflow_x_hidden()
-                            .flex_grow()
-                            .whitespace_nowrap()
-                            .child(
-                                h_flex()
-                                    .gap_1()
-                                    .child(
-                                        Label::new(display_name)
-                                            .size(LabelSize::Small)
-                                            .color(Color::Muted),
-                                    )
-                                    .into_any_element(),
-                            ),
-                    ),
-                ),
-        ))
     }
 
     pub fn render_project_branch(&self, cx: &mut Context<Self>) -> Option<impl IntoElement> {


### PR DESCRIPTION
- Removes flakey keybindings from buttons
- Moves git panel entries to use a standard ListItem
- Show a repo selector in the panel when more than one repo is present
- Remove temporary repo selector from title bar

Release Notes:

- N/A