### PR TITLE
WIP: Reuse existing panes when splitting

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1385,10 +1385,22 @@ impl PickerDelegate for FileFinderDelegate {
                                     let context = context.clone();
                                     move |menu, _, _| {
                                         menu.context(context)
-                                            .action("Split Left", pane::SplitLeft.boxed_clone())
-                                            .action("Split Right", pane::SplitRight.boxed_clone())
-                                            .action("Split Up", pane::SplitUp.boxed_clone())
-                                            .action("Split Down", pane::SplitDown.boxed_clone())
+                                            .action(
+                                                "Split Left",
+                                                pane::SplitLeft::default().boxed_clone(),
+                                            )
+                                            .action(
+                                                "Split Right",
+                                                pane::SplitRight::default().boxed_clone(),
+                                            )
+                                            .action(
+                                                "Split Up",
+                                                pane::SplitUp::default().boxed_clone(),
+                                            )
+                                            .action(
+                                                "Split Down",
+                                                pane::SplitDown::default().boxed_clone(),
+                                            )
                                     }
                                 }))
                             }

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -219,7 +219,7 @@ impl Render for KeyContextView {
                                 cx
                             ))
                             .on_click(|_, window, cx| {
-                                window.dispatch_action(workspace::SplitRight.boxed_clone(), cx);
+                                window.dispatch_action(workspace::SplitRight::default().boxed_clone(), cx);
                                 window.dispatch_action(zed_actions::OpenDefaultKeymap.boxed_clone(), cx);
                             }),
                     )
@@ -228,7 +228,7 @@ impl Render for KeyContextView {
                             .style(ButtonStyle::Filled)
                             .key_binding(ui::KeyBinding::for_action(&zed_actions::OpenKeymap, window, cx))
                             .on_click(|_, window, cx| {
-                                window.dispatch_action(workspace::SplitRight.boxed_clone(), cx);
+                                window.dispatch_action(workspace::SplitRight::default().boxed_clone(), cx);
                                 window.dispatch_action(zed_actions::OpenKeymap.boxed_clone(), cx);
                             }),
                     ),

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -183,10 +183,10 @@ impl TerminalPanel {
                                             split_context.clone(),
                                             |menu, split_context| menu.context(split_context),
                                         )
-                                        .action("Split Right", SplitRight.boxed_clone())
-                                        .action("Split Left", SplitLeft.boxed_clone())
-                                        .action("Split Up", SplitUp.boxed_clone())
-                                        .action("Split Down", SplitDown.boxed_clone())
+                                        .action("Split Right", SplitRight::default().boxed_clone())
+                                        .action("Split Left", SplitLeft::default().boxed_clone())
+                                        .action("Split Up", SplitUp::default().boxed_clone())
+                                        .action("Split Down", SplitDown::default().boxed_clone())
                                     })
                                     .into()
                                 }
@@ -390,7 +390,8 @@ impl TerminalPanel {
                 }
                 self.serialize(cx);
             }
-            pane::Event::Split(direction) => {
+            pane::Event::Split { direction, .. } => {
+                // TODO: support Split::use_existing
                 let Some(new_pane) = self.new_pane_with_cloned_active_terminal(window, cx) else {
                     return;
                 };

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -770,8 +770,8 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
             save_intent: Some(SaveIntent::Overwrite),
         }),
         VimCommand::new(("cq", "uit"), zed_actions::Quit),
