### PR TITLE
Add support for Go fuzz tests

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -587,6 +587,23 @@ impl ContextProvider for GoContextProvider {
                 ..TaskTemplate::default()
             },
             TaskTemplate {
+                label: format!(
+                    "go test {} -fuzz=Fuzz -run {}",
+                    GO_PACKAGE_TASK_VARIABLE.template_value(),
+                    VariableName::Symbol.template_value(),
+                ),
+                command: "go".into(),
+                args: vec![
+                    "test".into(),
+                    "-fuzz=Fuzz".into(),
+                    "-run".into(),
+                    format!("^{}\\$", VariableName::Symbol.template_value(),),
+                ],
+                tags: vec!["go-fuzz".to_owned()],
+                cwd: package_cwd.clone(),
+                ..TaskTemplate::default()
+            },
+            TaskTemplate {
                 label: format!("go run {}", GO_PACKAGE_TASK_VARIABLE.template_value(),),
                 command: "go".into(),
                 args: vec!["run".into(), ".".into()],

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -63,7 +63,7 @@
 (
   (
     (function_declaration name: (_) @run @_name
-      (#match? @_name "^Fuzz.+"))
+      (#match? @_name "^Fuzz"))
   ) @_
   (#set! tag go-fuzz)
 )

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -59,6 +59,15 @@
   (#set! tag go-benchmark)
 )
 
+; Functions names start with `Fuzz`
+(
+  (
+    (function_declaration name: (_) @run @_name
+      (#match? @_name "^Fuzz.+"))
+  ) @_
+  (#set! tag go-fuzz)
+)
+
 ; go run
 (
   (


### PR DESCRIPTION
Add support for go fuzz tests.

Closes #23809

Release Notes:

- Add support for Go fuzz tests
