### PR TITLE
Fix typo in `docs/src/languages/lua.md`

### DIFF
--- a/docs/src/languages/lua.md
+++ b/docs/src/languages/lua.md
@@ -23,7 +23,7 @@ See [LuaLS Settings Documentation](https://luals.github.io/wiki/settings/) for a
     "indent_style": "space",
     "indent_size": "4"
   },
-  "workspace.library": ["../soemdir/library"]
+  "workspace.library": ["../somedir/library"]
 }
 ```
 


### PR DESCRIPTION
This was mainly to fix formatting so that prettier lint passes, but looks like #24113 already fixed that

Release Notes:

- N/A