### PR TITLE
Only authenticate if the credentials provider has credentials when running in development

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -729,13 +729,14 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
 }
 
 async fn authenticate(client: Arc<Client>, cx: &AsyncApp) -> Result<()> {
+    let has_credentials = client.has_credentials(cx).await;
     if stdout_is_a_pty() {
         if client::IMPERSONATE_LOGIN.is_some() {
             client.authenticate_and_connect(false, cx).await?;
-        } else {
-            client.authenticate_and_connect(true, cx).await?
+        } else if has_credentials {
+            client.authenticate_and_connect(true, cx).await?;
         }
-    } else if client.has_credentials(cx).await {
+    } else if has_credentials {
         client.authenticate_and_connect(true, cx).await?;
     }
     Ok::<_, anyhow::Error>(())

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -729,14 +729,13 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
 }
 
 async fn authenticate(client: Arc<Client>, cx: &AsyncApp) -> Result<()> {
-    let has_credentials = client.has_credentials(cx).await;
     if stdout_is_a_pty() {
         if client::IMPERSONATE_LOGIN.is_some() {
             client.authenticate_and_connect(false, cx).await?;
-        } else if has_credentials {
+        } else if client.has_credentials(cx).await {
             client.authenticate_and_connect(true, cx).await?;
         }
-    } else if has_credentials {
+    } else if client.has_credentials(cx).await {
         client.authenticate_and_connect(true, cx).await?;
     }
     Ok::<_, anyhow::Error>(())


### PR DESCRIPTION
Closes #25394

Release Notes:

- N/A

Scenarios:

| Scenarios | What it does |
|------|--------|
| Interactive Terminal + Impersonate Active Login | Login without saved credentials |
| Interactive Terminal + Saved credentials | Login with saved credentials |
| Interactive Terminal + No credentials | Does nothing |
| Non-interactive Terminal + Saved credentials | Login with saved credentials |
| Non-interactive Terminal + No credentials | Does nothing |

@maxdeviant : You can take a look at it.

