### PR TITLE
editor: Fix crash caused by `editor::SelectPrevious`

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5363,6 +5363,21 @@ async fn test_select_previous_with_single_caret(cx: &mut gpui::TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_select_previous_empty_buffer(cx: &mut gpui::TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+    cx.set_state("aˇ");
+
+    cx.update_editor(|e, window, cx| e.select_previous(&SelectPrevious::default(), window, cx))
+        .unwrap();
+    cx.assert_editor_state("«aˇ»");
+    cx.update_editor(|e, window, cx| e.select_previous(&SelectPrevious::default(), window, cx))
+        .unwrap();
+    cx.assert_editor_state("«aˇ»");
+}
+
+#[gpui::test]
 async fn test_select_previous_with_multiple_carets(cx: &mut gpui::TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -7121,7 +7121,7 @@ impl<'a> Iterator for ReversedMultiBufferChunks<'a> {
             self.offset -= 1;
             Some("\n")
         } else {
-            let chunk = self.current_chunks.as_mut().unwrap().next().unwrap();
+            let chunk = self.current_chunks.as_mut().unwrap().next()?;
             self.offset -= chunk.len();
             Some(chunk)
         }


### PR DESCRIPTION
Closes #24345

Release Notes:

- Fixed a crash caused by calling `editor::SelectPrevious` twice in a row.
