### PR TITLE
edit prediction: Try to fix panic in `Buffer::preview_edits`

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1102,6 +1102,10 @@ impl Buffer {
         let mut syntax_snapshot = self.syntax_map.lock().snapshot();
         cx.background_executor().spawn(async move {
             if !edits.is_empty() {
+                if let Some(language) = language.clone() {
+                    syntax_snapshot.reparse(&old_snapshot, registry.clone(), language);
+                }
+
                 branch_buffer.edit(edits.iter().cloned());
                 let snapshot = branch_buffer.snapshot();
                 syntax_snapshot.interpolate(&snapshot);


### PR DESCRIPTION
We've seen a few crashes in `SyntaxSnapshot::reparse_with_ranges` during `Buffer::preview_edits`, where an offset conversion fails because it is out of range.
We are not sure how exactly this is happening. 
Our theory is that the syntax snapshot is using an outdated state when edits happen in the meantime (while interpolating). This is an attempt to see if it helps with the panics, hopefully we can revisit this when we have a better understanding of the issue.


Co-Authored-by: Antonio <antonio@zed.dev>

Release Notes:

- N/A
