### PR TITLE
Fix issue where changing the case of a vim object would be clipped at the end of the line

### DIFF
--- a/crates/vim/test_data/test_change_case_motion_object.json
+++ b/crates/vim/test_data/test_change_case_motion_object.json
@@ -1,0 +1,6 @@
+{"Put":{"state":"abc dˇef\n"}}
+{"Key":"g"}
+{"Key":"shift-u"}
+{"Key":"i"}
+{"Key":"w"}
+{"Get":{"state":"abc ˇDEF\n","mode":"Normal"}}


### PR DESCRIPTION
Co-authored-by: Conrad Irwin <conrad@zed.dev>

Closes #24124

Release Notes:

- Fixed an issue in vim mode where changing the case of an object at the end of the line would not change the case of the last character in the object
