### PR TITLE
Humble attempt at creating icons for .Rmd and .RData files.

### DIFF
--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -12,7 +12,7 @@
     "NOTES_EDITMSG": "vcs",
     "R": "r",
     "Rmd":"rmarkdown",
-    "RData":"storage",
+    "RData":"rdata",
     "TAG_EDITMSG": "vcs",
     "aac": "audio",
     "accdb": "storage",

--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -11,6 +11,7 @@
     "MERGE_MSG": "vcs",
     "NOTES_EDITMSG": "vcs",
     "R": "r",
+    "Rmd":"rmarkdown",
     "RData":"storage",
     "TAG_EDITMSG": "vcs",
     "aac": "audio",

--- a/assets/icons/file_icons/file_types.json
+++ b/assets/icons/file_icons/file_types.json
@@ -11,6 +11,7 @@
     "MERGE_MSG": "vcs",
     "NOTES_EDITMSG": "vcs",
     "R": "r",
+    "RData":"storage",
     "TAG_EDITMSG": "vcs",
     "aac": "audio",
     "accdb": "storage",

--- a/assets/icons/file_icons/rdata.svg
+++ b/assets/icons/file_icons/rdata.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+ <path d="M4 5 A4 1.5 0 0 1 12 5 L12 11 A4 1.5 0 0 1 4 11 L4 5" fill="none" stroke="black"/>
+ <text x="8" y="10" text-anchor="middle" alignment-baseline="middle" font-family="Arial" font-size="6" font-weight="bold" fill="black">R</text>
+</svg>

--- a/assets/icons/file_icons/rmarkdown.svg
+++ b/assets/icons/file_icons/rmarkdown.svg
@@ -1,0 +1,4 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+ <circle cx="8" cy="8" r="6" stroke="black" stroke-width="1"/>
+ <text x="8" y="9.5" font-family="serif" font-size="4.5" fill="black" text-anchor="middle">Rmd</text>
+</svg>


### PR DESCRIPTION
Release Notes:

- Manually coded logos for the two file extensions (tried my best to match the already present aesthetic).
- .Rdata icon can be replaced with the storage svg.

Edit: Just read the contributions file, sorry for the inconvenient PR ignore it. 

Replaced by #24925
