### PR TITLE
Add `Editor &&` to accept edit contexts in vim keymap

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -696,7 +696,7 @@
     }
   },
   {
-    "context": "edit_prediction && !edit_prediction_requires_modifier",
+    "context": "Editor && edit_prediction && !edit_prediction_requires_modifier",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to
       // "vim::Tab" shadow it, so it needs to be bound again.
@@ -704,7 +704,7 @@
     }
   },
   {
-    "context": "os != macos && edit_prediction",
+    "context": "os != macos && Editor && edit_prediction",
     "bindings": {
       // alt-l is provided as an alternative to tab/alt-tab. and will be displayed in the UI. This
       // is because alt-tab may not be available, as it is often used for window switching on Linux


### PR DESCRIPTION
Without this, these default vim bindings were taking precedence over user keybindings

Release Notes:

- N/A