### PR TITLE
Improve Markdown syntax highlighting

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -261,7 +261,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#fe8f40ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#aad84cff",
             "font_style": null,
             "font_weight": null
@@ -358,6 +363,11 @@
           },
           "tag": {
             "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#fe8f40ff",
             "font_style": null,
             "font_weight": null
           },
@@ -642,7 +652,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#f98d3fff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#85b304ff",
             "font_style": null,
             "font_weight": null
@@ -739,6 +754,11 @@
           },
           "tag": {
             "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#f98d3fff",
             "font_style": null,
             "font_weight": null
           },
@@ -1023,7 +1043,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#fead66ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#d5fe80ff",
             "font_style": null,
             "font_weight": null
@@ -1120,6 +1145,11 @@
           },
           "tag": {
             "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#fead66ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -236,6 +236,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#628b80ff",
             "font_style": null,
@@ -251,12 +256,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fe8f40ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#aad84cff",
             "font_style": null,
             "font_weight": null
@@ -306,13 +311,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#a6a5a0ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#d2a6ffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#5ac1feff",
             "font_style": null,
             "font_weight": null
           },
@@ -343,11 +358,6 @@
           },
           "tag": {
             "color": "#5ac1feff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#fe8f40ff",
             "font_style": null,
             "font_weight": null
           },
@@ -607,6 +617,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8ca7c2ff",
             "font_style": null,
@@ -622,12 +637,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#f98d3fff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#85b304ff",
             "font_style": null,
             "font_weight": null
@@ -677,13 +692,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#73777bff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#a37accff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#3b9ee5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -714,11 +739,6 @@
           },
           "tag": {
             "color": "#3b9ee5ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#f98d3fff",
             "font_style": null,
             "font_weight": null
           },
@@ -978,6 +998,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#7399a3ff",
             "font_style": null,
@@ -993,12 +1018,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fead66ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d5fe80ff",
             "font_style": null,
             "font_weight": null
@@ -1048,13 +1073,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#b4b3aeff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#dfbfffff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#72cffeff",
             "font_style": null,
             "font_weight": null
           },
@@ -1085,11 +1120,6 @@
           },
           "tag": {
             "color": "#72cffeff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#fead66ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -278,7 +278,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#8ec07cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -375,6 +380,11 @@
           },
           "tag": {
             "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -676,7 +686,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#8ec07cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -773,6 +788,11 @@
           },
           "tag": {
             "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1074,7 +1094,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#8ec07cff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -1171,6 +1196,11 @@
           },
           "tag": {
             "color": "#8ec07cff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1472,7 +1502,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#427b58ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -1569,6 +1604,11 @@
           },
           "tag": {
             "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1870,7 +1910,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#427b58ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -1967,6 +2012,11 @@
           },
           "tag": {
             "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2268,7 +2318,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#427b58ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -2365,6 +2420,11 @@
           },
           "tag": {
             "color": "#427b58ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -253,6 +253,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -268,12 +273,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -323,13 +328,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -360,11 +375,6 @@
           },
           "tag": {
             "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -641,6 +651,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -656,12 +671,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -711,13 +726,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -748,11 +773,6 @@
           },
           "tag": {
             "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1029,6 +1049,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -1044,12 +1069,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -1099,13 +1124,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
+          "punctuation.markup": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1136,11 +1171,6 @@
           },
           "tag": {
             "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1417,6 +1447,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1432,12 +1467,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -1487,13 +1522,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1524,11 +1569,6 @@
           },
           "tag": {
             "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1805,6 +1845,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1820,12 +1865,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -1875,13 +1920,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1912,11 +1967,6 @@
           },
           "tag": {
             "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2193,6 +2243,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -2208,12 +2263,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -2263,13 +2318,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
+          "punctuation.markup": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2300,11 +2365,6 @@
           },
           "tag": {
             "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -264,7 +264,12 @@
             "font_style": "normal",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#73ade9ff",
+            "font_style": "normal",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
@@ -361,6 +366,11 @@
           },
           "tag": {
             "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#a1c181ff",
             "font_style": null,
             "font_weight": null
           },
