### PR TITLE
Revert "Skip COMMIT_EDITMSG contents when opening the file  (#24146)"

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -177,34 +177,14 @@ fn commit_message_buffer(
                 )
                 .await
                 .with_context(|| format!("creating commit message file {commit_message_file:?}"))?;
-                let (worktree, relative_path) = project
+                let buffer = project
                     .update(&mut cx, |project, cx| {
-                        project.worktree_store().update(cx, |worktree_store, cx| {
-                            worktree_store.find_or_create_worktree(&commit_message_file, false, cx)
-                        })
+                        project.open_local_buffer(&commit_message_file, cx)
                     })?
                     .await
                     .with_context(|| {
-                        format!("deriving worktree for commit message file {commit_message_file:?}")
+                        format!("opening commit message buffer at {commit_message_file:?}",)
                     })?;
-
-                let buffer = project
-                    .update(&mut cx, |project, cx| {
-                        project.buffer_store().update(cx, |buffer_store, cx| {
-                            buffer_store.open_buffer(
-                                ProjectPath {
-                                    worktree_id: worktree.read(cx).id(),
-                                    path: Arc::from(relative_path),
-                                },
-                                true,
-                                cx,
-                            )
-                        })
-                    })
-                    .with_context(|| {
-                        format!("opening buffer for commit message file {commit_message_file:?}")
-                    })?
-                    .await?;
                 Ok(buffer)
             })
         }
