### PR TITLE
open_ai: Include o3-mini in `Model::from_id`

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -103,6 +103,7 @@ impl Model {
             "o1" => Ok(Self::O1),
             "o1-preview" => Ok(Self::O1Preview),
             "o1-mini" => Ok(Self::O1Mini),
+            "o3-mini" => Ok(Self::O3Mini),
             _ => Err(anyhow!("invalid model id")),
         }
     }


### PR DESCRIPTION
I was getting "Error interacting with language model Failed to connect to OpenAI API: The model '03-mini' does not exist or you do not have access to it." and after reading the source I believe this might be the culprit.

I have to admit I haven't tried this solution because the toolchain is foreign to me. This is a drive-by PR but I thought it might help anyway.

Release Notes:

- N/A