### PR TITLE
gpui: Implement `window_handle` method for Linux

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -751,7 +751,10 @@ where
 
 impl rwh::HasWindowHandle for WaylandWindow {
     fn window_handle(&self) -> Result<rwh::WindowHandle<'_>, rwh::HandleError> {
-        unimplemented!()
+        let state = self.borrow();
+        let window = NonNull::new(state.surface.id().as_ptr().cast::<c_void>()).unwrap();
+        let handle = rwh::WaylandWindowHandle::new(window);
+        Ok(unsafe { rwh::WindowHandle::borrow_raw(handle.into()) })
     }
 }
 impl rwh::HasDisplayHandle for WaylandWindow {

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -306,7 +306,8 @@ impl rwh::HasDisplayHandle for RawWindow {
 
 impl rwh::HasWindowHandle for X11Window {
     fn window_handle(&self) -> Result<rwh::WindowHandle, rwh::HandleError> {
-        unimplemented!()
+        let mut handle = rwh::XlibWindowHandle::new(self.0.x_window as u64);
+        Ok(unsafe { rwh::WindowHandle::borrow_raw(handle.into()) })
     }
 }
 impl rwh::HasDisplayHandle for X11Window {


### PR DESCRIPTION
Release Notes:

- N/A

Continue #24327 to fix `window_handle` method on Linux platform.

```
thread 'main' panicked at crates/gpui/examples/webview.rs:86:18:
Failed to create webview.: UnsupportedWindowHandle
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

However, since [Wry currently has problems supporting Linux](https://github.com/tauri-apps/wry/issues/1197), especially Wayland cannot run, our application has disabled WebView related functions on Linux.

I did use this method to connect Wry on Linux and it worked. But today, there may be other reasons on this device or many Wry changed some things I don't know that cause the WebView to render not correct. However, this change  can be let app startup not crash.
