### PR TITLE
Remove non-existent icon IndicatorX

### DIFF
--- a/crates/ui/src/components/icon.rs
+++ b/crates/ui/src/components/icon.rs
@@ -221,7 +221,6 @@ pub enum IconName {
     Hash,
     HistoryRerun,
     Indicator,
-    IndicatorX,
     Info,
     InlayHint,
     Keyboard,


### PR DESCRIPTION
There is no file indicator_x.svg in the assets directory.

09:49:05 [ERROR] could not find asset at path "icons/indicator_x.svg"

![image](https://github.com/user-attachments/assets/e9cc5ae3-4eb3-4e1e-b012-43ac7297c0a7)

Release Notes:

- N/A
