### PR TITLE
Revert "copilot: Correct o3-mini context length"

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -89,7 +89,7 @@ impl Model {
             Self::Gpt4o => 64000,
             Self::Gpt4 => 32768,
             Self::Gpt3_5Turbo => 12288,
-            Self::O3Mini => 200_000,
+            Self::O3Mini => 20000,
             Self::O1 => 20000,
             Self::Claude3_5Sonnet => 200_000,
         }


### PR DESCRIPTION
- Reverts zed-industries/zed#24152

Per comment here: 
- https://github.com/zed-industries/zed/pull/24152#issuecomment-2636808170

Confirmed.
<img width="676" alt="Screenshot 2025-02-05 at 9 49 51" src="https://github.com/user-attachments/assets/af585e99-a572-44aa-be64-45ec40df28f8" />

Release Notes:

- N/A