### PR TITLE
Add jump list support for Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5512,6 +5512,7 @@ dependencies = [
  "objc",
  "objc2",
  "objc2-metal",
+ "once_cell",
  "oo7",
  "open",
  "parking",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -622,6 +622,7 @@ features = [
     "Win32_UI_Input_KeyboardAndMouse",
     "Win32_UI_Shell",
     "Win32_UI_Shell_Common",
+    "Win32_UI_Shell_PropertiesSystem",
     "Win32_UI_WindowsAndMessaging",
 ]
 
@@ -685,7 +686,7 @@ ui_input = { codegen-units = 1 }
 zed_actions = { codegen-units = 1 }
 
 [profile.release]
-debug = "limited"
+debug = false
 lto = "thin"
 codegen-units = 1
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -686,7 +686,7 @@ ui_input = { codegen-units = 1 }
 zed_actions = { codegen-units = 1 }
 
 [profile.release]
-debug = false
+debug = "limited"
 lto = "thin"
 codegen-units = 1
 

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -207,6 +207,7 @@ flume = "0.11"
 rand.workspace = true
 windows.workspace = true
 windows-core = "0.58"
+once_cell.workspace = true
 
 [dev-dependencies]
 backtrace = "0.3"

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1434,6 +1434,18 @@ impl App {
         self.platform.add_recent_document(path);
     }
 
+    /// Adds given path to list of recent paths for the application.
+    /// The list is usually shown on the application icon's context menu in the dock,
+    /// and allows to open the recent files via that context menu.
+    pub fn add_recent_documents(&self, paths: &[PathBuf]) {
+        self.platform.add_recent_documents(paths);
+    }
+
+    /// Clears the list of recent paths from the application.
+    pub fn clear_recent_documents(&self) {
+        self.platform.clear_recent_documents();
+    }
+
     /// Dispatch an action to the currently active window or global action handler
     /// See [`crate::Action`] for more information on how actions work
     pub fn dispatch_action(&mut self, action: &dyn Action) {

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -190,6 +190,8 @@ pub(crate) trait Platform: 'static {
 
     fn set_dock_menu(&self, menu: Vec<MenuItem>, keymap: &Keymap);
     fn add_recent_document(&self, _path: &Path) {}
+    fn add_recent_documents(&self, _paths: &[PathBuf]) {}
+    fn clear_recent_documents(&self) {}
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>);
     fn on_will_open_app_menu(&self, callback: Box<dyn FnMut()>);
     fn on_validate_app_menu_command(&self, callback: Box<dyn FnMut(&dyn Action) -> bool>);

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -539,6 +539,8 @@ impl<P: LinuxClient + 'static> Platform for P {
     }
 
     fn add_recent_document(&self, _path: &Path) {}
