### PR TITLE
Make `"allow_rewrap": "anywhere"` the default for "Git Commit" files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1084,6 +1084,9 @@
     "Erlang": {
       "language_servers": ["erlang-ls", "!elp", "..."]
     },
+    "Git Commit": {
+      "allow_rewrap": "anywhere"
+    },
     "Go": {
       "code_actions_on_format": {
         "source.organizeImports": true


### PR DESCRIPTION
This PR makes `"allow_rewrap": "anywhere"` the default for "Git Commit" files.

Closes https://github.com/zed-industries/zed/issues/24987.

Release Notes:

- N/A
