### PR TITLE
edit predictions: Fix translucent "jump to edit" background color

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5800,6 +5800,9 @@ fn inline_completion_accept_indicator(
         .child(accept_keystroke.key.clone());
 
     let padding_right = if icon.is_some() { px(4.) } else { px(8.) };
+    let accent_color = cx.theme().colors().text_accent;
+    let editor_bg_color = cx.theme().colors().editor_background;
+    let bg_color = editor_bg_color.blend(accent_color.opacity(0.2));
 
     Some(
         h_flex()
@@ -5807,7 +5810,7 @@ fn inline_completion_accept_indicator(
             .pl_1()
             .pr(padding_right)
             .gap_1()
-            .bg(cx.theme().colors().text_accent.opacity(0.15))
+            .bg(bg_color)
             .border_1()
             .border_color(cx.theme().colors().text_accent.opacity(0.8))
             .rounded_md()


### PR DESCRIPTION
This PR uses a pretty cool GPUI method called `blend` to make this callout's background color not translucent.

| Before | Header |
|--------|--------|
| <img width="732" alt="Screenshot 2025-02-07 at 4 58 16 PM" src="https://github.com/user-attachments/assets/2a5df61b-dfa0-4edc-bffa-a605a2aa491a" /> | <img width="732" alt="Screenshot 2025-02-07 at 4 56 48 PM" src="https://github.com/user-attachments/assets/5dee9fca-6239-4ae0-80f5-dcc6abf0e779" /> | 

Release Notes:

- N/A
