### PR TITLE
workspace: Remove stray `println!`

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1804,7 +1804,6 @@ impl Workspace {
     }
 
     pub fn close_window(&mut self, _: &CloseWindow, window: &mut Window, cx: &mut Context<Self>) {
-        println!("workspace::close_window");
         let prepare = self.prepare_to_close(CloseIntent::CloseWindow, window, cx);
         cx.spawn_in(window, |_, mut cx| async move {
             if prepare.await? {


### PR DESCRIPTION
This PR removes a stray `println!` that was left over from #25185.

Release Notes:

- N/A
