### PR TITLE
rust: Add `raw` to keyword list for syntax highlighting

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -99,6 +99,7 @@
   "mod"
   "move"
   "pub"
+  "raw"
   "ref"
   "return"
   "static"


### PR DESCRIPTION
This PR adds support for syntax highlighting the `raw` keyword in Rust.

Release Notes:

- Added `raw` keyword to Rust language highlights (see the [Rust 1.82.0 announcement](https://blog.rust-lang.org/2024/10/17/Rust-1.82.0.html#native-syntax-for-creating-a-raw-pointer)).
