### PR TITLE
Fix go to definition split

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10850,7 +10850,13 @@ impl Editor {
                     let range = editor.range_for_match(&range);
                     let range = collapse_multiline_range(range);
 
-                    if Some(&target.buffer) == editor.buffer.read(cx).as_singleton().as_ref() {
+                    if editor
+                        .buffer
+                        .read(cx)
+                        .as_singleton()
+                        .as_ref()
+                        .is_some_and(|_| !split)
+                    {
                         editor.go_to_singleton_buffer_range(range.clone(), window, cx);
                     } else {
                         window.defer(cx, move |window, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10850,12 +10850,8 @@ impl Editor {
                     let range = editor.range_for_match(&range);
                     let range = collapse_multiline_range(range);
 
-                    if editor
-                        .buffer
-                        .read(cx)
-                        .as_singleton()
-                        .as_ref()
-                        .is_some_and(|_| !split)
+                    if !split
+                        && Some(&target.buffer) == editor.buffer.read(cx).as_singleton().as_ref()
                     {
                         editor.go_to_singleton_buffer_range(range.clone(), window, cx);
                     } else {


### PR DESCRIPTION
Closes #24982 

Release Notes:

- Fix `GoToDefinitionSplit` action bug where split wouldn't happen if definition was in the same active editor