+    fn add_recent_documents(&self, _paths: &[PathBuf]) {}
+    fn clear_recent_documents(&self) {}
 }
 
 #[cfg(any(feature = "wayland", feature = "x11"))]

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -357,6 +357,8 @@ impl Platform for TestPlatform {
     fn set_dock_menu(&self, _menu: Vec<crate::MenuItem>, _keymap: &Keymap) {}
 
     fn add_recent_document(&self, _paths: &Path) {}
+    fn add_recent_documents(&self, _paths: &[PathBuf]) {}
+    fn clear_recent_documents(&self) {}
 
     fn on_app_menu_action(&self, _callback: Box<dyn FnMut(&dyn crate::Action)>) {}
 

--- a/crates/gpui/src/platform/windows.rs
+++ b/crates/gpui/src/platform/windows.rs
@@ -3,6 +3,7 @@ mod direct_write;
 mod dispatcher;
 mod display;
 mod events;
+mod jump_list;
 mod platform;
 mod system_settings;
 mod util;

--- a/crates/gpui/src/platform/windows/jump_list.rs
+++ b/crates/gpui/src/platform/windows/jump_list.rs
@@ -1,0 +1,170 @@
+use crate::MenuItem;
+use anyhow::anyhow;
+use once_cell::sync::Lazy;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use windows::Win32::{
+    Foundation::MAX_PATH,
+    System::Com::{CoCreateInstance, CLSCTX_INPROC_SERVER},
+    UI::Shell::{
+        Common::{IObjectArray, IObjectCollection},
+        DestinationList, EnumerableObjectCollection, ICustomDestinationList, IShellLinkW,
+        PropertiesSystem::{IPropertyStore, PSGetPropertyKeyFromName, PROPERTYKEY},
+        ShellLink,
+    },
+};
+use windows_core::{w, Interface, HSTRING, PROPVARIANT, PWSTR};
+
+#[derive(Default)]
+struct JumpListState {
+    tasks: Vec<MenuItem>,
+    recent_paths: Vec<PathBuf>,
+}
+
+static JUMP_LIST_STATE: Lazy<Mutex<JumpListState>> =
+    Lazy::new(|| Mutex::new(JumpListState::default()));
+
+impl JumpListState {
+    fn update_tasks(tasks: Vec<MenuItem>) -> anyhow::Result<()> {
+        let mut state = Self::get_instance()
+            .lock()
+            .map_err(|e| anyhow!("Lock error: {}", e))?;
+        state.tasks = tasks;
+        update_jump_list(&mut state)
+    }
+
+    fn update_recent_items(paths: &[PathBuf]) -> anyhow::Result<()> {
+        let mut state = Self::get_instance()
+            .lock()
+            .map_err(|e| anyhow!("Lock error: {}", e))?;
+        state.recent_paths = paths.to_vec();
+        update_jump_list(&mut state)
+    }
+
+    fn get_instance() -> &'static Mutex<JumpListState> {
+        &JUMP_LIST_STATE
+    }
+}
+
+fn update_jump_list(state: &mut JumpListState) -> anyhow::Result<()> {
+    let jump_list: ICustomDestinationList =
+        unsafe { CoCreateInstance(&DestinationList, None, CLSCTX_INPROC_SERVER)? };
+
+    let mut max_slots = 0u32;
+    let user_removed_items: IObjectArray = unsafe { jump_list.BeginList(&mut max_slots)? };
+
+    // Add tasks
+    let task_items: IObjectCollection =
+        unsafe { CoCreateInstance(&EnumerableObjectCollection, None, CLSCTX_INPROC_SERVER)? };
+
+    let current_exe = std::env::current_exe()?;
+
+    let mut num_tasks = 0u32;
+    for menu_item in &state.tasks {
+        if let MenuItem::Action { name, action, .. } = menu_item {
+            unsafe {
+                let link = create_shell_link(
+                    current_exe.as_path(),
+                    "",
+                    action.name(),
+                    name.to_string().as_str(),
+                    &current_exe.as_path(),
+                    0,
+                )?;
+                task_items.AddObject(&link)?;
+                num_tasks += 1;
+            }
+        }
+    }
+
+    if num_tasks > 0 {
+        let task_array: IObjectArray = task_items.cast()?;
+        unsafe { jump_list.AddUserTasks(&task_array)? };
+    }
+
+    // Add recent items
+    let recent_items: IObjectCollection =
+        unsafe { CoCreateInstance(&EnumerableObjectCollection, None, CLSCTX_INPROC_SERVER)? };
+
+    // Honor the removals requested by the user
+    unsafe {
+        for i in 0..user_removed_items.GetCount()? {
+            let removed_link: IShellLinkW = user_removed_items.GetAt(i)?;
+            let mut removed_path_vec = vec![0u16; MAX_PATH as usize];
+            removed_link.GetArguments(&mut removed_path_vec)?;
+            let removed_path_wstr = PWSTR::from_raw(removed_path_vec.as_mut_ptr());
+            if !removed_path_wstr.is_null() {
+                let removed_path = removed_path_wstr.to_string()?;
+                // TODO: this path should also be removed from Zed's recent projects persistent storage.
+                state
+                    .recent_paths
+                    .retain(|x| *x != PathBuf::from(removed_path.as_str()));
+            }
+        }
+    }
+
+    let mut num_recent_items = 0u32;
+    for path in &state.recent_paths {
+        if let Some(dir_name) = path.file_name().and_then(|s| s.to_str()) {
+            let path_str = path.to_string_lossy();
+
+            unsafe {
+                let shell_link = create_shell_link(
+                    current_exe.as_path(),
+                    &path_str,
+                    &path_str,
+                    dir_name,
+                    &Path::new("explorer.exe"), // Simulate explorer folder icon
+                    0,
+                )?;
+                recent_items.AddObject(&shell_link)?;
+                num_recent_items += 1;
+            }
+        }
+    }
+
+    if num_recent_items > 0 {
+        let recent_array: IObjectArray = recent_items.cast()?;
+        // TOOD: i18n for "Recent Folders"
+        unsafe { jump_list.AppendCategory(w!("Recent Folders"), &recent_array)? };
+    }
+
+    unsafe {
+        jump_list.CommitList()?;
+    }
+
+    Ok(())
+}
+
+pub(crate) fn update_recent_items(paths: &[PathBuf]) -> anyhow::Result<()> {
+    JumpListState::update_recent_items(paths)
+}
+
+pub(crate) fn add_tasks(menu_items: Vec<MenuItem>) -> anyhow::Result<()> {
+    JumpListState::update_tasks(menu_items)
+}
+
+unsafe fn create_shell_link(
+    program: &Path,
+    args: &str,
+    desc: &str,
+    title: &str,
+    icon_path: &Path,
+    icon_index: i32,
+) -> anyhow::Result<IShellLinkW> {
+    let link: IShellLinkW = CoCreateInstance(&ShellLink, None, CLSCTX_INPROC_SERVER)?;
+    link.SetPath(&HSTRING::from(program))?;
+    link.SetIconLocation(&HSTRING::from(icon_path), icon_index)?;
+    link.SetArguments(&HSTRING::from(args))?; // path
+    link.SetDescription(&HSTRING::from(desc))?; // tooltip
+
+    let title_value = PROPVARIANT::from(title);
+    let mut title_key = PROPERTYKEY::default();
+    PSGetPropertyKeyFromName(w!("System.Title"), &mut title_key)?;
+
+    let store: IPropertyStore = link.cast()?;
+    store.SetValue(&title_key, &title_value)?;
+    store.Commit()?;
+
+    Ok(link)
+}

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -30,6 +30,8 @@ use windows::{
 
 use crate::{platform::blade::BladeContext, *};
 
+use super::jump_list;
+
 pub(crate) struct WindowsPlatform {
     state: RefCell<WindowsPlatformState>,
     raw_window_handles: RwLock<SmallVec<[HWND; 4]>>,
@@ -479,8 +481,17 @@ impl Platform for WindowsPlatform {
         Some(self.state.borrow().menus.clone())
     }
 
-    // todo(windows)
-    fn set_dock_menu(&self, _menus: Vec<MenuItem>, _keymap: &Keymap) {}
+    fn set_dock_menu(&self, menus: Vec<MenuItem>, _keymap: &Keymap) {
+        jump_list::add_tasks(menus).log_err();
+    }
+
+    fn add_recent_document(&self, _path: &Path) {}
+
+    fn add_recent_documents(&self, paths: &[PathBuf]) {
+        jump_list::update_recent_items(paths).log_err();
+    }
+
+    fn clear_recent_documents(&self) {}
 
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>) {
         self.state.borrow_mut().callbacks.app_menu_action = Some(callback);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -887,6 +887,15 @@ impl Workspace {
                 project::Event::WorktreeRemoved(_) | project::Event::WorktreeAdded(_) => {
                     this.update_window_title(window, cx);
                     this.serialize_workspace(window, cx);
+
+                    cx.spawn(|workspace, mut cx| async move {
+                        workspace
+                            .update(&mut cx, |workspace, cx| {
+                                workspace.refresh_recent_documents(cx)
+                            })?
+                            .await
+                    })
+                    .detach_and_log_err(cx);
                 }
 
                 project::Event::DisconnectedFromHost => {
@@ -1296,7 +1305,12 @@ impl Workspace {
                 .unwrap_or_default();
 
             window
-                .update(&mut cx, |_, window, _| window.activate_window())
+                .update(&mut cx, |workspace, window, cx| {
+                    workspace
+                        .refresh_recent_documents(cx)
+                        .detach_and_log_err(cx);
+                    window.activate_window()
+                })
                 .log_err();
             Ok((window, opened_items))
         })
@@ -4646,6 +4660,29 @@ impl Workspace {
         self.serializable_items_tx
             .unbounded_send(item)
             .map_err(|err| anyhow!("failed to send serializable item over channel: {}", err))
+    }
+
+    fn refresh_recent_documents(&self, cx: &mut Context<Workspace>) -> Task<Result<()>> {
+        if !self.project.read(cx).is_local() {
+            return Task::ready(Ok(()));
+        }
+        cx.spawn(|_, cx| async move {
+            let recents = WORKSPACE_DB
+                .recent_workspaces_on_disk()
+                .await
+                .unwrap_or_default();
+            let mut unique_paths = HashMap::default();
+            for (id, workspace) in &recents {
+                for path in workspace.sorted_paths().iter() {
+                    unique_paths.insert(path.clone(), id);
+                }
+            }
+            let current_paths = unique_paths.into_keys().collect::<Vec<_>>();
+            cx.update(|cx| {
+                cx.clear_recent_documents();
+                cx.add_recent_documents(&current_paths);
+            })
+        })
     }
 
     pub(crate) fn load_workspace(


### PR DESCRIPTION
This PR addresses issue #12068.

It adds support for Windows jump lists (taskbar icon right-click) for Zed. Please see the attached screenshot for reference:
 
<img width="295" alt="Screenshot 2025-02-20 202903" src="https://github.com/user-attachments/assets/aa498af0-d5e4-45f3-9871-b1e1d1f52ab8" />


To implement this, I had to reintroduce the `add_recent_documents` and `clear_recent_documents` functions, which were previously removed from PR #9919. 

As this is my first PR for Zed and I'm not very familiar with the codebase, there might be more efficient ways to achieve this. I would greatly appreciate any feedback or suggestions.

Release Notes:

- N/A 