@@ -278,6 +258,7 @@ impl GitPanel {
     pub fn new(
         workspace: &mut Workspace,
         window: &mut Window,
+        commit_message_buffer: Option<Entity<Buffer>>,
         cx: &mut Context<Workspace>,
     ) -> Entity<Self> {
         let fs = workspace.app_state().fs.clone();
@@ -294,7 +275,12 @@ impl GitPanel {
             })
             .detach();
 
-            let commit_editor = cx.new(|cx| commit_message_editor(None, window, cx));
+            let commit_editor =
+                cx.new(|cx| commit_message_editor(commit_message_buffer, window, cx));
+            commit_editor.update(cx, |editor, cx| {
+                editor.clear(window, cx);
+            });
+
             let scroll_handle = UniformListScrollHandle::new();
 
             cx.subscribe_in(

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -329,7 +329,6 @@ impl RemoteBufferStore {
         &self,
         path: Arc<Path>,
         worktree: Entity<Worktree>,
-        skip_file_contents: bool,
         cx: &mut Context<BufferStore>,
     ) -> Task<Result<Entity<Buffer>>> {
         let worktree_id = worktree.read(cx).id().to_proto();
@@ -342,7 +341,6 @@ impl RemoteBufferStore {
                     project_id,
                     worktree_id,
                     path: path_string,
-                    skip_file_contents,
                 })
                 .await?;
             let buffer_id = BufferId::new(response.buffer_id)?;
@@ -788,11 +786,10 @@ impl LocalBufferStore {
         &self,
         path: Arc<Path>,
         worktree: Entity<Worktree>,
-        skip_file_contents: bool,
         cx: &mut Context<BufferStore>,
     ) -> Task<Result<Entity<Buffer>>> {
         let load_buffer = worktree.update(cx, |worktree, cx| {
-            let load_file = worktree.load_file(path.as_ref(), skip_file_contents, cx);
+            let load_file = worktree.load_file(path.as_ref(), cx);
             let reservation = cx.reserve_entity();
             let buffer_id = BufferId::from(reservation.entity_id().as_non_zero_u64());
             cx.spawn(move |_, mut cx| async move {
@@ -976,7 +973,6 @@ impl BufferStore {
     pub fn open_buffer(
         &mut self,
         project_path: ProjectPath,
-        skip_file_contents: bool,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
         if let Some(buffer) = self.get_by_path(&project_path, cx) {
@@ -995,12 +991,8 @@ impl BufferStore {
                     return Task::ready(Err(anyhow!("no such worktree")));
                 };
                 let load_buffer = match &self.state {
-                    BufferStoreState::Local(this) => {
-                        this.open_buffer(path, worktree, skip_file_contents, cx)
-                    }
-                    BufferStoreState::Remote(this) => {
-                        this.open_buffer(path, worktree, skip_file_contents, cx)
-                    }
+                    BufferStoreState::Local(this) => this.open_buffer(path, worktree, cx),
+                    BufferStoreState::Remote(this) => this.open_buffer(path, worktree, cx),
                 };
 
                 entry
@@ -1493,7 +1485,7 @@ impl BufferStore {
                 let buffers = this.update(&mut cx, |this, cx| {
                     project_paths
                         .into_iter()
-                        .map(|project_path| this.open_buffer(project_path, false, cx))
+                        .map(|project_path| this.open_buffer(project_path, cx))
                         .collect::<Vec<_>>()
                 })?;
                 for buffer_task in buffers {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5616,7 +5616,7 @@ impl LspStore {
             lsp_store
                 .update(&mut cx, |lsp_store, cx| {
                     lsp_store.buffer_store().update(cx, |buffer_store, cx| {
-                        buffer_store.open_buffer(project_path, false, cx)
+                        buffer_store.open_buffer(project_path, cx)
                     })
                 })?
                 .await

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -795,7 +795,6 @@ message OpenBufferByPath {
     uint64 project_id = 1;
     uint64 worktree_id = 2;
     string path = 3;
-    bool skip_file_contents = 4;
 }
 
 message OpenBufferById {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -420,7 +420,6 @@ impl HeadlessProject {
                         worktree_id,
                         path: PathBuf::from(message.payload.path).into(),
                     },
-                    message.payload.skip_file_contents,
                     cx,
                 )
             });
@@ -487,7 +486,6 @@ impl HeadlessProject {
                         worktree_id: worktree.read(cx).id(),
                         path: path.into(),
                     },
-                    false,
                     cx,
                 )
             });
@@ -731,7 +729,6 @@ impl HeadlessProject {
                                 worktree_id: worktree.read(cx).id(),
                                 path: Arc::from(relative_path),
                             },
-                            true,
                             cx,
                         )
                     })

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -862,14 +862,9 @@ impl Worktree {
         }
     }
 
-    pub fn load_file(
-        &self,
-        path: &Path,
-        skip_file_contents: bool,
-        cx: &Context<Worktree>,
-    ) -> Task<Result<LoadedFile>> {
+    pub fn load_file(&self, path: &Path, cx: &Context<Worktree>) -> Task<Result<LoadedFile>> {
         match self {
-            Worktree::Local(this) => this.load_file(path, skip_file_contents, cx),
+            Worktree::Local(this) => this.load_file(path, cx),
             Worktree::Remote(_) => {
                 Task::ready(Err(anyhow!("remote worktrees can't yet load files")))
             }
@@ -1587,12 +1582,7 @@ impl LocalWorktree {
         })
     }
 
-    fn load_file(
-        &self,
-        path: &Path,
-        skip_file_contents: bool,
-        cx: &Context<Worktree>,
-    ) -> Task<Result<LoadedFile>> {
+    fn load_file(&self, path: &Path, cx: &Context<Worktree>) -> Task<Result<LoadedFile>> {
         let path = Arc::from(path);
         let abs_path = self.absolutize(&path);
         let fs = self.fs.clone();
@@ -1601,11 +1591,7 @@ impl LocalWorktree {
 
         cx.spawn(|this, _cx| async move {
             let abs_path = abs_path?;
-            let text = if skip_file_contents {
-                String::new()
-            } else {
-                fs.load(&abs_path).await?
-            };
+            let text = fs.load(&abs_path).await?;
 
             let worktree = this
                 .upgrade()

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -467,7 +467,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     let prev_read_dir_count = fs.read_dir_call_count();
     let loaded = tree
         .update(cx, |tree, cx| {
-            tree.load_file("one/node_modules/b/b1.js".as_ref(), false, cx)
+            tree.load_file("one/node_modules/b/b1.js".as_ref(), cx)
         })
         .await
         .unwrap();
@@ -507,7 +507,7 @@ async fn test_open_gitignored_files(cx: &mut TestAppContext) {
     let prev_read_dir_count = fs.read_dir_call_count();
     let loaded = tree
         .update(cx, |tree, cx| {
-            tree.load_file("one/node_modules/a/a2.js".as_ref(), false, cx)
+            tree.load_file("one/node_modules/a/a2.js".as_ref(), cx)
         })
         .await
         .unwrap();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -404,7 +404,7 @@ fn initialize_panels(
             workspace.add_panel(chat_panel, window, cx);
             workspace.add_panel(notification_panel, window, cx);
             cx.when_flag_enabled::<GitUiFeatureFlag>(window, |workspace, window, cx| {
-                let git_panel = git_ui::git_panel::GitPanel::new(workspace, window, cx);
+                let git_panel = git_ui::git_panel::GitPanel::new(workspace, window, None, cx);
                 workspace.add_panel(git_panel, window, cx);
             });
         })?;

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -952,7 +952,7 @@ impl LicenseDetectionWatcher {
     pub fn new(worktree: &Worktree, cx: &mut Context<Worktree>) -> Self {
         let (mut is_open_source_tx, is_open_source_rx) = watch::channel_with::<bool>(false);
 
-        let loaded_file_fut = worktree.load_file(Path::new("LICENSE"), false, cx);
+        let loaded_file_fut = worktree.load_file(Path::new("LICENSE"), cx);
 
         Self {
             is_open_source_rx,


### PR DESCRIPTION
This reverts commit ea66a54cf8b1650b39a3bea7b027b1441a099f04.

`COMMIT_EDITMSG` file usage is not the approach to the commit message editor in the end, so no need to adjust the public API for that.

Proto migration tests are expected to fail.

Release Notes:

- N/A
