### PR TITLE
Use the term "edit prediction" over "inline completion"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -24,7 +24,7 @@
   "base_keymap": "VSCode",
   // Features that can be globally enabled or disabled
   "features": {
-    // Which inline completion provider to use.
+    // Which edit prediction provider to use.
     "inline_completion_provider": "copilot"
   },
   // The name of a font to use for rendering text in the editor
@@ -161,8 +161,8 @@
   /// Whether to show the signature help after completion or a bracket pair inserted.
   /// If `auto_signature_help` is enabled, this setting will be treated as enabled also.
   "show_signature_help_after_edits": false,
-  /// Whether to show the inline completions next to the completions provided by a language server.
-  /// Only has an effect if inline completion provider supports it.
+  /// Whether to show the edit predictions next to the completions provided by a language server.
+  /// Only has an effect if edit prediction provider supports it.
   "show_inline_completions_in_menu": true,
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
@@ -196,10 +196,10 @@
   // Otherwise(when `true`), the closing characters are always skipped over and auto-removed
   // no matter how they were inserted.
   "always_treat_brackets_as_autoclosed": false,
-  // Controls whether inline completions are shown immediately (true)
+  // Controls whether edit predictions are shown immediately (true)
   // or manually by triggering `editor::ShowInlineCompletion` (false).
   "show_inline_completions": true,
-  // Controls whether inline completions are shown in a given language scope.
+  // Controls whether edit predictions are shown in a given language scope.
   // Example: ["string", "comment"]
   "inline_completions_disabled_in": [],
   // Whether to show tabs and spaces in the editor.
