### PR TITLE
gpui: Add `WindowKind::Child` kind

### DIFF
--- a/crates/gpui/examples/window_positioning.rs
+++ b/crates/gpui/examples/window_positioning.rs
@@ -47,7 +47,7 @@ impl Render for WindowContent {
     }
 }
 
-fn build_window_options(display_id: DisplayId, bounds: Bounds<Pixels>) -> WindowOptions {
+fn build_window_options(display_id: DisplayId, bounds: Bounds<Pixels>) -> WindowOptions<'static> {
     WindowOptions {
         // Set the bounds of the window in screen coordinates
         window_bounds: Some(WindowBounds::Windowed(bounds)),

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -592,7 +592,7 @@ impl App {
     /// functionality.
     pub fn open_window<V: 'static + Render>(
         &mut self,
-        options: crate::WindowOptions,
+        options: crate::WindowOptions<'_>,
         build_root_view: impl FnOnce(&mut Window, &mut App) -> Entity<V>,
     ) -> anyhow::Result<WindowHandle<V>> {
         self.update(|cx| {

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -157,7 +157,7 @@ impl AsyncApp {
     /// Open a window with the given options based on the root view returned by the given function.
     pub fn open_window<V>(
         &self,
-        options: crate::WindowOptions,
+        options: crate::WindowOptions<'_>,
         build_root_view: impl FnOnce(&mut Window, &mut App) -> Entity<V>,
     ) -> Result<WindowHandle<V>>
     where

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -912,7 +912,7 @@ pub trait InputHandler: 'static {
 
 /// The variables that can be configured when creating a new window
 #[derive(Debug)]
-pub struct WindowOptions {
+pub struct WindowOptions<'a> {
     /// Specifies the state and bounds of the window in screen coordinates.
     /// - `None`: Inherit the bounds.
     /// - `Some(WindowBounds)`: Open a window with corresponding state and its restore size.
@@ -928,7 +928,7 @@ pub struct WindowOptions {
     pub show: bool,
 
     /// The kind of window to create
-    pub kind: WindowKind,
+    pub kind: WindowKind<'a>,
 
     /// Whether the window should be movable by the user
     pub is_movable: bool,
@@ -960,7 +960,7 @@ pub struct WindowOptions {
     ),
     allow(dead_code)
 )]
-pub(crate) struct WindowParams {
+pub(crate) struct WindowParams<'a> {
     pub bounds: Bounds<Pixels>,
 
     /// The titlebar configuration of the window
@@ -969,7 +969,7 @@ pub(crate) struct WindowParams {
 
     /// The kind of window to create
     #[cfg_attr(any(target_os = "linux", target_os = "freebsd"), allow(dead_code))]
-    pub kind: WindowKind,
+    pub kind: WindowKind<'a>,
 
     /// Whether the window should be movable by the user
     #[cfg_attr(any(target_os = "linux", target_os = "freebsd"), allow(dead_code))]
@@ -1017,7 +1017,7 @@ impl WindowBounds {
     }
 }
 
-impl Default for WindowOptions {
+impl Default for WindowOptions<'_> {
     fn default() -> Self {
         Self {
             window_bounds: None,
@@ -1055,13 +1055,18 @@ pub struct TitlebarOptions {
 
 /// The kind of window to create
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
-pub enum WindowKind {
+pub enum WindowKind<'a> {
     /// A normal application window
     Normal,
 
     /// A window that appears above all other windows, usually used for alerts or popups
     /// use sparingly!
     PopUp,
+
+    /// A window that appears within another parent.
+    ///
+    /// X11, Wayland, macOS: Not implemented.
+    Child(raw_window_handle::WindowHandle<'a>),
 }
 
 /// The appearance of the window, as defined by the operating system.

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -503,6 +503,9 @@ impl X11WindowState {
                     ),
                 )?;
             }
+            if let WindowKind::Child(_) = params.kind {
+                // TODO: implement Child windows on x11
+            }
 
             check_reply(
                 || "X11 ChangeProperty32 setting protocols failed.",

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -528,6 +528,12 @@ impl MacWindow {
                     style_mask |= NSWindowStyleMaskNonactivatingPanel;
                     msg_send![PANEL_CLASS, alloc]
                 }
+                WindowKind::Child(_) => {
+                    // TODO: implement child windows on macOS
+                    //
+                    // fallback to WindowKind::Normal implementation
+                    msg_send![WINDOW_CLASS, alloc]
+                }
             };
 
             let display = display_id
@@ -671,6 +677,13 @@ impl MacWindow {
 
             match kind {
                 WindowKind::Normal => {
+                    native_window.setLevel_(NSNormalWindowLevel);
+                    native_window.setAcceptsMouseMovedEvents_(YES);
+                }
+                WindowKind::Child(_) => {
+                    // TODO: implement child windows on macOS
+                    //
+                    // fallback to WindowKind::Normal implementation
                     native_window.setLevel_(NSNormalWindowLevel);
                     native_window.setAcceptsMouseMovedEvents_(YES);
                 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -701,7 +701,7 @@ fn default_bounds(display_id: Option<DisplayId>, cx: &mut App) -> Bounds<Pixels>
 impl Window {
     pub(crate) fn new(
         handle: AnyWindowHandle,
-        options: WindowOptions,
+        options: WindowOptions<'_>,
         cx: &mut App,
     ) -> Result<Self> {
         let WindowOptions {


### PR DESCRIPTION
Add `WindowKind::Child` variant that holds a `raw_window_handle::WindowHandle<'a>` type
and so it introduces a lifetime bound on `WindowKind` and `WindowOptions` type
which is a breaking change.

Currently only implemented on Windows and stubbed on other platforms.

I am experimenting with gpui in a project where I want use gpui to render a window inside another HWND (Windows 11 Taskbar) and this was the only way that worked.

### Alternatives considered:

With #24327, I tried using `SetParent` API and `SetWindowLongPtrW` to add `WS_CHILD` window style but that didn't work, one of two things happen:
- gpui crashes due to double borrow because `SetWindowLongPtrW` and `WS_CHILD` will cause a resize and so a redraw while gpui is already redrawing. This is not the main problem though, so let's ignore it for now.
- If I don't use `SetWindowLongPtrW` to add `WS_CHILD`, the window is added to the parent (taskbar HWND in my case), but gpui doesn't render anything.   

Release Notes:

- Added `WindowKind::Child` variant to create child windows, only on Windows for now.
- **Breaking**: Added lifetime bound on `WindowKind` and `WindowOptions` types.