### PR TITLE
workspace: Prevent user from undoing persistent session deserialization

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1073,6 +1073,9 @@ impl SerializableItem for Editor {
                             buffer.set_language(Some(language), cx);
                         }
                         buffer.set_text(contents, cx);
+                        if let Some(entry) = buffer.peek_undo_stack() {
+                            buffer.forget_transaction(entry.transaction_id());
+                        }
                     })?;
 
                     cx.update(|window, cx| {
@@ -1127,6 +1130,9 @@ impl SerializableItem for Editor {
                                         );
                                     }
                                     buffer.set_text(buffer_text, cx);
+                                    if let Some(entry) = buffer.peek_undo_stack() {
+                                        buffer.forget_transaction(entry.transaction_id());
+                                    }
                                 })?;
                             }
 


### PR DESCRIPTION
Closes #21846

Release Notes:

- Fixed a bug that made it possible to undo changes in dirty deserialized buffer (with `restore_unsaved_buffers: true`)
