### PR TITLE
edit predictions: Do not use conflict context for other providers

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1591,6 +1591,10 @@ impl Editor {
     }
 
     pub fn edit_prediction_in_conflict(&self) -> bool {
+        if !self.show_edit_predictions_in_menu() {
+            return false;
+        }
+
         let showing_completions = self
             .context_menu
             .borrow()


### PR DESCRIPTION
This is to avoid confusing copilot/supermaven users when the cursor is on leading whitespace.

Release Notes:

- N/A
