### PR TITLE
assistant2: Remove blank line in parameter list

### DIFF
--- a/crates/assistant2/src/thread_history.rs
+++ b/crates/assistant2/src/thread_history.rs
@@ -20,7 +20,6 @@ impl ThreadHistory {
     pub(crate) fn new(
         assistant_panel: WeakEntity<AssistantPanel>,
         thread_store: Entity<ThreadStore>,
-
         cx: &mut Context<Self>,
     ) -> Self {
         Self {


### PR DESCRIPTION
This PR removes a blank line in the `ThreadHistory::new` parameter list.

Release Notes:

- N/A
