### PR TITLE
vim: Change into visual mode on select all matches

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1401,11 +1401,9 @@ impl SearchableItem for Editor {
         cx: &mut Context<Self>,
     ) {
         self.unfold_ranges(matches, false, false, cx);
-        let mut ranges = Vec::new();
-        for m in matches {
-            ranges.push(self.range_for_match(m))
-        }
-        self.change_selections(None, window, cx, |s| s.select_ranges(ranges));
+        self.change_selections(None, window, cx, |s| {
+            s.select_ranges(matches.iter().cloned())
+        });
     }
     fn replace(
         &mut self,


### PR DESCRIPTION
This Pull Request fixes an issue where selecting all matches on a search would not update vim to visual mode.

In the video below the following scenarios are tested:

1. Clicking "Select All Matches" in the buffer search bar correctly changes vim to visual mode
2. Pressing Enter jumps the cursor to the first match and does not change vim's mode
3. Selecting all matches with the `⌥⏎` changes vim to visual mode

https://github.com/user-attachments/assets/f7535638-987e-4f33-9364-292f99b60167

Thanks @ConradIrwin for both the quick pairing session and the solution! 🙇 

Closes #14681 

Release Notes:

- vim: Use visual mode for "select all matches" in search (to be consistent with `ga`)