### PR TITLE
Mostly fix hover tooltips not respecting occlusion

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -734,7 +734,6 @@ impl Element for InteractiveText {
 
                 if let Some(tooltip_builder) = self.tooltip_builder.clone() {
                     let active_tooltip = interactive_state.active_tooltip.clone();
-                    let pending_mouse_down = interactive_state.mouse_down_index.clone();
                     let build_tooltip = Rc::new({
                         let tooltip_is_hoverable = false;
                         let text_layout = text_layout.clone();
@@ -746,11 +745,12 @@ impl Element for InteractiveText {
                                 .map(|view| (view, tooltip_is_hoverable))
                         }
                     });
-                    // Use bounds instead of testing hitbox since check_is_hovered is also
-                    // called during prepaint.
-                    let source_bounds = hitbox.bounds;
-                    let check_is_hovered = Rc::new({
+
+                    // Use bounds instead of testing hitbox since this is called during prepaint.
+                    let check_is_hovered_during_prepaint = Rc::new({
+                        let source_bounds = hitbox.bounds;
                         let text_layout = text_layout.clone();
+                        let pending_mouse_down = interactive_state.mouse_down_index.clone();
                         move |window: &Window| {
                             text_layout
                                 .index_for_position(window.mouse_position())
@@ -759,11 +759,26 @@ impl Element for InteractiveText {
                                 && pending_mouse_down.get().is_none()
                         }
                     });
+
+                    let check_is_hovered = Rc::new({
+                        let hitbox = hitbox.clone();
+                        let text_layout = text_layout.clone();
+                        let pending_mouse_down = interactive_state.mouse_down_index.clone();
+                        move |window: &Window| {
+                            text_layout
+                                .index_for_position(window.mouse_position())
+                                .is_ok()
+                                && hitbox.is_hovered(window)
+                                && pending_mouse_down.get().is_none()
+                        }
+                    });
+
                     register_tooltip_mouse_handlers(
                         &active_tooltip,
                         self.tooltip_id,
                         build_tooltip,
                         check_is_hovered,
+                        check_is_hovered_during_prepaint,
                         window,
                     );
                 }


### PR DESCRIPTION
Regression in #22644

Unfortunately not a full fix, In the case where a tooltip gets displayed and then gets occluded after display, it will stick around until the mouse exits the hover bounds.

Release Notes:

- N/A