### PR TITLE
Remove old keymap comments about AcceptEditPrediction modifier changes

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -505,7 +505,6 @@
   {
     "context": "Editor && edit_prediction",
     "bindings": {
-      // Changing the modifier currently breaks accepting while you also an LSP completions menu open
       "alt-enter": "editor::AcceptEditPrediction"
     }
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -583,7 +583,6 @@
   {
     "context": "Editor && edit_prediction",
     "bindings": {
-      // Changing the modifier currently breaks accepting while you also an LSP completions menu open
       "alt-tab": "editor::AcceptEditPrediction"
     }
   },


### PR DESCRIPTION
This was fixed in #24442

Release Notes:

- N/A