### PR TITLE
edit prediction: Don't log an error if license file isn't found

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -957,8 +957,7 @@ impl LicenseDetectionWatcher {
         Self {
             is_open_source_rx,
             _is_open_source_task: cx.spawn(|_, _| async move {
-                // TODO: Don't display error if file not found
-                let Some(loaded_file) = loaded_file_fut.await.log_err() else {
+                let Ok(loaded_file) = loaded_file_fut.await else {
                     return;
                 };
 


### PR DESCRIPTION
Logging an error in this case isn't super necessary.

Release Notes:

- N/A
