### PR TITLE
Update url for "Read the blog post"

### DIFF
--- a/crates/zeta/src/onboarding_modal.rs
+++ b/crates/zeta/src/onboarding_modal.rs
@@ -67,7 +67,7 @@ impl ZedPredictModal {
     }
 
     fn view_blog(&mut self, _: &ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
-        cx.open_url("https://zed.dev/blog/edit-predictions");
+        cx.open_url("https://zed.dev/edit-predictions");
         cx.notify();
 
         onboarding_event!("Blog Link clicked");


### PR DESCRIPTION
Currently it is linking to a 404 on the zed.dev website since the url has been updated to 'zed.dev/edit-protection' and is no longer at 'zed.dev/blog/edit-protection'

Closes #24826 

Release Notes:
Fixed broken redirect link in Introducing:Edit Prediction modal

