### PR TITLE
go: Fix tree-sitter query for outlines

### DIFF
--- a/crates/languages/src/go/outline.scm
+++ b/crates/languages/src/go/outline.scm
@@ -1,8 +1,17 @@
 (comment) @annotation
 (type_declaration
     "type" @context
-    (type_spec
-        name: (_) @name)) @item
+    [
+        (type_spec
+            name: (_) @name) @item
+        (
+            "("
+            (type_spec
+                name: (_) @name) @item
+            ")"
+      )
+    ]
+)
 
 (function_declaration
     "func" @context
@@ -32,8 +41,18 @@
 (source_file
     (var_declaration
         "var" @context
-        (var_spec
-            name: (identifier) @name) @item))
+        [
+            (var_spec
+                name: (identifier) @name) @item
+            (var_spec_list
+                "("
+                (var_spec
+                    name: (identifier) @name) @item
+                ")"
+            )
+        ]
+     )
+)
 
 (method_elem
     name: (_) @name


### PR DESCRIPTION
Closes #14497

Release Notes:
- Fixed outline view for Go to correctly indent types and show missing variables. 
----
This PR fixes the tree-sitter query for outlines for Go code. It correctly indents "grouped" `type` declarations. It also fixes missing variables for "grouped" `var` declarations.

### Before: 
1. Incorrectly indented types from `G` to `K` and `aliasInt`
2. Missing vars `M` and `N` in outline 
![Screenshot_20250214_175404](https://github.com/user-attachments/assets/7c1142bd-fe60-4c65-9fa2-3bae4eb43d63)

### After:
1. Types no longer indented incorrectly
2. Missing vars `M` and `N` appear in the outline, as expected
![Screenshot_20250214_175431](https://github.com/user-attachments/assets/61010273-e98d-425d-93ad-17f04bd83b54)

### Caveats:
1. This fix comes from an hour or so of reading about tree-sitter and its query syntax. I'm not an expert. 
2. I'm not sure how to test this. I've done manual testing and it appears to works as expected without an regressions. 

