### PR TITLE
Remove extra space in `zed --version` string for non-stable

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -343,7 +343,7 @@ mod linux {
                 if *RELEASE_CHANNEL == "stable" {
                     "".to_string()
                 } else {
-                    format!(" {} ", *RELEASE_CHANNEL)
+                    format!("{} ", *RELEASE_CHANNEL)
                 },
                 option_env!("RELEASE_VERSION").unwrap_or_default(),
                 self.0.display(),


### PR DESCRIPTION
Release Notes:

- N/A