### PR TITLE
Undo inode/directory removal

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -10,7 +10,7 @@ Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
-MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;
+MimeType=text/plain;inode/directory;application/x-zerosize;x-scheme-handler/zed;
 Actions=NewWorkspace;
 
 [Desktop Action NewWorkspace]


### PR DESCRIPTION
I believe the PR at https://github.com/zed-industries/zed/pull/16940 was an incorrect decision, as `inode/directory` is a mime type that many, many text/code editor programs use on Linux. It is correct behavior. Not adding it means there is no way to open a folder using Zed, other than from the Zed UI directly.

I've added it myself on my own installation as well (I'm using KDE Plasma 6), and it works correctly.

If the Zed Editor starts being used as a file browser, it is incorrect system configuration, NOT incorrect program behavior. Therefore, I have undone the change.

Release Notes:
- Added the ability to open folders in Zed on Linux in file browsers.