@@ -653,7 +663,12 @@
             "font_style": "italic",
             "font_weight": null
           },
-          "link.uri": {
+          "link_text": {
+            "color": "#5b79e3ff",
+            "font_style": "italic",
+            "font_weight": null
+          },
+          "link_uri": {
             "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null
@@ -750,6 +765,11 @@
           },
           "tag": {
             "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "text.literal": {
+            "color": "#649f57ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -239,6 +239,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#788ca6ff",
             "font_style": null,
@@ -254,12 +259,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#73ade9ff",
             "font_style": "normal",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
@@ -309,13 +314,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#d07277ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b1574bff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#74ade8ff",
             "font_style": null,
             "font_weight": null
           },
@@ -346,11 +361,6 @@
           },
           "tag": {
             "color": "#74ade8ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#a1c181ff",
             "font_style": null,
             "font_weight": null
           },
@@ -618,6 +628,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#7274a7ff",
             "font_style": null,
@@ -633,12 +648,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#5b79e3ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null
@@ -688,13 +703,23 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
+          "punctuation.markup": {
             "color": "#d3604fff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b92b46ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "raw": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
+            "color": "#5c78e2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -725,11 +750,6 @@
           },
           "tag": {
             "color": "#5c78e2ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#649f57ff",
             "font_style": null,
             "font_weight": null
           },

--- a/crates/languages/src/gitcommit/highlights.scm
+++ b/crates/languages/src/gitcommit/highlights.scm
@@ -2,7 +2,7 @@
 (path) @string.special.path
 (branch) @string.special.symbol
 (commit) @constant
-(item) @markup.link.url
+(item) @link.uri.markup
 (header) @tag
 
 (change kind: "new file" @diff.plus)

--- a/crates/languages/src/gitcommit/highlights.scm
+++ b/crates/languages/src/gitcommit/highlights.scm
@@ -1,4 +1,4 @@
-(subject) @markup.heading
+(subject) @heading.markup
 (path) @string.special.path
 (branch) @string.special.symbol
 (commit) @constant

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -1,6 +1,6 @@
 (emphasis) @emphasis.markup
 (strong_emphasis) @emphasis.strong.markup
-(code_span) @raw.markup
+(code_span) @text.literal.markup
 (strikethrough) @strikethrough.markup
 
 [
@@ -11,10 +11,13 @@
   (image)
 ] @link.markup
 
-(inline_link ["(" ")"] @link.uri.markup)
-(image ["(" ")"] @link.uri.markup)
+(link_text) @link_text.markup
+(link_label) @link_text.markup
+
+(inline_link ["(" ")"] @link_uri.markup)
+(image ["(" ")"] @link_uri.markup)
 [
   (link_destination)
   (uri_autolink)
   (email_autolink)
-] @link.uri.markup
+] @link_uri.markup

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -1,6 +1,6 @@
 (emphasis) @emphasis.markup
 (strong_emphasis) @emphasis.strong.markup
-(code_span) @text.literal.markup
+(code_span) @text.literal.markup ; @raw.markup
 (strikethrough) @strikethrough.markup
 
 [
@@ -11,13 +11,13 @@
   (image)
 ] @link.markup
 
-(link_text) @link_text.markup
-(link_label) @link_text.markup
+(link_text) @link_text.markup ; @link.markup
+(link_label) @link_text.markup ; @link.label.markup
 
-(inline_link ["(" ")"] @link_uri.markup)
-(image ["(" ")"] @link_uri.markup)
+(inline_link ["(" ")"] @link_uri.markup) ; @link.uri.markup
+(image ["(" ")"] @link_uri.markup) ; @link.uri.markup
 [
   (link_destination)
   (uri_autolink)
   (email_autolink)
-] @link_uri.markup
+] @link_uri.markup ; @link.uri.markup

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -1,6 +1,20 @@
-(emphasis) @emphasis
-(strong_emphasis) @emphasis.strong
-(code_span) @text.literal
-(link_text) @link_text
-(link_label) @link_text
-(link_destination) @link_uri
+(emphasis) @markup.emphasis
+(strong_emphasis) @markup.emphasis.strong
+(code_span) @markup.raw
+(strikethrough) @markup.strikethrough
+
+[
+  (inline_link)
+  (shortcut_link)
+  (collapsed_reference_link)
+  (full_reference_link)
+  (image)
+] @markup.link
+
+(inline_link ["(" ")"] @markup.link.url)
+(image ["(" ")"] @markup.link.url)
+[
+  (link_destination)
+  (uri_autolink)
+  (email_autolink)
+] @markup.link.url

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -11,10 +11,10 @@
   (image)
 ] @link.markup
 
