### PR TITLE
python: Properly check for Pyright language server in local environment

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -83,7 +83,7 @@ impl LspAdapter for PythonLspAdapter {
         _: Arc<dyn LanguageToolchainStore>,
         _: &AsyncApp,
     ) -> Option<LanguageServerBinary> {
-        if let Some(pyright_bin) = delegate.which(Self::SERVER_NAME.as_ref()).await {
+        if let Some(pyright_bin) = delegate.which("pyright-langserver".as_ref()).await {
             let env = delegate.shell_env().await;
             Some(LanguageServerBinary {
                 path: pyright_bin,


### PR DESCRIPTION
Closes #24565 

As pointed out in https://github.com/zed-industries/zed/issues/24565#issuecomment-2657822723 , the name for the Pyright language server is `pyright-langserver`, not `pyright`. The latter is a CLI-tool as described in https://microsoft.github.io/pyright/#/command-line which only provides static type checking. It has neither LSP-capabilities nor a `--stdio` argument. Thus, the error as shown in the linked issue appears.

I disagree with the fix as described in https://github.com/zed-industries/zed/issues/24565#issuecomment-2657904208 , as it could only cause this error to reappear in rare scenarios where Pyright, but not the Pyright language server is installed in a user's environment. Just checking for `pyright-langserver` to be present in the environment seems more straightforward here.

Release Notes:

- Python: Fixed Pyright failing to start when installed locally
