### PR TITLE
Add horizontal scrollbar height setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -274,7 +274,9 @@
       "horizontal": true,
       /// When false, forcefully disables the vertical scrollbar. Otherwise, obey other settings.
       "vertical": true
-    }
+    },
+    /// The height of the horizontal scrollbar (in pixels)
+    "horizontal_height": 15
   },
   // Enable middle-click paste on Linux.
   "middle_click_paste": true,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -419,7 +419,8 @@ pub struct EditorStyle {
     pub background: Hsla,
     pub local_player: PlayerColor,
     pub text: TextStyle,
-    pub scrollbar_width: Pixels,
+    pub vertical_scrollbar_width: Pixels,
+    pub horizontal_scrollbar_height: Pixels,
     pub syntax: Arc<SyntaxTheme>,
     pub status: StatusColors,
     pub inlay_hints_style: HighlightStyle,
@@ -433,7 +434,8 @@ impl Default for EditorStyle {
             background: Hsla::default(),
             local_player: PlayerColor::default(),
             text: TextStyle::default(),
-            scrollbar_width: Pixels::default(),
+            vertical_scrollbar_width: Pixels::default(),
+            horizontal_scrollbar_height: Pixels::default(),
             syntax: Default::default(),
             // HACK: Status colors don't have a real default.
             // We should look into removing the status colors from the editor
@@ -11350,7 +11352,12 @@ impl Editor {
                                                 background: cx.theme().system().transparent,
                                                 local_player: cx.editor_style.local_player,
                                                 text: text_style,
-                                                scrollbar_width: cx.editor_style.scrollbar_width,
+                                                vertical_scrollbar_width: cx
+                                                    .editor_style
+                                                    .vertical_scrollbar_width,
+                                                horizontal_scrollbar_height: cx
+                                                    .editor_style
+                                                    .horizontal_scrollbar_height,
                                                 syntax: cx.editor_style.syntax.clone(),
                                                 status: cx.editor_style.status.clone(),
                                                 inlay_hints_style: HighlightStyle {
@@ -16114,7 +16121,10 @@ impl Render for Editor {
                 background,
                 local_player: cx.theme().players().local(),
                 text: text_style,
-                scrollbar_width: EditorElement::SCROLLBAR_WIDTH,
+                vertical_scrollbar_width: EditorElement::VERTICAL_SCROLLBAR_WIDTH,
+                horizontal_scrollbar_height: Pixels(
+                    EditorSettings::get_global(cx).scrollbar.horizontal_height as f32,
+                ),
                 syntax: cx.theme().syntax().clone(),
                 status: cx.theme().status().clone(),
                 inlay_hints_style: make_inlay_hints_style(cx),

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -107,6 +107,7 @@ pub struct Scrollbar {
     pub diagnostics: ScrollbarDiagnostics,
     pub cursors: bool,
     pub axes: ScrollbarAxes,
+    pub horizontal_height: u32,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -418,6 +419,10 @@ pub struct ScrollbarContent {
     pub cursors: Option<bool>,
     /// Forcefully enable or disable the scrollbar for each axis
     pub axes: Option<ScrollbarAxesContent>,
+    /// The height of the horizontal scrollbar (in pixels)
+    ///
+    /// Default: 15
+    pub horizontal_height: Option<u32>,
 }
 
 /// Forcefully enable or disable the scrollbar for each axis

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -172,7 +172,7 @@ pub struct EditorElement {
 type DisplayRowDelta = u32;
 
 impl EditorElement {
-    pub(crate) const SCROLLBAR_WIDTH: Pixels = px(15.);
+    pub(crate) const VERTICAL_SCROLLBAR_WIDTH: Pixels = px(15.);
 
     pub fn new(editor: &Entity<Editor>, style: EditorStyle) -> Self {
         Self {
@@ -1346,12 +1346,12 @@ impl EditorElement {
                 Bounds::from_corners(
                     point(
                         text_bounds.bottom_left().x,
-                        text_bounds.bottom_left().y - self.style.scrollbar_width,
+                        text_bounds.bottom_left().y - self.style.horizontal_scrollbar_height,
                     ),
                     point(
                         text_bounds.bottom_right().x
                             - if axes.vertical {
-                                self.style.scrollbar_width
+                                self.style.vertical_scrollbar_width
                             } else {
                                 px(0.)
                             },
@@ -3206,7 +3206,7 @@ impl EditorElement {
 
         let viewport_bounds =
             Bounds::new(Default::default(), window.viewport_size()).extend(Edges {
-                right: -Self::SCROLLBAR_WIDTH - MENU_GAP,
+                right: -Self::VERTICAL_SCROLLBAR_WIDTH - MENU_GAP,
                 ..Default::default()
             });
 
@@ -3364,7 +3364,7 @@ impl EditorElement {
         let max_height = line_height * 12. + POPOVER_Y_PADDING;
         let viewport_bounds =
             Bounds::new(Default::default(), window.viewport_size()).extend(Edges {
-                right: -Self::SCROLLBAR_WIDTH - MENU_GAP,
+                right: -Self::VERTICAL_SCROLLBAR_WIDTH - MENU_GAP,
                 ..Default::default()
             });
         self.layout_popovers_above_or_below_line(
@@ -3938,7 +3938,7 @@ impl EditorElement {
 
                 let viewport_bounds = Bounds::new(Default::default(), window.viewport_size())
                     .extend(Edges {
-                        right: -Self::SCROLLBAR_WIDTH,
+                        right: -Self::VERTICAL_SCROLLBAR_WIDTH,
                         ..Default::default()
                     });
 
@@ -5842,7 +5842,7 @@ impl EditorElement {
     }
 
     fn scrollbar_left(&self, bounds: &Bounds<Pixels>) -> Pixels {
-        bounds.top_right().x - self.style.scrollbar_width
+        bounds.top_right().x - self.style.vertical_scrollbar_width
     }
 
     fn column_pixels(&self, column: usize, window: &mut Window, _: &mut App) -> Pixels {
@@ -6861,8 +6861,10 @@ impl Element for EditorElement {
                         .unwrap_or_default();
                     let text_width = bounds.size.width - gutter_dimensions.width;
 
-                    let editor_width =
-                        text_width - gutter_dimensions.margin - em_width - style.scrollbar_width;
+                    let editor_width = text_width
+                        - gutter_dimensions.margin
+                        - em_width
+                        - style.vertical_scrollbar_width;
 
                     snapshot = self.editor.update(cx, |editor, cx| {
                         editor.last_bounds = Some(bounds);
@@ -7252,7 +7254,8 @@ impl Element for EditorElement {
                         let autoscrolled = if autoscroll_horizontally {
                             editor.autoscroll_horizontally(
                                 start_row,
-                                editor_width - (letter_size.width / 2.0) + style.scrollbar_width,
+                                editor_width - (letter_size.width / 2.0)
+                                    + style.vertical_scrollbar_width,
                                 scroll_width,
                                 em_width,
                                 &line_layouts,
@@ -7343,7 +7346,8 @@ impl Element for EditorElement {
                         let autoscrolled = if autoscroll_horizontally {
                             editor.autoscroll_horizontally(
                                 start_row,
-                                editor_width - (letter_size.width / 2.0) + style.scrollbar_width,
+                                editor_width - (letter_size.width / 2.0)
+                                    + style.vertical_scrollbar_width,
                                 scroll_width,
                                 em_width,
                                 &line_layouts,
@@ -7807,7 +7811,7 @@ impl ScrollbarRangeData {
         };
 
         let right_margin = if longest_line_width + longest_line_blame_width >= editor_width {
-            letter_size.width + style.scrollbar_width
+            letter_size.width + style.vertical_scrollbar_width
         } else {
             px(0.0)
         };

--- a/crates/prompt_library/src/prompt_library.rs
+++ b/crates/prompt_library/src/prompt_library.rs
@@ -1030,7 +1030,8 @@ impl PromptLibrary {
                                                         ),
                                                         ..Default::default()
                                                     },
-                                                    scrollbar_width: Pixels::ZERO,
+                                                    vertical_scrollbar_width: Pixels::ZERO,
+                                                    horizontal_scrollbar_height: Pixels::ZERO,
                                                     syntax: cx.theme().syntax().clone(),
                                                     status: cx.theme().status().clone(),
                                                     inlay_hints_style:


### PR DESCRIPTION
The horizontal scrollbar height is currently set to be the same as the vertical scrollbar width. This seems excessive, since the horizontal scrollbar does not need to house any indicators.

This PR adds a setting to control this height, with the default unchanged. It also does some renaming to better differentiate this from the vertical scrollbar width for clarity.

Partially addresses #14551.

Release Notes:

- Added a setting to control the horizontal scrollbar height.
