### PR TITLE
migrator: Sort dependencies in `Cargo.toml`

### DIFF
--- a/crates/migrator/Cargo.toml
+++ b/crates/migrator/Cargo.toml
@@ -14,9 +14,9 @@ doctest = false
 
 [dependencies]
 collections.workspace = true
+convert_case.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter.workspace = true
-convert_case.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true


### PR DESCRIPTION
This PR sorts the dependencies in the `Cargo.toml` for the `migrator` crate.

Release Notes:

- N/A
