### PR TITLE
toml: Bump to v0.1.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16954,7 +16954,7 @@ dependencies = [
 
 [[package]]
 name = "zed_toml"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/toml/Cargo.toml
+++ b/extensions/toml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_toml"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/toml/extension.toml
+++ b/extensions/toml/extension.toml
@@ -1,7 +1,7 @@
 id = "toml"
 name = "TOML"
 description = "TOML support."
-version = "0.1.2"
+version = "0.1.3"
 schema_version = 1
 authors = [
     "Max Brunsfeld <max@zed.dev>",


### PR DESCRIPTION
This PR bumps the TOML extension to v0.1.3.

Changes:

- https://github.com/zed-industries/zed/pull/25276

Release Notes:

- N/A
