### PR TITLE
Fix display of modifiers for edit prediction keybindings on linux

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5741,13 +5741,21 @@ impl Editor {
                                 },
                             )
                             .child(Label::new("Hold").size(LabelSize::Small))
-                            .children(ui::render_modifiers_for_edit_prediction(
-                                &accept_keystroke.modifiers,
-                                PlatformStyle::platform(),
-                                Some(Color::Default),
-                                Some(IconSize::Small.rems().into()),
-                                true,
-                            ))
+                            .child(h_flex().children(itertools::intersperse_with(
+                                ui::render_modifiers_for_edit_prediction(
+                                    &accept_keystroke.modifiers,
+                                    PlatformStyle::platform(),
+                                    Some(Color::Default),
+                                    Some(IconSize::Small.rems().into()),
+                                ),
+                                || {
+                                    if PlatformStyle::platform() != PlatformStyle::Mac {
+                                        "+".into_any_element()
+                                    } else {
+                                        gpui::Empty.into_any_element()
+                                    }
+                                },
+                            )))
                             .into_any(),
                     );
                 }
@@ -5811,17 +5819,27 @@ impl Editor {
                         .child(
                             h_flex()
                                 .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
-                                .gap_1()
-                                .children(ui::render_modifiers_for_edit_prediction(
-                                    &accept_keystroke.modifiers,
-                                    PlatformStyle::platform(),
-                                    Some(if !has_completion {
-                                        Color::Muted
-                                    } else {
-                                        Color::Default
-                                    }),
-                                    None,
-                                    true,
+                                .when(PlatformStyle::platform() == PlatformStyle::Mac, |parent| {
+                                    parent.gap_1()
+                                })
+                                .children(itertools::intersperse_with(
+                                    ui::render_modifiers_for_edit_prediction(
+                                        &accept_keystroke.modifiers,
+                                        PlatformStyle::platform(),
+                                        Some(if !has_completion {
+                                            Color::Muted
+                                        } else {
+                                            Color::Default
+                                        }),
+                                        None,
+                                    ),
+                                    || {
+                                        if PlatformStyle::platform() != PlatformStyle::Mac {
+                                            "+".into_any_element()
+                                        } else {
+                                            gpui::Empty.into_any_element()
+                                        }
+                                    },
                                 )),
                         )
                         .child(Label::new("Preview").into_any_element())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5741,7 +5741,7 @@ impl Editor {
                                 },
                             )
                             .child(Label::new("Hold").size(LabelSize::Small))
-                            .children(ui::render_modifiers(
+                            .children(ui::render_modifiers_for_edit_prediction(
                                 &accept_keystroke.modifiers,
                                 PlatformStyle::platform(),
                                 Some(Color::Default),
@@ -5812,7 +5812,7 @@ impl Editor {
                             h_flex()
                                 .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
                                 .gap_1()
-                                .children(ui::render_modifiers(
+                                .children(ui::render_modifiers_for_edit_prediction(
                                     &accept_keystroke.modifiers,
                                     PlatformStyle::platform(),
                                     Some(if !has_completion {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5813,7 +5813,7 @@ fn inline_completion_accept_indicator(
         .text_color(cx.theme().colors().text)
         .gap_1()
         .when(!editor.edit_prediction_preview_is_active(), |parent| {
-            parent.children(ui::render_modifiers(
+            parent.children(ui::render_modifiers_for_edit_prediction(
                 &accept_keystroke.modifiers,
                 PlatformStyle::platform(),
                 Some(Color::Default),

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -220,6 +220,90 @@ pub fn render_modifiers(
         })
 }
 
+// TODO: Dedupe with `render_modifiers`. Since this change is close to initial launch, de-risking it
+// by not changing the rendering for all modifiers.
+pub fn render_modifiers_for_edit_prediction(
+    modifiers: &Modifiers,
+    platform_style: PlatformStyle,
+    color: Option<Color>,
+    size: Option<AbsoluteLength>,
+    standalone: bool,
+) -> impl Iterator<Item = AnyElement> {
+    enum KeyOrIcon {
+        Key(String),
+        Icon(IconName),
+    }
+
+    struct Modifier {
+        enabled: bool,
+        mac: KeyOrIcon,
+        linux: &'static str,
+        windows: &'static str,
+    }
+
+    let table = {
+        use KeyOrIcon::*;
+
+        [
+            Modifier {
+                enabled: modifiers.function,
+                mac: Icon(IconName::Control),
+                linux: "Fn",
+                windows: "Fn",
+            },
+            Modifier {
+                enabled: modifiers.control,
+                mac: Icon(IconName::Control),
+                linux: "Ctrl",
+                windows: "Ctrl",
+            },
+            Modifier {
+                enabled: modifiers.alt,
+                mac: Icon(IconName::Option),
+                linux: "Alt",
+                windows: "Alt",
+            },
+            Modifier {
+                enabled: modifiers.platform,
+                mac: Icon(IconName::Command),
+                linux: "Super",
+                windows: "Win",
+            },
+            Modifier {
+                enabled: modifiers.shift,
+                mac: Icon(IconName::Shift),
+                linux: "Shift",
+                windows: "Shift",
+            },
+        ]
+    };
+
+    let filtered = table
+        .into_iter()
+        .filter(|modifier| modifier.enabled)
+        .collect::<Vec<_>>();
+    let last_ix = filtered.len().saturating_sub(1);
+
+    filtered
+        .into_iter()
+        .enumerate()
+        .map(move |(ix, modifier)| match platform_style {
+            PlatformStyle::Mac => modifier.mac,
+            PlatformStyle::Linux if standalone && ix == last_ix => {
+                KeyOrIcon::Key(modifier.linux.to_string())
+            }
+            PlatformStyle::Linux => KeyOrIcon::Key(format!("{}+", modifier.linux)),
+            PlatformStyle::Windows if standalone && ix == last_ix => {
+                KeyOrIcon::Key(modifier.windows.to_string())
+            }
+            PlatformStyle::Windows => KeyOrIcon::Key(format!("{}+", modifier.windows)),
+        })
+        .map(move |key_or_icon| match key_or_icon {
+            KeyOrIcon::Key(key) => Key::new(key, color).size(size).into_any_element(),
+            KeyOrIcon::Icon(icon) => KeyIcon::new(icon, color).size(size).into_any_element(),
+        })
+}
+
 #[derive(IntoElement)]
 pub struct Key {
     key: SharedString,

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -227,7 +227,6 @@ pub fn render_modifiers_for_edit_prediction(
     platform_style: PlatformStyle,
     color: Option<Color>,
     size: Option<AbsoluteLength>,
-    standalone: bool,
 ) -> impl Iterator<Item = AnyElement> {
     enum KeyOrIcon {
         Key(String),
@@ -282,21 +281,13 @@ pub fn render_modifiers_for_edit_prediction(
         .into_iter()
         .filter(|modifier| modifier.enabled)
         .collect::<Vec<_>>();
-    let last_ix = filtered.len().saturating_sub(1);
 
     filtered
         .into_iter()
-        .enumerate()
-        .map(move |(ix, modifier)| match platform_style {
+        .map(move |modifier| match platform_style {
             PlatformStyle::Mac => modifier.mac,
-            PlatformStyle::Linux if standalone && ix == last_ix => {
-                KeyOrIcon::Key(modifier.linux.to_string())
-            }
-            PlatformStyle::Linux => KeyOrIcon::Key(format!("{}+", modifier.linux)),
-            PlatformStyle::Windows if standalone && ix == last_ix => {
-                KeyOrIcon::Key(modifier.windows.to_string())
-            }
-            PlatformStyle::Windows => KeyOrIcon::Key(format!("{}+", modifier.windows)),
+            PlatformStyle::Linux => KeyOrIcon::Key(modifier.linux.to_string()),
+            PlatformStyle::Windows => KeyOrIcon::Key(modifier.windows.to_string()),
         })
         .map(move |key_or_icon| match key_or_icon {
             KeyOrIcon::Key(key) => Key::new(key, color).size(size).into_any_element(),


### PR DESCRIPTION
Notes For MacOS compatability:

- `gap` issue I created a workaround for is likely not great on Mac either
    - do the `+` icons also look nice on mac?
- ensure the `key_size` in the "Accept" menu is acceptable on mac
- TODO: ensure no `+` when there are no modifiers

Linux Before:
![image](https://github.com/user-attachments/assets/47be3755-5fdb-4f80-8a9e-36d912e7901e)

Linux After: (with multi-modifiers)
![image](https://github.com/user-attachments/assets/016e90af-50bb-4395-936f-3842ba253a1d)


Release Notes:

- Improved display of keybindings for edit prediction on Linux
