### PR TITLE
docs: Remove outdated note about pinning `@vue/language-server`

### DIFF
--- a/docs/src/languages/vue.md
+++ b/docs/src/languages/vue.md
@@ -4,5 +4,3 @@ Vue support is available through the [Vue extension](https://github.com/zed-exte
 
 - Tree Sitter: [tree-sitter-grammars/tree-sitter-vue](https://github.com/tree-sitter-grammars/tree-sitter-vue)
 - Language Server: [vuejs/language-tools/](https://github.com/vuejs/language-tools/)
-
-> `@vue/language-server` is pinned to v1.8 due to some issues in v2.x [#9846](https://github.com/zed-industries/zed/pull/9846)


### PR DESCRIPTION
This PR removes the outdated note about pinning `@vue/language-server` to v1.8.

As of https://github.com/zed-extensions/vue/pull/1 we now use the latest available version.

Release Notes:

- N/A
