### PR TITLE
gpui: Use local coordinates & add `scale` property

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6248,6 +6248,7 @@ async fn test_right_click_menu_behind_collab_panel(cx: &mut TestAppContext) {
     cx.simulate_event(MouseDownEvent {
         button: MouseButton::Right,
         position: new_tab_button_bounds.center(),
+        absolute_position: new_tab_button_bounds.center(),
         modifiers: Modifiers::default(),
         click_count: 1,
         first_mouse: false,
@@ -6260,6 +6261,7 @@ async fn test_right_click_menu_behind_collab_panel(cx: &mut TestAppContext) {
     cx.simulate_event(MouseDownEvent {
         button: MouseButton::Right,
         position: tab_bounds.center(),
+        absolute_position: new_tab_button_bounds.center(),
         modifiers: Modifiers::default(),
         click_count: 1,
         first_mouse: false,

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -859,7 +859,7 @@ impl CollabPanel {
                 el.on_secondary_mouse_down(cx.listener(
                     move |this, event: &MouseDownEvent, window, cx| {
                         this.deploy_participant_context_menu(
-                            event.position,
+                            event.absolute_position,
                             user_id,
                             role,
                             window,
@@ -2438,7 +2438,7 @@ impl CollabPanel {
                                     let contact = contact.clone();
                                     move |this, event: &ClickEvent, window, cx| {
                                         this.deploy_contact_context_menu(
-                                            event.down.position,
+                                            event.down.absolute_position,
                                             contact.clone(),
                                             window,
                                             cx,
@@ -2451,7 +2451,12 @@ impl CollabPanel {
             .on_secondary_mouse_down(cx.listener({
                 let contact = contact.clone();
                 move |this, event: &MouseDownEvent, window, cx| {
-                    this.deploy_contact_context_menu(event.position, contact.clone(), window, cx);
+                    this.deploy_contact_context_menu(
+                        event.absolute_position,
+                        contact.clone(),
+                        window,
+                        cx,
+                    );
                 }
             }))
             .start_slot(
@@ -2711,7 +2716,7 @@ impl CollabPanel {
                     .on_secondary_mouse_down(cx.listener(
                         move |this, event: &MouseDownEvent, window, cx| {
                             this.deploy_channel_context_menu(
-                                event.position,
+                                event.absolute_position,
                                 channel_id,
                                 ix,
                                 window,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -671,10 +671,10 @@ impl EditorElement {
         if !position_map.text_hitbox.is_hovered(window) {
             return;
         }
-        let point_for_position = position_map.point_for_position(event.position);
+        let point_for_position = position_map.point_for_position(event.absolute_position);
         mouse_context_menu::deploy_context_menu(
             editor,
-            Some(event.position),
+            Some(event.absolute_position),
             point_for_position.previous_valid,
             window,
             cx,
@@ -5102,7 +5102,7 @@ impl EditorElement {
 
                 let hitbox = hitbox.clone();
 
-                let mut mouse_position = window.mouse_position();
+                let mut mouse_position = window.mouse_position() - window.element_origin();
                 move |event: &MouseMoveEvent, phase, window, cx| {
                     if phase == DispatchPhase::Capture {
                         return;

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -243,6 +243,10 @@ name = "pattern"
 path = "examples/pattern.rs"
 
 [[example]]
+name = "scale"
+path = "examples/scale.rs"
+
+[[example]]
 name = "set_menus"
 path = "examples/set_menus.rs"
 

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -553,7 +553,7 @@ impl Element for TextElement {
 }
 
 impl Render for TextInput {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()
             .key_context("TextInput")

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -553,7 +553,7 @@ impl Element for TextElement {
 }
 
 impl Render for TextInput {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .flex()
             .key_context("TextInput")

--- a/crates/gpui/examples/scale.rs
+++ b/crates/gpui/examples/scale.rs
@@ -1,0 +1,68 @@
+use std::{f32::consts::PI, time::Duration};
+
+use gpui::{
+    div, prelude::*, px, rgb, size, white, Animation, AnimationExt, App, Application, Bounds,
+    Window,
+};
+
+struct MainView {}
+
+impl Render for MainView {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<'_, Self>) -> impl IntoElement {
+        div()
+            .flex()
+            .size_full()
+            .bg(rgb(0x202020))
+            .font_family("Sans")
+            .items_center()
+            .justify_between()
+            .child(ChildElement { scale: 1.0 })
+            .child(ChildElement { scale: 0.75 })
+            .child(ChildElement { scale: 0.5 })
+            .with_animation(
+                "animation",
+                Animation::new(Duration::from_millis(5000)).repeat(),
+                |el, delta| {
+                    el.child(ChildElement {
+                        scale: (2.0 * delta * PI).sin() * 0.5 + 1.0,
+                    })
+                },
+            )
+    }
+}
+
+#[derive(IntoElement)]
+struct ChildElement {
+    pub scale: f32,
+}
+
+impl RenderOnce for ChildElement {
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        div()
+            .flex()
+            .min_h(px(120.0))
+            .min_w(px(120.0))
+            .max_h(px(120.0))
+            .max_w(px(120.0))
+            .scale(self.scale)
+            .bg(white())
+            .items_center()
+            .justify_center()
+            .overflow_hidden()
+            .child(format!("Scale: {:.2}x", self.scale))
+    }
+}
+
+fn main() {
+    Application::new().run(|cx: &mut App| {
+        let bounds = Bounds::centered(None, size(px(500.0), px(500.0)), cx);
+        cx.open_window(
+            gpui::WindowOptions {
+                window_bounds: Some(gpui::WindowBounds::Windowed(bounds)),
+                ..Default::default()
+            },
+            |_, cx| cx.new(|_| MainView {}),
+        )
+        .unwrap();
+    });
+}

--- a/crates/gpui/examples/window_shadow.rs
+++ b/crates/gpui/examples/window_shadow.rs
@@ -166,7 +166,9 @@ impl Render for WindowShadow {
                                                 )
                                                 .on_click(|e, window, _| {
                                                     if e.down.button == MouseButton::Right {
-                                                        window.show_window_menu(e.up.position);
+                                                        window.show_window_menu(
+                                                            e.up.absolute_position,
+                                                        );
                                                     }
                                                 })
                                                 .text_color(black())

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -707,6 +707,7 @@ impl VisualTestContext {
     ) {
         self.simulate_event(MouseMoveEvent {
             position,
+            absolute_position: position,
             modifiers,
             pressed_button: button.into(),
         })
@@ -721,6 +722,7 @@ impl VisualTestContext {
     ) {
         self.simulate_event(MouseDownEvent {
             position,
+            absolute_position: position,
             modifiers,
             button,
             click_count: 1,
@@ -737,6 +739,7 @@ impl VisualTestContext {
     ) {
         self.simulate_event(MouseUpEvent {
             position,
+            absolute_position: position,
             modifiers,
             button,
             click_count: 1,
@@ -747,6 +750,7 @@ impl VisualTestContext {
     pub fn simulate_click(&mut self, position: Point<Pixels>, modifiers: Modifiers) {
         self.simulate_event(MouseDownEvent {
             position,
+            absolute_position: position,
             modifiers,
             button: MouseButton::Left,
             click_count: 1,
@@ -754,6 +758,7 @@ impl VisualTestContext {
         });
         self.simulate_event(MouseUpEvent {
             position,
+            absolute_position: position,
             modifiers,
             button: MouseButton::Left,
             click_count: 1,

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -794,7 +794,7 @@ impl VisualTestContext {
             window.invalidator.set_phase(DrawPhase::Prepaint);
             let mut element = Drawable::new(f(window, cx));
             element.layout_as_root(space.into(), window, cx);
-            window.with_absolute_element_offset(origin, |window| element.prepaint(window, cx));
+            window.with_coordinate_origin(origin, |window| element.prepaint(window, cx));
 
             window.invalidator.set_phase(DrawPhase::Paint);
             let (request_layout_state, prepaint_state) = element.paint(window, cx);

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -794,7 +794,7 @@ impl VisualTestContext {
             window.invalidator.set_phase(DrawPhase::Prepaint);
             let mut element = Drawable::new(f(window, cx));
             element.layout_as_root(space.into(), window, cx);
-            window.with_coordinate_origin(origin, |window| element.prepaint(window, cx));
+            window.with_element_origin(origin, |window| element.prepaint(window, cx));
 
             window.invalidator.set_phase(DrawPhase::Paint);
             let (request_layout_state, prepaint_state) = element.paint(window, cx);

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -334,7 +334,7 @@ impl<E: Element> Drawable<E> {
                 }
 
                 let bounds = window.layout_bounds(layout_id);
-                window.coordinate_space_layout_id = Some(layout_id);
+                window.element_layout_id = Some(layout_id);
                 let node_id = window.next_frame.dispatch_tree.push_node();
                 let prepaint = window.with_coordinate_origin(bounds.origin, |window| {
                     self.element.prepaint(
@@ -558,7 +558,7 @@ impl AnyElement {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<FocusHandle> {
-        window.with_coordinate_origin(origin + window.coordinate_space_origin, |window| {
+        window.with_coordinate_origin(origin + window.element_origin, |window| {
             self.prepaint(window, cx)
         })
     }
@@ -573,7 +573,7 @@ impl AnyElement {
         cx: &mut App,
     ) -> Option<FocusHandle> {
         self.layout_as_root(available_space, window, cx);
-        window.with_absolute_element_offset(origin, |window| self.prepaint(window, cx))
+        self.prepaint_at(origin, window, cx)
     }
 }
 

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -334,8 +334,9 @@ impl<E: Element> Drawable<E> {
                     debug_assert_eq!(global_id.as_ref().unwrap().0, window.element_id_stack);
                 }
 
-                let bounds = window.layout_bounds(layout_id);
+                let mut bounds = window.layout_bounds(layout_id);
                 let scale = window.layout_scale(layout_id);
+                bounds.size *= 1.0 / scale;
                 window.element_layout_id = Some(layout_id);
 
                 let node_id = window.next_frame.dispatch_tree.push_node();

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -336,7 +336,7 @@ impl<E: Element> Drawable<E> {
                 let bounds = window.layout_bounds(layout_id);
                 window.element_layout_id = Some(layout_id);
                 let node_id = window.next_frame.dispatch_tree.push_node();
-                let prepaint = window.with_coordinate_origin(bounds.origin, |window| {
+                let prepaint = window.with_element_origin(bounds.origin, |window| {
                     self.element.prepaint(
                         global_id.as_ref(),
                         Bounds {
@@ -386,7 +386,7 @@ impl<E: Element> Drawable<E> {
                 }
 
                 window.next_frame.dispatch_tree.set_active_node(node_id);
-                window.with_coordinate_origin(bounds.origin, |window| {
+                window.with_element_origin(bounds.origin, |window| {
                     self.element.paint(
                         global_id.as_ref(),
                         Bounds {
@@ -418,7 +418,7 @@ impl<E: Element> Drawable<E> {
         cx: &mut App,
     ) -> Size<Pixels> {
         if matches!(&self.phase, ElementDrawPhase::Start) {
-            window.with_coordinate_origin(Point::default(), |window| {
+            window.with_element_origin(Point::default(), |window| {
                 self.request_layout(window, cx);
             });
         }
@@ -558,7 +558,7 @@ impl AnyElement {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<FocusHandle> {
-        window.with_coordinate_origin(origin + window.element_origin, |window| {
+        window.with_element_origin(origin + window.element_origin(), |window| {
             self.prepaint(window, cx)
         })
     }

--- a/crates/gpui/src/elements/anchored.rs
+++ b/crates/gpui/src/elements/anchored.rs
@@ -201,7 +201,7 @@ impl Element for Anchored {
         let offset = desired.origin - bounds.origin;
         let offset = point(offset.x.round(), offset.y.round());
 
-        window.with_element_offset(offset, |window| {
+        window.with_coordinate_origin(offset, |window| {
             for child in &mut self.children {
                 child.prepaint(window, cx);
             }

--- a/crates/gpui/src/elements/anchored.rs
+++ b/crates/gpui/src/elements/anchored.rs
@@ -201,7 +201,7 @@ impl Element for Anchored {
         let offset = desired.origin - bounds.origin;
         let offset = point(offset.x.round(), offset.y.round());
 
-        window.with_coordinate_origin(offset, |window| {
+        window.with_element_origin(offset, |window| {
             for child in &mut self.children {
                 child.prepaint(window, cx);
             }

--- a/crates/gpui/src/elements/deferred.rs
+++ b/crates/gpui/src/elements/deferred.rs
@@ -1,5 +1,5 @@
 use crate::{
-    AnyElement, App, Bounds, Element, GlobalElementId, IntoElement, LayoutId, Pixels, Window,
+    AnyElement, App, Bounds, Element, GlobalElementId, IntoElement, LayoutId, Pixels, Point, Window,
 };
 
 /// Builds a `Deferred` element, which delays the layout and paint of its child.
@@ -54,8 +54,7 @@ impl Element for Deferred {
         _cx: &mut App,
     ) {
         let child = self.child.take().unwrap();
-        let element_offset = window.element_offset();
-        window.defer_draw(child, element_offset, self.priority)
+        window.defer_draw(child, Point::default(), self.priority)
     }
 
     fn paint(

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1203,11 +1203,13 @@ impl Element for Div {
             self.interactivity
                 .request_layout(global_id, window, cx, |style, window, cx| {
                     window.with_text_style(style.text_style().cloned(), |window| {
-                        child_layout_ids = self
-                            .children
-                            .iter_mut()
-                            .map(|child| child.request_layout(window, cx))
-                            .collect::<SmallVec<_>>();
+                        window.with_element_scale(style.scale, |window| {
+                            child_layout_ids = self
+                                .children
+                                .iter_mut()
+                                .map(|child| child.request_layout(window, cx))
+                                .collect::<SmallVec<_>>();
+                        });
                         window.request_layout(style, child_layout_ids.iter().copied(), cx)
                     })
                 });

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1232,7 +1232,7 @@ impl Element for Div {
         let mut child_min = point(Pixels::MAX, Pixels::MAX);
         let mut child_max = Point::default();
         if let Some(handle) = self.interactivity.scroll_anchor.as_ref() {
-            *handle.last_origin.borrow_mut() = bounds.origin - window.element_offset();
+            *handle.last_origin.borrow_mut() = bounds.origin; // TODO
         }
         let content_size = if request_layout.child_layout_ids.is_empty() {
             bounds.size
@@ -1276,11 +1276,14 @@ impl Element for Div {
             window,
             cx,
             |_style, scroll_offset, hitbox, window, cx| {
-                window.with_element_offset(scroll_offset, |window| {
-                    for child in &mut self.children {
-                        child.prepaint(window, cx);
-                    }
-                });
+                window.with_coordinate_origin(
+                    scroll_offset + window.element_origin,
+                    |window| {
+                        for child in &mut self.children {
+                            child.prepaint(window, cx);
+                        }
+                    },
+                );
 
                 if let Some(listener) = self.prepaint_listener.as_ref() {
                     listener(children_bounds, window, cx);

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -260,7 +260,7 @@ impl Interactivity {
                             (listener)(
                                 &DragMoveEvent {
                                     event: event.clone(),
-                                    bounds: hitbox.bounds,
+                                    bounds: hitbox.bounds + window.element_origin(),
                                     drag: PhantomData,
                                     dragged_item: Arc::clone(&drag.value),
                                 },

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1203,7 +1203,7 @@ impl Element for Div {
             self.interactivity
                 .request_layout(global_id, window, cx, |style, window, cx| {
                     window.with_text_style(style.text_style().cloned(), |window| {
-                        window.with_element_scale(style.scale, |window| {
+                        window.with_element_scale(style.scale * window.element_scale(), |window| {
                             child_layout_ids = self
                                 .children
                                 .iter_mut()

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -992,6 +992,7 @@ mod test {
         // And then receive a scroll event _before_ the next paint
         cx.simulate_event(ScrollWheelEvent {
             position: point(px(1.), px(1.)),
+            absolute_position: point(px(1.), px(1.)),
             delta: ScrollDelta::Pixels(point(px(0.), px(-500.))),
             ..Default::default()
         });

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -100,7 +100,7 @@ impl Element for Svg {
                         .as_ref()
                         .map(|transformation| {
                             transformation.into_matrix(
-                                (bounds + window.coordinate_space_origin).center(),
+                                (bounds + window.element_origin).center(),
                                 window.scale_factor(),
                             )
                         })

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -99,7 +99,10 @@ impl Element for Svg {
                         .transformation
                         .as_ref()
                         .map(|transformation| {
-                            transformation.into_matrix(bounds.center(), window.scale_factor())
+                            transformation.into_matrix(
+                                (bounds + window.coordinate_space_origin).center(),
+                                window.scale_factor(),
+                            )
                         })
                         .unwrap_or_default();
 

--- a/crates/gpui/src/elements/svg.rs
+++ b/crates/gpui/src/elements/svg.rs
@@ -100,7 +100,7 @@ impl Element for Svg {
                         .as_ref()
                         .map(|transformation| {
                             transformation.into_matrix(
-                                (bounds + window.element_origin).center(),
+                                (bounds + window.element_origin()).center(),
                                 window.scale_factor(),
                             )
                         })

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -666,7 +666,7 @@ impl Element for InteractiveText {
             |interactive_state, window| {
                 let mut interactive_state = interactive_state.unwrap_or_default();
                 if let Some(click_listener) = self.click_listener.take() {
-                    let mouse_position = window.mouse_position();
+                    let mouse_position = window.mouse_position() - window.element_origin();
                     if let Ok(ix) = text_layout.index_for_position(mouse_position) {
                         if self
                             .clickable_ranges
@@ -744,9 +744,10 @@ impl Element for InteractiveText {
                     let build_tooltip = Rc::new({
                         let tooltip_is_hoverable = false;
                         let text_layout = text_layout.clone();
+                        let origin = window.element_origin();
                         move |window: &mut Window, cx: &mut App| {
                             text_layout
-                                .index_for_position(window.mouse_position())
+                                .index_for_position(window.mouse_position() - origin)
                                 .ok()
                                 .and_then(|position| tooltip_builder(position, window, cx))
                                 .map(|view| (view, tooltip_is_hoverable))
@@ -758,11 +759,12 @@ impl Element for InteractiveText {
                         let source_bounds = hitbox.bounds;
                         let text_layout = text_layout.clone();
                         let pending_mouse_down = interactive_state.mouse_down_index.clone();
+                        let origin = window.element_origin();
                         move |window: &Window| {
                             text_layout
-                                .index_for_position(window.mouse_position())
+                                .index_for_position(window.mouse_position() - origin)
                                 .is_ok()
-                                && source_bounds.contains(&window.mouse_position())
+                                && source_bounds.contains(&(window.mouse_position() - origin))
                                 && pending_mouse_down.get().is_none()
                         }
                     });
@@ -771,9 +773,10 @@ impl Element for InteractiveText {
                         let hitbox = hitbox.clone();
                         let text_layout = text_layout.clone();
                         let pending_mouse_down = interactive_state.mouse_down_index.clone();
+                        let origin = window.element_origin();
                         move |window: &Window| {
                             text_layout
-                                .index_for_position(window.mouse_position())
+                                .index_for_position(window.mouse_position() - origin)
                                 .is_ok()
                                 && hitbox.is_hovered(window)
                                 && pending_mouse_down.get().is_none()

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -410,7 +410,6 @@ impl Element for UniformList {
                         for decoration in &self.decorations {
                             let mut decoration = decoration.as_ref().compute(
                                 visible_range.clone(),
-                                bounds,
                                 item_height,
                                 self.item_count,
                                 window,
@@ -475,7 +474,6 @@ pub trait UniformListDecoration {
     fn compute(
         &self,
         visible_range: Range<usize>,
-        bounds: Bounds<Pixels>,
         item_height: Pixels,
         item_count: usize,
         window: &mut Window,

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -401,7 +401,6 @@ impl InputEvent for MouseExitEvent {
 }
 impl MouseEvent for MouseExitEvent {
     fn with_local_coordinates(self, _origin: Point<Pixels>, _scale: f32) -> Self {
-        // TODO: convert to local coordinates
         self
     }
 }
@@ -437,20 +436,26 @@ impl Render for ExternalPaths {
 pub enum FileDropEvent {
     /// The files have entered the window.
     Entered {
-        /// The position of the mouse relative to the window.
+        /// The position relative to the current element
         position: Point<Pixels>,
+        /// The position of the mouse relative to the window
+        absolute_position: Point<Pixels>,
         /// The paths of the files that are being dragged.
         paths: ExternalPaths,
     },
     /// The files are being dragged over the window
     Pending {
-        /// The position of the mouse relative to the window.
+        /// The position relative to the current element
         position: Point<Pixels>,
+        /// The position of the mouse relative to the window
+        absolute_position: Point<Pixels>,
     },
     /// The files have been dropped onto the window.
     Submit {
-        /// The position of the mouse relative to the window.
+        /// The position relative to the current element
         position: Point<Pixels>,
+        /// The position of the mouse relative to the window
+        absolute_position: Point<Pixels>,
     },
     /// The user has stopped dragging the files over the window.
     Exited,
@@ -463,9 +468,33 @@ impl InputEvent for FileDropEvent {
     }
 }
 impl MouseEvent for FileDropEvent {
-    fn with_local_coordinates(self, _origin: Point<Pixels>, _scale: f32) -> Self {
-        // TODO: convert to local coordinates?
-        self
+    fn with_local_coordinates(self, origin: Point<Pixels>, scale: f32) -> Self {
+        match self {
+            Self::Entered {
+                position: _,
+                absolute_position,
+                paths,
+            } => Self::Entered {
+                position: (absolute_position - origin) / scale,
+                absolute_position,
+                paths,
+            },
+            Self::Pending {
+                position: _,
+                absolute_position,
+            } => Self::Pending {
+                position: (absolute_position - origin) / scale,
+                absolute_position,
+            },
+            Self::Submit {
+                position: _,
+                absolute_position,
+            } => Self::Submit {
+                position: (absolute_position - origin) / scale,
+                absolute_position,
+            },
+            x => x,
+        }
     }
 }
 

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -15,7 +15,10 @@ pub trait InputEvent: Sealed + 'static {
 pub trait KeyEvent: InputEvent {}
 
 /// A mouse event from the platform.
-pub trait MouseEvent: InputEvent {}
+pub trait MouseEvent: InputEvent + Clone {
+    /// Converts `absolute_position` to local coordinates and assigns it to `position`
+    fn with_local_coordinates(self, origin: Point<Pixels>) -> Self;
+}
 
 /// The key down event equivalent for the platform.
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -92,8 +95,11 @@ pub struct MouseDownEvent {
     /// Which mouse button was pressed.
     pub button: MouseButton,
 
-    /// The position of the mouse on the window.
+    /// The position within the current element
     pub position: Point<Pixels>,
+
+    /// The position of the mouse on the window.
+    pub absolute_position: Point<Pixels>,
 
     /// The modifiers that were held down when the mouse was pressed.
     pub modifiers: Modifiers,
@@ -111,7 +117,12 @@ impl InputEvent for MouseDownEvent {
         PlatformInput::MouseDown(self)
     }
 }
-impl MouseEvent for MouseDownEvent {}
+impl MouseEvent for MouseDownEvent {
+    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
+        self.position = self.absolute_position - origin;
+        self
+    }
+}
 
 /// A mouse up event from the platform
 #[derive(Clone, Debug, Default)]
@@ -119,8 +130,11 @@ pub struct MouseUpEvent {
     /// Which mouse button was released.
     pub button: MouseButton,
 
-    /// The position of the mouse on the window.
+    /// The position within the current element
     pub position: Point<Pixels>,
+
+    /// The position of the mouse on the window.
+    pub absolute_position: Point<Pixels>,
 
     /// The modifiers that were held down when the mouse was released.
     pub modifiers: Modifiers,
@@ -135,7 +149,12 @@ impl InputEvent for MouseUpEvent {
         PlatformInput::MouseUp(self)
     }
 }
-impl MouseEvent for MouseUpEvent {}
+impl MouseEvent for MouseUpEvent {
+    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
+        self.position = self.absolute_position - origin;
+        self
+    }
+}
 
 /// A click event, generated when a mouse button is pressed and released.
 #[derive(Clone, Debug, Default)]
@@ -215,8 +234,11 @@ impl Default for NavigationDirection {
 /// A mouse move event from the platform
 #[derive(Clone, Debug, Default)]
 pub struct MouseMoveEvent {
-    /// The position of the mouse on the window.
+    /// The position within the current element
     pub position: Point<Pixels>,
+
+    /// The position of the mouse on the window.
+    pub absolute_position: Point<Pixels>,
 
     /// The mouse button that was pressed, if any.
     pub pressed_button: Option<MouseButton>,
@@ -231,7 +253,12 @@ impl InputEvent for MouseMoveEvent {
         PlatformInput::MouseMove(self)
     }
 }
-impl MouseEvent for MouseMoveEvent {}
+impl MouseEvent for MouseMoveEvent {
+    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
+        self.position = self.absolute_position - origin;
+        self
+    }
+}
 
 impl MouseMoveEvent {
     /// Returns true if the left mouse button is currently held down.
@@ -243,8 +270,11 @@ impl MouseMoveEvent {
 /// A mouse wheel event from the platform
 #[derive(Clone, Debug, Default)]
 pub struct ScrollWheelEvent {
-    /// The position of the mouse on the window.
+    /// The position within the current element
     pub position: Point<Pixels>,
+
+    /// The position of the mouse on the window.
+    pub absolute_position: Point<Pixels>,
 
     /// The change in scroll wheel position for this event.
     pub delta: ScrollDelta,
@@ -262,7 +292,12 @@ impl InputEvent for ScrollWheelEvent {
         PlatformInput::ScrollWheel(self)
     }
 }
-impl MouseEvent for ScrollWheelEvent {}
+impl MouseEvent for ScrollWheelEvent {
+    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
+        self.position = self.absolute_position - origin;
+        self
+    }
+}
 
 impl Deref for ScrollWheelEvent {
     type Target = Modifiers;
@@ -364,7 +399,12 @@ impl InputEvent for MouseExitEvent {
         PlatformInput::MouseExited(self)
     }
 }
-impl MouseEvent for MouseExitEvent {}
+impl MouseEvent for MouseExitEvent {
+    fn with_local_coordinates(self, _origin: Point<Pixels>) -> Self {
+        // TODO: convert to local coordinates
+        self
+    }
+}
 
 impl Deref for MouseExitEvent {
     type Target = Modifiers;
@@ -422,7 +462,12 @@ impl InputEvent for FileDropEvent {
         PlatformInput::FileDrop(self)
     }
 }
-impl MouseEvent for FileDropEvent {}
+impl MouseEvent for FileDropEvent {
+    fn with_local_coordinates(self, _origin: Point<Pixels>) -> Self {
+        // TODO: convert to local coordinates
+        self
+    }
+}
 
 /// An enum corresponding to all kinds of platform input events.
 #[derive(Clone, Debug)]

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -17,7 +17,7 @@ pub trait KeyEvent: InputEvent {}
 /// A mouse event from the platform.
 pub trait MouseEvent: InputEvent + Clone {
     /// Converts `absolute_position` to local coordinates and assigns it to `position`
-    fn with_local_coordinates(self, origin: Point<Pixels>) -> Self;
+    fn with_local_coordinates(self, origin: Point<Pixels>, scale: f32) -> Self;
 }
 
 /// The key down event equivalent for the platform.
@@ -118,8 +118,8 @@ impl InputEvent for MouseDownEvent {
     }
 }
 impl MouseEvent for MouseDownEvent {
-    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
-        self.position = self.absolute_position - origin;
+    fn with_local_coordinates(mut self, origin: Point<Pixels>, scale: f32) -> Self {
+        self.position = (self.absolute_position - origin) / scale;
         self
     }
 }
@@ -150,8 +150,8 @@ impl InputEvent for MouseUpEvent {
     }
 }
 impl MouseEvent for MouseUpEvent {
-    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
-        self.position = self.absolute_position - origin;
+    fn with_local_coordinates(mut self, origin: Point<Pixels>, scale: f32) -> Self {
+        self.position = (self.absolute_position - origin) / scale;
         self
     }
 }
@@ -254,8 +254,8 @@ impl InputEvent for MouseMoveEvent {
     }
 }
 impl MouseEvent for MouseMoveEvent {
-    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
-        self.position = self.absolute_position - origin;
+    fn with_local_coordinates(mut self, origin: Point<Pixels>, scale: f32) -> Self {
+        self.position = (self.absolute_position - origin) / scale;
         self
     }
 }
@@ -293,8 +293,8 @@ impl InputEvent for ScrollWheelEvent {
     }
 }
 impl MouseEvent for ScrollWheelEvent {
-    fn with_local_coordinates(mut self, origin: Point<Pixels>) -> Self {
-        self.position = self.absolute_position - origin;
+    fn with_local_coordinates(mut self, origin: Point<Pixels>, scale: f32) -> Self {
+        self.position = (self.absolute_position - origin) / scale;
         self
     }
 }
@@ -400,7 +400,7 @@ impl InputEvent for MouseExitEvent {
     }
 }
 impl MouseEvent for MouseExitEvent {
-    fn with_local_coordinates(self, _origin: Point<Pixels>) -> Self {
+    fn with_local_coordinates(self, _origin: Point<Pixels>, _scale: f32) -> Self {
         // TODO: convert to local coordinates
         self
     }
@@ -463,8 +463,8 @@ impl InputEvent for FileDropEvent {
     }
 }
 impl MouseEvent for FileDropEvent {
-    fn with_local_coordinates(self, _origin: Point<Pixels>) -> Self {
-        // TODO: convert to local coordinates
+    fn with_local_coordinates(self, _origin: Point<Pixels>, _scale: f32) -> Self {
+        // TODO: convert to local coordinates?
         self
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1527,6 +1527,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                     }
                     let input = PlatformInput::MouseMove(MouseMoveEvent {
                         position: state.mouse_location.unwrap(),
+                        absolute_position: state.mouse_location.unwrap(),
                         pressed_button: state.button_pressed,
                         modifiers: state.modifiers,
                     });
@@ -1592,6 +1593,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                             let input = PlatformInput::MouseDown(MouseDownEvent {
                                 button,
                                 position: state.mouse_location.unwrap(),
+                                absolute_position: state.mouse_location.unwrap(),
                                 modifiers: state.modifiers,
                                 click_count: state.click.current_count,
                                 first_mouse: state.enter_token.take().is_some(),
@@ -1607,6 +1609,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                             let input = PlatformInput::MouseUp(MouseUpEvent {
                                 button,
                                 position: state.mouse_location.unwrap(),
+                                absolute_position: state.mouse_location.unwrap(),
                                 modifiers: state.modifiers,
                                 click_count: state.click.current_count,
                             });
@@ -1721,6 +1724,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                         if let Some(window) = state.mouse_focused_window.clone() {
                             let input = PlatformInput::ScrollWheel(ScrollWheelEvent {
                                 position: state.mouse_location.unwrap(),
+                                absolute_position: state.mouse_location.unwrap(),
                                 delta: ScrollDelta::Pixels(continuous),
                                 modifiers: state.modifiers,
                                 touch_phase: TouchPhase::Moved,
@@ -1732,6 +1736,7 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                         if let Some(window) = state.mouse_focused_window.clone() {
                             let input = PlatformInput::ScrollWheel(ScrollWheelEvent {
                                 position: state.mouse_location.unwrap(),
+                                absolute_position: state.mouse_location.unwrap(),
                                 delta: ScrollDelta::Lines(discrete),
                                 modifiers: state.modifiers,
                                 touch_phase: TouchPhase::Moved,

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1887,6 +1887,7 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
 
                             let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                                 position,
+                                absolute_position: position,
                                 paths: crate::ExternalPaths(paths),
                             });
 
@@ -1909,7 +1910,10 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
                 let position = Point::new(x.into(), y.into());
                 state.drag.position = position;
 
-                let input = PlatformInput::FileDrop(FileDropEvent::Pending { position });
+                let input = PlatformInput::FileDrop(FileDropEvent::Pending {
+                    position,
+                    absolute_position: position,
+                });
                 drop(state);
                 drag_window.handle_input(input);
             }
@@ -1940,6 +1944,7 @@ impl Dispatch<wl_data_device::WlDataDevice, ()> for WaylandClientStatePtr {
 
                 let input = PlatformInput::FileDrop(FileDropEvent::Submit {
                     position: state.drag.position,
+                    absolute_position: state.drag.position,
                 });
                 drop(state);
                 drag_window.handle_input(input);

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -697,8 +697,10 @@ impl X11Client {
                 } else if event.type_ == state.atoms.XdndLeave {
                     let position = state.xdnd_state.position;
                     drop(state);
-                    window
-                        .handle_input(PlatformInput::FileDrop(FileDropEvent::Pending { position }));
+                    window.handle_input(PlatformInput::FileDrop(FileDropEvent::Pending {
+                        position,
+                        absolute_position: position,
+                    }));
                     window.handle_input(PlatformInput::FileDrop(FileDropEvent::Exited {}));
                     self.0.borrow_mut().xdnd_state = Xdnd::default();
                 } else if event.type_ == state.atoms.XdndPosition {
@@ -732,8 +734,10 @@ impl X11Client {
                     );
                     let position = state.xdnd_state.position;
                     drop(state);
-                    window
-                        .handle_input(PlatformInput::FileDrop(FileDropEvent::Pending { position }));
+                    window.handle_input(PlatformInput::FileDrop(FileDropEvent::Pending {
+                        position,
+                        absolute_position: position,
+                    }));
                 } else if event.type_ == state.atoms.XdndDrop {
                     xdnd_send_finished(
                         &state.xcb_connection,
@@ -743,8 +747,10 @@ impl X11Client {
                     );
                     let position = state.xdnd_state.position;
                     drop(state);
-                    window
-                        .handle_input(PlatformInput::FileDrop(FileDropEvent::Submit { position }));
+                    window.handle_input(PlatformInput::FileDrop(FileDropEvent::Submit {
+                        position,
+                        absolute_position: position,
+                    }));
                     self.0.borrow_mut().xdnd_state = Xdnd::default();
                 }
             }
@@ -772,6 +778,7 @@ impl X11Client {
                                 .collect();
                             let input = PlatformInput::FileDrop(FileDropEvent::Entered {
                                 position: state.xdnd_state.position,
+                                absolute_position: state.xdnd_state.position,
                                 paths: crate::ExternalPaths(paths),
                             });
                             drop(state);

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1028,6 +1028,7 @@ impl X11Client {
                         window.handle_input(PlatformInput::MouseDown(crate::MouseDownEvent {
                             button,
                             position,
+                            absolute_position: position,
                             modifiers,
                             click_count: current_count,
                             first_mouse: false,
@@ -1074,6 +1075,7 @@ impl X11Client {
                         window.handle_input(PlatformInput::MouseUp(crate::MouseUpEvent {
                             button,
                             position,
+                            absolute_position: position,
                             modifiers,
                             click_count,
                         }));
@@ -1097,6 +1099,7 @@ impl X11Client {
                 if event.valuator_mask[0] & 3 != 0 {
                     window.handle_input(PlatformInput::MouseMove(crate::MouseMoveEvent {
                         position,
+                        absolute_position: position,
                         pressed_button,
                         modifiers,
                     }));
@@ -1933,6 +1936,7 @@ fn make_scroll_wheel_event(
     };
     crate::ScrollWheelEvent {
         position,
+        absolute_position: position,
         delta: ScrollDelta::Lines(delta),
         modifiers,
         touch_phase: TouchPhase::default(),

--- a/crates/gpui/src/platform/mac/events.rs
+++ b/crates/gpui/src/platform/mac/events.rs
@@ -120,13 +120,16 @@ impl PlatformInput {
                     _ => return None,
                 };
                 window_height.map(|window_height| {
+                    let position = point(
+                        px(native_event.locationInWindow().x as f32),
+                        // MacOS screen coordinates are relative to bottom left
+                        window_height - px(native_event.locationInWindow().y as f32),
+                    );
+
                     Self::MouseDown(MouseDownEvent {
                         button,
-                        position: point(
-                            px(native_event.locationInWindow().x as f32),
-                            // MacOS screen coordinates are relative to bottom left
-                            window_height - px(native_event.locationInWindow().y as f32),
-                        ),
+                        position,
+                        absolute_position: position,
                         modifiers: read_modifiers(native_event),
                         click_count: native_event.clickCount() as usize,
                         first_mouse: false,
@@ -147,12 +150,15 @@ impl PlatformInput {
                 };
 
                 window_height.map(|window_height| {
+                    let position = point(
+                        px(native_event.locationInWindow().x as f32),
+                        window_height - px(native_event.locationInWindow().y as f32),
+                    );
+
                     Self::MouseUp(MouseUpEvent {
                         button,
-                        position: point(
-                            px(native_event.locationInWindow().x as f32),
-                            window_height - px(native_event.locationInWindow().y as f32),
-                        ),
+                        position,
+                        absolute_position: position,
                         modifiers: read_modifiers(native_event),
                         click_count: native_event.clickCount() as usize,
                     })
@@ -171,12 +177,15 @@ impl PlatformInput {
 
                 match navigation_direction {
                     Some(direction) => window_height.map(|window_height| {
+                        let position = point(
+                            px(native_event.locationInWindow().x as f32),
+                            window_height - px(native_event.locationInWindow().y as f32),
+                        );
+
                         Self::MouseDown(MouseDownEvent {
                             button: MouseButton::Navigate(direction),
-                            position: point(
-                                px(native_event.locationInWindow().x as f32),
-                                window_height - px(native_event.locationInWindow().y as f32),
-                            ),
+                            position,
+                            absolute_position: position,
                             modifiers: read_modifiers(native_event),
                             click_count: 1,
                             first_mouse: false,
@@ -205,11 +214,14 @@ impl PlatformInput {
                     ScrollDelta::Lines(raw_data)
                 };
 
+                let position = point(
+                    px(native_event.locationInWindow().x as f32),
+                    window_height - px(native_event.locationInWindow().y as f32),
+                );
+
                 Self::ScrollWheel(ScrollWheelEvent {
-                    position: point(
-                        px(native_event.locationInWindow().x as f32),
-                        window_height - px(native_event.locationInWindow().y as f32),
-                    ),
+                    position,
+                    absolute_position: position,
                     delta,
                     touch_phase: phase,
                     modifiers: read_modifiers(native_event),
@@ -229,22 +241,28 @@ impl PlatformInput {
                 };
 
                 window_height.map(|window_height| {
+                    let position = point(
+                        px(native_event.locationInWindow().x as f32),
+                        window_height - px(native_event.locationInWindow().y as f32),
+                    );
+
                     Self::MouseMove(MouseMoveEvent {
                         pressed_button: Some(pressed_button),
-                        position: point(
-                            px(native_event.locationInWindow().x as f32),
-                            window_height - px(native_event.locationInWindow().y as f32),
-                        ),
+                        position,
+                        absolute_position: position,
                         modifiers: read_modifiers(native_event),
                     })
                 })
             }
             NSEventType::NSMouseMoved => window_height.map(|window_height| {
+                let position = point(
+                    px(native_event.locationInWindow().x as f32),
+                    window_height - px(native_event.locationInWindow().y as f32),
+                );
+
                 Self::MouseMove(MouseMoveEvent {
-                    position: point(
-                        px(native_event.locationInWindow().x as f32),
-                        window_height - px(native_event.locationInWindow().y as f32),
-                    ),
+                    position,
+                    absolute_position: position,
                     pressed_button: None,
                     modifiers: read_modifiers(native_event),
                 })

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1862,9 +1862,13 @@ extern "C" fn dragging_entered(this: &Object, _: Sel, dragging_info: id) -> NSDr
     let window_state = unsafe { get_window_state(this) };
     let position = drag_event_position(&window_state, dragging_info);
     let paths = external_paths_from_event(dragging_info);
-    if let Some(event) =
-        paths.map(|paths| PlatformInput::FileDrop(FileDropEvent::Entered { position, paths }))
-    {
+    if let Some(event) = paths.map(|paths| {
+        PlatformInput::FileDrop(FileDropEvent::Entered {
+            position,
+            absolute_position: position,
+            paths,
+        })
+    }) {
         if send_new_event(&window_state, event) {
             window_state.lock().external_files_dragged = true;
             return NSDragOperationCopy;
@@ -1878,7 +1882,10 @@ extern "C" fn dragging_updated(this: &Object, _: Sel, dragging_info: id) -> NSDr
     let position = drag_event_position(&window_state, dragging_info);
     if send_new_event(
         &window_state,
-        PlatformInput::FileDrop(FileDropEvent::Pending { position }),
+        PlatformInput::FileDrop(FileDropEvent::Pending {
+            position,
+            absolute_position: position,
+        }),
     ) {
         NSDragOperationCopy
     } else {
@@ -1900,7 +1907,10 @@ extern "C" fn perform_drag_operation(this: &Object, _: Sel, dragging_info: id) -
     let position = drag_event_position(&window_state, dragging_info);
     if send_new_event(
         &window_state,
-        PlatformInput::FileDrop(FileDropEvent::Submit { position }),
+        PlatformInput::FileDrop(FileDropEvent::Submit {
+            position,
+            absolute_position: position,
+        }),
     ) {
         YES
     } else {

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -284,6 +284,7 @@ fn handle_mouse_move_msg(
         let y = lparam.signed_hiword() as f32;
         let event = MouseMoveEvent {
             position: logical_point(x, y, scale_factor),
+            absolute_position: logical_point(x, y, scale_factor),
             pressed_button,
             modifiers: current_modifiers(),
         };
@@ -464,6 +465,7 @@ fn handle_mouse_down_msg(
         let event = MouseDownEvent {
             button,
             position: logical_point(x, y, scale_factor),
+            absolute_position: logical_point(x, y, scale_factor),
             modifiers: current_modifiers(),
             click_count,
             first_mouse: false,
@@ -499,6 +501,7 @@ fn handle_mouse_up_msg(
         let event = MouseUpEvent {
             button,
             position: logical_point(x, y, scale_factor),
+            absolute_position: logical_point(x, y, scale_factor),
             modifiers: current_modifiers(),
             click_count,
         };
@@ -554,6 +557,11 @@ fn handle_mouse_wheel_msg(
         unsafe { ScreenToClient(handle, &mut cursor_point).ok().log_err() };
         let event = ScrollWheelEvent {
             position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
+            absolute_position: logical_point(
+                cursor_point.x as f32,
+                cursor_point.y as f32,
+                scale_factor,
+            ),
             delta: ScrollDelta::Lines(match modifiers.shift {
                 true => Point {
                     x: wheel_distance,
@@ -600,6 +608,11 @@ fn handle_mouse_horizontal_wheel_msg(
         unsafe { ScreenToClient(handle, &mut cursor_point).ok().log_err() };
         let event = ScrollWheelEvent {
             position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
+            absolute_position: logical_point(
+                cursor_point.x as f32,
+                cursor_point.y as f32,
+                scale_factor,
+            ),
             delta: ScrollDelta::Lines(Point {
                 x: wheel_distance,
                 y: 0.0,
@@ -968,6 +981,11 @@ fn handle_nc_mouse_move_msg(
         unsafe { ScreenToClient(handle, &mut cursor_point).ok().log_err() };
         let event = MouseMoveEvent {
             position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
+            absolute_position: logical_point(
+                cursor_point.x as f32,
+                cursor_point.y as f32,
+                scale_factor,
+            ),
             pressed_button: None,
             modifiers: current_modifiers(),
         };
@@ -1009,6 +1027,11 @@ fn handle_nc_mouse_down_msg(
         let event = MouseDownEvent {
             button,
             position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
+            absolute_position: logical_point(
+                cursor_point.x as f32,
+                cursor_point.y as f32,
+                scale_factor,
+            ),
             modifiers: current_modifiers(),
             click_count,
             first_mouse: false,
@@ -1064,6 +1087,11 @@ fn handle_nc_mouse_up_msg(
         let event = MouseUpEvent {
             button,
             position: logical_point(cursor_point.x as f32, cursor_point.y as f32, scale_factor),
+            absolute_position: logical_point(
+                cursor_point.x as f32,
+                cursor_point.y as f32,
+                scale_factor,
+            ),
             modifiers: current_modifiers(),
             click_count: 1,
         };

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -851,6 +851,11 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
                         cursor_position.y as f32,
                         scale_factor,
                     ),
+                    absolute_position: logical_point(
+                        cursor_position.x as f32,
+                        cursor_position.y as f32,
+                        scale_factor,
+                    ),
                     paths: ExternalPaths(paths),
                 });
                 self.handle_drag_drop(input);
@@ -876,6 +881,11 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
         let scale_factor = self.0.state.borrow().scale_factor;
         let input = PlatformInput::FileDrop(FileDropEvent::Pending {
             position: logical_point(
+                cursor_position.x as f32,
+                cursor_position.y as f32,
+                scale_factor,
+            ),
+            absolute_position: logical_point(
                 cursor_position.x as f32,
                 cursor_position.y as f32,
                 scale_factor,
@@ -909,6 +919,11 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
         let scale_factor = self.0.state.borrow().scale_factor;
         let input = PlatformInput::FileDrop(FileDropEvent::Submit {
             position: logical_point(
+                cursor_position.x as f32,
+                cursor_position.y as f32,
+                scale_factor,
+            ),
+            absolute_position: logical_point(
                 cursor_position.x as f32,
                 cursor_position.y as f32,
                 scale_factor,

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -702,9 +702,7 @@ impl Path<Pixels> {
             id: self.id,
             order: self.order,
             bounds: self.bounds + offset,
-            content_mask: ContentMask {
-                bounds: self.content_mask.bounds + offset,
-            },
+            content_mask: self.content_mask.clone(),
             vertices: self
                 .vertices
                 .iter()

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -696,6 +696,27 @@ impl Path<Pixels> {
         }
     }
 
+    /// Translate this path by a given offset.
+    pub fn offset(&self, offset: Point<Pixels>) -> Path<Pixels> {
+        Path {
+            id: self.id,
+            order: self.order,
+            bounds: self.bounds + offset,
+            content_mask: ContentMask {
+                bounds: self.content_mask.bounds + offset,
+            },
+            vertices: self
+                .vertices
+                .iter()
+                .map(|vertex| vertex.offset(offset))
+                .collect(),
+            start: self.start + offset,
+            current: self.current + offset,
+            contour_count: self.contour_count,
+            color: self.color,
+        }
+    }
+
     /// Scale this path by the given factor.
     pub fn scale(&self, factor: f32) -> Path<ScaledPixels> {
         Path {
@@ -805,6 +826,16 @@ pub(crate) struct PathVertex<P: Clone + Default + Debug> {
 }
 
 impl PathVertex<Pixels> {
+    pub fn offset(&self, offset: Point<Pixels>) -> Self {
+        Self {
+            xy_position: self.xy_position + offset,
+            st_position: self.st_position,
+            content_mask: ContentMask {
+                bounds: self.content_mask.bounds + offset,
+            },
+        }
+    }
+
     pub fn scale(&self, factor: f32) -> PathVertex<ScaledPixels> {
         PathVertex {
             xy_position: self.xy_position.scale(factor),

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -177,6 +177,8 @@ pub struct Style {
     /// Controls the maximum size of the item
     #[refineable]
     pub max_size: Size<Length>,
+    /// Controls the scale of the item and its children, relative to its parent's scale.
+    pub scale: f32,
     /// Sets the preferred aspect ratio for the item. The ratio is calculated as width divided by height.
     pub aspect_ratio: Option<f32>,
 
@@ -711,6 +713,7 @@ impl Default for Style {
             size: Size::auto(),
             min_size: Size::auto(),
             max_size: Size::auto(),
+            scale: 1.0,
             aspect_ratio: None,
             gap: Size::default(),
             // Alignment

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -351,6 +351,12 @@ pub trait Styled: Sized {
         self
     }
 
+    /// Sets the scale of the element and its children, relative to the scale of its parent.
+    fn scale(mut self, scale: f32) -> Self {
+        self.style().scale = Some(scale);
+        self
+    }
+
     /// Sets the background color of the element.
     fn bg<F>(mut self, fill: F) -> Self
     where

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -20,7 +20,7 @@ struct NodeContext {
 }
 pub struct TaffyLayoutEngine {
     taffy: TaffyTree<NodeContext>,
-    absolute_layout_bounds: FxHashMap<LayoutId, Bounds<Pixels>>,
+    layout_bounds: FxHashMap<LayoutId, Bounds<Pixels>>,
     computed_layouts: FxHashSet<LayoutId>,
 }
 
@@ -30,14 +30,14 @@ impl TaffyLayoutEngine {
     pub fn new() -> Self {
         TaffyLayoutEngine {
             taffy: TaffyTree::new(),
-            absolute_layout_bounds: FxHashMap::default(),
+            layout_bounds: FxHashMap::default(),
             computed_layouts: FxHashSet::default(),
         }
     }
 
     pub fn clear(&mut self) {
         self.taffy.clear();
-        self.absolute_layout_bounds.clear();
+        self.layout_bounds.clear();
         self.computed_layouts.clear();
     }
 
@@ -159,7 +159,7 @@ impl TaffyLayoutEngine {
             let mut stack = SmallVec::<[LayoutId; 64]>::new();
             stack.push(id);
             while let Some(id) = stack.pop() {
-                self.absolute_layout_bounds.remove(&id);
+                self.layout_bounds.remove(&id);
                 stack.extend(
                     self.taffy
                         .children(id.into())
@@ -195,7 +195,7 @@ impl TaffyLayoutEngine {
     }
 
     pub fn layout_bounds(&mut self, id: LayoutId) -> Bounds<Pixels> {
-        if let Some(layout) = self.absolute_layout_bounds.get(&id).cloned() {
+        if let Some(layout) = self.layout_bounds.get(&id).cloned() {
             return layout;
         }
 
@@ -205,12 +205,7 @@ impl TaffyLayoutEngine {
             size: layout.size.into(),
         };
 
-        if let Some(parent_id) = self.taffy.parent(id.0) {
-            let parent_bounds = self.layout_bounds(parent_id.into());
-            bounds.origin += parent_bounds.origin;
-        }
-        self.absolute_layout_bounds.insert(id, bounds);
-
+        self.layout_bounds.insert(id, bounds);
         bounds
     }
 }

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -21,6 +21,7 @@ struct NodeContext {
 pub struct TaffyLayoutEngine {
     taffy: TaffyTree<NodeContext>,
     layout_bounds: FxHashMap<LayoutId, Bounds<Pixels>>,
+    layout_scales: FxHashMap<LayoutId, f32>,
     computed_layouts: FxHashSet<LayoutId>,
 }
 
@@ -31,6 +32,7 @@ impl TaffyLayoutEngine {
         TaffyLayoutEngine {
             taffy: TaffyTree::new(),
             layout_bounds: FxHashMap::default(),
+            layout_scales: FxHashMap::default(),
             computed_layouts: FxHashSet::default(),
         }
     }
@@ -38,6 +40,7 @@ impl TaffyLayoutEngine {
     pub fn clear(&mut self) {
         self.taffy.clear();
         self.layout_bounds.clear();
+        self.layout_scales.clear();
         self.computed_layouts.clear();
     }
 
@@ -64,6 +67,7 @@ impl TaffyLayoutEngine {
                 .into();
             parent_id
         };
+        self.layout_scales.insert(layout_id, style.scale);
         layout_id
     }
 
@@ -86,6 +90,7 @@ impl TaffyLayoutEngine {
             )
             .expect(EXPECT_MESSAGE)
             .into();
+        self.layout_scales.insert(layout_id, style.scale);
         layout_id
     }
 
@@ -207,6 +212,10 @@ impl TaffyLayoutEngine {
 
         self.layout_bounds.insert(id, bounds);
         bounds
+    }
+
+    pub fn layout_scale(&mut self, id: LayoutId) -> f32 {
+        *self.layout_scales.get(&id).unwrap()
     }
 }
 

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -351,7 +351,7 @@ fn paint_line(
                 }
 
                 let max_glyph_bounds = Bounds {
-                    origin: glyph_origin + window.element_origin,
+                    origin: glyph_origin + window.element_origin(),
                     size: max_glyph_size,
                 };
 

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -351,7 +351,7 @@ fn paint_line(
                 }
 
                 let max_glyph_bounds = Bounds {
-                    origin: glyph_origin,
+                    origin: glyph_origin + window.coordinate_space_origin,
                     size: max_glyph_size,
                 };
 

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -351,7 +351,7 @@ fn paint_line(
                 }
 
                 let max_glyph_bounds = Bounds {
-                    origin: glyph_origin + window.coordinate_space_origin,
+                    origin: glyph_origin + window.element_origin,
                     size: max_glyph_size,
                 };
 

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -351,8 +351,8 @@ fn paint_line(
                 }
 
                 let max_glyph_bounds = Bounds {
-                    origin: glyph_origin + window.element_origin(),
-                    size: max_glyph_size,
+                    origin: glyph_origin * window.element_scale() + window.element_origin(),
+                    size: max_glyph_size * px(window.element_scale()),
                 };
 
                 let content_mask = window.content_mask();

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2759,9 +2759,7 @@ impl Window {
                     });
 
                     // Measure and rescale output size for layout
-                    window.with_element_scale(scale, |window| {
-                        measure(known_size, available_space, window, cx).map(|size| size * scale)
-                    })
+                    measure(known_size, available_space, window, cx).map(|size| size * scale)
                 },
             )
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3107,17 +3107,17 @@ impl Window {
             // Track the mouse position with our own state, since accessing the platform
             // API for the mouse position can only occur on the main thread.
             PlatformInput::MouseMove(mouse_move) => {
-                self.mouse_position = mouse_move.position;
+                self.mouse_position = mouse_move.absolute_position;
                 self.modifiers = mouse_move.modifiers;
                 PlatformInput::MouseMove(mouse_move)
             }
             PlatformInput::MouseDown(mouse_down) => {
-                self.mouse_position = mouse_down.position;
+                self.mouse_position = mouse_down.absolute_position;
                 self.modifiers = mouse_down.modifiers;
                 PlatformInput::MouseDown(mouse_down)
             }
             PlatformInput::MouseUp(mouse_up) => {
-                self.mouse_position = mouse_up.position;
+                self.mouse_position = mouse_up.absolute_position;
                 self.modifiers = mouse_up.modifiers;
                 PlatformInput::MouseUp(mouse_up)
             }
@@ -3130,45 +3130,55 @@ impl Window {
                 PlatformInput::ModifiersChanged(modifiers_changed)
             }
             PlatformInput::ScrollWheel(scroll_wheel) => {
-                self.mouse_position = scroll_wheel.position;
+                self.mouse_position = scroll_wheel.absolute_position;
                 self.modifiers = scroll_wheel.modifiers;
                 PlatformInput::ScrollWheel(scroll_wheel)
             }
             // Translate dragging and dropping of external files from the operating system
             // to internal drag and drop events.
             PlatformInput::FileDrop(file_drop) => match file_drop {
-                FileDropEvent::Entered { position, paths } => {
-                    self.mouse_position = position;
+                FileDropEvent::Entered {
+                    position,
+                    absolute_position,
+                    paths,
+                } => {
+                    self.mouse_position = absolute_position;
                     if cx.active_drag.is_none() {
                         cx.active_drag = Some(AnyDrag {
                             value: Arc::new(paths.clone()),
                             view: cx.new(|_| paths).into(),
-                            cursor_offset: position,
+                            cursor_offset: absolute_position,
                         });
                     }
                     PlatformInput::MouseMove(MouseMoveEvent {
                         position,
-                        absolute_position: position,
+                        absolute_position,
                         pressed_button: Some(MouseButton::Left),
                         modifiers: Modifiers::default(),
                     })
                 }
-                FileDropEvent::Pending { position } => {
-                    self.mouse_position = position;
+                FileDropEvent::Pending {
+                    position,
+                    absolute_position,
+                } => {
+                    self.mouse_position = absolute_position;
                     PlatformInput::MouseMove(MouseMoveEvent {
                         position,
-                        absolute_position: position,
+                        absolute_position,
                         pressed_button: Some(MouseButton::Left),
                         modifiers: Modifiers::default(),
                     })
                 }
-                FileDropEvent::Submit { position } => {
+                FileDropEvent::Submit {
+                    position,
+                    absolute_position,
+                } => {
                     cx.activate(true);
                     self.mouse_position = position;
                     PlatformInput::MouseUp(MouseUpEvent {
                         button: MouseButton::Left,
                         position,
-                        absolute_position: position,
+                        absolute_position,
                         modifiers: Modifiers::default(),
                         click_count: 1,
                     })

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -416,7 +416,7 @@ impl MarkdownElement {
         let is_hovering_link = hitbox.is_hovered(window)
             && !self.markdown.read(cx).selection.pending
             && rendered_text
-                .link_for_position(window.mouse_position())
+                .link_for_position(window.mouse_position() - window.element_origin())
                 .is_some();
 
         if is_hovering_link {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2492,7 +2492,7 @@ impl OutlinePanel {
                             // panel from being deployed.
                             cx.stop_propagation();
                             outline_panel.deploy_context_menu(
-                                event.position,
+                                event.absolute_position,
                                 rendered_entry.clone(),
                                 window,
                                 cx,
@@ -4929,10 +4929,15 @@ impl Render for OutlinePanel {
                 MouseButton::Right,
                 cx.listener(move |outline_panel, event: &MouseDownEvent, window, cx| {
                     if let Some(entry) = outline_panel.selected_entry().cloned() {
-                        outline_panel.deploy_context_menu(event.position, entry, window, cx)
+                        outline_panel.deploy_context_menu(
+                            event.absolute_position,
+                            entry,
+                            window,
+                            cx,
+                        )
                     } else if let Some(entry) = outline_panel.fs_entries.first().cloned() {
                         outline_panel.deploy_context_menu(
-                            event.position,
+                            event.absolute_position,
                             PanelEntry::Fs(entry),
                             window,
                             cx,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3633,7 +3633,7 @@ impl ProjectPanel {
             })
             .on_drag_move::<DraggedSelection>(cx.listener(
                 move |this, event: &DragMoveEvent<DraggedSelection>, window, cx| {
-                    if event.bounds.contains(&event.event.position) {
+                    if event.bounds.contains(&event.event.absolute_position) {
                         if this.last_selection_drag_over_entry == Some(entry_id) {
                             return;
                         }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4025,7 +4025,7 @@ impl ProjectPanel {
                             if !this.marked_entries.contains(&selection) {
                                 this.marked_entries.clear();
                             }
-                            this.deploy_context_menu(event.position, entry_id, window, cx);
+                            this.deploy_context_menu(event.absolute_position, entry_id, window, cx);
                         },
                     ))
                     .overflow_x(),
@@ -4482,7 +4482,7 @@ impl Render for ProjectPanel {
                         // When deploying the context menu anywhere below the last project entry,
                         // act as if the user clicked the root of the last worktree.
                         if let Some(entry_id) = this.last_worktree_root_id {
-                            this.deploy_context_menu(event.position, entry_id, window, cx);
+                            this.deploy_context_menu(event.absolute_position, entry_id, window, cx);
                         }
                     }),
                 )

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1160,7 +1160,7 @@ impl Render for TerminalView {
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseDownEvent, window, cx| {
                     if !this.terminal.read(cx).mouse_mode(event.modifiers.shift) {
-                        this.deploy_context_menu(event.position, window, cx);
+                        this.deploy_context_menu(event.absolute_position, window, cx);
                         cx.notify();
                     }
                 }),

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -239,7 +239,9 @@ impl Render for TitleBar {
                                 .when(supported_controls.window_menu, |titlebar| {
                                     titlebar.on_mouse_down(
                                         gpui::MouseButton::Right,
-                                        move |ev, window, _| window.show_window_menu(ev.position),
+                                        move |ev, window, _| {
+                                            window.show_window_menu(ev.absolute_position)
+                                        },
                                     )
                                 })
                                 .on_mouse_move(cx.listener(move |this, _ev, window, _| {

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -140,7 +140,6 @@ mod uniform_list {
         fn compute(
             &self,
             visible_range: Range<usize>,
-            bounds: Bounds<Pixels>,
             item_height: Pixels,
             item_count: usize,
             window: &mut Window,
@@ -160,7 +159,7 @@ mod uniform_list {
                 visible_range.start,
                 includes_trailing_indent,
             );
-            let mut indent_guides = if let Some(ref custom_render) = self.render_fn {
+            let indent_guides = if let Some(ref custom_render) = self.render_fn {
                 let params = RenderIndentGuideParams {
                     indent_guides,
                     indent_size: self.indent_size,
@@ -184,12 +183,6 @@ mod uniform_list {
                     })
                     .collect()
             };
-            for guide in &mut indent_guides {
-                guide.bounds.origin += bounds.origin;
-                if let Some(hitbox) = guide.hitbox.as_mut() {
-                    hitbox.origin += bounds.origin;
-                }
-            }
 
             let indent_guides = IndentGuidesElement {
                 indent_guides: Rc::new(indent_guides),


### PR DESCRIPTION
Redo of #24352 (I wanted to get all the bugs with local coordinates rendering before adding scaling).

---

This PR changes the coordinate space of elements in GPUI to use local coordinates instead of window coordinates, meaning that the origin is always zero and the size of the bounds are not effected by the scale of the element when placed in the window. Events are also put into this coordinate space by default, but elements which need to access the absolute coordinates can still do so via the `absolute_position` property of mouse events.

There is still some work to do (see below), but the core is complete and Zed can be scaled at the root within rendering issues. This PR will not aim to make Zed fully scalable without issues (through if I find any, I will fix them), but it does aim to not break Zed in the transition to local coordinates.

<details>
<summary>Screenshot of Zed scaled at root</summary>

![Screenshot from 2025-02-12 22-34-49](https://github.com/user-attachments/assets/2ef16dee-a4e6-4582-be62-ae0d89a83e92)

</details>

<details>
<summary>Screenshot of scaled terminal panel</summary>

![Screenshot from 2025-02-12 22-40-37](https://github.com/user-attachments/assets/d0a318bb-4ffd-4ae8-8444-41200df37414)

</details>

<details>
<summary>Video of gpui `scale` example</summary>

[Screencast from 2025-02-12 22-42-48.webm](https://github.com/user-attachments/assets/5d7a757f-1059-412d-bf67-65379131bcbe)

</details>

TODO:
- [x] Put file drop events into local coordinates
- [ ] Make other Styled implementors react to the scale property
  - This only needs to be done for containers which call `request_layout` for each child. Scale is applied automatically to all other elements, but it cannot be propagated to children automatically.
- [ ] Fix issue with window & pane resize edges
  - Window resize edges is an issue with the absolute child canvas having the incorrect element offset. Likely a cause of other issues too
- [x] Fix issue with file hover in project panel
- [x] Fix issue with markdown tooltip not  showing
- [ ] Fix failing tests (are test contexts broken with local coords?)
- [ ] Go back through changes to main Zed code and account for scaling where local origin was accounted for
- [ ] Bug-test Zed (particularly anything using `position`, `window.mouse_position()` or has mouse interaction)
- [ ] Fix data-table example scroll bar
  - Horizontal editor scroll bar is broken as well.
- [ ] Document changed and added functions
- [ ] Check GPUI debugging tools for oversights
- [ ] Change the `bounds` parameter to element functions to be `Size` instead of `Bounds`, since the origin is always zero (should this be a separate PR? It touches a lot of files but also lets me check for bugs at each one)

Release Notes:

- N/A
