### PR TITLE
zeta: Respect `x-zed-minimum-required-version` header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17083,6 +17083,7 @@ dependencies = [
  "telemetry",
  "telemetry_events",
  "theme",
+ "thiserror 1.0.69",
  "tree-sitter-go",
  "tree-sitter-rust",
  "ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16849,9 +16849,9 @@ dependencies = [
 
 [[package]]
 name = "zed_llm_client"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614669bead4741b2fc352ae1967318be16949cf46f59013e548c6dbfdfc01252"
+checksum = "1bf21350eced858d129840589158a8f6895c4fa4327ae56dd8c7d6a98495bed4"
 dependencies = [
  "serde",
  "serde_json",
@@ -17073,6 +17073,7 @@ dependencies = [
  "postage",
  "project",
  "regex",
+ "release_channel",
  "reqwest_client",
  "rpc",
  "serde",

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -41,6 +41,7 @@ pub trait GitRepository: Send + Sync {
     /// Note that for symlink entries, this will return the contents of the symlink, not the target.
     fn load_committed_text(&self, path: &RepoPath) -> Option<String>;
 
+
     fn set_index_text(&self, path: &RepoPath, content: Option<String>) -> anyhow::Result<()>;
 
     /// Returns the URL of the remote with the given name.

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -41,7 +41,6 @@ pub trait GitRepository: Send + Sync {
     /// Note that for symlink entries, this will return the contents of the symlink, not the target.
     fn load_committed_text(&self, path: &RepoPath) -> Option<String>;
 
-
     fn set_index_text(&self, path: &RepoPath, content: Option<String>) -> anyhow::Result<()>;
 
     /// Returns the URL of the remote with the given name.

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -264,7 +264,13 @@ fn assign_edit_prediction_provider(
                     }
                 }
 
-                let zeta = zeta::Zeta::register(worktree, client.clone(), user_store, cx);
+                let zeta = zeta::Zeta::register(
+                    Some(cx.entity()),
+                    worktree,
+                    client.clone(),
+                    user_store,
+                    cx,
+                );
 
                 if let Some(buffer) = &singleton_buffer {
                     if buffer.read(cx).file().is_some() {

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -47,6 +47,7 @@ similar.workspace = true
 telemetry.workspace = true
 telemetry_events.workspace = true
 theme.workspace = true
+thiserror.workspace = true
 ui.workspace = true
 util.workspace = true
 uuid.workspace = true

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -39,6 +39,7 @@ menu.workspace = true
 postage.workspace = true
 project.workspace = true
 regex.workspace = true
+release_channel.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -355,6 +355,7 @@ impl Zeta {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn request_completion_impl<F, R>(
         &mut self,
         workspace: Option<Entity<Workspace>>,
@@ -759,9 +760,7 @@ and then another
                 if let Some(minimum_required_version) = response
                     .headers()
                     .get(MINIMUM_REQUIRED_VERSION_HEADER_NAME)
-                    .and_then(|version| {
-                        Some(SemanticVersion::from_str(version.to_str().ok()?).ok()?)
-                    })
+                    .and_then(|version| SemanticVersion::from_str(version.to_str().ok()?).ok())
                 {
                     if app_version < minimum_required_version {
                         return Err(anyhow!(ZedUpdateRequiredError {


### PR DESCRIPTION
This PR makes it so Zeta respects the `x-zed-minimum-required-version` header sent back from the server.

If the current Zed version is strictly less than the indicated minimum required version, we show an error indicating that an update is required in order to continue using Zeta:

<img width="472" alt="Screenshot 2025-02-12 at 6 15 44 PM" src="https://github.com/user-attachments/assets/51b85dff-23a0-464c-ae4b-5b8f46b5915c" />

Release Notes:

- N/A
