### PR TITLE
Remove unnecessary `icon` field from snapcraft.yaml

### DIFF
--- a/crates/zed/resources/snap/snapcraft.yaml.in
+++ b/crates/zed/resources/snap/snapcraft.yaml.in
@@ -9,7 +9,6 @@ description: |
 grade: stable
 confinement: classic
 compression: lzo
-icon: crates/zed/resources/app-icon.png
 website: https://zed.dev/
 source-code: https://github.com/zed-industries/zed
 issues: https://github.com/zed-industries/zed/issues


### PR DESCRIPTION
This is handled in `script/snap-build` by populating `snap/gui` with `zed.png` and `zed.desktop`

Release Notes:

- N/A