### PR TITLE
Fix clicking on file links in editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7650,7 +7650,6 @@ dependencies = [
  "anyhow",
  "assets",
  "env_logger 0.11.6",
- "futures 0.3.31",
  "gpui",
  "language",
  "languages",

--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -179,7 +179,7 @@ impl ActiveThread {
 
         let markdown = cx.new(|cx| {
             Markdown::new(
-                text,
+                text.into(),
                 markdown_style,
                 Some(self.language_registry.clone()),
                 None,

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -121,7 +121,7 @@ impl SlashCommandCompletionProvider {
                         Some(project::Completion {
                             old_range: name_range.clone(),
                             documentation: Some(CompletionDocumentation::SingleLine(
-                                command.description(),
+                                command.description().into(),
                             )),
                             new_text,
                             label: command.label(cx),

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -5,9 +5,9 @@ use assistant_slash_command::{AfterCompletion, SlashCommandLine, SlashCommandWor
 use editor::{CompletionProvider, Editor};
 use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{App, AppContext as _, Context, Entity, Task, WeakEntity, Window};
-use language::{Anchor, Buffer, CompletionDocumentation, LanguageServerId, ToPoint};
+use language::{Anchor, Buffer, LanguageServerId, ToPoint};
 use parking_lot::Mutex;
-use project::CompletionIntent;
+use project::{lsp_store::CompletionDocumentation, CompletionIntent};
 use rope::Point;
 use std::{
     cell::RefCell,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1,12 +1,13 @@
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
-    div, px, uniform_list, AnyElement, BackgroundExecutor, Div, Entity, FontWeight,
+    div, px, uniform_list, AnyElement, BackgroundExecutor, Div, Entity, Focusable, FontWeight,
     ListSizingBehavior, ScrollStrategy, SharedString, Size, StrikethroughStyle, StyledText,
-    UniformListScrollHandle, WeakEntity,
+    UniformListScrollHandle,
 };
 use language::Buffer;
 use language::{CodeLabel, CompletionDocumentation};
 use lsp::LanguageServerId;
+use markdown::Markdown;
 use multi_buffer::{Anchor, ExcerptId};
 use ordered_float::OrderedFloat;
 use project::{CodeAction, Completion, TaskSourceKind};
@@ -21,12 +22,12 @@ use std::{
 use task::ResolvedTask;
 use ui::{prelude::*, Color, IntoElement, ListItem, Pixels, Popover, Styled};
 use util::ResultExt;
-use workspace::Workspace;
 
+use crate::hover_popover::{hover_markdown_style, open_markdown_url};
 use crate::{
     actions::{ConfirmCodeAction, ConfirmCompletion},
-    render_parsed_markdown, split_words, styled_runs_for_code_label, CodeActionProvider,
-    CompletionId, CompletionProvider, DisplayRow, Editor, EditorStyle, ResolvedTasks,
+    split_words, styled_runs_for_code_label, CodeActionProvider, CompletionId, CompletionProvider,
+    DisplayRow, Editor, EditorStyle, ResolvedTasks,
 };
 
 pub const MENU_GAP: Pixels = px(4.);
@@ -137,15 +138,25 @@ impl CodeContextMenu {
     }
 
     pub fn render_aside(
-        &self,
-        style: &EditorStyle,
+        &mut self,
+        editor: &Editor,
         max_size: Size<Pixels>,
-        workspace: Option<WeakEntity<Workspace>>,
+        window: &mut Window,
         cx: &mut Context<Editor>,
     ) -> Option<AnyElement> {
         match self {
-            CodeContextMenu::Completions(menu) => menu.render_aside(style, max_size, workspace, cx),
+            CodeContextMenu::Completions(menu) => menu.render_aside(editor, max_size, window, cx),
             CodeContextMenu::CodeActions(_) => None,
+        }
+    }
+
+    pub fn focused(&self, window: &mut Window, cx: &mut Context<Editor>) -> bool {
+        match self {
+            CodeContextMenu::Completions(completions_menu) => completions_menu
+                .markdown_element
+                .as_ref()
+                .is_some_and(|markdown| markdown.focus_handle(cx).contains_focused(window, cx)),
+            CodeContextMenu::CodeActions(_) => false,
         }
     }
 }
@@ -169,6 +180,7 @@ pub struct CompletionsMenu {
     resolve_completions: bool,
     show_completion_documentation: bool,
     last_rendered_range: Rc<RefCell<Option<Range<usize>>>>,
+    markdown_element: Option<Entity<Markdown>>,
 }
 
 impl CompletionsMenu {
@@ -199,6 +211,7 @@ impl CompletionsMenu {
             scroll_handle: UniformListScrollHandle::new(),
             resolve_completions: true,
             last_rendered_range: RefCell::new(None).into(),
+            markdown_element: None,
         }
     }
 
@@ -255,6 +268,7 @@ impl CompletionsMenu {
             resolve_completions: false,
             show_completion_documentation: false,
             last_rendered_range: RefCell::new(None).into(),
+            markdown_element: None,
         }
     }
 
@@ -556,10 +570,10 @@ impl CompletionsMenu {
     }
 
     fn render_aside(
-        &self,
-        style: &EditorStyle,
+        &mut self,
+        editor: &Editor,
         max_size: Size<Pixels>,
-        workspace: Option<WeakEntity<Workspace>>,
+        window: &mut Window,
         cx: &mut Context<Editor>,
     ) -> Option<AnyElement> {
         if !self.show_completion_documentation {
@@ -574,14 +588,33 @@ impl CompletionsMenu {
             CompletionDocumentation::MultiLinePlainText(text) => {
                 div().child(SharedString::from(text.clone()))
             }
-            CompletionDocumentation::MultiLineMarkdown(parsed) if !parsed.text.is_empty() => div()
-                .child(render_parsed_markdown(
-                    "completions_markdown",
-                    parsed,
-                    &style,
-                    workspace,
-                    cx,
-                )),
+            CompletionDocumentation::MultiLineMarkdown(parsed) if !parsed.is_empty() => {
+                let markdown = self.markdown_element.get_or_insert_with(|| {
+                    cx.new(|cx| {
+                        let languages = editor
+                            .workspace
+                            .as_ref()
+                            .and_then(|(workspace, _)| workspace.upgrade())
+                            .map(|workspace| workspace.read(cx).app_state().languages.clone());
+                        let language = editor
+                            .language_at(self.initial_position, cx)
+                            .map(|l| l.name().to_proto());
+                        Markdown::new(
+                            String::new(),
+                            hover_markdown_style(window, cx),
+                            languages,
+                            language,
+                            window,
+                            cx,
+                        )
+                        .open_url(open_markdown_url)
+                    })
+                });
+                markdown.update(cx, |markdown, cx| {
+                    markdown.reset(parsed.clone(), window, cx);
+                });
+                div().child(markdown.clone())
+            }
             CompletionDocumentation::MultiLineMarkdown(_) => return None,
             CompletionDocumentation::SingleLine(_) => return None,
             CompletionDocumentation::Undocumented => return None,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -608,6 +608,7 @@ impl CompletionsMenu {
                             window,
                             cx,
                         )
+                        .copy_code_block_buttons(false)
                         .open_url(open_markdown_url)
                     })
                 });

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -586,9 +586,7 @@ impl CompletionsMenu {
             .documentation
             .as_ref()?
         {
-            CompletionDocumentation::MultiLinePlainText(text) => {
-                div().child(SharedString::from(text.clone()))
-            }
+            CompletionDocumentation::MultiLinePlainText(text) => div().child(text.clone()),
             CompletionDocumentation::MultiLineMarkdown(parsed) if !parsed.is_empty() => {
                 let markdown = self.markdown_element.get_or_insert_with(|| {
                     cx.new(|cx| {
@@ -601,7 +599,7 @@ impl CompletionsMenu {
                             .language_at(self.initial_position, cx)
                             .map(|l| l.name().to_proto());
                         Markdown::new(
-                            String::new(),
+                            SharedString::default(),
                             hover_markdown_style(window, cx),
                             languages,
                             language,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -5,11 +5,12 @@ use gpui::{
     UniformListScrollHandle,
 };
 use language::Buffer;
-use language::{CodeLabel, CompletionDocumentation};
+use language::CodeLabel;
 use lsp::LanguageServerId;
 use markdown::Markdown;
 use multi_buffer::{Anchor, ExcerptId};
 use ordered_float::OrderedFloat;
+use project::lsp_store::CompletionDocumentation;
 use project::{CodeAction, Completion, TaskSourceKind};
 
 use std::{

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -99,9 +99,9 @@ use itertools::Itertools;
 use language::{
     language_settings::{self, all_language_settings, language_settings, InlayHintSettings},
     markdown, point_from_lsp, AutoindentMode, BracketPair, Buffer, Capability, CharKind, CodeLabel,
-    CompletionDocumentation, CursorShape, Diagnostic, DiskState, EditPredictionsMode, EditPreview,
-    HighlightedText, IndentKind, IndentSize, Language, OffsetRangeExt, Point, Selection,
-    SelectionGoal, TextObject, TransactionId, TreeSitterOptions,
+    CursorShape, Diagnostic, DiskState, EditPredictionsMode, EditPreview, HighlightedText,
+    IndentKind, IndentSize, Language, OffsetRangeExt, Point, Selection, SelectionGoal, TextObject,
+    TransactionId, TreeSitterOptions,
 };
 use language::{point_to_lsp, BufferRow, CharClassifier, Runnable, RunnableRange};
 use linked_editing_ranges::refresh_linked_ranges;
@@ -132,7 +132,7 @@ use multi_buffer::{
     ToOffsetUtf16,
 };
 use project::{
-    lsp_store::{FormatTrigger, LspFormatTarget, OpenLspBufferHandle},
+    lsp_store::{CompletionDocumentation, FormatTrigger, LspFormatTarget, OpenLspBufferHandle},
     project_settings::{GitGutterSetting, ProjectSettings},
     CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, Location, LocationLink,
     PrepareRenameResponse, Project, ProjectItem, ProjectTransaction, TaskSourceKind,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15674,7 +15674,7 @@ fn snippet_completions(
                     documentation: snippet
                         .description
                         .clone()
-                        .map(CompletionDocumentation::SingleLine),
+                        .map(|description| CompletionDocumentation::SingleLine(description.into())),
                     lsp_completion: lsp::CompletionItem {
                         label: snippet.prefix.first().unwrap().clone(),
                         kind: Some(CompletionItemKind::SNIPPET),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6220,19 +6220,14 @@ impl Editor {
     }
 
     fn render_context_menu_aside(
-        &self,
-        style: &EditorStyle,
+        &mut self,
         max_size: Size<Pixels>,
+        window: &mut Window,
         cx: &mut Context<Editor>,
     ) -> Option<AnyElement> {
-        self.context_menu.borrow().as_ref().and_then(|menu| {
+        self.context_menu.borrow_mut().as_mut().and_then(|menu| {
             if menu.visible() {
-                menu.render_aside(
-                    style,
-                    max_size,
-                    self.workspace.as_ref().map(|(w, _)| w.clone()),
-                    cx,
-                )
+                menu.render_aside(self, max_size, window, cx)
             } else {
                 None
             }
@@ -14925,8 +14920,14 @@ impl Editor {
         if !self.hover_state.focused(window, cx) {
             hide_hover(self, cx);
         }
-
-        self.hide_context_menu(window, cx);
+        if !self
+            .context_menu
+            .borrow()
+            .as_ref()
+            .is_some_and(|context_menu| context_menu.focused(window, cx))
+        {
+            self.hide_context_menu(window, cx);
+        }
         self.discard_inline_completion(false, cx);
         cx.emit(EditorEvent::Blurred);
         cx.notify();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3426,9 +3426,11 @@ impl EditorElement {
                 available_within_viewport.right - px(1.),
                 MENU_ASIDE_MAX_WIDTH,
             );
-            let Some(mut aside) =
-                self.render_context_menu_aside(size(max_width, max_height - POPOVER_Y_PADDING), cx)
-            else {
+            let Some(mut aside) = self.render_context_menu_aside(
+                size(max_width, max_height - POPOVER_Y_PADDING),
+                window,
+                cx,
+            ) else {
                 return;
             };
             aside.layout_as_root(AvailableSpace::min_size(), window, cx);
@@ -3450,7 +3452,7 @@ impl EditorElement {
                     ),
                 ) - POPOVER_Y_PADDING,
             );
-            let Some(mut aside) = self.render_context_menu_aside(max_size, cx) else {
+            let Some(mut aside) = self.render_context_menu_aside(max_size, window, cx) else {
                 return;
             };
             let actual_size = aside.layout_as_root(AvailableSpace::min_size(), window, cx);
@@ -3491,7 +3493,7 @@ impl EditorElement {
 
         // Skip drawing if it doesn't fit anywhere.
         if let Some((aside, position)) = positioned_aside {
-            window.defer_draw(aside, position, 1);
+            window.defer_draw(aside, position, 2);
         }
     }
 
@@ -3512,14 +3514,14 @@ impl EditorElement {
     fn render_context_menu_aside(
         &self,
         max_size: Size<Pixels>,
-
+        window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
         if max_size.width < px(100.) || max_size.height < px(12.) {
             None
         } else {
             self.editor.update(cx, |editor, cx| {
-                editor.render_context_menu_aside(&self.style, max_size, cx)
+                editor.render_context_menu_aside(max_size, window, cx)
             })
         }
     }

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -358,8 +358,15 @@ fn show_hover(
                             },
                             ..Default::default()
                         };
-                        Markdown::new_text(text, markdown_style.clone(), None, None, window, cx)
-                            .open_url(open_markdown_url)
+                        Markdown::new_text(
+                            SharedString::new(text),
+                            markdown_style.clone(),
+                            None,
+                            None,
+                            window,
+                            cx,
+                        )
+                        .open_url(open_markdown_url)
                     })
                     .ok();
 
@@ -562,7 +569,7 @@ async fn parse_blocks(
     let rendered_block = cx
         .new_window_entity(|window, cx| {
             Markdown::new(
-                combined_text,
+                combined_text.into(),
                 hover_markdown_style(window, cx),
                 Some(language_registry.clone()),
                 fallback_language_name,

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -641,7 +641,7 @@ pub fn open_markdown_url(link: SharedString, window: &mut Window, cx: &mut App) 
                         let Some(fragment) = uri.fragment() else {
                             return anyhow::Ok(());
                         };
-                        let mut accum = 0 as u32;
+                        let mut accum = 0u32;
                         for c in fragment.chars() {
                             if c >= '0' && c <= '9' && accum < u32::MAX / 2 {
                                 accum *= 10;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -230,44 +230,6 @@ pub struct Diagnostic {
     pub data: Option<Value>,
 }
 
-#[derive(Clone, Debug)]
-pub enum CompletionDocumentation {
-    /// There is no documentation for this completion.
-    Undocumented,
-    /// A single line of documentation.
-    SingleLine(String),
-    /// Multiple lines of plain text documentation.
-    MultiLinePlainText(String),
-    /// Markdown documentation.
-    MultiLineMarkdown(String),
-}
-
-impl From<lsp::Documentation> for CompletionDocumentation {
-    fn from(docs: lsp::Documentation) -> Self {
-        match docs {
-            lsp::Documentation::String(text) => {
-                if text.lines().count() <= 1 {
-                    CompletionDocumentation::SingleLine(text)
-                } else {
-                    CompletionDocumentation::MultiLinePlainText(text)
-                }
-            }
-
-            lsp::Documentation::MarkupContent(lsp::MarkupContent { kind, value }) => match kind {
-                lsp::MarkupKind::PlainText => {
-                    if value.lines().count() <= 1 {
-                        CompletionDocumentation::SingleLine(value)
-                    } else {
-                        CompletionDocumentation::MultiLinePlainText(value)
-                    }
-                }
-
-                lsp::MarkupKind::Markdown => CompletionDocumentation::MultiLineMarkdown(value),
-            },
-        }
-    }
-}
-
 /// An operation used to synchronize this buffer with its other replicas.
 #[derive(Clone, Debug, PartialEq)]
 pub enum Operation {

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -20,7 +20,6 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
-futures.workspace = true
 gpui.workspace = true
 language.workspace = true
 linkify.workspace = true

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -34,7 +34,7 @@ util.workspace = true
 assets.workspace = true
 env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
-languages.workspace = true
+languages = { workspace = true, features = ["load-grammars"] }
 node_runtime.workspace = true
 settings = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }

--- a/crates/markdown/examples/markdown.rs
+++ b/crates/markdown/examples/markdown.rs
@@ -89,7 +89,7 @@ pub fn main() {
                 };
 
                 MarkdownExample::new(
-                    MARKDOWN_EXAMPLE.to_string(),
+                    MARKDOWN_EXAMPLE.into(),
                     markdown_style,
                     language_registry,
                     window,
@@ -107,7 +107,7 @@ struct MarkdownExample {
 
 impl MarkdownExample {
     pub fn new(
-        text: String,
+        text: SharedString,
         style: MarkdownStyle,
         language_registry: Arc<LanguageRegistry>,
         window: &mut Window,

--- a/crates/markdown/examples/markdown.rs
+++ b/crates/markdown/examples/markdown.rs
@@ -15,84 +15,12 @@ const MARKDOWN_EXAMPLE: &str = r#"
 ## Headings
 Headings are created by adding one or more `#` symbols before your heading text. The number of `#` you use will determine the size of the heading.
 
-```rust
-gpui::window::ViewContext
-impl<'a, V> ViewContext<'a, V>
-pub fn on_blur(&mut self, handle: &FocusHandle, listener: impl FnMut(&mut V, &mut iewContext<V>) + 'static) -> Subscription
-where
-    // Bounds from impl:
-    V: 'static,
 ```
+function a(b: T) {
 
-## Emphasis
-Emphasis can be added with italics or bold. *This text will be italic*. _This will also be italic_
-
-## Lists
-
-### Unordered Lists
-Unordered lists use asterisks `*`, plus `+`, or minus `-` as list markers.
-
-* Item 1
-* Item 2
-  * Item 2a
-  * Item 2b
-
-### Ordered Lists
-Ordered lists use numbers followed by a period.
-
-1. Item 1
-2. Item 2
-3. Item 3
-   1. Item 3a
-   2. Item 3b
-
-## Links
-Links are created using the format [http://zed.dev](https://zed.dev).
-
-They can also be detected automatically, for example https://zed.dev/blog.
-
-They may contain dollar signs:
-
-[https://svelte.dev/docs/svelte/$state](https://svelte.dev/docs/svelte/$state)
-
-https://svelte.dev/docs/svelte/$state
-
-## Images
-Images are like links, but with an exclamation mark `!` in front.
-
-```markdown
-![This is an image](/images/logo.png)
-```
-
-## Code
-Inline `code` can be wrapped with backticks `` ` ``.
-
-```markdown
-Inline `code` has `back-ticks around` it.
-```
-
-Code blocks can be created by indenting lines by four spaces or with triple backticks ```.
-
-```javascript
-function test() {
-  console.log("notice the blank line before this function?");
 }
 ```
 
-## Blockquotes
-Blockquotes are created with `>`.
-
-> This is a blockquote.
-
-## Horizontal Rules
-Horizontal rules are created using three or more asterisks `***`, dashes `---`, or underscores `___`.
-
-## Line breaks
-This is a
-\
-line break!
-
----
 
 Remember, markdown processors may have slight differences and extensions, so always refer to the specific documentation or guides relevant to your platform or editor for the best practices and additional features.
 "#;
@@ -185,8 +113,16 @@ impl MarkdownExample {
         window: &mut Window,
         cx: &mut App,
     ) -> Self {
-        let markdown =
-            cx.new(|cx| Markdown::new(text, style, Some(language_registry), None, window, cx));
+        let markdown = cx.new(|cx| {
+            Markdown::new(
+                text,
+                style,
+                Some(language_registry),
+                Some("TypeScript".to_string()),
+                window,
+                cx,
+            )
+        });
         Self { markdown }
     }
 }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -201,9 +201,9 @@ impl Markdown {
                     languages: HashMap::default(),
                 });
             }
-            let (events, langauge_names) = parse_markdown(&text);
-            let mut languages = HashMap::with_capacity(langauge_names.len());
-            for name in langauge_names {
+            let (events, language_names) = parse_markdown(&text);
+            let mut languages = HashMap::with_capacity(language_names.len());
+            for name in language_names {
                 if let Some(registry) = language_registry.as_ref() {
                     let language = if !name.is_empty() {
                         registry.language_for_name(&name)

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -58,15 +58,15 @@ use gpui::{
 use itertools::Itertools;
 use language::{
     language_settings::InlayHintKind, proto::split_operations, Buffer, BufferEvent, Capability,
-    CodeLabel, CompletionDocumentation, File as _, Language, LanguageName, LanguageRegistry,
-    PointUtf16, ToOffset, ToPointUtf16, Toolchain, ToolchainList, Transaction, Unclipped,
+    CodeLabel, File as _, Language, LanguageName, LanguageRegistry, PointUtf16, ToOffset,
+    ToPointUtf16, Toolchain, ToolchainList, Transaction, Unclipped,
 };
 use lsp::{
     CodeActionKind, CompletionContext, CompletionItemKind, DocumentHighlightKind, LanguageServerId,
     LanguageServerName, MessageActionItem,
 };
 use lsp_command::*;
-use lsp_store::{LspFormatTarget, OpenLspBufferHandle};
+use lsp_store::{CompletionDocumentation, LspFormatTarget, OpenLspBufferHandle};
 use node_runtime::NodeRuntime;
 use parking_lot::Mutex;
 pub use prettier_store::PrettierStore;

--- a/crates/recent_projects/src/ssh_connections.rs
+++ b/crates/recent_projects/src/ssh_connections.rs
@@ -208,7 +208,7 @@ impl SshPrompt {
             ..Default::default()
         };
         let markdown =
-            cx.new(|cx| Markdown::new_text(prompt, markdown_style, None, None, window, cx));
+            cx.new(|cx| Markdown::new_text(prompt.into(), markdown_style, None, None, window, cx));
         self.prompt = Some((markdown, tx));
         self.status_message.take();
         window.focus(&self.editor.focus_handle(cx));

--- a/crates/zed/src/zed/linux_prompts.rs
+++ b/crates/zed/src/zed/linux_prompts.rs
@@ -1,7 +1,7 @@
 use gpui::{
     div, App, AppContext as _, Context, Entity, EventEmitter, FocusHandle, Focusable, FontWeight,
     InteractiveElement, IntoElement, ParentElement, PromptHandle, PromptLevel, PromptResponse,
-    Refineable, Render, RenderablePromptHandle, Styled, TextStyleRefinement, Window,
+    Refineable, Render, RenderablePromptHandle, SharedString, Styled, TextStyleRefinement, Window,
 };
 use markdown::{Markdown, MarkdownStyle};
 use settings::Settings;
@@ -48,7 +48,14 @@ pub fn fallback_prompt_renderer(
                         selection_background_color: { cx.theme().players().local().selection },
                         ..Default::default()
                     };
-                    Markdown::new(text.to_string(), markdown_style, None, None, window, cx)
+                    Markdown::new(
+                        SharedString::new(text),
+                        markdown_style,
+                        None,
+                        None,
+                        window,
+                        cx,
+                    )
                 })
             }),
         }


### PR DESCRIPTION
Closes #18641
Contributes: #13194

Release Notes:

- Open LSP documentation file links in Zed not the system opener
- Render completion documentation markdown consistently with documentation markdown
