### PR TITLE
edit predictions: Fix fold not expanding after jump

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5128,6 +5128,7 @@ impl Editor {
                         .contains(&target.to_display_point(&position_map.snapshot).row())
                         || !self.edit_prediction_requires_modifier()
                     {
+                        self.unfold_ranges(&[target..target], true, false, cx);
                         // Note that this is also done in vim's handler of the Tab action.
                         self.change_selections(
                             Some(Autoscroll::newest()),


### PR DESCRIPTION
Closes #24938.

Release Notes:

- Edit predictions: Fix fold not expanding after jump
