### PR TITLE
vim: Fix yG

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1176,21 +1176,10 @@ impl Motion {
             if self.linewise() {
                 selection.start = map.prev_line_boundary(selection.start.to_point(map)).1;
 
-                if expand_to_surrounding_newline {
-                    if selection.end.row() < map.max_point().row() {
-                        *selection.end.row_mut() += 1;
-                        *selection.end.column_mut() = 0;
-                        selection.end = map.clip_point(selection.end, Bias::Right);
-                        // Don't reset the end here
-                        return Some(selection.start..selection.end);
-                    } else if selection.start.row().0 > 0 {
-                        *selection.start.row_mut() -= 1;
-                        *selection.start.column_mut() = map.line_len(selection.start.row());
-                        selection.start = map.clip_point(selection.start, Bias::Left);
-                    }
-                }
-
                 selection.end = map.next_line_boundary(selection.end.to_point(map)).1;
+                if expand_to_surrounding_newline {
+                    selection.end = movement::right(map, selection.end)
+                }
             } else {
                 // Another special case: When using the "w" motion in combination with an
                 // operator and the last word moved over is at the end of a line, the end of

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1707,3 +1707,16 @@ async fn test_ctrl_o_dot(cx: &mut gpui::TestAppContext) {
     cx.simulate_shared_keystrokes("l l escape .").await;
     cx.shared_state().await.assert_eq("hellˇllo world.");
 }
+
+#[gpui::test]
+async fn test_yy_shift_g(cx: &mut gpui::TestAppContext) {
+    let mut cx = NeovimBackedTestContext::new(cx).await;
+    cx.set_shared_wrap(12).await;
+
+    cx.set_shared_state("ˇabc def ghi jkl mno pqr stu vwx y&z")
+        .await;
+    cx.simulate_shared_keystrokes("y shift-g").await;
+    cx.shared_clipboard()
+        .await
+        .assert_eq("abc def ghi jkl mno pqr stu vwx y&z\n");
+}

--- a/crates/vim/src/test/neovim_backed_test_context.rs
+++ b/crates/vim/src/test/neovim_backed_test_context.rs
@@ -122,9 +122,9 @@ impl SharedClipboard {
                 # currently expected:
                 {}
                 # neovim register \"{}:
-                {}
+                {:?}
                 # zed register \"{}:
-                {}"},
+                {:?}"},
             message,
             self.state.initial,
             self.state.recent_keystrokes,

--- a/crates/vim/test_data/test_yy_shift_g.json
+++ b/crates/vim/test_data/test_yy_shift_g.json
@@ -1,0 +1,7 @@
+{"SetOption":{"value":"wrap"}}
+{"SetOption":{"value":"columns=12"}}
+{"Put":{"state":"ˇabc def ghi jkl mno pqr stu vwx y&z"}}
+{"Key":"y"}
+{"Key":"shift-g"}
+{"Get":{"state":"ˇabc def ghi jkl mno pqr stu vwx y&z","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"abc def ghi jkl mno pqr stu vwx y&z\n"}}


### PR DESCRIPTION
Closes #23589

Release Notes:

- vim: Fix linewise motion targets when softwrap enabled
