### PR TITLE
Fix/parse ssh command

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -202,7 +202,7 @@ impl SshConnectionOptions {
                 anyhow::bail!("unsupported argument: {:?}", arg);
             }
             let mut input = &arg as &str;
-            // destination might be: username1@username2@ip2@ip1
+            // Destination might be: username1@username2@ip2@ip1
             if let Some((u, rest)) = input.rsplit_once('@') {
                 input = rest;
                 username = Some(u.to_string());
@@ -238,7 +238,7 @@ impl SshConnectionOptions {
     pub fn ssh_url(&self) -> String {
         let mut result = String::from("ssh://");
         if let Some(username) = &self.username {
-            // username might be: username1@username2@ip2
+            // Username might be: username1@username2@ip2
             let username = username.replace("@", "%40");
             result.push_str(&username);
             result.push('@');

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -202,7 +202,8 @@ impl SshConnectionOptions {
                 anyhow::bail!("unsupported argument: {:?}", arg);
             }
             let mut input = &arg as &str;
-            if let Some((u, rest)) = input.split_once('@') {
+            // destination might be: username1@username2@ip2@ip1
+            if let Some((u, rest)) = input.rsplit_once('@') {
                 input = rest;
                 username = Some(u.to_string());
             }
@@ -237,7 +238,9 @@ impl SshConnectionOptions {
     pub fn ssh_url(&self) -> String {
         let mut result = String::from("ssh://");
         if let Some(username) = &self.username {
-            result.push_str(username);
+            // username might be: username1@username2@ip2
+            let username = username.replace("@", "%40");
+            result.push_str(&username);
             result.push('@');
         }
         result.push_str(&self.host);


### PR DESCRIPTION
Closes #25246 

Release Notes:

- fix parsing valid ssh command(`ssh -i ~/.ssh/jumpserver.pem -p23 jim.lv@es2@10.220.67.57@11.239.1.231`)
