### PR TITLE
Use `Vec` for `KeyContext` instead of `SmallVec`

### DIFF
--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -1,6 +1,5 @@
 use crate::SharedString;
 use anyhow::{anyhow, Result};
-use smallvec::SmallVec;
 use std::fmt;
 
 /// A datastructure for resolving whether an action should be dispatched
@@ -8,7 +7,7 @@ use std::fmt;
 /// and/or key value pairs representing the current context for the
 /// keymap.
 #[derive(Clone, Default, Eq, PartialEq, Hash)]
-pub struct KeyContext(SmallVec<[ContextEntry; 1]>);
+pub struct KeyContext(Vec<ContextEntry>);
 
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 /// An entry in a KeyContext


### PR DESCRIPTION
In Zed the key context almost always has more than 1 entry, so use of `SmallVec` is just adding overhead.

In Zed while using the editor this typically has more than 8 entries. Since `ContextEntry` is 48 bytes, if this were made to be a `SmallVec<[ContextEntry; 10]>` then it would use 480 bytes on the stack, which to me seems like a lot to be copying. So, instead opting to just use `Vec`

Release Notes:

- N/A