### PR TITLE
vim: Add ctrl-w a

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -615,6 +615,8 @@
       "ctrl-w c": "pane::CloseActiveItem",
       "ctrl-w ctrl-q": "pane::CloseActiveItem",
       "ctrl-w q": "pane::CloseActiveItem",
+      "ctrl-w ctrl-a": "pane::CloseAllItems",
+      "ctrl-w a": "pane::CloseAllItems",
       "ctrl-w ctrl-o": "workspace::CloseInactiveTabsAndPanes",
       "ctrl-w o": "workspace::CloseInactiveTabsAndPanes",
       "ctrl-w ctrl-n": "workspace::NewFileSplitHorizontal",


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- vim: Add `ctrl-w a` to close all items in the current pane
