### PR TITLE
project_panel: Add `hide_root` when only one folder in the project

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -604,7 +604,9 @@
       // 2. Never show indent guides:
       //    "never"
       "show": "always"
-    }
+    },
+    /// Hide main root dir
+    "hide_root": false
   },
   "outline_panel": {
     // Whether to show the outline panel button in the status bar

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -605,7 +605,7 @@
       //    "never"
       "show": "always"
     },
-    /// Hide main root dir
+    // Whether to hide the root entry when only one folder is open in the window.
     "hide_root": false
   },
   "outline_panel": {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -464,6 +464,9 @@ impl ProjectPanel {
                     if project_panel_settings.hide_gitignore != new_settings.hide_gitignore {
                         this.update_visible_entries(None, cx);
                     }
+                    if project_panel_settings.hide_root != new_settings.hide_root {
+                        this.update_visible_entries(None, cx);
+                    }
                     project_panel_settings = new_settings;
                     this.update_diagnostics(cx);
                     cx.notify();

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2109,19 +2109,11 @@ impl ProjectPanel {
     }
 
     fn select_first(&mut self, _: &SelectFirst, window: &mut Window, cx: &mut Context<Self>) {
-        let worktree = self
-            .visible_entries
-            .first()
-            .and_then(|(worktree_id, _, _)| {
-                self.project.read(cx).worktree_for_id(*worktree_id, cx)
-            });
-        if let Some(worktree) = worktree {
-            let worktree = worktree.read(cx);
-            let worktree_id = worktree.id();
-            if let Some(root_entry) = worktree.root_entry() {
+        if let Some((worktree_id, visible_worktree_entries, _)) = self.visible_entries.first() {
+            if let Some(entry) = visible_worktree_entries.first() {
                 let selection = SelectedEntry {
-                    worktree_id,
-                    entry_id: root_entry.id,
+                    worktree_id: *worktree_id,
+                    entry_id: entry.id,
                 };
                 self.selection = Some(selection);
                 if window.modifiers().shift {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2790,7 +2790,10 @@ impl ProjectPanel {
         let old_ancestors = std::mem::take(&mut self.ancestors);
         self.visible_entries.clear();
         let mut max_width_item = None;
-        for worktree in project.visible_worktrees(cx) {
+
+        let visible_worktrees: Vec<_> = project.visible_worktrees(cx).collect();
+        let hide_root = settings.hide_root && visible_worktrees.len() == 1;
+        for worktree in visible_worktrees {
             let worktree_snapshot = worktree.read(cx).snapshot();
             let worktree_id = worktree_snapshot.id();
 
@@ -2825,7 +2828,6 @@ impl ProjectPanel {
                 GitTraversal::new(&repo_snapshots, worktree_snapshot.entries(true, 0));
             let mut auto_folded_ancestors = vec![];
             while let Some(entry) = entry_iter.entry() {
-                let hide_root = ProjectPanelSettings::get_global(cx).hide_root;
                 if hide_root && Some(entry.entry) == worktree.read(cx).root_entry() {
                     entry_iter.advance();
                     continue;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3732,7 +3732,7 @@ impl ProjectPanel {
                     None
                 }
             })
-            .unwrap_or((0, 0));
+            .unwrap_or_else(|| (0, entry.path.components().count()));
 
         (depth, difference)
     }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2825,6 +2825,12 @@ impl ProjectPanel {
                 GitTraversal::new(&repo_snapshots, worktree_snapshot.entries(true, 0));
             let mut auto_folded_ancestors = vec![];
             while let Some(entry) = entry_iter.entry() {
+                let hide_root = ProjectPanelSettings::get_global(cx).hide_root;
+                if hide_root && Some(entry.entry) == worktree.read(cx).root_entry() {
+                    entry_iter.advance();
+                    continue;
+                }
+
                 if auto_collapse_dirs && entry.kind.is_dir() {
                     auto_folded_ancestors.push(entry.id);
                     if !self.unfolded_dir_ids.contains(&entry.id) {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -147,7 +147,7 @@ pub struct ProjectPanelSettingsContent {
     /// Settings related to indent guides in the project panel.
     pub indent_guides: Option<IndentGuidesSettingsContent>,
     /// Hide main root dir
-    /// 
+    ///
     /// Default: false
     pub hide_root: Option<bool>,
 }

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -146,9 +146,9 @@ pub struct ProjectPanelSettingsContent {
     pub show_diagnostics: Option<ShowDiagnostics>,
     /// Settings related to indent guides in the project panel.
     pub indent_guides: Option<IndentGuidesSettingsContent>,
-    /// Default: false
-    /// 
     /// Hide main root dir
+    /// 
+    /// Default: false
     pub hide_root: Option<bool>,
 }
 

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -44,6 +44,7 @@ pub struct ProjectPanelSettings {
     pub auto_fold_dirs: bool,
     pub scrollbar: ScrollbarSettings,
     pub show_diagnostics: ShowDiagnostics,
+    pub hide_root: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -145,6 +146,10 @@ pub struct ProjectPanelSettingsContent {
     pub show_diagnostics: Option<ShowDiagnostics>,
     /// Settings related to indent guides in the project panel.
     pub indent_guides: Option<IndentGuidesSettingsContent>,
+    /// Default: false
+    /// 
+    /// Hide main root dir
+    pub hide_root: Option<bool>,
 }
 
 impl Settings for ProjectPanelSettings {

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -146,7 +146,7 @@ pub struct ProjectPanelSettingsContent {
     pub show_diagnostics: Option<ShowDiagnostics>,
     /// Settings related to indent guides in the project panel.
     pub indent_guides: Option<IndentGuidesSettingsContent>,
-    /// Hide main root dir
+    /// Whether to hide the root entry when only one folder is open in the window.
     ///
     /// Default: false
     pub hide_root: Option<bool>,

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2475,6 +2475,7 @@ async fn test_select_directory(cx: &mut gpui::TestAppContext) {
         ]
     );
 }
+
 #[gpui::test]
 async fn test_select_first_last(cx: &mut gpui::TestAppContext) {
     init_test_with_editor(cx);
@@ -2542,6 +2543,40 @@ async fn test_select_first_last(cx: &mut gpui::TestAppContext) {
             "      file_1.py",
             "      file_2.py  <== selected",
         ]
+    );
+
+    cx.update(|_, cx| {
+        let settings = *ProjectPanelSettings::get_global(cx);
+        ProjectPanelSettings::override_global(
+            ProjectPanelSettings {
+                hide_root: true,
+                ..settings
+            },
+            cx,
+        );
+    });
+
+    let panel = workspace.update(cx, ProjectPanel::new).unwrap();
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &["> dir_1", "> zdir_2", "  file_1.py", "  file_2.py",],
+        "With hide_root=true, root should be hidden"
+    );
+
+    panel.update_in(cx, |panel, window, cx| {
+        panel.select_first(&SelectFirst, window, cx)
+    });
+
+    assert_eq!(
+        visible_entries_as_strings(&panel, 0..10, cx),
+        &[
+            "> dir_1  <== selected",
+            "> zdir_2",
+            "  file_1.py",
+            "  file_2.py",
+        ],
+        "With hide_root=true, first entry should be dir_1, not the hidden root"
     );
 }
 

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -2967,13 +2967,22 @@ async fn test_rename_with_hide_root(cx: &mut gpui::TestAppContext) {
         select_path(&panel, "root1", cx);
         panel.update_in(cx, |panel, window, cx| panel.rename(&Rename, window, cx));
 
+        #[cfg(target_os = "windows")]
         assert!(
-            panel.read_with(cx, |panel, _| panel.edit_state.is_some()),
-            "Rename should work with multiple worktrees even when hide_root=true"
+            panel.read_with(cx, |panel, _| panel.edit_state.is_none()),
+            "Rename should be blocked on Windows even with multiple worktrees"
         );
-        panel.update_in(cx, |panel, window, cx| {
-            panel.cancel(&menu::Cancel, window, cx)
-        });
+
+        #[cfg(not(target_os = "windows"))]
+        {
+            assert!(
+                panel.read_with(cx, |panel, _| panel.edit_state.is_some()),
+                "Rename should work with multiple worktrees on non-Windows when hide_root=true"
+            );
+            panel.update_in(cx, |panel, window, cx| {
+                panel.cancel(&menu::Cancel, window, cx)
+            });
+        }
     }
 }
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3099,7 +3099,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "indent_guides": {
       "show": "always"
     },
-    "hide_root": false,
+    "hide_root": false
   }
 }
 ```

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3098,7 +3098,8 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "show_diagnostics": "all",
     "indent_guides": {
       "show": "always"
-    }
+    },
+    "hide_root": false,
   }
 }
 ```


### PR DESCRIPTION
Closes #24188

Todo:
- [x] Hide root when only one worktree
- [x] Basic tests
- [x] Docs
- [x] Fix `select_first` + tests
- [x] Fix auto collapse dir + tests
- [x] Fix file / dir creation + tests
- [x] Fix root rename case

| Show root | Hide root |
|--------|--------|
| <img width="272" alt="Screenshot 2025-02-20 alle 22 35 55" src="https://github.com/user-attachments/assets/361d93c7-e1ad-4419-a5f4-be62c9632807" /> | <img width="269" alt="Screenshot 2025-02-20 alle 22 36 11" src="https://github.com/user-attachments/assets/62011f76-a24b-4297-9734-f5c3b9f75760" /> |
| <img width="275" alt="Screenshot 2025-02-20 alle 22 56 33" src="https://github.com/user-attachments/assets/77e7e6e6-3dfe-4e88-b4b0-b620cb809d2b" /> | <img width="267" alt="Screenshot 2025-02-20 alle 22 55 53" src="https://github.com/user-attachments/assets/fa1099c8-7ed0-45ef-a7cf-aeb54b8283b1" /> |


Release Notes:

- Added support to hide the root entry of the Project Panel when there’s only one folder in the project. This can be enabled by setting `hide_root` to `true` in the `project_panel` config. 
