### PR TITLE
Remove alt-tab / alt-enter binds in vim keymap, as they are in base

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -696,18 +696,6 @@
     }
   },
   {
-    "context": "os == macos && edit_prediction",
-    "bindings": {
-      "alt-tab": "editor::AcceptEditPrediction"
-    }
-  },
-  {
-    "context": "os != macos && edit_prediction",
-    "bindings": {
-      "alt-enter": "editor::AcceptEditPrediction"
-    }
-  },
-  {
     "context": "edit_prediction && !edit_prediction_requires_modifier",
     "bindings": {
       "tab": "editor::AcceptEditPrediction"


### PR DESCRIPTION
Was unnecessary to include these in #24596 as they will be available from the base keymap.

Release Notes:

- N/A