### PR TITLE
Don't open file finder menu on command

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -767,28 +767,13 @@
     }
   },
   {
-    "context": "FileFinder",
-    "bindings": {
-      "ctrl": "file_finder::ToggleMenu"
-    }
-  },
-  {
-    "context": "FileFinder && !menu_open",
+    "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
     "bindings": {
       "ctrl-shift-p": "file_finder::SelectPrev",
       "ctrl-j": "pane::SplitDown",
       "ctrl-k": "pane::SplitUp",
       "ctrl-h": "pane::SplitLeft",
       "ctrl-l": "pane::SplitRight"
-    }
-  },
-  {
-    "context": "FileFinder && menu_open",
-    "bindings": {
-      "j": "pane::SplitDown",
-      "k": "pane::SplitUp",
-      "h": "pane::SplitLeft",
-      "l": "pane::SplitRight"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -785,14 +785,7 @@
     }
   },
   {
-    "context": "FileFinder",
-    "use_key_equivalents": true,
-    "bindings": {
-      "cmd": "file_finder::ToggleMenu"
-    }
-  },
-  {
-    "context": "FileFinder && !menu_open",
+    "context": "FileFinder || (FileFinder > Picker > Editor) || (FileFinder > Picker > menu)",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-p": "file_finder::SelectPrev",
@@ -800,16 +793,6 @@
       "cmd-k": "pane::SplitUp",
       "cmd-h": "pane::SplitLeft",
       "cmd-l": "pane::SplitRight"
-    }
-  },
-  {
-    "context": "FileFinder && menu_open",
-    "use_key_equivalents": true,
-    "bindings": {
-      "j": "pane::SplitDown",
-      "k": "pane::SplitUp",
-      "h": "pane::SplitLeft",
-      "l": "pane::SplitRight"
     }
   },
   {

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -33,7 +33,7 @@ use std::{
 };
 use text::Point;
 use ui::{
-    prelude::*, ContextMenu, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, PopoverMenu,
+    prelude::*, ContextMenu, HighlightedLabel, ListItem, ListItemSpacing, PopoverMenu,
     PopoverMenuHandle,
 };
 use util::{paths::PathWithPosition, post_inc, ResultExt};
@@ -1301,11 +1301,7 @@ impl PickerDelegate for FileFinderDelegate {
         )
     }
 
-    fn render_footer(
-        &self,
-        window: &mut Window,
-        cx: &mut Context<Picker<Self>>,
-    ) -> Option<AnyElement> {
+    fn render_footer(&self, _: &mut Window, cx: &mut Context<Picker<Self>>) -> Option<AnyElement> {
         let context = self.focus_handle.clone();
         Some(
             h_flex()

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1316,11 +1316,9 @@ impl PickerDelegate for FileFinderDelegate {
                 .border_t_1()
                 .border_color(cx.theme().colors().border_variant)
                 .child(
-                    Button::new("open-selection", "Open")
-                        .key_binding(KeyBinding::for_action(&menu::Confirm, window, cx))
-                        .on_click(|_, window, cx| {
-                            window.dispatch_action(menu::Confirm.boxed_clone(), cx)
-                        }),
+                    Button::new("open-selection", "Open").on_click(|_, window, cx| {
+                        window.dispatch_action(menu::Confirm.boxed_clone(), cx)
+                    }),
                 )
                 .child(
                     PopoverMenu::new("menu-popover")
@@ -1328,14 +1326,8 @@ impl PickerDelegate for FileFinderDelegate {
                         .attach(gpui::Corner::TopRight)
                         .anchor(gpui::Corner::BottomRight)
                         .trigger(
-                            Button::new("actions-trigger", "Split Options")
-                                .selected_label_color(Color::Accent)
-                                .key_binding(KeyBinding::for_action_in(
-                                    &ToggleMenu,
-                                    &context,
-                                    window,
-                                    cx,
-                                )),
+                            Button::new("actions-trigger", "Split…")
+                                .selected_label_color(Color::Accent),
                         )
                         .menu({
                             move |window, cx| {


### PR DESCRIPTION
Closes #24740

Release Notes:

- Don't open the split menu in the file finder when command is pressed
