### PR TITLE
Support bash autoindenting

### DIFF
--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -93,3 +93,4 @@ tree-sitter-python.workspace = true
 tree-sitter-go.workspace = true
 tree-sitter-c.workspace = true
 tree-sitter-css.workspace = true
+tree-sitter-bash.workspace = true

--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -7,7 +7,7 @@ first_line_pattern = '^#!.*\b(?:ash|bash|dash|sh|zsh)\b'
 brackets = [
     { start = "[", end = "]", close = true, newline = false },
     { start = "(", end = ")", close = true, newline = false },
-    { start = "{", end = "}", close = true, newline = false },
+    { start = "{", end = "}", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]

--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -6,8 +6,23 @@ line_comments = ["# "]
 first_line_pattern = '^#!.*\b(?:ash|bash|dash|sh|zsh)\b'
 brackets = [
     { start = "[", end = "]", close = true, newline = false },
-    { start = "(", end = ")", close = true, newline = false },
+    { start = "(", end = ")", close = true, newline = true },
     { start = "{", end = "}", close = true, newline = true },
     { start = "\"", end = "\"", close = true, newline = false, not_in = ["comment", "string"] },
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
 ]
+
+### WARN: the following is not working when you insert an `elif` just before an else
+### example: (^ is cursor after hitting enter)
+### ```
+### if true; then
+###     foo
+###     elif
+###         ^
+### else
+###     bar
+### fi
+### ```
+increase_indent_pattern = "(\\s*|;)(do|then|in|else|elif)\\b.*$"
+decrease_indent_pattern = "(\\s*|;)(fi|done|esac|else|elif)\\b.*$"
+# make sure to test each line mode & block mode

--- a/crates/languages/src/bash/indents.scm
+++ b/crates/languages/src/bash/indents.scm
@@ -1,0 +1,10 @@
+(function_definition
+    "function"
+    body: (_ "{" (_)* @indent "}" @end)) @indent
+
+; (if_statement
+;     "if"
+;     (_)*
+;     "then"
+;     (_)* @indent
+;     ) @indent

--- a/crates/languages/src/bash/indents.scm
+++ b/crates/languages/src/bash/indents.scm
@@ -1,10 +1,12 @@
 (function_definition
-    "function"
-    body: (_ "{" (_)* @indent "}" @end)) @indent
+    "function"?
+    body: (
+        _
+        "{" @start
+        "}" @end
+    )) @indent
 
-; (if_statement
-;     "if"
-;     (_)*
-;     "then"
-;     (_)* @indent
-;     ) @indent
+(array
+    "(" @start
+    ")" @end
+    ) @indent


### PR DESCRIPTION
Creates an indents.scm file for bash and adds regexes for `{increase,decrease}_indent_pattern` in `crates/languages/src/bash/config.toml`
so that autoindent works as expected in bash

Note that this PR does not attempt to handle all cases where indenting might be desired in bash. I am aiming to support ~80% of what people want while avoiding the more gnarly/edge cases like indented blocks in case statements and indenting for associative arrays. 
This is done with the explicit hope that someone (possibly from the community) more familiar with and passionate about bash can come through at a later date and handle those cases

Closes #23628

Release Notes:

- Add basic support for autoindent functionality in bash/shell files
