### PR TITLE
context menu: Use `invisible()` to hide the check icon

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -681,7 +681,7 @@ impl Render for ContextMenu {
                                                                     div().flex_none().child(
                                                                         Icon::new(IconName::Check)
                                                                             .size(*icon_size)
-                                                                    ).opacity(0.)
+                                                                    ).invisible()
                                                                 };
                                                                 match position {
                                                                     IconPosition::Start => {


### PR DESCRIPTION
Follow up to: https://github.com/zed-industries/zed/pull/24549

Release Notes:

- N/A
