### PR TITLE
linux: Fix crash when NoKeymap event is received on Wayland

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1132,11 +1132,10 @@ impl Dispatch<wl_keyboard::WlKeyboard, ()> for WaylandClientStatePtr {
                 size,
                 ..
             } => {
-                assert_eq!(
-                    format,
-                    wl_keyboard::KeymapFormat::XkbV1,
-                    "Unsupported keymap format"
-                );
+                if format != wl_keyboard::KeymapFormat::XkbV1 {
+                    log::error!("Received keymap format {:?}, expected XkbV1", format);
+                    return;
+                }
                 let xkb_context = xkb::Context::new(xkb::CONTEXT_NO_FLAGS);
                 let keymap = unsafe {
                     xkb::Keymap::new_from_fd(


### PR DESCRIPTION
Closes #24139

For weird reasons, Sway on Arch Linux sends `NoKeymap` event when switching windows. This doesn't happen on other distros. Zed crashes due to assertion on this event to be `XkbV1`.  

To fix this, we ignore `NoKeymap` event instead crashing Zed.

Release Notes:

- Fixed crash in some cases while switching windows via keyboard in Wayland-based compositors like Sway.
