### PR TITLE
vim: Escape to normal mode when visual surround operation pending

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -382,9 +382,9 @@
     }
   },
   {
-    "context": "Editor && vim_mode == waiting",
+    "context": "Editor && vim_mode == waiting && (vim_operator == ys || vim_operator == cs)",
     "bindings": {
-        "escape": "vim::SwitchToNormalMode"
+      "escape": "vim::SwitchToNormalMode"
     }
   },
   {

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -382,6 +382,12 @@
     }
   },
   {
+    "context": "Editor && vim_mode == waiting",
+    "bindings": {
+        "escape": "vim::SwitchToNormalMode"
+    }
+  },
+  {
     "context": "vim_mode == operator",
     "bindings": {
       "ctrl-c": "vim::ClearOperators",


### PR DESCRIPTION
Closes #24382

Release Notes:

- vim: Ensure escape in surrounds mode returns to normal mode
