### PR TITLE
extension_cli: Include the list of what an extension provides in the generated manifest

### DIFF
--- a/crates/collab/src/db/queries/extensions.rs
+++ b/crates/collab/src/db/queries/extensions.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::str::FromStr;
 
 use chrono::Utc;
@@ -370,6 +371,7 @@ fn metadata_from_extension_and_version(
             repository: version.repository,
             schema_version: Some(version.schema_version),
             wasm_api_version: version.wasm_api_version,
+            provides: BTreeSet::default(),
         },
 
         published_at: convert_time_to_chrono(version.published_at),

--- a/crates/collab/src/db/tests/extension_tests.rs
+++ b/crates/collab/src/db/tests/extension_tests.rs
@@ -1,10 +1,12 @@
+use std::collections::BTreeSet;
+use std::sync::Arc;
+
 use super::Database;
 use crate::db::ExtensionVersionConstraints;
 use crate::{
     db::{queries::extensions::convert_time_to_chrono, ExtensionMetadata, NewExtensionVersion},
     test_both_dbs,
 };
-use std::sync::Arc;
 
 test_both_dbs!(
     test_extensions,
@@ -97,6 +99,7 @@ async fn test_extensions(db: &Arc<Database>) {
                     repository: "ext1/repo".into(),
                     schema_version: Some(1),
                     wasm_api_version: None,
+                    provides: BTreeSet::default(),
                 },
                 published_at: t0_chrono,
                 download_count: 0,
@@ -111,6 +114,7 @@ async fn test_extensions(db: &Arc<Database>) {
                     repository: "ext2/repo".into(),
                     schema_version: Some(0),
                     wasm_api_version: None,
+                    provides: BTreeSet::default(),
                 },
                 published_at: t0_chrono,
                 download_count: 0
@@ -132,6 +136,7 @@ async fn test_extensions(db: &Arc<Database>) {
                 repository: "ext2/repo".into(),
                 schema_version: Some(0),
                 wasm_api_version: None,
+                provides: BTreeSet::default(),
             },
             published_at: t0_chrono,
             download_count: 0
@@ -172,6 +177,7 @@ async fn test_extensions(db: &Arc<Database>) {
                     repository: "ext2/repo".into(),
                     schema_version: Some(0),
                     wasm_api_version: None,
+                    provides: BTreeSet::default(),
                 },
                 published_at: t0_chrono,
                 download_count: 7
@@ -186,6 +192,7 @@ async fn test_extensions(db: &Arc<Database>) {
                     repository: "ext1/repo".into(),
                     schema_version: Some(1),
                     wasm_api_version: None,
+                    provides: BTreeSet::default(),
                 },
                 published_at: t0_chrono,
                 download_count: 5,
@@ -258,6 +265,7 @@ async fn test_extensions(db: &Arc<Database>) {
                     repository: "ext2/repo".into(),
                     schema_version: Some(0),
                     wasm_api_version: None,
+                    provides: BTreeSet::default(),
                 },
                 published_at: t0_chrono,
                 download_count: 7
@@ -272,6 +280,7 @@ async fn test_extensions(db: &Arc<Database>) {
                     repository: "ext1/repo".into(),
                     schema_version: Some(1),
                     wasm_api_version: None,
+                    provides: BTreeSet::default(),
                 },
                 published_at: t0_chrono,
                 download_count: 5,
@@ -378,6 +387,7 @@ async fn test_extensions_by_id(db: &Arc<Database>) {
                 repository: "ext1/repo".into(),
                 schema_version: Some(1),
                 wasm_api_version: Some("0.0.4".into()),
+                provides: BTreeSet::default(),
             },
             published_at: t0_chrono,
             download_count: 0,

--- a/crates/rpc/src/extension.rs
+++ b/crates/rpc/src/extension.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
@@ -11,6 +13,22 @@ pub struct ExtensionApiManifest {
     pub repository: String,
     pub schema_version: Option<i32>,
     pub wasm_api_version: Option<String>,
+    #[serde(default)]
+    pub provides: BTreeSet<ExtensionProvides>,
+}
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum ExtensionProvides {
+    Themes,
+    IconThemes,
+    Languages,
+    Grammars,
+    LanguageServers,
+    ContextServers,
+    SlashCommands,
+    IndexedDocsProviders,
+    Snippets,
 }
 
 #[derive(Clone, Serialize, Deserialize, Debug, PartialEq)]


### PR DESCRIPTION
This PR updates the Zed extension CLI with support for populating the `provides` field in the generated extension manifest.

This field will contain the set of features that the extension provides.

For example:

```
"provides": ["themes", "icon-themes"]
```

Release Notes:

- N/A
