### PR TITLE
editor: Fix autoscroll flickering regression

### DIFF
--- a/a.rs
+++ b/a.rs
@@ -1,0 +1,3 @@
+fn a() {
+  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boopboop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop boop dsfssdfsdf
+}

--- a/a.rs
+++ b/a.rs
@@ -1,3 +1,0 @@
-fn a() {
-  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boopboop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop  boop boop dsfssdfsdf
-}

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7186,7 +7186,7 @@ impl Element for EditorElement {
                         let autoscrolled = if autoscroll_horizontally {
                             editor.autoscroll_horizontally(
                                 start_row,
-                                editor_width - (letter_size.width / 2.0),
+                                editor_width - (letter_size.width / 2.0) + style.scrollbar_width,
                                 scroll_width,
                                 em_width,
                                 &line_layouts,
@@ -7277,7 +7277,7 @@ impl Element for EditorElement {
                         let autoscrolled = if autoscroll_horizontally {
                             editor.autoscroll_horizontally(
                                 start_row,
-                                editor_width - (letter_size.width / 2.0),
+                                editor_width - (letter_size.width / 2.0) + style.scrollbar_width,
                                 scroll_width,
                                 em_width,
                                 &line_layouts,


### PR DESCRIPTION
This PR fixes autoscroll flickering issue caused by recent [#24735](https://github.com/zed-industries/zed/pull/24735) which fixes soft wrap scroll issues. 

Adding vertical scrollbar width to viewport width, so that autoscroll function don't try to scroll that much extra pixels.

Release Notes:

- N/A