### PR TITLE
Use `@boolean` for `true` and `false` in highlights

### DIFF
--- a/crates/languages/src/c/highlights.scm
+++ b/crates/languages/src/c/highlights.scm
@@ -102,8 +102,9 @@
 [
   (true)
   (false)
-  (null)
-] @constant
+] @boolean
+
+(null) @constant
 
 (identifier) @variable
 

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -153,6 +153,9 @@ type :(primitive_type) @type.primitive
 [
   (true)
   (false)
+] @boolean
+
+[
   (null)
   ("nullptr")
 ] @constant

--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -118,6 +118,9 @@
 [
   (true)
   (false)
+] @boolean
+
+[
   (nil)
   (iota)
 ] @constant.builtin

--- a/crates/languages/src/json/highlights.scm
+++ b/crates/languages/src/json/highlights.scm
@@ -11,6 +11,9 @@
 [
   (true)
   (false)
+] @boolean
+
+[
   (null)
 ] @constant
 

--- a/crates/languages/src/jsonc/highlights.scm
+++ b/crates/languages/src/jsonc/highlights.scm
@@ -11,6 +11,9 @@
 [
   (true)
   (false)
+] @boolean
+
+[
   (null)
 ] @constant
 

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -95,9 +95,12 @@
 ; Literals
 
 [
-  (none)
   (true)
   (false)
+] @boolean
+
+[
+  (none)
   (ellipsis)
 ] @constant.builtin
 

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -99,6 +99,7 @@
   "mod"
   "move"
   "pub"
+  "raw"
   "ref"
   "return"
   "static"
@@ -129,7 +130,7 @@
   (float_literal)
 ] @number
 
-(boolean_literal) @constant
+(boolean_literal) @boolean
 
 [
   (line_comment)

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -99,7 +99,6 @@
   "mod"
   "move"
   "pub"
-  "raw"
   "ref"
   "return"
   "static"


### PR DESCRIPTION
Release Notes:

- Fixed issue where `true` and `false` were highlighted as constants, ignoring the `boolean` highlight defined in themes.
  - This fix applies to: C, C++, Go, JSON, JSONC, Python, and Rust.
