### PR TITLE
git: Take only the first line of MERGE_MSG

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5492,7 +5492,7 @@ impl BackgroundScanner {
                             local_repository.dot_git_dir_abs_path.join("MERGE_MSG"),
                         )
                         .ok()
-                        .map(|merge_msg| merge_msg.lines().next().unwrap_or("").to_owned());
+                        .and_then(|merge_msg| Some(merge_msg.lines().next()?.to_owned()));
                         entry.status_scan_id += 1;
                     },
                 );

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5491,7 +5491,8 @@ impl BackgroundScanner {
                         entry.merge_message = std::fs::read_to_string(
                             local_repository.dot_git_dir_abs_path.join("MERGE_MSG"),
                         )
-                        .ok();
+                        .ok()
+                        .map(|merge_msg| merge_msg.lines().next().unwrap_or("").to_owned());
                         entry.status_scan_id += 1;
                     },
                 );


### PR DESCRIPTION
The rest of the generated message consists of comments that are redundant with what we show in the panel.

Release Notes:

- N/A