### PR TITLE
Revert "Make `ctrl-l` the default vim binding for AcceptEditPrediction (#24599)

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -698,15 +698,7 @@
   {
     "context": "edit_prediction && !edit_prediction_requires_modifier",
     "bindings": {
-      // "tab" is bound in the vim bindings above so that default editor behavior isn't used, so
-      // need to rebind it even though this is in the base keymap.
       "tab": "editor::AcceptEditPrediction"
-    }
-  },
-  {
-    "context": "edit_prediction",
-    "bindings": {
-      "ctrl-l": "editor::AcceptEditPrediction"
     }
   }
 ]


### PR DESCRIPTION
Didn't realize that the base keymap binds this to `editor::SelectLine`.

This reverts commit c5fe5f11396e0eeac765880eb6a17afbfbd53f78.

Release Notes:

- N/A