### PR TITLE
Get only last line of `uname -sm` output on remote server

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1634,7 +1634,7 @@ impl SshRemoteConnection {
 
     async fn platform(&self) -> Result<SshPlatform> {
         let uname = self.socket.run_command("uname", &["-sm"]).await?;
-        let Some((os, arch)) = uname.split_once(" ") else {
+        let Some((os, arch)) = uname.lines().last().unwrap_or("").split_once(" ") else {
             Err(anyhow!("unknown uname: {uname:?}"))?
         };
 


### PR DESCRIPTION
Closes #25382 

Release notes:

- SSH remoting: fixed connecting when your `.bashrc` writes to stdout. 
