### PR TITLE
editor: Ignore whitespaces in selection highlight

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4746,9 +4746,13 @@ impl Editor {
                         return None;
                     }
                     let buffer = editor.buffer().read(cx).snapshot(cx);
+                    let query = buffer.text_for_range(selection.range()).collect::<String>();
+                    if query.trim().is_empty() {
+                        editor.clear_background_highlights::<SelectedTextHighlight>(cx);
+                        return None;
+                    }
                     Some(cx.background_spawn(async move {
                         let mut ranges = Vec::new();
-                        let query = buffer.text_for_range(selection.range()).collect::<String>();
                         let selection_anchors = selection.range().to_anchors(&buffer);
                         for range in [buffer.anchor_before(0)..buffer.anchor_after(buffer.len())] {
                             for (search_buffer, search_range, excerpt_id) in


### PR DESCRIPTION
This PR prevents whitespace selections from being highlighted.

Before:
<img src="https://github.com/user-attachments/assets/79812ae5-6709-4e93-b203-b8f1d5ffbf7b" alt="image" width="400px" />

After:
<img src="https://github.com/user-attachments/assets/77540ef9-65df-476e-9cca-b2cef14f5f3a" alt="image" width="400px" />


Release Notes:

- Fixed an issue where whitespace selections were incorrectly highlighted.
