### PR TITLE
Use shell script language for bats files

### DIFF
--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -1,7 +1,7 @@
 name = "Shell Script"
 code_fence_block_name = "bash"
 grammar = "bash"
-path_suffixes = ["sh", "bats", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD"]
+path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "bats", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD"]
 line_comments = ["# "]
 first_line_pattern = '^#!.*\b(?:ash|bash|bats|dash|sh|zsh)\b'
 brackets = [

--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -1,9 +1,9 @@
 name = "Shell Script"
 code_fence_block_name = "bash"
 grammar = "bash"
-path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD"]
+path_suffixes = ["sh", "bats", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD"]
 line_comments = ["# "]
-first_line_pattern = '^#!.*\b(?:ash|bash|dash|sh|zsh)\b'
+first_line_pattern = '^#!.*\b(?:ash|bash|bats|dash|sh|zsh)\b'
 brackets = [
     { start = "[", end = "]", close = true, newline = false },
     { start = "(", end = ")", close = true, newline = true },


### PR DESCRIPTION
bats is a superset of bash. It's a common tool for writing TAP tests in bash.

https://bats-core.readthedocs.io/en/stable/tutorial.html#your-first-test

Release Notes:

- Added recognition for `.bats` files as "Shell Script".
