### PR TITLE
Add `editor::AcceptNextLineEditPrediction` to accept next line suggestion only

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -154,7 +154,8 @@
     "bindings": {
       "alt-]": "editor::NextEditPrediction",
       "alt-[": "editor::PreviousEditPrediction",
-      "alt-right": "editor::AcceptPartialEditPrediction"
+      "alt-right": "editor::AcceptNextWordEditPrediction",
+      "alt-down": "editor::AcceptNextLineEditPrediction"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -193,7 +193,8 @@
     "bindings": {
       "alt-tab": "editor::NextEditPrediction",
       "alt-shift-tab": "editor::PreviousEditPrediction",
-      "ctrl-cmd-right": "editor::AcceptPartialEditPrediction"
+      "ctrl-cmd-right": "editor::AcceptNextWordEditPrediction",
+      "ctrl-cmd-down": "editor::AcceptNextLineEditPrediction"
     }
   },
   {

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -577,13 +577,13 @@ mod tests {
             assert!(editor.has_active_inline_completion());
 
             // Accepting the first word of the suggestion should only accept the first word and still show the rest.
-            editor.accept_partial_inline_completion(&Default::default(), window, cx);
+            editor.accept_next_word_inline_completion(&Default::default(), window, cx);
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.text(cx), "one.copilot\ntwo\nthree\n");
             assert_eq!(editor.display_text(cx), "one.copilot1\ntwo\nthree\n");
 
             // Accepting next word should accept the non-word and copilot suggestion should be gone
-            editor.accept_partial_inline_completion(&Default::default(), window, cx);
+            editor.accept_next_word_inline_completion(&Default::default(), window, cx);
             assert!(!editor.has_active_inline_completion());
             assert_eq!(editor.text(cx), "one.copilot1\ntwo\nthree\n");
             assert_eq!(editor.display_text(cx), "one.copilot1\ntwo\nthree\n");
@@ -619,7 +619,7 @@ mod tests {
             assert!(editor.has_active_inline_completion());
 
             // Accepting the first word (non-word) of the suggestion should only accept the first word and still show the rest.
-            editor.accept_partial_inline_completion(&Default::default(), window, cx);
+            editor.accept_next_word_inline_completion(&Default::default(), window, cx);
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.text(cx), "one.123. \ntwo\nthree\n");
             assert_eq!(
@@ -628,7 +628,7 @@ mod tests {
             );
 
             // Accepting next word should accept the next word and copilot suggestion should still exist
-            editor.accept_partial_inline_completion(&Default::default(), window, cx);
+            editor.accept_next_word_inline_completion(&Default::default(), window, cx);
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.text(cx), "one.123. copilot\ntwo\nthree\n");
             assert_eq!(
@@ -637,7 +637,7 @@ mod tests {
             );
 
             // Accepting the whitespace should accept the non-word/whitespaces with newline and copilot suggestion should be gone
-            editor.accept_partial_inline_completion(&Default::default(), window, cx);
+            editor.accept_next_word_inline_completion(&Default::default(), window, cx);
             assert!(!editor.has_active_inline_completion());
             assert_eq!(editor.text(cx), "one.123. copilot\n 456\ntwo\nthree\n");
             assert_eq!(

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -238,7 +238,8 @@ actions!(
     [
         AcceptEditPrediction,
         AcceptPartialCopilotSuggestion,
-        AcceptPartialEditPrediction,
+        AcceptNextWordEditPrediction,
+        AcceptNextLineEditPrediction,
         AddSelectionAbove,
         AddSelectionBelow,
         ApplyAllDiffHunks,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5990,11 +5990,29 @@ impl Editor {
         self.edit_prediction_requires_modifier_in_indent_conflict = false;
     }
 
-    pub fn accept_partial_inline_completion(
+    pub fn accept_next_word_inline_completion(
         &mut self,
-        _: &AcceptPartialEditPrediction,
+        _: &AcceptNextWordEditPrediction,
         window: &mut Window,
         cx: &mut Context<Self>,
+    ) {
+        self.accept_partial_inline_completion(window, cx, ' ');
+    }
+
+    pub fn accept_next_line_inline_completion(
+        &mut self,
+        _: &AcceptNextLineEditPrediction,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.accept_partial_inline_completion(window, cx, '\n');
+    }
+
+    fn accept_partial_inline_completion(
+        &mut self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+        separator: char,
     ) {
         let Some(active_inline_completion) = self.active_inline_completion.as_ref() else {
             return;
@@ -6033,7 +6051,7 @@ impl Editor {
                     let mut partial_completion = text
                         .chars()
                         .by_ref()
-                        .take_while(|c| c.is_alphabetic())
+                        .take_while(|c| *c != separator)
                         .collect::<String>();
                     if partial_completion.is_empty() {
                         partial_completion = text

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5996,7 +5996,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.accept_partial_inline_completion(window, cx, ' ');
+        self.accept_partial_inline_completion(window, cx, |c| c.is_alphabetic());
     }
 
     pub fn accept_next_line_inline_completion(
@@ -6005,14 +6005,14 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.accept_partial_inline_completion(window, cx, '\n');
+        self.accept_partial_inline_completion(window, cx, |c| *c != '\n');
     }
 
     fn accept_partial_inline_completion(
         &mut self,
         window: &mut Window,
         cx: &mut Context<Self>,
-        separator: char,
+        take_condition: impl Fn(&char) -> bool,
     ) {
         let Some(active_inline_completion) = self.active_inline_completion.as_ref() else {
             return;
@@ -6051,7 +6051,7 @@ impl Editor {
                     let mut partial_completion = text
                         .chars()
                         .by_ref()
-                        .take_while(|c| *c != separator)
+                        .take_while(take_condition)
                         .collect::<String>();
                     if partial_completion.is_empty() {
                         partial_completion = text

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -529,7 +529,8 @@ impl EditorElement {
         register_action(editor, window, Editor::display_cursor_names);
         register_action(editor, window, Editor::unique_lines_case_insensitive);
         register_action(editor, window, Editor::unique_lines_case_sensitive);
-        register_action(editor, window, Editor::accept_partial_inline_completion);
+        register_action(editor, window, Editor::accept_next_word_inline_completion);
+        register_action(editor, window, Editor::accept_next_line_inline_completion);
         register_action(editor, window, Editor::accept_edit_prediction);
         register_action(editor, window, Editor::restore_file);
         register_action(editor, window, Editor::git_restore);

--- a/crates/migrator/src/migrations/m_2025_04_21/keymap.rs
+++ b/crates/migrator/src/migrations/m_2025_04_21/keymap.rs
@@ -1,0 +1,34 @@
+use collections::HashMap;
+use std::{ops::Range, sync::LazyLock};
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+use crate::patterns::KEYMAP_ACTION_STRING_PATTERN;
+
+pub const KEYMAP_PATTERNS: MigrationPatterns =
+    &[(KEYMAP_ACTION_STRING_PATTERN, replace_string_action)];
+
+fn replace_string_action(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let action_name_ix = query.capture_index_for_name("action_name")?;
+    let action_name_node = mat.nodes_for_capture_index(action_name_ix).next()?;
+    let action_name_range = action_name_node.byte_range();
+    let action_name = contents.get(action_name_range.clone())?;
+
+    if let Some(new_action_name) = STRING_REPLACE.get(&action_name) {
+        return Some((action_name_range, new_action_name.to_string()));
+    }
+
+    None
+}
+
+/// "ctrl-cmd-right": "editor::AcceptPartialEditPrediction" -> "editor::AcceptNextWordEditPrediction",
+static STRING_REPLACE: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
+    HashMap::from_iter([(
+        "editor::AcceptPartialEditPrediction",
+        "editor::AcceptNextWordEditPrediction",
+    )])
+});

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -201,7 +201,7 @@ fn register_backward_compatible_actions(editor: &mut Editor, cx: &mut Context<Ed
              _: &editor::actions::AcceptPartialCopilotSuggestion,
              window: &mut Window,
              cx: &mut Context<Editor>| {
-                editor.accept_partial_inline_completion(&Default::default(), window, cx);
+                editor.accept_next_word_inline_completion(&Default::default(), window, cx);
             },
         ))
         .detach();

--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -64,7 +64,8 @@ In these cases, `alt-tab` is used instead to accept the prediction. When the lan
 
 On Linux, `alt-tab` is often used by the window manager for switching windows, so `alt-l` is provided as the default binding for accepting predictions. `tab` and `alt-tab` also work, but aren't displayed by default.
 
-{#action editor::AcceptPartialEditPrediction} ({#kb editor::AcceptPartialEditPrediction}) can be used to accept the current edit prediction up to the next word boundary.
+{#action editor::AcceptNextWordEditPrediction} ({#kb editor::AcceptNextWordEditPrediction}) can be used to accept the current edit prediction up to the next word boundary.
+{#action editor::AcceptNextLineEditPrediction} ({#kb editor::AcceptNextLineEditPrediction}) can be used to accept the current edit prediction up to the new line boundary.
 
 See the [Configuring GitHub Copilot](#github-copilot) and [Configuring Supermaven](#supermaven) sections below for configuration of other providers. Only text insertions at the current cursor are supported for these providers, whereas the Zeta model provides multiple predictions including deletions.
 


### PR DESCRIPTION
Closes #20574 

Release Notes:

- Added editor action to accept next line suggestion only with `editor::AcceptNextLineEditPrediction`
- `editor::AcceptPartialEditPrediction` renamed to `editor::AcceptNextWordEditPrediction`

Checklist:
- [x] Default keybindings: ctrl-cmd-down on macos and alt-down on linux (by analogy for right)
- [x] Added migrations for settings 
- [x] Tested with supermaven 

https://github.com/user-attachments/assets/bdecb9a2-725d-40b8-85b0-57c132714e07


