### PR TITLE
Fix key binding hints disappearing when tooltip appears

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -778,6 +778,8 @@ impl Render for Dock {
             div()
                 .key_context(dispatch_context)
                 .track_focus(&self.focus_handle(cx))
+                // This is a workaround to ensure the key binding hints are visible.
+                .child(deferred(gpui::Empty))
         }
     }
 }


### PR DESCRIPTION
Open the recent project panel in an empty Zed window, when the tooltip appears, the key binding hints will disappear if those keymaps are declared with context.

After debugging, I found that `window.rendered_frame.dispatch_tree.context_stack` becomes an empty vector when the tooltip appears, the `bindings_for_action` function cannot find the correct hints.

I tried to fix the issue with minimal changes first, I'm not sure if these changes are appropriate, please let me know, Thanks.

## Before

https://github.com/user-attachments/assets/871622b1-2a27-46a6-9cab-57776ea99343

## After

https://github.com/user-attachments/assets/ad63e370-4500-4218-9bda-9c372024b8c0

Release Notes:

- N/A
