### PR TITLE
vim: Prevent around word operations from selecting indentation

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -2483,18 +2483,18 @@ mod test {
 
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
-        cx.simulate_shared_keystrokes("y a w").await;
+        cx.simulate_shared_keystrokes("escape y a w").await;
         cx.shared_clipboard().await.assert_eq("const ");
 
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
-        cx.simulate_shared_keystrokes("d a w").await;
+        cx.simulate_shared_keystrokes("escape d a w").await;
         cx.shared_clipboard().await.assert_eq("const ");
         cx.shared_state().await.assert_matches();
 
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
-        cx.simulate_shared_keystrokes("c a w").await;
+        cx.simulate_shared_keystrokes("escape c a w").await;
         cx.shared_clipboard().await.assert_eq("const ");
         cx.shared_state().await.assert_matches();
     }

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -2479,23 +2479,29 @@ mod test {
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
         cx.simulate_shared_keystrokes("v a w").await;
-        cx.shared_state().await.assert_matches();
+        cx.shared_state()
+            .await
+            .assert_eq("    «const ˇ»f = (x: unknown) => {");
 
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
-        cx.simulate_shared_keystrokes("escape y a w").await;
+        cx.simulate_shared_keystrokes("y a w").await;
         cx.shared_clipboard().await.assert_eq("const ");
 
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
-        cx.simulate_shared_keystrokes("escape d a w").await;
+        cx.simulate_shared_keystrokes("d a w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("    ˇf = (x: unknown) => {");
         cx.shared_clipboard().await.assert_eq("const ");
-        cx.shared_state().await.assert_matches();
 
         cx.set_shared_state("    ˇconst f = (x: unknown) => {")
             .await;
-        cx.simulate_shared_keystrokes("escape c a w").await;
+        cx.simulate_shared_keystrokes("c a w").await;
+        cx.shared_state()
+            .await
+            .assert_eq("    ˇf = (x: unknown) => {");
         cx.shared_clipboard().await.assert_eq("const ");
-        cx.shared_state().await.assert_matches();
     }
 }

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -2472,4 +2472,30 @@ mod test {
             Mode::Visual,
         );
     }
+    #[gpui::test]
+    async fn test_around_containing_word_indent(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state("    ˇconst f = (x: unknown) => {")
+            .await;
+        cx.simulate_shared_keystrokes("v a w").await;
+        cx.shared_state().await.assert_matches();
+
+        cx.set_shared_state("    ˇconst f = (x: unknown) => {")
+            .await;
+        cx.simulate_shared_keystrokes("y a w").await;
+        cx.shared_clipboard().await.assert_eq("const ");
+
+        cx.set_shared_state("    ˇconst f = (x: unknown) => {")
+            .await;
+        cx.simulate_shared_keystrokes("d a w").await;
+        cx.shared_clipboard().await.assert_eq("const ");
+        cx.shared_state().await.assert_matches();
+
+        cx.set_shared_state("    ˇconst f = (x: unknown) => {")
+            .await;
+        cx.simulate_shared_keystrokes("c a w").await;
+        cx.shared_clipboard().await.assert_eq("const ");
+        cx.shared_state().await.assert_matches();
+    }
 }

--- a/crates/vim/test_data/test_around_containing_word_indent.json
+++ b/crates/vim/test_data/test_around_containing_word_indent.json
@@ -3,21 +3,19 @@
 {"Key":"a"}
 {"Key":"w"}
 {"Get":{"state":"    «const ˇ»f = (x: unknown) => {","mode":"Visual"}}
-{"Key":"escape"}
+{"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
 {"Key":"y"}
 {"Key":"a"}
 {"Key":"w"}
 {"Get":{"state":"    ˇconst f = (x: unknown) => {","mode":"Normal"}}
 {"ReadRegister":{"name":"\"","value":"const "}}
 {"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
-{"Key":"escape"}
 {"Key":"d"}
 {"Key":"a"}
 {"Key":"w"}
 {"Get":{"state":"    ˇf = (x: unknown) => {","mode":"Normal"}}
 {"ReadRegister":{"name":"\"","value":"const "}}
 {"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
-{"Key":"escape"}
 {"Key":"c"}
 {"Key":"a"}
 {"Key":"w"}

--- a/crates/vim/test_data/test_around_containing_word_indent.json
+++ b/crates/vim/test_data/test_around_containing_word_indent.json
@@ -1,0 +1,23 @@
+{"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
+{"Key":"v"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"    «const ˇ»f = (x: unknown) => {","mode":"Visual"}}
+{"Key":"escape"}
+{"Key":"y"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"    ˇconst f = (x: unknown) => {","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"const "}}
+{"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
+{"Key":"d"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"    ˇf = (x: unknown) => {","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"const "}}
+{"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
+{"Key":"c"}
+{"Key":"a"}
+{"Key":"w"}
+{"Get":{"state":"    ˇf = (x: unknown) => {","mode":"Insert"}}
+{"ReadRegister":{"name":"\"","value":"const "}}

--- a/crates/vim/test_data/test_around_containing_word_indent.json
+++ b/crates/vim/test_data/test_around_containing_word_indent.json
@@ -10,12 +10,14 @@
 {"Get":{"state":"    ˇconst f = (x: unknown) => {","mode":"Normal"}}
 {"ReadRegister":{"name":"\"","value":"const "}}
 {"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
+{"Key":"escape"}
 {"Key":"d"}
 {"Key":"a"}
 {"Key":"w"}
 {"Get":{"state":"    ˇf = (x: unknown) => {","mode":"Normal"}}
 {"ReadRegister":{"name":"\"","value":"const "}}
 {"Put":{"state":"    ˇconst f = (x: unknown) => {"}}
+{"Key":"escape"}
 {"Key":"c"}
 {"Key":"a"}
 {"Key":"w"}


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/15323

Changes:
Added check for first word on line

Tested `v/c/d/y aw`. Matches standard neovim.

|initial|old|new|
|---|---|---|
|![image](https://github.com/user-attachments/assets/725b74e6-3aa0-40dc-9fd2-4d2b593e9926)|![image](https://github.com/user-attachments/assets/eeebd267-b4c6-4ea6-bb9a-fb913614754c)|![image](https://github.com/user-attachments/assets/fb695e54-b4c2-44a6-a588-909c1fd415e0)



Release Notes:

- vim: Prevent around word operations from selecting indentation