### PR TITLE
lsp: Send non-null workspaceFolders in initialize

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -791,7 +791,7 @@ impl LanguageServer {
                 }),
             },
             trace: None,
-            workspace_folders: None,
+            workspace_folders: Some(vec![]),
             client_info: release_channel::ReleaseChannel::try_global(cx).map(|release_channel| {
                 ClientInfo {
                     name: release_channel.display_name().to_string(),


### PR DESCRIPTION
This is a ~workaround for next-ls not handling null workspace folders in initialize request
Related to #25264
/cc @timfjord
Closes #ISSUE

Release Notes:

- Changed how workspace folders are shared with language servers, fixing a startup issue with `next-ls` in the process.
