### PR TITLE
Redact Google Gemini API keys from error messaging and log

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11090,6 +11090,7 @@ dependencies = [
  "gpui",
  "http_client",
  "log",
+ "regex",
  "reqwest 0.12.8",
  "serde",
  "smol",

--- a/crates/reqwest_client/Cargo.toml
+++ b/crates/reqwest_client/Cargo.toml
@@ -28,6 +28,7 @@ serde.workspace = true
 smol.workspace = true
 log.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
+regex.workspace = true
 reqwest.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
Now:
```
ERROR assistant_context_editor] error sending request for url (https://generativelanguage.googleapis.com/v1beta/models/gemini-pro:countTokens?key=REDACTED)
```

Release Notes:

- Improved redaction of Google Gemini keys from API errors in logs