### PR TITLE
vim: Load keymap after base keymap

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1250,12 +1250,13 @@ pub fn load_default_keymap(cx: &mut App) {
     }
 
     cx.bind_keys(KeymapFile::load_asset(DEFAULT_KEYMAP_PATH, cx).unwrap());
-    if VimModeSetting::get_global(cx).0 {
-        cx.bind_keys(KeymapFile::load_asset(VIM_KEYMAP_PATH, cx).unwrap());
-    }
 
     if let Some(asset_path) = base_keymap.asset_path() {
         cx.bind_keys(KeymapFile::load_asset(asset_path, cx).unwrap());
+    }
+
+    if VimModeSetting::get_global(cx).0 {
+        cx.bind_keys(KeymapFile::load_asset(VIM_KEYMAP_PATH, cx).unwrap());
     }
 }
 


### PR DESCRIPTION
Closes #22562

Release Notes:

- vim: Load vim keymap after a user-configured keymap
