### PR TITLE
Revert "Add syntax scopes to themes (#25323)"

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -236,11 +236,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#bfbdb6ff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#628b80ff",
             "font_style": null,
@@ -256,18 +251,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#fe8f40ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#aad84cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#bfbdb6ff",
             "font_style": null,
             "font_weight": null
           },
@@ -316,28 +306,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
+          "punctuation.list_marker": {
             "color": "#a6a5a0ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#d2a6ffff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#fe8f40ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#5ac1feff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#5ac1feff",
             "font_style": null,
             "font_weight": null
           },
@@ -371,17 +346,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#bfbdb6ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#59c2ffff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#59c2ffff",
             "font_style": null,
             "font_weight": null
@@ -632,11 +607,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#5c6166ff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#8ca7c2ff",
             "font_style": null,
@@ -652,18 +622,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#f98d3fff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#85b304ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#5c6166ff",
             "font_style": null,
             "font_weight": null
           },
@@ -712,28 +677,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
+          "punctuation.list_marker": {
             "color": "#73777bff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#a37accff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#f98d3fff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#3b9ee5ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#3b9ee5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -767,17 +717,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#5c6166ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#389ee6ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#389ee6ff",
             "font_style": null,
             "font_weight": null
@@ -1028,11 +978,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#cccac2ff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#7399a3ff",
             "font_style": null,
@@ -1048,18 +993,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#fead66ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#d5fe80ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#cccac2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1108,28 +1048,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
+          "punctuation.list_marker": {
             "color": "#b4b3aeff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#dfbfffff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#fead66ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#72cffeff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#72cffeff",
             "font_style": null,
             "font_weight": null
           },
@@ -1163,17 +1088,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#cccac2ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#73cfffff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#73cfffff",
             "font_style": null,
             "font_weight": null

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -253,11 +253,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#b8bb25ff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -273,18 +268,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#d3869bff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -333,28 +323,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
-            "color": "#83a598ff",
+          "punctuation.list_marker": {
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#83a598ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -388,17 +363,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#b8bb25ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#fabd2eff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -666,11 +641,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#b8bb25ff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -686,18 +656,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#d3869bff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -746,28 +711,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
-            "color": "#83a598ff",
+          "punctuation.list_marker": {
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#83a598ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -801,17 +751,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#b8bb25ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#fabd2eff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -1079,11 +1029,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#b8bb25ff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -1099,18 +1044,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#d3869bff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1159,28 +1099,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
-            "color": "#83a598ff",
+          "punctuation.list_marker": {
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#e5d5adff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#83a598ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1214,17 +1139,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#b8bb25ff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#fabd2eff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
@@ -1492,11 +1417,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#79740eff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1512,18 +1432,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#8f3e71ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1572,28 +1487,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
-            "color": "#066578ff",
+          "punctuation.list_marker": {
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#066578ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1627,17 +1527,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#79740eff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#b57613ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
@@ -1905,11 +1805,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#79740eff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1925,18 +1820,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#8f3e71ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1985,28 +1875,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
-            "color": "#066578ff",
+          "punctuation.list_marker": {
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#066578ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2040,17 +1915,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#79740eff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#b57613ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
@@ -2318,11 +2193,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#79740eff",
-            "font_style": null,
-            "font_weight": 700
-          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -2338,18 +2208,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#8f3e71ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2398,28 +2263,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
-            "color": "#066578ff",
+          "punctuation.list_marker": {
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#413d3aff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#066578ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2453,17 +2303,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#79740eff",
             "font_style": null,
             "font_weight": 700
           },
           "type": {
-            "color": "#b57613ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -239,11 +239,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#d07277ff",
-            "font_style": null,
-            "font_weight": 400
-          },
           "hint": {
             "color": "#788ca6ff",
             "font_style": null,
@@ -259,18 +254,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#73ade9ff",
             "font_style": "normal",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#6eb4bfff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#dce0e5ff",
             "font_style": null,
             "font_weight": null
           },
@@ -319,28 +309,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
+          "punctuation.list_marker": {
             "color": "#d07277ff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b1574bff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#a1c181ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#d07277ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#74ade8ff",
             "font_style": null,
             "font_weight": null
           },
@@ -374,17 +349,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#d07277ff",
             "font_style": null,
             "font_weight": 400
           },
           "type": {
-            "color": "#6eb4bfff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
@@ -643,11 +618,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "heading": {
-            "color": "#d3604fff",
-            "font_style": null,
-            "font_weight": 400
-          },
           "hint": {
             "color": "#7274a7ff",
             "font_style": null,
@@ -663,18 +633,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "link": {
+          "link_text": {
             "color": "#5b79e3ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link.url": {
+          "link_uri": {
             "color": "#3882b7ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "namespace": {
-            "color": "#242529ff",
             "font_style": null,
             "font_weight": null
           },
@@ -723,28 +688,13 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.markup": {
+          "punctuation.list_marker": {
             "color": "#d3604fff",
             "font_style": null,
             "font_weight": null
           },
           "punctuation.special": {
             "color": "#b92b46ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "raw": {
-            "color": "#649f57ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "selector": {
-            "color": "#d3604fff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "strikethrough": {
-            "color": "#5c78e2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -778,17 +728,17 @@
             "font_style": null,
             "font_weight": null
           },
+          "text.literal": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "title": {
             "color": "#d3604fff",
             "font_style": null,
             "font_weight": 400
           },
           "type": {
-            "color": "#3882b7ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "unit": {
             "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null


### PR DESCRIPTION
This reverts commit 2f416aebbe74f0bbaafe9b18310ff6025fd61916.

We shouldn't have merged this yet, as it currently breaks syntax highlighting for some languages that haven't had their requisite changes merged yet.

We also need to be aware of the impact this will have on downstream themes.

@chbk We should bundle any changes to the themes with the specific language highlights that depend on those changes (and if there are multiple languages that need the same change then pick one language to come first and then stack the rest of the changes on top of that).

Release Notes:

- Community: This is a revert of https://github.com/zed-industries/zed/pull/25323, so remove those notes from the release notes.
