### PR TITLE
Add support for custom app_id for window managers

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -270,6 +270,8 @@ pub struct App {
     pub(crate) tracked_entities: FxHashMap<WindowId, FxHashSet<EntityId>>,
     #[cfg(any(test, feature = "test-support", debug_assertions))]
     pub(crate) name: Option<&'static str>,
+    /// Represents the application identifier, which can be set via a command-line argument.
+    pub app_id: Option<String>,
 }
 
 impl App {
@@ -334,6 +336,7 @@ impl App {
 
                 #[cfg(any(test, feature = "test-support", debug_assertions))]
                 name: None,
+                app_id: None,
             }),
         });
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -578,6 +578,8 @@ fn main() {
             open_listener.open_urls(urls)
         }
 
+        cx.app_id = args.app_id; // None, by default
+
         match open_rx
             .try_next()
             .ok()
@@ -1005,6 +1007,10 @@ struct Args {
     /// Instructs zed to run as a dev server on this machine. (not implemented)
     #[arg(long)]
     dev_server_token: Option<String>,
+
+    /// Instructs zed to use custom app_id for window managers.
+    #[arg(long)]
+    app_id: Option<String>,
 }
 
 #[derive(Clone, Debug)]

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -123,7 +123,11 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowO
             .into_iter()
             .find(|display| display.uuid().ok() == Some(uuid))
     });
-    let app_id = ReleaseChannel::global(cx).app_id();
+    if cx.app_id.is_none() {
+        let default_app_id = ReleaseChannel::global(cx).app_id().to_string();
+        cx.app_id = Some(default_app_id);
+    }
+
     let window_decorations = match std::env::var("ZED_WINDOW_DECORATIONS") {
         Ok(val) if val == "server" => gpui::WindowDecorations::Server,
         Ok(val) if val == "client" => gpui::WindowDecorations::Client,
@@ -143,7 +147,7 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowO
         is_movable: true,
         display_id: display.map(|display| display.id()),
         window_background: cx.theme().window_background_appearance(),
-        app_id: Some(app_id.to_owned()),
+        app_id: cx.app_id.to_owned(),
         window_decorations: Some(window_decorations),
         window_min_size: Some(gpui::Size {
             width: px(360.0),


### PR DESCRIPTION
This PR adds an `app_id` field to `App`, allowing users to set a custom app ID via the new `--app-id` command-line argument. `build_window_options` now uses `cx.app_id`, defaulting to the release channel app ID if none is provided. 

**Why?**

While there are other potential use cases for a custom `app_id`, I personally use this to make it easier to manage multiple org/project workspaces. Zed’s concepts of Workspaces and Projects can be a bit confusing, and support for multi-root workspaces is currently missing (see issues #9459, #15120, and likely others). There's also no way to open a workspace by ID from workspaces table in `db.sqlite`.

Instead of making big or breaking changes, this PR introduces a minimal but useful tweak to help mitigate the lack of more advanced workspace support.

For example, having follwing project structure :

```
org1
    ├── logo.png
    ├── project-1
    ├── project-2
    └── project-3
```

Then, using a custom `.desktop` entry, you can assign a unique `app_id` so that window managers group all projects from the same org together. This doesn’t fully solve the problem of managing complex/multi-root workspaces, but it does provide a small quality-of-life improvement when dealing with massive org codebases.

**Example `dev.zed.Zed-Org1.desktop` entry**

```
[Desktop Entry]
Version=1.0
Type=Application
Name=Org 1
GenericName=Text Editor
TryExec=zed
Exec=zed-editor --app-id dev.zed.Zed-Org1 /devel/org1
Icon=/devel/org1/logo.png
Categories=Workspaces;
Actions=Project1;Project2;Project3;

[Desktop Action Project1]
Exec=zed-editor --app-id dev.zed.Zed-Org1 /devel/org1/project-1
Name=Open a project 1

[Desktop Action Project2]
Exec=zed-editor --app-id dev.zed.Zed-Org1 /devel/org1/project-2
Name=Open a project 2

[Desktop Action Project3]
Exec=zed-editor --app-id dev.zed.Zed-Org1 /devel/org1/project-3
Name=Open a project 3

``` 

Release Notes:

- Add support for custom app_id for window managers and --app-id flag