### PR TITLE
cli: Add Windows implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2604,6 +2604,7 @@ dependencies = [
  "serde",
  "tempfile",
  "util",
+ "windows 0.58.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -604,12 +604,16 @@ features = [
     "Win32_Graphics_Imaging",
     "Win32_Graphics_Imaging_D2D",
     "Win32_Security",
+    "Win32_Security_Authorization",
     "Win32_Security_Credentials",
     "Win32_Storage_FileSystem",
     "Win32_System_Com",
     "Win32_System_Com_StructuredStorage",
+    "Win32_System_Console",
     "Win32_System_DataExchange",
+    "Win32_System_IO",
     "Win32_System_LibraryLoader",
+    "Win32_System_Mailslots",
     "Win32_System_Memory",
     "Win32_System_Ole",
     "Win32_System_SystemInformation",
@@ -685,7 +689,7 @@ ui_input = { codegen-units = 1 }
 zed_actions = { codegen-units = 1 }
 
 [profile.release]
-debug = "limited"
+debug = false
 lto = "thin"
 codegen-units = 1
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -32,6 +32,9 @@ serde.workspace = true
 util.workspace = true
 tempfile.workspace = true
 
+[target.'cfg(target_os = "windows")'.dependencies]
+windows.workspace = true
+
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]
 exec.workspace =  true
 fork.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -206,15 +206,15 @@ fn main() {
         if *db::ZED_STATELESS || *release_channel::RELEASE_CHANNEL == ReleaseChannel::Dev {
             false
         } else {
-            #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+            #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
             {
                 crate::zed::listen_for_cli_connections(open_listener.clone()).is_err()
             }
 
-            #[cfg(target_os = "windows")]
-            {
-                !crate::zed::windows_only_instance::check_single_instance()
-            }
+            // #[cfg(target_os = "windows")]
+            // {
+            //     !crate::zed::windows_only_instance::check_single_instance()
+            // }
 
             #[cfg(target_os = "macos")]
             {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -8,6 +8,8 @@ mod migrate;
 mod open_listener;
 mod quick_action_bar;
 #[cfg(target_os = "windows")]
+pub(crate) mod windows_mailslots;
+#[cfg(target_os = "windows")]
 pub(crate) mod windows_only_instance;
 
 use anyhow::Context as _;

--- a/crates/zed/src/zed/windows_mailslots.rs
+++ b/crates/zed/src/zed/windows_mailslots.rs
@@ -1,0 +1,69 @@
+use std::io;
+use std::io::Read;
+use windows::Win32::System::SystemServices::{MAILSLOT_WAIT_FOREVER, SECURITY_DESCRIPTOR_REVISION};
+use windows::{
+    core::*, Win32::Foundation::*, Win32::Security::*, Win32::Storage::FileSystem::*,
+    Win32::System::Mailslots::*,
+};
+
+pub struct Mailslot {
+    handle: HANDLE,
+}
+unsafe impl Send for Mailslot {}
+
+impl Mailslot {
+    pub fn new(name: &str) -> io::Result<Self> {
+        let sd = windows::Win32::Security::PSECURITY_DESCRIPTOR::default();
+        unsafe {
+            InitializeSecurityDescriptor(sd, SECURITY_DESCRIPTOR_REVISION)?;
+            SetSecurityDescriptorDacl(sd, true, None, false)?;
+        }
+        // TODO(raggi); deinit. scopeguard maybe?
+
+        let sa = SECURITY_ATTRIBUTES {
+            nLength: std::mem::size_of::<SECURITY_ATTRIBUTES>() as u32,
+            lpSecurityDescriptor: sd.0,
+            bInheritHandle: FALSE,
+        };
+
+        let mailslot_path = format!("\\\\.\\mailslot\\{}", name);
+        let handle = unsafe {
+            CreateMailslotW(
+                &HSTRING::from(mailslot_path),
+                1024, // max message size 1024, matches Linux datagram buf size
+                MAILSLOT_WAIT_FOREVER,
+                Some(&sa),
+            )?
+        };
+
+        if handle == INVALID_HANDLE_VALUE {
+            return Err(std::io::Error::last_os_error());
+        }
+
+        Ok(Mailslot { handle })
+    }
+
+    pub fn recv(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.read(buf)
+    }
+}
+
+impl io::Read for Mailslot {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let mut len: u32 = buf.len() as u32;
+        unsafe { ReadFile(self.handle, Some(buf), Some(&mut len), None) }
+            .map(|_| len as usize)
+            .map_err(|e| e.into())
+    }
+}
+
+impl Drop for Mailslot {
+    fn drop(&mut self) {
+        if self.handle.is_invalid() {
+            return;
+        }
+        unsafe {
+            let _ = windows::Win32::Foundation::CloseHandle(self.handle);
+        }
+    }
+}


### PR DESCRIPTION
This is a strawman of the implementation for discussion and still has quite a number of small to medium sized issues.

It's presented as-is to foster discussion around approach and specific choices, for example this uses the Windows mailslot infrastructure in place of the UnixDatagram that is used on e.g. Linux. Windows has AF_UNIX, but only in stream mode, so that would not provide equivalent semantics.

Using FIFO might be reasonable also, but requires additional choices around framing and so on - the Mailslot API is a good match for how the datagram is used for one-way single short message communication.

Various things are snuck in here and would want to be addressed before submission:

- [ ] release mode debug info (convenience fix for unrelated build bug)
- [ ] seek clarity on expected binary file names in deployments (maybe make a libexec equivalent? maybe future TODO)
- [ ] cleanup newly introduced code comments, a couple of unused functions
- [ ] decide on title setting behavior for the CLI (if at all)

Updates #5394
Updates #23026

Release Notes:

- Initial CLI support on Windows
