### PR TITLE
terminal: Update terminal reopening from global to per-workspace

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -270,6 +270,22 @@ impl TerminalPanel {
             })?
         };
 
+        if let Some(workspace) = workspace.upgrade() {
+            terminal_panel
+                .update_in(&mut cx, |_, window, cx| {
+                    cx.subscribe_in(&workspace, window, |terminal_panel, _, e, window, cx| {
+                        if let workspace::Event::SpawnTask {
+                            action: spawn_in_terminal,
+                        } = e
+                        {
+                            terminal_panel.spawn_task(spawn_in_terminal, window, cx);
+                        };
+                    })
+                    .detach();
+                })
+                .ok();
+        }
+
         // Since panels/docks are loaded outside from the workspace, we cleanup here, instead of through the workspace.
         if let Some(workspace) = workspace.upgrade() {
             let cleanup_task = workspace.update_in(&mut cx, |workspace, window, cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4385,6 +4385,10 @@ impl Workspace {
         self.database_id
     }
 
+    pub fn session_id(&self) -> Option<String> {
+        self.session_id.clone()
+    }
+
     fn local_paths(&self, cx: &App) -> Option<Vec<Arc<Path>>> {
         let project = self.project().read(cx);
 


### PR DESCRIPTION
Closes #7145

Currently, terminal persistence is global, i.e. split configurations are restored across all workspaces. 

This PR changes it to per-workspace, so configurations are restored only within the same workspace. Opening a new window will start with a fresh terminal.

https://github.com/user-attachments/assets/d43fe747-9f28-4723-b409-e8dbb3a23912


Release Notes:

- Improved terminal reopening to be per workspace instead of global.
