### PR TITLE
copilot: Correct o3-mini context length

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -89,7 +89,7 @@ impl Model {
             Self::Gpt4o => 64000,
             Self::Gpt4 => 32768,
             Self::Gpt3_5Turbo => 12288,
-            Self::O3Mini => 200000,
+            Self::O3Mini => 200_000,
             Self::O1 => 20000,
             Self::Claude3_5Sonnet => 200_000,
         }

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -89,7 +89,7 @@ impl Model {
             Self::Gpt4o => 64000,
             Self::Gpt4 => 32768,
             Self::Gpt3_5Turbo => 12288,
-            Self::O3Mini => 20000,
+            Self::O3Mini => 200000,
             Self::O1 => 20000,
             Self::Claude3_5Sonnet => 200_000,
         }


### PR DESCRIPTION
It should be 200k (with 100k output). I can't find anything that puts it at 20k and the changeover in https://github.com/zed-industries/zed/commit/2f8237492641b4c97f61977a39f8a10225578a6d only changed the name from o1-mini to o3-mini

References:
* https://docs.github.com/en/copilot/using-github-copilot/asking-github-copilot-questions-in-github#ai-models-for-copilot-chat
* https://github.com/marketplace/models/azure-openai/o3-mini
* https://platform.openai.com/docs/models#o3-mini

Release Notes:

- Corrected Github Copilot o3-mini context length
