### PR TITLE
License detection: Add `LICENSE.txt` and `LICENCE.txt`

### DIFF
--- a/crates/zeta/src/license_detection.rs
+++ b/crates/zeta/src/license_detection.rs
@@ -1,5 +1,8 @@
 use regex::Regex;
 
+// The most common license locations, with US and UK English spelling
+pub const LICENSE_FILES_TO_CHECK: &[&str] = &["LICENSE", "LICENCE", "LICENSE.txt", "LICENCE.txt"];
+
 pub fn is_license_eligible_for_data_collection(license: &str) -> bool {
     // TODO: Include more licenses later (namely, Apache)
     for pattern in [MIT_LICENSE_REGEX, ISC_LICENSE_REGEX] {

--- a/crates/zeta/src/license_detection.rs
+++ b/crates/zeta/src/license_detection.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-// The most common license locations, with US and UK English spelling
+/// The most common license locations, with US and UK English spelling.
 pub const LICENSE_FILES_TO_CHECK: &[&str] = &["LICENSE", "LICENCE", "LICENSE.txt", "LICENCE.txt"];
 
 pub fn is_license_eligible_for_data_collection(license: &str) -> bool {

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -11,6 +11,7 @@ use db::kvp::KEY_VALUE_STORE;
 pub use init::*;
 use inline_completion::DataCollectionState;
 pub use license_detection::is_license_eligible_for_data_collection;
+use license_detection::LICENSE_FILES_TO_CHECK;
 pub use onboarding_banner::*;
 pub use rate_completion_modal::*;
 
@@ -951,8 +952,6 @@ struct LicenseDetectionWatcher {
 impl LicenseDetectionWatcher {
     pub fn new(worktree: &Worktree, cx: &mut Context<Worktree>) -> Self {
         let (mut is_open_source_tx, is_open_source_rx) = watch::channel_with::<bool>(false);
-
-        const LICENSE_FILES_TO_CHECK: [&'static str; 2] = ["LICENSE", "LICENCE"]; // US and UK English spelling
 
         // Check if worktree is a single file, if so we do not need to check for a LICENSE file
         let task = if worktree.abs_path().is_file() {


### PR DESCRIPTION
Also move the list of files to `crates/zeta/src/license_detection.rs` for better visibility.

Release Notes:

- N/A
