### PR TITLE
zeta: Remove `predict-edits-launch` feature flag

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -64,12 +64,6 @@ impl FeatureFlag for PredictEditsFeatureFlag {
     const NAME: &'static str = "predict-edits";
 }
 
-/// A feature flag that controls things that shouldn't go live until the predictive edits launch.
-pub struct PredictEditsLaunchFeatureFlag;
-impl FeatureFlag for PredictEditsLaunchFeatureFlag {
-    const NAME: &'static str = "predict-edits-launch";
-}
-
 pub struct PredictEditsRateCompletionsFeatureFlag;
 impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";

--- a/crates/zeta/src/onboarding_modal.rs
+++ b/crates/zeta/src/onboarding_modal.rs
@@ -4,7 +4,6 @@ use crate::{onboarding_event, ZED_PREDICT_DATA_COLLECTION_CHOICE};
 use anyhow::Context as _;
 use client::{Client, UserStore};
 use db::kvp::KEY_VALUE_STORE;
-use feature_flags::FeatureFlagAppExt as _;
 use fs::Fs;
 use gpui::{
     ease_in_out, svg, Animation, AnimationExt as _, ClickEvent, DismissEvent, Entity, EventEmitter,
@@ -288,16 +287,12 @@ impl Render for ZedPredictModal {
                 )),
             ));
 
-        let blog_post_button = cx
-            .has_flag::<feature_flags::PredictEditsLaunchFeatureFlag>()
-            .then(|| {
-                Button::new("view-blog", "Read the Blog Post")
-                    .full_width()
-                    .icon(IconName::ArrowUpRight)
-                    .icon_size(IconSize::Indicator)
-                    .icon_color(Color::Muted)
-                    .on_click(cx.listener(Self::view_blog))
-            });
+        let blog_post_button = Button::new("view-blog", "Read the Blog Post")
+            .full_width()
+            .icon(IconName::ArrowUpRight)
+            .icon_size(IconSize::Indicator)
+            .icon_color(Color::Muted)
+            .on_click(cx.listener(Self::view_blog));
 
         if self.user_store.read(cx).current_user().is_some() {
             let copy = match self.sign_in_status {
@@ -449,7 +444,7 @@ impl Render for ZedPredictModal {
                                 .full_width()
                                 .on_click(cx.listener(Self::accept_and_enable)),
                         )
-                        .children(blog_post_button),
+                        .child(blog_post_button),
                 )
         } else {
             base.child(
@@ -468,7 +463,7 @@ impl Render for ZedPredictModal {
                             .full_width()
                             .on_click(cx.listener(Self::sign_in)),
                     )
-                    .children(blog_post_button),
+                    .child(blog_post_button),
             )
         }
     }


### PR DESCRIPTION
This PR removes the `predict-edits-launch` feature flag that was added in #24720.

We don't need this anymore now that we've launched!

Release Notes:

- N/A
