### PR TITLE
Make OpenKeyContextView open to the right

### DIFF
--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -11,8 +11,7 @@ use ui::{
     Window,
 };
 use ui::{Button, ButtonStyle};
-use workspace::Item;
-use workspace::Workspace;
+use workspace::{Item, SplitDirection, Workspace};
 
 actions!(debug, [OpenKeyContextView]);
 
@@ -20,7 +19,12 @@ pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {
         workspace.register_action(|workspace, _: &OpenKeyContextView, window, cx| {
             let key_context_view = cx.new(|cx| KeyContextView::new(window, cx));
-            workspace.add_item_to_active_pane(Box::new(key_context_view), None, true, window, cx)
+            workspace.split_item(
+                SplitDirection::Right,
+                Box::new(key_context_view),
+                window,
+                cx,
+            )
         });
     })
     .detach();


### PR DESCRIPTION
Match the behavior of OpenSyntaxTreeView logs and OpenLanguageServerLogs

Release Notes:

- Make `debug::OpenSyntaxTreeView` automatically open in split to the right