### PR TITLE
Include prediction ID on edit prediction accepted/discarded events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16757,12 +16757,13 @@ dependencies = [
 
 [[package]]
 name = "zed_llm_client"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "656118e6b072924d28815cb892278f12c2548117794e733bd2c075ef4a0427e8"
+checksum = "614669bead4741b2fc352ae1967318be16949cf46f59013e548c6dbfdfc01252"
 dependencies = [
  "serde",
  "serde_json",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -561,7 +561,7 @@ wasmtime = { version = "24", default-features = false, features = [
 wasmtime-wasi = "24"
 which = "6.0.0"
 wit-component = "0.201"
-zed_llm_client = "0.3"
+zed_llm_client = "0.4"
 zstd = "0.11"
 metal = "0.31"
 

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -242,6 +242,7 @@ impl EditPredictionProvider for CopilotCompletionProvider {
             } else {
                 let position = cursor_position.bias_right(buffer);
                 Some(InlineCompletion {
+                    id: None,
                     edits: vec![(position..position, completion_text.into())],
                     edit_preview: None,
                 })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -490,6 +490,7 @@ enum InlineCompletion {
 struct InlineCompletionState {
     inlay_ids: Vec<InlayId>,
     completion: InlineCompletion,
+    completion_id: Option<SharedString>,
     invalidation_range: Range<Anchor>,
 }
 
@@ -4893,7 +4894,11 @@ impl Editor {
             return;
         };
 
-        self.report_inline_completion_event(true, cx);
+        self.report_inline_completion_event(
+            active_inline_completion.completion_id.clone(),
+            true,
+            cx,
+        );
 
         match &active_inline_completion.completion {
             InlineCompletion::Move { target, .. } => {
@@ -4942,7 +4947,11 @@ impl Editor {
             return;
         }
 
-        self.report_inline_completion_event(true, cx);
+        self.report_inline_completion_event(
+            active_inline_completion.completion_id.clone(),
+            true,
+            cx,
+        );
 
         match &active_inline_completion.completion {
             InlineCompletion::Move { target, .. } => {
@@ -5000,7 +5009,12 @@ impl Editor {
         cx: &mut Context<Self>,
     ) -> bool {
         if should_report_inline_completion_event {
-            self.report_inline_completion_event(false, cx);
+            let completion_id = self
+                .active_inline_completion
+                .as_ref()
+                .and_then(|active_completion| active_completion.completion_id.clone());
+
+            self.report_inline_completion_event(completion_id, false, cx);
         }
 
         if let Some(provider) = self.edit_prediction_provider() {
@@ -5010,7 +5024,7 @@ impl Editor {
         self.take_active_inline_completion(cx)
     }
 
-    fn report_inline_completion_event(&self, accepted: bool, cx: &App) {
+    fn report_inline_completion_event(&self, id: Option<SharedString>, accepted: bool, cx: &App) {
         let Some(provider) = self.edit_prediction_provider() else {
             return;
         };
@@ -5035,6 +5049,7 @@ impl Editor {
         telemetry::event!(
             event_type,
             provider = provider.name(),
+            prediction_id = id,
             suggestion_accepted = accepted,
             file_extension = extension,
         );
@@ -5250,6 +5265,7 @@ impl Editor {
         self.active_inline_completion = Some(InlineCompletionState {
             inlay_ids,
             completion,
+            completion_id: inline_completion.id,
             invalidation_range,
         });
 

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -333,6 +333,7 @@ fn propose_edits<T: ToOffset>(
     cx.update(|_, cx| {
         provider.update(cx, |provider, _| {
             provider.set_inline_completion(Some(inline_completion::InlineCompletion {
+                id: None,
                 edits: edits.collect(),
                 edit_preview: None,
             }))

--- a/crates/inline_completion/src/inline_completion.rs
+++ b/crates/inline_completion/src/inline_completion.rs
@@ -1,4 +1,4 @@
-use gpui::{App, Context, Entity};
+use gpui::{App, Context, Entity, SharedString};
 use language::Buffer;
 use project::Project;
 use std::ops::Range;
@@ -15,6 +15,8 @@ pub enum Direction {
 
 #[derive(Clone)]
 pub struct InlineCompletion {
+    /// The ID of the completion, if it has one.
+    pub id: Option<SharedString>,
     pub edits: Vec<(Range<language::Anchor>, String)>,
     pub edit_preview: Option<language::EditPreview>,
 }

--- a/crates/supermaven/src/supermaven_completion_provider.rs
+++ b/crates/supermaven/src/supermaven_completion_provider.rs
@@ -92,6 +92,7 @@ fn completion_from_diff(
     }
 
     InlineCompletion {
+        id: None,
         edits,
         edit_preview: None,
     }


### PR DESCRIPTION
This PR updates the edit predictions to include the prediction ID returned from the server on the resulting telemetry events indicating whether the prediction was accepted or discarded.

The `prediction_id` on the events can then be correlated with the `request_id` on the server-side prediction events.

Release Notes:

- N/A
