### PR TITLE
ci: Pin Prettier to a specific version for docs formatting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,12 +24,13 @@ jobs:
       - name: Prettier Check on /docs
         working-directory: ./docs
         run: |
-          PRETTIER_VERSION=3.5.0
           pnpm dlx prettier@${PRETTIER_VERSION} . --check || {
             echo "To fix, run from the root of the zed repo:"
             echo "  cd docs && pnpm dlx prettier@${PRETTIER_VERSION} . --write && cd .."
             false
           }
+        env:
+          PRETTIER_VERSION: 3.5.0
 
       - name: Check for Typos with Typos-CLI
         uses: crate-ci/typos@8e6a4285bcbde632c5d79900a7779746e8b7ea3f # v1.24.6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,9 +24,10 @@ jobs:
       - name: Prettier Check on /docs
         working-directory: ./docs
         run: |
-          pnpm dlx prettier . --check || {
+          PRETTIER_VERSION=3.5.0
+          pnpm dlx prettier@${PRETTIER_VERSION} . --check || {
             echo "To fix, run from the root of the zed repo:"
-            echo "  cd docs && pnpm dlx prettier . --write && cd .."
+            echo "  cd docs && pnpm dlx prettier@${PRETTIER_VERSION} . --write && cd .."
             false
           }
 

--- a/docs/theme/css/variables.css
+++ b/docs/theme/css/variables.css
@@ -13,8 +13,9 @@
   --menu-bar-height: 64px;
   --font: "IA Writer Quattro S", sans-serif;
   --title-font: "Lora", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    Liberation Mono, Courier New, monospace;
+  --mono-font:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
+    Courier New, monospace;
   --code-font-size: 0.875em
     /* please adjust the ace font size accordingly in editor.js */;
 


### PR DESCRIPTION
This PR pins Prettier to a specific version when we run the docs formatting check.

This should prevent drift when new Prettier versions are released that may impact the formatting.

Release Notes:

- N/A
