### PR TITLE
inline_completion_button: Put "Eager Preview Mode" menu entry behind a feature flag

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -69,6 +69,17 @@ impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";
 }
 
+/// A feature flag that controls whether "non eager mode" (holding `alt` to preview) is publicized.
+pub struct PredictEditsNonEagerModeFeatureFlag;
+impl FeatureFlag for PredictEditsNonEagerModeFeatureFlag {
+    const NAME: &'static str = "predict-edits-non-eager-mode";
+
+    fn enabled_for_staff() -> bool {
+        // Don't show to staff so it doesn't leak into media for the launch.
+        false
+    }
+}
+
 pub struct GitUiFeatureFlag;
 impl FeatureFlag for GitUiFeatureFlag {
     const NAME: &'static str = "git-ui";

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -569,12 +569,12 @@ impl InlineCompletionButton {
             );
         }
 
-        let is_eager_preview_enabled = match settings.edit_predictions_mode() {
-            language::EditPredictionsMode::Auto => false,
-            language::EditPredictionsMode::EagerPreview => true,
-        };
-        menu = if cx.is_staff() {
-            menu.separator().toggleable_entry(
+        if cx.has_flag::<feature_flags::PredictEditsNonEagerModeFeatureFlag>() {
+            let is_eager_preview_enabled = match settings.edit_predictions_mode() {
+                language::EditPredictionsMode::Auto => false,
+                language::EditPredictionsMode::EagerPreview => true,
+            };
+            menu = menu.separator().toggleable_entry(
                 "Eager Preview Mode",
                 is_eager_preview_enabled,
                 IconPosition::Start,
@@ -590,7 +590,6 @@ impl InlineCompletionButton {
                                     true => language::EditPredictionsMode::Auto,
                                     false => language::EditPredictionsMode::EagerPreview,
                                 };
-
                                 if let Some(edit_predictions) = settings.edit_predictions.as_mut() {
                                     edit_predictions.mode = new_mode;
                                 } else {
@@ -604,10 +603,8 @@ impl InlineCompletionButton {
                         );
                     }
                 },
-            )
-        } else {
-            menu
-        };
+            );
+        }
 
         if let Some(editor_focus_handle) = self.editor_focus_handle.clone() {
             menu = menu

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -590,6 +590,7 @@ impl InlineCompletionButton {
                                     true => language::EditPredictionsMode::Auto,
                                     false => language::EditPredictionsMode::EagerPreview,
                                 };
+
                                 if let Some(edit_predictions) = settings.edit_predictions.as_mut() {
                                     edit_predictions.mode = new_mode;
                                 } else {


### PR DESCRIPTION
This PR puts the "Eager Preview Mode" menu entry behind a feature flag rather than a staff flag.

Currently it defaults to `false` for staff so that it doesn't leak into any marketing/launch materials.

Folks who want to see it can opt-in to the flag explicitly, for now.

Release Notes:

- N/A
