### PR TITLE
Use cursor-style focus instead of outline-style

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3565,8 +3565,7 @@ impl ProjectPanel {
             .cursor_pointer()
             .rounded_none()
             .bg(bg_color)
-            .border_1()
-            .border_r_2()
+            .border_l_3()
             .border_color(border_color)
             .hover(|style| style.bg(bg_hover_color).border_color(border_hover_color))
             .when(is_local, |div| {

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -197,10 +197,10 @@ impl RenderOnce for ListItem {
                     // .when(self.state == InteractionState::Focused, |this| {
                     .when_some(self.focused, |this, focused| {
                         if focused {
-                            this.border_1()
-                                .border_color(cx.theme().colors().border_focused)
+                            this.border_l_3()
+                                .border_color(cx.theme().players().local().cursor)
                         } else {
-                            this.border_1()
+                            this.border_l_3()
                         }
                     })
                     .when(self.selectable, |this| {


### PR DESCRIPTION
Closes #ISSUE
![screenshot_2025-02-06_at_22 30 18_720](https://github.com/user-attachments/assets/d64696d4-3052-48cd-b5c7-aca6ae3cd112)

![screenshot_2025-02-06_at_22 30 20_720](https://github.com/user-attachments/assets/c0668b82-8208-406b-801d-102ebf496c7e)

Note: this would need to be done in the project/outline panels manually because they don't use list items; and in the collab panel because it doesn't track focus state.

Release Notes:

- N/A