### PR TITLE
Make migration notification not display if some bug causes no changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7878,6 +7878,7 @@ version = "0.1.0"
 dependencies = [
  "collections",
  "convert_case 0.7.1",
+ "log",
  "pretty_assertions",
  "streaming-iterator",
  "tree-sitter",

--- a/crates/migrator/Cargo.toml
+++ b/crates/migrator/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 collections.workspace = true
 convert_case.workspace = true
+log.workspace = true
 streaming-iterator.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter.workspace = true

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -29,11 +29,19 @@ fn migrate(text: &str, patterns: MigrationPatterns, query: &Query) -> Option<Str
     if edits.is_empty() {
         None
     } else {
-        let mut text = text.to_string();
-        for (range, replacement) in edits.into_iter().rev() {
-            text.replace_range(range, &replacement);
+        let mut new_text = text.to_string();
+        for (range, replacement) in edits.iter().rev() {
+            new_text.replace_range(range.clone(), replacement);
         }
-        Some(text)
+        if new_text == text {
+            log::error!(
+                "Edits computed for configuration migration do not cause a change: {:?}",
+                edits
+            );
+            None
+        } else {
+            Some(new_text)
+        }
     }
 }
 


### PR DESCRIPTION
When working on #24442, I did a project wide replacement of `AcceptInlineCompletion` with `AcceptEditPrediction`, as I was updating the branch to mmain and that rename had happened.  This also replaced it in the migrator, causing the migration notification to always pop up on keymap changes.

Checking if the migration actually changes the text makes it behave better if this variety of bug happens in the future.

Release Notes:

- N/A