### PR TITLE
vim: Fix cursor shape hollow only in block

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1146,8 +1146,10 @@ impl Vim {
         self.stop_recording_immediately(NormalBefore.boxed_clone(), cx);
         self.store_visual_marks(window, cx);
         self.clear_operator(window, cx);
-        self.update_editor(window, cx, |_, editor, _, cx| {
-            editor.set_cursor_shape(language::CursorShape::Hollow, cx);
+        self.update_editor(window, cx, |vim, editor, _, cx| {
+            if vim.cursor_shape() == CursorShape::Block {
+                editor.set_cursor_shape(CursorShape::Hollow, cx);
+            }
         });
     }
 


### PR DESCRIPTION
Closes #ISSUE

Before this, in Vim mode, as long as the window loses focus, regardless of the current cursor shape, it will definitely switch to a hollow cursor.

Release Notes:

- Fixed vim cursor shape hollow only in block
