### PR TITLE
zeta: Fix data collection display on the status bar menu

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -429,7 +429,7 @@ impl InlineCompletionButton {
                 menu = menu
                     .separator()
                     .header("Help Improve The Model")
-                    .header("For OSS Projects Only");
+                    .header("Valid Only For OSS Projects");
                 menu = menu.item(
                     // TODO: We want to add something later that communicates whether
                     // the current project is open-source.

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1359,6 +1359,12 @@ impl ProviderDataCollection {
         }
     }
 
+    pub fn user_data_collection_choice(&self, cx: &App) -> bool {
+        self.choice
+            .as_ref()
+            .map_or(false, |choice| choice.read(cx).is_enabled())
+    }
+
     pub fn data_collection_permission(&self, cx: &App) -> bool {
         self.choice
             .as_ref()
@@ -1432,7 +1438,10 @@ impl inline_completion::InlineCompletionProvider for ZetaInlineCompletionProvide
     }
 
     fn data_collection_state(&self, cx: &App) -> DataCollectionState {
-        if self.provider_data_collection.data_collection_permission(cx) {
+        if self
+            .provider_data_collection
+            .user_data_collection_choice(cx)
+        {
             DataCollectionState::Enabled
         } else {
             DataCollectionState::Disabled


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/24031

This PR adds a new function that allows the UI also to display the state of the data collection. Previously, we only showed that if the project adhered to the `is_open_source` condition. Now, we show it for all projects.

Release Notes:

- N/A
