### PR TITLE
inline_completion_button: Add menu option to toggle "Eager Preview"s for edit predictions

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -250,7 +250,7 @@ pub struct AllLanguageSettingsContent {
     pub features: Option<FeaturesContent>,
     /// The edit prediction settings.
     #[serde(default)]
-    pub edit_predictions: Option<InlineCompletionSettingsContent>,
+    pub edit_predictions: Option<EditPredictionSettingsContent>,
     /// The default language settings.
     #[serde(flatten)]
     pub defaults: LanguageSettingsContent,
@@ -428,7 +428,7 @@ pub struct LanguageSettingsContent {
 
 /// The contents of the edit prediction settings.
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
-pub struct InlineCompletionSettingsContent {
+pub struct EditPredictionSettingsContent {
     /// A list of globs representing files that edit predictions should be disabled for.
     /// This list adds to a pre-existing, sensible default set of globs.
     /// Any additional ones you add are combined with them.


### PR DESCRIPTION
This PR adds a menu option to the edit prediction menu to toggle the "Eager Preview" behavior:

<img width="252" alt="Screenshot 2025-02-11 at 2 44 52 PM" src="https://github.com/user-attachments/assets/232e879b-3c11-4edd-a549-f284e2bca391" />

Release Notes:

- N/A
