### PR TITLE
extensions_ui: Show extension features on cards

### DIFF
--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -6,7 +6,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 use std::{ops::Range, sync::Arc};
 
-use client::ExtensionMetadata;
+use client::{ExtensionMetadata, ExtensionProvides};
 use collections::{BTreeMap, BTreeSet};
 use editor::{Editor, EditorElement, EditorStyle};
 use extension_host::{ExtensionManifest, ExtensionOperation, ExtensionStore};
@@ -567,6 +567,11 @@ impl ExtensionsPage {
             _ => None,
         };
 
+        let mut provides = extension.manifest.provides.clone();
+        provides.insert(ExtensionProvides::Themes);
+        provides.insert(ExtensionProvides::IconThemes);
+        provides.insert(ExtensionProvides::LanguageServers);
+
         ExtensionCard::new()
             .overridden_by_dev_extension(has_dev_extension)
             .child(
@@ -588,7 +593,48 @@ impl ExtensionsPage {
                                         Headline::new(format!("(v{installed_version} installed)",))
                                             .size(HeadlineSize::XSmall)
                                     }),
-                            ),
+                            )
+                            .map(|parent| {
+                                if provides.is_empty() {
+                                    return parent;
+                                }
+
+                                parent.child(
+                                    h_flex().gap_2().children(
+                                        provides
+                                            .iter()
+                                            .map(|provides| {
+                                                let label = match provides {
+                                                    ExtensionProvides::Themes => "Themes",
+                                                    ExtensionProvides::IconThemes => "Icon Themes",
+                                                    ExtensionProvides::Languages => "Languages",
+                                                    ExtensionProvides::Grammars => "Grammars",
+                                                    ExtensionProvides::LanguageServers => {
+                                                        "Language Servers"
+                                                    }
+                                                    ExtensionProvides::ContextServers => {
+                                                        "Context Servers"
+                                                    }
+                                                    ExtensionProvides::SlashCommands => {
+                                                        "Slash Commands"
+                                                    }
+                                                    ExtensionProvides::IndexedDocsProviders => {
+                                                        "Indexed Docs Providers"
+                                                    }
+                                                    ExtensionProvides::Snippets => "Snippets",
+                                                };
+                                                div()
+                                                    .bg(cx.theme().colors().element_background)
+                                                    .border_1()
+                                                    .rounded_md()
+                                                    .child(
+                                                        Label::new(label).size(LabelSize::XSmall),
+                                                    )
+                                            })
+                                            .collect::<Vec<_>>(),
+                                    ),
+                                )
+                            }),
                     )
                     .child(
                         h_flex()

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -568,9 +568,12 @@ impl ExtensionsPage {
         };
 
         let mut provides = extension.manifest.provides.clone();
-        provides.insert(ExtensionProvides::Themes);
-        provides.insert(ExtensionProvides::IconThemes);
-        provides.insert(ExtensionProvides::LanguageServers);
+        // TODO: Remove before merging.
+        if provides.is_empty() {
+            provides.insert(ExtensionProvides::Themes);
+            provides.insert(ExtensionProvides::IconThemes);
+            provides.insert(ExtensionProvides::LanguageServers);
+        }
 
         ExtensionCard::new()
             .overridden_by_dev_extension(has_dev_extension)
@@ -580,7 +583,6 @@ impl ExtensionsPage {
                     .child(
                         h_flex()
                             .gap_2()
-                            .items_end()
                             .child(
                                 Headline::new(extension.manifest.name.clone())
                                     .size(HeadlineSize::Medium),
@@ -625,7 +627,9 @@ impl ExtensionsPage {
                                                 };
                                                 div()
                                                     .bg(cx.theme().colors().element_background)
+                                                    .px_0p5()
                                                     .border_1()
+                                                    .border_color(cx.theme().colors().border)
                                                     .rounded_md()
                                                     .child(
                                                         Label::new(label).size(LabelSize::XSmall),

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -567,14 +567,6 @@ impl ExtensionsPage {
             _ => None,
         };
 
-        let mut provides = extension.manifest.provides.clone();
-        // TODO: Remove before merging.
-        if provides.is_empty() {
-            provides.insert(ExtensionProvides::Themes);
-            provides.insert(ExtensionProvides::IconThemes);
-            provides.insert(ExtensionProvides::LanguageServers);
-        }
-
         ExtensionCard::new()
             .overridden_by_dev_extension(has_dev_extension)
             .child(
@@ -597,13 +589,15 @@ impl ExtensionsPage {
                                     }),
                             )
                             .map(|parent| {
-                                if provides.is_empty() {
+                                if extension.manifest.provides.is_empty() {
                                     return parent;
                                 }
 
                                 parent.child(
                                     h_flex().gap_2().children(
-                                        provides
+                                        extension
+                                            .manifest
+                                            .provides
                                             .iter()
                                             .map(|provides| {
                                                 let label = match provides {


### PR DESCRIPTION
This PR updates the extensions list to display the features that an extension provides.

<img width="1309" alt="Screenshot 2025-02-05 at 4 12 07 PM" src="https://github.com/user-attachments/assets/ff0c61cd-b7fe-49c3-9fc8-a0ab6b0511a6" />

Note that this will only show up for extensions that have this data (which will be extensions published/updated on or after now).

Here's the view with some mocked data:

<img width="1309" alt="Screenshot 2025-02-05 at 4 01 56 PM" src="https://github.com/user-attachments/assets/d6d6a818-d6ac-4162-9309-95472b17833a" />

Release Notes:

- N/A
