### PR TITLE
Add `#[track_caller]` to gpui foreground executor spawn methods

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1040,6 +1040,7 @@ impl App {
 
     /// Spawns the future returned by the given function on the thread pool. The closure will be invoked
     /// with [AsyncApp], which allows the application state to be accessed across await points.
+    #[track_caller]
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -172,6 +172,7 @@ impl AsyncApp {
     }
 
     /// Schedule a future to be polled in the background.
+    #[track_caller]
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,
@@ -297,6 +298,7 @@ impl AsyncWindowContext {
 
     /// Schedule a future to be executed on the main thread. This is used for collecting
     /// the results of background tasks and updating the UI.
+    #[track_caller]
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncWindowContext) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,

--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -183,6 +183,7 @@ impl<'a, T: 'static> Context<'a, T> {
     /// Spawn the future returned by the given function.
     /// The function is provided a weak handle to the entity owned by this context and a context that can be held across await points.
     /// The returned task must be held or detached.
+    #[track_caller]
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(WeakEntity<T>, AsyncApp) -> Fut) -> Task<R>
     where
         T: 'static,
@@ -583,6 +584,7 @@ impl<'a, T: 'static> Context<'a, T> {
     /// The given callback is invoked with a [`WeakEntity<V>`] to avoid leaking the view for a long-running process.
     /// It's also given an [`AsyncWindowContext`], which can be used to access the state of the view across await points.
     /// The returned future will be polled on the main thread.
+    #[track_caller]
     pub fn spawn_in<Fut, R>(
         &self,
         window: &Window,

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -317,6 +317,7 @@ impl TestAppContext {
     }
 
     /// Run the given task on the main thread.
+    #[track_caller]
     pub fn spawn<Fut, R>(&self, f: impl FnOnce(AsyncApp) -> Fut) -> Task<R>
     where
         Fut: Future<Output = R> + 'static,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1307,6 +1307,7 @@ impl Window {
     /// Spawn the future returned by the given closure on the application thread pool.
     /// The closure is provided a handle to the current window and an `AsyncWindowContext` for
     /// use within your future.
+    #[track_caller]
     pub fn spawn<Fut, R>(&self, cx: &App, f: impl FnOnce(AsyncWindowContext) -> Fut) -> Task<R>
     where
         R: 'static,


### PR DESCRIPTION
Use of this location info was added in #21758 to help with diagnosing `remote-server` panics on drop of tasks on a different thread.  However, currently those panics are just saying "local task dropped by a thread that didn't spawn it. Task spawned at /home/ubuntu/actions-runner/_work/zed/zed/crates/gpui/src/app/async_context.rs:164:34".  Not useful to just know which gpui spawn method is being used, need the caller of these methods instead.

Release Notes:

- N/A