@@ -775,7 +775,7 @@
   //      "load_direnv": "shell_hook"
   "load_direnv": "direct",
   "inline_completions": {
-    // A list of globs representing files that inline completions should be disabled for.
+    // A list of globs representing files that edit predictions should be disabled for.
     "disabled_globs": [
       "**/.env*",
       "**/*.pem",

--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -510,7 +510,7 @@ fn for_snowflake(
             ),
             Event::InlineCompletion(e) => (
                 format!(
-                    "Inline Completion {}",
+                    "Edit Prediction {}",
                     if e.suggestion_accepted {
                         "Accepted"
                     } else {
@@ -520,7 +520,7 @@ fn for_snowflake(
                 serde_json::to_value(e).unwrap(),
             ),
             Event::InlineCompletionRating(e) => (
-                "Inline Completion Rated".to_string(),
+                "Edit Prediction Rated".to_string(),
                 serde_json::to_value(e).unwrap(),
             ),
             Event::Call(e) => {

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -393,7 +393,7 @@ mod tests {
             assert_eq!(editor.text(cx), "one.\ntwo\nthree\n");
         });
 
-        // Ensure existing inline completion is interpolated when inserting again.
+        // Ensure existing edit prediction is interpolated when inserting again.
         cx.simulate_keystroke("c");
         executor.run_until_parked();
         cx.update_editor(|editor, _, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -678,7 +678,7 @@ pub struct Editor {
     /// Used to prevent flickering as the user types while the menu is open
     stale_inline_completion_in_menu: Option<InlineCompletionState>,
     // enable_inline_completions is a switch that Vim can use to disable
-    // inline completions based on its mode.
+    // edit predictions based on its mode.
     enable_inline_completions: bool,
     show_inline_completions_override: Option<bool>,
     menu_inline_completions_policy: MenuInlineCompletionsPolicy,
@@ -4927,8 +4927,8 @@ impl Editor {
             .and_then(|file| Some(file.path().extension()?.to_string_lossy().to_string()));
 
         let event_type = match accepted {
-            true => "Inline Completion Accepted",
-            false => "Inline Completion Discarded",
+            true => "Edit Prediction Accepted",
+            false => "Edit Prediction Discarded",
         };
         telemetry::event!(
             event_type,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -368,8 +368,8 @@ pub struct EditorSettingsContent {
     /// Default: false
     pub show_signature_help_after_edits: Option<bool>,
 
-    /// Whether to show the inline completions next to the completions provided by a language server.
-    /// Only has an effect if inline completion provider supports it.
+    /// Whether to show the edit predictions next to the completions provided by a language server.
+    /// Only has an effect if edit prediction provider supports it.
     ///
     /// Default: true
     pub show_inline_completions_in_menu: Option<bool>,

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -59,7 +59,7 @@ pub fn all_language_settings<'a>(
 /// The settings for all languages.
 #[derive(Debug, Clone)]
 pub struct AllLanguageSettings {
-    /// The inline completion settings.
+    /// The edit prediction settings.
     pub inline_completions: InlineCompletionSettings,
     defaults: LanguageSettings,
     languages: HashMap<LanguageName, LanguageSettings>,
@@ -109,10 +109,10 @@ pub struct LanguageSettings {
     /// - `"!<language_server_id>"` - A language server ID prefixed with a `!` will be disabled.
     /// - `"..."` - A placeholder to refer to the **rest** of the registered language servers for this language.
     pub language_servers: Vec<String>,
-    /// Controls whether inline completions are shown immediately (true)
+    /// Controls whether edit predictions are shown immediately (true)
     /// or manually by triggering `editor::ShowInlineCompletion` (false).
     pub show_inline_completions: bool,
-    /// Controls whether inline completions are shown in the given language
+    /// Controls whether edit predictions are shown in the given language
     /// scopes.
     pub inline_completions_disabled_in: Vec<String>,
     /// Whether to show tabs and spaces in the editor.
@@ -195,7 +195,7 @@ impl LanguageSettings {
     }
 }
 
-/// The provider that supplies inline completions.
+/// The provider that supplies edit predictions.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum InlineCompletionProvider {
@@ -206,13 +206,13 @@ pub enum InlineCompletionProvider {
     Zed,
 }
 
-/// The settings for inline completions, such as [GitHub Copilot](https://github.com/features/copilot)
+/// The settings for edit predictions, such as [GitHub Copilot](https://github.com/features/copilot)
 /// or [Supermaven](https://supermaven.com).
 #[derive(Clone, Debug, Default)]
 pub struct InlineCompletionSettings {
-    /// The provider that supplies inline completions.
+    /// The provider that supplies edit predictions.
     pub provider: InlineCompletionProvider,
-    /// A list of globs representing files that inline completions should be disabled for.
+    /// A list of globs representing files that edit predictions should be disabled for.
     pub disabled_globs: Vec<GlobMatcher>,
 }
 
@@ -222,7 +222,7 @@ pub struct AllLanguageSettingsContent {
     /// The settings for enabling/disabling features.
     #[serde(default)]
     pub features: Option<FeaturesContent>,
-    /// The inline completion settings.
+    /// The edit prediction settings.
     #[serde(default)]
     pub inline_completions: Option<InlineCompletionSettingsContent>,
     /// The default language settings.
@@ -322,13 +322,13 @@ pub struct LanguageSettingsContent {
     /// Default: ["..."]
     #[serde(default)]
     pub language_servers: Option<Vec<String>>,
-    /// Controls whether inline completions are shown immediately (true)
+    /// Controls whether edit predictions are shown immediately (true)
     /// or manually by triggering `editor::ShowInlineCompletion` (false).
     ///
     /// Default: true
     #[serde(default)]
     pub show_inline_completions: Option<bool>,
-    /// Controls whether inline completions are shown in the given language
+    /// Controls whether edit predictions are shown in the given language
     /// scopes.
     ///
     /// Example: ["string", "comment"]
@@ -400,10 +400,10 @@ pub struct LanguageSettingsContent {
     pub show_completion_documentation: Option<bool>,
 }
 
-/// The contents of the inline completion settings.
+/// The contents of the edit prediction settings.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct InlineCompletionSettingsContent {
-    /// A list of globs representing files that inline completions should be disabled for.
+    /// A list of globs representing files that edit predictions should be disabled for.
     #[serde(default)]
     pub disabled_globs: Option<Vec<String>>,
 }
@@ -414,7 +414,7 @@ pub struct InlineCompletionSettingsContent {
 pub struct FeaturesContent {
     /// Whether the GitHub Copilot feature is enabled.
     pub copilot: Option<bool>,
-    /// Determines which inline completion provider to use.
+    /// Determines which edit prediction provider to use.
     pub inline_completion_provider: Option<InlineCompletionProvider>,
 }
 
@@ -876,7 +876,7 @@ impl AllLanguageSettings {
         }
     }
 
-    /// Returns whether inline completions are enabled for the given path.
+    /// Returns whether edit predictions are enabled for the given path.
     pub fn inline_completions_enabled_for_path(&self, path: &Path) -> bool {
         !self
             .inline_completions
@@ -885,7 +885,7 @@ impl AllLanguageSettings {
             .any(|glob| glob.is_match(path))
     }
 
-    /// Returns whether inline completions are enabled for the given language and path.
+    /// Returns whether edit predictions are enabled for the given language and path.
     pub fn inline_completions_enabled(
         &self,
         language: Option<&Arc<Language>>,

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -34,7 +34,7 @@ impl SupermavenCompletionProvider {
     }
 }
 
-// Computes the inline completion from the difference between the completion text.
+// Computes the edit prediction from the difference between the completion text.
 // this is defined by greedily matching the buffer text against the completion text, with any leftover buffer placed at the end.
 // for example, given the completion text "moo cows are cool" and the buffer text "cowsre pool", the completion state would be
 // the inlays "moo ", " a", and "cool" which will render as "[moo ]cows[ a]re [cool]pool" in the editor.

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -295,7 +295,7 @@ impl Render for QuickActionBar {
                         );
 
                         menu = menu.toggleable_entry(
-                            "Inline Completions",
+                            "Edit Predictions",
                             inline_completions_enabled,
                             IconPosition::Start,
                             Some(editor::actions::ToggleInlineCompletions.boxed_clone()),

--- a/crates/zeta/src/onboarding_modal.rs
+++ b/crates/zeta/src/onboarding_modal.rs
@@ -274,7 +274,7 @@ impl Render for ZedPredictModal {
 
         if self.user_store.read(cx).current_user().is_some() {
             let copy = match self.sign_in_status {
-                SignInStatus::Idle => "Get accurate and instant edit predictions at every keystroke. Before setting Zed as your inline completions provider:",
+                SignInStatus::Idle => "Get accurate and instant edit predictions at every keystroke. Before setting Zed as your edit prediction provider:",
                 SignInStatus::SignedIn => "Almost there! Ensure you:",
                 SignInStatus::Waiting => unreachable!(),
             };
@@ -423,7 +423,7 @@ impl Render for ZedPredictModal {
                 )
         } else {
             base.child(
-                Label::new("To set Zed as your inline completions provider, please sign in.")
+                Label::new("To set Zed as your edit prediction provider, please sign in.")
                     .color(Color::Muted),
             )
             .child(

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -885,7 +885,7 @@ and then another
     ) {
         self.rated_completions.insert(completion.id);
         telemetry::event!(
-            "Inline Completion Rated",
+            "Edit Prediction Rated",
             rating,
             input_events = completion.input_events,
             input_excerpt = completion.input_excerpt,

--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -3,7 +3,7 @@
 Zed supports two sources for completions:
 
 1. "Code Completions" provided by Language Servers (LSPs) automatically installed by Zed or via [Zed Language Extensions](languages.md).
-2. "Inline Completions" provided by external APIs like [GitHub Copilot](#github-copilot) or [Supermaven](#supermaven).
+2. "Edit Predictions" provided by external APIs like [GitHub Copilot](#github-copilot) or [Supermaven](#supermaven).
 
 ## Code Completions
 
@@ -20,7 +20,7 @@ For more information, see:
 - [Configuring Supported Languages](./configuring-languages.md)
 - [List of Zed Supported Languages](./languages.md).
 
-## Configuring Inline Completions
+## Configuring Edit Predictions
 
 ### GitHub Copilot
 
@@ -50,17 +50,17 @@ To use Supermaven, add the following to your `settings.json`:
 
 You should be able to sign-in to Supermaven by clicking on the Supermaven icon in the status bar and following the setup instructions.
 
-## Using Inline completions
+## Using Edit Predictions
 
-Once you have configured an Inline Completions provider, you can start using inline completions in your code. Inline completions will appear as you type, and you can accept them by pressing `tab` or `enter` or hide them by pressing `esc`.
+Once you have configured an Edit Prediction provider, you can start using edit predictions completions in your code. Edit predictions will appear as you type, and you can accept them by pressing `tab` or `enter` or hide them by pressing `esc`.
 
-There are a number of actions/shortcuts available to interact with inline completions:
+There are a number of actions/shortcuts available to interact with edit predictions:
 
-- `editor: accept inline completion` (`tab`): To accept the current inline completion
-- `editor: accept partial inline completion` (`ctrl-cmd-right`): To accept the current inline completion up to the next word boundary
-- `editor: show inline completion` (`alt-tab`): Trigger an inline completion request manually
-- `editor: next inline completion` (`alt-tab`): To cycle to the next inline completion
-- `editor: previous inline completion` (`alt-shift-tab`): To cycle to the previous inline completion
+- `editor: accept inline completion` (`tab`): To accept the current edit prediction
+- `editor: accept partial inline completion` (`ctrl-cmd-right`): To accept the current edit prediction up to the next word boundary
+- `editor: show inline completion` (`alt-tab`): Trigger an edit prediction request manually
+- `editor: next inline completion` (`alt-tab`): To cycle to the next edit prediction
+- `editor: previous inline completion` (`alt-shift-tab`): To cycle to the previous edit prediction
 
 ### Disabling Inline-Completions
 
@@ -72,9 +72,9 @@ To disable completions that appear automatically as you type, add the following 
 }
 ```
 
-You can trigger inline completions manually by executing `editor: show inline completion` (`alt-tab`).
+You can trigger edit predictions manually by executing `editor: show inline completion` (`alt-tab`).
 
-You can also add this as a language-specific setting in your `settings.json` to disable inline completions for a specific language:
+You can also add this as a language-specific setting in your `settings.json` to disable edit predictions for a specific language:
 
 ```json
 {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -375,9 +375,9 @@ There are two options to choose from:
 1. `shell_hook`: Use the shell hook to load direnv. This relies on direnv to activate upon entering the directory. Supports POSIX shells and fish.
 2. `direct`: Use `direnv export json` to load direnv. This will load direnv directly without relying on the shell hook and might cause some inconsistencies. This allows direnv to work with any shell.
 
-## Inline Completions
+## Edit Predictions
 
-- Description: Settings for inline completions.
+- Description: Settings for edit predictions.
 - Setting: `inline_completions`
 - Default:
 
@@ -398,7 +398,7 @@ There are two options to choose from:
 
 ### Disabled Globs
 
-- Description: A list of globs representing files that inline completions should be disabled for.
+- Description: A list of globs representing files that edit predictions should be disabled for.
 - Setting: `disabled_globs`
 - Default: `[".env"]`
 
@@ -406,9 +406,9 @@ There are two options to choose from:
 
 List of `string` values
 
-## Inline Completions Disabled in
+## Edit Predictions Disabled in
 
-- Description: A list of language scopes in which inline completions should be disabled.
+- Description: A list of language scopes in which edit predictions should be disabled.
 - Setting: `inline_completions_disabled_in`
 - Default: `[]`
 
@@ -416,19 +416,19 @@ List of `string` values
 
 List of `string` values
 
-1. Don't show inline completions in comments:
+1. Don't show edit predictions in comments:
 
 ```json
 "disabled_in": ["comment"]
 ```
 
-2. Don't show inline completions in strings and comments:
+2. Don't show edit predictions in strings and comments:
 
 ```json
 "disabled_in": ["comment", "string"]
 ```
 
-3. Only in Go, don't show inline completions in strings and comments:
+3. Only in Go, don't show edit predictions in strings and comments:
 
 ```json
 {
@@ -1652,9 +1652,9 @@ Or to set a `socks5` proxy:
 
 `boolean` values
 
-## Show Inline Completions
+## Show Edit Predictions
 
-- Description: Whether to show inline completions as you type or manually by triggering `editor::ShowInlineCompletion`.
+- Description: Whether to show edit predictions as you type or manually by triggering `editor::ShowInlineCompletion`.
 - Setting: `show_inline_completions`
 - Default: `true`
 


### PR DESCRIPTION
Note that this does *not* involve any breaking code changes.

cc @0xtimsb - I didn't change any settings or anything here. That can happen separately!

Release Notes:

- N/A
