### PR TITLE
windows: Fix incorrect button ID setting for TaskDialog

### DIFF
--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -611,19 +611,10 @@ impl PlatformWindow for WindowsWindow {
                         let encoded = HSTRING::from(btn_string);
                         let button_id = if btn_string == "Cancel" {
                             IDCANCEL.0
-                        } else if btn_string == "No" {
-                            IDNO.0
-                        } else if btn_string == "OK" {
-                            IDOK.0
-                        } else if btn_string == "Retry" {
-                            IDRETRY.0
-                        } else if btn_string == "Yes" {
-                            IDYES.0
                         } else {
                             index as i32 - 100
                         };
                         button_id_map.push(button_id);
-                        println!("Creating button {}, {}, {}", btn_string, index, button_id);
                         buttons.push(TASKDIALOG_BUTTON {
                             nButtonID: button_id,
                             pszButtonText: PCWSTR::from_raw(encoded.as_ptr()),
@@ -642,7 +633,6 @@ impl PlatformWindow for WindowsWindow {
                         .iter()
                         .position(|&button_id| button_id == res)
                         .unwrap_or(0);
-                    println!("Clicked: {}, {}", res, clicked);
                     let _ = done_tx.send(clicked as usize);
                 }
             })

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -633,7 +633,7 @@ impl PlatformWindow for WindowsWindow {
                         .iter()
                         .position(|&button_id| button_id == res)
                         .unwrap_or(0);
-                    let _ = done_tx.send(clicked as usize);
+                    let _ = done_tx.send(clicked);
                 }
             })
             .detach();

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -577,8 +577,7 @@ impl PlatformWindow for WindowsWindow {
             .executor
             .spawn(async move {
                 unsafe {
-                    let mut config;
-                    config = std::mem::zeroed::<TASKDIALOGCONFIG>();
+                    let mut config = TASKDIALOGCONFIG::default();
                     config.cbSize = std::mem::size_of::<TASKDIALOGCONFIG>() as _;
                     config.hwndParent = handle;
                     let title;
@@ -599,17 +598,17 @@ impl PlatformWindow for WindowsWindow {
                     };
                     config.pszWindowTitle = title;
                     config.Anonymous1.pszMainIcon = main_icon;
-                    let instruction = msg.encode_utf16().chain(Some(0)).collect_vec();
+                    let instruction = HSTRING::from(msg);
                     config.pszMainInstruction = PCWSTR::from_raw(instruction.as_ptr());
                     let hints_encoded;
                     if let Some(ref hints) = detail_string {
-                        hints_encoded = hints.encode_utf16().chain(Some(0)).collect_vec();
+                        hints_encoded = HSTRING::from(hints);
                         config.pszContent = PCWSTR::from_raw(hints_encoded.as_ptr());
                     };
                     let mut buttons = Vec::new();
                     let mut btn_encoded = Vec::new();
                     for (index, btn_string) in answers.iter().enumerate() {
-                        let encoded = btn_string.encode_utf16().chain(Some(0)).collect_vec();
+                        let encoded = HSTRING::from(btn_string);
                         buttons.push(TASKDIALOG_BUTTON {
                             nButtonID: index as _,
                             pszButtonText: PCWSTR::from_raw(encoded.as_ptr()),

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -627,12 +627,13 @@ impl PlatformWindow for WindowsWindow {
                     config.pfCallback = None;
                     let mut res = std::mem::zeroed();
                     let _ = TaskDialogIndirect(&config, Some(&mut res), None, None)
-                        .inspect_err(|e| log::error!("unable to create task dialog: {}", e));
+                        .context("unable to create task dialog")
+                        .log_err();
 
                     let clicked = button_id_map
                         .iter()
                         .position(|&button_id| button_id == res)
-                        .unwrap_or(0);
+                        .unwrap();
                     let _ = done_tx.send(clicked);
                 }
             })


### PR DESCRIPTION
Closes #22821

It turns out that on Windows, the `Cancel` button should **always** have a button ID of `2`. Even if the button label is something like "Don't Cancel", when the user presses the `Esc` key, Windows will still report that the button with ID `2` was pressed.

Release Notes:

- N/A
