### PR TITLE
Clean up edit predictions settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -792,11 +792,11 @@
     ],
     // When to show edit predictions previews in buffer.
     // This setting takes two possible values:
-    // 1. Display inline when there are no language server completions available.
-    //     "inline_preview": "auto"
-    // 2. Display inline when holding modifier key (alt by default).
-    //     "inline_preview": "when_holding_modifier"
-    "inline_preview": "auto"
+    // 1. Display inline when holding modifier key (alt by default).
+    //     "mode": "auto"
+    // 2. Display inline when there are no language server completions available.
+    //     "mode": "eager_preview"
+    "mode": "auto"
   },
   // Settings specific to journaling
   "journal": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -168,9 +168,6 @@
   /// Whether to show the signature help after completion or a bracket pair inserted.
   /// If `auto_signature_help` is enabled, this setting will be treated as enabled also.
   "show_signature_help_after_edits": false,
-  /// Whether to show the edit predictions next to the completions provided by a language server.
-  /// Only has an effect if edit prediction provider supports it.
-  "show_edit_predictions_in_menu": true,
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
   // if 'soft_wrap' is set to 'preferred_line_length', and will show any

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -95,8 +95,8 @@ use itertools::Itertools;
 use language::{
     language_settings::{self, all_language_settings, language_settings, InlayHintSettings},
     markdown, point_from_lsp, AutoindentMode, BracketPair, Buffer, Capability, CharKind, CodeLabel,
-    CompletionDocumentation, CursorShape, Diagnostic, EditPreview, HighlightedText, IndentKind,
-    IndentSize, InlineCompletionPreviewMode, Language, OffsetRangeExt, Point, Selection,
+    CompletionDocumentation, CursorShape, Diagnostic, EditPredictionsMode, EditPreview,
+    HighlightedText, IndentKind, IndentSize, Language, OffsetRangeExt, Point, Selection,
     SelectionGoal, TextObject, TransactionId, TreeSitterOptions,
 };
 use language::{point_to_lsp, BufferRow, CharClassifier, Runnable, RunnableRange};
@@ -5054,9 +5054,8 @@ impl Editor {
                     provider.provider.show_completions_in_menu()
                 });
 
-        let preview_requires_modifier = all_language_settings(file, cx)
-            .inline_completions_preview_mode()
-            == InlineCompletionPreviewMode::WhenHoldingModifier;
+        let preview_requires_modifier = all_language_settings(file, cx).edit_predictions_mode()
+            == EditPredictionsMode::WhenHoldingModifier;
 
         EditPredictionSettings::Enabled {
             show_in_menu,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5047,7 +5047,6 @@ impl Editor {
         );
 
         let show_in_menu = by_provider
-            && EditorSettings::get_global(cx).show_edit_predictions_in_menu
             && self
                 .edit_prediction_provider
                 .as_ref()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5055,7 +5055,7 @@ impl Editor {
                 });
 
         let preview_requires_modifier = all_language_settings(file, cx).edit_predictions_mode()
-            == EditPredictionsMode::WhenHoldingModifier;
+            == EditPredictionsMode::Auto;
 
         EditPredictionSettings::Enabled {
             show_in_menu,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5054,8 +5054,8 @@ impl Editor {
                     provider.provider.show_completions_in_menu()
                 });
 
