### PR TITLE
edit predictions: Preview while holding modifier mode

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -783,7 +783,14 @@
       "**/*.cert",
       "**/*.crt",
       "**/secrets.yml"
-    ]
+    ],
+    // When to show edit predictions previews in buffer.
+    // This setting takes two possible values:
+    // 1. Display inline when there are no language server completions available.
+    //     "inline_preview": "auto"
+    // 2. Display inline when holding modifier key (alt by default).
+    //     "inline_preview": "when_holding_modifier"
+    "inline_preview": "auto"
   },
   // Settings specific to journaling
   "journal": {

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -459,7 +459,7 @@ impl ContextEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.editor.read(cx).has_active_completions_menu() {
+        if self.editor.read(cx).has_visible_completions_menu() {
             return;
         }
 

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -169,7 +169,6 @@ pub struct CompletionsMenu {
     resolve_completions: bool,
     show_completion_documentation: bool,
     last_rendered_range: Rc<RefCell<Option<Range<usize>>>>,
-    pub previewing_inline_completion: bool,
 }
 
 impl CompletionsMenu {
@@ -200,7 +199,6 @@ impl CompletionsMenu {
             scroll_handle: UniformListScrollHandle::new(),
             resolve_completions: true,
             last_rendered_range: RefCell::new(None).into(),
-            previewing_inline_completion: false,
         }
     }
 
@@ -257,7 +255,6 @@ impl CompletionsMenu {
             resolve_completions: false,
             show_completion_documentation: false,
             last_rendered_range: RefCell::new(None).into(),
-            previewing_inline_completion: false,
         }
     }
 
@@ -410,12 +407,8 @@ impl CompletionsMenu {
         .detach();
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.entries.borrow().is_empty()
-    }
-
     pub fn visible(&self) -> bool {
-        !self.is_empty() && !self.previewing_inline_completion
+        !self.entries.borrow().is_empty()
     }
 
     fn origin(&self) -> ContextMenuOrigin {
@@ -708,10 +701,6 @@ impl CompletionsMenu {
         self.selected_item = 0;
         // This keeps the display consistent when y_flipped.
         self.scroll_handle.scroll_to_item(0, ScrollStrategy::Top);
-    }
-
-    pub fn set_previewing_inline_completion(&mut self, value: bool) {
-        self.previewing_inline_completion = value;
     }
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3159,7 +3159,10 @@ impl EditorElement {
 
         {
             let editor = self.editor.read(cx);
-            if editor.has_active_completions_menu() && editor.show_inline_completions_in_menu(cx) {
+            if editor.inline_completion_visible_in_cursor_popover(
+                editor.has_active_inline_completion(),
+                cx,
+            ) {
                 height_above_menu +=
                     editor.edit_prediction_cursor_popover_height() + POPOVER_Y_PADDING;
                 edit_prediction_popover_visible = true;
@@ -3663,7 +3666,12 @@ impl EditorElement {
         const PADDING_X: Pixels = Pixels(24.);
         const PADDING_Y: Pixels = Pixels(2.);
 
-        let active_inline_completion = self.editor.read(cx).active_inline_completion.as_ref()?;
+        let editor = self.editor.read(cx);
+        let active_inline_completion = editor.active_inline_completion.as_ref()?;
+
+        if editor.inline_completion_visible_in_cursor_popover(true, cx) {
+            return None;
+        }
 
         match &active_inline_completion.completion {
             InlineCompletion::Move { target, .. } => {
@@ -3730,7 +3738,7 @@ impl EditorElement {
                 display_mode,
                 snapshot,
             } => {
-                if self.editor.read(cx).has_active_completions_menu() {
+                if self.editor.read(cx).has_visible_completions_menu() {
                     return None;
                 }
 

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -158,7 +158,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.pending_rename.is_some() || self.has_active_completions_menu() {
+        if self.pending_rename.is_some() || self.has_visible_completions_menu() {
             return;
         }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -21,6 +21,7 @@ mod toolchain;
 pub mod buffer_tests;
 pub mod markdown;
 
+pub use crate::language_settings::InlineCompletionPreviewMode;
 use crate::language_settings::SoftWrap;
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -214,6 +214,19 @@ pub struct InlineCompletionSettings {
     pub provider: InlineCompletionProvider,
     /// A list of globs representing files that edit predictions should be disabled for.
     pub disabled_globs: Vec<GlobMatcher>,
+    /// When to show edit predictions previews in buffer.
+    pub inline_preview: InlineCompletionPreviewMode,
+}
+
+/// The mode in which edit predictions should be displayed.
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InlineCompletionPreviewMode {
+    /// Display inline when there are no language server completions available.
+    #[default]
+    Auto,
+    /// Display inline when holding modifier key (alt by default).
+    WhenHoldingModifier,
 }
 
 /// The settings for all languages.
@@ -406,6 +419,9 @@ pub struct InlineCompletionSettingsContent {
     /// A list of globs representing files that edit predictions should be disabled for.
     #[serde(default)]
     pub disabled_globs: Option<Vec<String>>,
+    /// When to show edit predictions previews in buffer.
+    #[serde(default)]
+    pub inline_preview: InlineCompletionPreviewMode,
 }
 
 /// The settings for enabling/disabling features.
@@ -890,6 +906,11 @@ impl AllLanguageSettings {
         self.language(None, language.map(|l| l.name()).as_ref(), cx)
             .show_inline_completions
     }
+
+    /// Returns the edit predictions preview mode for the given language and path.
+    pub fn inline_completions_preview_mode(&self) -> InlineCompletionPreviewMode {
+        self.inline_completions.inline_preview
+    }
 }
 
 fn merge_with_editorconfig(settings: &mut LanguageSettings, cfg: &EditorconfigProperties) {
@@ -987,6 +1008,12 @@ impl settings::Settings for AllLanguageSettings {
             .features
             .as_ref()
             .and_then(|f| f.inline_completion_provider);
+        let mut inline_completions_preview = default_value
+            .inline_completions
+            .as_ref()
+            .map(|inline_completions| inline_completions.inline_preview)
+            .ok_or_else(Self::missing_default)?;
+
         let mut completion_globs: HashSet<&String> = default_value
             .inline_completions
             .as_ref()
@@ -1017,12 +1044,13 @@ impl settings::Settings for AllLanguageSettings {
             {
                 inline_completion_provider = Some(provider);
             }
-            if let Some(globs) = user_settings
-                .inline_completions
-                .as_ref()
-                .and_then(|f| f.disabled_globs.as_ref())
-            {
-                completion_globs.extend(globs.iter());
+
+            if let Some(inline_completions) = user_settings.inline_completions.as_ref() {
+                inline_completions_preview = inline_completions.inline_preview;
+
+                if let Some(disabled_globs) = inline_completions.disabled_globs.as_ref() {
+                    completion_globs.extend(disabled_globs.iter());
+                }
             }
 
             // A user's global settings override the default global settings and
@@ -1075,6 +1103,7 @@ impl settings::Settings for AllLanguageSettings {
                     .iter()
                     .filter_map(|g| Some(globset::Glob::new(g).ok()?.compile_matcher()))
                     .collect(),
+                inline_preview: inline_completions_preview,
             },
             defaults,
             languages,


### PR DESCRIPTION
This PR adds a new `inline_completions.inline_preview` config which can be set to `auto` (current behavior) or to `when_holding_modifier`. 
When set to the latter, instead of showing edit prediction previews inline in the buffer, we'll show it in a popover (even when there's no LSP completion) so your isn't constantly moving as completions arrive.

https://github.com/user-attachments/assets/3615d151-3633-4ee4-98b9-66ee0aa735b8

Release Notes:

- N/A
