### PR TITLE
edit predictions: Put back status bar button tooltips

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -291,6 +291,31 @@ impl Render for InlineCompletionButton {
                     .when(enabled && !show_editor_predictions, |this| {
                         this.indicator(Indicator::dot().color(Color::Muted))
                             .indicator_border_color(Some(cx.theme().colors().status_bar_background))
+                    })
+                    .when(!self.popover_menu_handle.is_deployed(), |element| {
+                        element.tooltip(move |window, cx| {
+                            if enabled {
+                                if show_editor_predictions {
+                                    Tooltip::for_action("Edit Prediction", &ToggleMenu, window, cx)
+                                } else {
+                                    Tooltip::with_meta(
+                                        "Edit Prediction",
+                                        Some(&ToggleMenu),
+                                        "Hidden For This File",
+                                        window,
+                                        cx,
+                                    )
+                                }
+                            } else {
+                                Tooltip::with_meta(
+                                    "Edit Prediction",
+                                    Some(&ToggleMenu),
+                                    "Disabled For This File",
+                                    window,
+                                    cx,
+                                )
+                            }
+                        })
                     });
 
                 let this = cx.entity().clone();


### PR DESCRIPTION
These were wrongly removed in https://github.com/zed-industries/zed/pull/24540; putting them back.

cc @SomeoneToIgnore 

Release Notes:

- N/A
