### PR TITLE
emacs: Add support for paragraph navigation

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -49,7 +49,7 @@
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo
       "alt-{": "editor::MoveToStartOfParagraph", // backward-paragraph
-      "alt-}": "editor::MoveToStartOfParagraph", // forward-paragraph
+      "alt-}": "editor::MoveToEndOfParagraph", // forward-paragraph
       "ctrl-v": "editor::MovePageDown", // scroll-up
       "alt-v": "editor::MovePageUp", // scroll-down
       "ctrl-x [": "editor::MoveToBeginning", // beginning-of-buffer

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -48,6 +48,8 @@
       "ctrl-_": "editor::Undo", // undo
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo
+      "alt-{": "editor::MoveToStartOfParagraph", // backward-paragraph
+      "alt-}": "editor::MoveToStartOfParagraph", // forward-paragraph
       "ctrl-v": "editor::MovePageDown", // scroll-up
       "alt-v": "editor::MovePageUp", // scroll-down
       "ctrl-x [": "editor::MoveToBeginning", // beginning-of-buffer

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -49,7 +49,7 @@
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo
       "alt-{": "editor::MoveToStartOfParagraph", // backward-paragraph
-      "alt-}": "editor::MoveToStartOfParagraph", // forward-paragraph
+      "alt-}": "editor::MoveToEndOfParagraph", // forward-paragraph
       "ctrl-v": "editor::MovePageDown", // scroll-up
       "alt-v": "editor::MovePageUp", // scroll-down
       "ctrl-x [": "editor::MoveToBeginning", // beginning-of-buffer

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -48,6 +48,8 @@
       "ctrl-_": "editor::Undo", // undo
       "ctrl-/": "editor::Undo", // undo
       "ctrl-x u": "editor::Undo", // undo
+      "alt-{": "editor::MoveToStartOfParagraph", // backward-paragraph
+      "alt-}": "editor::MoveToStartOfParagraph", // forward-paragraph
       "ctrl-v": "editor::MovePageDown", // scroll-up
       "alt-v": "editor::MovePageUp", // scroll-down
       "ctrl-x [": "editor::MoveToBeginning", // beginning-of-buffer


### PR DESCRIPTION
Release Notes:

- emacs: Added support for `alt-{` and `alt-}` paragraph navigation