### PR TITLE
lsp: Check for existing snapshots before sending off a didOpen notification

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1921,17 +1921,20 @@ impl LocalLspStore {
                     version: 0,
                     snapshot: initial_snapshot.clone(),
                 };
-                self.buffer_snapshots
+                let previous_snapshots = self
+                    .buffer_snapshots
                     .entry(buffer_id)
                     .or_default()
                     .insert(server.server_id(), vec![snapshot]);
 
-                server.register_buffer(
-                    uri.clone(),
-                    adapter.language_id(&language.name()),
-                    0,
-                    initial_snapshot.text(),
-                );
+                if previous_snapshots.is_none() {
+                    server.register_buffer(
+                        uri.clone(),
+                        adapter.language_id(&language.name()),
+                        0,
+                        initial_snapshot.text(),
+                    );
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed Zed sending out didOpen notification to a language server when opening documents.
