### PR TITLE
Fix slow focus transitions to the terminal panel

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -139,6 +139,7 @@ impl WindowInvalidator {
 
     pub fn not_painting(&self) -> bool {
         self.inner.borrow().draw_phase == DrawPhase::None
+            || self.inner.borrow().draw_phase == DrawPhase::Focus
     }
 
     #[track_caller]

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -137,9 +137,8 @@ impl WindowInvalidator {
         self.inner.borrow_mut().dirty_views = views;
     }
 
-    pub fn not_painting(&self) -> bool {
+    pub fn not_drawing(&self) -> bool {
         self.inner.borrow().draw_phase == DrawPhase::None
-            || self.inner.borrow().draw_phase == DrawPhase::Focus
     }
 
     #[track_caller]
@@ -1055,7 +1054,7 @@ impl Window {
 
     /// Mark the window as dirty, scheduling it to be redrawn on the next frame.
     pub fn refresh(&mut self) {
-        if self.invalidator.not_painting() {
+        if self.invalidator.not_drawing() {
             self.refreshing = true;
             self.invalidator.set_dirty(true);
         }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -582,6 +582,11 @@ impl Pane {
 
         if let Some(active_item) = self.active_item() {
             if self.focus_handle.is_focused(window) {
+                // Schedule a redraw next frame, so that the focus changes below take effect
+                cx.on_next_frame(window, |_, _, cx| {
+                    cx.notify();
+                });
+
                 // Pane was focused directly. We need to either focus a view inside the active item,
                 // or focus the active item itself
                 if let Some(weak_last_focus_handle) =

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3004,8 +3004,12 @@ impl Pane {
 }
 
 impl Focusable for Pane {
-    fn focus_handle(&self, _cx: &App) -> FocusHandle {
-        self.focus_handle.clone()
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        if let Some(item) = self.active_item() {
+            item.item_focus_handle(cx)
+        } else {
+            self.focus_handle.clone()
+        }
     }
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3004,12 +3004,8 @@ impl Pane {
 }
 
 impl Focusable for Pane {
-    fn focus_handle(&self, cx: &App) -> FocusHandle {
-        if let Some(item) = self.active_item() {
-            item.item_focus_handle(cx)
-        } else {
-            self.focus_handle.clone()
-        }
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
     }
 }
 


### PR DESCRIPTION
This long standing bug was caused by `Pane`'s focus_in handler bouncing the focus to another handle.
Because focus resolution happens _after_ a frame has been rendered, the only way to deal with this case is to schedule another frame to be redrawn. However, we where suppressing all window refreshes that occur during a focus transfer, causing this focus change to be completely missed. However, changing this behavior can lead to infinite notify loops, due to drawing a frame causing another to be rendered.

This PR fixes this problem narrowly by adding an `on_next_frame()` callback in the pane's focus handle, so that the focus changes take effect almost immediately. But only for this case, where we know it doesn't cause infinite notify loops. 

TODO:
- [x] Fix the infinite notify loop bug or determine a third way to fix this lag

Release Notes:

- Fixed a bug where shifting focus to the terminal panel could be slow
