### PR TITLE
gpui: Update asset paths for more examples

### DIFF
--- a/crates/gpui/examples/gif_viewer.rs
+++ b/crates/gpui/examples/gif_viewer.rs
@@ -25,15 +25,8 @@ impl Render for GifViewer {
 fn main() {
     env_logger::init();
     Application::new().run(|cx: &mut App| {
-        let cwd = std::env::current_dir().expect("Failed to get current working directory");
-        let gif_path = cwd.join("crates/gpui/examples/image/black-cat-typing.gif");
-
-        if !gif_path.exists() {
-            eprintln!("Image file not found at {:?}", gif_path);
-            eprintln!("Make sure you're running this example from the root of the gpui crate");
-            cx.quit();
-            return;
-        }
+        let gif_path =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples/image/black-cat-typing.gif");
 
         cx.open_window(
             WindowOptions {

--- a/crates/gpui/examples/image_loading.rs
+++ b/crates/gpui/examples/image_loading.rs
@@ -29,7 +29,7 @@ impl AssetSource for Assets {
     }
 }
 
-const IMAGE: &str = "examples/image/app-icon.png";
+const IMAGE: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/examples/image/app-icon.png");
 
 #[derive(Copy, Clone, Hash)]
 struct LoadImageParameters {

--- a/crates/gpui/examples/opacity.rs
+++ b/crates/gpui/examples/opacity.rs
@@ -159,7 +159,7 @@ impl Render for HelloWorld {
 fn main() {
     Application::new()
         .with_assets(Assets {
-            base: PathBuf::from("crates/gpui/examples"),
+            base: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples"),
         })
         .run(|cx: &mut App| {
             let bounds = Bounds::centered(None, size(px(500.0), px(500.0)), cx);
@@ -171,5 +171,6 @@ fn main() {
                 |window, cx| cx.new(|cx| HelloWorld::new(window, cx)),
             )
             .unwrap();
+            cx.activate(true);
         });
 }

--- a/crates/gpui/examples/svg/svg.rs
+++ b/crates/gpui/examples/svg/svg.rs
@@ -70,7 +70,7 @@ impl Render for SvgExample {
 fn main() {
     Application::new()
         .with_assets(Assets {
-            base: PathBuf::from("crates/gpui/examples"),
+            base: PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("examples"),
         })
         .run(|cx: &mut App| {
             let bounds = Bounds::centered(None, size(px(300.0), px(300.0)), cx);
@@ -82,5 +82,6 @@ fn main() {
                 |_, cx| cx.new(|_| SvgExample),
             )
             .unwrap();
+            cx.activate(true);
         });
 }


### PR DESCRIPTION
This PR updates the asset paths used in more GPUI examples such that they work when run from the repository root or from within `crates/gpui`.

Release Notes:

- N/A
