### PR TITLE
assistant2: Combine history views into one

### DIFF
--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -7,6 +7,7 @@ mod context;
 mod context_picker;
 mod context_store;
 mod context_strip;
+mod history_store;
 mod inline_assistant;
 mod inline_prompt_editor;
 mod message_editor;

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -41,7 +41,6 @@ actions!(
         ToggleModelSelector,
         RemoveAllContext,
         OpenHistory,
-        OpenPromptEditorHistory,
         OpenConfiguration,
         RemoveSelectedThread,
         Chat,

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -192,7 +192,7 @@ impl AssistantPanel {
                 )
             }),
             message_editor,
-            context_store,
+            context_store: context_store.clone(),
             context_editor: None,
             context_history: None,
             configuration: None,
@@ -202,7 +202,7 @@ impl AssistantPanel {
                 chrono::Local::now().offset().local_minus_utc(),
             )
             .unwrap(),
-            history: cx.new(|cx| ThreadHistory::new(weak_self, thread_store, cx)),
+            history: cx.new(|cx| ThreadHistory::new(weak_self, thread_store, context_store, cx)),
             new_item_context_menu_handle: PopoverMenuHandle::default(),
             open_history_context_menu_handle: PopoverMenuHandle::default(),
             width: None,
@@ -350,7 +350,7 @@ impl AssistantPanel {
         cx.notify();
     }
 
-    fn open_saved_prompt_editor(
+    pub(crate) fn open_saved_prompt_editor(
         &mut self,
         path: PathBuf,
         window: &mut Window,

--- a/crates/assistant2/src/history_store.rs
+++ b/crates/assistant2/src/history_store.rs
@@ -1,0 +1,61 @@
+use assistant_context_editor::SavedContextMetadata;
+use chrono::{DateTime, Utc};
+use gpui::{prelude::*, Entity};
+
+use crate::thread_store::{SavedThreadMetadata, ThreadStore};
+
+pub enum HistoryEntry {
+    Thread(SavedThreadMetadata),
+    Context(SavedContextMetadata),
+}
+
+impl HistoryEntry {
+    pub fn updated_at(&self) -> DateTime<Utc> {
+        match self {
+            HistoryEntry::Thread(thread) => thread.updated_at,
+            HistoryEntry::Context(context) => context.mtime.to_utc(),
+        }
+    }
+}
+
+pub struct HistoryStore {
+    thread_store: Entity<ThreadStore>,
+    context_store: Entity<assistant_context_editor::ContextStore>,
+}
+
+impl HistoryStore {
+    pub fn new(
+        thread_store: Entity<ThreadStore>,
+        context_store: Entity<assistant_context_editor::ContextStore>,
+        _cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            thread_store,
+            context_store,
+        }
+    }
+
+    /// Returns the number of history entries.
+    pub fn entry_count(&self, cx: &mut Context<Self>) -> usize {
+        self.entries(cx).len()
+    }
+
+    pub fn entries(&self, cx: &mut Context<Self>) -> Vec<HistoryEntry> {
+        let mut history_entries = Vec::new();
+
+        for thread in self.thread_store.update(cx, |this, _cx| this.threads()) {
+            history_entries.push(HistoryEntry::Thread(thread));
+        }
+
+        for context in self.context_store.update(cx, |this, _cx| this.contexts()) {
+            history_entries.push(HistoryEntry::Context(context));
+        }
+
+        history_entries.sort_unstable_by_key(|entry| std::cmp::Reverse(entry.updated_at()));
+        history_entries
+    }
+
+    pub fn recent_entries(&self, limit: usize, cx: &mut Context<Self>) -> Vec<HistoryEntry> {
+        self.entries(cx).into_iter().take(limit).collect()
+    }
+}

--- a/crates/assistant_context_editor/src/context.rs
+++ b/crates/assistant_context_editor/src/context.rs
@@ -3366,7 +3366,7 @@ impl SavedContextV0_1_0 {
     }
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SavedContextMetadata {
     pub title: String,
     pub path: PathBuf,

--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -350,6 +350,12 @@ impl ContextStore {
         }
     }
 
+    pub fn contexts(&self) -> Vec<SavedContextMetadata> {
+        let mut contexts = self.contexts_metadata.iter().cloned().collect::<Vec<_>>();
+        contexts.sort_unstable_by_key(|thread| std::cmp::Reverse(thread.mtime));
+        contexts
+    }
+
     pub fn create(&mut self, cx: &mut Context<Self>) -> Entity<AssistantContext> {
         let context = cx.new(|cx| {
             AssistantContext::local(


### PR DESCRIPTION
This PR combines the two history views in Assistant2 into one.

<img width="1309" alt="Screenshot 2025-02-20 at 5 34 37 PM" src="https://github.com/user-attachments/assets/fbb08542-58b5-4930-8a20-254234e335fa" />

<img width="1309" alt="Screenshot 2025-02-20 at 5 34 41 PM" src="https://github.com/user-attachments/assets/1174849e-edad-4e02-8bf3-bb92aafba4f8" />


Release Notes:

- N/A
