### PR TITLE
Fix for #25039

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -1546,7 +1546,9 @@ fn surrounding_markers(
         }
         // Adjust closing.start to exclude whitespace after a newline, if present
         if let Some(end) = last_newline_end {
-            closing.start = end;
+            if end > opening.end {
+                closing.start = end;
+            }
         }
     }
 


### PR DESCRIPTION
- Fixes: https://github.com/zed-industries/zed/issues/25039

Release Notes:

- vim: Fix crash in `ci{` 
