### PR TITLE
Conditionally render divider between button groups in the status bar

### DIFF
--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -86,9 +86,6 @@ impl Render for DiagnosticIndicator {
 
         h_flex()
             .gap_2()
-            .pl_1()
-            .border_l_1()
-            .border_color(cx.theme().colors().border)
             .child(
                 ButtonLike::new("diagnostic-indicator")
                     .child(diagnostic_indicator)

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::SettingsStore;
 use std::sync::Arc;
-use ui::{h_flex, ContextMenu, IconButton, Tooltip};
+use ui::{h_flex, ContextMenu, Divider, IconButton, Tooltip};
 use ui::{prelude::*, right_click_menu};
 
 pub(crate) const RESIZE_HANDLE_SIZE: Pixels = Pixels(6.);
@@ -801,7 +801,7 @@ impl Render for PanelButtons {
             DockPosition::Bottom | DockPosition::Right => (Corner::BottomRight, Corner::TopRight),
         };
 
-        let buttons = dock
+        let buttons: Vec<_> = dock
             .panel_entries
             .iter()
             .enumerate()
@@ -869,9 +869,16 @@ impl Render for PanelButtons {
                                 }),
                         ),
                 )
-            });
+            })
+            .collect();
 
-        h_flex().gap_0p5().children(buttons)
+        let has_buttons = !buttons.is_empty();
+        h_flex()
+            .gap_0p5()
+            .children(buttons)
+            .when(has_buttons, |this| {
+                this.h_flex().gap_1().child(Divider::vertical())
+            })
     }
 }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -11,7 +11,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::SettingsStore;
 use std::sync::Arc;
-use ui::{h_flex, ContextMenu, Divider, IconButton, Tooltip};
+use ui::{h_flex, ContextMenu, Divider, DividerColor, IconButton, Tooltip};
 use ui::{prelude::*, right_click_menu};
 
 pub(crate) const RESIZE_HANDLE_SIZE: Pixels = Pixels(6.);
@@ -874,10 +874,10 @@ impl Render for PanelButtons {
 
         let has_buttons = !buttons.is_empty();
         h_flex()
-            .gap_0p5()
+            .gap_1()
             .children(buttons)
             .when(has_buttons, |this| {
-                this.h_flex().gap_1().child(Divider::vertical())
+                this.child(Divider::vertical().color(DividerColor::Border))
             })
     }
 }


### PR DESCRIPTION
In the left hand status bar, there are two groups of buttons. There was a border between the two hardcoded on the first button of the second group, however, if all buttons in the first group are hidden, the border doesn't need to be rendered.

(Not handled in this PR) A potentially better approach would be to change StatusBar's definition from `left_items` and `right_items` to `left_groups` and `right_groups`, and render dividers between each group of items. That seemed like a bigger refactor than I wanted to handle for now, but is an option for the future.

If you use these settings on `main`, the border will show, but with nothing to the left of it.

```json
{
  "collaboration_panel": {
    "button": false
  },
  "outline_panel": {
    "button": false
  },
  "project_panel": {
    "button": false,
  },
}
```

Screenshots:

Before:
<img width="117" alt="Screenshot 2025-02-02 at 6 19 24 PM" src="https://github.com/user-attachments/assets/b3401b47-6172-4392-9277-31aa1affaf7a" />
<img width="134" alt="Screenshot 2025-02-02 at 6 20 12 PM" src="https://github.com/user-attachments/assets/1e8caee6-1da8-47f6-8499-9a93b6d8fa27" />

After:
<img width="125" alt="Screenshot 2025-02-02 at 6 19 58 PM" src="https://github.com/user-attachments/assets/9b9f421c-660b-41cb-80e0-acb774c66054" />
<img width="132" alt="Screenshot 2025-02-02 at 6 20 20 PM" src="https://github.com/user-attachments/assets/87e0e475-084b-44df-b820-573c68728c1a" />

Release Notes:

- Conditionally render divider in status bar
