### PR TITLE
deno: Make downloaded language server binary executable

### DIFF
--- a/extensions/deno/src/deno.rs
+++ b/extensions/deno/src/deno.rs
@@ -74,6 +74,8 @@ impl DenoExtension {
             )
             .map_err(|e| format!("failed to download file: {e}"))?;
 
+            zed::make_file_executable(&binary_path)?;
+
             let entries =
                 fs::read_dir(".").map_err(|e| format!("failed to list working directory {e}"))?;
             for entry in entries {


### PR DESCRIPTION
Closes #20347

This PR fixes the downloaded Deno LSP binary not being able to start by marking it as executable.

Release Notes:

- N/A 
