### PR TITLE
zeta: Use DTOs from `zed_llm_client` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16635,6 +16635,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed_llm_client"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54ca07d631d9d758f1820c7a7e7854ca00619b9783a5b6b3b6057fef06c786cb"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zed_lua"
 version = "0.1.1"
 dependencies = [
@@ -16873,6 +16882,7 @@ dependencies = [
  "workspace",
  "worktree",
  "zed_actions",
+ "zed_llm_client",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -546,6 +546,7 @@ wasmtime = { version = "24", default-features = false, features = [
 wasmtime-wasi = "24"
 which = "6.0.0"
 wit-component = "0.201"
+zed_llm_client = "0.1.1"
 zstd = "0.11"
 metal = "0.31"
 

--- a/crates/rpc/src/llm.rs
+++ b/crates/rpc/src/llm.rs
@@ -33,18 +33,3 @@ pub struct PerformCompletionParams {
     pub model: String,
     pub provider_request: Box<serde_json::value::RawValue>,
 }
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PredictEditsParams {
-    pub outline: Option<String>,
-    pub input_events: String,
-    pub input_excerpt: String,
-    /// Whether the user provided consent for sampling this interaction.
-    #[serde(default)]
-    pub can_collect_data: bool,
-}
-
-#[derive(Debug, Serialize, Deserialize)]
-pub struct PredictEditsResponse {
-    pub output_excerpt: String,
-}

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -38,7 +38,6 @@ log.workspace = true
 menu.workspace = true
 postage.workspace = true
 regex.workspace = true
-rpc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
@@ -52,6 +51,7 @@ uuid.workspace = true
 workspace.workspace = true
 worktree.workspace = true
 zed_actions.workspace = true
+zed_llm_client.workspace = true
 
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -29,7 +29,6 @@ use language::{
 };
 use language_models::LlmApiToken;
 use postage::watch;
-use rpc::{PredictEditsParams, PredictEditsResponse, EXPIRED_LLM_TOKEN_HEADER_NAME};
 use settings::WorktreeId;
 use std::{
     borrow::Cow,
@@ -47,6 +46,7 @@ use telemetry_events::InlineCompletionRating;
 use util::ResultExt;
 use uuid::Uuid;
 use worktree::Worktree;
+use zed_llm_client::{PredictEditsBody, PredictEditsResponse, EXPIRED_LLM_TOKEN_HEADER_NAME};
 
 const CURSOR_MARKER: &'static str = "<|user_cursor_is_here|>";
 const START_OF_FILE_MARKER: &'static str = "<|start_of_file|>";
@@ -369,7 +369,7 @@ impl Zeta {
         perform_predict_edits: F,
     ) -> Task<Result<Option<InlineCompletion>>>
     where
-        F: FnOnce(Arc<Client>, LlmApiToken, bool, PredictEditsParams) -> R + 'static,
+        F: FnOnce(Arc<Client>, LlmApiToken, bool, PredictEditsBody) -> R + 'static,
         R: Future<Output = Result<PredictEditsResponse>> + Send + 'static,
     {
         let snapshot = self.report_changes_for_buffer(&buffer, cx);
@@ -425,7 +425,7 @@ impl Zeta {
 
             log::debug!("Events:\n{}\nExcerpt:\n{}", input_events, input_excerpt);
 
-            let body = PredictEditsParams {
+            let body = PredictEditsBody {
                 input_events: input_events.clone(),
                 input_excerpt: input_excerpt.clone(),
                 outline: Some(input_outline.clone()),
@@ -625,7 +625,7 @@ and then another
         client: Arc<Client>,
         llm_token: LlmApiToken,
         _is_staff: bool,
-        body: PredictEditsParams,
+        body: PredictEditsBody,
     ) -> impl Future<Output = Result<PredictEditsResponse>> {
         async move {
             let http_client = client.http_client();


### PR DESCRIPTION
This PR updates the `zeta` crate to use the predictive edit DTOs defined in the `zed_llm_client` crate.

This way we aren't duplicating their definitions (and risk them going out of sync).

Release Notes:

- N/A
