### PR TITLE
Fix link to the PHP extension

### DIFF
--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -1,6 +1,6 @@
 # PHP
 
-PHP support is available through the [PHP extension](https://github.com/zed-industries/zed/tree/main/extensions/php).
+PHP support is available through the [PHP extension](https://github.com/zed-extensions/php).
 
 - Tree Sitter: https://github.com/tree-sitter/tree-sitter-php
 - Language Servers:


### PR DESCRIPTION
Fix broken links to [PHP extensions](https://github.com/zed-extensions/php) from [the documentation](https://zed.dev/docs/languages/php).

Release Notes:

- N/A

