### PR TITLE
panel: Remove unneeded `lib.name` field in `Cargo.toml`

### DIFF
--- a/crates/panel/Cargo.toml
+++ b/crates/panel/Cargo.toml
@@ -9,13 +9,9 @@ license = "GPL-3.0-or-later"
 workspace = true
 
 [lib]
-name = "panel"
 path = "src/panel.rs"
 
 [dependencies]
 gpui.workspace = true
 ui.workspace = true
 workspace.workspace = true
-
-[features]
-default = []

--- a/script/new-crate
+++ b/script/new-crate
@@ -53,8 +53,10 @@ license = "$LICENSE_MODE"
 workspace = true
 
 [lib]
-name = "$CRATE_NAME"
 path = "src/$CRATE_NAME.rs"
+
+[features]
+default = []
 
 [dependencies]
 anyhow.workspace = true
@@ -67,9 +69,6 @@ util.workspace = true
 # client.workspace = true
 # project.workspace = true
 # settings.workspace = true
-
-[features]
-default = []
 EOF
 )
 


### PR DESCRIPTION
This PR removes the `name` field from under `lib` in the `Cargo.toml` file for the `panel` crate, as it isn't necessary.

Also removed it from `script/new-crate`.

Release Notes:

- N/A