-(inline_link ["(" ")"] @markup.link.url)
-(image ["(" ")"] @markup.link.url)
+(inline_link ["(" ")"] @link.uri.markup)
+(image ["(" ")"] @link.uri.markup)
 [
   (link_destination)
   (uri_autolink)
   (email_autolink)
-] @markup.link.url
+] @link.uri.markup

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -1,7 +1,7 @@
-(emphasis) @markup.emphasis
-(strong_emphasis) @markup.emphasis.strong
-(code_span) @markup.raw
-(strikethrough) @markup.strikethrough
+(emphasis) @emphasis.markup
+(strong_emphasis) @emphasis.strong.markup
+(code_span) @raw.markup
+(strikethrough) @strikethrough.markup
 
 [
   (inline_link)
@@ -9,7 +9,7 @@
   (collapsed_reference_link)
   (full_reference_link)
   (image)
-] @markup.link
+] @link.markup
 
 (inline_link ["(" ")"] @markup.link.url)
 (image ["(" ")"] @markup.link.url)

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -8,8 +8,8 @@
   (atx_heading)
   (setext_heading)
   (thematic_break)
-] @title.markup
-(setext_heading (paragraph) @title.markup)
+] @title.markup ; @heading.markup
+(setext_heading (paragraph) @title.markup) ; @heading.markup
 
 [
   (list_marker_plus)
@@ -17,7 +17,7 @@
   (list_marker_star)
   (list_marker_dot)
   (list_marker_parenthesis)
-] @punctuation.list_marker.markup
+] @punctuation.list_marker.markup ; @punctuation.list.markup
 
 (block_quote_marker) @punctuation.markup
 (pipe_table_header "|" @punctuation.markup)
@@ -31,4 +31,4 @@
 (fenced_code_block_delimiter) @punctuation.embedded.markup
 
 (link_reference_definition) @link.markup
-(link_destination) @link_uri.markup
+(link_destination) @link_uri.markup ; @link.uri.markup

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -8,8 +8,8 @@
   (atx_heading)
   (setext_heading)
   (thematic_break)
-] @heading.markup
-(setext_heading (paragraph) @heading.markup)
+] @title.markup
+(setext_heading (paragraph) @title.markup)
 
 [
   (list_marker_plus)
@@ -17,9 +17,9 @@
   (list_marker_star)
   (list_marker_dot)
   (list_marker_parenthesis)
-  (block_quote_marker)
-] @punctuation.markup
+] @punctuation.list_marker.markup
 
+(block_quote_marker) @punctuation.markup
 (pipe_table_header "|" @punctuation.markup)
 (pipe_table_row "|" @punctuation.markup)
 (pipe_table_delimiter_row "|" @punctuation.markup)
@@ -31,4 +31,4 @@
 (fenced_code_block_delimiter) @punctuation.embedded.markup
 
 (link_reference_definition) @link.markup
-(link_destination) @link.uri.markup
+(link_destination) @link_uri.markup

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -31,4 +31,4 @@
 (fenced_code_block_delimiter) @punctuation.embedded.markup
 
 (link_reference_definition) @link.markup
-(link_destination) @markup.link.url
+(link_destination) @link.uri.markup

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -8,8 +8,8 @@
   (atx_heading)
   (setext_heading)
   (thematic_break)
