### PR TITLE
ui: Remove `track_focus` method from Picker render

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -814,7 +814,6 @@ impl<D: PickerDelegate> Render for Picker<D> {
                         .overflow_hidden()
                         .children(self.delegate.render_header(window, cx))
                         .child(self.render_element_container(cx))
-                        .track_focus(&self.focus_handle(cx))
                         .on_hover(cx.listener(|this, hovered, window, cx| {
                             if *hovered {
                                 this.scrollbar_visibility = true;


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/25025

Removing the `track_focus` method fix the focus hijack that we introduced in the previous PR. cc @0xtimsb 
Also, I don't see any immediate affect in the actual scrollbar behavior without this! Holler if that's not the case.

Release Notes:

- N/A
