### PR TITLE
Improve JSON syntax highlighting

### DIFF
--- a/crates/languages/src/json/highlights.scm
+++ b/crates/languages/src/json/highlights.scm
@@ -13,9 +13,12 @@
   (false)
 ] @boolean
 
+(null) @constant.builtin
+
 [
-  (null)
-] @constant
+  ","
+  ":"
+] @punctuation.delimiter
 
 [
   "{"

--- a/crates/languages/src/jsonc/highlights.scm
+++ b/crates/languages/src/jsonc/highlights.scm
@@ -13,9 +13,12 @@
   (false)
 ] @boolean
 
+(null) @constant.builtin
+
 [
-  (null)
-] @constant
+  ","
+  ":"
+] @punctuation.delimiter
 
 [
   "{"


### PR DESCRIPTION
Release Notes:

  - Improved JSON syntax highlighting.

| Zed 0.174.6 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/46c8ae89-aca1-4756-b66c-78ccd8f3778d) | ![Image](https://github.com/user-attachments/assets/3ba5e5db-1467-40d7-a502-2790feec8ad3) |

- `null`: `constant` -> `constant.builtin`
- `,`, `:`: `punctuation.delimiter`

```json
{
  "property": null,
  "boolean": true
}
```