### PR TITLE
Fail if `cargo about` emits warnings

### DIFF
--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -24,11 +24,20 @@ else
 fi
 
 echo "Generating cargo licenses"
+
+stderr_file=$(mktemp)
+
 cargo about generate \
     --fail \
     -c script/licenses/zed-licenses.toml \
-    "${TEMPLATE_FILE}" >> $OUTPUT_FILE
+    "${TEMPLATE_FILE}" \
+    2> >(tee "$stderr_file") \
+    >> $OUTPUT_FILE
 
+if cat "$stderr_file" | grep -v "\[WARN\]" > /dev/null; then
+    echo "Error: License check failed - warnings found" >&2
+    exit 1
+fi
 
 sed -i.bak 's/&quot;/"/g' $OUTPUT_FILE
 sed -i.bak 's/&#x27;/'\''/g' $OUTPUT_FILE # The ` '\'' ` thing ends the string, appends a single quote, and re-opens the string
@@ -38,3 +47,5 @@ sed -i.bak 's/&lt;/</g' $OUTPUT_FILE
 sed -i.bak 's/&gt;/>/g' $OUTPUT_FILE
 
 rm -rf "${OUTPUT_FILE}.bak"
+
+echo "generate-licenses completed. See $OUTPUT_FILE"

--- a/script/generate-licenses-csv
+++ b/script/generate-licenses-csv
@@ -14,10 +14,21 @@ else
 fi
 
 echo "Generating cargo licenses"
+
+stderr_file=$(mktemp)
+
 cargo about generate \
     --fail \
     -c script/licenses/zed-licenses.toml \
     script/licenses/template.csv.hbs \
+    2> >(tee "$stderr_file") \
     | awk 'NR==1{print;next} NF{print | "sort"}' \
     > $OUTPUT_FILE
-echo "Completed. See $OUTPUT_FILE"
+
+# Check that there are no warnings.
+if echo "$about_stderr" | grep -v "\[WARN\]" > /dev/null; then
+    echo "Error: License check failed - warnings found" >&2
+    exit 1
+fi
+
+echo "generate-licenses-csv completed. See $OUTPUT_FILE"


### PR DESCRIPTION
Warnings are emitted despite --fail have no license field like `ring`

Release Notes:

- N/A