### PR TITLE
edit predictions: Fix manually requesting completions

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -507,15 +507,6 @@ enum EditPredictionSettings {
     },
 }
 
-impl EditPredictionSettings {
-    pub fn is_enabled(&self) -> bool {
-        match self {
-            EditPredictionSettings::Disabled => false,
-            EditPredictionSettings::Enabled { .. } => true,
-        }
-    }
-}
-
 enum InlineCompletionHighlight {}
 
 pub enum MenuInlineCompletionsPolicy {
@@ -5322,11 +5313,6 @@ impl Editor {
 
         self.edit_prediction_settings =
             self.edit_prediction_settings_at_position(&buffer, cursor_buffer_position, cx);
-
-        if !self.edit_prediction_settings.is_enabled() {
-            self.discard_inline_completion(false, cx);
-            return None;
-        }
 
         self.edit_prediction_cursor_on_leading_whitespace =
             multibuffer.is_line_whitespace_upto(cursor);


### PR DESCRIPTION
We were disabling edit predictions altogether when `show_edit_predictions` was set to `false`. However, even in that case, `editor::ShowEditPrediction` is supposed to let your request a prediction manually.

Release Notes:

- Fixed `editor::ShowEditPrediction` when `show_edit_predictions` is set to `false`.