### PR TITLE
Require `alt-tab` for `AcceptEditPrediction` when `tab` inserting whitespace is desired

### DIFF
--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -1,10 +1,9 @@
 use gpui::{prelude::*, Entity};
 use indoc::indoc;
 use inline_completion::EditPredictionProvider;
-use language::{Language, LanguageConfig};
 use multi_buffer::{Anchor, MultiBufferSnapshot, ToPoint};
 use project::Project;
-use std::{num::NonZeroU32, ops::Range, sync::Arc};
+use std::ops::Range;
 use text::{Point, ToOffset};
 
 use crate::{
@@ -121,54 +120,6 @@ async fn test_inline_completion_jump_button(cx: &mut gpui::TestAppContext) {
         line 2
         line 3
         line 4
-    "});
-}
-
-#[gpui::test]
-async fn test_indentation(cx: &mut gpui::TestAppContext) {
-    init_test(cx, |settings| {
-        settings.defaults.tab_size = NonZeroU32::new(4)
-    });
-
-    let language = Arc::new(
-        Language::new(
-            LanguageConfig::default(),
-            Some(tree_sitter_rust::LANGUAGE.into()),
-        )
-        .with_indents_query(r#"(_ "(" ")" @end) @indent"#)
-        .unwrap(),
-    );
-
-    let mut cx = EditorTestContext::new(cx).await;
-    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
-    let provider = cx.new(|_| FakeInlineCompletionProvider::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-
-    cx.set_state(indoc! {"
-        const a: A = (
-        ˇ
-        );
-    "});
-
-    propose_edits(
-        &provider,
-        vec![(Point::new(1, 0)..Point::new(1, 0), "    const function()")],
-        &mut cx,
-    );
-    cx.update_editor(|editor, window, cx| editor.update_visible_inline_completion(window, cx));
-
-    assert_editor_active_edit_completion(&mut cx, |_, edits| {
-        assert_eq!(edits.len(), 1);
-        assert_eq!(edits[0].1.as_str(), "    const function()");
-    });
-
-    // When the cursor is before the suggested indentation level, accepting a
-    // completion should just indent.
-    accept_completion(&mut cx);
-    cx.assert_editor_state(indoc! {"
-        const a: A = (
-            ˇ
-        );
     "});
 }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4236,6 +4236,21 @@ impl MultiBufferSnapshot {
         indent
     }
 
+    pub fn is_line_whitespace_upto<T>(&self, position: T) -> bool
+    where
+        T: ToOffset,
+    {
+        for char in self.reversed_chars_at(position) {
+            if !char.is_whitespace() {
+                return false;
+            }
+            if char == '\n' {
+                return true;
+            }
+        }
+        return true;
+    }
+
     pub fn prev_non_blank_row(&self, mut row: MultiBufferRow) -> Option<MultiBufferRow> {
         while row.0 > 0 {
             row.0 -= 1;


### PR DESCRIPTION
Moves tab whitespace insertion logic out of `AcceptEditPrediction` handler.

`edit_prediction_requires_modifier` context will now be true when on a line with leading whitespace, so that `alt-tab` is used to accept predictions in this case.  This way leading indentation can be typed when edit predictions are visible

Release Notes:

- N/A