### PR TITLE
docs: Remove empty Tree-sitter grammar link in the Tailwind docs

### DIFF
--- a/docs/src/languages/tailwindcss.md
+++ b/docs/src/languages/tailwindcss.md
@@ -2,7 +2,6 @@
 
 Tailwind CSS support is built into Zed.
 
-- Tree Sitter: []
 - Language Server: [tailwindlabs/tailwindcss-intellisense](https://github.com/tailwindlabs/tailwindcss-intellisense)
 
 ## Configuration


### PR DESCRIPTION
This PR removes the empty Tree-sitter grammar link in the Tailwind docs.

Tailwind does not use a Tree-sitter grammar.

Release Notes:

- N/A
