### PR TITLE
collab: Add `has_overdue_invoices` to `billing_customers`

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -430,6 +430,7 @@ CREATE TABLE IF NOT EXISTS billing_customers (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     user_id INTEGER NOT NULL REFERENCES users(id),
+    has_overdue_invoices BOOLEAN NOT NULL DEFAULT FALSE,
     stripe_customer_id TEXT NOT NULL
 );
 

--- a/crates/collab/migrations/20250204224004_add_has_overdue_invoices_to_billing_customers.sql
+++ b/crates/collab/migrations/20250204224004_add_has_overdue_invoices_to_billing_customers.sql
@@ -1,0 +1,2 @@
+alter table billing_customers
+add column has_overdue_invoices bool not null default false;

--- a/crates/collab/src/db/queries/billing_customers.rs
+++ b/crates/collab/src/db/queries/billing_customers.rs
@@ -10,6 +10,7 @@ pub struct CreateBillingCustomerParams {
 pub struct UpdateBillingCustomerParams {
     pub user_id: ActiveValue<UserId>,
     pub stripe_customer_id: ActiveValue<String>,
+    pub has_overdue_invoices: ActiveValue<bool>,
 }
 
 impl Database {
@@ -43,6 +44,7 @@ impl Database {
                 id: ActiveValue::set(id),
                 user_id: params.user_id.clone(),
                 stripe_customer_id: params.stripe_customer_id.clone(),
+                has_overdue_invoices: params.has_overdue_invoices.clone(),
                 ..Default::default()
             })
             .exec(&*tx)

--- a/crates/collab/src/db/tables/billing_customer.rs
+++ b/crates/collab/src/db/tables/billing_customer.rs
@@ -9,6 +9,7 @@ pub struct Model {
     pub id: BillingCustomerId,
     pub user_id: UserId,
     pub stripe_customer_id: String,
+    pub has_overdue_invoices: bool,
     pub created_at: DateTime,
 }
 


### PR DESCRIPTION
This PR adds a new `has_overdue_invoices` field to the `billing_customers` table.

This will be used to statefully track whether a customer has overdue invoices, and also to reset it when the invoices are paid.

We will set this field to `true` when a subscription is canceled with the reason `payment_failed`.

Release Notes:

- N/A
