### PR TITLE
Stop logging missing custom theme errors on startup

### DIFF
--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -156,7 +156,7 @@ impl ThemeSettings {
             // If the selected theme doesn't exist, fall back to a default theme
             // based on the system appearance.
             let theme_registry = ThemeRegistry::global(cx);
-            if theme_registry.get(theme_name).ok().is_none() {
+            if theme_registry.get(theme_name).is_none() {
                 theme_name = Self::default_theme(*system_appearance);
             };
 
@@ -569,9 +569,12 @@ impl ThemeSettings {
 
         let mut new_theme = None;
 
-        if let Some(theme) = themes.get(theme).log_err() {
-            self.active_theme = theme.clone();
-            new_theme = Some(theme);
+        match themes.get(theme) {
+            Some(theme) => {
+                self.active_theme = theme.clone();
+                new_theme = Some(theme);
+            }
+            None => log::error!("Missing theme switched to: {theme}"),
         }
 
         self.apply_theme_overrides();
@@ -737,8 +740,7 @@ impl settings::Settings for ThemeSettings {
                 this.theme_selection = Some(value.clone());
 
                 let theme_name = value.theme(*system_appearance);
-
-                if let Some(theme) = themes.get(theme_name).log_err() {
+                if let Some(theme) = themes.get(theme_name) {
                     this.active_theme = theme;
                 }
             }

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -162,11 +162,11 @@ impl ThemeSelectorDelegate {
         if let Some(mat) = self.matches.get(self.selected_index) {
             let registry = ThemeRegistry::global(cx);
             match registry.get(&mat.string) {
-                Ok(theme) => {
+                Some(theme) => {
                     Self::set_theme(theme, cx);
                 }
-                Err(error) => {
-                    log::error!("error loading theme {}: {}", mat.string, error)
+                None => {
+                    log::error!("selected theme not found: {}", mat.string)
                 }
             }
         }

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -417,6 +417,7 @@ fn main() {
 
         SystemAppearance::init(cx);
         theme::init(theme::LoadThemes::All(Box::new(Assets)), cx);
+        load_user_themes_in_background(fs.clone(), cx);
         theme_extension::init(
             extension_host_proxy.clone(),
             ThemeRegistry::global(cx),
@@ -552,7 +553,6 @@ fn main() {
         telemetry.flush_events();
 
         let fs = app_state.fs.clone();
-        load_user_themes_in_background(fs.clone(), cx);
         watch_themes(fs.clone(), cx);
         watch_languages(fs.clone(), app_state.languages.clone(), cx);
         watch_file_types(fs.clone(), cx);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/24539

* Zed's init flow requires the Theme settings to be evaluated before theme-related extensions may run

The error happens at the time `theme::init` is made: this one sets the global for `ThemeRegistry` and register its settings:

https://github.com/zed-industries/zed/blob/0e42a6949082fee2948035767dd7a3bf5e116b93/crates/theme/src/theme.rs#L96-L102

the settings are evaluated using both default and user json settings, and error in

https://github.com/zed-industries/zed/blob/0e42a6949082fee2948035767dd7a3bf5e116b93/crates/theme/src/settings.rs#L741 

as by the time `theme::init` is called, nothing related to user extensions is not loaded, and also, no user extensions can provide themes until `theme_extension::init` is done, which starts to process extension code and needs `ThemeRegistry`'s global:

https://github.com/zed-industries/zed/blob/0e42a6949082fee2948035767dd7a3bf5e116b93/crates/zed/src/main.rs#L420-L424

* Even knowing the settings text, e.g. `"theme": "Catppuccin Latte",` , it's not clear which extension this comes out of: theme names for extensions are retrieved by reading the extension metadata out of the FS:

https://github.com/zed-industries/zed/blob/0e42a6949082fee2948035767dd7a3bf5e116b93/crates/theme/src/registry.rs#L201-L206

where we query by extension path, and its metadata may contain the theme name needed.

-----------------------

I have not found a good way to untangle this, so use a compromise of an approach:

* reduce the theme race time by calling `load_user_themes_in_background` right between `theme::init` and `theme_extension::init` calls, making it the first thing to start running after extension themes are enabled
* reduce the theme race by making `load_user_themes` more concurrent: before, we chained the async tasks as `next_dir_entry().await -> dir_entry.init_theme().await -> next_dir_entry().await ->  ..`
The newer method uses `.buffer_unordered(10)` Stream API to run max 10 tasks with extension-related init code
* stop logging error messages with backtraces for missing settings in all `.get(` call cases, and skip error logging for settings loading entirely

Release Notes:

- N/A