### PR TITLE
edit prediction: Don't show and discard completion if toggled off in the buffer

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1989,7 +1989,12 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         self.show_inline_completions_override = show_edit_predictions;
-        self.refresh_inline_completion(false, true, window, cx);
+
+        if let Some(false) = show_edit_predictions {
+            self.discard_inline_completion(false, cx);
+        } else {
+            self.refresh_inline_completion(false, true, window, cx);
+        }
     }
 
     fn inline_completions_disabled_in_scope(


### PR DESCRIPTION
Discards an inline completion when it's toggled to off (using, say, a keyboard shortcut). This matches the behaviour in VS Code and JetBrains, and I think is a bit more intuitive.

(https://github.com/zed-industries/zed/discussions/24895)

Release Notes:

- N/A