### PR TITLE
Use last keybind (highest precedence) for `AcceptEditPrediction` display

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1574,6 +1574,7 @@ impl Editor {
             window
                 .bindings_for_action_in_context(&AcceptEditPrediction, context)
                 .into_iter()
+                .rev()
                 .next(),
         )
     }


### PR DESCRIPTION
Fix of PR #24582

Release Notes:

- N/A