### PR TITLE
Improve C++ highlighting for sized type specifiers

### DIFF
--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -69,6 +69,7 @@
 (auto) @type
 (type_identifier) @type
 type :(primitive_type) @type.primitive
+(sized_type_specifier) @type.primitive
 
 (requires_clause
     constraint: (template_type
@@ -131,7 +132,6 @@ type :(primitive_type) @type.primitive
   "using"
   "virtual"
   "while"
-  (sized_type_specifier)
   (storage_class_specifier)
   (type_qualifier)
 ] @keyword


### PR DESCRIPTION
For consistency, sized type specifiers should be highlighted the same way as primitive types, to make sure 'unsigned', 'int' and 'unsigned int' are all the same color. [A previous change](https://github.com/zed-industries/zed/pull/18016) moved primitive types from `@keyword` to `@type`, and this PR adjusts the sized type specifier to follow suit.

Before this change:

![image](https://github.com/user-attachments/assets/d0982ced-882f-4477-b716-f07ac4a72170)

After this change:

![image](https://github.com/user-attachments/assets/2fb6a7e7-061b-46e1-a4e3-e906e1e87bd8)

Release Notes:

- Improved C++ syntax highlighting for sized type specifiers.