### PR TITLE
git_ui: Git panel polish

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -386,6 +386,10 @@ impl Focusable for ProjectDiff {
 impl Item for ProjectDiff {
     type Event = EditorEvent;
 
+    fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
+        Some(Icon::new(IconName::GitBranch).color(Color::Muted))
+    }
+
     fn to_item_events(event: &EditorEvent, f: impl FnMut(ItemEvent)) {
         Editor::to_item_events(event, f)
     }


### PR DESCRIPTION
- Hides header when no active repo/no repo
- Entire commit editor now has i-beam cursor on hover
- Adds an icon to the project diff tab

Release Notes:

- N/A
