### PR TITLE
language_model_selector: Authenticate all providers up front

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6960,12 +6960,14 @@ dependencies = [
 name = "language_model_selector"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "feature_flags",
  "gpui",
  "language_model",
  "picker",
  "proto",
  "ui",
+ "util",
  "workspace",
  "zed_actions",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6960,14 +6960,13 @@ dependencies = [
 name = "language_model_selector"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "feature_flags",
  "gpui",
  "language_model",
+ "log",
  "picker",
  "proto",
  "ui",
- "util",
  "workspace",
  "zed_actions",
 ]

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -12,11 +12,13 @@ workspace = true
 path = "src/language_model_selector.rs"
 
 [dependencies]
+anyhow.workspace = true
 feature_flags.workspace = true
 gpui.workspace = true
 language_model.workspace = true
 picker.workspace = true
 proto.workspace = true
 ui.workspace = true
+util.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -12,13 +12,12 @@ workspace = true
 path = "src/language_model_selector.rs"
 
 [dependencies]
-anyhow.workspace = true
 feature_flags.workspace = true
 gpui.workspace = true
 language_model.workspace = true
+log.workspace = true
 picker.workspace = true
 proto.workspace = true
 ui.workspace = true
-util.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true


### PR DESCRIPTION
This PR fixes an issue where configured language model providers would not show up unless the configuration view was opened.

The problem was that we were filtering unauthenticated language model providers out of the language model selector, but would only authenticate the active provider when the selector loaded. Authenticating the rest of the providers was deferred until the configuration view was opened for the first time.

Closes https://github.com/zed-industries/zed/issues/21821.

Release Notes:

- Fixed an issue where configured languages models were not showing up in the language model selector until the configuration view was opened for the first time.
