### PR TITLE
Do not fail hard on selection persistence if the editor is removed

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2223,7 +2223,7 @@ impl Editor {
                         .collect();
                     DB.save_editor_selections(editor_id, workspace_id, selections)
                         .await
-                        .context("persisting editor selections")
+                        .with_context(|| format!("persisting editor selections for editor {editor_id}, workspace {workspace_id:?}"))
                         .log_err();
                 });
             }

--- a/crates/editor/src/persistence.rs
+++ b/crates/editor/src/persistence.rs
@@ -247,7 +247,7 @@ impl EditorDb {
                 r#"
 DELETE FROM editor_selections WHERE editor_id = ?1 AND workspace_id = ?2;
 
-INSERT INTO editor_selections (editor_id, workspace_id, start, end)
+INSERT OR IGNORE INTO editor_selections (editor_id, workspace_id, start, end)
 VALUES {placeholders};
 "#
             );


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/25083

Follows practices from editors' scroll position persisting: https://github.com/zed-industries/zed/blob/5a05b7461e476d7ddc59418868ebdab6687b8d2f/crates/editor/src/persistence.rs#L200 and do not fail hard if the editor with the ID given does not exist.
Also add the problematic IDs into the error context to see them in the error logs.

Release Notes:

- N/A
