### PR TITLE
ui: Add `buffer_font` method to labels

### DIFF
--- a/crates/ui/src/components/label/highlighted_label.rs
+++ b/crates/ui/src/components/label/highlighted_label.rs
@@ -75,6 +75,11 @@ impl LabelCommon for HighlightedLabel {
         self.base = self.base.single_line();
         self
     }
+
+    fn buffer_font(mut self, cx: &App) -> Self {
+        self.base = self.base.buffer_font(cx);
+        self
+    }
 }
 
 pub fn highlight_ranges(

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -172,6 +172,11 @@ impl LabelCommon for Label {
         self.base = self.base.single_line();
         self
     }
+
+    fn buffer_font(mut self, cx: &App) -> Self {
+        self.base = self.base.buffer_font(cx);
+        self
+    }
 }
 
 impl RenderOnce for Label {

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -55,6 +55,9 @@ pub trait LabelCommon {
 
     /// Sets the label to render as a single line.
     fn single_line(self) -> Self;
+
+    /// Sets the font to the buffer's
+    fn buffer_font(self, cx: &App) -> Self;
 }
 
 #[derive(IntoElement)]
@@ -157,6 +160,13 @@ impl LabelCommon for LabelLike {
 
     fn single_line(mut self) -> Self {
         self.single_line = true;
+        self
+    }
+
+    fn buffer_font(mut self, cx: &App) -> Self {
+        self.base = self
+            .base
+            .font(theme::ThemeSettings::get_global(cx).buffer_font.clone());
         self
     }
 }

--- a/crates/ui/src/styles/color.rs
+++ b/crates/ui/src/styles/color.rs
@@ -86,3 +86,9 @@ impl Color {
         }
     }
 }
+
+impl From<Hsla> for Color {
+    fn from(color: Hsla) -> Self {
+        Color::Custom(color)
+    }
+}


### PR DESCRIPTION
Now you don't need to wrap the `Label` in a `div` anymore 

Release Notes:

- N/A 