### PR TITLE
feature: Adds editor commands for selecting next/previous syntax siblings

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -368,6 +368,8 @@ gpui::actions!(
         SelectDown,
         SelectEnclosingSymbol,
         SelectLargerSyntaxNode,
+        SelectNextSyntaxNode,
+        SelectPreviousSyntaxNode,
         SelectLeft,
         SelectLine,
         SelectPageDown,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10084,6 +10084,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
         direction: SyntaxMovement,
+        named_only: bool,
     ) {
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).snapshot(cx);
@@ -10104,9 +10105,9 @@ impl Editor {
                         match direction {
                             SyntaxMovement::Parent => buffer.syntax_ancestor(new_range.clone()),
                             SyntaxMovement::NextSibling => 
-                                buffer.syntax_sibling(new_range.clone(), SiblingDirection::Next),
+                                buffer.syntax_sibling(new_range.clone(), SiblingDirection::Next, named_only),
                             SyntaxMovement::PreviousSibling => 
-                                buffer.syntax_sibling(new_range.clone(), SiblingDirection::Previous),
+                                buffer.syntax_sibling(new_range.clone(), SiblingDirection::Previous, named_only),
                         }
                 {
                     new_node = Some(node);
@@ -10155,7 +10156,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.select_syntax_helper(window, cx, SyntaxMovement::Parent);
+        self.select_syntax_helper(window, cx, SyntaxMovement::Parent, false);
     }
 
     pub fn select_next_syntax_node(
@@ -10164,7 +10165,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.select_syntax_helper(window, cx, SyntaxMovement::NextSibling);
+        self.select_syntax_helper(window, cx, SyntaxMovement::NextSibling, true);
     }
 
     pub fn select_previous_syntax_node(
@@ -10173,7 +10174,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.select_syntax_helper(window, cx, SyntaxMovement::PreviousSibling);
+        self.select_syntax_helper(window, cx, SyntaxMovement::PreviousSibling, true);
     }
     
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -321,6 +321,8 @@ impl EditorElement {
         });
         register_action(editor, window, Editor::toggle_comments);
         register_action(editor, window, Editor::select_larger_syntax_node);
+        register_action(editor, window, Editor::select_next_syntax_node);
+        register_action(editor, window, Editor::select_previous_syntax_node);
         register_action(editor, window, Editor::select_smaller_syntax_node);
         register_action(editor, window, Editor::select_enclosing_symbol);
         register_action(editor, window, Editor::move_to_enclosing_bracket);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3228,6 +3228,7 @@ impl BufferSnapshot {
         &'a self,
         range: Range<T>,
         direction: SiblingDirection,
+        named_only: bool,
     ) -> Option<tree_sitter::Node<'a>> {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let mut result: Option<tree_sitter::Node<'a>> = None;
