### PR TITLE
gpui: Implement `HasWindowHandle` on `Window`

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -23,6 +23,7 @@ use futures::FutureExt;
 #[cfg(target_os = "macos")]
 use media::core_video::CVImageBuffer;
 use parking_lot::RwLock;
+use raw_window_handle::{HandleError, HasWindowHandle};
 use refineable::Refineable;
 use slotmap::SlotMap;
 use smallvec::SmallVec;
@@ -3941,6 +3942,12 @@ impl AnyWindowHandle {
             .context("the type of the window's root view has changed")?;
 
         cx.read_window(&view, read)
+    }
+}
+
+impl HasWindowHandle for Window {
+    fn window_handle(&self) -> Result<raw_window_handle::WindowHandle<'_>, HandleError> {
+        self.platform_window.window_handle()
     }
 }
 


### PR DESCRIPTION
Implement `raw_window_handle::HasWindowHandle` for `gpui::Window`

This opens a lot of possibility of using gpui with platform specific APIs.

Edit: With this exposed, we can use crates like `window-vibrancy`, `muda` (menus crate) or even use `wry` (a webview renderer) to create a child `WebView` inside the gpui window.  

Release Notes:

- N/A