### PR TITLE
Accept edit predictions with `alt-tab` in addition to `tab`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -503,17 +503,17 @@
     }
   },
   {
+    "context": "Editor && inline_completion",
+    "bindings": {
+      // Changing the modifier currently breaks accepting while you also an LSP completions menu open
+      "alt-enter": "editor::AcceptInlineCompletion"
+    }
+  },
+  {
     "context": "Editor && inline_completion && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptInlineCompletion"
-    }
-  },
-  {
-    "context": "Editor && inline_completion && showing_completions",
-    "bindings": {
-      // Currently, changing this binding breaks the preview behavior
-      "alt-enter": "editor::AcceptInlineCompletion"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -580,17 +580,17 @@
     }
   },
   {
+    "context": "Editor && inline_completion",
+    "bindings": {
+      // Changing the modifier currently breaks accepting while you also an LSP completions menu open
+      "alt-tab": "editor::AcceptInlineCompletion"
+    }
+  },
+  {
     "context": "Editor && inline_completion && !showing_completions",
     "use_key_equivalents": true,
     "bindings": {
       "tab": "editor::AcceptInlineCompletion"
-    }
-  },
-  {
-    "context": "Editor && inline_completion && showing_completions",
-    "bindings": {
-      // Currently, changing this binding breaks the preview behavior
-      "alt-tab": "editor::AcceptInlineCompletion"
     }
   },
   {


### PR DESCRIPTION
When you have an edit prediction available, you can now also accept it with `alt-tab` (or `alt-enter` on Linux) even if you don't have an LSP completions menu open. This is meant to lower the mental load when going from one mode to another.

Release Notes:

- N/A