### PR TITLE
vim: Fix :wq in multibuffer

### DIFF
--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -250,7 +250,7 @@ async fn test_basic_following(
     });
     executor.run_until_parked();
     // are you sure you want to leave the call?
-    cx_c.simulate_prompt_answer(0);
+    cx_c.simulate_prompt_answer("Yes");
     cx_c.cx.update(|_| {
         drop(workspace_c);
     });

--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -250,7 +250,7 @@ async fn test_basic_following(
     });
     executor.run_until_parked();
     // are you sure you want to leave the call?
-    cx_c.simulate_prompt_answer("Yes");
+    cx_c.simulate_prompt_answer("Close window and hang up");
     cx_c.cx.update(|_| {
         drop(workspace_c);
     });

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -296,6 +296,11 @@ impl TestAppContext {
         self.test_platform.has_pending_prompt()
     }
 
+    /// Returns true if there's an alert dialog open.
+    pub fn pending_prompt(&self) -> Option<(String, String)> {
+        self.test_platform.pending_prompt()
+    }
+
     /// All the urls that have been opened with cx.open_url() during this test.
     pub fn opened_url(&self) -> Option<String> {
         self.test_platform.opened_url.borrow().clone()

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -286,8 +286,9 @@ impl TestAppContext {
     }
 
     /// Simulates clicking a button in an platform-level alert dialog.
-    pub fn simulate_prompt_answer(&self, button_ix: usize) {
-        self.test_platform.simulate_prompt_answer(button_ix);
+    #[track_caller]
+    pub fn simulate_prompt_answer(&self, button: &str) {
+        self.test_platform.simulate_prompt_answer(button);
     }
 
     /// Returns true if there's an alert dialog open.

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -159,7 +159,7 @@ impl PlatformWindow for TestWindow {
         _level: crate::PromptLevel,
         msg: &str,
         detail: Option<&str>,
-        _answers: &[&str],
+        answers: &[&str],
     ) -> Option<futures::channel::oneshot::Receiver<usize>> {
         Some(
             self.0
@@ -167,7 +167,7 @@ impl PlatformWindow for TestWindow {
                 .platform
                 .upgrade()
                 .expect("platform dropped")
-                .prompt(msg, detail),
+                .prompt(msg, detail, answers),
         )
     }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -9551,7 +9551,7 @@ mod tests {
             cx.has_pending_prompt(),
             "Should have a prompt after the deletion"
         );
-        cx.simulate_prompt_answer(0);
+        cx.simulate_prompt_answer("Delete");
         assert!(
             !cx.has_pending_prompt(),
             "Should have no prompts after prompt was replied to"

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -694,8 +694,7 @@ mod tests {
             cx.has_pending_prompt(),
             "Dirty workspace should prompt before opening the new recent project"
         );
-        // Cancel
-        cx.simulate_prompt_answer(0);
+        cx.simulate_prompt_answer("Cancel");
         assert!(
             !cx.has_pending_prompt(),
             "Should have no pending prompt after cancelling"

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1577,12 +1577,10 @@ mod test {
         // conflict!
         cx.simulate_keystrokes("i @ escape");
         cx.simulate_keystrokes(": w enter");
-        assert!(cx.has_pending_prompt());
-        // "Cancel"
-        cx.simulate_prompt_answer(0);
+        cx.simulate_prompt_answer("Cancel");
+
         assert_eq!(fs.load(path).await.unwrap().replace("\r\n", "\n"), "oops\n");
         assert!(!cx.has_pending_prompt());
-        // force overwrite
         cx.simulate_keystrokes(": w ! enter");
         assert!(!cx.has_pending_prompt());
         assert_eq!(fs.load(path).await.unwrap().replace("\r\n", "\n"), "@@\n");

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1257,6 +1257,19 @@ pub mod test {
                 is_dirty: false,
             })
         }
+
+        pub fn new_dirty(id: u64, path: &str, cx: &mut App) -> Entity<Self> {
+            let entry_id = Some(ProjectEntryId::from_proto(id));
+            let project_path = Some(ProjectPath {
+                worktree_id: WorktreeId::from_usize(0),
+                path: Path::new(path).into(),
+            });
+            cx.new(|_| Self {
+                entry_id,
+                project_path,
+                is_dirty: true,
+            })
+        }
     }
 
     impl TestItem {
@@ -1460,10 +1473,17 @@ pub mod test {
             _: bool,
             _: Entity<Project>,
             _window: &mut Window,
-            _: &mut Context<Self>,
+            cx: &mut Context<Self>,
         ) -> Task<anyhow::Result<()>> {
             self.save_count += 1;
             self.is_dirty = false;
+            for item in &self.project_items {
+                item.update(cx, |item, cx| {
+                    if item.is_dirty {
+                        item.is_dirty = false;
+                    }
+                })
+            }
             Task::ready(Ok(()))
         }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1478,7 +1478,7 @@ pub mod test {
             self.save_count += 1;
             self.is_dirty = false;
             for item in &self.project_items {
-                item.update(cx, |item, cx| {
+                item.update(cx, |item, _| {
                     if item.is_dirty {
                         item.is_dirty = false;
                     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1551,7 +1551,7 @@ impl Pane {
                 // storing these in advance, in case they have changed since this task
                 // was started.
                 let mut dirty_project_item_ids = Vec::new();
-                let Some(item_ix) = pane.update(&mut cx, |pane, cx| {
+                let Some(_) = pane.update(&mut cx, |pane, cx| {
                     item_to_close.for_each_project_item(
                         cx,
                         &mut |project_item_id, project_item| {
@@ -1596,7 +1596,6 @@ impl Pane {
                     && !Self::save_item(
                         project.clone(),
                         &pane,
-                        item_ix,
                         &*item_to_close,
                         save_intent,
                         &mut cx,
@@ -1777,7 +1776,6 @@ impl Pane {
     pub async fn save_item(
         project: Entity<Project>,
         pane: &WeakEntity<Pane>,
-        item_ix: usize,
         item: &dyn ItemHandle,
         save_intent: SaveIntent,
         cx: &mut AsyncWindowContext,
@@ -1791,6 +1789,13 @@ impl Pane {
         if save_intent == SaveIntent::Skip {
             return Ok(true);
         }
+        let Some(item_ix) = pane
+            .update(cx, |pane, _| pane.index_for_item(item))
+            .ok()
+            .flatten()
+        else {
+            return Ok(true);
+        };
 
         let (mut has_conflict, mut is_dirty, mut can_save, is_singleton, has_deleted_file) = cx
             .update(|_window, cx| {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1552,10 +1552,7 @@ impl Pane {
         });
 
         let workspace = self.workspace.clone();
-        let Some(project) = workspace
-            .update(cx, |workspace, _| workspace.project().clone())
-            .ok()
-        else {
+        let Some(project) = self.project.upgrade() else {
             return Task::ready(Ok(()));
         };
         cx.spawn_in(window, |pane, mut cx| async move {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8190,7 +8190,6 @@ mod tests {
         dirty_regular_buffer.update(cx, |buffer, cx| {
             buffer.project_items[0].update(cx, |pi, cx| pi.is_dirty = true)
         });
-        dbg!("wow!");
 
         let close_multi_buffer_task = pane
             .update_in(cx, |pane, window, cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8187,6 +8187,11 @@ mod tests {
             );
         });
 
+        dirty_regular_buffer.update(cx, |buffer, cx| {
+            buffer.project_items[0].update(cx, |pi, cx| pi.is_dirty = true)
+        });
+        dbg!("wow!");
+
         let close_multi_buffer_task = pane
             .update_in(cx, |pane, window, cx| {
                 pane.close_active_item(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -8188,7 +8188,7 @@ mod tests {
         });
 
         dirty_regular_buffer.update(cx, |buffer, cx| {
-            buffer.project_items[0].update(cx, |pi, cx| pi.is_dirty = true)
+            buffer.project_items[0].update(cx, |pi, _| pi.is_dirty = true)
         });
 
         let close_multi_buffer_task = pane

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -2057,7 +2057,7 @@ mod tests {
             .unwrap();
         executor.run_until_parked();
 
-        cx.simulate_prompt_answer(1);
+        cx.simulate_prompt_answer("Don't Save");
         close.await.unwrap();
         assert!(!window_is_edited(window, cx));
 
@@ -2118,7 +2118,7 @@ mod tests {
         assert_eq!(cx.update(|cx| cx.windows().len()), 1);
 
         // The window is successfully closed after the user dismisses the prompt.
-        cx.simulate_prompt_answer(1);
+        cx.simulate_prompt_answer("Don't Save");
         executor.run_until_parked();
         assert_eq!(cx.update(|cx| cx.windows().len()), 0);
     }
@@ -2853,7 +2853,7 @@ mod tests {
             })
             .unwrap();
         cx.background_executor.run_until_parked();
-        cx.simulate_prompt_answer(0);
+        cx.simulate_prompt_answer("Overwrite");
         save_task.await.unwrap();
         window
             .update(cx, |_, _, cx| {
@@ -3152,7 +3152,7 @@ mod tests {
             },
         );
         cx.background_executor.run_until_parked();
-        cx.simulate_prompt_answer(1);
+        cx.simulate_prompt_answer("Don't Save");
         cx.background_executor.run_until_parked();
 
         window


### PR DESCRIPTION
Supercedes #24561
Closes #21059

Before this change we would skip saving multibuffers regardless of the save intent. Now we correctly save them.

Along the way:
* Prompt to save when closing the last singleton copy of an item (even if it's still open in a multibuffer).
* Update our file name prompt to pull out dirty project items from multibuffers instead of counting multibuffers as untitled files.
* Fix our prompt test helpers to require passing the button name instead of the index. A few tests were passing invalid responses to save prompts.
* Refactor the code a bit to hopefully clarify it for the next bug.

Release Notes:

- Fixed edge-cases when closing multiple items including multibuffers. Previously no prompt was generated when closing an item that was open in a multibuffer, now you will be prompted.
- vim: Fix :wq in a multibuffer
