### PR TITLE
gpui: Make `image` example work regardless of how it is run

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5546,6 +5546,7 @@ dependencies = [
  "rand 0.8.5",
  "raw-window-handle",
  "refineable",
+ "reqwest_client",
  "resvg",
  "schemars",
  "seahash",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -202,11 +202,12 @@ windows-core = "0.58"
 backtrace = "0.3"
 collections = { workspace = true, features = ["test-support"] }
 env_logger.workspace = true
-rand.workspace = true
-util = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
-unicode-segmentation.workspace = true
 lyon = { version = "1.0", features = ["extra"] }
+rand.workspace = true
+unicode-segmentation.workspace = true
+reqwest_client = { workspace = true, features = ["test-support"] }
+util = { workspace = true, features = ["test-support"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 embed-resource = "3.0"


### PR DESCRIPTION
This PR updates the GPUI `image` example such that it works when run in the following ways:

- `cargo run -p gpui --example image` from the repository root
- `cargo run --example image` from within `crates/gpui`

Release Notes:

- N/A
