### PR TITLE
Fix outline panel issues in a multi-worktree set-up

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -6558,10 +6558,11 @@ outline: struct OutlineEntryExcerpt
                                     None
                                 }
                             }) {
-                            Some(root_path) => root_path
-                                .join(&directory.entry.path)
-                                .to_string_lossy()
-                                .to_string(),
+                            Some(root_path) => format!(
+                                "{}/{}",
+                                root_path.display(),
+                                directory.entry.path.display(),
+                            ),
                             None => format!(
                                 "{}/",
                                 directory

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2,6 +2,7 @@ mod outline_panel_settings;
 
 use std::{
     cmp,
+    collections::BTreeMap,
     hash::Hash,
     ops::Range,
     path::{Path, PathBuf, MAIN_SEPARATOR_STR},
@@ -2626,7 +2627,7 @@ impl OutlinePanel {
                 .spawn(async move {
                     let mut processed_external_buffers = HashSet::default();
                     let mut new_worktree_entries =
-                        HashMap::<WorktreeId, HashMap<ProjectEntryId, GitEntry>>::default();
+                        BTreeMap::<WorktreeId, HashMap<ProjectEntryId, GitEntry>>::default();
                     let mut worktree_excerpts = HashMap::<
                         WorktreeId,
                         HashMap<ProjectEntryId, (BufferId, Vec<ExcerptId>)>,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/22993

Properly calculates depth and maintains worktree order, when displaying multiple worktrees in the outline panel.

Release Notes:

- Fixed outline panel issues in a multi-worktree set-up
