### PR TITLE
Rename `EditPredictionsMode::Auto` to `ModifierPreview`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -801,7 +801,7 @@
     // 1. Display inline when there are no language server completions available.
     //     "mode": "eager_preview"
     // 2. Display inline when holding modifier key (alt by default).
-    //     "mode": "auto"
+    //     "mode": "modifier_preview"
     "mode": "eager_preview"
   },
   // Settings specific to journaling

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4953,8 +4953,8 @@ impl Editor {
                     provider.provider.show_completions_in_menu()
                 });
 
-        let preview_requires_modifier =
-            all_language_settings(file, cx).edit_predictions_mode() == EditPredictionsMode::Auto;
+        let preview_requires_modifier = all_language_settings(file, cx).edit_predictions_mode()
+            == EditPredictionsMode::ModifierPreview;
 
         EditPredictionSettings::Enabled {
             show_in_menu,

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -571,7 +571,7 @@ impl InlineCompletionButton {
 
         if cx.has_flag::<feature_flags::PredictEditsNonEagerModeFeatureFlag>() {
             let is_eager_preview_enabled = match settings.edit_predictions_mode() {
-                language::EditPredictionsMode::Auto => false,
+                language::EditPredictionsMode::ModifierPreview => false,
                 language::EditPredictionsMode::EagerPreview => true,
             };
             menu = menu.separator().toggleable_entry(
@@ -587,7 +587,7 @@ impl InlineCompletionButton {
                             cx,
                             move |settings, _cx| {
                                 let new_mode = match is_eager_preview_enabled {
-                                    true => language::EditPredictionsMode::Auto,
+                                    true => language::EditPredictionsMode::ModifierPreview,
                                     false => language::EditPredictionsMode::EagerPreview,
                                 };
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -237,7 +237,7 @@ pub struct EditPredictionSettings {
 pub enum EditPredictionsMode {
     /// If provider supports it, display inline when holding modifier key (e.g., alt).
     /// Otherwise, eager preview is used.
-    Auto,
+    ModifierPreview,
     /// Display inline when there are no language server completions available.
     #[default]
     EagerPreview,


### PR DESCRIPTION
Rationale is that `Auto` doesn't make sense when it isn't the default.

This breaks configurations that specify `Auto`.  Decided that this is ok because it is not documented.  It is in the default keymap and json schemas though, so it's possible some users may have found it.

Release Notes:

- N/A