### PR TITLE
assistant2: Add file icons for mentioned creases

### DIFF
--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -288,8 +288,11 @@ impl PickerDelegate for FileContextPickerDelegate {
 
                 editor.insert("\n", window, cx); // Needed to end the fold
 
+                let file_icon = FileIcons::get_icon(&Path::new(&full_path), cx)
+                    .unwrap_or_else(|| SharedString::new(""));
+
                 let placeholder = FoldPlaceholder {
-                    render: render_fold_icon_button(IconName::File, file_name.into()),
+                    render: render_fold_icon_button(file_icon, file_name.into()),
                     ..Default::default()
                 };
 
@@ -459,15 +462,27 @@ pub fn render_file_context_entry(
 }
 
 fn render_fold_icon_button(
-    icon: IconName,
+    icon: SharedString,
     label: SharedString,
 ) -> Arc<dyn Send + Sync + Fn(FoldId, Range<Anchor>, &mut Window, &mut App) -> AnyElement> {
     Arc::new(move |fold_id, _fold_range, _window, _cx| {
         ButtonLike::new(fold_id)
             .style(ButtonStyle::Filled)
             .layer(ElevationIndex::ElevatedSurface)
-            .child(Icon::new(icon))
-            .child(Label::new(label.clone()).single_line())
+            .child(
+                h_flex()
+                    .gap_1()
+                    .child(
+                        Icon::from_path(icon.clone())
+                            .size(IconSize::Small)
+                            .color(Color::Muted),
+                    )
+                    .child(
+                        Label::new(label.clone())
+                            .size(LabelSize::Small)
+                            .single_line(),
+                    ),
+            )
             .into_any_element()
     })
 }


### PR DESCRIPTION
This PR makes the mentioned file creases/buttons use `FileIcons`.

<img width="700" alt="Screenshot 2025-01-21 at 11 20 49 AM" src="https://github.com/user-attachments/assets/876da534-c11a-4d13-af82-a5948863f954" />

Release Notes:

- N/A
