### PR TITLE
language_tools: Add background color to syntax tree view

### DIFF
--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -293,7 +293,8 @@ impl SyntaxTreeView {
 
 impl Render for SyntaxTreeView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let mut rendered = div().flex_1();
+        let colors = cx.theme().colors();
+        let mut rendered = div().flex_1().bg(colors.background);
 
         if let Some(layer) = self
             .editor

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -293,8 +293,7 @@ impl SyntaxTreeView {
 
 impl Render for SyntaxTreeView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let colors = cx.theme().colors();
-        let mut rendered = div().flex_1().bg(colors.background);
+        let mut rendered = div().flex_1().bg(cx.theme().colors().editor_background);
 
         if let Some(layer) = self
             .editor


### PR DESCRIPTION
Closes #22830 

@jansol, please take a look. I don't know if this is correct as I couldn't really tell the difference. I just added the active theme's background color to the main container of the tree view. 

<img width="1309" alt="Screenshot 2025-02-09 at 10 29 15 AM" src="https://github.com/user-attachments/assets/dadf9333-0074-4bfa-bb06-ed4c4f275200" />
 
Release Notes:

- Added an explicit background color to the syntax tree view.

cc: @iamnbutler 