### PR TITLE
lsp: Add support for Show Document

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -781,6 +781,7 @@ impl LanguageServer {
                     show_message: Some(ShowMessageRequestClientCapabilities {
                         message_action_item: None,
                     }),
+                    show_document: Some(ShowDocumentClientCapabilities { support: true }),
                     ..Default::default()
                 }),
             },

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -782,7 +782,6 @@ impl LanguageServer {
                         message_action_item: None,
                     }),
                     show_document: Some(ShowDocumentClientCapabilities { support: true }),
-                    ..Default::default()
                 }),
             },
             trace: None,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -821,17 +821,13 @@ impl LocalLspStore {
         language_server
             .on_request::<lsp::request::ShowDocument, _, _>({
                 let this = this.clone();
-                let name = name.to_string();
                 move |params, mut cx| {
                     let this = this.clone();
                     let (tx, rx) = smol::channel::bounded(1);
                     async move {
                         let request = LanguageServerShowDocumentRequest {
                             uri: params.uri,
-                            external: match params.external {
-                                Some(opt) => opt,
-                                None => false,
-                            },
+                            external: params.external.unwrap_or(false),
                             response_channel: tx,
                         };
                         let did_update = this

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -117,8 +117,8 @@ pub use worktree::{
 pub use buffer_store::ProjectTransaction;
 pub use lsp_store::{
     DiagnosticSummary, LanguageServerLogType, LanguageServerProgress, LanguageServerPromptRequest,
-    LanguageServerStatus, LanguageServerToQuery, LspStore, LspStoreEvent,
-    SERVER_PROGRESS_THROTTLE_TIMEOUT,
+    LanguageServerShowDocumentRequest, LanguageServerStatus, LanguageServerToQuery, LspStore,
+    LspStoreEvent, SERVER_PROGRESS_THROTTLE_TIMEOUT,
 };
 pub use toolchain_store::ToolchainStore;
 const MAX_PROJECT_SEARCH_HISTORY_SIZE: usize = 500;
@@ -252,6 +252,7 @@ pub enum Event {
         notification_id: SharedString,
     },
     LanguageServerPrompt(LanguageServerPromptRequest),
+    LanguageServerShowDocument(LanguageServerShowDocumentRequest),
     LanguageNotFound(Entity<Buffer>),
     ActiveEntryChanged(Option<ProjectEntryId>),
     ActivateProjectPanel,
@@ -2334,6 +2335,9 @@ impl Project {
             LspStoreEvent::RefreshInlayHints => cx.emit(Event::RefreshInlayHints),
             LspStoreEvent::LanguageServerPrompt(prompt) => {
                 cx.emit(Event::LanguageServerPrompt(prompt.clone()))
+            }
+            LspStoreEvent::LanguageServerShowDocument(request) => {
+                cx.emit(Event::LanguageServerShowDocument(request.clone()))
             }
             LspStoreEvent::DiskBasedDiagnosticsStarted { language_server_id } => {
                 cx.emit(Event::DiskBasedDiagnosticsStarted {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -941,6 +941,25 @@ impl Workspace {
                     );
                 }
 
+                project::Event::LanguageServerShowDocument(request) => {
+                    if request.external {
+                        cx.open_url(request.uri.as_str());
+                        let request = request.clone();
+                        cx.background_executor()
+                            .spawn(async move {
+                                request.respond(Ok(())).await;
+                            })
+                            .detach();
+                    } else {
+                        let request = request.clone();
+                        cx.background_executor()
+                            .spawn(async move {
+                                request.respond(Err(anyhow!("not implemented"))).await;
+                            })
+                            .detach();
+                    }
+                }
+
                 _ => {}
             }
             cx.notify()


### PR DESCRIPTION
Closes #17931 and https://github.com/zed-industries/zed/discussions/24852

Release Notes:

- Added support for LSP's Show Document Request.

----
This PR adds support for LSP's window/showDocument server requests. The URI returned by the server is opened in default browser. 
- I haven't implemented this for headless projects (remote development). I can't get remote development to work on my machine (my server complains about the GLIBC version being too new).
- I'm not sure how to implement automated tests for this feature. If you could point me in the right direction I can write some tests. 