### PR TITLE
Fix handling of empty blocks in BlockMap::chunks

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -2070,18 +2070,30 @@ pub mod tests {
             )
         });
 
-        // Insert a block in the middle of a multi-line string literal
+        // Insert two blocks in the middle of a multi-line string literal.
+        // The second block has zero height.
         map.update(cx, |map, cx| {
             map.insert_blocks(
-                [BlockProperties {
-                    placement: BlockPlacement::Below(
-                        buffer_snapshot.anchor_before(Point::new(1, 0)),
-                    ),
-                    height: 1,
-                    style: BlockStyle::Sticky,
-                    render: Arc::new(|_| div().into_any()),
-                    priority: 0,
-                }],
+                [
+                    BlockProperties {
+                        placement: BlockPlacement::Below(
+                            buffer_snapshot.anchor_before(Point::new(1, 0)),
+                        ),
+                        height: 1,
+                        style: BlockStyle::Sticky,
+                        render: Arc::new(|_| div().into_any()),
+                        priority: 0,
+                    },
+                    BlockProperties {
+                        placement: BlockPlacement::Below(
+                            buffer_snapshot.anchor_before(Point::new(2, 0)),
+                        ),
+                        height: 0,
+                        style: BlockStyle::Sticky,
+                        render: Arc::new(|_| div().into_any()),
+                        priority: 0,
+                    },
+                ],
                 cx,
             )
         });


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/23391

Release Notes:

- Fixed a bug that sometimes caused incorrect syntax highlighting when deploying the inline assistant.
