### PR TITLE
context_menu: Use `when` instead of if-block

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -671,18 +671,16 @@ impl Render for ContextMenu {
                                                         .when_some(
                                                             *toggle,
                                                             |list_item, (position, toggled)| {
-                                                                let contents = if toggled {
+                                                                let contents =
                                                                     div().flex_none().child(
                                                                         Icon::new(IconName::Check)
                                                                             .color(Color::Accent)
                                                                             .size(*icon_size)
                                                                     )
-                                                                } else {
-                                                                    div().flex_none().child(
-                                                                        Icon::new(IconName::Check)
-                                                                            .size(*icon_size)
-                                                                    ).invisible()
-                                                                };
+                                                                    .when(!toggled, |contents|
+                                                                        contents.invisible()
+                                                                    );
+
                                                                 match position {
                                                                     IconPosition::Start => {
                                                                         list_item


### PR DESCRIPTION
See https://github.com/zed-industries/zed/pull/24562#issuecomment-2648343416 . Should have just added that to my original comment btw - sorry!

CC @danilo-leal 

Release Notes:

- N/A
