### PR TITLE
file_icons: Resolve icon properly for exact file name match

### DIFF
--- a/crates/file_icons/src/file_icons.rs
+++ b/crates/file_icons/src/file_icons.rs
@@ -54,7 +54,7 @@ impl FileIcons {
 
         // check if file name is in suffixes
         // e.g. catch file named `eslint.config.js` instead of `.eslint.config.js`
-        if let Some(typ) = path.to_str().and_then(|typ| this.suffixes.get(typ)) {
+        if let Some(typ) = path.file_name().and_then(|typ| typ.to_str()) {
             let maybe_path = get_icon_from_suffix(typ);
             if maybe_path.is_some() {
                 return maybe_path;


### PR DESCRIPTION
Follow-up to #24391 

The current approach has two issues:
- For the described case of `eslint.config.js`, for which a mapping exists in `suffixes`, this would get mapped from `eslint.config.js` to `eslint`. However, for `eslint`, there is no mapping within `suffixes`, thus currently `get_icon_from_suffix` would return `None` and a wrong item would be returned at a later step.
- Paths passed to this method are relative to the worktree root, thus e.g. `eslint.config.js` files in subdirectories would still be assigned the wrong icon.

---

Behaviour on `main`:
<img width="281" alt="main" src="https://github.com/user-attachments/assets/19b5e5f8-e413-4ac9-a0a1-2c72f810aa86" />

Behaviour with this change:
<img width="299" alt="pr" src="https://github.com/user-attachments/assets/eec70cbd-df39-49b4-8b07-d22afa949781" />

CC @probably-neb 

Release Notes:

- N/A
