### PR TITLE
edit predictions: Update migration banner text

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -29,7 +29,7 @@ use gpui::{
     WindowOptions,
 };
 use image_viewer::ImageInfo;
-use migrate::{MigrationType, MigratorBanner, MigratorEvent, MigratorNotification};
+use migrate::{MigrationBanner, MigrationEvent, MigrationNotification, MigrationType};
 use migrator::{migrate_keymap, migrate_settings};
 pub use open_listener::*;
 use outline_panel::OutlinePanel;
@@ -871,8 +871,8 @@ fn initialize_pane(
             toolbar.add_item(lsp_log_item, window, cx);
             let syntax_tree_item = cx.new(|_| language_tools::SyntaxTreeToolbarItemView::new());
             toolbar.add_item(syntax_tree_item, window, cx);
-            let migrator_banner = cx.new(|cx| MigratorBanner::new(workspace, cx));
-            toolbar.add_item(migrator_banner, window, cx);
+            let migration_banner = cx.new(|cx| MigrationBanner::new(workspace, cx));
+            toolbar.add_item(migration_banner, window, cx);
         })
     });
 }
@@ -1106,7 +1106,7 @@ pub fn handle_settings_file_changes(
     cx: &mut App,
     settings_changed: impl Fn(Option<anyhow::Error>, &mut App) + 'static,
 ) {
-    MigratorNotification::set_global(cx.new(|_| MigratorNotification), cx);
+    MigrationNotification::set_global(cx.new(|_| MigrationNotification), cx);
     let content = cx
         .background_executor()
         .block(user_settings_file_rx.next())
@@ -1137,9 +1137,9 @@ pub fn handle_settings_file_changes(
             }
 
             cx.update(|cx| {
-                if let Some(notifier) = MigratorNotification::try_global(cx) {
+                if let Some(notifier) = MigrationNotification::try_global(cx) {
                     notifier.update(cx, |_, cx| {
-                        cx.emit(MigratorEvent::ContentChanged {
+                        cx.emit(MigrationEvent::ContentChanged {
                             migration_type: MigrationType::Settings,
                             migrated: content_migrated,
                         });
@@ -1221,9 +1221,9 @@ pub fn handle_keymap_file_changes(
                 }
             };
             cx.update(|cx| {
-                if let Some(notifier) = MigratorNotification::try_global(cx) {
+                if let Some(notifier) = MigrationNotification::try_global(cx) {
                     notifier.update(cx, |_, cx| {
-                        cx.emit(MigratorEvent::ContentChanged {
+                        cx.emit(MigrationEvent::ContentChanged {
                             migration_type: MigrationType::Keymap,
                             migrated: content_migrated,
                         });

--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -18,42 +18,42 @@ pub enum MigrationType {
     Settings,
 }
 
-pub struct MigratorBanner {
+pub struct MigrationBanner {
     migration_type: Option<MigrationType>,
 }
 
-pub enum MigratorEvent {
+pub enum MigrationEvent {
     ContentChanged {
         migration_type: MigrationType,
         migrated: bool,
     },
 }
 
-pub struct MigratorNotification;
+pub struct MigrationNotification;
 
-impl EventEmitter<MigratorEvent> for MigratorNotification {}
+impl EventEmitter<MigrationEvent> for MigrationNotification {}
 
-impl MigratorNotification {
+impl MigrationNotification {
     pub fn try_global(cx: &App) -> Option<Entity<Self>> {
-        cx.try_global::<GlobalMigratorNotification>()
+        cx.try_global::<GlobalMigrationNotification>()
             .map(|notifier| notifier.0.clone())
     }
 
     pub fn set_global(notifier: Entity<Self>, cx: &mut App) {
-        cx.set_global(GlobalMigratorNotification(notifier));
+        cx.set_global(GlobalMigrationNotification(notifier));
     }
 }
 
-struct GlobalMigratorNotification(Entity<MigratorNotification>);
+struct GlobalMigrationNotification(Entity<MigrationNotification>);
 
-impl Global for GlobalMigratorNotification {}
+impl Global for GlobalMigrationNotification {}
 
-impl MigratorBanner {
+impl MigrationBanner {
     pub fn new(_: &Workspace, cx: &mut Context<'_, Self>) -> Self {
-        if let Some(notifier) = MigratorNotification::try_global(cx) {
+        if let Some(notifier) = MigrationNotification::try_global(cx) {
             cx.subscribe(
                 &notifier,
-                move |migrator_banner, _, event: &MigratorEvent, cx| {
+                move |migrator_banner, _, event: &MigrationEvent, cx| {
                     migrator_banner.handle_notification(event, cx);
                 },
             )
@@ -80,9 +80,9 @@ impl MigratorBanner {
         }
     }
 
-    fn handle_notification(&mut self, event: &MigratorEvent, cx: &mut Context<'_, Self>) {
+    fn handle_notification(&mut self, event: &MigrationEvent, cx: &mut Context<'_, Self>) {
         match event {
-            MigratorEvent::ContentChanged {
+            MigrationEvent::ContentChanged {
                 migration_type,
                 migrated,
             } => {
@@ -100,9 +100,9 @@ impl MigratorBanner {
     }
 }
 
-impl EventEmitter<ToolbarItemEvent> for MigratorBanner {}
+impl EventEmitter<ToolbarItemEvent> for MigrationBanner {}
 
-impl ToolbarItemView for MigratorBanner {
+impl ToolbarItemView for MigrationBanner {
     fn set_active_pane_item(
         &mut self,
         active_pane_item: Option<&dyn ItemHandle>,
@@ -155,7 +155,7 @@ impl ToolbarItemView for MigratorBanner {
     }
 }
 
-impl Render for MigratorBanner {
+impl Render for MigrationBanner {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let migration_type = self.migration_type;
         let file_type = match migration_type {

--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -189,10 +189,11 @@ impl Render for MigratorBanner {
                             .gap_0p5()
                             .child(
                                 Label::new(format!(
-                                    "Your {} file requires migration to support this version of Zed. A backup will be saved to",
+                                    "Your {} file uses deprecated settings which can be \
+                                    automatically updated. A backup will be saved to",
                                     file_type
                                 ))
-                                .color(Color::Default)
+                                .color(Color::Default),
                             )
                             .child(
                                 div()
@@ -202,32 +203,30 @@ impl Render for MigratorBanner {
                                     .child(
                                         Label::new(backup_file_name)
                                             .buffer_font(cx)
-                                            .size(LabelSize::Small)
+                                            .size(LabelSize::Small),
                                     ),
-                            )
-                    )
+                            ),
+                    ),
             )
             .child(
-                Button::new("backup-and-migrate", "Backup and Migrate").on_click(
-                    move |_, _, cx| {
-                        let fs = <dyn Fs>::global(cx);
-                        match migration_type {
-                            Some(MigrationType::Keymap) => {
-                                cx.spawn(
-                                    move |_| async move { write_keymap_migration(&fs).await.ok() },
-                                )
-                                .detach();
-                            }
-                            Some(MigrationType::Settings) => {
-                                cx.spawn(move |_| async move {
-                                    write_settings_migration(&fs).await.ok()
-                                })
-                                .detach();
-                            }
-                            None => unreachable!(),
+                Button::new("backup-and-migrate", "Backup and Update").on_click(move |_, _, cx| {
+                    let fs = <dyn Fs>::global(cx);
+                    match migration_type {
+                        Some(MigrationType::Keymap) => {
+                            cx.spawn(
+                                move |_| async move { write_keymap_migration(&fs).await.ok() },
+                            )
+                            .detach();
                         }
-                    },
-                ),
+                        Some(MigrationType::Settings) => {
+                            cx.spawn(
+                                move |_| async move { write_settings_migration(&fs).await.ok() },
+                            )
+                            .detach();
+                        }
+                        None => unreachable!(),
+                    }
+                }),
             )
             .into_any_element()
     }


### PR DESCRIPTION
Rationale for the changes:

* `requires migration` -> `uses some deprecated settings` changed because really it isn't required by this version of Zed, and I believe we hope to offer support for deprecated settings and their migration for a long time.

* Rename of `migration` -> `updated` is because to me, "updated" feels lighter and more accurate. To me migration has connotations of moving to a whole new format.

Formatting changes are due to shortening the line causing cargo fmt to go from not formatting the code to doing so.

Release Notes:

- N/A