### PR TITLE
popover_menu: Add docs to the `trigger_with_tooltip` method

### DIFF
--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -178,6 +178,7 @@ impl<M: ManagedView> PopoverMenu<M> {
         self
     }
 
+    /// This method prevents the trigger button tooltip from being seen when the menu is open.
     pub fn trigger_with_tooltip<T: PopoverTrigger + ButtonCommon>(
         mut self,
         t: T,

--- a/crates/ui/src/components/popover_menu.rs
+++ b/crates/ui/src/components/popover_menu.rs
@@ -201,26 +201,26 @@ impl<M: ManagedView> PopoverMenu<M> {
         self
     }
 
-    /// anchor defines which corner of the menu to anchor to the attachment point
-    /// (by default the cursor position, but see attach)
+    /// Defines which corner of the menu to anchor to the attachment point.
+    /// By default, it uses the cursor position. Also see the `attach` method.
     pub fn anchor(mut self, anchor: Corner) -> Self {
         self.anchor = anchor;
         self
     }
 
-    /// attach defines which corner of the handle to attach the menu's anchor to
+    /// Defines which corner of the handle to attach the menu's anchor to.
     pub fn attach(mut self, attach: Corner) -> Self {
         self.attach = Some(attach);
         self
     }
 
-    /// offset offsets the position of the content by that many pixels.
+    /// Offsets the position of the content by that many pixels.
     pub fn offset(mut self, offset: Point<Pixels>) -> Self {
         self.offset = Some(offset);
         self
     }
 
-    /// attach something upon opening the menu
+    /// Attaches something upon opening the menu.
     pub fn on_open(mut self, on_open: Rc<dyn Fn(&mut Window, &mut App)>) -> Self {
         self.on_open = Some(on_open);
         self


### PR DESCRIPTION
Felt like this was relevant particularly as we're living with both `trigger` and `trigger_with_tooltip`. At some point, I believe there should be only one (`trigger_with_tooltip`) and that should be then renamed to just `trigger` back again! We're supporting both for now just for ease of migration/avoiding big changes.

Release Notes:

- N/A
