### PR TITLE
vim: Handle visual selection when jumping to mark

### DIFF
--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -121,7 +121,7 @@ impl Vim {
             }
         } else {
             // Save the last anchor so as to jump to it later.
-            let anchor: Option<Anchor> = anchors.last_mut().map(|last| last.clone());
+            let anchor: Option<Anchor> = anchors.last_mut().map(|anchor| *anchor);
             let should_jump = self.mode == Mode::Visual
                 || self.mode == Mode::VisualLine
                 || self.mode == Mode::VisualBlock;
@@ -151,15 +151,10 @@ impl Vim {
                 }
             });
 
-            if should_jump && anchor.is_some() {
-                self.motion(
-                    Motion::Jump {
-                        anchor: anchor.unwrap(),
-                        line,
-                    },
-                    window,
-                    cx,
-                )
+            if should_jump {
+                if let Some(anchor) = anchor {
+                    self.motion(Motion::Jump { anchor, line }, window, cx)
+                }
             }
         }
     }

--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -105,7 +105,7 @@ impl Vim {
             _ => self.marks.get(&*text).cloned(),
         };
 
-        let Some(anchors) = anchors else { return };
+        let Some(mut anchors) = anchors else { return };
 
         let is_active_operator = self.active_operator().is_some();
         if is_active_operator {
@@ -120,6 +120,9 @@ impl Vim {
                 )
             }
         } else {
+            // Save the last anchor so as to jump to it later.
+            let anchor: Option<Anchor> = anchors.last_mut().map(|last| last.clone());
+
             self.update_editor(window, cx, |vim, editor, window, cx| {
                 let map = editor.snapshot(window, cx);
                 let mut ranges: Vec<Range<Anchor>> = Vec::new();
@@ -131,61 +134,8 @@ impl Vim {
                             .display_snapshot
                             .buffer_snapshot
                             .anchor_before(point.to_point(&map.display_snapshot));
-
-                        if vim.mode == Mode::Visual
-                            || vim.mode == Mode::VisualLine
-                            || vim.mode == Mode::VisualBlock
-                        {
-                            editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
-                                s.move_with(|map, selection| {
-                                    let was_reversed = selection.reversed;
-                                    let mut current_head = selection.head();
-
-                                    // our motions assume the current character is after the cursor,
-                                    // but in (forward) visual mode the current character is just
-                                    // before the end of the selection.
-
-                                    // If the file ends with a newline (which is common) we don't do this.
-                                    // so that if you go to the end of such a file you can use "up" to go
-                                    // to the previous line and have it work somewhat as expected.
-                                    #[allow(clippy::nonminimal_bool)]
-                                    if !selection.reversed
-                                        && !selection.is_empty()
-                                        && !(selection.end.column() == 0
-                                            && selection.end == map.max_point())
-                                    {
-                                        current_head = movement::left(map, selection.end)
-                                    }
-
-                                    selection.set_head(point, SelectionGoal::None);
-
-                                    // ensure the current character is included in the selection.
-                                    if !selection.reversed {
-                                        let next_point = if vim.mode == Mode::VisualBlock {
-                                            movement::saturating_right(map, selection.end)
-                                        } else {
-                                            movement::right(map, selection.end)
-                                        };
-
-                                        if !(next_point.column() == 0
-                                            && next_point == map.max_point())
-                                        {
-                                            selection.end = next_point;
-                                        }
-                                    }
-
-                                    // vim always ensures the anchor character stays selected.
-                                    // if our selection has reversed, we need to move the opposite end
-                                    // to ensure the anchor is still selected.
-                                    if was_reversed && !selection.reversed {
-                                        selection.start = movement::left(map, selection.start);
-                                    } else if !was_reversed && selection.reversed {
-                                        selection.end = movement::right(map, selection.end);
-                                    }
-                                })
-                            });
-                        }
                     }
+
                     if ranges.last() != Some(&(anchor..anchor)) {
                         ranges.push(anchor..anchor);
                     }
@@ -197,9 +147,13 @@ impl Vim {
                 {
                     editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
                         s.select_anchor_ranges(ranges)
-                    })
+                    });
                 }
             });
+
+            if let Some(anchor) = anchor {
+                self.motion(Motion::Jump { anchor, line }, window, cx)
+            }
         }
     }
 }


### PR DESCRIPTION
Fix how vim mode handles jumping to mark, when one of vim's visual modes is active, in order to behave just like neovim. Here's a quick video showing the updated behavior ↓

https://github.com/user-attachments/assets/db91f574-d7e8-429d-952e-3435c43e31bd

Closes #18131 

Release Notes:

- Fixed vim's visual selections when jumping to marks
