### PR TITLE
status_bar: Only show divider for left dock

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -876,7 +876,7 @@ impl Render for PanelButtons {
         h_flex()
             .gap_1()
             .children(buttons)
-            .when(has_buttons, |this| {
+            .when(has_buttons && dock.position == DockPosition::Left, |this| {
                 this.child(Divider::vertical().color(DividerColor::Border))
             })
     }


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/24114

Just fixing the UI so that the divider only shows for the left-positioned items.

Release Notes:

- N/A
