### PR TITLE
Improve `cargo about` licenses configuration

### DIFF
--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -10,19 +10,13 @@ accepted = [
     "ISC",
     "CC0-1.0",
     "Unicode-3.0",
-    "Unicode-DFS-2016",
     "OpenSSL",
     "Zlib",
-    "BSL-1.0"
-]
-workarounds = [
-    "ring",
-    "wasmtime",
 ]
 
 [procinfo.clarify]
 license = "MIT"
-[[procinfo.clarify.git]]
+[[procinfo.clarify.files]]
 path = 'LICENSE.md'
 checksum = '37db33bbbd7348969eda397b89a16f252d56c1ca7481b6ccaf56ccdcbab5dcca'
 
@@ -40,144 +34,150 @@ checksum = '03b114f53e6587a398931762ee11e2395bfdba252a329940e2c8c9e81813845b'
 
 [pet.clarify]
 license = "MIT"
-[[pet.clarify.git]]
-path = 'LICENSE'
+[[pet.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-conda.clarify]
 license = "MIT"
-[[pet-conda.clarify.git]]
-path = 'LICENSE'
+[[pet-conda.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-core.clarify]
 license = "MIT"
-[[pet-core.clarify.git]]
-path = 'LICENSE'
+[[pet-core.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-env-var-path.clarify]
 license = "MIT"
-[[pet-env-var-path.clarify.git]]
-path = 'LICENSE'
+[[pet-env-var-path.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-fs.clarify]
 license = "MIT"
-[[pet-fs.clarify.git]]
-path = 'LICENSE'
+[[pet-fs.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-global-virtualenvs.clarify]
 license = "MIT"
-[[pet-global-virtualenvs.clarify.git]]
-path = 'LICENSE'
+[[pet-global-virtualenvs.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-homebrew.clarify]
 license = "MIT"
-[[pet-homebrew.clarify.git]]
-path = 'LICENSE'
+[[pet-homebrew.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-jsonrpc.clarify]
 license = "MIT"
-[[pet-jsonrpc.clarify.git]]
-path = 'LICENSE'
+[[pet-jsonrpc.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-linux-global-python.clarify]
 license = "MIT"
-[[pet-linux-global-python.clarify.git]]
-path = 'LICENSE'
+[[pet-linux-global-python.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-mac-commandlinetools.clarify]
 license = "MIT"
-[[pet-mac-commandlinetools.clarify.git]]
-path = 'LICENSE'
+[[pet-mac-commandlinetools.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-mac-python-org.clarify]
 license = "MIT"
-[[pet-mac-python-org.clarify.git]]
-path = 'LICENSE'
+[[pet-mac-python-org.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-mac-xcode.clarify]
 license = "MIT"
-[[pet-mac-xcode.clarify.git]]
-path = 'LICENSE'
+[[pet-mac-xcode.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-pipenv.clarify]
 license = "MIT"
-[[pet-pipenv.clarify.git]]
-path = 'LICENSE'
+[[pet-pipenv.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-pixi.clarify]
 license = "MIT"
-[[pet-pixi.clarify.git]]
-path = 'LICENSE'
+[[pet-pixi.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-poetry.clarify]
 license = "MIT"
-[[pet-poetry.clarify.git]]
-path = 'LICENSE'
+[[pet-poetry.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-pyenv.clarify]
 license = "MIT"
-[[pet-pyenv.clarify.git]]
-path = 'LICENSE'
+[[pet-pyenv.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-python-utils.clarify]
 license = "MIT"
-[[pet-python-utils.clarify.git]]
-path = 'LICENSE'
+[[pet-python-utils.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-reporter.clarify]
 license = "MIT"
-[[pet-reporter.clarify.git]]
-path = 'LICENSE'
+[[pet-reporter.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-telemetry.clarify]
 license = "MIT"
-[[pet-telemetry.clarify.git]]
-path = 'LICENSE'
+[[pet-telemetry.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-venv.clarify]
 license = "MIT"
-[[pet-venv.clarify.git]]
-path = 'LICENSE'
+[[pet-venv.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-virtualenv.clarify]
 license = "MIT"
-[[pet-virtualenv.clarify.git]]
-path = 'LICENSE'
+[[pet-virtualenv.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-virtualenvwrapper.clarify]
 license = "MIT"
-[[pet-virtualenvwrapper.clarify.git]]
-path = 'LICENSE'
+[[pet-virtualenvwrapper.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-windows-registry.clarify]
 license = "MIT"
-[[pet-windows-registry.clarify.git]]
-path = 'LICENSE'
+[[pet-windows-registry.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
 
 [pet-windows-store.clarify]
 license = "MIT"
-[[pet-windows-store.clarify.git]]
-path = 'LICENSE'
+[[pet-windows-store.clarify.files]]
+path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
+
+[ring.clarify]
+license = "ISC AND OpenSSL"
+[[ring.clarify.files]]
+path = 'LICENSE'
+checksum = '76b39f9b371688eac9d8323f96ee80b3aef5ecbc2217f25377bd4e4a615296a9'


### PR DESCRIPTION
* Remove unneeded accepted licenses

* Removes use of `workarounds`

  - `wasmtime` no longer needed in list

  - `ring` now checks the license SHA

* Checks license from `files` instead of from `git`. Execution time ~17s instead of ~24s

Release Notes:

- N/A