### PR TITLE
Rename `model` based variable names to `entity` 

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -442,7 +442,7 @@ impl AssistantPanel {
 
     fn handle_assistant_configuration_event(
         &mut self,
-        _model: &Entity<AssistantConfiguration>,
+        _entity: &Entity<AssistantConfiguration>,
         event: &AssistantConfigurationEvent,
         window: &mut Window,
         cx: &mut Context<Self>,

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -92,8 +92,8 @@ impl ContextStrip {
         let active_item = workspace.read(cx).active_item(cx)?;
 
         let editor = active_item.to_any().downcast::<Editor>().ok()?.read(cx);
-        let active_buffer_model = editor.buffer().read(cx).as_singleton()?;
-        let active_buffer = active_buffer_model.read(cx);
+        let active_buffer_entity = editor.buffer().read(cx).as_singleton()?;
+        let active_buffer = active_buffer_entity.read(cx);
 
         let path = active_buffer.file()?.path();
 
@@ -115,7 +115,7 @@ impl ContextStrip {
 
         Some(SuggestedContext::File {
             name,
-            buffer: active_buffer_model.downgrade(),
+            buffer: active_buffer_entity.downgrade(),
             icon_path,
         })
     }
@@ -393,9 +393,9 @@ impl Render for ContextStrip {
             .on_action(cx.listener(Self::remove_focused_context))
             .on_action(cx.listener(Self::accept_suggested_context))
             .on_children_prepainted({
-                let model = cx.entity().downgrade();
+                let entity = cx.entity().downgrade();
                 move |children_bounds, _window, cx| {
-                    model
+                    entity
                         .update(cx, |this, _| {
                             this.children_bounds = Some(children_bounds);
                         })

--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -31,11 +31,11 @@ use std::{
 use util::{ResultExt, TryFutureExt};
 
 pub(crate) fn init(client: &AnyProtoClient) {
-    client.add_model_message_handler(ContextStore::handle_advertise_contexts);
-    client.add_model_request_handler(ContextStore::handle_open_context);
-    client.add_model_request_handler(ContextStore::handle_create_context);
-    client.add_model_message_handler(ContextStore::handle_update_context);
-    client.add_model_request_handler(ContextStore::handle_synchronize_contexts);
+    client.add_entity_message_handler(ContextStore::handle_advertise_contexts);
+    client.add_entity_request_handler(ContextStore::handle_open_context);
+    client.add_entity_request_handler(ContextStore::handle_create_context);
+    client.add_entity_message_handler(ContextStore::handle_update_context);
+    client.add_entity_request_handler(ContextStore::handle_synchronize_contexts);
 }
 
 #[derive(Clone)]
@@ -310,7 +310,7 @@ impl ContextStore {
                 .client
                 .subscribe_to_entity(remote_id)
                 .log_err()
-                .map(|subscription| subscription.set_model(&cx.entity(), &mut cx.to_async()));
+                .map(|subscription| subscription.set_entity(&cx.entity(), &mut cx.to_async()));
             self.advertise_contexts(cx);
         } else {
             self.client_subscription = None;

--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -15,8 +15,8 @@ use util::ResultExt;
 pub const ACKNOWLEDGE_DEBOUNCE_INTERVAL: Duration = Duration::from_millis(250);
 
 pub(crate) fn init(client: &AnyProtoClient) {
-    client.add_model_message_handler(ChannelBuffer::handle_update_channel_buffer);
-    client.add_model_message_handler(ChannelBuffer::handle_update_channel_buffer_collaborators);
+    client.add_entity_message_handler(ChannelBuffer::handle_update_channel_buffer);
+    client.add_entity_message_handler(ChannelBuffer::handle_update_channel_buffer_collaborators);
 }
 
 pub struct ChannelBuffer {
@@ -81,7 +81,7 @@ impl ChannelBuffer {
                 collaborators: Default::default(),
                 acknowledge_task: None,
                 channel_id: channel.id,
-                subscription: Some(subscription.set_model(&cx.entity(), &mut cx.to_async())),
+                subscription: Some(subscription.set_entity(&cx.entity(), &mut cx.to_async())),
                 user_store,
                 channel_store,
             };

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -95,9 +95,9 @@ pub enum ChannelChatEvent {
 
 impl EventEmitter<ChannelChatEvent> for ChannelChat {}
 pub fn init(client: &AnyProtoClient) {
-    client.add_model_message_handler(ChannelChat::handle_message_sent);
-    client.add_model_message_handler(ChannelChat::handle_message_removed);
-    client.add_model_message_handler(ChannelChat::handle_message_updated);
+    client.add_entity_message_handler(ChannelChat::handle_message_sent);
+    client.add_entity_message_handler(ChannelChat::handle_message_removed);
+    client.add_entity_message_handler(ChannelChat::handle_message_updated);
 }
 
 impl ChannelChat {
@@ -132,7 +132,7 @@ impl ChannelChat {
                 last_acknowledged_id: None,
                 rng: StdRng::from_entropy(),
                 first_loaded_message_id: None,
-                _subscription: subscription.set_model(&cx.entity(), &mut cx.to_async()),
+                _subscription: subscription.set_entity(&cx.entity(), &mut cx.to_async()),
             }
         })?;
         Self::handle_loaded_messages(

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -381,7 +381,7 @@ pub struct PendingEntitySubscription<T: 'static> {
 }
 
 impl<T: 'static> PendingEntitySubscription<T> {
-    pub fn set_model(mut self, model: &Entity<T>, cx: &AsyncApp) -> Subscription {
+    pub fn set_entity(mut self, entity: &Entity<T>, cx: &AsyncApp) -> Subscription {
         self.consumed = true;
         let mut handlers = self.client.handler_set.lock();
         let id = (TypeId::of::<T>(), self.remote_id);
@@ -394,7 +394,7 @@ impl<T: 'static> PendingEntitySubscription<T> {
         handlers.entities_by_type_and_remote_id.insert(
             id,
             EntityMessageSubscriber::Entity {
-                handle: model.downgrade().into(),
+                handle: entity.downgrade().into(),
             },
         );
         drop(handlers);
@@ -688,8 +688,8 @@ impl Client {
         H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncApp) -> F + Send + Sync,
         F: 'static + Future<Output = Result<()>>,
     {
-        self.add_message_handler_impl(entity, move |model, message, _, cx| {
-            handler(model, message, cx)
+        self.add_message_handler_impl(entity, move |entity, message, _, cx| {
+            handler(entity, message, cx)
         })
     }
 
@@ -711,7 +711,7 @@ impl Client {
         let message_type_id = TypeId::of::<M>();
         let mut state = self.handler_set.lock();
         state
-            .models_by_message_type
+            .entities_by_message_type
             .insert(message_type_id, entity.into());
 
         let prev_handler = state.message_handlers.insert(
@@ -740,7 +740,7 @@ impl Client {
 
     pub fn add_request_handler<M, E, H, F>(
         self: &Arc<Self>,
-        model: WeakEntity<E>,
+        entity: WeakEntity<E>,
         handler: H,
     ) -> Subscription
     where
@@ -749,7 +749,7 @@ impl Client {
         H: 'static + Sync + Fn(Entity<E>, TypedEnvelope<M>, AsyncApp) -> F + Send + Sync,
         F: 'static + Future<Output = Result<M::Response>>,
     {
-        self.add_message_handler_impl(model, move |handle, envelope, this, cx| {
+        self.add_message_handler_impl(entity, move |handle, envelope, this, cx| {
             Self::respond_to_request(envelope.receipt(), handler(handle, envelope, cx), this)
         })
     }
@@ -1943,9 +1943,9 @@ mod tests {
 
         let (done_tx1, done_rx1) = smol::channel::unbounded();
         let (done_tx2, done_rx2) = smol::channel::unbounded();
-        AnyProtoClient::from(client.clone()).add_model_message_handler(
-            move |model: Entity<TestModel>, _: TypedEnvelope<proto::JoinProject>, mut cx| {
-                match model.update(&mut cx, |model, _| model.id).unwrap() {
+        AnyProtoClient::from(client.clone()).add_entity_message_handler(
+            move |entity: Entity<TestEntity>, _: TypedEnvelope<proto::JoinProject>, mut cx| {
+                match entity.update(&mut cx, |entity, _| entity.id).unwrap() {
                     1 => done_tx1.try_send(()).unwrap(),
                     2 => done_tx2.try_send(()).unwrap(),
                     _ => unreachable!(),
@@ -1953,15 +1953,15 @@ mod tests {
                 async { Ok(()) }
             },
         );
-        let model1 = cx.new(|_| TestModel {
+        let entity1 = cx.new(|_| TestEntity {
             id: 1,
             subscription: None,
         });
-        let model2 = cx.new(|_| TestModel {
+        let entity2 = cx.new(|_| TestEntity {
             id: 2,
             subscription: None,
         });
-        let model3 = cx.new(|_| TestModel {
+        let entity3 = cx.new(|_| TestEntity {
             id: 3,
             subscription: None,
         });
@@ -1969,17 +1969,17 @@ mod tests {
         let _subscription1 = client
             .subscribe_to_entity(1)
             .unwrap()
-            .set_model(&model1, &mut cx.to_async());
+            .set_entity(&entity1, &mut cx.to_async());
         let _subscription2 = client
             .subscribe_to_entity(2)
             .unwrap()
-            .set_model(&model2, &mut cx.to_async());
+            .set_entity(&entity2, &mut cx.to_async());
         // Ensure dropping a subscription for the same entity type still allows receiving of
         // messages for other entity IDs of the same type.
         let subscription3 = client
             .subscribe_to_entity(3)
             .unwrap()
-            .set_model(&model3, &mut cx.to_async());
+            .set_entity(&entity3, &mut cx.to_async());
         drop(subscription3);
 
         server.send(proto::JoinProject { project_id: 1 });
@@ -2001,11 +2001,11 @@ mod tests {
         });
         let server = FakeServer::for_client(user_id, &client, cx).await;
 
-        let model = cx.new(|_| TestModel::default());
+        let entity = cx.new(|_| TestEntity::default());
         let (done_tx1, _done_rx1) = smol::channel::unbounded();
         let (done_tx2, done_rx2) = smol::channel::unbounded();
         let subscription1 = client.add_message_handler(
-            model.downgrade(),
+            entity.downgrade(),
             move |_, _: TypedEnvelope<proto::Ping>, _| {
                 done_tx1.try_send(()).unwrap();
                 async { Ok(()) }
@@ -2013,7 +2013,7 @@ mod tests {
         );
         drop(subscription1);
         let _subscription2 = client.add_message_handler(
-            model.downgrade(),
+            entity.downgrade(),
             move |_, _: TypedEnvelope<proto::Ping>, _| {
                 done_tx2.try_send(()).unwrap();
                 async { Ok(()) }
@@ -2036,27 +2036,27 @@ mod tests {
         });
         let server = FakeServer::for_client(user_id, &client, cx).await;
 
-        let model = cx.new(|_| TestModel::default());
+        let entity = cx.new(|_| TestEntity::default());
         let (done_tx, done_rx) = smol::channel::unbounded();
         let subscription = client.add_message_handler(
-            model.clone().downgrade(),
-            move |model: Entity<TestModel>, _: TypedEnvelope<proto::Ping>, mut cx| {
-                model
-                    .update(&mut cx, |model, _| model.subscription.take())
+            entity.clone().downgrade(),
+            move |entity: Entity<TestEntity>, _: TypedEnvelope<proto::Ping>, mut cx| {
+                entity
+                    .update(&mut cx, |entity, _| entity.subscription.take())
                     .unwrap();
                 done_tx.try_send(()).unwrap();
                 async { Ok(()) }
             },
         );
-        model.update(cx, |model, _| {
-            model.subscription = Some(subscription);
+        entity.update(cx, |entity, _| {
+            entity.subscription = Some(subscription);
         });
         server.send(proto::Ping {});
         done_rx.recv().await.unwrap();
     }
 
     #[derive(Default)]
-    struct TestModel {
+    struct TestEntity {
         id: usize,
         subscription: Option<Subscription>,
     }

--- a/crates/collab/src/tests/channel_buffer_tests.rs
+++ b/crates/collab/src/tests/channel_buffer_tests.rs
@@ -342,7 +342,7 @@ async fn test_multiple_handles_to_channel_buffer(
         future::try_join3(channel_buffer_1, channel_buffer_2, channel_buffer_3)
             .await
             .unwrap();
-    let channel_buffer_model_id = channel_buffer.entity_id();
+    let channel_buffer_entity_id = channel_buffer.entity_id();
     assert_eq!(channel_buffer, channel_buffer_2);
     assert_eq!(channel_buffer, channel_buffer_3);
 
@@ -366,7 +366,7 @@ async fn test_multiple_handles_to_channel_buffer(
         .update(cx_a, |store, cx| store.open_channel_buffer(channel_id, cx))
         .await
         .unwrap();
-    assert_ne!(channel_buffer.entity_id(), channel_buffer_model_id);
+    assert_ne!(channel_buffer.entity_id(), channel_buffer_entity_id);
     channel_buffer.update(cx_a, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, _| {
             assert_eq!(buffer.text(), "hello");

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -849,10 +849,10 @@ impl TestClient {
     ) -> (Entity<Workspace>, &'a mut VisualTestContext) {
         let window = cx.update(|cx| cx.active_window().unwrap().downcast::<Workspace>().unwrap());
 
-        let model = window.root(cx).unwrap();
+        let entity = window.root(cx).unwrap();
         let cx = VisualTestContext::from_window(*window.deref(), cx).as_mut();
         // it might be nice to try and cleanup these at the end of each test.
-        (model, cx)
+        (entity, cx)
     }
 }
 
@@ -861,9 +861,9 @@ pub fn open_channel_notes(
     cx: &mut VisualTestContext,
 ) -> Task<anyhow::Result<Entity<ChannelView>>> {
     let window = cx.update(|_, cx| cx.active_window().unwrap().downcast::<Workspace>().unwrap());
-    let model = window.root(cx).unwrap();
+    let entity = window.root(cx).unwrap();
 
-    cx.update(|window, cx| ChannelView::open(channel_id, None, model.clone(), window, cx))
+    cx.update(|window, cx| ChannelView::open(channel_id, None, entity.clone(), window, cx))
 }
 
 impl Drop for TestClient {

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -97,14 +97,14 @@ impl ChatPanel {
         });
 
         cx.new(|cx| {
-            let model = cx.entity().downgrade();
+            let entity = cx.entity().downgrade();
             let message_list = ListState::new(
                 0,
                 gpui::ListAlignment::Bottom,
                 px(1000.),
                 move |ix, window, cx| {
-                    if let Some(model) = model.upgrade() {
-                        model.update(cx, |this: &mut Self, cx| {
+                    if let Some(entity) = entity.upgrade() {
+                        entity.update(cx, |this: &mut Self, cx| {
                             this.render_message(ix, window, cx).into_any_element()
                         })
                     } else {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -239,14 +239,14 @@ impl CollabPanel {
             )
             .detach();
 
-            let model = cx.entity().downgrade();
+            let entity = cx.entity().downgrade();
             let list_state = ListState::new(
                 0,
                 gpui::ListAlignment::Top,
                 px(1000.),
                 move |ix, window, cx| {
-                    if let Some(model) = model.upgrade() {
-                        model.update(cx, |this, cx| this.render_list_entry(ix, window, cx))
+                    if let Some(entity) = entity.upgrade() {
+                        entity.update(cx, |this, cx| this.render_list_entry(ix, window, cx))
                     } else {
                         div().into_any()
                     }

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -110,13 +110,13 @@ impl NotificationPanel {
             })
             .detach();
 
-            let model = cx.entity().downgrade();
+            let entity = cx.entity().downgrade();
             let notification_list =
                 ListState::new(0, ListAlignment::Top, px(1000.), move |ix, window, cx| {
-                    model
+                    entity
                         .upgrade()
-                        .and_then(|model| {
-                            model.update(cx, |this, cx| this.render_notification(ix, window, cx))
+                        .and_then(|entity| {
+                            entity.update(cx, |this, cx| this.render_notification(ix, window, cx))
                         })
                         .unwrap_or_else(|| div().into_any())
                 });
@@ -323,9 +323,9 @@ impl NotificationPanel {
                                             .justify_end()
                                             .child(Button::new("decline", "Decline").on_click({
                                                 let notification = notification.clone();
-                                                let model = cx.entity().clone();
+                                                let entity = cx.entity().clone();
                                                 move |_, _, cx| {
-                                                    model.update(cx, |this, cx| {
+                                                    entity.update(cx, |this, cx| {
                                                         this.respond_to_notification(
                                                             notification.clone(),
                                                             false,
@@ -336,9 +336,9 @@ impl NotificationPanel {
                                             }))
                                             .child(Button::new("accept", "Accept").on_click({
                                                 let notification = notification.clone();
-                                                let model = cx.entity().clone();
+                                                let entity = cx.entity().clone();
                                                 move |_, _, cx| {
-                                                    model.update(cx, |this, cx| {
+                                                    entity.update(cx, |this, cx| {
                                                         this.respond_to_notification(
                                                             notification.clone(),
                                                             true,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -62,9 +62,9 @@ fn test_edit_events(cx: &mut TestAppContext) {
     let editor1 = cx.add_window({
         let events = events.clone();
         |window, cx| {
-            let model = cx.entity().clone();
+            let entity = cx.entity().clone();
             cx.subscribe_in(
-                &model,
+                &entity,
                 window,
                 move |_, _, event: &EditorEvent, _, _| match event {
                     EditorEvent::Edited { .. } => events.borrow_mut().push(("editor1", "edited")),
@@ -10196,15 +10196,15 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
     let is_still_following = Rc::new(RefCell::new(true));
     let follower_edit_event_count = Rc::new(RefCell::new(0));
     let pending_update = Rc::new(RefCell::new(None));
-    let leader_model = leader.root(cx).unwrap();
-    let follower_model = follower.root(cx).unwrap();
+    let leader_entity = leader.root(cx).unwrap();
+    let follower_entity = follower.root(cx).unwrap();
     _ = follower.update(cx, {
         let update = pending_update.clone();
         let is_still_following = is_still_following.clone();
         let follower_edit_event_count = follower_edit_event_count.clone();
         |_, window, cx| {
             cx.subscribe_in(
-                &leader_model,
+                &leader_entity,
                 window,
                 move |_, leader, event, window, cx| {
                     leader.read(cx).add_event_to_update_proto(
@@ -10218,7 +10218,7 @@ async fn test_following(cx: &mut gpui::TestAppContext) {
             .detach();
 
             cx.subscribe_in(
-                &follower_model,
+                &follower_entity,
                 window,
                 move |_, _, event: &EditorEvent, _window, _cx| {
                     if matches!(Editor::to_follow_event(event), Some(FollowEvent::Unfollow)) {
@@ -10384,11 +10384,11 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
     // Start following the editor when it has no excerpts.
     let mut state_message =
         leader.update_in(cx, |leader, window, cx| leader.to_state_proto(window, cx));
-    let workspace_model = workspace.root(cx).unwrap();
+    let workspace_entity = workspace.root(cx).unwrap();
     let follower_1 = cx
         .update_window(*workspace.deref(), |_, window, cx| {
             Editor::from_state_proto(
-                workspace_model,
+                workspace_entity,
                 ViewId {
                     creator: Default::default(),
                     id: 0,
@@ -10486,11 +10486,11 @@ async fn test_following_with_multiple_excerpts(cx: &mut gpui::TestAppContext) {
     // Start following separately after it already has excerpts.
     let mut state_message =
         leader.update_in(cx, |leader, window, cx| leader.to_state_proto(window, cx));
-    let workspace_model = workspace.root(cx).unwrap();
+    let workspace_entity = workspace.root(cx).unwrap();
     let follower_2 = cx
         .update_window(*workspace.deref(), |_, window, cx| {
             Editor::from_state_proto(
-                workspace_model,
+                workspace_entity,
                 ViewId {
                     creator: Default::default(),
                     id: 0,

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -321,7 +321,7 @@ impl GitPanel {
                 current_modifiers: window.modifiers(),
                 width: Some(px(360.)),
                 scrollbar_state: ScrollbarState::new(scroll_handle.clone())
-                    .parent_model(&cx.entity()),
+                    .parent_entity(&cx.entity()),
                 repository_selector,
                 selected_entry: None,
                 show_scrollbar: false,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -821,13 +821,13 @@ impl Element for MarkdownElement {
         let mut context = KeyContext::default();
         context.add("Markdown");
         window.set_key_context(context);
-        let model = self.markdown.clone();
+        let entity = self.markdown.clone();
         window.on_action(std::any::TypeId::of::<crate::Copy>(), {
             let text = rendered_markdown.text.clone();
             move |_, phase, window, cx| {
                 let text = text.clone();
                 if phase == DispatchPhase::Bubble {
-                    model.update(cx, move |this, cx| this.copy(&text, window, cx))
+                    entity.update(cx, move |this, cx| this.copy(&text, window, cx))
                 }
             }
         });

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -796,9 +796,9 @@ impl OutlinePanel {
                 show_scrollbar: !Self::should_autohide_scrollbar(cx),
                 hide_scrollbar_task: None,
                 vertical_scrollbar_state: ScrollbarState::new(scroll_handle.clone())
-                    .parent_model(&cx.entity()),
+                    .parent_entity(&cx.entity()),
                 horizontal_scrollbar_state: ScrollbarState::new(scroll_handle.clone())
-                    .parent_model(&cx.entity()),
+                    .parent_entity(&cx.entity()),
                 max_width_item_index: None,
                 scroll_handle,
                 focus_handle,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -281,16 +281,16 @@ impl<D: PickerDelegate> Picker<D> {
                 ElementContainer::UniformList(UniformListScrollHandle::new())
             }
             ContainerKind::List => {
-                let model = cx.entity().downgrade();
+                let entity = cx.entity().downgrade();
                 ElementContainer::List(ListState::new(
                     0,
                     gpui::ListAlignment::Top,
                     px(1000.),
                     move |ix, window, cx| {
-                        model
+                        entity
                             .upgrade()
-                            .map(|model| {
-                                model.update(cx, |this, cx| {
+                            .map(|entity| {
+                                entity.update(cx, |this, cx| {
                                     this.render_element(window, cx, ix).into_any_element()
                                 })
                             })

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -894,15 +894,15 @@ impl LocalBufferStore {
 
 impl BufferStore {
     pub fn init(client: &AnyProtoClient) {
-        client.add_model_message_handler(Self::handle_buffer_reloaded);
-        client.add_model_message_handler(Self::handle_buffer_saved);
-        client.add_model_message_handler(Self::handle_update_buffer_file);
-        client.add_model_request_handler(Self::handle_save_buffer);
-        client.add_model_request_handler(Self::handle_blame_buffer);
-        client.add_model_request_handler(Self::handle_reload_buffers);
-        client.add_model_request_handler(Self::handle_get_permalink_to_line);
-        client.add_model_request_handler(Self::handle_get_staged_text);
-        client.add_model_message_handler(Self::handle_update_diff_base);
+        client.add_entity_message_handler(Self::handle_buffer_reloaded);
+        client.add_entity_message_handler(Self::handle_buffer_saved);
+        client.add_entity_message_handler(Self::handle_update_buffer_file);
+        client.add_entity_request_handler(Self::handle_save_buffer);
+        client.add_entity_request_handler(Self::handle_blame_buffer);
+        client.add_entity_request_handler(Self::handle_reload_buffers);
+        client.add_entity_request_handler(Self::handle_get_permalink_to_line);
+        client.add_entity_request_handler(Self::handle_get_staged_text);
+        client.add_entity_message_handler(Self::handle_update_diff_base);
     }
 
     /// Creates a buffer store, optionally retaining its buffers.

--- a/crates/project/src/debounced_delay.rs
+++ b/crates/project/src/debounced_delay.rs
@@ -35,7 +35,7 @@ impl<E: 'static> DebouncedDelay<E> {
         self.cancel_channel = Some(sender);
 
         let previous_task = self.task.take();
-        self.task = Some(cx.spawn(move |model, mut cx| async move {
+        self.task = Some(cx.spawn(move |entity, mut cx| async move {
             let mut timer = cx.background_executor().timer(delay).fuse();
             if let Some(previous_task) = previous_task {
                 previous_task.await;
@@ -46,7 +46,7 @@ impl<E: 'static> DebouncedDelay<E> {
                 _ = timer => {}
             }
 
-            if let Ok(task) = model.update(&mut cx, |project, cx| (func)(project, cx)) {
+            if let Ok(task) = entity.update(&mut cx, |project, cx| (func)(project, cx)) {
                 task.await;
             }
         }));

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -387,18 +387,18 @@ impl ImageStoreImpl for Entity<LocalImageStore> {
             let LoadedBinaryFile { file, content } = load_file.await?;
             let image = create_gpui_image(content)?;
 
-            let model = cx.new(|cx| ImageItem {
+            let entity = cx.new(|cx| ImageItem {
                 id: cx.entity_id().as_non_zero_u64().into(),
                 file: file.clone(),
                 image,
                 reload_task: None,
             })?;
 
-            let image_id = cx.read_entity(&model, |model, _| model.id)?;
+            let image_id = cx.read_entity(&entity, |model, _| model.id)?;
 
             this.update(&mut cx, |this, cx| {
                 image_store.update(cx, |image_store, cx| {
-                    image_store.add_image(model.clone(), cx)
+                    image_store.add_image(entity.clone(), cx)
                 })??;
                 this.local_image_ids_by_path.insert(
                     ProjectPath {
@@ -415,7 +415,7 @@ impl ImageStoreImpl for Entity<LocalImageStore> {
                 anyhow::Ok(())
             })??;
 
-            Ok(model)
+            Ok(entity)
         })
     }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2854,37 +2854,37 @@ struct CoreSymbol {
 
 impl LspStore {
     pub fn init(client: &AnyProtoClient) {
-        client.add_model_request_handler(Self::handle_multi_lsp_query);
-        client.add_model_request_handler(Self::handle_restart_language_servers);
-        client.add_model_request_handler(Self::handle_cancel_language_server_work);
-        client.add_model_message_handler(Self::handle_start_language_server);
-        client.add_model_message_handler(Self::handle_update_language_server);
-        client.add_model_message_handler(Self::handle_language_server_log);
-        client.add_model_message_handler(Self::handle_update_diagnostic_summary);
-        client.add_model_request_handler(Self::handle_format_buffers);
-        client.add_model_request_handler(Self::handle_resolve_completion_documentation);
-        client.add_model_request_handler(Self::handle_apply_code_action);
-        client.add_model_request_handler(Self::handle_inlay_hints);
-        client.add_model_request_handler(Self::handle_get_project_symbols);
-        client.add_model_request_handler(Self::handle_resolve_inlay_hint);
-        client.add_model_request_handler(Self::handle_open_buffer_for_symbol);
-        client.add_model_request_handler(Self::handle_refresh_inlay_hints);
-        client.add_model_request_handler(Self::handle_on_type_formatting);
-        client.add_model_request_handler(Self::handle_apply_additional_edits_for_completion);
-        client.add_model_request_handler(Self::handle_register_buffer_with_language_servers);
-        client.add_model_request_handler(Self::handle_rename_project_entry);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetCodeActions>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetCompletions>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetHover>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetDefinition>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetDeclaration>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetTypeDefinition>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetDocumentHighlights>);
-        client.add_model_request_handler(Self::handle_lsp_command::<GetReferences>);
-        client.add_model_request_handler(Self::handle_lsp_command::<PrepareRename>);
-        client.add_model_request_handler(Self::handle_lsp_command::<PerformRename>);
-        client.add_model_request_handler(Self::handle_lsp_command::<lsp_ext_command::ExpandMacro>);
-        client.add_model_request_handler(Self::handle_lsp_command::<LinkedEditingRange>);
+        client.add_entity_request_handler(Self::handle_multi_lsp_query);
+        client.add_entity_request_handler(Self::handle_restart_language_servers);
+        client.add_entity_request_handler(Self::handle_cancel_language_server_work);
+        client.add_entity_message_handler(Self::handle_start_language_server);
+        client.add_entity_message_handler(Self::handle_update_language_server);
+        client.add_entity_message_handler(Self::handle_language_server_log);
+        client.add_entity_message_handler(Self::handle_update_diagnostic_summary);
+        client.add_entity_request_handler(Self::handle_format_buffers);
+        client.add_entity_request_handler(Self::handle_resolve_completion_documentation);
+        client.add_entity_request_handler(Self::handle_apply_code_action);
+        client.add_entity_request_handler(Self::handle_inlay_hints);
+        client.add_entity_request_handler(Self::handle_get_project_symbols);
+        client.add_entity_request_handler(Self::handle_resolve_inlay_hint);
+        client.add_entity_request_handler(Self::handle_open_buffer_for_symbol);
+        client.add_entity_request_handler(Self::handle_refresh_inlay_hints);
+        client.add_entity_request_handler(Self::handle_on_type_formatting);
+        client.add_entity_request_handler(Self::handle_apply_additional_edits_for_completion);
+        client.add_entity_request_handler(Self::handle_register_buffer_with_language_servers);
+        client.add_entity_request_handler(Self::handle_rename_project_entry);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetCodeActions>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetCompletions>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetHover>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetDefinition>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetDeclaration>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetTypeDefinition>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetDocumentHighlights>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetReferences>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<PrepareRename>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<PerformRename>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<lsp_ext_command::ExpandMacro>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<LinkedEditingRange>);
     }
 
     pub fn as_remote(&self) -> Option<&RemoteLspStore> {

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -240,7 +240,7 @@ pub struct SettingsObserver {
 /// upstream.
 impl SettingsObserver {
     pub fn init(client: &AnyProtoClient) {
-        client.add_model_message_handler(Self::handle_update_worktree_settings);
+        client.add_entity_message_handler(Self::handle_update_worktree_settings);
     }
 
     pub fn new_local(

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -51,7 +51,7 @@ impl EventEmitter<crate::Event> for TaskStore {}
 impl TaskStore {
     pub fn init(client: Option<&AnyProtoClient>) {
         if let Some(client) = client {
-            client.add_model_request_handler(Self::handle_task_context_for_location);
+            client.add_entity_request_handler(Self::handle_task_context_for_location);
         }
     }
 

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -26,9 +26,9 @@ enum ToolchainStoreInner {
 impl EventEmitter<ToolchainStoreEvent> for ToolchainStore {}
 impl ToolchainStore {
     pub fn init(client: &AnyProtoClient) {
-        client.add_model_request_handler(Self::handle_activate_toolchain);
-        client.add_model_request_handler(Self::handle_list_toolchains);
-        client.add_model_request_handler(Self::handle_active_toolchain);
+        client.add_entity_request_handler(Self::handle_activate_toolchain);
+        client.add_entity_request_handler(Self::handle_list_toolchains);
+        client.add_entity_request_handler(Self::handle_active_toolchain);
     }
 
     pub fn local(

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -37,16 +37,16 @@ impl ToolchainStore {
         project_environment: Entity<ProjectEnvironment>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let model = cx.new(|_| LocalToolchainStore {
+        let entity = cx.new(|_| LocalToolchainStore {
             languages,
             worktree_store,
             project_environment,
             active_toolchains: Default::default(),
         });
-        let subscription = cx.subscribe(&model, |_, _, e: &ToolchainStoreEvent, cx| {
+        let subscription = cx.subscribe(&entity, |_, _, e: &ToolchainStoreEvent, cx| {
             cx.emit(e.clone())
         });
-        Self(ToolchainStoreInner::Local(model, subscription))
+        Self(ToolchainStoreInner::Local(entity, subscription))
     }
     pub(super) fn remote(project_id: u64, client: AnyProtoClient, cx: &mut App) -> Self {
         Self(ToolchainStoreInner::Remote(

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -72,13 +72,13 @@ impl EventEmitter<WorktreeStoreEvent> for WorktreeStore {}
 
 impl WorktreeStore {
     pub fn init(client: &AnyProtoClient) {
-        client.add_model_request_handler(Self::handle_create_project_entry);
-        client.add_model_request_handler(Self::handle_copy_project_entry);
-        client.add_model_request_handler(Self::handle_delete_project_entry);
-        client.add_model_request_handler(Self::handle_expand_project_entry);
-        client.add_model_request_handler(Self::handle_expand_all_for_project_entry);
-        client.add_model_request_handler(Self::handle_git_branches);
-        client.add_model_request_handler(Self::handle_update_branch);
+        client.add_entity_request_handler(Self::handle_create_project_entry);
+        client.add_entity_request_handler(Self::handle_copy_project_entry);
+        client.add_entity_request_handler(Self::handle_delete_project_entry);
+        client.add_entity_request_handler(Self::handle_expand_project_entry);
+        client.add_entity_request_handler(Self::handle_expand_all_for_project_entry);
+        client.add_entity_request_handler(Self::handle_git_branches);
+        client.add_entity_request_handler(Self::handle_update_branch);
     }
 
     pub fn local(retain_worktrees: bool, fs: Arc<dyn Fs>) -> Self {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -445,9 +445,9 @@ impl ProjectPanel {
                 show_scrollbar: !Self::should_autohide_scrollbar(cx),
                 hide_scrollbar_task: None,
                 vertical_scrollbar_state: ScrollbarState::new(scroll_handle.clone())
-                    .parent_model(&cx.entity()),
+                    .parent_entity(&cx.entity()),
                 horizontal_scrollbar_state: ScrollbarState::new(scroll_handle.clone())
-                    .parent_model(&cx.entity()),
+                    .parent_entity(&cx.entity()),
                 max_width_item_index: None,
                 diagnostics: Default::default(),
                 scroll_handle,

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -1263,7 +1263,7 @@ impl RemoteServerProjects {
                 state = new_state.clone();
             }
         }
-        let scroll_state = state.scrollbar.parent_model(&cx.entity());
+        let scroll_state = state.scrollbar.parent_entity(&cx.entity());
         let connect_button = div()
             .id("ssh-connect-new-server-container")
             .track_focus(&state.add_new_server.focus_handle)

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -185,21 +185,21 @@ impl HeadlessProject {
         client.add_request_handler(cx.weak_entity(), Self::handle_shutdown_remote_server);
         client.add_request_handler(cx.weak_entity(), Self::handle_ping);
 
-        client.add_model_request_handler(Self::handle_add_worktree);
+        client.add_entity_request_handler(Self::handle_add_worktree);
         client.add_request_handler(cx.weak_entity(), Self::handle_remove_worktree);
 
-        client.add_model_request_handler(Self::handle_open_buffer_by_path);
-        client.add_model_request_handler(Self::handle_open_new_buffer);
-        client.add_model_request_handler(Self::handle_find_search_candidates);
-        client.add_model_request_handler(Self::handle_open_server_settings);
+        client.add_entity_request_handler(Self::handle_open_buffer_by_path);
+        client.add_entity_request_handler(Self::handle_open_new_buffer);
+        client.add_entity_request_handler(Self::handle_find_search_candidates);
+        client.add_entity_request_handler(Self::handle_open_server_settings);
 
-        client.add_model_request_handler(BufferStore::handle_update_buffer);
-        client.add_model_message_handler(BufferStore::handle_close_buffer);
+        client.add_entity_request_handler(BufferStore::handle_update_buffer);
+        client.add_entity_message_handler(BufferStore::handle_close_buffer);
 
-        client.add_model_request_handler(Self::handle_stage);
-        client.add_model_request_handler(Self::handle_unstage);
-        client.add_model_request_handler(Self::handle_commit);
-        client.add_model_request_handler(Self::handle_open_commit_message_buffer);
+        client.add_entity_request_handler(Self::handle_stage);
+        client.add_entity_request_handler(Self::handle_unstage);
+        client.add_entity_request_handler(Self::handle_commit);
+        client.add_entity_request_handler(Self::handle_open_commit_message_buffer);
 
         client.add_request_handler(
             extensions.clone().downgrade(),

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -127,7 +127,7 @@ impl Cell {
             } => {
                 let source = source.join("");
 
-                let model = cx.new(|cx| {
+                let entity = cx.new(|cx| {
                     let markdown_parsing_task = {
                         let languages = languages.clone();
                         let source = source.clone();
@@ -159,7 +159,7 @@ impl Cell {
                     }
                 });
 
-                Cell::Markdown(model)
+                Cell::Markdown(entity)
             }
             nbformat::v4::Cell::Code {
                 id,

--- a/crates/rpc/src/proto_client.rs
+++ b/crates/rpc/src/proto_client.rs
@@ -53,7 +53,7 @@ pub struct ProtoMessageHandlerSet {
     pub entity_types_by_message_type: HashMap<TypeId, TypeId>,
     pub entities_by_type_and_remote_id: HashMap<(TypeId, u64), EntityMessageSubscriber>,
     pub entity_id_extractors: HashMap<TypeId, fn(&dyn AnyTypedEnvelope) -> u64>,
-    pub models_by_message_type: HashMap<TypeId, AnyWeakEntity>,
+    pub entities_by_message_type: HashMap<TypeId, AnyWeakEntity>,
     pub message_handlers: HashMap<TypeId, ProtoMessageHandler>,
 }
 
@@ -71,7 +71,7 @@ pub type ProtoMessageHandler = Arc<
 impl ProtoMessageHandlerSet {
     pub fn clear(&mut self) {
         self.message_handlers.clear();
-        self.models_by_message_type.clear();
+        self.entities_by_message_type.clear();
         self.entities_by_type_and_remote_id.clear();
         self.entity_id_extractors.clear();
     }
@@ -79,10 +79,11 @@ impl ProtoMessageHandlerSet {
     fn add_message_handler(
         &mut self,
         message_type_id: TypeId,
-        model: gpui::AnyWeakEntity,
+        entity: gpui::AnyWeakEntity,
         handler: ProtoMessageHandler,
     ) {
-        self.models_by_message_type.insert(message_type_id, model);
+        self.entities_by_message_type
+            .insert(message_type_id, entity);
         let prev_handler = self.message_handlers.insert(message_type_id, handler);
         if prev_handler.is_some() {
             panic!("registered handler for the same message twice");
@@ -92,7 +93,7 @@ impl ProtoMessageHandlerSet {
     fn add_entity_message_handler(
         &mut self,
         message_type_id: TypeId,
-        model_type_id: TypeId,
+        entity_type_id: TypeId,
         entity_id_extractor: fn(&dyn AnyTypedEnvelope) -> u64,
         handler: ProtoMessageHandler,
     ) {
@@ -100,7 +101,7 @@ impl ProtoMessageHandlerSet {
             .entry(message_type_id)
             .or_insert(entity_id_extractor);
         self.entity_types_by_message_type
-            .insert(message_type_id, model_type_id);
+            .insert(message_type_id, entity_type_id);
         let prev_handler = self.message_handlers.insert(message_type_id, handler);
         if prev_handler.is_some() {
             panic!("registered handler for the same message twice");
@@ -116,7 +117,7 @@ impl ProtoMessageHandlerSet {
         let payload_type_id = message.payload_type_id();
         let mut this = this.lock();
         let handler = this.message_handlers.get(&payload_type_id)?.clone();
-        let entity = if let Some(entity) = this.models_by_message_type.get(&payload_type_id) {
+        let entity = if let Some(entity) = this.entities_by_message_type.get(&payload_type_id) {
             entity.upgrade()?
         } else {
             let extract_entity_id = *this.entity_id_extractors.get(&payload_type_id)?;
@@ -207,7 +208,7 @@ impl AnyProtoClient {
         self.0.send(envelope, T::NAME)
     }
 
-    pub fn add_request_handler<M, E, H, F>(&self, model: gpui::WeakEntity<E>, handler: H)
+    pub fn add_request_handler<M, E, H, F>(&self, entity: gpui::WeakEntity<E>, handler: H)
     where
         M: RequestMessage,
         E: 'static,
@@ -216,12 +217,12 @@ impl AnyProtoClient {
     {
         self.0.message_handler_set().lock().add_message_handler(
             TypeId::of::<M>(),
-            model.into(),
-            Arc::new(move |model, envelope, client, cx| {
-                let model = model.downcast::<E>().unwrap();
+            entity.into(),
+            Arc::new(move |entity, envelope, client, cx| {
+                let entity = entity.downcast::<E>().unwrap();
                 let envelope = envelope.into_any().downcast::<TypedEnvelope<M>>().unwrap();
                 let request_id = envelope.message_id();
-                handler(model, *envelope, cx)
+                handler(entity, *envelope, cx)
                     .then(move |result| async move {
                         match result {
                             Ok(response) => {
@@ -239,7 +240,7 @@ impl AnyProtoClient {
         )
     }
 
-    pub fn add_model_request_handler<M, E, H, F>(&self, handler: H)
+    pub fn add_entity_request_handler<M, E, H, F>(&self, handler: H)
     where
         M: EnvelopedMessage + RequestMessage + EntityMessage,
         E: 'static,
@@ -247,7 +248,7 @@ impl AnyProtoClient {
         F: 'static + Future<Output = anyhow::Result<M::Response>>,
     {
         let message_type_id = TypeId::of::<M>();
-        let model_type_id = TypeId::of::<E>();
+        let entity_type_id = TypeId::of::<E>();
         let entity_id_extractor = |envelope: &dyn AnyTypedEnvelope| {
             envelope
                 .as_any()
@@ -261,13 +262,13 @@ impl AnyProtoClient {
             .lock()
             .add_entity_message_handler(
                 message_type_id,
-                model_type_id,
+                entity_type_id,
                 entity_id_extractor,
-                Arc::new(move |model, envelope, client, cx| {
-                    let model = model.downcast::<E>().unwrap();
+                Arc::new(move |entity, envelope, client, cx| {
+                    let entity = entity.downcast::<E>().unwrap();
                     let envelope = envelope.into_any().downcast::<TypedEnvelope<M>>().unwrap();
                     let request_id = envelope.message_id();
-                    handler(model, *envelope, cx)
+                    handler(entity, *envelope, cx)
                         .then(move |result| async move {
                             match result {
                                 Ok(response) => {
@@ -285,7 +286,7 @@ impl AnyProtoClient {
             );
     }
 
-    pub fn add_model_message_handler<M, E, H, F>(&self, handler: H)
+    pub fn add_entity_message_handler<M, E, H, F>(&self, handler: H)
     where
         M: EnvelopedMessage + EntityMessage,
         E: 'static,
@@ -293,7 +294,7 @@ impl AnyProtoClient {
         F: 'static + Future<Output = anyhow::Result<()>>,
     {
         let message_type_id = TypeId::of::<M>();
-        let model_type_id = TypeId::of::<E>();
+        let entity_type_id = TypeId::of::<E>();
         let entity_id_extractor = |envelope: &dyn AnyTypedEnvelope| {
             envelope
                 .as_any()
@@ -307,12 +308,12 @@ impl AnyProtoClient {
             .lock()
             .add_entity_message_handler(
                 message_type_id,
-                model_type_id,
+                entity_type_id,
                 entity_id_extractor,
-                Arc::new(move |model, envelope, _, cx| {
-                    let model = model.downcast::<E>().unwrap();
+                Arc::new(move |entity, envelope, _, cx| {
+                    let entity = entity.downcast::<E>().unwrap();
                     let envelope = envelope.into_any().downcast::<TypedEnvelope<M>>().unwrap();
-                    handler(model, *envelope, cx).boxed_local()
+                    handler(entity, *envelope, cx).boxed_local()
                 }),
             );
     }

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -47,14 +47,14 @@ pub struct IndentGuides {
 }
 
 pub fn indent_guides<V: Render>(
-    model: Entity<V>,
+    entity: Entity<V>,
     indent_size: Pixels,
     colors: IndentGuideColors,
     compute_indents_fn: impl Fn(&mut V, Range<usize>, &mut Window, &mut Context<V>) -> SmallVec<[usize; 64]>
         + 'static,
 ) -> IndentGuides {
     let compute_indents_fn = Box::new(move |range, window: &mut Window, cx: &mut App| {
-        model.update(cx, |this, cx| compute_indents_fn(this, range, window, cx))
+        entity.update(cx, |this, cx| compute_indents_fn(this, range, window, cx))
     });
     IndentGuides {
         colors,
@@ -78,7 +78,7 @@ impl IndentGuides {
     /// Sets a custom callback that will be called when the indent guides need to be rendered.
     pub fn with_render_fn<V: Render>(
         mut self,
-        model: Entity<V>,
+        entity: Entity<V>,
         render_fn: impl Fn(
                 &mut V,
                 RenderIndentGuideParams,
@@ -88,7 +88,7 @@ impl IndentGuides {
             + 'static,
     ) -> Self {
         let render_fn = move |params, window: &mut Window, cx: &mut App| {
-            model.update(cx, |this, cx| render_fn(this, params, window, cx))
+            entity.update(cx, |this, cx| render_fn(this, params, window, cx))
         };
         self.render_fn = Some(Box::new(render_fn));
         self

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -114,7 +114,7 @@ impl ScrollbarState {
     }
 
     /// Set a parent model which should be notified whenever this Scrollbar gets a scroll event.
-    pub fn parent_model<V: 'static>(mut self, v: &Entity<V>) -> Self {
+    pub fn parent_entity<V: 'static>(mut self, v: &Entity<V>) -> Self {
         self.parent_id = Some(v.entity_id());
         self
     }

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -95,14 +95,14 @@ impl VimTestContext {
         Self { cx }
     }
 
-    pub fn update_entity<F, T, R>(&mut self, model: Entity<T>, update: F) -> R
+    pub fn update_entity<F, T, R>(&mut self, entity: Entity<T>, update: F) -> R
     where
         T: 'static,
         F: FnOnce(&mut T, &mut Window, &mut Context<T>) -> R + 'static,
     {
         let window = self.window;
         self.update_window(window, move |_, window, cx| {
-            model.update(cx, |t, cx| update(t, window, cx))
+            entity.update(cx, |t, cx| update(t, window, cx))
         })
         .unwrap()
     }
@@ -131,7 +131,7 @@ impl VimTestContext {
     }
 
     pub fn mode(&mut self) -> Mode {
-        self.update_editor(|editor, _, cx| editor.addon::<VimAddon>().unwrap().model.read(cx).mode)
+        self.update_editor(|editor, _, cx| editor.addon::<VimAddon>().unwrap().entity.read(cx).mode)
     }
 
     pub fn active_operator(&mut self) -> Option<Operator> {
@@ -139,7 +139,7 @@ impl VimTestContext {
             editor
                 .addon::<VimAddon>()
                 .unwrap()
-                .model
+                .entity
                 .read(cx)
                 .operator_stack
                 .last()
@@ -153,7 +153,7 @@ impl VimTestContext {
             self.update_editor(|editor, _window, _cx| editor.addon::<VimAddon>().cloned().unwrap());
 
         self.update(|window, cx| {
-            vim.model.update(cx, |vim, cx| {
+            vim.entity.update(cx, |vim, cx| {
                 vim.switch_mode(mode, true, window, cx);
             });
         });

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -173,7 +173,7 @@ pub fn init(cx: &mut App) {
                 .and_then(|item| item.act_as::<Editor>(cx))
                 .and_then(|editor| editor.read(cx).addon::<VimAddon>().cloned());
             let Some(vim) = vim else { return };
-            vim.model.update(cx, |_, cx| {
+            vim.entity.update(cx, |_, cx| {
                 cx.defer_in(window, |vim, window, cx| vim.search_submit(window, cx))
             })
         });
@@ -183,12 +183,12 @@ pub fn init(cx: &mut App) {
 
 #[derive(Clone)]
 pub(crate) struct VimAddon {
-    pub(crate) model: Entity<Vim>,
+    pub(crate) entity: Entity<Vim>,
 }
 
 impl editor::Addon for VimAddon {
     fn extend_key_context(&self, key_context: &mut KeyContext, cx: &App) {
-        self.model.read(cx).extend_key_context(key_context, cx)
+        self.entity.read(cx).extend_key_context(key_context, cx)
     }
 
     fn to_any(&self) -> &dyn std::any::Any {
@@ -298,7 +298,7 @@ impl Vim {
                 if toggle {
                     let is_relative = editor
                         .addon::<VimAddon>()
-                        .map(|vim| vim.model.read(cx).mode != Mode::Insert);
+                        .map(|vim| vim.entity.read(cx).mode != Mode::Insert);
                     editor.set_relative_line_number(is_relative, cx)
                 } else {
                     editor.set_relative_line_number(None, cx)
@@ -324,7 +324,9 @@ impl Vim {
     fn activate(editor: &mut Editor, window: &mut Window, cx: &mut Context<Editor>) {
         let vim = Vim::new(window, cx);
 
-        editor.register_addon(VimAddon { model: vim.clone() });
+        editor.register_addon(VimAddon {
+            entity: vim.clone(),
+        });
 
         vim.update(cx, |_, cx| {
             Vim::action(editor, cx, |vim, action: &SwitchMode, window, cx| {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1504,8 +1504,8 @@ pub mod test {
             _window: &mut Window,
             cx: &mut App,
         ) -> Task<anyhow::Result<Entity<Self>>> {
-            let model = cx.new(|cx| Self::new_deserialized(workspace_id, cx));
-            Task::ready(Ok(model))
+            let entity = cx.new(|cx| Self::new_deserialized(workspace_id, cx));
+            Task::ready(Ok(entity))
         }
 
         fn cleanup(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2540,8 +2540,10 @@ impl Pane {
         let navigate_backward = IconButton::new("navigate_backward", IconName::ArrowLeft)
             .icon_size(IconSize::Small)
             .on_click({
-                let model = cx.entity().clone();
-                move |_, window, cx| model.update(cx, |pane, cx| pane.navigate_backward(window, cx))
+                let entity = cx.entity().clone();
+                move |_, window, cx| {
+                    entity.update(cx, |pane, cx| pane.navigate_backward(window, cx))
+                }
             })
             .disabled(!self.can_navigate_backward())
             .tooltip({
@@ -2554,8 +2556,8 @@ impl Pane {
         let navigate_forward = IconButton::new("navigate_forward", IconName::ArrowRight)
             .icon_size(IconSize::Small)
             .on_click({
-                let model = cx.entity().clone();
-                move |_, window, cx| model.update(cx, |pane, cx| pane.navigate_forward(window, cx))
+                let entity = cx.entity().clone();
+                move |_, window, cx| entity.update(cx, |pane, cx| pane.navigate_forward(window, cx))
             })
             .disabled(!self.can_navigate_forward())
             .tooltip({

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -229,9 +229,9 @@ impl Zeta {
         cx: &mut App,
     ) -> Entity<Self> {
         let this = Self::global(cx).unwrap_or_else(|| {
-            let model = cx.new(|cx| Self::new(client, user_store, cx));
-            cx.set_global(ZetaGlobal(model.clone()));
-            model
+            let entity = cx.new(|cx| Self::new(client, user_store, cx));
+            cx.set_global(ZetaGlobal(entity.clone()));
+            entity
         });
 
         this.update(cx, move |this, cx| {


### PR DESCRIPTION
## Context
While looking through the client crate, I noticed that some of the old functions and variables were still using gpui::model name that was deprecated during the gpui3 transition. This PR renames those instances of model to entity to be more inline with gpui3. 

In addition, I also renamed `model` to `entity` in cases found by the below search terms given by @someone13574 

- model = cx.
- model: Entity
- model: &Entity
- OpenedModelHandle
- model.update
- model.upgrade
- model = .*\.root (regex)
- parent_model
- model = cx.new
- cx.spawn(move |model

Release Notes:

- N/A
