### PR TITLE
Display accept keybinding in edit prediction preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14268,6 +14268,7 @@ dependencies = [
  "strum",
  "theme",
  "ui_macros",
+ "util",
  "windows 0.58.0",
 ]
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -163,7 +163,7 @@ use ui::{
     h_flex, prelude::*, ButtonSize, ButtonStyle, Disclosure, IconButton, IconName, IconSize,
     Tooltip,
 };
-use util::{defer, maybe, post_inc, RangeExt, ResultExt, TakeUntilExt, TryFutureExt};
+use util::{capitalize, defer, maybe, post_inc, RangeExt, ResultExt, TakeUntilExt, TryFutureExt};
 use workspace::item::{ItemHandle, PreviewTabsSettings};
 use workspace::notifications::{DetachAndPromptErr, NotificationId, NotifyTaskExt};
 use workspace::{
@@ -5513,6 +5513,7 @@ impl Editor {
                 .child(div().w_full())
                 .child(
                     h_flex()
+                        .opacity(if has_completion { 1.0 } else { 0.1 })
                         .border_l_1()
                         .border_color(cx.theme().colors().border_variant)
                         .pl_2()
@@ -5529,22 +5530,8 @@ impl Editor {
                                     } else {
                                         None
                                     },
-                                )),
-                        )
-                        .opacity(if has_completion { 1.0 } else { 0.1 })
-                        .child(
-                            if self
-                                .active_inline_completion
-                                .as_ref()
-                                .map_or(false, |c| c.is_move())
-                            {
-                                div()
-                                    .child(ui::Key::new(&accept_keystroke.key, None))
-                                    .font(buffer_font.clone())
-                                    .into_any()
-                            } else {
-                                Label::new("Preview").color(Color::Muted).into_any_element()
-                            },
+                                ))
+                                .child(ui::Key::new(capitalize(&accept_keystroke.key), None)),
                         ),
                 )
                 .into_any(),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -73,7 +73,7 @@ use ui::{
     POPOVER_Y_PADDING,
 };
 use unicode_segmentation::UnicodeSegmentation;
-use util::{RangeExt, ResultExt};
+use util::{capitalize, RangeExt, ResultExt};
 use workspace::{item::Item, notifications::NotifyTaskExt, Workspace};
 
 const INLINE_BLAME_PADDING_EM_WIDTHS: f32 = 7.;
@@ -5839,7 +5839,7 @@ fn inline_completion_accept_indicator(
             PlatformStyle::platform(),
             Some(Color::Default),
         ))
-        .child(accept_keystroke.key.clone());
+        .child(capitalize(&accept_keystroke.key));
 
     let padding_right = if icon.is_some() { px(4.) } else { px(8.) };
 

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -24,6 +24,7 @@ story = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 theme.workspace = true
 ui_macros.workspace = true
+util.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -4,6 +4,7 @@ use crate::{h_flex, prelude::*, Icon, IconName, IconSize};
 use gpui::{
     relative, Action, AnyElement, App, FocusHandle, IntoElement, Keystroke, Modifiers, Window,
 };
+use util::capitalize;
 
 #[derive(Debug, IntoElement, Clone)]
 pub struct KeyBinding {
@@ -354,14 +355,6 @@ pub fn text_for_keystroke(keystroke: &Keystroke, platform_style: PlatformStyle) 
     text.push_str(key);
 
     text
-}
-
-fn capitalize(str: &str) -> String {
-    let mut chars = str.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
-    }
 }
 
 #[cfg(test)]

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -41,6 +41,14 @@ macro_rules! debug_panic {
     };
 }
 
+pub fn capitalize(str: &str) -> String {
+    let mut chars = str.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
 pub fn truncate(s: &str, max_chars: usize) -> &str {
     match s.char_indices().nth(max_chars) {
         None => s,


### PR DESCRIPTION
On Linux, now displays "Alt + Enter" on the right of edit prediction previews instead of "Alt Preview".  Particularly on Linux and Windows (where Enter is used instead of Tab), it was not very clear what to press to accept. This is also more consistent with the jump prediction preview, where "Alt + Enter" is already displayed.

For consistency, prediction popovers now also have capitalized keystroke - "Tab Accept" instead of "tab Accept"

Release Notes:

- N/A