### PR TITLE
gpui: Fix text alignment for non-wrapped lines

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1684,7 +1684,7 @@ impl Interactivity {
                     .ok()
                     .and_then(|mut text| text.pop())
                 {
-                    text.paint(hitbox.origin, FONT_SIZE, TextAlign::Left, window, cx)
+                    text.paint(hitbox.origin, FONT_SIZE, TextAlign::Left, None, window, cx)
                         .ok();
 
                     let text_bounds = crate::Bounds {

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -392,8 +392,15 @@ impl TextLayout {
         let mut line_origin = bounds.origin;
         let text_style = window.text_style();
         for line in &element_state.lines {
-            line.paint(line_origin, line_height, text_style.text_align, window, cx)
-                .log_err();
+            line.paint(
+                line_origin,
+                line_height,
+                text_style.text_align,
+                Some(bounds.size.width),
+                window,
+                cx,
+            )
+            .log_err();
             line_origin.y += line.size(line_height).height;
         }
     }

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -107,6 +107,7 @@ impl WrappedLine {
         origin: Point<Pixels>,
         line_height: Pixels,
         align: TextAlign,
+        align_width: Option<Pixels>,
         window: &mut Window,
         cx: &mut App,
     ) -> Result<()> {
@@ -115,7 +116,7 @@ impl WrappedLine {
             &self.layout.unwrapped_layout,
             line_height,
             align,
-            self.layout.wrap_width,
+            align_width.or(self.wrap_width),
             &self.decoration_runs,
             &self.wrap_boundaries,
             window,

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -223,7 +223,7 @@ fn paint_line(
                     glyph_origin.x = aligned_origin_x(
                         origin,
                         align_width.unwrap_or(layout.width),
-                        prev_glyph_position.x,
+                        glyph.position.x,
                         &align,
                         layout,
                         wraps.peek(),
@@ -427,17 +427,7 @@ fn aligned_origin_x(
     wrap_boundary: Option<&&WrapBoundary>,
 ) -> Pixels {
     let end_of_line = if let Some(WrapBoundary { run_ix, glyph_ix }) = wrap_boundary {
-        if layout.runs[*run_ix].glyphs.len() == glyph_ix + 1 {
-            // Next glyph is in next run
-            layout
-                .runs
-                .get(run_ix + 1)
-                .and_then(|run| run.glyphs.first())
-                .map_or(layout.width, |glyph| glyph.position.x)
-        } else {
-            // Get next glyph
-            layout.runs[*run_ix].glyphs[*glyph_ix + 1].position.x
-        }
+        layout.runs[*run_ix].glyphs[*glyph_ix].position.x
     } else {
         layout.width
     };


### PR DESCRIPTION
Fixes https://github.com/zed-industries/zed/pull/24090#issuecomment-2629737437 and another problem which would cause text to be one glyph further to the left than it should.

@huacnlee, can you test this?

Release Notes:

- N/A
