### PR TITLE
deno: Bump to v0.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16798,7 +16798,7 @@ dependencies = [
 
 [[package]]
 name = "zed_deno"
-version = "0.0.2"
+version = "0.1.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/deno/Cargo.toml
+++ b/extensions/deno/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_deno"
-version = "0.0.2"
+version = "0.1.0"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/deno/extension.toml
+++ b/extensions/deno/extension.toml
@@ -1,7 +1,7 @@
 id = "deno"
 name = "Deno"
 description = "Deno support."
-version = "0.0.2"
+version = "0.1.0"
 schema_version = 1
 authors = ["Lino Le Van <11367844+lino-levan@users.noreply.github.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Deno extension to v0.1.0.

Changes:

- https://github.com/zed-industries/zed/pull/16955
- https://github.com/zed-industries/zed/pull/25252

Release Notes:

- N/A
