### PR TITLE
Force manual publishing of preview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,6 +482,6 @@ jobs:
       - bundle
     steps:
       - name: gh release
-        run: gh release edit $GITHUB_REF_NAME --draft=false
+        run: gh release edit $GITHUB_REF_NAME --draft=true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is just a temporary change to help us debug with some weird issues happening:
- Discord release not firing for certain builds
- Random blank release drafts showing up

Release Notes:

- N/A
