### PR TITLE
Remove unnecessary Arc from AhoCorasick since it's using it internally

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -55,7 +55,7 @@ impl SearchInputs {
 #[derive(Clone, Debug)]
 pub enum SearchQuery {
     Text {
-        search: Arc<AhoCorasick>,
+        search: AhoCorasick,
         replacement: Option<String>,
         whole_word: bool,
         case_sensitive: bool,
@@ -101,7 +101,7 @@ impl SearchQuery {
             buffers,
         };
         Ok(Self::Text {
-            search: Arc::new(search),
+            search,
             replacement: None,
             whole_word,
             case_sensitive,


### PR DESCRIPTION
This PR removes the unnecessary `Arc` around the `AhoCorasick` struct, since [it's already using it internally](https://docs.rs/aho-corasick/latest/aho_corasick/struct.AhoCorasick.html#cloning).

Release Notes:

- N/A