### PR TITLE
title_bar: Add menu item to deploy icon theme selector

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -670,8 +670,12 @@ impl TitleBar {
                         .action("Settings", zed_actions::OpenSettings.boxed_clone())
                         .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                         .action(
-                            "Themes…",
+                            "Themes",
                             zed_actions::theme_selector::Toggle::default().boxed_clone(),
+                        )
+                        .action(
+                            "Icons",
+                            zed_actions::icon_theme_selector::Toggle::default().boxed_clone(),
                         )
                         .action("Extensions", zed_actions::Extensions.boxed_clone())
                         .separator()
@@ -713,8 +717,12 @@ impl TitleBar {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                             .action(
-                                "Themes…",
+                                "Themes",
                                 zed_actions::theme_selector::Toggle::default().boxed_clone(),
+                            )
+                            .action(
+                                "Icons",
+                                zed_actions::icon_theme_selector::Toggle::default().boxed_clone(),
                             )
                             .action("Extensions", zed_actions::Extensions.boxed_clone())
                             .separator()

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -670,11 +670,11 @@ impl TitleBar {
                         .action("Settings", zed_actions::OpenSettings.boxed_clone())
                         .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                         .action(
-                            "Themes",
+                            "Themes…",
                             zed_actions::theme_selector::Toggle::default().boxed_clone(),
                         )
                         .action(
-                            "Icons",
+                            "Icon Themes…",
                             zed_actions::icon_theme_selector::Toggle::default().boxed_clone(),
                         )
                         .action("Extensions", zed_actions::Extensions.boxed_clone())
@@ -717,11 +717,11 @@ impl TitleBar {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())
                             .action("Key Bindings", Box::new(zed_actions::OpenKeymap))
                             .action(
-                                "Themes",
+                                "Themes…",
                                 zed_actions::theme_selector::Toggle::default().boxed_clone(),
                             )
                             .action(
-                                "Icons",
+                                "Icon Themes…",
                                 zed_actions::icon_theme_selector::Toggle::default().boxed_clone(),
                             )
                             .action("Extensions", zed_actions::Extensions.boxed_clone())


### PR DESCRIPTION
Added the icons option in the title bar between Themes and Extension.

| Before                                                                                                                                              | After                                                                                                                                               |
| --------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="215" alt="Screenshot 2025-02-07 at 5 18 10 PM" src="https://github.com/user-attachments/assets/ff8bf5ce-c176-4d8c-8b0e-bb1cc65ec1d8" /> | <img width="206" alt="Screenshot 2025-02-07 at 5 18 01 PM" src="https://github.com/user-attachments/assets/c47a302e-98af-4530-a908-097b8306f2f0" /> |

Release Notes:

- Added an option to open the icon theme selector from the user menu.