### PR TITLE
Pass "menu" key presses in windows down as a `Keystroke`

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1249,6 +1249,7 @@ fn parse_syskeydown_msg_keystroke(wparam: WPARAM) -> Option<Keystroke> {
         VK_ESCAPE => "escape",
         VK_INSERT => "insert",
         VK_DELETE => "delete",
+        VK_APPS => "menu",
         _ => {
             let basic_key = basic_vkcode_to_string(vk_code, modifiers);
             if basic_key.is_some() {
@@ -1303,6 +1304,7 @@ fn parse_keydown_msg_keystroke(wparam: WPARAM) -> Option<KeystrokeOrModifier> {
         VK_ESCAPE => "escape",
         VK_INSERT => "insert",
         VK_DELETE => "delete",
+        VK_APPS => "menu",
         _ => {
             if is_modifier(VIRTUAL_KEY(vk_code)) {
                 return Some(KeystrokeOrModifier::Modifier(modifiers));


### PR DESCRIPTION
This is second part needed for #17819.
There is already binding in default bindings: `"menu": "editor::OpenContextMenu",` (but won't work on windows without this change)

Release Notes:

- Handle "menu" key in windows
