### PR TITLE
vim: Update `vi{`

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1760,6 +1760,17 @@ mod test {
             Mode::Normal,
         );
         cx.simulate_keystrokes("v i {");
+        cx.assert_state(
+            indoc! {
+                "ˇfunc empty(a string) bool {
+                   «if a == \"\" {
+                      return true
+                   }
+                   return false»
+                }"
+            },
+            Mode::Visual,
+        );
 
         cx.set_state(
             indoc! {
@@ -1773,6 +1784,17 @@ mod test {
             Mode::Normal,
         );
         cx.simulate_keystrokes("v i {");
+        cx.assert_state(
+            indoc! {
+                "func empty(a string) bool {
+                     if a == \"\" {
+                         «ˇreturn true»
+                     }
+                     return false
+                }"
+            },
+            Mode::Visual,
+        );
 
         cx.set_state(
             indoc! {
@@ -1786,6 +1808,41 @@ mod test {
             Mode::Normal,
         );
         cx.simulate_keystrokes("v i {");
+        cx.assert_state(
+            indoc! {
+                "func empty(a string) bool {
+                     if a == \"\" {
+                         «ˇreturn true»
+                     }
+                     return false
+                }"
+            },
+            Mode::Visual,
+        );
+
+        cx.set_state(
+            indoc! {
+                "func empty(a string) bool {
+                     if a == \"\" {
+                         return true
+                     }
+                     return false
+                ˇ}"
+            },
+            Mode::Normal,
+        );
+        cx.simulate_keystrokes("v i {");
+        cx.assert_state(
+            indoc! {
+                "func empty(a string) bool {
+                     «ˇif a == \"\" {
+                         return true
+                     }
+                     return false»
+                }"
+            },
+            Mode::Visual,
+        );
     }
 
     #[gpui::test]

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -422,7 +422,7 @@ impl Object {
 /// If the selection spans multiple lines and is preceded by an opening brace (`{`),
 /// this function will trim the selection to exclude the final newline
 /// in order to preserve a properly indented line.
-fn preserve_indented_newline(map: &DisplaySnapshot, selection: &mut Selection<DisplayPoint>) {
+pub fn preserve_indented_newline(map: &DisplaySnapshot, selection: &mut Selection<DisplayPoint>) {
     let (start_point, end_point) = (selection.start.to_point(map), selection.end.to_point(map));
 
     if start_point.row == end_point.row {

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -446,6 +446,7 @@ pub fn preserve_indented_newline(map: &DisplaySnapshot, selection: &mut Selectio
                         match ch {
                             '\n' => {
                                 selection.end = offset.to_display_point(map);
+                                selection.reversed = true;
                                 break;
                             }
                             ch if !ch.is_whitespace() => break,

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1762,8 +1762,8 @@ mod test {
         cx.simulate_keystrokes("v i {");
         cx.assert_state(
             indoc! {
-                "ˇfunc empty(a string) bool {
-                   «if a == \"\" {
+                "func empty(a string) bool {
+                   «ˇif a == \"\" {
                       return true
                    }
                    return false»

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -16,7 +16,7 @@ use workspace::searchable::Direction;
 
 use crate::{
     motion::{first_non_whitespace, next_line_end, start_of_line, Motion},
-    object::Object,
+    object::{self, Object},
     state::{Mode, Operator},
     Vim,
 };
@@ -374,6 +374,9 @@ impl Vim {
                                     selection.start = range.start;
                                 } else {
                                     selection.end = range.end;
+                                }
+                                if !around && object.is_multiline() {
+                                    object::preserve_indented_newline(map, selection);
                                 }
                             }
 

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -377,7 +377,6 @@ impl Vim {
                                 }
                                 if !around && object.is_multiline() {
                                     object::preserve_indented_newline(map, selection);
-                                    selection.reversed = true;
                                 }
                             }
 

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -377,6 +377,7 @@ impl Vim {
                                 }
                                 if !around && object.is_multiline() {
                                     object::preserve_indented_newline(map, selection);
+                                    selection.reversed = true;
                                 }
                             }
 

--- a/crates/vim/test_data/test_multiline_surrounding_character_objects.json
+++ b/crates/vim/test_data/test_multiline_surrounding_character_objects.json
@@ -1,8 +1,8 @@
-{"Put":{"state":"func empty(a string) bool {\n   if a == \"\" {\n      return true\n   }\n   ˇreturn false\n}"}}
+{"Put":{"state":"func empty(a string) bool {\n     if a == \"\" {\n      return true\n   }\n   ˇreturn false\n}"}}
 {"Key":"v"}
 {"Key":"i"}
 {"Key":"{"}
-{"Get":{"state":"func empty(a string) bool {\n   ˇif a == \"\" {\n      return true\n   }\n   return false«»\n}","mode":"Visual"}}
+{"Get":{"state":"func empty(a string) bool {\n     «ˇif a == \"\" {\n      return true\n   }\n   return false»\n}","mode":"Visual"}}
 {"Put":{"state":"func empty(a string) bool {\n     if a == \"\" {\n         ˇreturn true\n     }\n     return false\n}"}}
 {"Key":"v"}
 {"Key":"i"}

--- a/crates/vim/test_data/test_multiline_surrounding_character_objects.json
+++ b/crates/vim/test_data/test_multiline_surrounding_character_objects.json
@@ -2,14 +2,19 @@
 {"Key":"v"}
 {"Key":"i"}
 {"Key":"{"}
-{"Get":{"state":"func empty(a string) bool {\n«   if a == \"\" {\n      return true\n   }\n   return false\nˇ»}","mode":"Visual"}}
+{"Get":{"state":"func empty(a string) bool {\n   ˇif a == \"\" {\n      return true\n   }\n   return false«»\n}","mode":"Visual"}}
 {"Put":{"state":"func empty(a string) bool {\n     if a == \"\" {\n         ˇreturn true\n     }\n     return false\n}"}}
 {"Key":"v"}
 {"Key":"i"}
 {"Key":"{"}
-{"Get":{"state":"func empty(a string) bool {\n     if a == \"\" {\n«         return true\nˇ»     }\n     return false\n}","mode":"Visual"}}
+{"Get":{"state":"func empty(a string) bool {\n     if a == \"\" {\n         «ˇreturn true»\n     }\n     return false\n}","mode":"Visual"}}
 {"Put":{"state":"func empty(a string) bool {\n     if a == \"\" ˇ{\n         return true\n     }\n     return false\n}"}}
 {"Key":"v"}
 {"Key":"i"}
 {"Key":"{"}
-{"Get":{"state":"func empty(a string) bool {\n     if a == \"\" {\n«         return true\nˇ»     }\n     return false\n}","mode":"Visual"}}
+{"Get":{"state":"func empty(a string) bool {\n     if a == \"\" {\n         «ˇreturn true»\n     }\n     return false\n}","mode":"Visual"}}
+{"Put":{"state":"func empty(a string) bool {\n     if a == \"\" {\n         return true\n     }\n     return false\nˇ}"}}
+{"Key":"v"}
+{"Key":"i"}
+{"Key":"{"}
+{"Get":{"state":"func empty(a string) bool {\n     «ˇif a == \"\" {\n         return true\n     }\n     return false»\n}","mode":"Visual"}}


### PR DESCRIPTION
Small fix: Following up on https://github.com/zed-industries/zed/pull/24518 where i missed `vi{`.

Matching neovim(mini.ai), `vi{` should not have the newline selected (Now `vi{d`/`vi{c` can match `di{`/`ci{`).

Also moved the cursor to the start.

|prev|new|neovim|
|---|---|---|
|![image](https://github.com/user-attachments/assets/0311fbe5-df2e-4feb-977d-de33a3af7fdc)|![image](https://github.com/user-attachments/assets/a940c6ba-268b-4401-8c43-38ca17848542)|![image](https://github.com/user-attachments/assets/dab2c47d-660c-4ae3-bf79-635265222cc1)|

Release Notes:

- N/A
