### PR TITLE
Improve syntax highlighting

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -236,6 +236,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#628b80ff",
             "font_style": null,
@@ -251,13 +256,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fe8f40ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#aad84cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#bfbdb6ff",
             "font_style": null,
             "font_weight": null
           },
@@ -306,13 +316,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#a6a5a0ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#5ac1feff",
             "font_style": null,
             "font_weight": null
           },
@@ -346,17 +371,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#fe8f40ff",
+          "type": {
+            "color": "#59c2ffff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#bfbdb6ff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#59c2ffff",
             "font_style": null,
             "font_weight": null
@@ -607,6 +627,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8ca7c2ff",
             "font_style": null,
@@ -622,13 +647,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#f98d3fff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#85b304ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#5c6166ff",
             "font_style": null,
             "font_weight": null
           },
@@ -677,13 +707,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#73777bff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#3b9ee5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -717,17 +762,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#f98d3fff",
+          "type": {
+            "color": "#389ee6ff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#5c6166ff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#389ee6ff",
             "font_style": null,
             "font_weight": null
@@ -978,6 +1018,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#7399a3ff",
             "font_style": null,
@@ -993,13 +1038,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fead66ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d5fe80ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#cccac2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1048,13 +1098,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#b4b3aeff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#72cffeff",
             "font_style": null,
             "font_weight": null
           },