-] @markup.heading
-(setext_heading (paragraph) @markup.heading)
+] @heading.markup
+(setext_heading (paragraph) @heading.markup)
 
 [
   (list_marker_plus)
@@ -27,8 +27,8 @@
 
 (fenced_code_block
   (info_string
-    (language) @punctuation.markup.embedded))
-(fenced_code_block_delimiter) @punctuation.markup.embedded
+    (language) @punctuation.embedded.markup))
+(fenced_code_block_delimiter) @punctuation.embedded.markup
 
-(link_reference_definition) @markup.link
+(link_reference_definition) @link.markup
 (link_destination) @markup.link.url

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -1,7 +1,15 @@
 [
+  (paragraph)
+  (indented_code_block)
+  (pipe_table)
+] @text
+
+[
   (atx_heading)
   (setext_heading)
-] @title
+  (thematic_break)
+] @markup.heading
+(setext_heading (paragraph) @markup.heading)
 
 [
   (list_marker_plus)
@@ -9,8 +17,18 @@
   (list_marker_star)
   (list_marker_dot)
   (list_marker_parenthesis)
-] @punctuation.list_marker
+  (block_quote_marker)
+] @punctuation.markup
+
+(pipe_table_header "|" @punctuation.markup)
+(pipe_table_row "|" @punctuation.markup)
+(pipe_table_delimiter_row "|" @punctuation.markup)
+(pipe_table_delimiter_cell "-" @punctuation.markup)
 
 (fenced_code_block
   (info_string
-    (language) @text.literal))
+    (language) @punctuation.markup.embedded))
+(fenced_code_block_delimiter) @punctuation.markup.embedded
+
+(link_reference_definition) @markup.link
+(link_destination) @markup.link.url


### PR DESCRIPTION
Release Notes:

  - Improved Markdown syntax highlighting
  - Added syntax scopes to themes

Changes to highlights:

| Zed 0.174.6 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/b069fd33-e9d0-4d50-9f4c-316bb0b16ca8) | ![Image](https://github.com/user-attachments/assets/a33facba-91b9-4d2e-bbe8-63f08f08ab07) |

Changes to include the `markup` scope, conforming to [Neovim](https://github.com/nvim-treesitter/nvim-treesitter/blob/38e46a6d7ade5c8718f77b2b9fd98a0f7ab32c1e/queries/markdown/highlights.scm#L59), [VS Code](https://github.com/microsoft/vscode/blob/dfad570d15959a6ce7210a313a1190e76e8fe2e2/extensions/markdown-basics/syntaxes/markdown.tmLanguage.json#L60), [Atom](https://github.com/atom/language-gfm/blob/6686ac6ccca2632af24d5c200f85bcd80b9fa752/grammars/gfm.json#L147), and [Zed itself](https://github.com/zed-industries/zed/blob/1e255e41ccfdb88e2266469f1ccfe0d41533280b/crates/languages/src/gitcommit/highlights.scm#L1).

- `paragraph`, `indented_code_block`, `pipe_table`: `text`
- `# Heading`: `title` -> `title.markup`
- `-`, `1.`, `>`, `|`: `punctuation.markup`
- ```` ``` ````: `punctuation.embedded.markup`
- `[1]: url.com`, `[link](url.com)`: `link.markup`
- `url.com`: `link_uri` -> `link_uri.markup`
- `*italic*`: `emphasis` -> `emphasis.markup`
- `**bold**`: `emphasis.strong` -> `emphasis.strong.markup`
- ``` `raw` ```: `text.literal` -> `text.literal.markup`
- `~~strikethrough~~`: `strikethrough.markup`

````md

# Heading

Some stylized text:
- `raw`
- *italic*
- ~strike~
- **strong**

> quoted

```python
print("some code")
```

1. Here is an ![image](image.jpg)
2. A [link](https://github.com/zed-industries)
3. And even a [referenced link][1]

[1]: https://zed.dev

| tables | are |
| --- | --- |
| properly | scoped |

````

Changes to themes:

  - Added highlighting rules for the following new scopes, using theme colors:
    - `heading`
    - `link`
    - `punctuation.list_marker` -> `punctuation.markup`
    - `raw`
    - `strikethrough`
