### PR TITLE
zeta: Update URL to edit prediction blog post

### DIFF
--- a/crates/zeta/src/onboarding_modal.rs
+++ b/crates/zeta/src/onboarding_modal.rs
@@ -67,7 +67,7 @@ impl ZedPredictModal {
     }
 
     fn view_blog(&mut self, _: &ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
-        cx.open_url("https://zed.dev/blog/edit-predictions");
+        cx.open_url("https://zed.dev/blog/edit-prediction");
         cx.notify();
 
         onboarding_event!("Blog Link clicked");


### PR DESCRIPTION
This PR updates the URL to the edit prediction blog post.

Release Notes:

- N/A