-        let preview_requires_modifier = all_language_settings(file, cx).edit_predictions_mode()
-            == EditPredictionsMode::Auto;
+        let preview_requires_modifier =
+            all_language_settings(file, cx).edit_predictions_mode() == EditPredictionsMode::Auto;
 
         EditPredictionSettings::Enabled {
             show_in_menu,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -35,7 +35,6 @@ pub struct EditorSettings {
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
     pub jupyter: Jupyter,
-    pub show_edit_predictions_in_menu: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -367,12 +366,6 @@ pub struct EditorSettingsContent {
     ///
     /// Default: false
     pub show_signature_help_after_edits: Option<bool>,
-
-    /// Whether to show the edit predictions next to the completions provided by a language server.
-    /// Only has an effect if edit prediction provider supports it.
-    ///
-    /// Default: true
-    pub show_edit_predictions_in_menu: Option<bool>,
 
     /// Jupyter REPL settings.
     pub jupyter: Option<JupyterContent>,

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -551,9 +551,9 @@ impl InlineCompletionButton {
             );
         }
 
-        let is_eager_preview_enabled = match settings.inline_completions_preview_mode() {
-            language::InlineCompletionPreviewMode::Auto => true,
-            language::InlineCompletionPreviewMode::WhenHoldingModifier => false,
+        let is_eager_preview_enabled = match settings.edit_predictions_mode() {
+            language::EditPredictionsMode::Auto => false,
+            language::EditPredictionsMode::EagerPreview => true,
         };
         menu = menu.separator().toggleable_entry(
             "Eager Preview",
@@ -567,17 +567,17 @@ impl InlineCompletionButton {
                         fs.clone(),
                         cx,
                         move |settings, _cx| {
-                            let inline_preview = match is_eager_preview_enabled {
-                                true => language::InlineCompletionPreviewMode::WhenHoldingModifier,
-                                false => language::InlineCompletionPreviewMode::Auto,
+                            let new_mode = match is_eager_preview_enabled {
+                                true => language::EditPredictionsMode::Auto,
+                                false => language::EditPredictionsMode::EagerPreview,
                             };
 
                             if let Some(edit_predictions) = settings.edit_predictions.as_mut() {
-                                edit_predictions.inline_preview = inline_preview;
+                                edit_predictions.mode = new_mode;
                             } else {
                                 settings.edit_predictions =
                                     Some(language_settings::EditPredictionSettingsContent {
-                                        inline_preview,
+                                        mode: new_mode,
                                         ..Default::default()
                                     });
                             }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -21,7 +21,7 @@ mod toolchain;
 pub mod buffer_tests;
 pub mod markdown;
 
-pub use crate::language_settings::InlineCompletionPreviewMode;
+pub use crate::language_settings::EditPredictionsMode;
 use crate::language_settings::SoftWrap;
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -235,7 +235,7 @@ pub struct EditPredictionSettings {
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EditPredictionsMode {
-    /// If provider supports it, display inline when holding modifier key (e.g alt).
+    /// If provider supports it, display inline when holding modifier key (e.g., alt).
     /// Otherwise, eager preview is used.
     #[default]
     Auto,
@@ -1028,7 +1028,7 @@ impl settings::Settings for AllLanguageSettings {
         let mut edit_predictions_mode = default_value
             .edit_predictions
             .as_ref()
-            .map(|inline_completions| inline_completions.inline_preview)
+            .map(|edit_predictions| edit_predictions.mode)
             .ok_or_else(Self::missing_default)?;
 
         let mut completion_globs: HashSet<&String> = default_value
@@ -1062,10 +1062,10 @@ impl settings::Settings for AllLanguageSettings {
                 edit_prediction_provider = Some(provider);
             }
 
-            if let Some(inline_completions) = user_settings.edit_predictions.as_ref() {
-                edit_predictions_mode = inline_completions.inline_preview;
+            if let Some(edit_predictions) = user_settings.edit_predictions.as_ref() {
+                edit_predictions_mode = edit_predictions.mode;
 
-                if let Some(disabled_globs) = inline_completions.disabled_globs.as_ref() {
+                if let Some(disabled_globs) = edit_predictions.disabled_globs.as_ref() {
                     completion_globs.extend(disabled_globs.iter());
                 }
             }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -227,19 +227,20 @@ pub struct EditPredictionSettings {
     /// This list adds to a pre-existing, sensible default set of globs.
     /// Any additional ones you add are combined with them.
     pub disabled_globs: Vec<GlobMatcher>,
-    /// When to show edit predictions previews in buffer.
-    pub inline_preview: InlineCompletionPreviewMode,
+    /// Configures how edit predictions are displayed in the buffer.
+    pub mode: EditPredictionsMode,
 }
 
 /// The mode in which edit predictions should be displayed.
 #[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum InlineCompletionPreviewMode {
-    /// Display inline when there are no language server completions available.
+pub enum EditPredictionsMode {
+    /// If provider supports it, display inline when holding modifier key (e.g alt).
+    /// Otherwise, eager preview is used.
     #[default]
     Auto,
-    /// Display inline when holding modifier key (alt by default).
-    WhenHoldingModifier,
+    /// Display inline when there are no language server completions available.
+    EagerPreview,
 }
 
 /// The settings for all languages.
@@ -434,9 +435,10 @@ pub struct EditPredictionSettingsContent {
     /// Any additional ones you add are combined with them.
     #[serde(default)]
     pub disabled_globs: Option<Vec<String>>,
-    /// When to show edit predictions previews in buffer.
+    /// The mode used to display edit predictions in the buffer.
+    /// Provider support required.
     #[serde(default)]
-    pub inline_preview: InlineCompletionPreviewMode,
+    pub mode: EditPredictionsMode,
 }
 
 /// The settings for enabling/disabling features.
@@ -923,8 +925,8 @@ impl AllLanguageSettings {
     }
 
     /// Returns the edit predictions preview mode for the given language and path.
-    pub fn inline_completions_preview_mode(&self) -> InlineCompletionPreviewMode {
-        self.edit_predictions.inline_preview
+    pub fn edit_predictions_mode(&self) -> EditPredictionsMode {
+        self.edit_predictions.mode
     }
 }
 
@@ -1023,7 +1025,7 @@ impl settings::Settings for AllLanguageSettings {
             .features
             .as_ref()
             .and_then(|f| f.edit_prediction_provider);
-        let mut inline_completions_preview = default_value
+        let mut edit_predictions_mode = default_value
             .edit_predictions
             .as_ref()
             .map(|inline_completions| inline_completions.inline_preview)
@@ -1061,7 +1063,7 @@ impl settings::Settings for AllLanguageSettings {
             }
 
             if let Some(inline_completions) = user_settings.edit_predictions.as_ref() {
-                inline_completions_preview = inline_completions.inline_preview;
+                edit_predictions_mode = inline_completions.inline_preview;
 
                 if let Some(disabled_globs) = inline_completions.disabled_globs.as_ref() {
                     completion_globs.extend(disabled_globs.iter());
@@ -1118,7 +1120,7 @@ impl settings::Settings for AllLanguageSettings {
                     .iter()
                     .filter_map(|g| Some(globset::Glob::new(g).ok()?.compile_matcher()))
                     .collect(),
-                inline_preview: inline_completions_preview,
+                mode: edit_predictions_mode,
             },
             defaults,
             languages,


### PR DESCRIPTION
This PR does some clean up for the edit predictions settings:

- Removed `editor.show_edit_predictions_in_menu`
- Renamed `edit_predictions.inline_preview` to `edit_predictions.mode`

Release Notes:

- N/A
