### PR TITLE
assistant_context_editor: Fix patch block not rendering due to window reborrow

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -845,7 +845,7 @@ impl ContextEditor {
                                 gutter_width,
                                 block_id,
                                 selected,
-                                *window,
+                                window,
                                 cx,
                             )
                         })

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -832,19 +832,20 @@ impl ContextEditor {
                 let render_block: RenderBlock = Arc::new({
                     let this = this.clone();
                     let patch_range = range.clone();
-                    move |cx: &mut BlockContext<'_, '_>| {
+                    move |cx: &mut BlockContext| {
                         let max_width = cx.max_width;
                         let gutter_width = cx.gutter_dimensions.full_width();
                         let block_id = cx.block_id;
                         let selected = cx.selected;
-                        this.update_in(cx, |this, window, cx| {
+                        let window = &mut cx.window;
+                        this.update(cx.app, |this, cx| {
                             this.render_patch_block(
                                 patch_range.clone(),
                                 max_width,
                                 gutter_width,
                                 block_id,
                                 selected,
-                                window,
+                                *window,
                                 cx,
                             )
                         })


### PR DESCRIPTION
This PR fixes an issue where the Assistant patch block was not being rendered when using "Suggest Edits".

The issue was that the `BlockContext` already has a borrow of the `Window`, so we can't use `update_in` to reborrow the window.

The fix is to reuse the existing `&mut Window` reference from the `BlockContext` so we don't need to `update_in`.

Closes #24169.

Release Notes:

- Assistant: Fixed an issue where the patch block was not being rendered when using "Suggest Edits".
