### PR TITLE
Fix completion details on new clangd versions

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -120,20 +120,21 @@ impl super::LspAdapter for CLspAdapter {
         completion: &lsp::CompletionItem,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
-        let label_detail = 
-            match &completion.label_details {
-                Some(label_detail) => match &label_detail.detail {
-                    Some(detail) => detail.trim(),
-                    None => "",
-                },
+        let label_detail = match &completion.label_details {
+            Some(label_detail) => match &label_detail.detail {
+                Some(detail) => detail.trim(),
                 None => "",
-            };
+            },
+            None => "",
+        };
 
         let label = completion
             .label
             .strip_prefix('•')
             .unwrap_or(&completion.label)
-            .trim().to_owned() + label_detail;
+            .trim()
+            .to_owned()
+            + label_detail;
 
         match completion.kind {
             Some(lsp::CompletionItemKind::FIELD) if completion.detail.is_some() => {

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -120,11 +120,20 @@ impl super::LspAdapter for CLspAdapter {
         completion: &lsp::CompletionItem,
         language: &Arc<Language>,
     ) -> Option<CodeLabel> {
+        let label_detail = 
+            match &completion.label_details {
+                Some(label_detail) => match &label_detail.detail {
+                    Some(detail) => detail.trim(),
+                    None => "",
+                },
+                None => "",
+            };
+
         let label = completion
             .label
             .strip_prefix('•')
             .unwrap_or(&completion.label)
-            .trim();
+            .trim().to_owned() + label_detail;
 
         match completion.kind {
             Some(lsp::CompletionItemKind::FIELD) if completion.detail.is_some() => {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -708,7 +708,7 @@ impl LanguageServer {
                                 ],
                             }),
                             insert_replace_support: Some(true),
-                            label_details_support: Some(false),
+                            label_details_support: Some(true),
                             ..Default::default()
                         }),
                         completion_list: Some(CompletionListCapability {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -708,7 +708,7 @@ impl LanguageServer {
                                 ],
                             }),
                             insert_replace_support: Some(true),
-                            label_details_support: Some(true),
+                            label_details_support: Some(false),
                             ..Default::default()
                         }),
                         completion_list: Some(CompletionListCapability {


### PR DESCRIPTION
Fixes #16057

In newer versions of clangd, the switch labelDetailsSupport in the json passed to the language server modifies the format of the returned json. Zed handles well the old format, but misses the function parameters in the new one. For example:
The old format looks like this:
```json
...
"label": " Window(int width, int height, const char *name, bool vsync, bool resizable)",
...
```
and with labelDetailsSupport = true:
```json
...
 "label": " Window",
 "labelDetails": {
     "detail": "(int width, int height, const char *name, bool vsync, bool resizable)"
 },
...
```
A simple solution is to just to not tell the language server that label details are supported and force it to use the old format. This is a dirty fix, but makes the completions behave like in the old versions of clangd. 

I do not know if this will break another language server. From what I've found out most lsp-s do not depend on that setting and provide all completion data either way. If not, this switch will need to be exposed in a config or be at least lsp-dependant. 

Lastly, I do not know Rust, maybe will need help to make a better fix for the issue.

Release Notes:

- Fixed broken C++ completion suggestions