### PR TITLE
ui: Fix keybind sizing for non-default UI font sizes

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -230,7 +230,9 @@ pub struct Key {
 impl RenderOnce for Key {
     fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
         let single_char = self.key.len() == 1;
-        let size = self.size.unwrap_or(px(14.).into());
+        let size = self
+            .size
+            .unwrap_or_else(|| TextSize::default().rems(cx).into());
 
         div()
             .py_0()


### PR DESCRIPTION
Closes #24597 

This fixes the regression from https://github.com/zed-industries/zed/commit/00971fbe415fdc4695307f192134093c7bcd138c which removed the `text_ui(cx)` - call from the keybinding render. The removal caused improperly scaled font rendering as shown in the images below.

This PR reintroduces this behaviour for all cases where `size` is not set.

| | `main` | With this patch | Parent of https://github.com/zed-industries/zed/commit/00971fbe415fdc4695307f192134093c7bcd138c
| --- | ---- | ---- | --- |
| Small font size (10px) | <img width="204" alt="cur_small" src="https://github.com/user-attachments/assets/2bb1615a-c346-4da5-855c-01894744ee74" /> | <img width="205" alt="pr_small" src="https://github.com/user-attachments/assets/26ab70f0-d6ca-439b-aaea-4d6ded4f8f11" /> | <img width="203" alt="prev_small" src="https://github.com/user-attachments/assets/92a04008-8408-4a98-83a2-59fdd6e5708a" /> |
| Large font size | <img width="369" alt="cur_big" src="https://github.com/user-attachments/assets/8400c205-19b6-479c-a3d1-df12ed4e84da" /> | <img width="398" alt="pr_big" src="https://github.com/user-attachments/assets/01f495aa-0be1-4169-ae09-4292b0e638ff" /> |  <img width="389" alt="prev_big" src="https://github.com/user-attachments/assets/e041a8ea-a958-4a3b-8fef-0f7fe5079c34" /> |


Release Notes:

- Fixed keybind hints being improperly scaled for custom ui font sizes
