### PR TITLE
gpui: Fix the resource loading error in the image examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5546,6 +5546,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "refineable",
+ "reqwest_client",
  "resvg",
  "schemars",
  "seahash",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -203,6 +203,7 @@ backtrace = "0.3"
 collections = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
 rand.workspace = true
+reqwest_client.workspace = true
 util = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 unicode-segmentation.workspace = true

--- a/crates/gpui/examples/image/image.rs
+++ b/crates/gpui/examples/image/image.rs
@@ -9,6 +9,7 @@ use gpui::{
     Bounds, Context, ImageSource, KeyBinding, Menu, MenuItem, Point, SharedString, SharedUri,
     TitlebarOptions, Window, WindowBounds, WindowOptions,
 };
+use reqwest_client::ReqwestClient;
 
 struct Assets {
     base: PathBuf,
@@ -127,10 +128,13 @@ actions!(image, [Quit]);
 fn main() {
     env_logger::init();
 
+    let http_client = ReqwestClient::user_agent("gpui_image_example").unwrap();
+
     Application::new()
         .with_assets(Assets {
-            base: PathBuf::from("crates/gpui/examples"),
+            base: PathBuf::from("examples"),
         })
+        .with_http_client(Arc::new(http_client))
         .run(|cx: &mut App| {
             cx.activate(true);
             cx.on_action(|_: &Quit, cx| cx.quit());
@@ -158,7 +162,7 @@ fn main() {
             cx.open_window(window_options, |_, cx| {
                 cx.new(|_| ImageShowcase {
                     // Relative path to your root project path
-                    local_resource: PathBuf::from_str("crates/gpui/examples/image/app-icon.png")
+                    local_resource: PathBuf::from_str("examples/image/app-icon.png")
                         .unwrap()
                         .into(),
 

--- a/crates/gpui/examples/opacity.rs
+++ b/crates/gpui/examples/opacity.rs
@@ -159,7 +159,7 @@ impl Render for HelloWorld {
 fn main() {
     Application::new()
         .with_assets(Assets {
-            base: PathBuf::from("crates/gpui/examples"),
+            base: PathBuf::from("examples"),
         })
         .run(|cx: &mut App| {
             let bounds = Bounds::centered(None, size(px(500.0), px(500.0)), cx);

--- a/crates/gpui/examples/svg/svg.rs
+++ b/crates/gpui/examples/svg/svg.rs
@@ -70,7 +70,7 @@ impl Render for SvgExample {
 fn main() {
     Application::new()
         .with_assets(Assets {
-            base: PathBuf::from("crates/gpui/examples"),
+            base: PathBuf::from("examples"),
         })
         .run(|cx: &mut App| {
             let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);


### PR DESCRIPTION
## Before
<img width="200" alt="SCR-20250211-pnve" src="https://github.com/user-attachments/assets/253c675b-2a13-42a8-9653-ac2bf0e54058" />
<img width="300" alt="SCR-20250211-povq" src="https://github.com/user-attachments/assets/4b60b35e-4ef0-4e29-82e4-842ae439c3a8" />
<img width="600" alt="SCR-20250211-ppbf" src="https://github.com/user-attachments/assets/f84cac4b-e37b-40ab-a770-7dfdfd4c4ddf" />


## After
<img width="200" alt="SCR-20250211-pmim" src="https://github.com/user-attachments/assets/bc77a97e-e12a-4951-af64-703503873d31" />
<img width="300" alt="SCR-20250211-ppiy" src="https://github.com/user-attachments/assets/86850569-2bc8-4c0b-b3cb-85b715954d1d" />
<img width="600" alt="SCR-20250211-ppmc" src="https://github.com/user-attachments/assets/5f6e5166-ffd5-44b6-8d21-a965ac3618e8" />


Release Notes:

- N/A