### PR TITLE
Highlight `super` and `this` as keywords in JS/TS/TSX

### DIFF
--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -1,3 +1,5 @@
+(identifier) @variable
+
 (type_identifier) @type
 (field_identifier) @variable.member
 

--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -59,8 +59,8 @@
 
 ; Literals
 
-(this) @variable.special
-(super) @variable.special
+(this) @keyword
+(super) @keyword
 
 [
   (null)

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -62,8 +62,8 @@
 
 ; Literals
 
-(this) @variable.special
-(super) @variable.special
+(this) @keyword
+(super) @keyword
 
 [
   (null)

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -77,8 +77,8 @@
 
 ; Literals
 
-(this) @variable.special
-(super) @variable.special
+(this) @keyword
+(super) @keyword
 
 [
   (null)


### PR DESCRIPTION
Closes #24951

We were highlighting both as `@variable.special` however, they are _techinically_ keywords and other editors (VSCode/WebStorm) seem to highlight them as keywords as well. 

Release Notes:

- N/A
