### PR TITLE
gpui: Add text alignment

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1661,6 +1661,8 @@ impl Interactivity {
         window: &mut Window,
         cx: &mut App,
     ) {
+        use crate::TextAlign;
+
         if global_id.is_some()
             && (style.debug || style.debug_below || cx.has_global::<crate::DebugBelow>())
             && hitbox.is_hovered(window)
@@ -1682,7 +1684,8 @@ impl Interactivity {
                     .ok()
                     .and_then(|mut text| text.pop())
                 {
-                    text.paint(hitbox.origin, FONT_SIZE, window, cx).ok();
+                    text.paint(hitbox.origin, FONT_SIZE, TextAlign::Left, window, cx)
+                        .ok();
 
                     let text_bounds = crate::Bounds {
                         origin: hitbox.origin,

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -390,8 +390,10 @@ impl TextLayout {
 
         let line_height = element_state.line_height;
         let mut line_origin = bounds.origin;
+        let text_style = window.text_style();
         for line in &element_state.lines {
-            line.paint(line_origin, line_height, window, cx).log_err();
+            line.paint(line_origin, line_height, text_style.text_align, window, cx)
+                .log_err();
             line_origin.y += line.size(line_height).height;
         }
     }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -293,6 +293,20 @@ pub enum TextOverflow {
     Ellipsis(&'static str),
 }
 
+/// How to align text within the element
+#[derive(Copy, Clone, Debug, Default, PartialEq, Eq)]
+pub enum TextAlign {
+    /// Align the text to the left of the element
+    #[default]
+    Left,
+
+    /// Center the text within the element
+    Center,
+
+    /// Align the text to the right of the element
+    Right,
+}
+
 /// The properties that can be used to style text in GPUI
 #[derive(Refineable, Clone, Debug, PartialEq)]
 #[refineable(Debug)]
@@ -335,6 +349,10 @@ pub struct TextStyle {
 
     /// The text should be truncated if it overflows the width of the element
     pub text_overflow: Option<TextOverflow>,
+
+    /// How the text should be aligned within the element
+    pub text_align: TextAlign,
+
     /// The number of lines to display before truncating the text
     pub line_clamp: Option<usize>,
 }
@@ -362,6 +380,7 @@ impl Default for TextStyle {
             strikethrough: None,
             white_space: WhiteSpace::Normal,
             text_overflow: None,
+            text_align: TextAlign::default(),
             line_clamp: None,
         }
     }

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,9 +1,9 @@
-use crate::TextStyleRefinement;
 use crate::{
     self as gpui, px, relative, rems, AbsoluteLength, AlignItems, CursorStyle, DefiniteLength,
     Fill, FlexDirection, FlexWrap, Font, FontStyle, FontWeight, Hsla, JustifyContent, Length,
     SharedString, StrikethroughStyle, StyleRefinement, TextOverflow, WhiteSpace,
 };
+use crate::{TextAlign, TextStyleRefinement};
 pub use gpui_macros::{
     border_style_methods, box_shadow_style_methods, cursor_style_methods, margin_style_methods,
     overflow_style_methods, padding_style_methods, position_style_methods,
@@ -75,6 +75,14 @@ pub trait Styled: Sized {
         self.text_style()
             .get_or_insert_with(Default::default)
             .text_overflow = Some(overflow);
+        self
+    }
+
+    /// Set the text alignment of the element.
+    fn text_align(mut self, align: TextAlign) -> Self {
+        self.text_style()
+            .get_or_insert_with(Default::default)
+            .text_align = Some(align);
         self
     }
 

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -86,6 +86,21 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets the text alignment to left
+    fn text_left(mut self) -> Self {
+        self.text_align(TextAlign::Left)
+    }
+
+    /// Sets the text alignment to center
+    fn text_center(mut self) -> Self {
+        self.text_align(TextAlign::Center)
+    }
+
+    /// Sets the text alignment to right
+    fn text_right(mut self) -> Self {
+        self.text_align(TextAlign::Right)
+    }
+
     /// Sets the truncate to prevent text from wrapping and truncate overflowing text with an ellipsis (…) if needed.
     /// [Docs](https://tailwindcss.com/docs/text-overflow#truncate)
     fn truncate(mut self) -> Self {


### PR DESCRIPTION
Adds a text property for controlling left, center, or right text alignment.

#8792 should stay open since this doesn't add support for `justify` (which would require a much bigger change since this can just alter the origin of each line, but justify requires changing spacing, whereas justify requires changes to each platform's shaping code).

Release Notes:

- N/A
