### PR TITLE
title_bar: Hide screen share when user doesn't have the permission

### DIFF
--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -428,25 +428,25 @@ impl TitleBar {
                 .on_click(move |_, _, cx| toggle_deafen(&Default::default(), cx))
                 .into_any_element(),
             );
-        }
 
-        if screen_sharing_supported {
-            children.push(
-                IconButton::new("screen-share", ui::IconName::Screen)
-                    .style(ButtonStyle::Subtle)
-                    .icon_size(IconSize::Small)
-                    .toggle_state(is_screen_sharing)
-                    .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-                    .tooltip(Tooltip::text(if is_screen_sharing {
-                        "Stop Sharing Screen"
-                    } else {
-                        "Share Screen"
-                    }))
-                    .on_click(move |_, window, cx| {
-                        toggle_screen_sharing(&Default::default(), window, cx)
-                    })
-                    .into_any_element(),
-            );
+            if screen_sharing_supported {
+                children.push(
+                    IconButton::new("screen-share", ui::IconName::Screen)
+                        .style(ButtonStyle::Subtle)
+                        .icon_size(IconSize::Small)
+                        .toggle_state(is_screen_sharing)
+                        .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                        .tooltip(Tooltip::text(if is_screen_sharing {
+                            "Stop Sharing Screen"
+                        } else {
+                            "Share Screen"
+                        }))
+                        .on_click(move |_, window, cx| {
+                            toggle_screen_sharing(&Default::default(), window, cx)
+                        })
+                        .into_any_element(),
+                );
+            }
         }
 
         children.push(div().pr_2().into_any_element());


### PR DESCRIPTION
On macos: 
- user has the required permission to screen share. 
- user doesn't have the can_use_microphone permission


When an user doesn't have the can_use_microphone permission the screen share icon would be visible. If an user therefor would click on it, we would give the error that they don't have the permission given to zed to screen share. (which is false). 

I've tested this together with @JosephTLyons because we first thought it was a mac os permission issue. 

Should we mention in the zed.dev/docs/collaboration what kind of permissions are needed to be able to screen share? 

Release Notes:

- Fixed: Screen sharing would be visible even when user didn't have the right permission resulting in errors later on. 
