### PR TITLE
Fix F10 and Alt+F handling on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1235,7 +1235,23 @@ fn parse_syskeydown_msg_keystroke(wparam: WPARAM) -> Option<Keystroke> {
         VK_ESCAPE => "escape",
         VK_INSERT => "insert",
         VK_DELETE => "delete",
-        _ => return basic_vkcode_to_string(vk_code, modifiers),
+        _ => {
+            let basic_key = basic_vkcode_to_string(vk_code, modifiers);
+            if basic_key.is_some() {
+                return basic_key;
+            } else {
+                if vk_code >= VK_F1.0 && vk_code <= VK_F24.0 {
+                    let offset = vk_code - VK_F1.0;
+                    return Some(Keystroke {
+                        modifiers,
+                        key: format!("f{}", offset + 1),
+                        key_char: None,
+                    });
+                } else {
+                    return None;
+                }
+            }
+        }
     }
     .to_owned();
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1290,7 +1290,6 @@ fn parse_keydown_msg_keystroke(wparam: WPARAM) -> Option<KeystrokeOrModifier> {
         VK_INSERT => "insert",
         VK_DELETE => "delete",
         _ => {
-            let vk_code = wparam.loword();
             if is_modifier(VIRTUAL_KEY(vk_code)) {
                 return Some(KeystrokeOrModifier::Modifier(modifiers));
             }


### PR DESCRIPTION
Closes #24744
and should also fix #17819 

The change is split into two commits, first one adds F10 handling (it needs to be handled inside `parse_syskeydown_msg_keystroke`, the second one properly handles `Alt+Fn` combinations, this also needs to happen in `parse_syskeydown_msg_keystroke` and is similar to a fragment inside `parse_keydown_msg_keystroke`

Release Notes:

- Fixes F10 and Alt+Fn handling on windows