-        VimCommand::new(("sp", "lit"), workspace::SplitHorizontal),
-        VimCommand::new(("vs", "plit"), workspace::SplitVertical),
+        VimCommand::new(("sp", "lit"), workspace::SplitHorizontal::default()),
+        VimCommand::new(("vs", "plit"), workspace::SplitVertical::default()),
         VimCommand::new(
             ("bd", "elete"),
             workspace::CloseActiveItem {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3515,7 +3515,16 @@ impl Workspace {
         {
             let target_pane = self.find_or_create_pane_in_direction(window, &pane, direction, cx);
             target_pane.update(cx, |pane, cx| {
-                pane.add_item(clone, true, true, None, window, cx)
+                let project_entry_id = clone
+                    .is_singleton(cx)
+                    .then_some(Some(()))
+                    .and_then(|_| clone.project_entry_ids(cx).first().cloned());
+                if let Some(project_entry_id) = project_entry_id {
+                    if let Some(existing) = pane.item_for_entry(project_entry_id, cx) {
+                        pane.remove_item(existing.item_id(), true, false, window, cx);
+                    }
+                }
+                pane.add_item(clone, true, true, None, window, cx);
             });
             Some(target_pane)
         } else {

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -151,10 +151,10 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::submenu(Menu {
                     name: "Editor Layout".into(),
                     items: vec![
-                        MenuItem::action("Split Up", workspace::SplitUp),
-                        MenuItem::action("Split Down", workspace::SplitDown),
-                        MenuItem::action("Split Left", workspace::SplitLeft),
-                        MenuItem::action("Split Right", workspace::SplitRight),
+                        MenuItem::action("Split Up", workspace::SplitUp::default()),
+                        MenuItem::action("Split Down", workspace::SplitDown::default()),
+                        MenuItem::action("Split Left", workspace::SplitLeft::default()),
+                        MenuItem::action("Split Right", workspace::SplitRight::default()),
                     ],
                 }),
                 MenuItem::separator(),

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -39,7 +39,6 @@ version_info=$(rustc --version --verbose)
 host_line=$(echo "$version_info" | grep host)
 target_triple=${host_line#*: }
 musl_triple=${target_triple%-gnu}-musl
-remote_server_triple=${REMOTE_SERVER_TARGET:-"${musl_triple}"}
 rustup_installed=false
 if command -v rustup >/dev/null 2>&1; then
     rustup_installed=true
@@ -48,47 +47,26 @@ fi
 # Generate the licenses first, so they can be baked into the binaries
 script/generate-licenses
 
-if "$rustup_installed"; then
-    rustup target add "$remote_server_triple"
-fi
-
 export CC=$(which clang)
 
 # Build binary in release mode
 export RUSTFLAGS="${RUSTFLAGS:-} -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib"
 cargo build --release --target "${target_triple}" --package zed --package cli
-# Build remote_server in separate invocation to prevent feature unification from other crates
-# from influencing dynamic libraries required by it.
-if [[ "$remote_server_triple" == "$musl_triple" ]]; then
-    export RUSTFLAGS="${RUSTFLAGS:-} -C target-feature=+crt-static"
-fi
-cargo build --release --target "${remote_server_triple}" --package remote_server
 
 # Strip debug symbols and save them for upload to DigitalOcean
 objcopy --only-keep-debug "${target_dir}/${target_triple}/release/zed" "${target_dir}/${target_triple}/release/zed.dbg"
-objcopy --only-keep-debug "${target_dir}/${remote_server_triple}/release/remote_server" "${target_dir}/${remote_server_triple}/release/remote_server.dbg"
 objcopy --strip-debug "${target_dir}/${target_triple}/release/zed"
 objcopy --strip-debug "${target_dir}/${target_triple}/release/cli"
-objcopy --strip-debug "${target_dir}/${remote_server_triple}/release/remote_server"
 
 gzip -f "${target_dir}/${target_triple}/release/zed.dbg"
-gzip -f "${target_dir}/${remote_server_triple}/release/remote_server.dbg"
 
 if [[ -n "${DIGITALOCEAN_SPACES_SECRET_KEY:-}" && -n "${DIGITALOCEAN_SPACES_ACCESS_KEY:-}" ]]; then
     upload_to_blob_store_public \
         "zed-debug-symbols" \
         "${target_dir}/${target_triple}/release/zed.dbg.gz" \
         "$channel/zed-$version-${target_triple}.dbg.gz"
-    upload_to_blob_store_public \
-        "zed-debug-symbols" \
-        "${target_dir}/${remote_server_triple}/release/remote_server.dbg.gz" \
-        "$channel/remote_server-$version-${remote_server_triple}.dbg.gz"
 fi
 
-# Ensure that remote_server does not depend on libssl nor libcrypto, as we got rid of these deps.
-if ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'; then
-    echo "Error: remote_server still depends on libssl or libcrypto" && exit 1
-fi
 
 suffix=""
 if [ "$channel" != "stable" ]; then
@@ -157,4 +135,3 @@ remove_match="zed(-[a-zA-Z0-9]+)?-linux-$(uname -m)\.tar\.gz"
 ls "${target_dir}/release" | grep -E ${remove_match} | xargs -d "\n" -I {} rm -f "${target_dir}/release/{}" || true
 tar -czvf "${target_dir}/release/$archive" -C ${temp_dir} "zed$suffix.app"
 
-gzip -f --stdout --best "${target_dir}/${remote_server_triple}/release/remote_server" > "${target_dir}/zed-remote-server-linux-${arch}.gz"


### PR DESCRIPTION
This PR adds an optional argument to `pane::Split*` actions called `use_existing`. This argument defaults to false. When it is true, Zed will try to split the active item of the current pane *into* an existing pane in the designated Split direction.

Open questions/further work:
* Implement this feature for terminal_panel and `editor::GoToXSplit` actions
* Consider implementing this feature for other actions?
* Do folks like the argument name "use_existing"? Is it clear enough?

Closes #24889 

Release Notes:

- Added `use_existing` optional argument to `pane::Split*` actions, allowing existing panes to be reused