### PR TITLE
Disable edit prediction in Cloudflare Workers `.dev.vars` files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -788,6 +788,7 @@
       "**/*.key",
       "**/*.cert",
       "**/*.crt",
+      "**/.dev.vars",
       "**/secrets.yml"
     ],
     // When to show edit predictions previews in buffer.


### PR DESCRIPTION
This PR adds `.dev.vars` files as a default exclusion for edit prediction.

These files are used by Cloudflare Workers and are likely to contain secrets.

Release Notes:

- Excluded Cloudflare Workers `.dev.vars` files from edit prediction.
