### PR TITLE
Bump stale/close timeout deadlines

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -19,8 +19,8 @@ jobs:
 
             Thanks for your help!
           close-issue-message: "This issue was closed due to inactivity. If you're still experiencing this problem, please open a new issue with a link to this issue."
-          days-before-stale: 120
-          days-before-close: 7
+          days-before-stale: 180
+          days-before-close: 60
           any-of-issue-labels: "bug,panic / crash"
           operations-per-run: 1000
           ascending: true


### PR DESCRIPTION
Closes #None

Release Notes:

Stale deadline mentioned in #9878 and #9880 
