### PR TITLE
Make it a bit clearer when people are running dev builds

### DIFF
--- a/crates/feedback/src/system_specs.rs
+++ b/crates/feedback/src/system_specs.rs
@@ -64,12 +64,17 @@ impl Display for SystemSpecs {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let os_information = format!("OS: {} {}", self.os_name, self.os_version);
         let app_version_information = format!(
-            "Zed: v{} ({})",
+            "Zed: v{} ({}) {}",
             self.app_version,
             match &self.commit_sha {
                 Some(commit_sha) => format!("{} {}", self.release_channel, commit_sha),
                 None => self.release_channel.to_string(),
-            }
+            },
+            if cfg!(debug_assertions) {
+                "(Taylor's Version)"
+            } else {
+                ""
+            },
         );
         let system_specs = [
             app_version_information,

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -880,7 +880,12 @@ fn about(
 ) {
     let release_channel = ReleaseChannel::global(cx).display_name();
     let version = env!("CARGO_PKG_VERSION");
-    let message = format!("{release_channel} {version}");
+    let debug = if cfg!(debug_assertions) {
+        "(debug)"
+    } else {
+        ""
+    };
+    let message = format!("{release_channel} {version} {debug}");
     let detail = AppCommitSha::try_global(cx).map(|sha| sha.0.clone());
 
     let prompt = window.prompt(PromptLevel::Info, &message, detail.as_deref(), &["OK"], cx);


### PR DESCRIPTION
Release Notes:

- Include an indicator in About/CopySystemSpecs when running in debug mode
