### PR TITLE
project_panel: Fix worktree root rename

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1535,6 +1535,10 @@ impl Project {
         })
     }
 
+    /// Renames the project entry with given `entry_id`.
+    ///
+    /// `new_path` is a relative path to worktree root.
+    /// If root entry is renamed then its new root name is used instead.
     pub fn rename_entry(
         &mut self,
         entry_id: ProjectEntryId,
@@ -1557,14 +1561,12 @@ impl Project {
         cx.spawn(|_, mut cx| async move {
             let (old_abs_path, new_abs_path) = {
                 let root_path = worktree.update(&mut cx, |this, _| this.abs_path())?;
-                if is_root_entry {
-                    (
-                        root_path.join(&old_path),
-                        root_path.parent().unwrap().join(&new_path),
-                    )
+                let new_abs_path = if is_root_entry {
+                    root_path.parent().unwrap().join(&new_path)
                 } else {
-                    (root_path.join(&old_path), root_path.join(&new_path))
-                }
+                    root_path.join(&new_path)
+                };
+                (root_path.join(&old_path), new_abs_path)
             };
             LspStore::will_rename_entry(
                 lsp_store.clone(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -733,7 +733,7 @@ impl ProjectPanel {
                             .action("Copy Path", Box::new(CopyPath))
                             .action("Copy Relative Path", Box::new(CopyRelativePath))
                             .separator()
-                            .action("Rename", Box::new(Rename))
+                            .when(!is_root, |menu| menu.action("Rename", Box::new(Rename)))
                             .when(!is_root & !is_remote, |menu| {
                                 menu.action("Trash", Box::new(Trash { skip_prompt: false }))
                             })
@@ -1348,6 +1348,9 @@ impl ProjectPanel {
             if let Some(worktree) = self.project.read(cx).worktree_for_id(worktree_id, cx) {
                 let sub_entry_id = self.unflatten_entry_id(entry_id);
                 if let Some(entry) = worktree.read(cx).entry_for_id(sub_entry_id) {
+                    if Some(entry) == worktree.read(cx).root_entry() {
+                        return;
+                    }
                     self.edit_state = Some(EditState {
                         worktree_id,
                         entry_id: sub_entry_id,
@@ -7281,6 +7284,7 @@ mod tests {
     }
 
     #[gpui::test]
+    #[cfg_attr(target_os = "windows", ignore)]
     async fn test_rename_root_of_worktree(cx: &mut gpui::TestAppContext) {
         init_test_with_editor(cx);
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -733,7 +733,9 @@ impl ProjectPanel {
                             .action("Copy Path", Box::new(CopyPath))
                             .action("Copy Relative Path", Box::new(CopyRelativePath))
                             .separator()
-                            .when(!is_root, |menu| menu.action("Rename", Box::new(Rename)))
+                            .when(!is_root || !cfg!(target_os = "windows"), |menu| {
+                                menu.action("Rename", Box::new(Rename))
+                            })
                             .when(!is_root & !is_remote, |menu| {
                                 menu.action("Trash", Box::new(Trash { skip_prompt: false }))
                             })
@@ -1348,6 +1350,7 @@ impl ProjectPanel {
             if let Some(worktree) = self.project.read(cx).worktree_for_id(worktree_id, cx) {
                 let sub_entry_id = self.unflatten_entry_id(entry_id);
                 if let Some(entry) = worktree.read(cx).entry_for_id(sub_entry_id) {
+                    #[cfg(target_os = "windows")]
                     if Some(entry) == worktree.read(cx).root_entry() {
                         return;
                     }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1835,6 +1835,10 @@ impl LocalWorktree {
         }))
     }
 
+    /// Rename an entry.
+    ///
+    /// `new_path` is the new relative path to the worktree root.
+    /// If the root entry is renamed then `new_path` is the new root name instead.
     fn rename_entry(
         &self,
         entry_id: ProjectEntryId,


### PR DESCRIPTION
Closes #7923

This PR fixes root worktree renaming by:  

1. Handling the case where `new_path` is the new root name instead of a relative path from the root.  
2. [#20313](https://github.com/zed-industries/zed/pull/20313) added functionality to watch for root worktree renames made externally, e.g., via Finder. This PR avoids relying on that watcher because, when renaming explicitly from Zed, we can eagerly perform the necessary work (of course after fs rename) instead of waiting for the watcher to detect the rename. This prevents UI glitches during renaming root.

Todo:

- [x] Fix wrong abs paths when root is renamed
- [x] Fix explicit scan entry func to handle renamed root dir
- [x] Tests
- [x] Test on Linux
- [x] Tested with single and multipe worktrees
- [x] Tested when single file is root file

Release Notes:

- Fixed an issue where worktree root name couldn't be renamed in project panel.