### PR TITLE
vim: Save file when using :wq

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1550,6 +1550,8 @@ impl Pane {
                 let should_save = dirty_project_item_ids
                     .iter()
                     .any(|id| saved_project_items_ids.insert(*id))
+                    || save_intent == SaveIntent::Save
+                    || save_intent == SaveIntent::Overwrite
                     // Always propose to save singleton files without any project paths: those cannot be saved via multibuffer, as require a file path selection modal.
                     || cx
                         .update(|_window, cx| {


### PR DESCRIPTION
This Pull Request updates the way `close_items` determines whether to save the open buffers by taking into consideration the `save_intent` parameter. If this is set to either `Save` or `Overwrite`, the buffers will always be saved. 

This fixes the bug where using `:wq` or `:wq!` in vim mode would not actually save the buffer before closing the open item, in case the buffer was open in another place.

Closes #21059 

Release Notes:

- Fix `:wq` and `:wq!` to work when buffer is open in another tab
