### PR TITLE
docs: Update link to Scheme extension

### DIFF
--- a/docs/src/languages/scheme.md
+++ b/docs/src/languages/scheme.md
@@ -1,5 +1,5 @@
 # Scheme
 
-Scheme support is available through the [Scheme extension](https://github.com/zed-industries/zed/tree/main/extensions/scheme).
+Scheme support is available through the [Scheme extension](https://github.com/zed-extensions/scheme).
 
 - Tree Sitter: [6cdh/tree-sitter-scheme](https://github.com/6cdh/tree-sitter-scheme)


### PR DESCRIPTION
This PR updates the link to the Scheme extension in the docs, as it was moved to a separate repo in #24078.

Release Notes:

- N/A