@@ -3235,7 +3236,7 @@ impl BufferSnapshot {
             .syntax
             .layers_for_range(range.clone(), &self.text, true)
         {
-            match layer.next_prev_sibling(range.clone(), &direction) {
+            match layer.next_prev_sibling(range.clone(), &direction, named_only) {
                 Some(node) => {
                     result = Some(node);
                     break;

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1569,7 +1569,7 @@ impl<'a> SyntaxLayer<'a> {
             let node_range = cursor.node().byte_range();
             if node_range.start <= range.start
                 && node_range.end >= range.end
-                && node_range.len() > range.len()
+                && node_range.len() >= range.len()
             {
                 break Some(cursor.node());
             }

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1579,13 +1579,9 @@ impl<'a> SyntaxLayer<'a> {
         }
     }
 
-
-    pub fn next_prev_sibling(&self, range: Range<usize>, direction: &SiblingDirection) -> Option<Node<'a>> {
+    pub fn next_prev_sibling(&self, range: Range<usize>, direction: &SiblingDirection, named_only: bool) -> Option<Node<'a>> {
         let mut current_node = self.smallest_containing_node(range);
-        dbg!(direction);
-        dbg!(&current_node);
         loop {
-            dbg!(&current_node);
             match current_node {
                 Some(node) => {
                     match match direction {
@@ -1593,10 +1589,17 @@ impl<'a> SyntaxLayer<'a> {
                         SiblingDirection::Previous => node.prev_sibling(),
                     } {
                         Some(sibling) => {
-                            break Some(sibling);
+                            if named_only{
+                                if sibling.is_named() {
+                                    break Some(sibling);
+                                }else{
+                                    current_node = Some(sibling);
+                                }
+                            } else {
+                                break Some(sibling);
+                            }
                         }
                         None => {
-                            dbg!("no sibling");
                             current_node = node.parent();
                         }
                     }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -21,7 +21,7 @@ use language::{
     CharKind, Chunk, CursorShape, DiagnosticEntry, DiskState, File, IndentSize, Language,
     LanguageScope, OffsetRangeExt, OffsetUtf16, Outline, OutlineItem, Point, PointUtf16, Selection,
     TextDimension, TextObject, ToOffset as _, ToPoint as _, TransactionId, TreeSitterOptions,
-    Unclipped,
+    Unclipped, SiblingDirection,
 };
 
 use rope::DimensionPair;
@@ -5684,6 +5684,19 @@ impl MultiBufferSnapshot {
         let node = excerpt
             .buffer()
             .syntax_ancestor(excerpt.map_range_to_buffer(range))?;
+        Some((node, excerpt.map_range_from_buffer(node.byte_range())))
+    }
+
+    pub fn syntax_sibling<T: ToOffset>(
+        &self,
+        range: Range<T>,
+        direction: SiblingDirection,
+    ) -> Option<(tree_sitter::Node, Range<usize>)> {
+        let range = range.start.to_offset(self)..range.end.to_offset(self);
+        let mut excerpt = self.excerpt_containing(range.clone())?;
+        let node = excerpt
+            .buffer()
+            .syntax_sibling(excerpt.map_range_to_buffer(range), direction)?;
         Some((node, excerpt.map_range_from_buffer(node.byte_range())))
     }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5691,12 +5691,13 @@ impl MultiBufferSnapshot {
         &self,
         range: Range<T>,
         direction: SiblingDirection,
+        named_only: bool,
     ) -> Option<(tree_sitter::Node, Range<usize>)> {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let mut excerpt = self.excerpt_containing(range.clone())?;
         let node = excerpt
             .buffer()
-            .syntax_sibling(excerpt.map_range_to_buffer(range), direction)?;
+            .syntax_sibling(excerpt.map_range_to_buffer(range), direction, named_only)?;
         Some((node, excerpt.map_range_from_buffer(node.byte_range())))
     }
 

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -113,6 +113,8 @@ pub fn app_menus() -> Vec<Menu> {
                 ),
                 MenuItem::action("Expand Selection", editor::actions::SelectLargerSyntaxNode),
                 MenuItem::action("Shrink Selection", editor::actions::SelectSmallerSyntaxNode),
+                MenuItem::action("Select Next Syntax Node", editor::actions::SelectNextSyntaxNode),
+                MenuItem::action("Select Previous Syntax Node", editor::actions::SelectPreviousSyntaxNode),
                 MenuItem::separator(),
                 MenuItem::action("Add Cursor Above", editor::actions::AddSelectionAbove),
                 MenuItem::action("Add Cursor Below", editor::actions::AddSelectionBelow),

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -6,7 +6,7 @@ use assistant_settings::AssistantSettings;
 use editor::actions::{
     AddSelectionAbove, AddSelectionBelow, DuplicateLineDown, GoToDiagnostic, GoToHunk,
     GoToPrevDiagnostic, GoToPrevHunk, MoveLineDown, MoveLineUp, SelectAll, SelectLargerSyntaxNode,
-    SelectNext, SelectSmallerSyntaxNode, ToggleGoToLine,
+    SelectNext, SelectNextSyntaxNode, SelectPreviousSyntaxNode, SelectSmallerSyntaxNode, ToggleGoToLine,
 };
 use editor::{Editor, EditorSettings};
 use gpui::{
@@ -191,6 +191,8 @@ impl Render for QuickActionBar {
                                 }),
                             )
                             .action("Expand Selection", Box::new(SelectLargerSyntaxNode))
+                            .action("Select Next Syntax Node", Box::new(SelectNextSyntaxNode))
+                            .action("Select Previous Syntax Node", Box::new(SelectPreviousSyntaxNode))
                             .action("Shrink Selection", Box::new(SelectSmallerSyntaxNode))
                             .action("Add Cursor Above", Box::new(AddSelectionAbove))
                             .action("Add Cursor Below", Box::new(AddSelectionBelow))


### PR DESCRIPTION
Adds editor commands for selecting the next and previous syntax siblings inpired from the ki-editor in support of the following discussion:
https://github.com/zed-industries/zed/discussions/6447#discussioncomment-10713526


Release Notes:
- Adds commands SelectNextSyntaxNode & SelectPreviousSyntaxNode 
- Adds improved abstraction for selecting the smallest ts-node that encapuslates or is equal to selection

