### PR TITLE
zed_extension_api: Use v0.3.0 WIT files for codegen

### DIFF
--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -195,7 +195,7 @@ mod wit {
 
     wit_bindgen::generate!({
         skip: ["init-extension"],
-        path: "./wit/since_v0.2.0",
+        path: "./wit/since_v0.3.0",
     });
 }
 


### PR DESCRIPTION
This PR updates the `zed_extension_api` to use the v0.3.0 WIT files for code generation.

I missed this in https://github.com/zed-industries/zed/pull/25357.

Release Notes:

- N/A
