### PR TITLE
linux: Fix reload hangs for several minutes

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -181,16 +181,9 @@ impl<P: LinuxClient + 'static> Platform for P {
         log::info!("Restarting process, using app path: {:?}", app_path);
 
         // Script to wait for the current process to exit and then restart the app.
-        // We also wait for possibly open TCP sockets by the process to be closed,
-        // since on Linux it's not guaranteed that a process' resources have been
-        // cleaned up when `kill -0` returns.
         let script = format!(
             r#"
             while kill -0 {pid} 2>/dev/null; do
-                sleep 0.1
-            done
-
-            while lsof -nP -iTCP -a -p {pid} 2>/dev/null; do
                 sleep 0.1
             done
 


### PR DESCRIPTION
Closes #22666

This PR fixes the long wait time to open Zed (2 mins in my case) after reloading on Linux. 

This bug fix is funny:

1. We were using TCP for Zed instances to talk to each other. Reload was broken here too due to TCP connections not being killed on time.
2. [#11488](https://github.com/zed-industries/zed/pull/11488) PR fixed the TCP connection issue by adding a wait until it gets killed. I suppose at that time, this wait time was small.
3. Later, we changed how Zed talks to each other in [#11585](https://github.com/zed-industries/zed/pull/11585) by using Datagram and removing TCP. The new approach simply uses a `.sock` file and a file descriptor to check if some program is listening to it.
4. TCP check is now unnecessary, and it still wait for a long time (I suppose, TIME_WAIT time, don't quote me on this), even though we don’t use TCP anymore for this.

This PR just removes that unnecessary TCP wait.

Release Notes:

- Fixed issue where reload hangs for several minutes on Linux.
