### PR TITLE
Fix `cargo test` task for tests module in `lib.rs`, `main.rs`, `mod.rs`

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -469,9 +469,6 @@ const RUST_BIN_NAME_TASK_VARIABLE: VariableName =
 const RUST_BIN_KIND_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("RUST_BIN_KIND"));
 
-const RUST_MAIN_FUNCTION_TASK_VARIABLE: VariableName =
-    VariableName::Custom(Cow::Borrowed("_rust_main_function_end"));
-
 const RUST_TEST_FRAGMENT_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("RUST_TEST_FRAGMENT"));
 


### PR DESCRIPTION
Closes #19161

Release Notes:
- Fixed not being able to spawn the `cargo test` task for a `tests` module in `lib.rs`, `main.rs`, or `mod.rs`