### PR TITLE
Wrap AnyView.cached_style in an Rc to make the struct much smaller

### DIFF
--- a/crates/gpui/src/view.rs
+++ b/crates/gpui/src/view.rs
@@ -8,6 +8,7 @@ use anyhow::Result;
 use collections::FxHashSet;
 use refineable::Refineable;
 use std::mem;
+use std::rc::Rc;
 use std::{any::TypeId, fmt, ops::Range};
 
 struct AnyViewState {
@@ -73,7 +74,7 @@ impl<V: Render> Element for Entity<V> {
 pub struct AnyView {
     entity: AnyEntity,
     render: fn(&AnyView, &mut Window, &mut App) -> AnyElement,
-    cached_style: Option<StyleRefinement>,
+    cached_style: Option<Rc<StyleRefinement>>,
 }
 
 impl<V: Render> From<Entity<V>> for AnyView {
@@ -91,7 +92,7 @@ impl AnyView {
     /// When using this method, the view's previous layout and paint will be recycled from the previous frame if [Context::notify] has not been called since it was rendered.
     /// The one exception is when [Window::refresh] is called, in which case caching is ignored.
     pub fn cached(mut self, style: StyleRefinement) -> Self {
-        self.cached_style = Some(style);
+        self.cached_style = Some(style.into());
         self
     }
 


### PR DESCRIPTION
Byte size before was 672, now is 56.  The `cached` method is only used in two places, so this was a lot of extra bytes being shuffled around for every `AnyView` not using this.

Release Notes:

- N/A