### PR TITLE
extensions_ui: Add general structure for filtering extensions by what they provide

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4490,6 +4490,7 @@ dependencies = [
  "db",
  "editor",
  "extension_host",
+ "feature_flags",
  "fs",
  "fuzzy",
  "gpui",

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -8,8 +8,9 @@ mod extension_store_test;
 use anyhow::{anyhow, bail, Context as _, Result};
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
+use client::ExtensionProvides;
 use client::{proto, telemetry::Telemetry, Client, ExtensionMetadata, GetExtensionsResponse};
-use collections::{btree_map, BTreeMap, HashMap, HashSet};
+use collections::{btree_map, BTreeMap, BTreeSet, HashMap, HashSet};
 use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
 pub use extension::ExtensionManifest;
 use extension::{
@@ -464,12 +465,24 @@ impl ExtensionStore {
     pub fn fetch_extensions(
         &self,
         search: Option<&str>,
+        provides_filter: Option<&BTreeSet<ExtensionProvides>>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<ExtensionMetadata>>> {
         let version = CURRENT_SCHEMA_VERSION.to_string();
         let mut query = vec![("max_schema_version", version.as_str())];
         if let Some(search) = search {
             query.push(("filter", search));
+        }
+
+        let provides_filter = provides_filter.map(|provides_filter| {
+            provides_filter
+                .iter()
+                .map(|provides| provides.to_string())
+                .collect::<Vec<_>>()
+                .join(",")
+        });
+        if let Some(provides_filter) = provides_filter.as_deref() {
+            query.push(("provides", provides_filter));
         }
 
         self.fetch_extensions_from_api("/extensions", &query, cx)

--- a/crates/extensions_ui/Cargo.toml
+++ b/crates/extensions_ui/Cargo.toml
@@ -18,6 +18,7 @@ collections.workspace = true
 db.workspace = true
 editor.workspace = true
 extension_host.workspace = true
+feature_flags.workspace = true
 fs.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true

--- a/crates/rpc/src/extension.rs
+++ b/crates/rpc/src/extension.rs
@@ -19,7 +19,18 @@ pub struct ExtensionApiManifest {
 }
 
 #[derive(
-    Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy, Serialize, Deserialize, EnumString,
+    Debug,
+    PartialEq,
+    Eq,
+    PartialOrd,
+    Ord,
+    Hash,
+    Clone,
+    Copy,
+    Serialize,
+    Deserialize,
+    EnumString,
+    strum::Display,
 )]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]


### PR DESCRIPTION
This PR adds the general structure for filtering the extensions list by what the extensions provide.

Currently flagged for Zed staff until we get some design direction on how best to present the filter.

Release Notes:

- N/A
