### PR TITLE
ui: Add `show_scrollbar` method to Picker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9776,6 +9776,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ui",
+ "util",
  "workspace",
 ]
 

--- a/crates/picker/Cargo.toml
+++ b/crates/picker/Cargo.toml
@@ -23,6 +23,7 @@ menu.workspace = true
 schemars.workspace = true
 serde.workspace = true
 ui.workspace = true
+util.workspace = true
 workspace.workspace = true
 
 [dev-dependencies]

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -3,8 +3,8 @@ use editor::{scroll::Autoscroll, Editor};
 use gpui::{
     actions, div, impl_actions, list, prelude::*, uniform_list, AnyElement, App, ClickEvent,
     Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Length,
-    ListSizingBehavior, ListState, MouseButton, MouseUpEvent, Render, ScrollStrategy, Stateful,
-    Task, UniformListScrollHandle, Window,
+    ListSizingBehavior, ListState, MouseButton, MouseUpEvent, Render, ScrollHandle, ScrollStrategy,
+    Stateful, Task, UniformListScrollHandle, Window,
 };
 use head::Head;
 use schemars::JsonSchema;
@@ -266,12 +266,16 @@ impl<D: PickerDelegate> Picker<D> {
         cx: &mut Context<Self>,
     ) -> Self {
         let element_container = Self::create_element_container(container, cx);
-        let scroll_handle = match &element_container {
-            ElementContainer::UniformList(scroll_handle) => scroll_handle.clone(),
-            ElementContainer::List(_) => unimplemented!(), // todo: smit
+        let scrollbar_state = match &element_container {
+            ElementContainer::UniformList(scroll_handle) => {
+                ScrollbarState::new(scroll_handle.clone())
+            }
+            ElementContainer::List(_) => {
+                // todo smit: implement for list
+                ScrollbarState::new(ScrollHandle::new())
+            }
         };
         let focus_handle = cx.focus_handle();
-
         let mut this = Self {
             delegate,
             head,
@@ -283,8 +287,7 @@ impl<D: PickerDelegate> Picker<D> {
             focus_handle,
             show_scrollbar: false,
             scrollbar_visibility: true,
-            scrollbar_state: ScrollbarState::new(scroll_handle),
-
+            scrollbar_state,
             is_modal: true,
             hide_scrollbar_task: None,
         };

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -50,7 +50,7 @@ pub struct Picker<D: PickerDelegate> {
     width: Option<Length>,
     max_height: Option<Length>,
     focus_handle: FocusHandle,
-    /// An external control to display scrollbar in the `Picker`.
+    /// An external control to display a scrollbar in the `Picker`.
     show_scrollbar: bool,
     /// An internal state that controls whether to show the scrollbar based on the user's focus.
     scrollbar_visibility: bool,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -50,7 +50,9 @@ pub struct Picker<D: PickerDelegate> {
     width: Option<Length>,
     max_height: Option<Length>,
     focus_handle: FocusHandle,
+    /// An external control to display scrollbar in the `Picker`.
     show_scrollbar: bool,
+    /// An internal state that controls whether to show the scrollbar based on the user's focus.
     scrollbar_visibility: bool,
     scrollbar_state: ScrollbarState,
     hide_scrollbar_task: Option<Task<()>>,
@@ -669,22 +671,21 @@ impl<D: PickerDelegate> Picker<D> {
         };
 
         match &self.element_container {
-            ElementContainer::UniformList(scroll_handle) =>
-                uniform_list(
-                    cx.entity().clone(),
-                    "candidates",
-                    self.delegate.match_count(),
-                    move |picker, visible_range, window, cx| {
-                        visible_range
-                            .map(|ix| picker.render_element(window, cx, ix))
-                            .collect()
-                    },
-                )
-                .with_sizing_behavior(sizing_behavior)
-                .flex_grow()
-                .py_1()
-                .track_scroll(scroll_handle.clone())
-                .into_any_element(),
+            ElementContainer::UniformList(scroll_handle) => uniform_list(
+                cx.entity().clone(),
+                "candidates",
+                self.delegate.match_count(),
+                move |picker, visible_range, window, cx| {
+                    visible_range
+                        .map(|ix| picker.render_element(window, cx, ix))
+                        .collect()
+                },
+            )
+            .with_sizing_behavior(sizing_behavior)
+            .flex_grow()
+            .py_1()
+            .track_scroll(scroll_handle.clone())
+            .into_any_element(),
             ElementContainer::List(state) => list(state.clone())
                 .with_sizing_behavior(sizing_behavior)
                 .flex_grow()


### PR DESCRIPTION
Now, you can pass `show_scrollbar` to Picker that implement a `uniform_list`. If that's on, the scrollbar should auto-hide if you move your focus elsewhere. By default, this method is turned off.

Release Notes:

- N/A