@@ -1088,17 +1153,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#fead66ff",
+          "type": {
+            "color": "#73cfffff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#cccac2ff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#73cfffff",
             "font_style": null,
             "font_weight": null

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -253,6 +253,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -268,13 +273,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -323,13 +333,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -363,17 +388,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#83a598ff",
+          "type": {
+            "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#b8bb25ff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -641,6 +661,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -656,13 +681,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -711,13 +741,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -751,17 +796,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#83a598ff",
+          "type": {
+            "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#b8bb25ff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -1029,6 +1069,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -1044,13 +1089,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1099,13 +1149,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1139,17 +1204,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#83a598ff",
+          "type": {
+            "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#b8bb25ff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -1417,6 +1477,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1432,13 +1497,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1487,13 +1557,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1527,17 +1612,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#066578ff",
+          "type": {
+            "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#79740eff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
@@ -1805,6 +1885,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1820,13 +1905,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1875,13 +1965,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1915,17 +2020,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#066578ff",
+          "type": {
+            "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#79740eff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
@@ -2193,6 +2293,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -2208,13 +2313,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2263,13 +2373,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2303,17 +2428,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#066578ff",
+          "type": {
+            "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#79740eff",
-            "font_style": null,
-            "font_weight": 700
-          },
-          "type": {
+          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -239,6 +239,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#788ca6ff",
             "font_style": null,
@@ -254,13 +259,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#73ade9ff",
             "font_style": "normal",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#dce0e5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -309,13 +319,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#d07277ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b1574bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#74ade8ff",
             "font_style": null,
             "font_weight": null
           },
@@ -349,17 +374,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#a1c181ff",
+          "type": {
+            "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#d07277ff",
-            "font_style": null,
-            "font_weight": 400
-          },
-          "type": {
+          "unit": {
             "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
@@ -618,6 +638,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#7274a7ff",
             "font_style": null,
@@ -633,13 +658,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#5b79e3ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#3882b7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#242529ff",
             "font_style": null,
             "font_weight": null
           },
@@ -688,13 +718,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#d3604fff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b92b46ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#5c78e2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -728,17 +773,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#649f57ff",
+          "type": {
+            "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null
           },
-          "title": {
-            "color": "#d3604fff",
-            "font_style": null,
-            "font_weight": 400
-          },
-          "type": {
+          "unit": {
             "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null

--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -4,11 +4,10 @@
   (heredoc_body)
   (heredoc_start)
   (ansi_c_string)
+  (word)
 ] @string
 
-(command_name) @function
-
-(variable_name) @property
+(variable_name) @variable
 
 [
   "case"
@@ -35,23 +34,66 @@
 (comment) @comment
 
 (function_definition name: (word) @function)
+(command_name (word) @function)
 
-(file_descriptor) @number
+[
+  (file_descriptor)
+  (number)
+] @number
+
+(regex) @string.regex
 
 [
   (command_substitution)
   (process_substitution)
   (expansion)
-]@embedded
+] @embedded
+
 
 [
   "$"
   "&&"
   ">"
   ">>"
+  ">&"
+  ">&-"
   "<"
   "|"
+  ":"
+  "//"
+  "/"
+  "%"
+  "%%"
+  "#"
+  "##"
+  "="
+  "=="
 ] @operator
+
+(test_operator) @keyword.operator
+
+[
+  ";"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+(simple_expansion
+  "$" @punctuation.special)
+(expansion
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(command_substitution
+  "$(" @punctuation.special
+  ")" @punctuation.special)
 
 (
   (command (_) @constant)

--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -103,12 +103,12 @@
   (true)
   (false)
   (null)
-] @constant
+] @constant.builtin
 
 (identifier) @variable
 
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+((identifier) @constant.variable
+ (#match? @constant.variable "^_*[A-Z][A-Z\\d_]*$"))
 
 (call_expression
   function: (identifier) @function)

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -77,8 +77,8 @@ type :(primitive_type) @type.primitive
 (attribute
     name: (identifier) @keyword)
 
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+((identifier) @constant.variable
+ (#match? @constant.variable "^_*[A-Z][A-Z\\d_]*$"))
 
 (statement_identifier) @label
 (this) @variable.special
@@ -155,7 +155,7 @@ type :(primitive_type) @type.primitive
   (false)
   (null)
   ("nullptr")
-] @constant
+] @constant.builtin
 
 (number_literal) @number
 

--- a/crates/languages/src/css/highlights.scm
+++ b/crates/languages/src/css/highlights.scm
@@ -11,6 +11,7 @@
   ">"
   "+"
   "-"
+  "|"
   "*"
   "/"
   "="
@@ -19,35 +20,48 @@
   "~="
   "$="
   "*="
+] @operator
+
+[
   "and"
   "or"
   "not"
   "only"
-] @operator
+] @keyword.operator
 
 (attribute_selector (plain_value) @string)
 
+[
+  (id_name)
+  (class_name)
+] @selector
+
+(namespace_name) @namespace
+(namespace_selector (tag_name) @namespace "|")
+
 (attribute_name) @attribute
-(pseudo_element_selector (tag_name) @attribute)
-(pseudo_class_selector (class_name) @attribute)
+(pseudo_element_selector "::" (tag_name) @attribute)
+(pseudo_class_selector ":" (class_name) @attribute)
 
 [
-  (class_name)
-  (id_name)
-  (namespace_name)
   (feature_name)
+  (property_name)
 ] @property
 
-(property_name) @constant
-
 (function_name) @function
+
+[
+  (plain_value)
+  (keyframes_name)
+  (keyword_query)
+] @constant
 
 (
   [
     (property_name)
     (plain_value)
-  ] @variable.special
-  (#match? @variable.special "^--")
+  ] @variable
+  (#match? @variable "^--")
 )
 
 [
@@ -61,7 +75,7 @@
   (to)
   (from)
   (important)
-]  @keyword
+] @keyword
 
 (string_value) @string
 (color_value) @string.special
@@ -71,7 +85,7 @@
   (float_value)
 ] @number
 
-(unit) @type
+(unit) @constant.unit
 
 [
   ","
@@ -79,7 +93,7 @@
   "."
   "::"
   ";"
-  "#"
+  (id_selector "#")
 ] @punctuation.delimiter
 
 [

--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -2,6 +2,7 @@
 
 (type_identifier) @type
 (field_identifier) @variable.member
+(package_identifier) @variable.namespace
 
 (keyed_element
   .
@@ -20,6 +21,15 @@
 
 (method_declaration
   name: (field_identifier) @function.method)
+(method_elem
+  name: (field_identifier) @function.method)
+
+[
+  ";"
+  "."
+  ","
+  ":"
+] @punctuation.delimiter
 
 [
   "("
@@ -113,7 +123,7 @@
 ] @number
 
 (const_spec
-  name: (identifier) @constant)
+  name: (identifier) @constant.variable)
 
 [
   (true)

--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -54,8 +54,8 @@
   (identifier)
   (shorthand_property_identifier)
   (shorthand_property_identifier_pattern)
- ] @constant
- (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
+ ] @constant.variable
+ (#match? @constant.variable "^_*[A-Z_][A-Z\\d_]*$"))
 
 ; Literals
 
@@ -65,12 +65,9 @@
 [
   (null)
   (undefined)
-] @constant.builtin
-
-[
   (true)
   (false)
-] @boolean
+] @constant.builtin
 
 (comment) @comment
 
@@ -82,6 +79,7 @@
 (escape_sequence) @string.escape
 
 (regex) @string.regex
+(regex_flags) @keyword.regex
 (number) @number
 
 ; Tokens
@@ -210,6 +208,8 @@
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
+(decorator "@" @punctuation.special)
+
 ; Keywords
 
 [ "abstract"
@@ -229,11 +229,13 @@
 ] @keyword
 
 ; JSX elements
-(jsx_opening_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
-(jsx_closing_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
-(jsx_self_closing_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
+(jsx_opening_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_self_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
 
-(jsx_attribute (property_identifier) @attribute)
-(jsx_opening_element (["<" ">"]) @punctuation.bracket)
-(jsx_closing_element (["</" ">"]) @punctuation.bracket)
-(jsx_self_closing_element (["<" "/>"]) @punctuation.bracket)
+(jsx_attribute (property_identifier) @attribute.jsx)
+(jsx_opening_element (["<" ">"]) @punctuation.jsx.bracket)
+(jsx_closing_element (["</" ">"]) @punctuation.jsx.bracket)
+(jsx_self_closing_element (["<" "/>"]) @punctuation.jsx.bracket)
+(jsx_attribute "=" @punctuation.jsx.delimiter)
+(jsx_text) @text.jsx

--- a/crates/languages/src/jsdoc/highlights.scm
+++ b/crates/languages/src/jsdoc/highlights.scm
@@ -1,2 +1,2 @@
-(tag_name) @keyword
-(type) @type
+(tag_name) @comment.doc.keyword
+(type) @comment.doc.type

--- a/crates/languages/src/json/highlights.scm
+++ b/crates/languages/src/json/highlights.scm
@@ -12,7 +12,12 @@
   (true)
   (false)
   (null)
-] @constant
+] @constant.builtin
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
 
 [
   "{"

--- a/crates/languages/src/jsonc/highlights.scm
+++ b/crates/languages/src/jsonc/highlights.scm
@@ -12,7 +12,12 @@
   (true)
   (false)
   (null)
-] @constant
+] @constant.builtin
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
 
 [
   "{"

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -1,6 +1,20 @@
-(emphasis) @emphasis
-(strong_emphasis) @emphasis.strong
-(code_span) @text.literal
-(link_text) @link_text
-(link_label) @link_text
-(link_destination) @link_uri
+(emphasis) @markup.emphasis
+(strong_emphasis) @markup.emphasis.strong
+(code_span) @markup.raw
+(strikethrough) @markup.strikethrough
+
+[
+  (inline_link)
+  (shortcut_link)
+  (collapsed_reference_link)
+  (full_reference_link)
+  (image)
+] @markup.link
+
+(inline_link ["(" ")"] @markup.link.url)
+(image ["(" ")"] @markup.link.url)
+[
+  (link_destination)
+  (uri_autolink)
+  (email_autolink)
+] @markup.link.url

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -1,7 +1,15 @@
 [
+  (paragraph)
+  (indented_code_block)
+  (pipe_table)
+] @text
+
+[
   (atx_heading)
   (setext_heading)
-] @title
+  (thematic_break)
+] @markup.heading
+(setext_heading (paragraph) @markup.heading)
 
 [
   (list_marker_plus)
@@ -9,8 +17,18 @@
   (list_marker_star)
   (list_marker_dot)
   (list_marker_parenthesis)
-] @punctuation.list_marker
+  (block_quote_marker)
+] @punctuation.markup
+
+(pipe_table_header "|" @punctuation.markup)
+(pipe_table_row "|" @punctuation.markup)
+(pipe_table_delimiter_row "|" @punctuation.markup)
+(pipe_table_delimiter_cell "-" @punctuation.markup)
 
 (fenced_code_block
   (info_string
-    (language) @text.literal))
+    (language) @punctuation.markup.embedded))
+(fenced_code_block_delimiter) @punctuation.markup.embedded
+
+(link_reference_definition) @markup.link
+(link_destination) @markup.link.url

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -5,9 +5,10 @@
   (#match? @type.class "^_*[A-Z][A-Za-z0-9_]*$"))
 
 ; ALL_CAPS for constants:
-((identifier) @constant
-  (#match? @constant "^_*[A-Z][A-Z0-9_]*$"))
+((identifier) @constant.variable
+  (#match? @constant.variable "^_*[A-Z][A-Z0-9_]*$"))
 
+(identifier) @variable
 (attribute attribute: (identifier) @property)
 (type (identifier) @type)
 (generic_type (identifier) @type)
@@ -115,6 +116,12 @@
 ]
 
 [
+  "."
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
   "("
   ")"
   "["
@@ -187,6 +194,7 @@
   "&"
   "%"
   "%="
+  "@"
   "^"
   "+"
   "->"

--- a/crates/languages/src/regex/highlights.scm
+++ b/crates/languages/src/regex/highlights.scm
@@ -4,24 +4,22 @@
   "(?"
   "(?:"
   "(?<"
+  "(?P="
+  "<"
   ">"
   "["
   "]"
   "{"
   "}"
-] @punctuation.bracket
+] @punctuation.regex.bracket
 
-(group_name) @property
+(group_name) @label.regex
 
 [
   (identity_escape)
   (control_letter_escape)
   (character_class_escape)
   (control_escape)
-  (start_assertion)
-  (end_assertion)
-  (boundary_assertion)
-  (non_boundary_assertion)
 ] @string.escape
 
 [
@@ -31,18 +29,26 @@
   "|"
   "="
   "!"
-] @operator
+  (start_assertion)
+  (end_assertion)
+] @operator.regex
+
+[
+  (boundary_assertion)
+  (non_boundary_assertion)
+  (backreference_escape)
+] @keyword.operator.regex
 
 (count_quantifier
   [
     (decimal_digits) @number
-    "," @punctuation.delimiter
+    "," @punctuation.regex.delimiter
   ])
 
 (character_class
   [
-    "^" @operator
-    (class_range "-" @operator)
+    "^" @operator.regex
+    (class_range "-" @operator.regex)
   ])
 
 (class_character) @constant.character

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -1,3 +1,4 @@
+(identifier) @variable
 (type_identifier) @type
 (primitive_type) @type.builtin
 (self) @variable.special
@@ -47,8 +48,8 @@
  (#match? @type "^[A-Z]"))
 
 ; Assume all-caps names are constants
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+((identifier) @constant.variable
+ (#match? @constant.variable "^_*[A-Z][A-Z\\d_]*$"))
 
 [
   "("
@@ -129,7 +130,7 @@
   (float_literal)
 ] @number
 
-(boolean_literal) @constant
+(boolean_literal) @constant.builtin
 
 [
   (line_comment)

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -57,8 +57,8 @@
   (identifier)
   (shorthand_property_identifier)
   (shorthand_property_identifier_pattern)
- ] @constant
- (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
+ ] @constant.variable
+ (#match? @constant.variable "^_*[A-Z_][A-Z\\d_]*$"))
 
 ; Literals
 
@@ -68,12 +68,9 @@
 [
   (null)
   (undefined)
-] @constant.builtin
-
-[
   (true)
   (false)
-] @boolean
+] @constant.builtin
 
 (comment) @comment
 
@@ -221,6 +218,8 @@
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
 
+(decorator "@" @punctuation.special)
+
 ; Keywords
 
 [ "abstract"
@@ -240,11 +239,13 @@
 ] @keyword
 
 ; JSX elements
-(jsx_opening_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
-(jsx_closing_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
-(jsx_self_closing_element (identifier) @tag (#match? @tag "^[a-z][^.]*$"))
+(jsx_opening_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
+(jsx_self_closing_element (identifier) @tag.jsx (#match? @tag.jsx "^[a-z][^.]*$"))
 
-(jsx_attribute (property_identifier) @attribute)
-(jsx_opening_element (["<" ">"]) @punctuation.bracket)
-(jsx_closing_element (["</" ">"]) @punctuation.bracket)
-(jsx_self_closing_element (["<" "/>"]) @punctuation.bracket)
+(jsx_attribute (property_identifier) @attribute.jsx)
+(jsx_opening_element (["<" ">"]) @punctuation.jsx.bracket)
+(jsx_closing_element (["</" ">"]) @punctuation.jsx.bracket)
+(jsx_self_closing_element (["<" "/>"]) @punctuation.jsx.bracket)
+(jsx_attribute "=" @punctuation.jsx.delimiter)
+(jsx_text) @text.jsx

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -31,8 +31,8 @@
   (identifier)
   (shorthand_property_identifier)
   (shorthand_property_identifier_pattern)
- ] @constant
- (#match? @constant "^_*[A-Z_][A-Z\\d_]*$"))
+ ] @constant.variable
+ (#match? @constant.variable "^_*[A-Z_][A-Z\\d_]*$"))
 
 ; Properties
 
@@ -83,12 +83,9 @@
 [
   (null)
   (undefined)
-] @constant.builtin
-
-[
   (true)
   (false)
-] @boolean
+] @constant.builtin
 
 (literal_type
   [
@@ -198,6 +195,8 @@
 (type_arguments
   "<" @punctuation.bracket
   ">" @punctuation.bracket)
+
+(decorator "@" @punctuation.special)
 
 ; Keywords
 


### PR DESCRIPTION
A PR to improve syntax highlighting and add missing scopes.
Changes are listed below with examples.

Release Notes:

  - Improved syntax highlighting for Bash, C, C++, CSS, Go, JavaScript, JSDoc, TSX, TypeScript, JSON, Markdown, Python, Regex, Rust

---

### Bash

| Zed 0.174.5 | With this PR |
| --- | --- |
|  ![](https://github.com/user-attachments/assets/a8cf83d7-8df3-4785-85dc-1c8f951c4c7d) | ![](https://github.com/user-attachments/assets/2f416067-833d-4631-b39c-69c05234e685) |

- `>&`, `>&-`, `:`, `//`, `/`, `%`, `%%`, `#`, `##`, `=`, `==`: `operator`
- `-lt`, `-le`, `-gt`, `-ge`, `-eq`, `-ne`, `-z`, `-n`: `keyword.operator`, as defined in other languages
- `regex`: `string.regex`, as defined in other languages
- `number`: `number`
- `string`: `string`
- `variable`: `property` -> `variable`
- `;`: `punctuation.delimiter`
- `(`, `)`, `{`, `}`, `[`, `]`: `punctuation.bracket`
- `$`, `${ }`, `$( )`: `punctuation.special`, as defined in other languages

```bash
variable=I\ like\ Zed
function my_function() {
  echo "Hello world, ${variable//regex/string}" > file
}
if [ $(uid) -lt 600 ]; then
  my_function;
  cat file | grep hello >&3
fi
```

---

### C, C++

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/1269a5d3-c057-4368-b4b0-016db9b19551) | ![](https://github.com/user-attachments/assets/7cca4f7b-0232-4b34-b253-f3307c7ce86d) |

- `true`, `false`, `NULL`, `nullptr`: `constant` -> `constant.builtin`, as defined in other languages
- `IDENTIFIER`: `constant` -> `constant.variable`, different from constant literals

```cpp
#include <stdbool.h>
int a[] = {true, false};
const int * IDENTIFIER = nullptr;
```

---

### CSS

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/8d945988-d33a-4cc5-a44d-b411d2884a8a) | ![](https://github.com/user-attachments/assets/87c54811-0600-4edc-97e2-24695896c752) |

- `|`: `operator`
- `and`, `or`, `not`, `only`: `operator` -> `keyword.operator`, as defined in other languages
- `keyword_query`: `constant`, like in [Atom](https://github.com/atom/language-css/blob/9e4afce058b4593edf03ed1dec6033b163c678f0/grammars/css.cson#L1368) and [VS Code](https://github.com/microsoft/vscode/blob/0fe195613ed9901f669cd0f799fe807f0189d029/extensions/css/syntaxes/css.tmLanguage.json#L1368)
- `namespace_name`: `property` -> `namespace`, not a property name
- `property_name`: `constant` -> `property`, like `feature_name` already defined
- `plain_value`: `constant`
- `keyframes_name`: `constant`, to stay coherent as it is tokenized as `plain_value` when referenced
- `unit`: `type` -> `constant.unit`, [Atom](https://github.com/atom/language-css/blob/9e4afce058b4593edf03ed1dec6033b163c678f0/grammars/tree-sitter-css.cson#L73) and [VS Code](https://github.com/microsoft/vscode/blob/336801752dd09afa76f5429fba846e533bcdb7d9/extensions/css/syntaxes/css.tmLanguage.json#L1393) also have a `unit` scope for this
- `id_name`, `class_name`: `property` -> `selector`, not property names, these tokens deserve their own scope. [Atom](https://github.com/atom/language-css/blob/9e4afce058b4593edf03ed1dec6033b163c678f0/grammars/tree-sitter-css.cson#L45), [VS Code](https://github.com/microsoft/vscode/blob/0fe195613ed9901f669cd0f799fe807f0189d029/extensions/css/syntaxes/css.tmLanguage.json#L1638), [Neovim](https://github.com/nvim-treesitter/nvim-treesitter/blob/38e46a6d7ade5c8718f77b2b9fd98a0f7ab32c1e/queries/css/highlights.scm#L21) resort to recycling other scopes

```css
@media keyword_query and not keyword_query {}
@supports (feature_name: plain_value) {}
@namespace namespace_name url("string");
namespace_name|tag_name {}
@keyframes keyframes_name {
  to {
    top: 200unit;
    color: #c01045;
  }
}
tag_name::before,
#id_name:nth-child(even),
.class_name[attribute_name=plain_value] {
  property_name: 2em 1.2em;
  --variable: rgb(250, 0, 0);
  color: var(--variable);
  animation: keyframes_name 5s plain_value;
}
```

---

### Go

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/dd0ab5a5-146d-4cfc-845b-cc5a7df84425) | ![](https://github.com/user-attachments/assets/7be0c179-79d4-49fa-b0a7-14f6e35bbd4f) |

- `constant`: `constant` -> `constant.variable`, different from constant literals
- `package_identifier`: `namespace`
- `method_elem`: `function.method`
- `;` ,`.` ,`,` ,`:`: `punctuation.delimiter`

```go
package my_package
import (
  pkg "fmt"
)
type A interface {
  method_elem(foo int, bar float64) int
}
func main() {
  identifier := true
  const constant int = 3
  for i := 0; i <= 3; i++ {
    pkg.Println(identifier)
  }
}
```

---

### JavaScript, JSDoc, TSX, TypeScript

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/e216b3b2-0fe2-488d-9f6d-d11033a09c6c) | ![](https://github.com/user-attachments/assets/0f944219-dbf9-436f-9f91-1cb52ed6e4e1) |

- `IDENTIFIER`: `constant` -> `constant.variable`, different from constant literals
- `true`, `false`: `boolean` -> `constant.builtin`, this is the only language that has the `boolean` scope, so conforming to the majority
- `jsx_text`: `text.jsx`
- `=`: `punctuation.jsx.delimiter`
- `@`: `punctuation.special`, as in Python
- `jsdoc`: added `comment.doc` scope for [themes that highlight it](https://github.com/zed-industries/zed/blob/1fa105eaa5705306d979f5a492fd10b122bbda37/assets/themes/one/one.json#L199)

```javascript
/**
 * @keyword comment
 */
@log
class X {
  render() {
    return (
      <div jsx_attribute="value">
        <Input onKeyPress={super.bind(this)}/>
        jsx_text
      </div>
    );
  }
}
const IDENTIFIER = true
```

---

### JSON

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/e86889e9-f252-4d4c-9d89-7747520ccc23) | ![](https://github.com/user-attachments/assets/0eb55800-6029-4dd5-8b57-5617eb2612f8) |

- `true`, `false`, `null`: `constant` -> `constant.builtin`, as defined in other languages
- `,`, `:`: `punctuation.delimiter`

```json
{
  "property": null,
  "boolean": true
}
```

---

### Markdown

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/94f6f965-3e3d-40b1-9f8f-2082bde41dca) | ![](https://github.com/user-attachments/assets/afe0b059-788d-4add-b98f-5b83116284d7) |

Changes to include the `markup` scope, conforming to [Neovim](https://github.com/nvim-treesitter/nvim-treesitter/blob/38e46a6d7ade5c8718f77b2b9fd98a0f7ab32c1e/queries/markdown/highlights.scm#L59), [VS Code](https://github.com/microsoft/vscode/blob/dfad570d15959a6ce7210a313a1190e76e8fe2e2/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json#L60), [Atom](https://github.com/atom/language-gfm/blob/6686ac6ccca2632af24d5c200f85bcd80b9fa752/grammars/gfm.json#L147), and [Zed itself](https://github.com/zed-industries/zed/blob/1e255e41ccfdb88e2266469f1ccfe0d41533280b/crates/languages/src/gitcommit/highlights.scm#L1).

- `# Heading`: `title` -> `markup.heading`, as in the gitcommit grammar
- ```` ``` ````: `punctuation.markup.embedded`
- `-`, `1.`, `>`, `|`: `punctuation.markup`
- `*italic*`: `emphasis` -> `markup.emphasis`
- `**bold**`: `emphasis.strong` -> `markup.emphasis.strong`
- `~~strikethrough~~`: `markup.strikethrough`
- ``` `raw` ```: `text.literal` -> `markup.raw`
- `[link](url.com)`: `markup.link`
- `url.com`: `link_uri` -> `markup.link.url`, as in the gitcommit grammar
- `paragraph`, `indented_code_block`, `pipe_table`: `text`

````md

# Heading

Some stylized text:
- `raw`
- *italic*
- ~strike~
- **strong**

> quoted

```python
print("some code")
```

1. Here is an ![image](image.jpg)
2. A [link](https://github.com/zed-industries)
3. And even a [referenced link][1]

[1]: https://zed.dev

| tables | are |
| --- | --- |
| properly | scoped |

````

---

### Python

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/03a9bea6-fee9-4ed8-9179-a36e1f37f008) | ![](https://github.com/user-attachments/assets/b36f5bf1-0d59-45cb-b6e9-23ac20492a5d) |

- `@`: `operator`, for matrix multiplication
- `IDENTIFIER`: `constant` -> `constant.variable`, different from constant literals
- `identifier`: `variable`
- `.`, `,`, `:`: `punctuation.delimiter`

```python
class Mat(list):
  def __matmul__(self, b):
    ...
a, b = Mat(), Mat()
identifier = a @ b
IDENTIFIER = b @ a
```

---

### Regex

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/754a242b-492d-40f7-8662-5a4e6295beaa) | ![](https://github.com/user-attachments/assets/ea73405a-2fc7-4706-b8cc-b34433c37cd0) |

- `^`, `$`, `\b`, `\B`, `\k`: `string.escape` -> `operator`
- `group_name`: `property` -> `label`
- `(?P=`, `<`: `punctuation.bracket`
- added `regex` scope to target regex tokens specifically

```js
regex = /^(?<group>[!\.\?])\b[a-z]+word\k<group>$/g
```

---

### Rust

| Zed 0.174.5 | With this PR |
| --- | --- |
| ![](https://github.com/user-attachments/assets/fe64a7c8-ce49-4140-aae9-61f3fccc7daa) | ![](https://github.com/user-attachments/assets/e88500cc-2600-4de7-915e-f66cbf84631d) |

- `true`, `false`: `constant` -> `constant.builtin`, as defined in other languages
- `IDENTIFIER`: `constant` -> `constant.variable`, different from constant literals
- `identifier`: `variable`

```rust
let identifier = true;
const IDENTIFIER: i32 = 3;
```
