### PR TITLE
license detection: Include the UPL license

### DIFF
--- a/crates/zeta/src/license_detection.rs
+++ b/crates/zeta/src/license_detection.rs
@@ -5,7 +5,7 @@ pub const LICENSE_FILES_TO_CHECK: &[&str] = &["LICENSE", "LICENCE", "LICENSE.txt
 
 pub fn is_license_eligible_for_data_collection(license: &str) -> bool {
     // TODO: Include more licenses later (namely, Apache)
-    for pattern in [MIT_LICENSE_REGEX, ISC_LICENSE_REGEX] {
+    for pattern in [MIT_LICENSE_REGEX, ISC_LICENSE_REGEX, UPL_LICENSE_REGEX] {
         let regex = Regex::new(pattern.trim()).unwrap();
         if regex.is_match(license.trim()) {
             return true;
@@ -54,6 +54,44 @@ ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE\.$
+"#;
+
+const UPL_LICENSE_REGEX: &str = r#"
+Copyright.*?
+
+The Universal Permissive License.*?
+
+Subject to the condition set forth below, permission is hereby granted to any person
+obtaining a copy of this software, associated documentation and/or data \(collectively
+the "Software"\), free of charge and under any and all copyright rights in the
+Software, and any and all patent rights owned or freely licensable by each licensor
+hereunder covering either \(i\) the unmodified Software as contributed to or provided
+by such licensor, or \(ii\) the Larger Works \(as defined below\), to deal in both
+
+\(a\) the Software, and
+
+\(b\) any piece of software and/or hardware listed in the lrgrwrks\.txt file if one is
+    included with the Software \(each a "Larger Work" to which the Software is
+    contributed by such licensors\),
+
+without restriction, including without limitation the rights to copy, create
+derivative works of, display, perform, and distribute the Software and make, use,
+sell, offer for sale, import, export, have made, and have sold the Software and the
+Larger Work\(s\), and to sublicense the foregoing rights on either these or other
+terms\.
+
+This license is subject to the following condition:
+
+The above copyright notice and either this complete permission notice or at a minimum
+a reference to the UPL must be included in all copies or substantial portions of the
+Software\.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT\. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE\.$
 "#;
 
 #[cfg(test)]
@@ -202,6 +240,102 @@ mod tests {
                 WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
                 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
                 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+                This project is dual licensed under the ISC License and the MIT License.
+            "#
+            .trim(),
+        );
+
+        assert!(!is_license_eligible_for_data_collection(&example_license));
+    }
+
+    #[test]
+    fn test_upl_positive_detection() {
+        let example_license = unindent(
+            r#"
+                Copyright (c) 2025, John Doe
+
+                The Universal Permissive License (UPL), Version 1.0
+
+                Subject to the condition set forth below, permission is hereby granted to any person
+                obtaining a copy of this software, associated documentation and/or data (collectively
+                the "Software"), free of charge and under any and all copyright rights in the
+                Software, and any and all patent rights owned or freely licensable by each licensor
+                hereunder covering either (i) the unmodified Software as contributed to or provided
+                by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+
+                (a) the Software, and
+
+                (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is
+                    included with the Software (each a "Larger Work" to which the Software is
+                    contributed by such licensors),
+
+                without restriction, including without limitation the rights to copy, create
+                derivative works of, display, perform, and distribute the Software and make, use,
+                sell, offer for sale, import, export, have made, and have sold the Software and the
+                Larger Work(s), and to sublicense the foregoing rights on either these or other
+                terms.
+
+                This license is subject to the following condition:
+
+                The above copyright notice and either this complete permission notice or at a minimum
+                a reference to the UPL must be included in all copies or substantial portions of the
+                Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+                INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+                PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+                HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+                CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+                OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+            "#
+            .trim(),
+        );
+
+        assert!(is_license_eligible_for_data_collection(&example_license));
+    }
+
+    #[test]
+    fn test_upl_negative_detection() {
+        let example_license = unindent(
+            r#"
+                UPL License
+
+                Copyright (c) 2024, John Doe
+
+                The Universal Permissive License (UPL), Version 1.0
+
+                Subject to the condition set forth below, permission is hereby granted to any person
+                obtaining a copy of this software, associated documentation and/or data (collectively
+                the "Software"), free of charge and under any and all copyright rights in the
+                Software, and any and all patent rights owned or freely licensable by each licensor
+                hereunder covering either (i) the unmodified Software as contributed to or provided
+                by such licensor, or (ii) the Larger Works (as defined below), to deal in both
+
+                (a) the Software, and
+
+                (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if one is
+                    included with the Software (each a "Larger Work" to which the Software is
+                    contributed by such licensors),
+
+                without restriction, including without limitation the rights to copy, create
+                derivative works of, display, perform, and distribute the Software and make, use,
+                sell, offer for sale, import, export, have made, and have sold the Software and the
+                Larger Work(s), and to sublicense the foregoing rights on either these or other
+                terms.
+
+                This license is subject to the following condition:
+
+                The above copyright notice and either this complete permission notice or at a minimum
+                a reference to the UPL must be included in all copies or substantial portions of the
+                Software.
+
+                THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+                INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+                PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+                HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+                CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+                OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
                 This project is dual licensed under the ISC License and the MIT License.
             "#


### PR DESCRIPTION
For projects such as https://github.com/roc-lang/roc that uses this license.

Release Notes:

- N/A
