### PR TITLE
extension_host: Remove duplicate linker registration

### DIFF
--- a/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs
@@ -39,18 +39,7 @@ pub type ExtensionKeyValueStore = Arc<dyn KeyValueStoreDelegate>;
 
 pub fn linker() -> &'static Linker<WasmState> {
     static LINKER: OnceLock<Linker<WasmState>> = OnceLock::new();
-    LINKER.get_or_init(|| {
-        super::new_linker(|linker, f| {
-            Extension::add_to_linker(linker, f)?;
-            latest::zed::extension::github::add_to_linker(linker, f)?;
-            latest::zed::extension::http_client::add_to_linker(linker, f)?;
-            latest::zed::extension::lsp::add_to_linker(linker, f)?;
-            latest::zed::extension::nodejs::add_to_linker(linker, f)?;
-            latest::zed::extension::platform::add_to_linker(linker, f)?;
-            latest::zed::extension::slash_command::add_to_linker(linker, f)?;
-            Ok(())
-        })
-    })
+    LINKER.get_or_init(|| super::new_linker(Extension::add_to_linker))
 }
 
 impl From<Command> for latest::Command {


### PR DESCRIPTION
This PR fixes a panic that would occur when loading an extension using v0.2.0 of the extension API after #25357 landed:

```
Thread "<unnamed>" panicked with "called `Result::unwrap()` on an `Err` value: map entry `zed:extension/github` defined twice" at crates/extension_host/src/wasm_host/wit.rs:38:31
https://github.com/zed-industries/zed/blob/10a6cd00e7d5bff07605598500123d987e0ea67e/src/crates/extension_host/src/wasm_host/wit.rs#L38 (may not be uploaded, line may be incorrect if files modified)
   0: backtrace::backtrace::libunwind::trace
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/backtrace/libunwind.rs:116:5
      backtrace::backtrace::trace_unsynchronized
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/backtrace/mod.rs:66:5
   1: backtrace::backtrace::trace
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/backtrace/mod.rs:53:14
   2: backtrace::capture::Backtrace::create
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/capture.rs:292:9
   3: backtrace::capture::Backtrace::new
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.74/src/capture.rs:257:22
   4: zed::reliability::init_panic_hook::{{closure}}
             at /Users/maxdeviant/projects/zed/crates/zed/src/reliability.rs:56:29
   5: <alloc::boxed::Box<F,A> as core::ops::function::Fn<Args>>::call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/alloc/src/boxed.rs:2084:9
      std::panicking::rust_panic_with_hook
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:808:13
   6: std::panicking::begin_panic_handler::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:674:13
   7: std::sys::backtrace::__rust_end_short_backtrace
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/backtrace.rs:168:18
   8: rust_begin_unwind
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/panicking.rs:665:5
   9: core::panicking::panic_fmt
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/panicking.rs:74:14
  10: core::result::unwrap_failed
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/result.rs:1679:5
  11: core::result::Result<T,E>::unwrap
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/result.rs:1102:23
      extension_host::wasm_host::wit::new_linker
             at /Users/maxdeviant/projects/zed/crates/extension_host/src/wasm_host/wit.rs:38:5
  12: extension_host::wasm_host::wit::since_v0_2_0::linker::{{closure}}
             at /Users/maxdeviant/projects/zed/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs:43:9
  13: std::sync::once_lock::OnceLock<T>::get_or_init::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once_lock.rs:276:50
  14: std::sync::once_lock::OnceLock<T>::initialize::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once_lock.rs:483:19
  15: std::sync::once::Once::call_once_force::{{closure}}
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once.rs:217:40
  16: std::sys::sync::once::queue::Once::call
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sys/sync/once/queue.rs:183:21
  17: std::sync::once::Once::call_once_force
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once.rs:217:9
  18: std::sync::once_lock::OnceLock<T>::initialize
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once_lock.rs:482:9
  19: std::sync::once_lock::OnceLock<T>::get_or_try_init
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once_lock.rs:364:9
  20: std::sync::once_lock::OnceLock<T>::get_or_init
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/std/src/sync/once_lock.rs:276:15
  21: extension_host::wasm_host::wit::since_v0_2_0::linker
             at /Users/maxdeviant/projects/zed/crates/extension_host/src/wasm_host/wit/since_v0_2_0.rs:42:5
  22: extension_host::wasm_host::wit::Extension::instantiate_async::{{closure}}
             at /Users/maxdeviant/projects/zed/crates/extension_host/src/wasm_host/wit.rs:122:17
  23: extension_host::wasm_host::WasmHost::load_extension::{{closure}}
             at /Users/maxdeviant/projects/zed/crates/extension_host/src/wasm_host.rs:385:14
  24: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /rustc/eeb90cda1969383f56a2637cbd3037bdf598841c/library/core/src/future/future.rs:123:9
  25: async_task::raw::RawTask<F,T,S,M>::run
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.7.1/src/raw.rs:557:17
  26: async_task::runnable::Runnable<M>::run
             at /Users/maxdeviant/.cargo/registry/src/index.crates.io-6f17d22bba15001f/async-task-4.7.1/src/runnable.rs:781:18
  27: gpui::platform::mac::dispatcher::trampoline
             at /Users/maxdeviant/projects/zed/crates/gpui/src/platform/mac/dispatcher.rs:106:5
  28: <unknown>
  29: <unknown>
  30: <unknown>
  31: _pthread_mach_thread_np
```

We don't need the added `add_to_linker` calls anymore.

Release Notes:

- N/A
