### PR TITLE
inline completion: Respect `disabled_globs` when manually requesting completions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4758,6 +4758,10 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.inline_completions_enabled(cx) {
+            return;
+        }
+
         if !self.has_active_inline_completion() {
             self.refresh_inline_completion(false, true, window, cx);
             return;


### PR DESCRIPTION
When requesting completions manually with `editor: Show inline completion`, we did not check if completions are actually disabled for the current file (`inline_completions > disabled_globs`)

Release Notes:

- Fixed an issue where the `inline_completions > disabled_globs` setting would not be respected when manually requesting a completion (`editor: Show inline completion`)
