### PR TITLE
zeta: Add `LICENSE.md` and `LICENCE.md` to license detection

### DIFF
--- a/crates/zeta/src/license_detection.rs
+++ b/crates/zeta/src/license_detection.rs
@@ -1,7 +1,7 @@
 use regex::Regex;
 
 /// The most common license locations, with US and UK English spelling.
-pub const LICENSE_FILES_TO_CHECK: &[&str] = &["LICENSE", "LICENCE", "LICENSE.txt", "LICENCE.txt"];
+pub const LICENSE_FILES_TO_CHECK: &[&str] = &["LICENSE", "LICENCE", "LICENSE.txt", "LICENCE.txt", "LICENSE.md", "LICENCE.md"];
 
 pub fn is_license_eligible_for_data_collection(license: &str) -> bool {
     // TODO: Include more licenses later (namely, Apache)

--- a/crates/zeta/src/license_detection.rs
+++ b/crates/zeta/src/license_detection.rs
@@ -1,7 +1,14 @@
 use regex::Regex;
 
 /// The most common license locations, with US and UK English spelling.
-pub const LICENSE_FILES_TO_CHECK: &[&str] = &["LICENSE", "LICENCE", "LICENSE.txt", "LICENCE.txt", "LICENSE.md", "LICENCE.md"];
+pub const LICENSE_FILES_TO_CHECK: &[&str] = &[
+    "LICENSE",
+    "LICENCE",
+    "LICENSE.txt",
+    "LICENCE.txt",
+    "LICENSE.md",
+    "LICENCE.md",
+];
 
 pub fn is_license_eligible_for_data_collection(license: &str) -> bool {
     // TODO: Include more licenses later (namely, Apache)


### PR DESCRIPTION
Maybe it's not a very common, but it has a place to be.

Release Notes:

- Added `LICENSE.md` and `LICENCE.md` files to license detection for edit prediction.