### PR TITLE
theme: Improve contrast for One Light's `read_background` token

### DIFF
--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -451,7 +451,7 @@
         "editor.invisible": "#a3a3a4ff",
         "editor.wrap_guide": "#383a410d",
         "editor.active_wrap_guide": "#383a411a",
-        "editor.document_highlight.read_background": "#5c78e21a",
+        "editor.document_highlight.read_background": "#5c78e225",
         "editor.document_highlight.write_background": "#a3a3a466",
         "terminal.background": "#fafafaff",
         "terminal.foreground": "#242529ff",


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/20575

Subtle change, but more pronounced in single characters.

| Before | After |
|--------|--------|
| <img width="700" alt="Screenshot 2025-02-07 at 4 58 16 PM" src="https://github.com/user-attachments/assets/dc9332e1-6e86-44a9-bb7a-5f195d778127" /> |  <img width="700" alt="Screenshot 2025-02-07 at 4 58 16 PM" src="https://github.com/user-attachments/assets/d8fd408f-f8ea-4b87-bd20-345ffc24b5b1" /> | 

Release Notes:

- N/A
