### PR TITLE
docs: Add a light border to h2s

### DIFF
--- a/docs/theme/css/general.css
+++ b/docs/theme/css/general.css
@@ -79,6 +79,12 @@ h6 code {
   display: none !important;
 }
 
+h2 {
+  padding-bottom: 1rem;
+  border-bottom: 1px solid;
+  border-color: var(--border-light);
+}
+
 h2,
 h3 {
   margin-block-start: 1.5em;

--- a/docs/theme/css/variables.css
+++ b/docs/theme/css/variables.css
@@ -13,8 +13,9 @@
   --menu-bar-height: 64px;
   --font: "IA Writer Quattro S", sans-serif;
   --title-font: "Lora", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
-    Liberation Mono, Courier New, monospace;
+  --mono-font:
+    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
+    Courier New, monospace;
   --code-font-size: 0.875em
     /* please adjust the ace font size accordingly in editor.js */;
 

--- a/docs/theme/css/variables.css
+++ b/docs/theme/css/variables.css
@@ -13,9 +13,8 @@
   --menu-bar-height: 64px;
   --font: "IA Writer Quattro S", sans-serif;
   --title-font: "Lora", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  --mono-font:
-    ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono,
-    Courier New, monospace;
+  --mono-font: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas,
+    Liberation Mono, Courier New, monospace;
   --code-font-size: 0.875em
     /* please adjust the ace font size accordingly in editor.js */;
 
@@ -98,7 +97,7 @@
   --title-color: hsl(220, 92%, 80%);
 
   --border: hsl(220, 13%, 20%);
-  --border-light: hsl(220, 13%, 90%);
+  --border-light: hsl(220, 13%, 15%);
   --border-hover: hsl(220, 13%, 40%);
 
   --media-bg: hsl(220, 13%, 8%);


### PR DESCRIPTION
I was finding hard to navigate the "Configuring Zed" page with just white space creating a boundary between the different chunks of content. I think a slight border below the h2 heading helps a lot with that!

Release Notes:

- N/A
