### PR TITLE
Fix linux zeta modifiers display

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14414,6 +14414,7 @@ dependencies = [
  "strum",
  "theme",
  "ui_macros",
+ "util",
  "windows 0.58.0",
 ]
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5925,7 +5925,7 @@ impl Editor {
                             h_flex()
                                 .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
                                 .when(is_platform_style_mac, |parent| parent.gap_1())
-                                .children(itertools::intersperse_with(
+                                .child(h_flex().children(itertools::intersperse_with(
                                     ui::render_modifiers_for_edit_prediction(
                                         &accept_keystroke.modifiers,
                                         PlatformStyle::platform(),
@@ -5943,7 +5943,7 @@ impl Editor {
                                             gpui::Empty.into_any_element()
                                         }
                                     },
-                                )),
+                                ))),
                         )
                         .child(Label::new("Preview").into_any_element())
                         .opacity(if has_completion { 1.0 } else { 0.4 }),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5667,7 +5667,7 @@ impl Editor {
             .bg(bg_color)
             .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
             .text_size(TextSize::XSmall.rems(cx))
-            .children(ui::render_modifiers(
+            .children(ui::render_modifiers_for_edit_prediction(
                 &accept_keystroke.modifiers,
                 PlatformStyle::platform(),
                 Some(if accept_keystroke.modifiers == window.modifiers() {
@@ -5676,7 +5676,6 @@ impl Editor {
                     Color::Muted
                 }),
                 Some(IconSize::XSmall.rems().into()),
-                false,
             ))
             .child(accept_keystroke.key.clone())
             .into()
@@ -5807,12 +5806,11 @@ impl Editor {
                                 },
                             )
                             .child(Label::new("Hold").size(LabelSize::Small))
-                            .children(ui::render_modifiers(
+                            .children(ui::render_modifiers_for_edit_prediction(
                                 &accept_keystroke.modifiers,
                                 PlatformStyle::platform(),
                                 Some(Color::Default),
                                 Some(IconSize::Small.rems().into()),
-                                true,
                             ))
                             .into_any(),
                     );
@@ -5886,7 +5884,7 @@ impl Editor {
                             h_flex()
                                 .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
                                 .gap_1()
-                                .children(ui::render_modifiers(
+                                .children(ui::render_modifiers_for_edit_prediction(
                                     &accept_keystroke.modifiers,
                                     PlatformStyle::platform(),
                                     Some(if !has_completion {
@@ -5895,7 +5893,6 @@ impl Editor {
                                         Color::Default
                                     }),
                                     None,
-                                    true,
                                 )),
                         )
                         .child(Label::new("Preview").into_any_element())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5683,8 +5683,11 @@ impl Editor {
             })
             .when(!is_platform_style_mac, |parent| {
                 parent.child(
-                    Key::new(accept_keystroke.key.clone(), Some(Color::Default))
-                        .size(Some(IconSize::XSmall.rems().into())),
+                    Key::new(
+                        util::capitalize(&accept_keystroke.key),
+                        Some(Color::Default),
+                    )
+                    .size(Some(IconSize::XSmall.rems().into())),
                 )
             })
             .into()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5686,11 +5686,12 @@ impl Editor {
             .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
             .text_size(TextSize::XSmall.rems(cx))
             .child(h_flex().children(itertools::intersperse_with(
-                ui::render_modifiers_for_edit_prediction(
+                ui::render_modifiers(
                     &accept_keystroke.modifiers,
                     PlatformStyle::platform(),
                     Some(modifiers_color),
                     Some(IconSize::XSmall.rems().into()),
+                    true,
                 ),
                 gen_plus_icon_on_non_mac,
             )))
@@ -5811,8 +5812,6 @@ impl Editor {
                 .child(Icon::new(IconName::ZedPredict))
         }
 
-        let is_platform_style_mac = PlatformStyle::platform() == PlatformStyle::Mac;
-
         let completion = match &self.active_inline_completion {
             Some(completion) => match &completion.completion {
                 InlineCompletion::Move {
@@ -5836,21 +5835,12 @@ impl Editor {
                                 },
                             )
                             .child(Label::new("Hold").size(LabelSize::Small))
-                            // Agus! - h_flex() look ok with multiple modifiers on mac? Or is gap needed here
-                            .child(h_flex().children(itertools::intersperse_with(
-                                ui::render_modifiers_for_edit_prediction(
-                                    &accept_keystroke.modifiers,
-                                    PlatformStyle::platform(),
-                                    Some(Color::Default),
-                                    Some(IconSize::Small.rems().into()),
-                                ),
-                                || {
-                                    if !is_platform_style_mac {
-                                        "+".into_any_element()
-                                    } else {
-                                        gpui::Empty.into_any_element()
-                                    }
-                                },
+                            .child(h_flex().children(ui::render_modifiers(
+                                &accept_keystroke.modifiers,
+                                PlatformStyle::platform(),
+                                Some(Color::Default),
+                                Some(IconSize::Small.rems().into()),
+                                false,
                             )))
                             .into_any(),
                     );
@@ -5925,24 +5915,16 @@ impl Editor {
                             h_flex()
                                 .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
                                 .when(is_platform_style_mac, |parent| parent.gap_1())
-                                .child(h_flex().children(itertools::intersperse_with(
-                                    ui::render_modifiers_for_edit_prediction(
-                                        &accept_keystroke.modifiers,
-                                        PlatformStyle::platform(),
-                                        Some(if !has_completion {
-                                            Color::Muted
-                                        } else {
-                                            Color::Default
-                                        }),
-                                        None,
-                                    ),
-                                    || {
-                                        if !is_platform_style_mac {
-                                            "+".into_any_element()
-                                        } else {
-                                            gpui::Empty.into_any_element()
-                                        }
-                                    },
+                                .child(h_flex().children(ui::render_modifiers(
+                                    &accept_keystroke.modifiers,
+                                    PlatformStyle::platform(),
+                                    Some(if !has_completion {
+                                        Color::Muted
+                                    } else {
+                                        Color::Default
+                                    }),
+                                    None,
+                                    false,
                                 ))),
                         )
                         .child(Label::new("Preview").into_any_element())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5657,11 +5657,6 @@ impl Editor {
     fn render_edit_prediction_accept_keybind(&self, window: &mut Window, cx: &App) -> Option<Div> {
         let accept_binding = self.accept_edit_prediction_keybind(window, cx);
         let accept_keystroke = accept_binding.keystroke()?;
-        let colors = cx.theme().colors();
-        let accent_color = colors.text_accent;
-        let editor_bg_color = colors.editor_background;
-        // TODO use shared function
-        let bg_color = editor_bg_color.blend(accent_color.opacity(0.1));
 
         let is_platform_style_mac = PlatformStyle::platform() == PlatformStyle::Mac;
 
@@ -5671,33 +5666,18 @@ impl Editor {
             Color::Muted
         };
 
-        let gen_plus_icon_on_non_mac = || {
-            if !is_platform_style_mac {
-                Label::new("+").color(modifiers_color).into_any_element()
-            } else {
-                gpui::Empty.into_any_element()
-            }
-        };
-
         h_flex()
             .px_0p5()
             .when(is_platform_style_mac, |parent| parent.gap_0p5())
-            .bg(bg_color)
             .font(theme::ThemeSettings::get_global(cx).buffer_font.clone())
             .text_size(TextSize::XSmall.rems(cx))
-            .child(h_flex().children(itertools::intersperse_with(
-                ui::render_modifiers(
-                    &accept_keystroke.modifiers,
-                    PlatformStyle::platform(),
-                    Some(modifiers_color),
-                    Some(IconSize::XSmall.rems().into()),
-                    true,
-                ),
-                gen_plus_icon_on_non_mac,
+            .child(h_flex().children(ui::render_modifiers(
+                &accept_keystroke.modifiers,
+                PlatformStyle::platform(),
+                Some(modifiers_color),
+                Some(IconSize::XSmall.rems().into()),
+                true,
             )))
-            .when(accept_keystroke.modifiers.modified(), |parent| {
-                parent.child(gen_plus_icon_on_non_mac())
-            })
             .when(is_platform_style_mac, |parent| {
                 parent.child(accept_keystroke.key.clone())
             })

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3811,6 +3811,7 @@ impl EditorElement {
 
                 let mut element = v_flex()
                     .items_end()
+                    .flex_grow()
                     .child(
                         h_flex()
                             .h(ACCEPT_INDICATOR_HEIGHT)
@@ -3820,19 +3821,19 @@ impl EditorElement {
                             .shadow_sm()
                             .bg(Editor::edit_prediction_line_popover_bg_color(cx))
                             .border_1()
-                            .border_b_0()
                             .border_color(cx.theme().colors().border)
                             .rounded_t_lg()
                             .children(editor.render_edit_prediction_accept_keybind(window, cx)),
                     )
                     .child(
-                        div()
+                        h_flex()
                             .bg(cx.theme().colors().editor_background)
                             .border_1()
                             .shadow_sm()
                             .border_color(cx.theme().colors().border)
                             .rounded_lg()
                             .rounded_tr(Pixels::ZERO)
+                            .flex_1()
                             .child(styled_text),
                     )
                     .into_any();

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -26,6 +26,7 @@ story = { workspace = true, optional = true }
 strum = { workspace = true, features = ["derive"] }
 theme.workspace = true
 ui_macros.workspace = true
+util.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/ui.rs"
 chrono.workspace = true
 component.workspace = true
 gpui.workspace = true
-itertools = { workspace = true, optional = true }
+itertools.workspace = true
 linkme.workspace = true
 menu.workspace = true
 serde.workspace = true
@@ -32,7 +32,7 @@ windows.workspace = true
 
 [features]
 default = []
-stories = ["dep:itertools", "dep:story"]
+stories = ["dep:story"]
 
 # cargo-machete doesn't understand that linkme is used in the component macro
 [package.metadata.cargo-machete]

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -110,7 +110,7 @@ pub fn render_key(
     let key_icon = icon_for_key(keystroke, platform_style);
     match key_icon {
         Some(icon) => KeyIcon::new(icon, color).size(size).into_any_element(),
-        None => Key::new(capitalize(&keystroke.key), color)
+        None => Key::new(util::capitalize(&keystroke.key), color)
             .size(size)
             .into_any_element(),
     }
@@ -402,20 +402,12 @@ pub fn text_for_keystroke(keystroke: &Keystroke, platform_style: PlatformStyle) 
     let key = match keystroke.key.as_str() {
         "pageup" => "PageUp",
         "pagedown" => "PageDown",
-        key => &capitalize(key),
+        key => &util::capitalize(key),
     };
 
     text.push_str(key);
 
     text
-}
-
-fn capitalize(str: &str) -> String {
-    let mut chars = str.chars();
-    match chars.next() {
-        None => String::new(),
-        Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
-    }
 }
 
 #[cfg(test)]

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -220,7 +220,7 @@ pub fn render_modifiers(
     let platform_keys = itertools::intersperse(platform_keys, separator.clone());
 
     platform_keys
-        .chain(if trailing_separator {
+        .chain(if modifiers.modified() && trailing_separator {
             Some(separator)
         } else {
             None

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -787,6 +787,28 @@ impl<'a> PartialOrd for NumericPrefixWithSuffix<'a> {
     }
 }
 
+/// Capitalizes the first character of a string.
+///
+/// This function takes a string slice as input and returns a new `String` with the first character
+/// capitalized.
+///
+/// # Examples
+///
+/// ```
+/// use util::capitalize;
+///
+/// assert_eq!(capitalize("hello"), "Hello");
+/// assert_eq!(capitalize("WORLD"), "WORLD");
+/// assert_eq!(capitalize(""), "");
+/// ```
+pub fn capitalize(str: &str) -> String {
+    let mut chars = str.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first_char) => first_char.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
 fn emoji_regex() -> &'static Regex {
     static EMOJI_REGEX: LazyLock<Regex> =
         LazyLock::new(|| Regex::new("(\\p{Emoji}|\u{200D})").unwrap());


### PR DESCRIPTION
Improves rendering of Zeta keybind shortcuts on Linux

Before:
![image](https://github.com/user-attachments/assets/9b6a61f7-dade-480f-a864-acdcede05957)

After: (with muting modifier changes merged)
![image](https://github.com/user-attachments/assets/dd616d29-ac2e-4c8b-bf9b-5d74f8e4f1c4)


Release Notes:

- N/A
