### PR TITLE
terminal: Change context menu item label

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -258,7 +258,7 @@ impl TerminalView {
                 })
                 .separator()
                 .action(
-                    "Close",
+                    "Close Terminal",
                     Box::new(CloseActiveItem {
                         save_intent: None,
                         close_pinned: true,

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -258,7 +258,7 @@ impl TerminalView {
                 })
                 .separator()
                 .action(
-                    "Close Terminal",
+                    "Close Terminal Tab",
                     Box::new(CloseActiveItem {
                         save_intent: None,
                         close_pinned: true,


### PR DESCRIPTION
Super subtle, but when I initially saw just "Close", I got weirded out asking myself "why there's a menu item to close the context menu?", to only then realize that it didn't close the menu, but the terminal _tab_. Might be obvious, because that's how buffer tabs are labled, but I don't know, it feels like the redundancy here is overall positive.

Release Notes:

- N/A
