### PR TITLE
docs: Update icon theme docs with `file_stems` and `file_suffixes`

### DIFF
--- a/docs/src/extensions/icon-themes.md
+++ b/docs/src/extensions/icon-themes.md
@@ -13,13 +13,13 @@ There are two important directories for an icon theme extension:
 - `icon_themes`: This directory will contain one or more JSON files containing the icon theme definitions.
 - `icons`: This directory contains the icons assets that will be distributed with the extension. You can created subdirectories in this directory, if so desired.
 
-Each icon theme file should adhere to the JSON schema specified at [`https://zed.dev/schema/icon_themes/v0.1.0.json`](https://zed.dev/schema/icon_themes/v0.1.0.json).
+Each icon theme file should adhere to the JSON schema specified at [`https://zed.dev/schema/icon_themes/v0.2.0.json`](https://zed.dev/schema/icon_themes/v0.2.0.json).
 
 Here is an example of the structure of an icon theme:
 
 ```json
 {
-  "$schema": "https://zed.dev/schema/icon_themes/v0.1.0.json",
+  "$schema": "https://zed.dev/schema/icon_themes/v0.2.0.json",
   "name": "My Icon Theme",
   "author": "Your Name",
   "themes": [
@@ -34,9 +34,17 @@ Here is an example of the structure of an icon theme:
         "collapsed": "./icons/chevron-right.svg",
         "expanded": "./icons/chevron-down.svg"
       },
+      "file_stems": {
+        "Makefile": "make"
+      },
+      "file_suffixes": {
+        "mp3": "audio",
+        "rs": "rust"
+      },
       "file_icons": {
         "audio": { "path": "./icons/audio.svg" },
         "default": { "path": "./icons/file.svg" },
+        "make": { "path": "./icons/make.svg" },
         "rust": { "path": "./icons/rust.svg" }
         // ...
       }


### PR DESCRIPTION
This PR updates the icon theme docs with examples of `file_stems` and `file_suffixes` that were added in https://github.com/zed-industries/zed/pull/24926.

Release Notes:

- N/A
