### PR TITLE
file_finder: Add `SelectNext` action

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -44,7 +44,7 @@ use workspace::{
     Workspace,
 };
 
-actions!(file_finder, [SelectPrev, ToggleMenu]);
+actions!(file_finder, [SelectPrev, SelectNext, ToggleMenu]);
 
 impl ModalView for FileFinder {
     fn on_before_dismiss(
@@ -204,6 +204,11 @@ impl FileFinder {
         window.dispatch_action(Box::new(menu::SelectPrev), cx);
     }
 
+    fn handle_select_next(&mut self, _: &SelectNext, window: &mut Window, cx: &mut Context<Self>) {
+        self.init_modifiers = Some(window.modifiers());
+        window.dispatch_action(Box::new(menu::SelectNext), cx);
+    }
+
     fn handle_toggle_menu(&mut self, _: &ToggleMenu, window: &mut Window, cx: &mut Context<Self>) {
         self.picker.update(cx, |picker, cx| {
             let menu_handle = &picker.delegate.popover_menu_handle;
@@ -317,6 +322,7 @@ impl Render for FileFinder {
             .w(modal_max_width)
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
             .on_action(cx.listener(Self::handle_select_prev))
+            .on_action(cx.listener(Self::handle_select_next))
             .on_action(cx.listener(Self::handle_toggle_menu))
             .on_action(cx.listener(Self::go_to_file_split_left))
             .on_action(cx.listener(Self::go_to_file_split_right))


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- I wanted Zed to emulate the actions of my other IDEs, by doing something like this:

```json
{
    "context": "Editor && !menu",
    "bindings": {
      "tab": "file_finder::SelectNext",
      "shift-tab": "file_finder::SelectPrev"
    }
  },
```

But there was only a `SelectPrev` option. I added a `SelectNext` handler too, I compiled and tested the changes and it works. Video below:


https://github.com/user-attachments/assets/50a5f48e-64a5-4506-9880-8864591acff6


