### PR TITLE
title_bar: Allow deafening audio without microphone permission

### DIFF
--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -350,6 +350,42 @@ impl TitleBar {
                 .into_any_element(),
         );
 
+        children.push(
+            IconButton::new(
+                "mute-sound",
+                if is_deafened {
+                    ui::IconName::AudioOff
+                } else {
+                    ui::IconName::AudioOn
+                },
+            )
+            .style(ButtonStyle::Subtle)
+            .selected_style(ButtonStyle::Tinted(TintColor::Error))
+            .icon_size(IconSize::Small)
+            .toggle_state(is_deafened)
+            .tooltip(move |window, cx| {
+                if is_deafened {
+                    let label = "Unmute Audio";
+
+                    if !muted_by_user {
+                        Tooltip::with_meta(label, None, "Microphone will be unmuted", window, cx)
+                    } else {
+                        Tooltip::simple(label, cx)
+                    }
+                } else {
+                    let label = "Mute Audio";
+
+                    if !muted_by_user {
+                        Tooltip::with_meta(label, None, "Microphone will be muted", window, cx)
+                    } else {
+                        Tooltip::simple(label, cx)
+                    }
+                }
+            })
+            .on_click(move |_, _, cx| toggle_deafen(&Default::default(), cx))
+            .into_any_element(),
+        );
+
         if can_use_microphone {
             children.push(
                 IconButton::new(
@@ -384,48 +420,6 @@ impl TitleBar {
                 .on_click(move |_, _window, cx| {
                     toggle_mute(&Default::default(), cx);
                 })
-                .into_any_element(),
-            );
-
-            children.push(
-                IconButton::new(
-                    "mute-sound",
-                    if is_deafened {
-                        ui::IconName::AudioOff
-                    } else {
-                        ui::IconName::AudioOn
-                    },
-                )
-                .style(ButtonStyle::Subtle)
-                .selected_style(ButtonStyle::Tinted(TintColor::Error))
-                .icon_size(IconSize::Small)
-                .toggle_state(is_deafened)
-                .tooltip(move |window, cx| {
-                    if is_deafened {
-                        let label = "Unmute Audio";
-
-                        if !muted_by_user {
-                            Tooltip::with_meta(
-                                label,
-                                None,
-                                "Microphone will be unmuted",
-                                window,
-                                cx,
-                            )
-                        } else {
-                            Tooltip::simple(label, cx)
-                        }
-                    } else {
-                        let label = "Mute Audio";
-
-                        if !muted_by_user {
-                            Tooltip::with_meta(label, None, "Microphone will be muted", window, cx)
-                        } else {
-                            Tooltip::simple(label, cx)
-                        }
-                    }
-                })
-                .on_click(move |_, _, cx| toggle_deafen(&Default::default(), cx))
                 .into_any_element(),
             );
 


### PR DESCRIPTION
The deafen audio button wasn't visible in the titlebar unless you had the 'use microphone permission'. Meaning if I would join a call, and didn't receive permission to speak, I wouldn't be able to use the deafen audio button. 

Now the button is directly visible when you join a call. So you can deafen the audio even if you didn't receive the mic permission.

Release Notes:

- N/A
