### PR TITLE
Revert "file_finder: Remove common segments of long paths in search results (#25049)"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -701,7 +701,6 @@ codegen-units = 16
 [workspace.lints.clippy]
 dbg_macro = "deny"
 todo = "deny"
-too_many_arguments = "allow"
 
 # Motivation: We use `vec![a..b]` a lot when dealing with ranges in text, so
 # warning on this rule produces a lot of noise.

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -387,6 +387,7 @@ impl InlineAssistant {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn suggest_assist(
         &mut self,
         editor: &Entity<Editor>,
@@ -1674,6 +1675,7 @@ impl Focusable for PromptEditor {
 impl PromptEditor {
     const MAX_LINES: u8 = 8;
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         id: InlineAssistId,
         gutter_dimensions: Arc<Mutex<GutterDimensions>>,
@@ -2332,6 +2334,7 @@ struct InlineAssist {
 }
 
 impl InlineAssist {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         assist_id: InlineAssistId,
         group_id: InlineAssistGroupId,

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -702,6 +702,7 @@ impl Focusable for PromptEditor {
 impl PromptEditor {
     const MAX_LINES: u8 = 8;
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         id: TerminalInlineAssistId,
         prompt_history: VecDeque<String>,

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -36,6 +36,7 @@ pub struct ContextStrip {
 }
 
 impl ContextStrip {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         context_store: Entity<ContextStore>,
         workspace: WeakEntity<Workspace>,

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -480,6 +480,7 @@ impl InlineAssistant {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn suggest_assist(
         &mut self,
         editor: &Entity<Editor>,
@@ -1450,6 +1451,7 @@ struct InlineAssistScrollLock {
 }
 
 impl EditorInlineAssists {
+    #[allow(clippy::too_many_arguments)]
     fn new(editor: &Entity<Editor>, window: &mut Window, cx: &mut App) -> Self {
         let (highlight_updates_tx, mut highlight_updates_rx) = async_watch::channel(());
         Self {
@@ -1561,6 +1563,7 @@ pub struct InlineAssist {
 }
 
 impl InlineAssist {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         assist_id: InlineAssistId,
         group_id: InlineAssistGroupId,

--- a/crates/assistant2/src/inline_prompt_editor.rs
+++ b/crates/assistant2/src/inline_prompt_editor.rs
@@ -823,6 +823,7 @@ impl InlineAssistId {
 }
 
 impl PromptEditor<BufferCodegen> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_buffer(
         id: InlineAssistId,
         gutter_dimensions: Arc<Mutex<GutterDimensions>>,
@@ -983,6 +984,7 @@ impl TerminalInlineAssistId {
 }
 
 impl PromptEditor<TerminalCodegen> {
+    #[allow(clippy::too_many_arguments)]
     pub fn new_terminal(
         id: TerminalInlineAssistId,
         prompt_history: VecDeque<String>,

--- a/crates/assistant_context_editor/src/context.rs
+++ b/crates/assistant_context_editor/src/context.rs
@@ -650,6 +650,7 @@ impl AssistantContext {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         id: ContextId,
         replica_id: ReplicaId,
@@ -770,6 +771,7 @@ impl AssistantContext {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn deserialize(
         saved_context: SavedContext,
         path: PathBuf,

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -517,6 +517,7 @@ impl ContextEditor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn run_command(
         &mut self,
         command_range: Range<language::Anchor>,
@@ -2057,6 +2058,7 @@ impl ContextEditor {
             .unwrap_or_else(|| Cow::Borrowed(DEFAULT_TAB_TITLE))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_patch_block(
         &mut self,
         range: Range<text::Anchor>,

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -136,6 +136,7 @@ impl SlashCommandCompletionProvider {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn complete_command_argument(
         &self,
         command_name: &str,

--- a/crates/assistant_slash_command/src/assistant_slash_command.rs
+++ b/crates/assistant_slash_command/src/assistant_slash_command.rs
@@ -88,7 +88,7 @@ pub trait SlashCommand: 'static + Send + Sync {
     fn accepts_arguments(&self) -> bool {
         self.requires_argument()
     }
-
+    #[allow(clippy::too_many_arguments)]
     fn run(
         self: Arc<Self>,
         arguments: &[String],

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -719,6 +719,7 @@ impl BufferDiff {
         Some(start..end)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn update_diff(
         this: Entity<BufferDiff>,
         buffer: text::BufferSnapshot,

--- a/crates/collab/src/db/queries/messages.rs
+++ b/crates/collab/src/db/queries/messages.rs
@@ -229,6 +229,7 @@ impl Database {
     }
 
     /// Creates a new channel message.
+    #[allow(clippy::too_many_arguments)]
     pub async fn create_channel_message(
         &self,
         channel_id: ChannelId,

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -122,6 +122,7 @@ impl Database {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn get_or_create_user_by_github_account_tx(
         &self,
         github_login: &str,

--- a/crates/collab/src/llm/db/queries/usages.rs
+++ b/crates/collab/src/llm/db/queries/usages.rs
@@ -289,6 +289,7 @@ impl LlmDatabase {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn record_usage(
         &self,
         user_id: UserId,
@@ -553,6 +554,7 @@ impl LlmDatabase {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn update_usage_for_measure(
         &self,
         user_id: UserId,

--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -33,6 +33,7 @@ pub struct LlmTokenClaims {
 const LLM_TOKEN_LIFETIME: Duration = Duration::from_secs(60 * 60);
 
 impl LlmTokenClaims {
+    #[allow(clippy::too_many_arguments)]
     pub fn create(
         user: &user::Model,
         is_staff: bool,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -691,6 +691,7 @@ impl Server {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn handle_connection(
         self: &Arc<Self>,
         connection: Connection,
@@ -1074,6 +1075,7 @@ pub fn routes(server: Arc<Server>) -> Router<(), Body> {
         .layer(Extension(server))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn handle_websocket_request(
     TypedHeader(ProtocolVersion(protocol_version)): TypedHeader<ProtocolVersion>,
     app_version_header: Option<TypedHeader<AppVersionHeader>>,

--- a/crates/collab/src/tests/randomized_test_helpers.rs
+++ b/crates/collab/src/tests/randomized_test_helpers.rs
@@ -463,6 +463,7 @@ impl<T: RandomizedTest> TestPlan<T> {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn apply_server_operation(
         plan: Arc<Mutex<Self>>,
         deterministic: BackgroundExecutor,

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -869,6 +869,7 @@ impl CollabPanel {
             })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_participant_project(
         &self,
         project_id: u64,

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -113,6 +113,7 @@ pub struct DisplayMap {
 }
 
 impl DisplayMap {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         buffer: Entity<MultiBuffer>,
         font: Font,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -723,6 +723,7 @@ impl BlockMap {
         self.show_excerpt_controls
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn header_and_footer_blocks<'a, R, T>(
         show_excerpt_controls: bool,
         excerpt_footer_height: u32,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5934,6 +5934,7 @@ impl Editor {
         editor_bg_color.blend(accent_color.opacity(0.1))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_edit_prediction_cursor_popover(
         &self,
         min_width: Pixels,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -931,6 +931,7 @@ impl EditorElement {
         cx.notify()
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_selections(
         &self,
         start_anchor: Anchor,
@@ -1102,6 +1103,7 @@ impl EditorElement {
         cursors
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_visible_cursors(
         &self,
         snapshot: &EditorSnapshot,
@@ -1451,6 +1453,7 @@ impl EditorElement {
         axis_pair(horizontal_scrollbar, vertical_scrollbar)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn prepaint_crease_toggles(
         &self,
         crease_toggles: &mut [Option<AnyElement>],
@@ -1485,6 +1488,7 @@ impl EditorElement {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn prepaint_crease_trailers(
         &self,
         trailers: Vec<Option<AnyElement>>,
@@ -1600,6 +1604,7 @@ impl EditorElement {
         display_hunks
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_inline_blame(
         &self,
         display_row: DisplayRow,
@@ -1686,6 +1691,7 @@ impl EditorElement {
         Some(element)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_blame_entries(
         &self,
         buffer_rows: &[RowInfo],
@@ -1754,6 +1760,7 @@ impl EditorElement {
         Some(shaped_lines)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_indent_guides(
         &self,
         content_origin: gpui::Point<Pixels>,
@@ -1871,6 +1878,7 @@ impl EditorElement {
         (offset_y, length)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_run_indicators(
         &self,
         line_height: Pixels,
@@ -1963,6 +1971,7 @@ impl EditorElement {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_code_actions_indicator(
         &self,
         line_height: Pixels,
@@ -2061,6 +2070,7 @@ impl EditorElement {
         relative_rows
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_line_numbers(
         &self,
         gutter_hitbox: Option<&Hitbox>,
@@ -2273,6 +2283,7 @@ impl EditorElement {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn prepaint_lines(
         &self,
         start_row: DisplayRow,
@@ -2299,6 +2310,7 @@ impl EditorElement {
         line_elements
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_block(
         &self,
         block: &Block,
@@ -2760,6 +2772,7 @@ impl EditorElement {
         }))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_blocks(
         &self,
         rows: Range<DisplayRow>,
@@ -2944,6 +2957,7 @@ impl EditorElement {
 
     /// Returns true if any of the blocks changed size since the previous frame. This will trigger
     /// a restart of rendering for the editor based on the new sizes.
+    #[allow(clippy::too_many_arguments)]
     fn layout_blocks(
         &self,
         blocks: &mut Vec<BlockLayout>,
@@ -2987,6 +3001,7 @@ impl EditorElement {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_sticky_buffer_header(
         &self,
         StickyHeaderExcerpt {
@@ -3061,6 +3076,7 @@ impl EditorElement {
         header
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_cursor_popovers(
         &self,
         line_height: Pixels,
@@ -3249,6 +3265,7 @@ impl EditorElement {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_gutter_menu(
         &self,
         line_height: Pixels,
@@ -3301,6 +3318,7 @@ impl EditorElement {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_popovers_above_or_below_line(
         &self,
         target_position: gpui::Point<Pixels>,
@@ -3405,6 +3423,7 @@ impl EditorElement {
         Some((laid_out_popovers, y_flipped))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_context_menu_aside(
         &self,
         y_flipped: bool,
@@ -3526,6 +3545,7 @@ impl EditorElement {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_edit_prediction_popover(
         &self,
         text_bounds: &Bounds<Pixels>,
@@ -3982,6 +4002,7 @@ impl EditorElement {
         Some(element)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_hover_popovers(
         &self,
         snapshot: &EditorSnapshot,
@@ -4098,6 +4119,7 @@ impl EditorElement {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_diff_hunk_controls(
         &self,
         row_range: Range<DisplayRow>,
@@ -4178,6 +4200,7 @@ impl EditorElement {
         controls
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn layout_signature_help(
         &self,
         hitbox: &Hitbox,
@@ -5416,6 +5439,7 @@ impl EditorElement {
         });
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn paint_highlighted_range(
         &self,
         range: Range<DisplayPoint>,
@@ -5830,6 +5854,7 @@ impl AcceptEditPredictionBinding {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn prepaint_gutter_button(
     button: IconButton,
     row: DisplayRow,
@@ -6069,6 +6094,7 @@ impl fmt::Debug for LineFragment {
 }
 
 impl LineWithInvisibles {
+    #[allow(clippy::too_many_arguments)]
     fn from_chunks<'a>(
         chunks: impl Iterator<Item = HighlightedChunk<'a>>,
         editor_style: &EditorStyle,
@@ -6273,6 +6299,7 @@ impl LineWithInvisibles {
         layouts
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn prepaint(
         &mut self,
         line_height: Pixels,
@@ -6307,6 +6334,7 @@ impl LineWithInvisibles {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw(
         &self,
         layout: &EditorLayout,
@@ -6350,6 +6378,7 @@ impl LineWithInvisibles {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn draw_invisibles(
         &self,
         selection_ranges: &[Range<DisplayPoint>],
@@ -7679,6 +7708,7 @@ struct ScrollbarRangeData {
 }
 
 impl ScrollbarRangeData {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         scrollbar_bounds: Bounds<Pixels>,
         letter_size: Size<Pixels>,

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -224,6 +224,7 @@ impl ScrollManager {
         self.anchor.scroll_position(snapshot)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn set_scroll_position(
         &mut self,
         scroll_position: gpui::Point<f32>,
@@ -298,6 +299,7 @@ impl ScrollManager {
         );
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn set_anchor(
         &mut self,
         anchor: ScrollAnchor,

--- a/crates/evals/src/eval.rs
+++ b/crates/evals/src/eval.rs
@@ -399,6 +399,7 @@ async fn run_evaluation(
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn run_eval_project(
     evaluation_project: EvaluationProject,
     user_store: &Entity<UserStore>,

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -191,7 +191,7 @@ static mut EXTENSION: Option<Box<dyn Extension>> = None;
 pub static ZED_API_VERSION: [u8; 6] = *include_bytes!(concat!(env!("OUT_DIR"), "/version_bytes"));
 
 mod wit {
-    #![allow(clippy::missing_safety_doc)]
+    #![allow(clippy::too_many_arguments, clippy::missing_safety_doc)]
 
     wit_bindgen::generate!({
         skip: ["init-extension"],

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -218,6 +218,7 @@ impl ExtensionStore {
         cx.global::<GlobalExtensionStore>().0.clone()
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         extensions_dir: PathBuf,
         build_dir: Option<PathBuf>,

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -25,7 +25,6 @@ use project::{PathMatchCandidateSet, Project, ProjectPath, WorktreeId};
 use settings::Settings;
 use std::{
     cmp,
-    ops::Range,
     path::{Path, PathBuf},
     sync::{
         atomic::{self, AtomicBool},
@@ -382,7 +381,6 @@ impl PartialOrd for ProjectPanelOrdMatch {
 struct Matches {
     separate_history: bool,
     matches: Vec<Match>,
-    elided_byte_range: Option<Range<usize>>,
 }
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
@@ -392,35 +390,6 @@ enum Match {
         panel_match: Option<ProjectPanelOrdMatch>,
     },
     Search(ProjectPanelOrdMatch),
-}
-
-struct MatchLabels {
-    path: String,
-    path_positions: Vec<usize>,
-    file_name: String,
-    file_name_positions: Vec<usize>,
-}
-
-#[derive(Clone, Copy, Debug)]
-struct EmWidths {
-    normal: Pixels,
-    small: Pixels,
-}
-
-fn em_widths(window: &mut Window, cx: &mut App) -> EmWidths {
-    let style = window.text_style();
-    let font_id = window.text_system().resolve_font(&style.font());
-    let font_size = TextSize::Default.rems(cx).to_pixels(window.rem_size());
-    let normal = cx
-        .text_system()
-        .em_width(font_id, font_size)
-        .unwrap_or(px(16.));
-    let font_size = TextSize::Small.rems(cx).to_pixels(window.rem_size());
-    let small = cx
-        .text_system()
-        .em_width(font_id, font_size)
-        .unwrap_or(px(10.));
-    EmWidths { normal, small }
 }
 
 impl Match {
@@ -436,43 +405,6 @@ impl Match {
             Match::History { panel_match, .. } => panel_match.as_ref(),
             Match::Search(panel_match) => Some(&panel_match),
         }
-    }
-
-    fn common_prefix<'a>(&self, other: &'a Path) -> &'a Path {
-        let mut prefix = other;
-        let path_positions = match self {
-            Match::History {
-                panel_match: Some(mat),
-                ..
-            }
-            | Match::Search(mat) => mat.0.positions.as_slice(),
-            Match::History {
-                panel_match: None, ..
-            } => &[],
-        };
-        let first_path_position = *path_positions.iter().min().unwrap_or(&0);
-        while self.path().strip_prefix(prefix).is_err()
-            || prefix.to_string_lossy().len() > first_path_position
-        {
-            let Some(parent) = prefix.parent() else {
-                break;
-            };
-            prefix = parent;
-        }
-        prefix
-    }
-
-    fn approx_width(&self, em_widths: EmWidths) -> Pixels {
-        let file_name = self.path().file_name().map_or_else(
-            || self.path().to_string_lossy(),
-            |file_name| file_name.to_string_lossy(),
-        );
-        let parent = self
-            .path()
-            .parent()
-            .map_or_else(|| "".into(), |parent| parent.to_string_lossy());
-        px(file_name.chars().count() as f32) * em_widths.normal
-            + px(parent.chars().count() as f32) * em_widths.small
     }
 }
 
@@ -519,11 +451,7 @@ impl Matches {
         query: Option<&FileSearchQuery>,
         new_search_matches: impl Iterator<Item = ProjectPanelOrdMatch>,
         extend_old_matches: bool,
-        em_widths: EmWidths,
-        max_width: Pixels,
     ) {
-        self.elided_byte_range = None;
-
         let Some(query) = query else {
             // assuming that if there's no query, then there's no search matches.
             self.matches.clear();
@@ -579,31 +507,6 @@ impl Matches {
                 }
             }
         }
-
-        let Some((first, rest)) = self.matches.split_first() else {
-            return;
-        };
-        let mut prefix = first.path().as_ref();
-        let mut widest_match = first.approx_width(em_widths);
-        for mat in rest {
-            widest_match = widest_match.max(mat.approx_width(em_widths));
-            prefix = mat.common_prefix(prefix);
-        }
-
-        if widest_match > max_width {
-            let components = prefix.components().collect::<Vec<_>>();
-            let prefix = prefix.to_string_lossy();
-            if components.len() > 3 {
-                let after_first = components[1..].iter().collect::<PathBuf>();
-                let after_first = after_first.to_string_lossy();
-                let start = prefix.len() - after_first.len();
-                let after_first_before_last = components[1..components.len() - 2]
-                    .iter()
-                    .collect::<PathBuf>();
-                let after_first_before_last = after_first_before_last.to_string_lossy();
-                self.elided_byte_range = Some(start..start + after_first_before_last.len());
-            }
-        }
     }
 
     /// If a < b, then a is a worse match, aligning with the `ProjectPanelOrdMatch` ordering.
@@ -628,25 +531,6 @@ impl Matches {
             (Match::Search(_), Match::History { .. }) if separate_history => cmp::Ordering::Less,
 
             _ => a.panel_match().cmp(&b.panel_match()),
-        }
-    }
-}
-
-impl MatchLabels {
-    fn check(&self) {
-        let file_name = &self.file_name;
-        for i in &self.file_name_positions {
-            assert!(
-                self.file_name.is_char_boundary(*i),
-                "{i} is not a valid char boundary in file name {file_name:?}"
-            );
-        }
-        let path = &self.path;
-        for i in &self.path_positions {
-            assert!(
-                self.path.is_char_boundary(*i),
-                "{i} is not a valid char boundary in path {path:?}"
-            );
         }
     }
 }
@@ -760,6 +644,7 @@ impl FileSearchQuery {
 }
 
 impl FileFinderDelegate {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         file_finder: WeakEntity<FileFinder>,
         workspace: WeakEntity<Workspace>,
@@ -860,10 +745,10 @@ impl FileFinderDelegate {
             .map(ProjectPanelOrdMatch);
             let did_cancel = cancel_flag.load(atomic::Ordering::Relaxed);
             picker
-                .update_in(&mut cx, |picker, window, cx| {
+                .update(&mut cx, |picker, cx| {
                     picker
                         .delegate
-                        .set_search_matches(search_id, did_cancel, query, matches, window, cx)
+                        .set_search_matches(search_id, did_cancel, query, matches, cx)
                 })
                 .log_err();
         })
@@ -875,13 +760,9 @@ impl FileFinderDelegate {
         did_cancel: bool,
         query: FileSearchQuery,
         matches: impl IntoIterator<Item = ProjectPanelOrdMatch>,
-        window: &mut Window,
+
         cx: &mut Context<Picker<Self>>,
     ) {
-        let em_widths = em_widths(window, cx);
-        let file_finder_settings = FileFinderSettings::get_global(cx);
-        let max_width = FileFinder::modal_max_width(file_finder_settings.modal_max_width, window);
-
         if search_id >= self.latest_search_id {
             self.latest_search_id = search_id;
             let query_changed = Some(query.path_query())
@@ -903,8 +784,6 @@ impl FileFinderDelegate {
                 Some(&query),
                 matches.into_iter(),
                 extend_old_matches,
-                em_widths,
-                max_width,
             );
 
             self.selected_index = selected_match.map_or_else(
@@ -923,8 +802,13 @@ impl FileFinderDelegate {
         }
     }
 
-    fn labels_for_match(&self, path_match: &Match, cx: &App, ix: usize) -> MatchLabels {
-        let mut labels = match &path_match {
+    fn labels_for_match(
+        &self,
+        path_match: &Match,
+        cx: &App,
+        ix: usize,
+    ) -> (String, Vec<usize>, String, Vec<usize>) {
+        let (file_name, file_name_positions, full_path, full_path_positions) = match &path_match {
             Match::History {
                 path: entry_path,
                 panel_match,
@@ -939,18 +823,18 @@ impl FileFinderDelegate {
 
                 if !has_worktree {
                     if let Some(absolute_path) = &entry_path.absolute {
-                        return MatchLabels {
-                            file_name: absolute_path
+                        return (
+                            absolute_path
                                 .file_name()
                                 .map_or_else(
                                     || project_relative_path.to_string_lossy(),
                                     |file_name| file_name.to_string_lossy(),
                                 )
                                 .to_string(),
-                            file_name_positions: Vec::new(),
-                            path: absolute_path.to_string_lossy().to_string(),
-                            path_positions: Vec::new(),
-                        };
+                            Vec::new(),
+                            absolute_path.to_string_lossy().to_string(),
+                            Vec::new(),
+                        );
                     }
                 }
 
@@ -981,39 +865,44 @@ impl FileFinderDelegate {
             Match::Search(path_match) => self.labels_for_path_match(&path_match.0),
         };
 
-        if labels.file_name_positions.is_empty() {
+        if file_name_positions.is_empty() {
             if let Some(user_home_path) = std::env::var("HOME").ok() {
                 let user_home_path = user_home_path.trim();
                 if !user_home_path.is_empty() {
-                    if labels.path.starts_with(user_home_path) {
-                        labels.path.replace_range(0..user_home_path.len(), "~");
-                        labels.path_positions.retain_mut(|position| {
-                            if *position >= user_home_path.len() {
-                                *position -= user_home_path.len();
-                                *position += 1;
-                                true
-                            } else {
-                                false
-                            }
-                        })
+                    if (&full_path).starts_with(user_home_path) {
+                        return (
+                            file_name,
+                            file_name_positions,
+                            full_path.replace(user_home_path, "~"),
+                            full_path_positions,
+                        );
                     }
                 }
             }
         }
 
-        labels.check();
-        labels
+        (
+            file_name,
+            file_name_positions,
+            full_path,
+            full_path_positions,
+        )
     }
 
-    fn labels_for_path_match(&self, path_match: &PathMatch) -> MatchLabels {
+    fn labels_for_path_match(
+        &self,
+        path_match: &PathMatch,
+    ) -> (String, Vec<usize>, String, Vec<usize>) {
+        let path = &path_match.path;
+        let path_string = path.to_string_lossy();
+        let full_path = [path_match.path_prefix.as_ref(), path_string.as_ref()].join("");
         let mut path_positions = path_match.positions.clone();
 
-        let file_name = path_match.path.file_name().map_or_else(
+        let file_name = path.file_name().map_or_else(
             || path_match.path_prefix.to_string(),
             |file_name| file_name.to_string_lossy().to_string(),
         );
-        let mut path = path_match.path.to_string_lossy().to_string();
-        let file_name_start = path_match.path_prefix.len() + path.len() - file_name.len();
+        let file_name_start = path_match.path_prefix.len() + path_string.len() - file_name.len();
         let file_name_positions = path_positions
             .iter()
             .filter_map(|pos| {
@@ -1025,31 +914,10 @@ impl FileFinderDelegate {
             })
             .collect();
 
-        path.drain(file_name_start.saturating_sub(path_match.path_prefix.len())..);
-        path_positions.retain_mut(|idx| {
-            if *idx < path.len() {
-                if let Some(elided_range) = &self.matches.elided_byte_range {
-                    if *idx >= elided_range.end {
-                        *idx += '…'.len_utf8();
-                        *idx -= elided_range.len();
-                    }
-                }
-                true
-            } else {
-                false
-            }
-        });
+        let full_path = full_path.trim_end_matches(&file_name).to_string();
+        path_positions.retain(|idx| *idx < full_path.len());
 
-        if let Some(elided_range) = &self.matches.elided_byte_range {
-            path.replace_range(elided_range.clone(), "…");
-        }
-
-        MatchLabels {
-            file_name,
-            file_name_positions,
-            path,
-            path_positions,
-        }
+        (file_name, file_name_positions, full_path, path_positions)
     }
 
     fn lookup_absolute_path(
@@ -1101,17 +969,10 @@ impl FileFinderDelegate {
             }
 
             picker
-                .update_in(&mut cx, |picker, window, cx| {
+                .update_in(&mut cx, |picker, _, cx| {
                     let picker_delegate = &mut picker.delegate;
                     let search_id = util::post_inc(&mut picker_delegate.search_count);
-                    picker_delegate.set_search_matches(
-                        search_id,
-                        false,
-                        query,
-                        path_matches,
-                        window,
-                        cx,
-                    );
+                    picker_delegate.set_search_matches(search_id, false, query, path_matches, cx);
 
                     anyhow::Ok(())
                 })
@@ -1188,10 +1049,6 @@ impl PickerDelegate for FileFinderDelegate {
         window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Task<()> {
-        let em_widths = em_widths(window, cx);
-        let file_finder_settings = FileFinderSettings::get_global(cx);
-        let max_width = FileFinder::modal_max_width(file_finder_settings.modal_max_width, window);
-
         let raw_query = raw_query.replace(' ', "");
         let raw_query = raw_query.trim();
         if raw_query.is_empty() {
@@ -1219,8 +1076,6 @@ impl PickerDelegate for FileFinderDelegate {
                     None,
                     None.into_iter(),
                     false,
-                    em_widths,
-                    max_width,
                 );
 
                 self.first_update = false;
@@ -1414,10 +1269,11 @@ impl PickerDelegate for FileFinderDelegate {
                 .size(IconSize::Small.rems())
                 .into_any_element(),
         };
-        let labels = self.labels_for_match(path_match, cx, ix);
+        let (file_name, file_name_positions, full_path, full_path_positions) =
+            self.labels_for_match(path_match, cx, ix);
 
         let file_icon = if settings.file_icons {
-            FileIcons::get_icon(Path::new(&labels.file_name), cx)
+            FileIcons::get_icon(Path::new(&file_name), cx)
                 .map(Icon::from_path)
                 .map(|icon| icon.color(Color::Muted))
         } else {
@@ -1435,12 +1291,9 @@ impl PickerDelegate for FileFinderDelegate {
                     h_flex()
                         .gap_2()
                         .py_px()
-                        .child(HighlightedLabel::new(
-                            labels.file_name,
-                            labels.file_name_positions,
-                        ))
+                        .child(HighlightedLabel::new(file_name, file_name_positions))
                         .child(
-                            HighlightedLabel::new(labels.path, labels.path_positions)
+                            HighlightedLabel::new(full_path, full_path_positions)
                                 .size(LabelSize::Small)
                                 .color(Color::Muted),
                         ),

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -384,7 +384,6 @@ async fn test_matching_cancellation(cx: &mut TestAppContext) {
                 ProjectPanelOrdMatch(matches[1].clone()),
                 ProjectPanelOrdMatch(matches[3].clone()),
             ],
-            window,
             cx,
         );
 
@@ -399,7 +398,6 @@ async fn test_matching_cancellation(cx: &mut TestAppContext) {
                 ProjectPanelOrdMatch(matches[2].clone()),
                 ProjectPanelOrdMatch(matches[3].clone()),
             ],
-            window,
             cx,
         );
 
@@ -494,11 +492,12 @@ async fn test_single_file_worktrees(cx: &mut TestAppContext) {
         let matches = collect_search_matches(picker).search_matches_only();
         assert_eq!(matches.len(), 1);
 
-        let labels = delegate.labels_for_path_match(&matches[0]);
-        assert_eq!(labels.file_name, "the-file");
-        assert_eq!(labels.file_name_positions, &[0, 1, 4]);
-        assert_eq!(labels.path, "");
-        assert_eq!(labels.path_positions, &[0; 0]);
+        let (file_name, file_name_positions, full_path, full_path_positions) =
+            delegate.labels_for_path_match(&matches[0]);
+        assert_eq!(file_name, "the-file");
+        assert_eq!(file_name_positions, &[0, 1, 4]);
+        assert_eq!(full_path, "");
+        assert_eq!(full_path_positions, &[0; 0]);
     });
 
     // Since the worktree root is a file, searching for its name followed by a slash does

--- a/crates/fuzzy/src/matcher.rs
+++ b/crates/fuzzy/src/matcher.rs
@@ -164,6 +164,7 @@ impl<'a> Matcher<'a> {
         score
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn recursive_score_match(
         &mut self,
         path: &[char],

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -115,6 +115,7 @@ pub struct WaylandWindowStatePtr {
 }
 
 impl WaylandWindowState {
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         handle: AnyWindowHandle,
         surface: wl_surface::WlSurface,

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -353,6 +353,7 @@ where
 }
 
 impl X11WindowState {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         handle: AnyWindowHandle,
         client: X11ClientStatePtr,
@@ -711,6 +712,7 @@ enum WmHintPropertyState {
 }
 
 impl X11Window {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         handle: AnyWindowHandle,
         client: X11ClientStatePtr,

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -132,6 +132,7 @@ impl WrappedLine {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn paint_line(
     origin: Point<Pixels>,
     layout: &LineLayout,

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1250,6 +1250,7 @@ fn parse_text(
     })
 }
 
+#[allow(clippy::too_many_arguments)]
 fn get_injections(
     config: &InjectionConfig,
     text: &BufferSnapshot,

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -393,6 +393,7 @@ impl LanguageServer {
         Ok(server)
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new_internal<Stdin, Stdout, Stderr, F>(
         server_id: LanguageServerId,
         server_name: LanguageServerName,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2902,6 +2902,7 @@ impl MultiBuffer {
         snapshot.check_invariants();
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn recompute_diff_transforms_for_edit(
         &self,
         edit: &Edit<TypedOffset<Excerpt>>,

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2360,6 +2360,7 @@ impl OutlinePanel {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_search_match(
         &mut self,
         multi_buffer_snapshot: Option<&MultiBufferSnapshot>,
@@ -2451,6 +2452,7 @@ impl OutlinePanel {
         ))
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn entry_element(
         &self,
         rendered_entry: PanelEntry,
@@ -3834,6 +3836,7 @@ impl OutlinePanel {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn push_entry(
         &self,
         state: &mut GenerationState,
@@ -4051,6 +4054,7 @@ impl OutlinePanel {
         update_cached_entries
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_excerpt_entries(
         &self,
         state: &mut GenerationState,
@@ -4109,6 +4113,7 @@ impl OutlinePanel {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn add_search_entries(
         &mut self,
         state: &mut GenerationState,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1201,6 +1201,7 @@ impl LocalLspStore {
         Ok(project_transaction)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn execute_formatters(
         lsp_store: WeakEntity<LspStore>,
         formatters: &[Formatter],
@@ -1450,6 +1451,7 @@ impl LocalLspStore {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn format_via_lsp(
         this: &WeakEntity<LspStore>,
         buffer: &Entity<Buffer>,
@@ -2958,6 +2960,7 @@ impl LspStore {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new_local(
         buffer_store: Entity<BufferStore>,
         worktree_store: Entity<WorktreeStore>,
@@ -3051,6 +3054,7 @@ impl LspStore {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn new_remote(
         buffer_store: Entity<BufferStore>,
         worktree_store: Entity<WorktreeStore>,
@@ -4462,6 +4466,7 @@ impl LspStore {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn resolve_completion_remote(
         project_id: u64,
         server_id: LanguageServerId,
@@ -7514,6 +7519,7 @@ impl LspStore {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn insert_newly_running_language_server(
         &mut self,
         adapter: Arc<CachedLspAdapter>,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -971,6 +971,7 @@ impl Project {
         .await
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn from_join_project_response(
         response: TypedEnvelope<proto::JoinProjectResponse>,
         subscriptions: [EntitySubscription; 5],

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1279,6 +1279,7 @@ impl From<SshRemoteClient> for AnyProtoClient {
 
 #[async_trait(?Send)]
 trait RemoteConnection: Send + Sync {
+    #[allow(clippy::too_many_arguments)]
     fn start_proxy(
         &self,
         unique_identifier: String,

--- a/crates/rich_text/src/rich_text.rs
+++ b/crates/rich_text/src/rich_text.rs
@@ -175,6 +175,7 @@ impl RichText {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn render_markdown_mut(
     block: &str,
     mut mentions: &[Mention],

--- a/crates/semantic_index/src/worktree_index.rs
+++ b/crates/semantic_index/src/worktree_index.rs
@@ -116,6 +116,7 @@ impl WorktreeIndex {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         worktree: Entity<Worktree>,
         db_connection: heed::Env,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -325,6 +325,7 @@ pub struct TerminalBuilder {
 }
 
 impl TerminalBuilder {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         working_directory: Option<PathBuf>,
         python_venv_directory: Option<PathBuf>,

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -171,6 +171,7 @@ impl InteractiveElement for TerminalElement {
 impl StatefulInteractiveElement for TerminalElement {}
 
 impl TerminalElement {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         terminal: Entity<Terminal>,
         terminal_view: Entity<TerminalView>,

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -191,6 +191,7 @@ impl TitleBar {
             )
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render_collaborator(
         &self,
         user: &Arc<User>,

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -85,6 +85,7 @@ impl ToolchainSelector {
         Some(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn new(
         workspace: WeakEntity<Workspace>,
         project: Entity<Project>,
@@ -142,6 +143,7 @@ pub struct ToolchainSelectorDelegate {
 }
 
 impl ToolchainSelectorDelegate {
+    #[allow(clippy::too_many_arguments)]
     fn new(
         active_toolchain: Option<Toolchain>,
         toolchain_selector: WeakEntity<ToolchainSelector>,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -843,6 +843,7 @@ impl Pane {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub(crate) fn open_item(
         &mut self,
         project_entry_id: Option<ProjectEntryId>,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -122,6 +122,7 @@ impl PaneGroup {
         };
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         &self,
         project: &Entity<Project>,
@@ -227,6 +228,7 @@ impl Member {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn render(
         &self,
         project: &Entity<Project>,
@@ -676,6 +678,7 @@ impl PaneAxis {
         None
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn render(
         &self,
         project: &Entity<Project>,
@@ -879,6 +882,7 @@ mod element {
             self
         }
 
+        #[allow(clippy::too_many_arguments)]
         fn compute_resize(
             flexes: &Arc<Mutex<Vec<f32>>>,
             e: &MouseMoveEvent,
@@ -968,6 +972,7 @@ mod element {
             window.refresh();
         }
 
+        #[allow(clippy::too_many_arguments)]
         fn layout_handle(
             axis: Axis,
             pane_bounds: Bounds<Pixels>,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2696,6 +2696,7 @@ impl Workspace {
         )
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn add_item(
         &mut self,
         pane: Entity<Pane>,

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -355,6 +355,7 @@ impl Zeta {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn request_completion_impl<F, R>(
         &mut self,
         workspace: Option<Entity<Workspace>>,
@@ -792,6 +793,7 @@ and then another
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn process_completion_response(
         prediction_response: PredictEditsResponse,
         buffer: Entity<Buffer>,


### PR DESCRIPTION
This reverts commit 9ef0501853825db41e702c03ab398bf531a8bc1f due to a panic.

```
{
  "thread": "main",
  "payload": "9 is not a valid char boundary in path \"crates/…/LiveKitBridge/\"",
  "location_data": {
    "file": "crates/file_finder/src/file_finder.rs",
    "line": 646
  }
}
```

Release Notes:

- N/A