### PR TITLE
cli: Fix comment

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -121,7 +121,7 @@ fn main() -> Result<()> {
     // Intercept version designators
     #[cfg(target_os = "macos")]
     if let Some(channel) = std::env::args().nth(1).filter(|arg| arg.starts_with("--")) {
-        //When the first argument is a name of a release channel, we're gonna spawn off a cli of that version, with trailing args passed along.
+        // When the first argument is a name of a release channel, we're going to spawn off the CLI of that version, with trailing args passed along.
         use std::str::FromStr as _;
 
         if let Ok(channel) = release_channel::ReleaseChannel::from_str(&channel[2..]) {


### PR DESCRIPTION
This PR fixes a comment in the `cli` crate that seems to have been inadvertently changed in #25185.

I also reworded it to be a bit more formal.

Release Notes:

- N/A
