### PR TITLE
Fix `editor::SplitSelectionIntoLines` adding an extra line at the end

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9122,17 +9122,18 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let mut new_selection_ranges = Vec::new();
         let selections = self
             .selections
             .all::<Point>(cx)
             .into_iter()
             .map(|selection| selection.start..selection.end)
             .collect::<Vec<_>>();
+        self.unfold_ranges(&selections, true, true, cx);
 
+        let mut new_selection_ranges = Vec::new();
         {
             let buffer = self.buffer.read(cx).read(cx);
-            for selection in &selections {
+            for selection in selections {
                 for row in selection.start.row..selection.end.row {
                     let cursor = Point::new(row, buffer.line_len(MultiBufferRow(row)));
                     new_selection_ranges.push(cursor..cursor);
@@ -9140,7 +9141,6 @@ impl Editor {
                 new_selection_ranges.push(selection.end..selection.end);
             }
         }
-        self.unfold_ranges(&selections, true, true, cx);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.select_ranges(new_selection_ranges);
         });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9138,7 +9138,14 @@ impl Editor {
                     let cursor = Point::new(row, buffer.line_len(MultiBufferRow(row)));
                     new_selection_ranges.push(cursor..cursor);
                 }
-                new_selection_ranges.push(selection.end..selection.end);
+
+                let is_multiline_selection = selection.start.row != selection.end.row;
+                // Don't insert last one if it's a multi-line selection ending at the start of a line,
+                // so this action feels more ergonomic when paired with other selection operations
+                let should_skip_last = is_multiline_selection && selection.end.column == 0;
+                if !should_skip_last {
+                    new_selection_ranges.push(selection.end..selection.end);
+                }
             }
         }
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9122,21 +9122,25 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let mut to_unfold = Vec::new();
         let mut new_selection_ranges = Vec::new();
+        let selections = self
+            .selections
+            .all::<Point>(cx)
+            .into_iter()
+            .map(|selection| selection.start..selection.end)
+            .collect::<Vec<_>>();
+
         {
-            let selections = self.selections.all::<Point>(cx);
             let buffer = self.buffer.read(cx).read(cx);
-            for selection in selections {
+            for selection in &selections {
                 for row in selection.start.row..selection.end.row {
                     let cursor = Point::new(row, buffer.line_len(MultiBufferRow(row)));
                     new_selection_ranges.push(cursor..cursor);
                 }
                 new_selection_ranges.push(selection.end..selection.end);
-                to_unfold.push(selection.start..selection.end);
             }
         }
-        self.unfold_ranges(&to_unfold, true, true, cx);
+        self.unfold_ranges(&selections, true, true, cx);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.select_ranges(new_selection_ranges);
         });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5021,7 +5021,6 @@ async fn test_add_selection_above_below(cx: &mut TestAppContext) {
 
     let mut cx = EditorTestContext::new(cx).await;
 
-    // let buffer = MultiBuffer::build_simple("abc\ndefghi\n\njk\nlmno\n", cx);
     cx.set_state(indoc!(
         r#"abc
            defˇghi

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4917,18 +4917,25 @@ async fn test_split_selection_into_lines(cx: &mut TestAppContext) {
         "aaˇ\nbbˇ\nccˇ\nddˇ\neeˇ\nffˇ",
     );
 
-    // // Whole buffer, left-to-right, last line ends with newline
-    // test(
-    //     &mut cx,
-    //     "«ˇaa\nbb\ncc\ndd\nee\nff\n»",
-    //     "aaˇ\nbbˇ\nccˇ\nddˇ\neeˇ\nffˇ\n",
-    // );
-    // // Same thing, right-to-left
-    // test(
-    //     &mut cx,
-    //     "«aa\nbb\ncc\ndd\nee\nff\nˇ»",
-    //     "aaˇ\nbbˇ\nccˇ\nddˇ\neeˇ\nffˇ\n",
-    // );
+    // Whole buffer, left-to-right, last line ends with newline
+    test(
+        &mut cx,
+        "«ˇaa\nbb\ncc\ndd\nee\nff\n»",
+        "aaˇ\nbbˇ\nccˇ\nddˇ\neeˇ\nffˇ\n",
+    );
+    // Same thing, right-to-left
+    test(
+        &mut cx,
+        "«aa\nbb\ncc\ndd\nee\nff\nˇ»",
+        "aaˇ\nbbˇ\nccˇ\nddˇ\neeˇ\nffˇ\n",
+    );
+
+    // Starts at the end of a line, ends at the start of another
+    test(
+        &mut cx,
+        "aa\nbb«ˇ\ncc\ndd\nee\n»ff\n",
+        "aa\nbbˇ\nccˇ\nddˇ\neeˇ\nff\n",
+    );
 }
 
 #[gpui::test]
@@ -5002,8 +5009,7 @@ fn test_split_selection_into_lines_interacting_with_creases(cx: &mut TestAppCont
                 DisplayPoint::new(DisplayRow(3), 5)..DisplayPoint::new(DisplayRow(3), 5),
                 DisplayPoint::new(DisplayRow(4), 5)..DisplayPoint::new(DisplayRow(4), 5),
                 DisplayPoint::new(DisplayRow(5), 5)..DisplayPoint::new(DisplayRow(5), 5),
-                DisplayPoint::new(DisplayRow(6), 5)..DisplayPoint::new(DisplayRow(6), 5),
-                DisplayPoint::new(DisplayRow(7), 0)..DisplayPoint::new(DisplayRow(7), 0)
+                DisplayPoint::new(DisplayRow(6), 5)..DisplayPoint::new(DisplayRow(6), 5)
             ]
         );
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4879,11 +4879,7 @@ async fn test_split_selection_into_lines(cx: &mut TestAppContext) {
     let mut cx = EditorTestContext::new(cx).await;
 
     #[track_caller]
-    fn test<'a>(
-        cx: &'a mut EditorTestContext,
-        initial_state: &'static str,
-        expected_state: &'static str,
-    ) {
+    fn test(cx: &mut EditorTestContext, initial_state: &'static str, expected_state: &'static str) {
         cx.set_state(initial_state);
         cx.update_editor(|e, window, cx| {
             e.split_selection_into_lines(&SplitSelectionIntoLines, window, cx)

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5007,7 +5007,7 @@ async fn test_split_selection_into_lines_interacting_with_creases(cx: &mut TestA
     EditorTestContext::for_editor(editor, cx)
         .await
         .assert_editor_state(
-            "aaaaaˇ\nbbbbbˇ\ncccccˇ\ndddddˇ\neeeeeˇ\nfffffˇ\ngggggˇ\nhhhhhˇ\niiiiiˇ",
+            "aaaaaˇ\nbbbbbˇ\ncccccˇ\ndddddˇ\neeeeeˇ\nfffffˇ\ngggggˇ\nhhhhh\niiiii",
         );
 }
 

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -975,7 +975,10 @@ pub struct TextSummary {
     pub chars: usize,
     /// Length in UTF-16 code units
     pub len_utf16: OffsetUtf16,
-    /// A point representing the number of lines and the length of the last line
+    /// A point representing the number of lines and the length of the last line.
+    ///
+    /// In other words, it marks the point after the last byte in the text, (if
+    /// EOF was a character, this would be its position).
     pub lines: Point,
     /// How many `char`s are in the first line
     pub first_line_chars: u32,


### PR DESCRIPTION
Closes #4795

Release Notes:

- Fixed `editor: split selection into lines` adding an extra line at end of selection
