### PR TITLE
Fix formatters not running in order

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1245,7 +1245,6 @@ impl LocalLspStore {
     ) -> anyhow::Result<()> {
         let mut prev_transaction_id = initial_transaction_id;
 
-        dbg!(formatters.len());
         for formatter in formatters {
             let operation = match formatter {
                 Formatter::LanguageServer { name } => {
@@ -1382,11 +1381,6 @@ impl LocalLspStore {
                     if this_transaction_id.is_some() {
                         prev_transaction_id = this_transaction_id;
                     }
-                    dbg!((
-                        initial_transaction_id,
-                        prev_transaction_id,
-                        this_transaction_id
-                    ));
                 }
 
                 if let Some(transaction_id) = initial_transaction_id {


### PR DESCRIPTION
Previously, if multiple formatters were specified for the same language, they would be run in parallel on the state of the file, and then all edits would be applied. This lead to incorrect output with many unwanted artifacts.
This PR refactors the formatting code to clean it up, and ensure results from previous formatters are passed in to subsequent formatters.

Closes #15544

Release Notes:

- Fixed an issue where when running multiple formatters they would be ran in parallel rather than sequentially, leading to unwanted artifacts and incorrect output.
