### PR TITLE
edit predictions: Clarify `disabled_globs` documentation

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -783,6 +783,8 @@
   "load_direnv": "direct",
   "edit_predictions": {
     // A list of globs representing files that edit predictions should be disabled for.
+    // There's a sensible default list of globs already included.
+    // Any addition to this list will be merged with the default list.
     "disabled_globs": [
       "**/.env*",
       "**/*.pem",

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -224,6 +224,8 @@ pub struct EditPredictionSettings {
     /// The provider that supplies edit predictions.
     pub provider: EditPredictionProvider,
     /// A list of globs representing files that edit predictions should be disabled for.
+    /// There's a sensible default list of globs already included.
+    /// Any addition to this list will be merged with the default list.
     pub disabled_globs: Vec<GlobMatcher>,
     /// When to show edit predictions previews in buffer.
     pub inline_preview: InlineCompletionPreviewMode,
@@ -428,6 +430,8 @@ pub struct LanguageSettingsContent {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct InlineCompletionSettingsContent {
     /// A list of globs representing files that edit predictions should be disabled for.
+    /// There's a sensible default list of globs already included.
+    /// Any addition to this list will be merged with the default list.
     #[serde(default)]
     pub disabled_globs: Option<Vec<String>>,
     /// When to show edit predictions previews in buffer.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -224,8 +224,8 @@ pub struct EditPredictionSettings {
     /// The provider that supplies edit predictions.
     pub provider: EditPredictionProvider,
     /// A list of globs representing files that edit predictions should be disabled for.
-    /// There's a sensible default list of globs already included.
-    /// Any addition to this list will be merged with the default list.
+    /// This list adds to a pre-existing, sensible default set of globs.
+    /// Any additional ones you add are combined with them.
     pub disabled_globs: Vec<GlobMatcher>,
     /// When to show edit predictions previews in buffer.
     pub inline_preview: InlineCompletionPreviewMode,
@@ -430,8 +430,8 @@ pub struct LanguageSettingsContent {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct InlineCompletionSettingsContent {
     /// A list of globs representing files that edit predictions should be disabled for.
-    /// There's a sensible default list of globs already included.
-    /// Any addition to this list will be merged with the default list.
+    /// This list adds to a pre-existing, sensible default set of globs.
+    /// Any additional ones you add are combined with them.
     #[serde(default)]
     pub disabled_globs: Option<Vec<String>>,
     /// When to show edit predictions previews in buffer.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -398,9 +398,9 @@ There are two options to choose from:
 
 ### Disabled Globs
 
-- Description: A list of globs representing files that edit predictions should be disabled for.
+- Description: A list of globs representing files that edit predictions should be disabled for. There's a sensible default list of globs already included. Any addition to this list will be merged with the default list.
 - Setting: `disabled_globs`
-- Default: `[".env"]`
+- Default: `["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"]`
 
 **Options**
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -398,13 +398,13 @@ There are two options to choose from:
 
 ### Disabled Globs
 
-- Description: A list of globs representing files that edit predictions should be disabled for. There's a sensible default list of globs already included. Any addition to this list will be merged with the default list.
+- Description: A list of globs for which edit predictions should be disabled for. This list adds to a pre-existing, sensible default set of globs. Any additional ones you add are combined with them.
 - Setting: `disabled_globs`
 - Default: `["**/.env*", "**/*.pem", "**/*.key", "**/*.cert", "**/*.crt", "**/secrets.yml"]`
 
 **Options**
 
-List of `string` values
+List of `string` values.
 
 ## Edit Predictions Disabled in
 


### PR DESCRIPTION
This PR clarifies how the `disabled_globs` work.

Release Notes:

- N/A
