### PR TITLE
Improve Bash syntax highlighting

### DIFF
--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -4,11 +4,10 @@
   (heredoc_body)
   (heredoc_start)
   (ansi_c_string)
+  (word)
 ] @string
 
-(command_name) @function
-
-(variable_name) @property
+(variable_name) @variable
 
 [
   "case"
@@ -35,23 +34,66 @@
 (comment) @comment
 
 (function_definition name: (word) @function)
+(command_name (word) @function)
 
-(file_descriptor) @number
+[
+  (file_descriptor)
+  (number)
+] @number
+
+(regex) @string.regex
 
 [
   (command_substitution)
   (process_substitution)
   (expansion)
-]@embedded
+] @embedded
+
 
 [
   "$"
   "&&"
   ">"
   ">>"
+  ">&"
+  ">&-"
   "<"
   "|"
+  ":"
+  "//"
+  "/"
+  "%"
+  "%%"
+  "#"
+  "##"
+  "="
+  "=="
 ] @operator
+
+(test_operator) @keyword.operator
+
+[
+  ";"
+] @punctuation.delimiter
+
+[
+  "("
+  ")"
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket
+
+(simple_expansion
+  "$" @punctuation.special)
+(expansion
+  "${" @punctuation.special
+  "}" @punctuation.special) @embedded
+
+(command_substitution
+  "$(" @punctuation.special
+  ")" @punctuation.special)
 
 (
   (command (_) @constant)


### PR DESCRIPTION
Release Notes:

  - Improved Bash syntax highlighting

| Zed 0.174.6 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/ecff952a-c10c-447a-8a99-ebd4ac6d6936) | ![Image](https://github.com/user-attachments/assets/37568a83-f32c-4d4c-bd9a-3ebbe9aa40ae) |

- `string`: `string`
- `variable`: `property` -> `variable`
- `number`: `number`
- `regex`: `string.regex`
- `>&`, `>&-`, `:`, `//`, `/`, `%`, `%%`, `#`, `##`, `=`, `==`: `operator`
- `-lt`, `-le`, `-gt`, `-ge`, `-eq`, `-ne`, `-z`, `-n`: `keyword.operator`
- `;`: `punctuation.delimiter`
- `(`, `)`, `{`, `}`, `[`, `]`: `punctuation.bracket`
- `$`, `${ }`, `$( )`: `punctuation.special`, as defined in other languages

```bash
variable=I\ like\ Zed
function my_function() {
  echo "Hello world, ${variable//regex/string}" > file
}
if [ $(uid) -lt 600 ]; then
  my_function;
  cat file | grep hello >&3
fi
```