### PR TITLE
docs: Emphasize that Rust must be installed via rustup

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -14,6 +14,8 @@ Extensions can add the following capabilities to Zed:
 
 Before starting to develop an extension for Zed, be sure to [install Rust via rustup](https://www.rust-lang.org/tools/install).
 
+> Rust must be installed via rustup. If you have Rust installed via homebrew or otherwise, installing dev extensions will not work.
+
 When developing an extension, you can use it in Zed without needing to publish it by installing it as a _dev extension_.
 
 From the extensions page, click the `Install Dev Extension` button and select the directory containing your extension.


### PR DESCRIPTION
Just tried installing a dev extension and kept getting "error: failed to install dev extension".

Turns out this was because I had rust installed via homebrew and not rust. Once I switched to rustup, it worked perfectly fine.

Release Notes:

- N/A