### PR TITLE
file_icons: Add separate icon key for Bicep files

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -18,6 +18,7 @@
     "bash_logout": "terminal",
     "bash_profile": "terminal",
     "bashrc": "terminal",
+    "bicep": "bicep",
     "bmp": "image",
     "c": "c",
     "c++": "cpp",

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -61,6 +61,7 @@ pub struct IconDefinition {
 const FILE_ICONS: &[(&str, &str)] = &[
     ("astro", "icons/file_icons/astro.svg"),
     ("audio", "icons/file_icons/audio.svg"),
+    ("bicep", "icons/file_icons/file.svg"),
     ("bun", "icons/file_icons/bun.svg"),
     ("c", "icons/file_icons/c.svg"),
     ("code", "icons/file_icons/code.svg"),


### PR DESCRIPTION
This PR adds support for bicep file icon:

Release Notes:

- Icon themes: Added the ability to change the file icon for Bicep (`.bicep`) files.