### PR TITLE
Preserve Wrangler logs during docs deployment CI runs

### DIFF
--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -63,3 +63,10 @@ jobs:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           command: deploy .cloudflare/docs-proxy/src/worker.js
+
+      - name: Preserve Wrangler logs
+        uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4
+        if: always()
+        with:
+          name: wrangler_logs
+          path: /home/runner/.config/.wrangler/logs/


### PR DESCRIPTION
Adds a log collection step to debug errors like https://github.com/zed-industries/zed/actions/runs/13175284280/job/36773129216#step:8:29

During testing though, the CI had passed, so 500 seems to be unrelated to Zed changes: https://github.com/zed-industries/zed/actions/runs/13175800537/job/36774702686

Release Notes:

- N/A
