### PR TITLE
Correctly handle `[[` autoclosing in Markdown

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -3,6 +3,7 @@ grammar = "markdown"
 path_suffixes = ["md", "mdx", "mdwn", "markdown", "MD"]
 word_characters = ["-"]
 block_comment = ["<!-- ", " -->"]
+autoclose_before = "}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/11151

Release Notes:

- Fixed mismatched autoclose brackets in Markdown so `[[` now correctly adds `]]`. 
