### PR TITLE
Add copy_path_with_file_number shortcut

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -364,6 +364,7 @@
       "ctrl-.": "editor::ToggleCodeActions",
       "ctrl-k r": "editor::RevealInFileManager",
       "ctrl-k p": "editor::CopyPath",
+      "ctrl-k n": "editor::CopyPathWithLineNumber",
       "ctrl-\\": "pane::SplitRight",
       "ctrl-k v": "markdown::OpenPreviewToTheSide",
       "ctrl-shift-v": "markdown::OpenPreview",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -431,6 +431,7 @@
       "cmd-.": "editor::ToggleCodeActions",
       "cmd-k r": "editor::RevealInFileManager",
       "cmd-k p": "editor::CopyPath",
+      "cmd-k n": "editor::CopyPathWithLineNumber",
       "cmd-\\": "pane::SplitRight",
       "cmd-k v": "markdown::OpenPreviewToTheSide",
       "cmd-shift-v": "markdown::OpenPreview",

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13070,7 +13070,22 @@ impl Editor {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(path) = self.target_file_abs_path(cx) {
+        let path = self.target_file_abs_path(cx);
+        self.copy_path_base(cx, path);
+    }
+
+    pub fn copy_relative_path(
+        &mut self,
+        _: &zed_actions::workspace::CopyRelativePath,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let path = self.target_file_path(cx);
+        self.copy_path_base(cx, path);
+    }
+
+    fn copy_path_base(&mut self, cx: &mut Context<Self>, path: Option<PathBuf>) {
+        if let Some(path) = path {
             if let Some(path) = path.to_str() {
                 cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
             }
@@ -13083,26 +13098,8 @@ impl Editor {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(path) = self.target_file_abs_path(cx) {
-            if let Some(path) = path.to_str() {
-                let selection = self.selections.newest::<Point>(cx).start.row + 1;
-                let path_with_line_number = format!("{}:{}", path, selection);
-                cx.write_to_clipboard(ClipboardItem::new_string(path_with_line_number));
-            }
-        }
-    }
-
-    pub fn copy_relative_path(
-        &mut self,
-        _: &zed_actions::workspace::CopyRelativePath,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        if let Some(path) = self.target_file_path(cx) {
-            if let Some(path) = path.to_str() {
-                cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
-            }
-        }
+        let path = self.target_file_abs_path(cx);
+        self.copy_path_with_line_number_base(cx, path);
     }
 
     pub fn copy_relative_path_with_line_number(
@@ -13111,7 +13108,12 @@ impl Editor {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(path) = self.target_file_path(cx) {
+        let path = self.target_file_path(cx);
+        self.copy_path_with_line_number_base(cx, path);
+    }
+
+    fn copy_path_with_line_number_base(&mut self, cx: &mut Context<Self>, path: Option<PathBuf>) {
+        if let Some(path) = path {
             if let Some(path) = path.to_str() {
                 let selection = self.selections.newest::<Point>(cx).start.row + 1;
                 let path_with_line_number = format!("{}:{}", path, selection);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13077,6 +13077,21 @@ impl Editor {
         }
     }
 
+    pub fn copy_path_with_line_number(
+        &mut self,
+        _: &zed_actions::workspace::CopyPathWithLineNumber,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(path) = self.target_file_abs_path(cx) {
+            if let Some(path) = path.to_str() {
+                let selection = self.selections.newest::<Point>(cx).start.row + 1;
+                let path_with_line_number = format!("{}:{}", path, selection);
+                cx.write_to_clipboard(ClipboardItem::new_string(path_with_line_number));
+            }
+        }
+    }
+
     pub fn copy_relative_path(
         &mut self,
         _: &zed_actions::workspace::CopyRelativePath,
@@ -13086,6 +13101,21 @@ impl Editor {
         if let Some(path) = self.target_file_path(cx) {
             if let Some(path) = path.to_str() {
                 cx.write_to_clipboard(ClipboardItem::new_string(path.to_string()));
+            }
+        }
+    }
+
+    pub fn copy_relative_path_with_line_number(
+        &mut self,
+        _: &zed_actions::workspace::CopyRelativePathWithLineNumber,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(path) = self.target_file_path(cx) {
+            if let Some(path) = path.to_str() {
+                let selection = self.selections.newest::<Point>(cx).start.row + 1;
+                let path_with_line_number = format!("{}:{}", path, selection);
+                cx.write_to_clipboard(ClipboardItem::new_string(path_with_line_number));
             }
         }
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -409,7 +409,9 @@ impl EditorElement {
         register_action(editor, window, hover_popover::hover);
         register_action(editor, window, Editor::reveal_in_finder);
         register_action(editor, window, Editor::copy_path);
+        register_action(editor, window, Editor::copy_path_with_line_number);
         register_action(editor, window, Editor::copy_relative_path);
+        register_action(editor, window, Editor::copy_relative_path_with_line_number);
         register_action(editor, window, Editor::copy_file_name);
         register_action(editor, window, Editor::copy_file_name_without_extension);
         register_action(editor, window, Editor::copy_highlight_json);

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -104,11 +104,31 @@ pub mod workspace {
 
     action_with_deprecated_aliases!(
         workspace,
+        CopyPathWithLineNumber,
+        [
+            "editor::CopyPathWithLineNumber",
+            "outline_panel::CopyPathWithLineNumber",
+            "project_panel::CopyPathWithLineNumber"
+        ]
+    );
+
+    action_with_deprecated_aliases!(
+        workspace,
         CopyRelativePath,
         [
             "editor::CopyRelativePath",
             "outline_panel::CopyRelativePath",
             "project_panel::CopyRelativePath"
+        ]
+    );
+
+    action_with_deprecated_aliases!(
+        workspace,
+        CopyRelativePathWithLineNumber,
+        [
+            "editor::CopyRelativePathWithLineNumber",
+            "outline_panel::CopyRelativePathWithLineNumber",
+            "project_panel::CopyRelativePathWithLineNumber"
         ]
     );
 }


### PR DESCRIPTION
Hi. It's my first time contributing so sorry in advance if I'm mixing something up.

This PR adds shortcuts enabling copying file path (absolute and relative) with line number appended, in the following format:

```
crates/editor/src/editor.rs:13094
```

I use this feature constantly when working in VS code to run only a specific test case with Rspec (other testing frameworks also support this behaviour). 

I've also noticed that there is `editor::CopyPermalinkToLine` shortcut, so a local path with line number should probably also be supported.

Release Notes:

- Added `CopyPathWithLineNumber` and `CopyRelativePathWithLineNumber` shortcuts 