### PR TITLE
Track caller on `<usize as ToOffset>::to_offset`

### DIFF
--- a/crates/gpui/src/arena.rs
+++ b/crates/gpui/src/arena.rs
@@ -116,6 +116,7 @@ impl<T: ?Sized> ArenaBox<T> {
         }
     }
 
+    #[track_caller]
     fn validate(&self) {
         assert!(
             self.valid.get(),

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -7320,6 +7320,7 @@ impl ToOffset for Point {
 }
 
 impl ToOffset for usize {
+    #[track_caller]
     fn to_offset<'a>(&self, snapshot: &MultiBufferSnapshot) -> usize {
         assert!(*self <= snapshot.len(), "offset is out of range");
         *self


### PR DESCRIPTION
To get useful logs when reporting bugs involving offsets out of range

Release Notes:

- N/A
