### PR TITLE
image_viewer: Fix `cargo test` errors

### DIFF
--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -12,6 +12,9 @@ workspace = true
 path = "src/image_viewer.rs"
 doctest = false
 
+[features]
+test-support = ["gpui/test-support"]
+
 [dependencies]
 anyhow.workspace = true
 db.workspace = true
@@ -27,6 +30,3 @@ workspace.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }
-
-[features]
-test-support = ["gpui/test-support"]

--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -25,5 +25,8 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 
+[dev-dependencies]
+editor = { workspace = true, features = ["test-support"] }
+
 [features]
 test-support = ["gpui/test-support"]


### PR DESCRIPTION
This PR fixes the errors when running `cargo test` in the `image_viewer` crate.

Release Notes:

- N/A
