### PR TITLE
Add a script that sets up a trusted MITM proxy

### DIFF
--- a/script/mitm-proxy.sh
+++ b/script/mitm-proxy.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -e
+
+CONTAINER_ID=$(docker run -d --rm -it -v ~/.mitmproxy:/home/mitmproxy/.mitmproxy -p 9876:8080 mitmproxy/mitmproxy mitmdump)
+
+trap 'docker stop '"$CONTAINER_ID"' 1> /dev/null || true; exit 1' SIGINT
+
+echo "Add the root certificate created in ~/.mitmproxy to your certificate chain for HTTP"
+echo "on macOS:"
+echo "sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ~/.mitmproxy/mitmproxy-ca-cert.pem"
+echo "Press enter to continue"
+read
+
+http_proxy=http://localhost:9876 cargo run
+
+# Clean up detached proxy after running
+docker stop "$CONTAINER_ID" 2>/dev/null || true


### PR DESCRIPTION
In an effort to squash bugs like: https://github.com/zed-industries/zed/issues/19620, and improve confidence on PRs like: https://github.com/zed-industries/zed/pull/24656, I created this little test script using `mitmproxy` to simulate the situation.

Unfortunately,  I don't see any issues with our current usage of the local certificate store using this script. But I'd like to have it as a base to build off of.

Release Notes:

- N/A
