### PR TITLE
Show whitespace in hunk while "show_whitespaces": "selection"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -226,6 +226,9 @@
   // - It is adjacent to an edge (start or end)
   // - It is adjacent to a whitespace (left or right)
   "show_whitespaces": "selection",
+  // Whether to show whitespaces in the git diff view.
+  // This setting will override the "show_whitespaces" setting in git diff view.
+  "show_whitespaces_in_git_diff": false,
   // Settings related to calls in Zed
   "calls": {
     // Join calls with the microphone live by default

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6390,15 +6390,18 @@ impl LineWithInvisibles {
             )
         };
 
+        let is_highlighted = layout.highlighted_rows.contains_key(&row);
+
         let invisible_iter = self.invisibles.iter().map(extract_whitespace_info);
         match whitespace_setting {
             ShowWhitespaceSetting::None => (),
             ShowWhitespaceSetting::All => invisible_iter.for_each(|(_, paint)| paint(window, cx)),
             ShowWhitespaceSetting::Selection => invisible_iter.for_each(|([start, _], paint)| {
                 let invisible_point = DisplayPoint::new(row, start as u32);
-                if !selection_ranges
-                    .iter()
-                    .any(|region| region.start <= invisible_point && invisible_point < region.end)
+                if !is_highlighted
+                    && !selection_ranges.iter().any(|region| {
+                        region.start <= invisible_point && invisible_point < region.end
+                    })
                 {
                     return;
                 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -144,6 +144,8 @@ pub struct LanguageSettings {
     /// Whether to display inline and alongside documentation for items in the
     /// completions menu.
     pub show_completion_documentation: bool,
+    /// Whether or not show whitespaces in git diff. This setting will override the global whitespace setting.
+    pub show_whitespaces_in_git_diff: bool,
 }
 
 impl LanguageSettings {
@@ -425,6 +427,10 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub show_completion_documentation: Option<bool>,
+    /// Whether or not show whitespaces in git diff. This setting will override the global whitespace setting.
+    ///
+    /// Default: false
+    pub show_whitespaces_in_git_diff: Option<bool>,
 }
 
 /// The contents of the edit prediction settings.
@@ -1245,6 +1251,10 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
     merge(
         &mut settings.show_completion_documentation,
         src.show_completion_documentation,
+    );
+    merge(
+        &mut settings.show_whitespaces_in_git_diff,
+        src.show_whitespaces_in_git_diff,
     );
 }
 


### PR DESCRIPTION
Closes #25250 

Release Notes:

- Show whitespace in hunk while setting `"show_whitespaces": "selection"`
- add `show_whitespaces_in_git_diff` settings. this setting will override the `show_whitespaces` setting in git diff hunk

![GkPQLFea0AANrYj](https://github.com/user-attachments/assets/2132b5c1-8812-4c2b-b92e-3a1d049d58de)
