### PR TITLE
terminal: Handle shift+click selection

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1512,6 +1512,12 @@ impl Terminal {
                         _ => None,
                     };
 
+                    if selection_type == Some(SelectionType::Simple) && e.modifiers.shift {
+                        self.events
+                            .push_back(InternalEvent::UpdateSelection(position));
+                        return;
+                    }
+
                     let selection = selection_type
                         .map(|selection_type| Selection::new(selection_type, point, side));
 


### PR DESCRIPTION
Closes #16951

Handle the case where you click on the terminal while pressing Shift. 

Instead of setting a new selection head, we simply update the selection to that point. This allows you to repeatedly extend the selection to new points by pressing Shift while preserving the original selection head.

Preview:

Selection works in direct terminal, but doesn't on Vim like program, which is expected.

https://github.com/user-attachments/assets/e46987d8-a9a3-495d-8dd9-98d461317a8d


Release Notes:

- Added ability to extend selection with Shift + click in the terminal.
