### PR TITLE
Add `constructor` highlighting for JS/TS/TSX

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -25,6 +25,9 @@
   name: (identifier) @function)
 (method_definition
   name: (property_identifier) @function.method)
+(method_definition
+    name: (property_identifier) @constructor
+    (#eq? @constructor "constructor"))
 
 (pair
   key: (property_identifier) @function.method
@@ -44,12 +47,6 @@
   right: [(function_expression) (arrow_function)])
 
 ; Special identifiers
-
-(class_declaration
-  (class_body
-    (method_definition
-      name: (property_identifier) @constructor
-      (#eq? @constructor "constructor"))))
 
 ((identifier) @type
  (#match? @type "^[A-Z]"))

--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -45,6 +45,12 @@
 
 ; Special identifiers
 
+(class_declaration
+  (class_body
+    (method_definition
+      name: (property_identifier) @constructor
+      (#eq? @constructor "constructor"))))
+
 ((identifier) @type
  (#match? @type "^[A-Z]"))
 (type_identifier) @type

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -44,12 +44,9 @@
   right: [(function_expression) (arrow_function)])
 
 ; Special identifiers
-
-(class_declaration
-  (class_body
-    (method_definition
-      name: (property_identifier) @constructor
-      (#eq? @constructor "constructor"))))
+(method_definition
+    name: (property_identifier) @constructor
+    (#eq? @constructor "constructor"))
 
 ((identifier) @type
  (#match? @type "^[A-Z]"))

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -25,6 +25,9 @@
   name: (identifier) @function)
 (method_definition
   name: (property_identifier) @function.method)
+(method_definition
+    name: (property_identifier) @constructor
+    (#eq? @constructor "constructor"))
 
 (pair
   key: (property_identifier) @function.method
@@ -44,9 +47,6 @@
   right: [(function_expression) (arrow_function)])
 
 ; Special identifiers
-(method_definition
-    name: (property_identifier) @constructor
-    (#eq? @constructor "constructor"))
 
 ((identifier) @type
  (#match? @type "^[A-Z]"))

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -45,8 +45,11 @@
 
 ; Special identifiers
 
-((identifier) @constructor
- (#match? @constructor "^[A-Z]"))
+(class_declaration
+  (class_body
+    (method_definition
+      name: (property_identifier) @constructor
+      (#eq? @constructor "constructor"))))
 
 ((identifier) @type
  (#match? @type "^[A-Z]"))

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -57,6 +57,9 @@
   name: (identifier) @function)
 (method_definition
   name: (property_identifier) @function.method)
+(method_definition
+    name: (property_identifier) @constructor
+    (#eq? @constructor "constructor"))
 
 (pair
   key: (property_identifier) @function.method


### PR DESCRIPTION
Closes #19267

Adds highlight field specifically for `constructor` in JS/TS/TSX so that it can be highlighted as a different color than regular methods

Release Notes:

- N/A
