### PR TITLE
editor: Do not highlight selected text + Clear highlight preemptively when new selection is detected 

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4782,6 +4782,15 @@ impl Editor {
             self.clear_background_highlights::<SelectedTextHighlight>(cx);
             return;
         }
+        if self.selections.count() != 1 || self.selections.line_mode {
+            self.clear_background_highlights::<SelectedTextHighlight>(cx);
+            return;
+        }
+        let selection = self.selections.newest::<Point>(cx);
+        if selection.is_empty() || selection.start.row != selection.end.row {
+            self.clear_background_highlights::<SelectedTextHighlight>(cx);
+            return;
+        }
         let debounce = EditorSettings::get_global(cx).selection_highlight_debounce;
         self.selection_highlight_task = Some(cx.spawn_in(window, |editor, mut cx| async move {
             cx.background_executor()


### PR DESCRIPTION
When selecting text, it highlights all matching occurences along with selected text itself. This causes highlight overlap, which looks bit odd. This PR fixes it.

Bonus:

Context: We have an edge case (which we already cover) where we don’t want to clear `SelectedTextHighlight` every time the selection changes. This happens when you are dragging the selection across some word, if you clear it directly on selection change, due to debounce wait, the highlight take some time to appear, which causes flickering for the user. We solve this by not clearing it directly but only clearing it when a new selection is found. This avoids the flicker.

However, we also need to clear the selection even before the debounce wait if we detect early on that the selection is different from previous ones. Otherwise, the user will have to wait until the debounce time to see it cleared on the screen.

The code for this is a little repetitive because we check the buffer state both before and after the debounce. But this is necessary.

---
Before:

Notice overlapping corners and selected text is bit darker in this case.
![image](https://github.com/user-attachments/assets/ec371079-b513-4216-9f6e-73d1aff99250)

After:
![image](https://github.com/user-attachments/assets/0fb9cd58-5d4b-49e8-91cb-78999c3a54a8)

Release Notes:

- N/A
