### PR TITLE
file_icons: Use a separate icon key for Svelte files

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -186,7 +186,7 @@
     "sh": "terminal",
     "sql": "storage",
     "sqlite": "storage",
-    "svelte": "template",
+    "svelte": "svelte",
     "svg": "image",
     "swift": "swift",
     "tcl": "tcl",

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -112,6 +112,7 @@ const FILE_ICONS: &[(&str, &str)] = &[
     ("scala", "icons/file_icons/scala.svg"),
     ("settings", "icons/file_icons/settings.svg"),
     ("storage", "icons/file_icons/database.svg"),
+    ("svelte", "icons/file_icons/template.svg"),
     ("swift", "icons/file_icons/swift.svg"),
     ("tcl", "icons/file_icons/tcl.svg"),
     ("template", "icons/file_icons/html.svg"),


### PR DESCRIPTION
This PR updates the file icon mappings such that Svelte (`.svelte`) files map to the `svelte` key.

Release Notes:

- Icon themes: Added the ability to change the file icon for Svelte (`.svelte`) files.
