### PR TITLE
ruby_runtime: Initial implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2818,6 +2818,7 @@ dependencies = [
  "reqwest 0.11.27",
  "reqwest_client",
  "rpc",
+ "ruby_runtime",
  "rustc-demangle",
  "scrypt",
  "sea-orm",
@@ -4486,6 +4487,7 @@ dependencies = [
  "release_channel",
  "remote",
  "reqwest_client",
+ "ruby_runtime",
  "schemars",
  "semantic_version",
  "serde",
@@ -10128,6 +10130,7 @@ dependencies = [
  "release_channel",
  "remote",
  "rpc",
+ "ruby_runtime",
  "schemars",
  "serde",
  "serde_json",
@@ -10962,6 +10965,7 @@ dependencies = [
  "remote",
  "reqwest_client",
  "rpc",
+ "ruby_runtime",
  "rust-embed",
  "serde",
  "serde_json",
@@ -11334,6 +11338,31 @@ dependencies = [
  "spki 0.7.3",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "ruby_runtime"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-compression",
+ "async-std",
+ "async-tar",
+ "async-trait",
+ "async-watch",
+ "async_zip",
+ "futures 0.3.31",
+ "http_client",
+ "log",
+ "paths",
+ "semver",
+ "serde",
+ "serde_json",
+ "smol",
+ "tempfile",
+ "util",
+ "walkdir",
+ "which 6.0.3",
 ]
 
 [[package]]
@@ -16322,6 +16351,7 @@ dependencies = [
  "postage",
  "project",
  "remote",
+ "ruby_runtime",
  "schemars",
  "serde",
  "serde_json",
@@ -16739,6 +16769,7 @@ dependencies = [
  "repl",
  "reqwest_client",
  "rope",
+ "ruby_runtime",
  "search",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -112,6 +112,7 @@ members = [
     "crates/rich_text",
     "crates/rope",
     "crates/rpc",
+    "crates/ruby_runtime",
     "crates/schema_generator",
     "crates/search",
     "crates/semantic_index",
@@ -313,6 +314,7 @@ reqwest_client = { path = "crates/reqwest_client" }
 rich_text = { path = "crates/rich_text" }
 rope = { path = "crates/rope" }
 rpc = { path = "crates/rpc" }
+ruby_runtime = { path = "crates/ruby_runtime" }
 search = { path = "crates/search" }
 semantic_index = { path = "crates/semantic_index" }
 semantic_version = { path = "crates/semantic_version" }

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -51,6 +51,7 @@ rand.workspace = true
 reqwest = { version = "0.11", features = ["json"] }
 reqwest_client.workspace = true
 rpc.workspace = true
+ruby_runtime.workspace = true
 rustc-demangle.workspace = true
 scrypt = "0.11"
 sea-orm = { version = "1.1.0-rc.1", features = ["sqlx-postgres", "postgres-array", "runtime-tokio-rustls", "with-uuid"] }

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -23,6 +23,7 @@ use project::{
 };
 use remote::SshRemoteClient;
 use remote_server::{HeadlessAppState, HeadlessProject};
+use ruby_runtime::RubyRuntime;
 use serde_json::json;
 use settings::SettingsStore;
 use std::{path::Path, sync::Arc};
@@ -74,6 +75,7 @@ async fn test_sharing_an_ssh_remote_project(
     server_cx.update(HeadlessProject::init);
     let remote_http_client = Arc::new(BlockedHttpClient);
     let node = NodeRuntime::unavailable();
+    let ruby = RubyRuntime::unavailable();
     let languages = Arc::new(LanguageRegistry::new(server_cx.executor()));
     let _headless_project = server_cx.new(|cx| {
         client::init_settings(cx);
@@ -83,6 +85,7 @@ async fn test_sharing_an_ssh_remote_project(
                 fs: remote_fs.clone(),
                 http_client: remote_http_client,
                 node_runtime: node,
+                ruby_runtime: ruby,
                 languages,
                 extension_host_proxy: Arc::new(ExtensionHostProxy::new()),
             },
@@ -241,6 +244,7 @@ async fn test_ssh_collaboration_git_branches(
     server_cx.update(HeadlessProject::init);
     let remote_http_client = Arc::new(BlockedHttpClient);
     let node = NodeRuntime::unavailable();
+    let ruby = RubyRuntime::unavailable();
     let languages = Arc::new(LanguageRegistry::new(server_cx.executor()));
     let headless_project = server_cx.new(|cx| {
         client::init_settings(cx);
@@ -250,6 +254,7 @@ async fn test_ssh_collaboration_git_branches(
                 fs: remote_fs.clone(),
                 http_client: remote_http_client,
                 node_runtime: node,
+                ruby_runtime: ruby,
                 languages,
                 extension_host_proxy: Arc::new(ExtensionHostProxy::new()),
             },
@@ -408,6 +413,7 @@ async fn test_ssh_collaboration_formatting_with_prettier(
                 fs: remote_fs.clone(),
                 http_client: remote_http_client,
                 node_runtime: NodeRuntime::unavailable(),
+                ruby_runtime: RubyRuntime::unavailable(),
                 languages,
                 extension_host_proxy: Arc::new(ExtensionHostProxy::new()),
             },

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -29,6 +29,7 @@ use rpc::{
     proto::{self, ChannelRole},
     RECEIVE_TIMEOUT,
 };
+use ruby_runtime::RubyRuntime;
 use semantic_version::SemanticVersion;
 use serde_json::json;
 use session::{AppSession, Session};
@@ -285,6 +286,7 @@ impl TestServer {
             fs: fs.clone(),
             build_window_options: |_, _| Default::default(),
             node_runtime: NodeRuntime::unavailable(),
+            ruby_runtime: RubyRuntime::unavailable(),
             session,
         });
 

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -24,6 +24,9 @@ pub use wit::{
         npm_package_latest_version,
     },
     zed::extension::platform::{current_platform, Architecture, Os},
+    zed::extension::ruby::{
+        gems_install_gem, gems_installed_version, gems_latest_version, ruby_binary_path,
+    },
     zed::extension::slash_command::{
         SlashCommand, SlashCommandArgumentCompletion, SlashCommandOutput, SlashCommandOutputSection,
     },

--- a/crates/extension_api/wit/since_v0.2.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.2.0/extension.wit
@@ -5,6 +5,7 @@ world extension {
     import http-client;
     import platform;
     import nodejs;
+    import ruby;
 
     use common.{range};
     use lsp.{completion, symbol};

--- a/crates/extension_api/wit/since_v0.2.0/ruby.wit
+++ b/crates/extension_api/wit/since_v0.2.0/ruby.wit
@@ -1,0 +1,13 @@
+interface ruby {
+    /// Returns the path to the currently active Ruby binary.
+    ruby-binary-path: func() -> result<string, string>;
+
+    /// Returns the latest version of the given Ruby gem.
+    gems-latest-version: func(gem-name: string) -> result<string, string>;
+
+    /// Returns the installed version of the given Ruby gem, if it exists.
+    gems-installed-version: func(gem-name: string) -> result<option<string>, string>;
+
+    /// Installs the specified Ruby gem.
+    gems-install-gem: func(gem-name: string, version: string, binaries: list<string>) -> result<_, string>;
+}

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -36,6 +36,7 @@ paths.workspace = true
 project.workspace = true
 remote.workspace = true
 release_channel.workspace = true
+ruby_runtime.workspace = true
 schemars.workspace = true
 semantic_version.workspace = true
 serde.workspace = true

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -40,6 +40,7 @@ use node_runtime::NodeRuntime;
 use project::ContextProviderWithTasks;
 use release_channel::ReleaseChannel;
 use remote::SshRemoteClient;
+use ruby_runtime::RubyRuntime;
 use semantic_version::SemanticVersion;
 use serde::{Deserialize, Serialize};
 use settings::Settings;
@@ -182,6 +183,7 @@ pub fn init(
     fs: Arc<dyn Fs>,
     client: Arc<Client>,
     node_runtime: NodeRuntime,
+    ruby_runtime: RubyRuntime,
     cx: &mut App,
 ) {
     ExtensionSettings::register(cx);
@@ -196,6 +198,7 @@ pub fn init(
             client.http_client().clone(),
             Some(client.telemetry().clone()),
             node_runtime,
+            ruby_runtime,
             cx,
         )
     });
@@ -228,6 +231,7 @@ impl ExtensionStore {
         builder_client: Arc<dyn HttpClient>,
         telemetry: Option<Arc<Telemetry>>,
         node_runtime: NodeRuntime,
+        ruby_runtime: RubyRuntime,
         cx: &mut Context<Self>,
     ) -> Self {
         let work_dir = extensions_dir.join("work");
@@ -250,6 +254,7 @@ impl ExtensionStore {
                 fs.clone(),
                 http_client.clone(),
                 node_runtime,
+                ruby_runtime,
                 extension_host_proxy,
                 work_dir,
                 cx,

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -17,6 +17,7 @@ use parking_lot::Mutex;
 use project::{Project, DEFAULT_COMPLETION_CONTEXT};
 use release_channel::AppVersion;
 use reqwest_client::ReqwestClient;
+use ruby_runtime::RubyRuntime;
 use serde_json::json;
 use settings::{Settings as _, SettingsStore};
 use std::{
@@ -269,6 +270,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
     let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
     language_extension::init(proxy.clone(), language_registry.clone());
     let node_runtime = NodeRuntime::unavailable();
+    let ruby_runtime = RubyRuntime::unavailable();
 
     let store = cx.new(|cx| {
         ExtensionStore::new(
@@ -280,6 +282,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
             http_client.clone(),
             None,
             node_runtime.clone(),
+            ruby_runtime.clone(),
             cx,
         )
     });
@@ -406,6 +409,7 @@ async fn test_extension_store(cx: &mut TestAppContext) {
             http_client.clone(),
             None,
             node_runtime.clone(),
+            ruby_runtime.clone(),
             cx,
         )
     });
@@ -494,6 +498,7 @@ async fn test_extension_store_with_test_extension(cx: &mut TestAppContext) {
     let language_registry = project.read_with(cx, |project, _cx| project.languages().clone());
     language_extension::init(proxy.clone(), language_registry.clone());
     let node_runtime = NodeRuntime::unavailable();
+    let ruby_runtime = RubyRuntime::unavailable();
 
     let mut status_updates = language_registry.language_server_binary_statuses();
 
@@ -592,6 +597,7 @@ async fn test_extension_store_with_test_extension(cx: &mut TestAppContext) {
             builder_client,
             None,
             node_runtime,
+            ruby_runtime,
             cx,
         )
     });

--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -13,6 +13,7 @@ use http_client::HttpClient;
 use language::{LanguageConfig, LanguageName, LanguageQueries, LoadedLanguage};
 use lsp::LanguageServerName;
 use node_runtime::NodeRuntime;
+use ruby_runtime::RubyRuntime;
 
 use crate::wasm_host::{WasmExtension, WasmHost};
 
@@ -40,6 +41,7 @@ impl HeadlessExtensionStore {
         extension_dir: PathBuf,
         extension_host_proxy: Arc<ExtensionHostProxy>,
         node_runtime: NodeRuntime,
+        ruby_runtime: RubyRuntime,
         cx: &mut App,
     ) -> Entity<Self> {
         cx.new(|cx| Self {
@@ -48,6 +50,7 @@ impl HeadlessExtensionStore {
                 fs.clone(),
                 http_client.clone(),
                 node_runtime,
+                ruby_runtime,
                 extension_host_proxy.clone(),
                 extension_dir.join("work"),
                 cx,

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -23,6 +23,7 @@ use language::LanguageName;
 use lsp::LanguageServerName;
 use node_runtime::NodeRuntime;
 use release_channel::ReleaseChannel;
+use ruby_runtime::RubyRuntime;
 use semantic_version::SemanticVersion;
 use std::{
     path::{Path, PathBuf},
@@ -40,6 +41,7 @@ pub struct WasmHost {
     release_channel: ReleaseChannel,
     http_client: Arc<dyn HttpClient>,
     node_runtime: NodeRuntime,
+    ruby_runtime: RubyRuntime,
     pub(crate) proxy: Arc<ExtensionHostProxy>,
     fs: Arc<dyn Fs>,
     pub work_dir: PathBuf,
@@ -329,6 +331,7 @@ impl WasmHost {
         fs: Arc<dyn Fs>,
         http_client: Arc<dyn HttpClient>,
         node_runtime: NodeRuntime,
+        ruby_runtime: RubyRuntime,
         proxy: Arc<ExtensionHostProxy>,
         work_dir: PathBuf,
         cx: &mut App,
@@ -345,6 +348,7 @@ impl WasmHost {
             work_dir,
             http_client,
             node_runtime,
+            ruby_runtime,
             proxy,
             release_channel: ReleaseChannel::global(cx),
             _main_thread_message_task: task,

--- a/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
@@ -497,6 +497,52 @@ impl nodejs::Host for WasmState {
     }
 }
 
+impl ruby::Host for WasmState {
+    async fn ruby_binary_path(&mut self) -> wasmtime::Result<Result<String, String>> {
+        self.host
+            .ruby_runtime
+            .binary_path()
+            .await
+            .map(|path| path.to_string_lossy().to_string())
+            .to_wasmtime_result()
+    }
+
+    async fn gems_installed_version(
+        &mut self,
+        gem_name: String,
+    ) -> wasmtime::Result<Result<Option<String>, String>> {
+        self.host
+            .ruby_runtime
+            .gem_installed_version(&self.work_dir(), &gem_name)
+            .await
+            .to_wasmtime_result()
+    }
+
+    async fn gems_latest_version(
+        &mut self,
+        gem_name: String,
+    ) -> wasmtime::Result<Result<String, String>> {
+        self.host
+            .ruby_runtime
+            .gem_latest_version(&self.work_dir(), &gem_name)
+            .await
+            .to_wasmtime_result()
+    }
+
+    async fn gems_install_gem(
+        &mut self,
+        gem_name: String,
+        version: String,
+        binaries: Vec<String>,
+    ) -> wasmtime::Result<Result<(), String>> {
+        self.host
+            .ruby_runtime
+            .gem_install_gem(&self.work_dir(), &gem_name, &version, binaries.clone())
+            .await
+            .to_wasmtime_result()
+    }
+}
+
 #[async_trait]
 impl lsp::Host for WasmState {}
 

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -58,6 +58,7 @@ rpc.workspace = true
 schemars.workspace = true
 task.workspace = true
 tempfile.workspace = true
+ruby_runtime.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -51,6 +51,7 @@ release_channel.workspace = true
 remote.workspace = true
 reqwest_client.workspace = true
 rpc.workspace = true
+ruby_runtime.workspace = true
 rust-embed = { workspace = true, optional = true, features = ["debug-embed"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -21,6 +21,7 @@ use rpc::{
     proto::{self, SSH_PEER_ID, SSH_PROJECT_ID},
     AnyProtoClient, TypedEnvelope,
 };
+use ruby_runtime::RubyRuntime;
 
 use settings::initial_server_settings_content;
 use smol::stream::StreamExt;
@@ -50,6 +51,7 @@ pub struct HeadlessAppState {
     pub fs: Arc<dyn Fs>,
     pub http_client: Arc<dyn HttpClient>,
     pub node_runtime: NodeRuntime,
+    pub ruby_runtime: RubyRuntime,
     pub languages: Arc<LanguageRegistry>,
     pub extension_host_proxy: Arc<ExtensionHostProxy>,
 }
@@ -67,6 +69,7 @@ impl HeadlessProject {
             fs,
             http_client,
             node_runtime,
+            ruby_runtime,
             languages,
             extension_host_proxy: proxy,
         }: HeadlessAppState,
@@ -166,6 +169,7 @@ impl HeadlessProject {
             paths::remote_extensions_dir().to_path_buf(),
             proxy,
             node_runtime,
+            ruby_runtime,
             cx,
         );
 

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -19,6 +19,7 @@ use project::{
     Project, ProjectPath,
 };
 use remote::SshRemoteClient;
+use ruby_runtime::RubyRuntime;
 use serde_json::json;
 use settings::{initial_server_settings_content, Settings, SettingsLocation, SettingsStore};
 use smol::stream::StreamExt;
@@ -1407,6 +1408,7 @@ pub async fn init_test(
     let (opts, ssh_server_client) = SshRemoteClient::fake_server(cx, server_cx);
     let http_client = Arc::new(BlockedHttpClient);
     let node_runtime = NodeRuntime::unavailable();
+    let ruby_runtime = RubyRuntime::unavailable();
     let languages = Arc::new(LanguageRegistry::new(cx.executor()));
     let proxy = Arc::new(ExtensionHostProxy::new());
     server_cx.update(HeadlessProject::init);
@@ -1419,6 +1421,7 @@ pub async fn init_test(
                 fs: server_fs.clone(),
                 http_client,
                 node_runtime,
+                ruby_runtime,
                 languages,
                 extension_host_proxy: proxy,
             },

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -15,6 +15,7 @@ use language::LanguageRegistry;
 use node_runtime::{NodeBinaryOptions, NodeRuntime};
 use paths::logs_dir;
 use project::project_settings::ProjectSettings;
+use ruby_runtime::RubyRuntime;
 
 use release_channel::{AppVersion, ReleaseChannel, RELEASE_CHANNEL};
 use remote::proxy::ProxyLaunchError;
@@ -467,6 +468,7 @@ pub fn execute_run(
             };
 
             let node_runtime = NodeRuntime::new(http_client.clone(), node_settings_rx);
+            let ruby_runtime = RubyRuntime::new();
 
             let mut languages = LanguageRegistry::new(cx.background_executor().clone());
             languages.set_language_server_download_dir(paths::languages_dir().clone());
@@ -478,6 +480,7 @@ pub fn execute_run(
                     fs,
                     http_client,
                     node_runtime,
+                    ruby_runtime,
                     languages,
                     extension_host_proxy,
                 },

--- a/crates/ruby_runtime/Cargo.toml
+++ b/crates/ruby_runtime/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "ruby_runtime"
+version = "0.1.0"
+publish.workspace = true
+edition.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/ruby_runtime.rs"
+doctest = false
+
+[features]
+test-support = ["tempfile"]
+
+[dependencies]
+anyhow.workspace = true
+async-compression.workspace = true
+async-watch.workspace = true
+async-tar.workspace = true
+async-trait.workspace = true
+async_zip.workspace = true
+futures.workspace = true
+http_client.workspace = true
+log.workspace = true
+paths.workspace = true
+regex.workspace = true
+semver.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+smol.workspace = true
+tempfile = { workspace = true, optional = true }
+util.workspace = true
+walkdir = "2.5.0"
+which.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+async-std = { version = "1.12.0", features = ["unstable"] }
+
+[dev-dependencies]
+tempfile.workspace = true

--- a/crates/ruby_runtime/src/ruby_runtime.rs
+++ b/crates/ruby_runtime/src/ruby_runtime.rs
@@ -1,0 +1,326 @@
+use anyhow::{anyhow, bail, Context, Result};
+use regex::Regex;
+use smol::fs::unix::PermissionsExt;
+use smol::lock::Mutex;
+use std::fs;
+use std::process::Output;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::ResultExt;
+
+#[derive(Clone)]
+pub struct RubyRuntime(Arc<Mutex<RubyRuntimeState>>);
+
+struct RubyRuntimeState {
+    instance: Option<Box<dyn RubyRuntimeTrait>>,
+}
+
+impl RubyRuntime {
+    pub fn new() -> Self {
+        RubyRuntime(Arc::new(Mutex::new(RubyRuntimeState { instance: None })))
+    }
+
+    pub fn unavailable() -> Self {
+        RubyRuntime(Arc::new(Mutex::new(RubyRuntimeState { instance: None })))
+    }
+
+    async fn instance(&self) -> Result<Box<dyn RubyRuntimeTrait>> {
+        let mut state = self.0.lock().await;
+
+        if let Some(instance) = state.instance.as_ref() {
+            return Ok(instance.boxed_clone());
+        }
+
+        if let Some(instance) = SystemRubyRuntime::detect().await {
+            state.instance = Some(instance.boxed_clone());
+            return Ok(instance);
+        }
+
+        let instance = Box::new(UnavailableRubyRuntime);
+
+        state.instance = Some(instance.boxed_clone());
+        return Ok(instance);
+    }
+
+    pub async fn binary_path(&self) -> Result<PathBuf> {
+        self.instance().await?.binary_path()
+    }
+
+    pub async fn run_gem_subcommand(
+        &self,
+        directory: &Path,
+        subcommand: &str,
+        args: &[&str],
+    ) -> Result<Output> {
+        self.instance()
+            .await?
+            .run_gem_subcommand(directory, subcommand, args)
+            .await
+    }
+
+    pub async fn gem_installed_version(
+        &self,
+        directory: &Path,
+        name: &str,
+    ) -> Result<Option<String>> {
+        self.instance()
+            .await?
+            .gem_installed_version(directory, name)
+            .await
+    }
+
+    pub async fn gem_latest_version(&self, directory: &Path, name: &str) -> Result<String> {
+        self.gem_all_versions(directory, name)
+            .await
+            .and_then(|versions| {
+                versions
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| anyhow!("No versions found for gem {}", name))
+            })
+    }
+
+    pub async fn gem_install_gem(
+        &self,
+        directory: &Path,
+        name: &str,
+        version: &str,
+        binaries: Vec<String>,
+    ) -> Result<()> {
+        let arguments = [
+            "--no-user-install",      // Do not install gems in user's home directory
+            "--no-format-executable", // Do not make installed executable names match Ruby
+            "--no-document",          // Do not generate documentation
+            &format!("{name}:{version}"),
+        ];
+
+        self.run_gem_subcommand(directory, "install", &arguments)
+            .await?;
+
+        if binaries.is_empty() {
+            return Ok(());
+        }
+
+        for binary in binaries {
+            let bin_path = directory.join(&binary);
+
+            let bin_wrapper = format!(
+                r#"#!/usr/bin/env bash
+export GEM_PATH="{gem_path}:$GEM_PATH"
+exec "{exec_path}" "$@"
+"#,
+                gem_path = directory.display(),
+                exec_path = directory.join("bin").join(&binary).display()
+            );
+
+            fs::write(&bin_path, bin_wrapper).with_context(|| {
+                format!(
+                    "Failed to write binary wrapper for '{}' to {:?}",
+                    &binary, bin_path
+                )
+            })?;
+
+            let mut perms = fs::metadata(&bin_path)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&bin_path, perms).with_context(|| {
+                format!(
+                    "Failed to set executable permissions for '{}' at {:?}",
+                    binary, bin_path
+                )
+            })?;
+        }
+
+        Ok(())
+    }
+
+    async fn gem_all_versions(&self, directory: &Path, name: &str) -> Result<Vec<String>> {
+        let output = self
+            .instance()
+            .await?
+            .run_gem_subcommand(directory, "list", &[name, "--remote", "--all"])
+            .await?;
+
+        let output = String::from_utf8_lossy(&output.stdout);
+
+        output
+            .lines()
+            .find(|line| line.starts_with(name))
+            .and_then(|line| {
+                line.rfind('(')
+                    .and_then(|start| line.rfind(')').map(|end| &line[start + 1..end]))
+            })
+            .map(|versions| versions.split(", ").map(String::from).collect())
+            .ok_or_else(|| anyhow!("Failed to parse gem list output."))
+    }
+}
+
+#[async_trait::async_trait]
+trait RubyRuntimeTrait: Send + Sync {
+    fn boxed_clone(&self) -> Box<dyn RubyRuntimeTrait>;
+    fn binary_path(&self) -> Result<PathBuf>;
+
+    async fn run_gem_subcommand(
+        &self,
+        directory: &Path,
+        subcommand: &str,
+        args: &[&str],
+    ) -> Result<Output>;
+
+    async fn gem_installed_version(&self, directory: &Path, name: &str) -> Result<Option<String>>;
+}
+
+#[derive(Clone)]
+pub struct SystemRubyRuntime {
+    ruby: PathBuf,
+    gem: PathBuf,
+    // TODO: Put .gemrc with GEM_PATH
+    // scratch_dir: PathBuf,
+}
+
+impl SystemRubyRuntime {
+    const MIN_VERSION: semver::Version = semver::Version::new(3, 4, 1);
+
+    async fn new(ruby: PathBuf, gem: PathBuf) -> Result<Box<dyn RubyRuntimeTrait>> {
+        let output = util::command::new_smol_command(&ruby)
+            .arg("--version")
+            .output()
+            .await
+            .with_context(|| format!("running ruby from {:?}", ruby))?;
+
+        if !output.status.success() {
+            anyhow::bail!(
+                "failed to run ruby --version. stdout: {}, stderr: {}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr),
+            );
+        }
+
+        let version_str = String::from_utf8_lossy(&output.stdout);
+        let version_str = version_str
+            .trim()
+            .split_whitespace()
+            .nth(1)
+            .ok_or_else(|| anyhow!("Unable to parse Ruby version"))?;
+        let version = semver::Version::parse(version_str)?;
+        if version < Self::MIN_VERSION {
+            anyhow::bail!(
+                "ruby at {} is too old. want: {}, got: {}",
+                ruby.to_string_lossy(),
+                Self::MIN_VERSION,
+                version
+            )
+        }
+
+        // let scratch_dir = paths::support_dir().join("ruby");
+        // fs::create_dir(&scratch_dir).await.ok();
+        // fs::create_dir(scratch_dir.join("cache")).await.ok();
+
+        Ok(Box::new(Self {
+            ruby,
+            gem,
+            // scratch_dir,
+        }))
+    }
+
+    async fn detect() -> Option<Box<dyn RubyRuntimeTrait>> {
+        let ruby = which::which("ruby").ok()?;
+        let gem = which::which("gem").ok()?;
+        Self::new(ruby, gem).await.log_err()
+    }
+}
+
+#[async_trait::async_trait]
+impl RubyRuntimeTrait for SystemRubyRuntime {
+    fn boxed_clone(&self) -> Box<dyn RubyRuntimeTrait> {
+        Box::new(self.clone())
+    }
+
+    fn binary_path(&self) -> Result<PathBuf> {
+        Ok(self.ruby.clone())
+    }
+
+    async fn run_gem_subcommand(
+        &self,
+        directory: &Path,
+        subcommand: &str,
+        args: &[&str],
+    ) -> anyhow::Result<Output> {
+        let mut command = util::command::new_smol_command(self.gem.clone());
+
+        let gem_home = directory;
+
+        command
+            .env_clear()
+            .env("PATH", std::env::var_os("PATH").unwrap_or_default())
+            .env("GEM_HOME", gem_home)
+            .arg(subcommand)
+            .args(args);
+
+        let output = command.output().await?;
+        if !output.status.success() {
+            return Err(anyhow!(
+                "failed to execute gem {subcommand} subcommand:\nstdout: {:?}\nstderr: {:?}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            ));
+        }
+
+        Ok(output)
+    }
+
+    async fn gem_installed_version(&self, directory: &Path, name: &str) -> Result<Option<String>> {
+        // Example output from `gem list`:
+        /*
+            *** LOCAL GEMS ***
+
+            abbrev (0.1.2)
+            prism (default: 1.2.0)
+            test-unit (3.6.7)
+        */
+        let re = Regex::new(r"^(\S+) \((\S+)\)$").unwrap();
+
+        let output = self.run_gem_subcommand(directory, "list", &[]).await?;
+
+        let output =
+            String::from_utf8(output.stdout).context("Failed to parse gem list output as UTF-8")?;
+
+        for line in output.lines() {
+            let captures = match re.captures(line) {
+                Some(c) => c,
+                None => continue,
+            };
+
+            let gem_package = captures.get(1).map(|m| m.as_str());
+            let version = captures.get(2).map(|m| m.as_str());
+
+            if gem_package == Some(name) {
+                return Ok(version.map(|v| v.to_owned()));
+            }
+        }
+
+        Ok(None)
+    }
+}
+
+pub struct UnavailableRubyRuntime;
+
+#[async_trait::async_trait]
+impl RubyRuntimeTrait for UnavailableRubyRuntime {
+    fn boxed_clone(&self) -> Box<dyn RubyRuntimeTrait> {
+        Box::new(UnavailableRubyRuntime)
+    }
+
+    fn binary_path(&self) -> Result<PathBuf> {
+        bail!("binary_path: no ruby runtime available")
+    }
+
+    async fn run_gem_subcommand(&self, _: &Path, _: &str, _: &[&str]) -> anyhow::Result<Output> {
+        bail!("run_gem_subcommand: no ruby runtime available")
+    }
+
+    async fn gem_installed_version(&self, _: &Path, _: &str) -> Result<Option<String>> {
+        bail!("gem_installed_version: no ruby runtime available")
+    }
+}

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -49,6 +49,7 @@ parking_lot.workspace = true
 postage.workspace = true
 project.workspace = true
 remote.workspace = true
+ruby_runtime.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -63,6 +63,7 @@ use project::{
     DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
 };
 use remote::{ssh_session::ConnectionIdentifier, SshClientDelegate, SshConnectionOptions};
+use ruby_runtime::RubyRuntime;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use session::AppSession;
@@ -616,6 +617,7 @@ pub struct AppState {
     pub fs: Arc<dyn fs::Fs>,
     pub build_window_options: fn(Option<Uuid>, &mut App) -> WindowOptions,
     pub node_runtime: NodeRuntime,
+    pub ruby_runtime: RubyRuntime,
     pub session: Entity<AppSession>,
 }
 
@@ -679,6 +681,7 @@ impl AppState {
             user_store,
             workspace_store,
             node_runtime: NodeRuntime::unavailable(),
+            ruby_runtime: RubyRuntime::unavailable(),
             build_window_options: |_, _| Default::default(),
             session,
         })
@@ -4887,6 +4890,7 @@ impl Workspace {
     #[cfg(any(test, feature = "test-support"))]
     pub fn test_new(project: Entity<Project>, window: &mut Window, cx: &mut Context<Self>) -> Self {
         use node_runtime::NodeRuntime;
+        use ruby_runtime::RubyRuntime;
         use session::Session;
 
         let client = project.read(cx).client();
@@ -4903,6 +4907,7 @@ impl Workspace {
             fs: project.read(cx).fs().clone(),
             build_window_options: |_, _| Default::default(),
             node_runtime: NodeRuntime::unavailable(),
+            ruby_runtime: RubyRuntime::unavailable(),
             session,
         });
         let workspace = Self::new(Default::default(), project, app_state, window, cx);

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -98,6 +98,7 @@ remote.workspace = true
 repl.workspace = true
 reqwest_client.workspace = true
 rope.workspace = true
+ruby_runtime.workspace = true
 search.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -33,6 +33,7 @@ use parking_lot::Mutex;
 use project::project_settings::ProjectSettings;
 use recent_projects::{open_ssh_project, SshSettings};
 use release_channel::{AppCommitSha, AppVersion, ReleaseChannel};
+use ruby_runtime::RubyRuntime;
 use session::{AppSession, Session};
 use settings::{watch_config_file, Settings, SettingsStore};
 use simplelog::ConfigBuilder;
@@ -356,6 +357,7 @@ fn main() {
         })
         .detach();
         let node_runtime = NodeRuntime::new(client.http_client(), rx);
+        let ruby_runtime = RubyRuntime::new();
 
         language::init(cx);
         language_extension::init(extension_host_proxy.clone(), languages.clone());
@@ -401,6 +403,7 @@ fn main() {
             build_window_options,
             workspace_store,
             node_runtime: node_runtime.clone(),
+            ruby_runtime: ruby_runtime.clone(),
             session: app_session,
         });
         AppState::set_global(Arc::downgrade(&app_state), cx);
@@ -465,6 +468,7 @@ fn main() {
             app_state.fs.clone(),
             app_state.client.clone(),
             app_state.node_runtime.clone(),
+            app_state.ruby_runtime.clone(),
             cx,
         );
         recent_projects::init(cx);


### PR DESCRIPTION
Closes #25099

This is a proof of concept for providing Ruby runtime to extensions through Zed extensions API.

## The idea

In the spirit of the [`node_runtime`](https://github.com/zed-industries/zed/blob/main/crates/node_runtime/src/node_runtime.rs) which provides limited methods for working with Node.js and `npm`, this PR is about introducing the `ruby_runtime` - a runtime for providing limited methods for working with Ruby. This is a proof of concept only.

## How it works

In the same way as Zed does for `node.js`, the Ruby runtime relies on the correct environment when Zed starts

When an extension installs a Ruby gem, the Ruby runtime uses the detected Ruby version and installs the requested gem into the extenstion's working directory. The installed gem is not installed into the user's gemset to avoid activation errors like `can't activate date (=3.6.3), already activated date-3.6.6] (Gem::Exception)`. Additionally, that method does not alter the user-installed gems. This is achieved by setting the `GEM_PATH` environment variable to the extension directory for all operations.

In the same way as Node runtime does, the Ruby runtime provides the following functions:

- `binary_path` returns path to the Ruby binary, for example, `/Users/vslobodin/.local/share/mise/installs/ruby/3.4.1/bin/ruby`.
- `gems-latest-version(gem-name: string)` Returns the latest version of the given Ruby gem name via `gem-name`.
- `gems-installed-version(gem-name: string)` Returns the installed version of the given Ruby gem, if it exists.
- `gems-install-gem(gem-name: string, version: string, binaries: list<string>)` Installs the specified version of a Ruby gem by its name. Plus, wrappes its binaries with a special shell wrapper that sets `GEM_PATH` before running the gem. This is required to run a Gem outside of the user gemset:
    
    For instance, a Ruby extension installs the `solargraph` gem. After installing it, if the `binaries` param was passed, the Ruby runtime creates wrappers for each given `binary` with the following content:
    
    ```shell
    #!/usr/bin/env bash
    export GEM_PATH="{gem_path}:$GEM_PATH"
    exec "{exec_path}" "$@"
    ```
    
    where:
    
    - `gem_path` path to the extension working dir.
    - `exec_path` path to the actual Ruby gem binary.

    For `solargraph` this wrapper will be:
    
    ```shell
    #!/usr/bin/env bash
    export GEM_PATH="/Users/vslobodin/Library/Application Support/Zed/extensions/work/ruby:$GEM_PATH"
    exec "/Users/vslobodin/Library/Application Support/Zed/extensions/work/ruby/bin/solargraph" "$@"
    ```
    
- `bundle-installed-version(gem-name: string)` Not implemented but the idea of this method is to check if the given Ruby gem is available in the worktree `Gemfile`.

## Notes about the implementation

- `SystemRubyRuntime` - the currently available Ruby runtime which should point to a Ruby version that is activated in a worktree. A shell-based activation of the Ruby version is necessary to ensure the Ruby runtime uses the correct Ruby version.
- `UnavailableRubyRuntime` - unavailale Ruby runtime with stubbed methods.

See also my comments please.

## Known limitations and issues

1. The Ruby runtime relies on the correct Ruby version being activated in a worktree. In theory, there could be an issue if detection of a Ruby version fails.

## Possible improvements and ideas

1. If the system Ruby version is not detected or its version is too low, macOS ships with Ruby 2.6.10 out of the box, and this version is [unmaintained](https://endoflife.date/ruby).
3. Implement support for activating the correct Ruby version for most popular Ruby version managers. Ruby LSP for VSCode [does that](https://github.com/Shopify/ruby-lsp/tree/main/vscode/src/ruby) and that can be served as a reference.

## References

- The idea of installing gems separately was ported from [the `mason.nvim` extension](https://github.com/williamboman/mason.nvim) for `neovim`.
- [Ruby LSP for VSCode](https://github.com/Shopify/ruby-lsp/tree/main/vscode/src/ruby)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
