### PR TITLE
theme: Return structured errors when a theme is not found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13481,6 +13481,7 @@ dependencies = [
  "serde_repr",
  "settings",
  "strum",
+ "thiserror 1.0.69",
  "util",
  "uuid",
 ]

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -36,6 +36,7 @@ serde_json_lenient.workspace = true
 serde_repr.workspace = true
 settings.workspace = true
 strum.workspace = true
+thiserror.workspace = true
 util.workspace = true
 uuid.workspace = true
 


### PR DESCRIPTION
This PR updates the `ThemeRegistry` to return structured errors from the `get` and `get_icon_theme` methods (which are used to retrieve themes and icon themes, respectively).

We want to be able to carry the name of the theme that was not found as state on the error, which is why we use a `Result` and not an `Option`. However, we also want to be able to accurately identify when the error case is "not found" so we can take appropriate action, based on the circumstances.

By using a custom error type instead of an `anyhow::Error`, we get both.

There isn't any functional change in this PR. This just sets us up for future improvements in this error.

Release Notes:

- N/A
