### PR TITLE
Fix branches with slashes in their names not being listed

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -371,7 +371,7 @@ impl GitRepository for RealGitRepository {
             "%(contents:subject)",
         ]
         .join("%00");
-        let args = vec!["for-each-ref", "refs/heads/*", "--format", &fields];
+        let args = vec!["for-each-ref", "refs/heads/**/*", "--format", &fields];
 
         let output = new_std_command(&self.git_binary_path)
             .current_dir(&working_directory)


### PR DESCRIPTION
`refs/heads/*` doesn't match e.g. `refs/heads/cole/branch-with-slash` (thanks fnmatch), but `refs/heads/**/*` does. This also works for several levels of slash.

Release Notes:

- N/A