### PR TITLE
php: Update `brackets.scm`

### DIFF
--- a/extensions/php/languages/php/brackets.scm
+++ b/extensions/php/languages/php/brackets.scm
@@ -1,1 +1,4 @@
 ("{" @open "}" @close)
+("(" @open ")" @close)
+("[" @open "]" @close)
+("\"" @open "\"" @close)


### PR DESCRIPTION
Closes #24550 

This PR adds some missing brackets to the PHP language extension.

Release Notes:

- N/A
