### PR TITLE
vim: Preserve trailing whitespace in inner text object selections

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1338,6 +1338,21 @@ fn surrounding_markers(
                 opening.end = range.end
             }
         }
+
+        let mut last_newline_end = None;
+        for (ch, range) in movement::chars_before(map, closing.start) {
+            if !ch.is_whitespace() {
+                break;
+            }
+            if ch == '\n' {
+                last_newline_end = Some(range.end);
+                break;
+            }
+        }
+        // Adjust closing.start to exclude whitespace after a newline, if present
+        if let Some(end) = last_newline_end {
+            closing.start = end;
+        }
     }
 
     let result = if around {

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -2261,6 +2261,20 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_anybrackets_trailing_space(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state("(trailingˇ whitespace          )")
+            .await;
+        cx.simulate_shared_keystrokes("v i b").await;
+        cx.shared_state().await.assert_matches();
+        cx.simulate_shared_keystrokes("escape y i b").await;
+        cx.shared_clipboard()
+            .await
+            .assert_eq("trailing whitespace          ");
+    }
+
+    #[gpui::test]
     async fn test_tags(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new_html(cx).await;
 

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1338,15 +1338,6 @@ fn surrounding_markers(
                 opening.end = range.end
             }
         }
-
-        for (ch, range) in movement::chars_before(map, closing.start) {
-            if !ch.is_whitespace() {
-                break;
-            }
-            if ch != '\n' {
-                closing.start = range.start
-            }
-        }
     }
 
     let result = if around {

--- a/crates/vim/test_data/test_anybrackets_trailing_space.json
+++ b/crates/vim/test_data/test_anybrackets_trailing_space.json
@@ -1,0 +1,11 @@
+{"Put":{"state":"(trailingˇ whitespace          )"}}
+{"Key":"v"}
+{"Key":"i"}
+{"Key":"b"}
+{"Get":{"state":"(«trailing whitespace          ˇ»)","mode":"Visual"}}
+{"Key":"escape"}
+{"Key":"y"}
+{"Key":"i"}
+{"Key":"b"}
+{"Get":{"state":"(ˇtrailing whitespace          )","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"trailing whitespace          "}}


### PR DESCRIPTION
Closes #24438

Changes: Adjusted loop to only trim whitespace between last newline and closing marker, when using inner objects like `y/d/c i b`

| Start   | Fixed `vib`   | Previous `vib`   |
| ---------- | ---------- | ---------- |
| ![image](https://github.com/user-attachments/assets/3d64dd7d-ed3d-4a85-9f98-f2f83799a738) | ![image](https://github.com/user-attachments/assets/841beb59-31b1-475e-93f0-f4deaf18939c) | ![image](https://github.com/user-attachments/assets/736d4c6f-20e1-4563-9471-1e8195455df4) |



Release Notes:

- vim: Preserve trailing whitespace in inner text object selections
