### PR TITLE
editor: Disable "Open in Terminal" when it's not possible

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -154,11 +154,6 @@ pub fn deploy_context_menu(
 
         let focus = window.focused(cx);
         let has_reveal_target = editor.target_file(cx).is_some();
-        let reveal_in_finder_label = if cfg!(target_os = "macos") {
-            "Reveal in Finder"
-        } else {
-            "Reveal in File Manager"
-        };
         let has_selections = editor
             .selections
             .all::<PointUtf16>(cx)
@@ -196,14 +191,22 @@ pub fn deploy_context_menu(
                 .action("Paste", Box::new(Paste))
                 .separator()
                 .map(|builder| {
+                    let reveal_in_finder_label = if cfg!(target_os = "macos") {
+                        "Reveal in Finder"
+                    } else {
+                        "Reveal in File Manager"
+                    };
+                    const OPEN_IN_TERMINAL_LABEL: &str = "Open in Terminal";
                     if has_reveal_target {
-                        builder.action(reveal_in_finder_label, Box::new(RevealInFileManager))
+                        builder
+                            .action(reveal_in_finder_label, Box::new(RevealInFileManager))
+                            .action(OPEN_IN_TERMINAL_LABEL, Box::new(OpenInTerminal))
                     } else {
                         builder
                             .disabled_action(reveal_in_finder_label, Box::new(RevealInFileManager))
+                            .disabled_action(OPEN_IN_TERMINAL_LABEL, Box::new(OpenInTerminal))
                     }
                 })
-                .action("Open in Terminal", Box::new(OpenInTerminal))
                 .map(|builder| {
                     const COPY_PERMALINK_LABEL: &str = "Copy Permalink";
                     if has_git_repo {


### PR DESCRIPTION
When impossible to trigger action, the button should be disabled.

Release Notes:

- N/A
