### PR TITLE
docs: Fix `modal_max_width` naming

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -652,15 +652,15 @@
     // There are 5 possible width values:
     //
     // 1. Small: This value is essentially a fixed width.
-    //    "modal_width": "small"
+    //    "modal_max_width": "small"
     // 2. Medium:
-    //    "modal_width": "medium"
+    //    "modal_max_width": "medium"
     // 3. Large:
-    //    "modal_width": "large"
+    //    "modal_max_width": "large"
     // 4. Extra Large:
-    //    "modal_width": "xlarge"
+    //    "modal_max_width": "xlarge"
     // 5. Fullscreen: This value removes any horizontal padding, as it consumes the whole viewport width.
-    //    "modal_width": "full"
+    //    "modal_max_width": "full"
     //
     // Default: small
     "modal_max_width": "small"

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1574,7 +1574,7 @@ Or to set a `socks5` proxy:
 ### Modal Max Width
 
 - Description: Max-width of the file finder modal. It can take one of these values: `small`, `medium`, `large`, `xlarge`, and `full`.
-- Setting: `max_modal_width`
+- Setting: `modal_max_width`
 - Default: `small`
 
 ## Preferred Line Length


### PR DESCRIPTION
Fixes `modal_max_width` doc, the settings `modal_max_width` was `max_modal_width` in the doc.

Release Notes:

- N/A
