### PR TITLE
Adjust pane magnification and handle conditions in layout

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1161,11 +1161,13 @@ mod element {
             for (ix, child) in layout.children.iter_mut().enumerate() {
                 if ix < children_len - 1 {
                     let divider_bounds = Bounds {
-                        origin: child.bounds.origin.apply_along(
-                            self.axis,
-                            |origin| origin + child.bounds.size.along(self.axis)
-                        ),
-                        size: child.bounds.size.apply_along(self.axis, |_| px(DIVIDER_SIZE)),
+                        origin: child.bounds.origin.apply_along(self.axis, |origin| {
+                            origin + child.bounds.size.along(self.axis)
+                        }),
+                        size: child
+                            .bounds
+                            .size
+                            .apply_along(self.axis, |_| px(DIVIDER_SIZE)),
                     };
                     window.paint_quad(gpui::fill(
                         divider_bounds,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1115,7 +1115,7 @@ mod element {
             }
 
             for (ix, child_layout) in layout.children.iter_mut().enumerate() {
-                if ix < len - 1 {
+                if active_pane_magnification.is_none() && ix < len - 1 {
                     child_layout.handle = Some(Self::layout_handle(
                         self.axis,
                         child_layout.bounds,
@@ -1137,7 +1137,8 @@ mod element {
             window: &mut Window,
             cx: &mut App,
         ) {
-            for child in &mut layout.children {
+            let children_len = layout.children.len();
+            for (_ix, child) in layout.children.iter_mut().enumerate() {
                 child.element.paint(window, cx);
             }
 
@@ -1157,7 +1158,21 @@ mod element {
                 .border_size
                 .and_then(|val| (val >= 0.).then_some(val));
 
-            for (ix, child) in &mut layout.children.iter_mut().enumerate() {
+            for (ix, child) in layout.children.iter_mut().enumerate() {
+                if ix < children_len - 1 {
+                    let divider_bounds = Bounds {
+                        origin: child.bounds.origin.apply_along(
+                            self.axis,
+                            |origin| origin + child.bounds.size.along(self.axis)
+                        ),
+                        size: child.bounds.size.apply_along(self.axis, |_| px(DIVIDER_SIZE)),
+                    };
+                    window.paint_quad(gpui::fill(
+                        divider_bounds,
+                        cx.theme().colors().pane_group_border,
+                    ));
+                }
+
                 if overlay_opacity.is_some() || overlay_border.is_some() {
                     // the overlay has to be painted in origin+1px with size width-1px
                     // in order to accommodate the divider between panels

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1087,7 +1087,7 @@ mod element {
                         if self.active_pane_ix == Some(ix) {
                             magnification
                         } else {
-                            1.
+                            total_flex / len as f32
                         }
                     })
                     .unwrap_or_else(|| flexes[ix]);
@@ -1115,7 +1115,7 @@ mod element {
             }
 
             for (ix, child_layout) in layout.children.iter_mut().enumerate() {
-                if active_pane_magnification.is_none() && ix < len - 1 {
+                if ix < len - 1 {
                     child_layout.handle = Some(Self::layout_handle(
                         self.axis,
                         child_layout.bounds,


### PR DESCRIPTION
I wasn’t sure about the purpose of the if active_pane_magnification.is_none() check, as I didn’t notice any side effects after removing it. However, the issue was resolved without it.



Closes #4265 

Release Notes:

-Fixed
1. Pane shrinking issue is fixed by calculating the remaining area in the pane group instead of attempting “1” to it.
2. Pane separation issue is fixed.
