### PR TITLE
Revert "inline completion: Respect `disabled_globs` when manually requesting completions (#24121)"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4694,10 +4694,6 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.inline_completions_enabled(cx) {
-            return;
-        }
-
         if !self.has_active_inline_completion() {
             self.refresh_inline_completion(false, true, window, cx);
             return;


### PR DESCRIPTION
This reverts commit eb820ab800ea2a0023667b5c0eb91daa7c9ab084.
The previous PR broke manual completions. Turns out there is more confusing behavior then i realized, will follow up with another PR soon.

Closes #ISSUE

Release Notes:

- N/A
