### PR TITLE
Fix TypeScript block indenting when using allman style

### DIFF
--- a/crates/languages/src/typescript/indents.scm
+++ b/crates/languages/src/typescript/indents.scm
@@ -5,8 +5,10 @@
     (lexical_declaration)
     (variable_declaration)
     (assignment_expression)
-    (if_statement)
-    (for_statement)
+    ; below handled by  `(_ "{" "}" @end) @indent`
+    ; (if_statement)
+    ; (for_statement)
+    ; (while_statement)
 ] @indent
 
 (_ "[" "]" @end) @indent


### PR DESCRIPTION
Closes #24976 

Release Notes:

- Fixed an issue where writing TypeScript using Allman style would result in incorrect auto-indent behavior