### PR TITLE
Add syntax scopes to themes

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -236,6 +236,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#628b80ff",
             "font_style": null,
@@ -251,13 +256,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fe8f40ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#aad84cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#bfbdb6ff",
             "font_style": null,
             "font_weight": null
           },
@@ -306,13 +316,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#a6a5a0ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#5ac1feff",
             "font_style": null,
             "font_weight": null
           },
@@ -346,17 +371,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#fe8f40ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#bfbdb6ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#59c2ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#59c2ffff",
             "font_style": null,
             "font_weight": null
@@ -607,6 +632,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8ca7c2ff",
             "font_style": null,
@@ -622,13 +652,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#f98d3fff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#85b304ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#5c6166ff",
             "font_style": null,
             "font_weight": null
           },
@@ -677,13 +712,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#73777bff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#3b9ee5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -717,17 +767,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#f98d3fff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#5c6166ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#389ee6ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#389ee6ff",
             "font_style": null,
             "font_weight": null
@@ -978,6 +1028,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#7399a3ff",
             "font_style": null,
@@ -993,13 +1048,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fead66ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d5fe80ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#cccac2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1048,13 +1108,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#b4b3aeff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#72cffeff",
             "font_style": null,
             "font_weight": null
           },
@@ -1088,17 +1163,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#fead66ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#cccac2ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#73cfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#73cfffff",
             "font_style": null,
             "font_weight": null

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -253,6 +253,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -268,13 +273,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -323,13 +333,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -363,17 +388,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#83a598ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#b8bb25ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -641,6 +666,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -656,13 +686,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -711,13 +746,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -751,17 +801,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#83a598ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#b8bb25ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -1029,6 +1079,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -1044,13 +1099,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#d3869bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1099,13 +1159,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1139,17 +1214,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#83a598ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#b8bb25ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#fabd2eff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -1417,6 +1492,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1432,13 +1512,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1487,13 +1572,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1527,17 +1627,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#066578ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#79740eff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
@@ -1805,6 +1905,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1820,13 +1925,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1875,13 +1985,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1915,17 +2040,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#066578ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#79740eff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
@@ -2193,6 +2318,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -2208,13 +2338,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#8f3e71ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2263,13 +2398,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2303,17 +2453,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#066578ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#79740eff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
+            "color": "#b57613ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -239,6 +239,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#788ca6ff",
             "font_style": null,
@@ -254,13 +259,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#73ade9ff",
             "font_style": "normal",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#dce0e5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -309,13 +319,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#d07277ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b1574bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#74ade8ff",
             "font_style": null,
             "font_weight": null
           },
@@ -349,17 +374,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#a1c181ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#d07277ff",
             "font_style": null,
             "font_weight": 400
           },
           "type": {
+            "color": "#6eb4bfff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
@@ -618,6 +643,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#7274a7ff",
             "font_style": null,
@@ -633,13 +663,18 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#5b79e3ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.url": {
             "color": "#3882b7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "namespace": {
+            "color": "#242529ff",
             "font_style": null,
             "font_weight": null
           },
@@ -688,13 +723,28 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#d3604fff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b92b46ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "selector": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#5c78e2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -728,17 +778,17 @@
             "font_style": null,
             "font_weight": null
           },
-          "text.literal": {
-            "color": "#649f57ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "title": {
             "color": "#d3604fff",
             "font_style": null,
             "font_weight": 400
           },
           "type": {
+            "color": "#3882b7ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "unit": {
             "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null


### PR DESCRIPTION
Release Notes:

  - Added syntax scopes to themes

Supports:

  - [Improve CSS syntax highlighting](https://github.com/zed-industries/zed/pull/25326)
  - [Improve Go syntax highlighting](https://github.com/zed-industries/zed/pull/25327)
  - [Improve Markdown syntax highlighting](https://github.com/zed-industries/zed/pull/25330)

Changes:

  - Adds highlighting rules for the following new scopes, using theme colors:
    - `heading`
    - `namespace`
    - `selector`
    - `strikethrough`
    - `unit`

  - Renames scopes that are no longer used in `zed/crates/languages/src` or `zed/extensions` to their new names:
    - `punctuation.list_marker` -> `punctuation.markup`
    - `link_text` -> `link`
    - `link_uri` -> `link.url`, as defined in the [gitcommit grammar](https://github.com/zed-industries/zed/blob/dff47a843695d03160680502e6d94634e376698e/crates/languages/src/gitcommit/highlights.scm#L5)
    - `text.literal` -> `raw`