### PR TITLE
zeta: Promote line comment to doc comment

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -189,7 +189,8 @@ pub struct Zeta {
     data_collection_choice: Entity<DataCollectionChoice>,
     llm_token: LlmApiToken,
     _llm_token_subscription: Subscription,
-    tos_accepted: bool, // Terms of service accepted
+    /// Whether the terms of service have been accepted.
+    tos_accepted: bool,
     _user_store_subscription: Subscription,
     license_detection_watchers: HashMap<WorktreeId, Rc<LicenseDetectionWatcher>>,
 }


### PR DESCRIPTION
This PR promotes a line comment for the `tos_accepted` field to a doc comment.

Release Notes:

- N/A
