### PR TITLE
theme: Fix Svelte file icon

### DIFF
--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -112,7 +112,7 @@ const FILE_ICONS: &[(&str, &str)] = &[
     ("scala", "icons/file_icons/scala.svg"),
     ("settings", "icons/file_icons/settings.svg"),
     ("storage", "icons/file_icons/database.svg"),
-    ("svelte", "icons/file_icons/template.svg"),
+    ("svelte", "icons/file_icons/html.svg"),
     ("swift", "icons/file_icons/swift.svg"),
     ("tcl", "icons/file_icons/tcl.svg"),
     ("template", "icons/file_icons/html.svg"),


### PR DESCRIPTION
This PR fixes the file icon used for Svelte files in the default icon theme, as I used the wrong icon name in #24644.

Release Notes:

- N/A
