### PR TITLE
edit predictions: Fix manually requested predictions

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3561,7 +3561,9 @@ impl EditorElement {
         let editor = self.editor.read(cx);
         let active_inline_completion = editor.active_inline_completion.as_ref()?;
 
-        if editor.edit_prediction_visible_in_cursor_popover(true) {
+        if !editor.edit_predictions_enabled()
+            || editor.edit_prediction_visible_in_cursor_popover(true)
+        {
             return None;
         }
 


### PR DESCRIPTION
We were disabling edit predictions altogether when `show_edit_predictions` was set to `false`. However, even in that case, `editor::ShowEditPrediction` is supposed to let your request a prediction manually.

https://github.com/user-attachments/assets/1e3f5014-b4f1-4b40-a3a3-cf194dd700ca


Release Notes:

- Fixed `editor::ShowEditPrediction` when `show_edit_predictions` is set to `false`.