### PR TITLE
docs: Fix casing of "Tree-sitter"

### DIFF
--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -2265,13 +2265,13 @@ mod test {
             (
                 "c i q",
                 "This is a \"simple 'qˇuote'\" example.",
-                "This is a \"ˇ\" example.", // Not supported by tree sitter queries for now
+                "This is a \"ˇ\" example.", // Not supported by Tree-sitter queries for now
                 Mode::Insert,
             ),
             (
                 "c a q",
                 "This is a \"simple 'qˇuote'\" example.",
-                "This is a ˇ example.", // Not supported by tree sitter queries for now
+                "This is a ˇ example.", // Not supported by Tree-sitter queries for now
                 Mode::Insert,
             ),
             (

--- a/docs/src/languages/asciidoc.md
+++ b/docs/src/languages/asciidoc.md
@@ -3,4 +3,4 @@
 AsciiDoc language support in Zed is provided by the community-maintained [AsciiDoc extension](https://github.com/andreicek/zed-asciidoc).
 Report issues to: [https://github.com/andreicek/zed-asciidoc/issues](https://github.com/andreicek/zed-asciidoc/issues)
 
-- Tree Sitter: [cathaysia/tree-sitter-asciidoc](https://github.com/cathaysia/tree-sitter-asciidoc)
+- Tree-sitter: [cathaysia/tree-sitter-asciidoc](https://github.com/cathaysia/tree-sitter-asciidoc)

--- a/docs/src/languages/astro.md
+++ b/docs/src/languages/astro.md
@@ -2,7 +2,7 @@
 
 Astro support is available through the [Astro extension](https://github.com/zed-extensions/astro).
 
-- Tree Sitter: [virchau13/tree-sitter-astro](https://github.com/virchau13/tree-sitter-astro)
+- Tree-sitter: [virchau13/tree-sitter-astro](https://github.com/virchau13/tree-sitter-astro)
 - Language Server: [withastro/language-tools](https://github.com/withastro/language-tools)
 
 <!--

--- a/docs/src/languages/bash.md
+++ b/docs/src/languages/bash.md
@@ -3,7 +3,7 @@
 Bash language support in Zed is provided by the community-maintained [Basher extension](https://github.com/d1y/bash.zed).
 Report issues to: [https://github.com/d1y/bash.zed/issues](https://github.com/d1y/bash.zed/issues)
 
-- Tree Sitter: [tree-sitter/tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash)
+- Tree-sitter: [tree-sitter/tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash)
 - Language Server: [bash-lsp/bash-language-server](https://github.com/bash-lsp/bash-language-server)
 
 ## Configuration

--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -2,7 +2,7 @@
 
 C support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c)
+- Tree-sitter: [tree-sitter/tree-sitter-c](https://github.com/tree-sitter/tree-sitter-c)
 - Language Server: [clangd/clangd](https://github.com/clangd/clangd)
 
 ## Clangd: Force detect as C

--- a/docs/src/languages/clojure.md
+++ b/docs/src/languages/clojure.md
@@ -2,7 +2,7 @@
 
 Clojure support is available through the [Clojure extension](https://github.com/zed-extensions/clojure).
 
-- Tree Sitter: [prcastro/tree-sitter-clojure](https://github.com/prcastro/tree-sitter-clojure)
+- Tree-sitter: [prcastro/tree-sitter-clojure](https://github.com/prcastro/tree-sitter-clojure)
 - Language Server: [clojure-lsp/clojure-lsp](https://github.com/clojure-lsp/clojure-lsp)
 
 <!--

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -2,7 +2,7 @@
 
 C++ support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp)
+- Tree-sitter: [tree-sitter/tree-sitter-cpp](https://github.com/tree-sitter/tree-sitter-cpp)
 - Language Server: [clangd/clangd](https://github.com/clangd/clangd)
 
 ## Binary

--- a/docs/src/languages/csharp.md
+++ b/docs/src/languages/csharp.md
@@ -4,7 +4,7 @@ Note language name is "CSharp" for settings not "C#'
 
 C# support is available through the [C# extension](https://github.com/zed-industries/zed/tree/main/extensions/csharp).
 
-- Tree Sitter: [tree-sitter/tree-sitter-c-sharp](https://github.com/tree-sitter/tree-sitter-c-sharp)
+- Tree-sitter: [tree-sitter/tree-sitter-c-sharp](https://github.com/tree-sitter/tree-sitter-c-sharp)
 - Language Server: [OmniSharp/omnisharp-roslyn](https://github.com/OmniSharp/omnisharp-roslyn)
 
 ## Configuration

--- a/docs/src/languages/css.md
+++ b/docs/src/languages/css.md
@@ -2,7 +2,7 @@
 
 CSS support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-css](https://github.com/tree-sitter/tree-sitter-css)
+- Tree-sitter: [tree-sitter/tree-sitter-css](https://github.com/tree-sitter/tree-sitter-css)
 - Language Servers:
   - [microsoft/vscode-html-languageservice](https://github.com/microsoft/vscode-html-languageservice)
   - [tailwindcss-language-server](https://github.com/tailwindlabs/tailwindcss-intellisense)

--- a/docs/src/languages/dart.md
+++ b/docs/src/languages/dart.md
@@ -2,7 +2,7 @@
 
 Dart support is available through the [Dart extension](https://github.com/zed-extensions/dart).
 
-- Tree Sitter: [UserNobody14/tree-sitter-dart](https://github.com/UserNobody14/tree-sitter-dart)
+- Tree-sitter: [UserNobody14/tree-sitter-dart](https://github.com/UserNobody14/tree-sitter-dart)
 - Language Server: [dart language-server](https://github.com/dart-lang/sdk)
 
 ## Pre-requisites

--- a/docs/src/languages/diff.md
+++ b/docs/src/languages/diff.md
@@ -2,7 +2,7 @@
 
 Diff support is available natively in Zed.
 
-- Tree Sitter: [zed-industries/the-mikedavis/tree-sitter-diff](https://github.com/the-mikedavis/tree-sitter-diff)
+- Tree-sitter: [zed-industries/the-mikedavis/tree-sitter-diff](https://github.com/the-mikedavis/tree-sitter-diff)
 
 ## Configuration
 

--- a/docs/src/languages/docker.md
+++ b/docs/src/languages/docker.md
@@ -12,5 +12,5 @@ Docker `compose.yaml` language support in Zed is provided by the [Docker Compose
 
 `Dockerfile` language support in Zed is provided by the [Dockerfile extension](https://github.com/d1y/dockerfile.zed). Please issues to: [https://github.com/d1y/dockerfile.zed/issues](https://github.com/d1y/dockerfile.zed/issues).
 
-- Tree Sitter: [camdencheek/tree-sitter-dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile)
+- Tree-sitter: [camdencheek/tree-sitter-dockerfile](https://github.com/camdencheek/tree-sitter-dockerfile)
 - Language Server: [rcjsuen/dockerfile-language-server](https://github.com/rcjsuen/dockerfile-language-server)

--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -2,7 +2,7 @@
 
 Elixir support is available through the [Elixir extension](https://github.com/zed-industries/zed/tree/main/extensions/elixir).
 
-- Tree Sitter:
+- Tree-sitter:
   - [elixir-lang/tree-sitter-elixir](https://github.com/elixir-lang/tree-sitter-elixir)
   - [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
 - Language servers:
@@ -99,4 +99,4 @@ See [ElixirLS configuration settings](https://github.com/elixir-lsp/elixir-ls#el
 
 Zed also supports HEEx templates. HEEx is a mix of [EEx](https://hexdocs.pm/eex/1.12.3/EEx.html) (Embedded Elixir) and HTML, and is used in Phoenix LiveView applications.
 
-- Tree Sitter: [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
+- Tree-sitter: [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)

--- a/docs/src/languages/elm.md
+++ b/docs/src/languages/elm.md
@@ -2,7 +2,7 @@
 
 Elm support is available through the [Elm extension](https://github.com/zed-extensions/elm).
 
-- Tree Sitter: [elm-tooling/tree-sitter-elm](https://github.com/elm-tooling/tree-sitter-elm)
+- Tree-sitter: [elm-tooling/tree-sitter-elm](https://github.com/elm-tooling/tree-sitter-elm)
 - Language Server: [elm-tooling/elm-language-server](https://github.com/elm-tooling/elm-language-server)
 
 ## Setup

--- a/docs/src/languages/erlang.md
+++ b/docs/src/languages/erlang.md
@@ -2,7 +2,7 @@
 
 Erlang support is available through the [Erlang extension](https://github.com/zed-industries/zed/tree/main/extensions/erlang).
 
-- Tree Sitter: [WhatsApp/tree-sitter-erlang](https://github.com/WhatsApp/tree-sitter-erlang)
+- Tree-sitter: [WhatsApp/tree-sitter-erlang](https://github.com/WhatsApp/tree-sitter-erlang)
 - Language Server: [erlang-ls/erlang_ls](https://github.com/erlang-ls/erlang_ls)
 
 ## See also:

--- a/docs/src/languages/fish.md
+++ b/docs/src/languages/fish.md
@@ -3,4 +3,4 @@
 Fish language support in Zed is provided by the community-maintained [Fish extension](https://github.com/hasit/zed-fish).
 Report issues to: [https://github.com/hasit/zed-fish/issues](https://github.com/hasit/zed-fish/issues)
 
-- Tree Sitter: [ram02z/tree-sitter-fish](https://github.com/ram02z/tree-sitter-fish)
+- Tree-sitter: [ram02z/tree-sitter-fish](https://github.com/ram02z/tree-sitter-fish)

--- a/docs/src/languages/gdscript.md
+++ b/docs/src/languages/gdscript.md
@@ -3,7 +3,7 @@
 Godot [GDScript](https://gdscript.com/) language support in Zed is provided by the community-maintained [GDScript extension](https://github.com/grndctrl/zed-gdscript).
 Report issues to: [https://github.com/grndctrl/zed-gdscript/issues](https://github.com/grndctrl/zed-gdscript/issues)
 
-- Tree Sitter: [PrestonKnopp/tree-sitter-gdscript](https://github.com/PrestonKnopp/tree-sitter-gdscript) and [PrestonKnopp/tree-sitter-godot-resource](https://github.com/PrestonKnopp/tree-sitter-godot-resource)
+- Tree-sitter: [PrestonKnopp/tree-sitter-gdscript](https://github.com/PrestonKnopp/tree-sitter-gdscript) and [PrestonKnopp/tree-sitter-godot-resource](https://github.com/PrestonKnopp/tree-sitter-godot-resource)
 - Language Server: [gdscript-language-server](https://github.com/godotengine/godot)
 
 ## Setup

--- a/docs/src/languages/gleam.md
+++ b/docs/src/languages/gleam.md
@@ -2,7 +2,7 @@
 
 Gleam support is available through the [Gleam extension](https://github.com/gleam-lang/zed-gleam). To learn about Gleam, see the [docs](https://gleam.run/documentation/) or check out the [`stdlib` reference](https://hexdocs.pm/gleam_stdlib/). The Gleam language server has a variety of features, including go-to definition, automatic imports, and [more](https://gleam.run/language-server/).
 
-- Tree Sitter: [gleam-lang/tree-sitter-gleam](https://github.com/gleam-lang/tree-sitter-gleam)
+- Tree-sitter: [gleam-lang/tree-sitter-gleam](https://github.com/gleam-lang/tree-sitter-gleam)
 - Language Server: [gleam lsp](https://github.com/gleam-lang/gleam/tree/main/compiler-core/src/language_server)
 
 See also:

--- a/docs/src/languages/glsl.md
+++ b/docs/src/languages/glsl.md
@@ -2,5 +2,5 @@
 
 GLSL (OpenGL Shading Language) support is available through the [GLSL Extension](https://github.com/zed-industries/zed/tree/main/extensions/glsl/)
 
-- Tree Sitter: [theHamsta/tree-sitter-glsl](https://github.com/theHamsta/tree-sitter-glsl)
+- Tree-sitter: [theHamsta/tree-sitter-glsl](https://github.com/theHamsta/tree-sitter-glsl)
 - Language Server: [nolanderc/glsl_analyzer](https://github.com/nolanderc/glsl_analyzer)

--- a/docs/src/languages/go.md
+++ b/docs/src/languages/go.md
@@ -2,7 +2,7 @@
 
 Go support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go)
+- Tree-sitter: [tree-sitter/tree-sitter-go](https://github.com/tree-sitter/tree-sitter-go)
 - Language Server: [golang/tools/tree/master/gopls](https://github.com/golang/tools/tree/master/gopls)
 
 ## Setup
@@ -74,16 +74,16 @@ See [gopls inlayHints documentation](https://github.com/golang/tools/blob/master
 
 ## Go Mod
 
-- Tree Sitter: [camdencheek/tree-sitter-go-mod](https://github.com/camdencheek/tree-sitter-go-mod)
+- Tree-sitter: [camdencheek/tree-sitter-go-mod](https://github.com/camdencheek/tree-sitter-go-mod)
 - Language Server: N/A
 
 ## Go Sum
 
-- Tree Sitter: [amaanq/tree-sitter-go-sum](https://github.com/amaanq/tree-sitter-go-sum)
+- Tree-sitter: [amaanq/tree-sitter-go-sum](https://github.com/amaanq/tree-sitter-go-sum)
 - Language Server: N/A
 
 ## Go Work
 
-- Tree Sitter:
+- Tree-sitter:
   [tree-sitter-go-work](https://github.com/d1y/tree-sitter-go-work)
 - Language Server: N/A

--- a/docs/src/languages/groovy.md
+++ b/docs/src/languages/groovy.md
@@ -3,5 +3,5 @@
 Groovy language support in Zed is provided by the community-maintained [Groovy extension](https://github.com/valentinegb/zed-groovy).
 Report issues to: [https://github.com/valentinegb/zed-groovy/issues](https://github.com/valentinegb/zed-groovy/issues)
 
-- Tree Sitter: [murtaza64/tree-sitter-groovy](https://github.com/murtaza64/tree-sitter-groovy)
+- Tree-sitter: [murtaza64/tree-sitter-groovy](https://github.com/murtaza64/tree-sitter-groovy)
 - Language Server: [GroovyLanguageServer/groovy-language-server](https://github.com/GroovyLanguageServer/groovy-language-server)

--- a/docs/src/languages/haskell.md
+++ b/docs/src/languages/haskell.md
@@ -2,7 +2,7 @@
 
 Haskell support is available through the [Haskell extension](https://github.com/zed-industries/zed/tree/main/extensions/haskell).
 
-- Tree Sitter: [tree-sitter-haskell](https://github.com/tree-sitter/tree-sitter-haskell)
+- Tree-sitter: [tree-sitter-haskell](https://github.com/tree-sitter/tree-sitter-haskell)
 - Language Server: [haskell-language-server](https://github.com/haskell/haskell-language-server)
 
 See: official [configuring haskell-language-server](https://haskell-language-server.readthedocs.io/en/latest/configuration.html) docs for more.

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -2,7 +2,7 @@
 
 HTML support is available through the [HTML extension](https://github.com/zed-industries/zed/tree/main/extensions/html).
 
-- Tree Sitter: [tree-sitter/tree-sitter-html](https://github.com/tree-sitter/tree-sitter-html)
+- Tree-sitter: [tree-sitter/tree-sitter-html](https://github.com/tree-sitter/tree-sitter-html)
 - Language Server: [microsoft/vscode-html-languageservice](https://github.com/microsoft/vscode-html-languageservice)
 
 This extension is automatically installed.

--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -7,7 +7,7 @@ There are two extensions that provide Java language support for Zed:
 
 Both use:
 
-- Tree Sitter: [tree-sitter/tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java)
+- Tree-sitter: [tree-sitter/tree-sitter-java](https://github.com/tree-sitter/tree-sitter-java)
 - Language Server: [eclipse-jdtls/eclipse.jdt.ls](https://github.com/eclipse-jdtls/eclipse.jdt.ls)
 
 ## Install OpenJDK

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -2,7 +2,7 @@
 
 JavaScript support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript)
+- Tree-sitter: [tree-sitter/tree-sitter-javascript](https://github.com/tree-sitter/tree-sitter-javascript)
 - Language Server: [typescript-language-server/typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
 
 ## Code formatting

--- a/docs/src/languages/json.md
+++ b/docs/src/languages/json.md
@@ -2,7 +2,7 @@
 
 JSON support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-json](https://github.com/tree-sitter/tree-sitter-json)
+- Tree-sitter: [tree-sitter/tree-sitter-json](https://github.com/tree-sitter/tree-sitter-json)
 - Language Server: [zed-industries/json-language-server](https://github.com/zed-industries/json-language-server)
 
 ## JSONC

--- a/docs/src/languages/jsonnet.md
+++ b/docs/src/languages/jsonnet.md
@@ -2,7 +2,7 @@
 
 Jsonnet language support in Zed is provided by the community-maintained [Jsonnet extension](https://github.com/narqo/zed-jsonnet).
 
-- Tree Sitter: [sourcegraph/tree-sitter-jsonnet](https://github.com/sourcegraph/tree-sitter-jsonnet)
+- Tree-sitter: [sourcegraph/tree-sitter-jsonnet](https://github.com/sourcegraph/tree-sitter-jsonnet)
 - Language Server: [grafana/jsonnet-language-server](https://github.com/grafana/jsonnet-language-server)
 
 ## Configuration

--- a/docs/src/languages/julia.md
+++ b/docs/src/languages/julia.md
@@ -3,7 +3,7 @@
 Julia language support in Zed is provided by the community-maintained [Julia extension](https://github.com/JuliaEditorSupport/zed-julia).
 Report issues to: [https://github.com/JuliaEditorSupport/zed-julia/issues](https://github.com/JuliaEditorSupport/zed-julia/issues)
 
-- Tree Sitter: [tree-sitter/tree-sitter-julia](https://github.com/tree-sitter/tree-sitter-julia)
+- Tree-sitter: [tree-sitter/tree-sitter-julia](https://github.com/tree-sitter/tree-sitter-julia)
 - Language Server: [julia-vscode/LanguageServer.jl](https://github.com/julia-vscode/LanguageServer.jl)
 
 <!--

--- a/docs/src/languages/kotlin.md
+++ b/docs/src/languages/kotlin.md
@@ -3,7 +3,7 @@
 Kotlin language support in Zed is provided by the community-maintained [Kotlin extension](https://github.com/zed-extensions/kotlin).
 Report issues to: [https://github.com/zed-extensions/kotlin/issues](https://github.com/zed-extensions/kotlin/issues)
 
-- Tree Sitter: [fwcd/tree-sitter-kotlin](https://github.com/fwcd/tree-sitter-kotlin)
+- Tree-sitter: [fwcd/tree-sitter-kotlin](https://github.com/fwcd/tree-sitter-kotlin)
 - Language Server: [fwcd/kotlin-language-server](https://github.com/fwcd/kotlin-language-server)
 
 ## Configuration

--- a/docs/src/languages/lua.md
+++ b/docs/src/languages/lua.md
@@ -2,7 +2,7 @@
 
 Lua support is available through the [Lua extension](https://github.com/zed-industries/zed/tree/main/extensions/lua).
 
-- Tree Sitter: [tree-sitter-grammars/tree-sitter-lua](https://github.com/tree-sitter-grammars/tree-sitter-lua)
+- Tree-sitter: [tree-sitter-grammars/tree-sitter-lua](https://github.com/tree-sitter-grammars/tree-sitter-lua)
 - Language server: [LuaLS/lua-language-server](https://github.com/LuaLS/lua-language-server)
 
 ## luarc.json

--- a/docs/src/languages/luau.md
+++ b/docs/src/languages/luau.md
@@ -5,7 +5,7 @@
 Luau language support in Zed is provided by the community-maintained [Luau extension](https://github.com/4teapo/zed-luau).
 Report issues to: [https://github.com/4teapo/zed-luau/issues](https://github.com/4teapo/zed-luau/issues)
 
-- Tree Sitter: [4teapo/tree-sitter-luau](https://github.com/4teapo/tree-sitter-luau)
+- Tree-sitter: [4teapo/tree-sitter-luau](https://github.com/4teapo/tree-sitter-luau)
 - Language Server: [JohnnyMorganz/luau-lsp](https://github.com/JohnnyMorganz/luau-lsp)
 
 ## Configuration

--- a/docs/src/languages/makefile.md
+++ b/docs/src/languages/makefile.md
@@ -3,4 +3,4 @@
 Makefile language support in Zed is provided by the community-maintained [Make extension](https://github.com/caius/zed-make).
 Report issues to: [https://github.com/caius/zed-make/issues](https://github.com/caius/zed-make/issues).
 
-- Tree Sitter: [caius/tree-sitter-make](https://github.com/caius/tree-sitter-make)
+- Tree-sitter: [caius/tree-sitter-make](https://github.com/caius/tree-sitter-make)

--- a/docs/src/languages/markdown.md
+++ b/docs/src/languages/markdown.md
@@ -2,7 +2,7 @@
 
 Markdown support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter-markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown)
+- Tree-sitter: [tree-sitter-markdown](https://github.com/tree-sitter-grammars/tree-sitter-markdown)
 - Language Server: N/A
 
 ## Syntax Highlighting Code Blocks

--- a/docs/src/languages/nim.md
+++ b/docs/src/languages/nim.md
@@ -3,7 +3,7 @@
 Nim language support in Zed is provided by the community-maintained [Nim extension](https://github.com/foxoman/zed-nim).
 Report issues to: [https://github.com/foxoman/zed-nim/issues](https://github.com/foxoman/zed-nim/issues)
 
-- Tree Sitter: [alaviss/tree-sitter-nim](https://github.com/alaviss/tree-sitter-nim)
+- Tree-sitter: [alaviss/tree-sitter-nim](https://github.com/alaviss/tree-sitter-nim)
 - Language Server: [nim-lang/langserver](https://github.com/nim-lang/langserver)
 
 ## Formatting

--- a/docs/src/languages/ocaml.md
+++ b/docs/src/languages/ocaml.md
@@ -2,7 +2,7 @@
 
 OCaml support is available through the [OCaml extension](https://github.com/zed-extensions/ocaml).
 
-- Tree Sitter: [tree-sitter/tree-sitter-ocaml](https://github.com/tree-sitter/tree-sitter-ocaml)
+- Tree-sitter: [tree-sitter/tree-sitter-ocaml](https://github.com/tree-sitter/tree-sitter-ocaml)
 - Language Server: [ocaml/ocaml-lsp](https://github.com/ocaml/ocaml-lsp)
 
 ## Setup Instructions

--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -2,7 +2,7 @@
 
 PHP support is available through the [PHP extension](https://github.com/zed-extensions/php).
 
-- Tree Sitter: https://github.com/tree-sitter/tree-sitter-php
+- Tree-sitter: https://github.com/tree-sitter/tree-sitter-php
 - Language Servers:
   - [phpactor](https://github.com/phpactor/phpactor)
   - [intelephense](https://github.com/bmewburn/vscode-intelephense/)
@@ -45,4 +45,4 @@ To switch to `intelephense`, add the following to your `settings.json`:
 
 Zed supports syntax highlighting for PHPDoc comments.
 
-- Tree Sitter: [claytonrcarter/tree-sitter-phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc)
+- Tree-sitter: [claytonrcarter/tree-sitter-phpdoc](https://github.com/claytonrcarter/tree-sitter-phpdoc)

--- a/docs/src/languages/prisma.md
+++ b/docs/src/languages/prisma.md
@@ -2,7 +2,7 @@
 
 Prisma support is available through the [Prisma extension](https://github.com/zed-extensions/prisma).
 
-- Tree Sitter: [victorhqc/tree-sitter-prisma](https://github.com/victorhqc/tree-sitter-prisma)
+- Tree-sitter: [victorhqc/tree-sitter-prisma](https://github.com/victorhqc/tree-sitter-prisma)
 - Language-Server: [prisma/language-tools](https://github.com/prisma/language-tools)
 
 <!--

--- a/docs/src/languages/proto.md
+++ b/docs/src/languages/proto.md
@@ -2,7 +2,7 @@
 
 Proto/proto3 (Protocol Buffers definition language) support is available through the [Proto extension](https://github.com/zed-industries/zed/tree/main/extensions/proto).
 
-- Tree Sitter: [coder3101/tree-sitter-proto](https://github.com/coder3101/tree-sitter-proto)
+- Tree-sitter: [coder3101/tree-sitter-proto](https://github.com/coder3101/tree-sitter-proto)
 - Language Servers: [protobuf-language-server](https://github.com/lasorda/protobuf-language-server)
 
 <!--

--- a/docs/src/languages/purescript.md
+++ b/docs/src/languages/purescript.md
@@ -2,5 +2,5 @@
 
 PureScript support is available through the [PureScript extension](https://github.com/zed-industries/zed/tree/main/extensions/purescript).
 
-- Tree Sitter: [postsolar/tree-sitter-purescript](https://github.com/postsolar/tree-sitter-purescript)
+- Tree-sitter: [postsolar/tree-sitter-purescript](https://github.com/postsolar/tree-sitter-purescript)
 - Language-Server: [nwolverson/purescript-language-server](https://github.com/nwolverson/purescript-language-server)

--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -2,7 +2,7 @@
 
 Python support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python)
+- Tree-sitter: [tree-sitter-python](https://github.com/tree-sitter/tree-sitter-python)
 - Language Server: [microsoft/pyright](https://github.com/microsoft/pyright)
 
 ## Configuration

--- a/docs/src/languages/r.md
+++ b/docs/src/languages/r.md
@@ -2,7 +2,7 @@
 
 R support is available through the [R extension](https://github.com/ocsmit/zed-r).
 
-- Tree Sitter: [r-lib/tree-sitter-r](https://github.com/r-lib/tree-sitter-r)
+- Tree-sitter: [r-lib/tree-sitter-r](https://github.com/r-lib/tree-sitter-r)
 - Language-Server: [REditorSupport/languageserver](https://github.com/REditorSupport/languageserver)
 
 ## Installation

--- a/docs/src/languages/racket.md
+++ b/docs/src/languages/racket.md
@@ -2,6 +2,6 @@
 
 Racket support is available through the [Racket extension](https://github.com/zed-extensions/racket).
 
-- Tree Sitter: [zed-industries/tree-sitter-racket](https://github.com/zed-industries/tree-sitter-racket)
+- Tree-sitter: [zed-industries/tree-sitter-racket](https://github.com/zed-industries/tree-sitter-racket)
 
 The [racket-language-server](https://docs.racket-lang.org/racket-language-server/index.html) is not yet supported in Zed, please see [Issue #15789](https://github.com/zed-industries/zed/issues/15789) for more information.

--- a/docs/src/languages/rego.md
+++ b/docs/src/languages/rego.md
@@ -2,7 +2,7 @@
 
 Rego language support in Zed is provided by the community-maintained [Rego extension](https://github.com/StyraInc/zed-rego).
 
-- Tree Sitter: [FallenAngel97/tree-sitter-rego](https://github.com/FallenAngel97/tree-sitter-rego)
+- Tree-sitter: [FallenAngel97/tree-sitter-rego](https://github.com/FallenAngel97/tree-sitter-rego)
 - Language Server: [StyraInc/regal](https://github.com/StyraInc/regal)
 
 ## Installation

--- a/docs/src/languages/roc.md
+++ b/docs/src/languages/roc.md
@@ -5,7 +5,7 @@
 Roc language support in Zed is provided by the community-maintained [Roc extension](https://github.com/h2000/zed-roc).
 Report issues to: [https://github.com/h2000/zed-roc/issues](https://github.com/h2000/zed-roc/issues)
 
-- Tree Sitter: [faldor20/tree-sitter-roc](https://github.com/faldor20/tree-sitter-roc)
+- Tree-sitter: [faldor20/tree-sitter-roc](https://github.com/faldor20/tree-sitter-roc)
 - Language Server: [roc-lang/roc/tree/main/crates/language_server](https://github.com/roc-lang/roc/tree/main/crates/language_server)
 
 ## Setup

--- a/docs/src/languages/rst.md
+++ b/docs/src/languages/rst.md
@@ -3,5 +3,5 @@
 ReStructuredText language support in Zed is provided by the community-maintained [reST extension](https://github.com/elmarco/zed-rst).
 Report issues to: [https://github.com/elmarco/zed-rst/issues](https://github.com/elmarco/zed-rst/issues)
 
-- Tree Sitter: [stsewd/tree-sitter-rst.git](https://github.com/stsewd/tree-sitter-rst.git)
+- Tree-sitter: [stsewd/tree-sitter-rst.git](https://github.com/stsewd/tree-sitter-rst.git)
 - Language Server: [swyddfa/esbonio](https://github.com/swyddfa/esbonio)

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -2,7 +2,7 @@
 
 Rust support is available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust)
+- Tree-sitter: [tree-sitter/tree-sitter-rust](https://github.com/tree-sitter/tree-sitter-rust)
 - Language Server: [rust-lang/rust-analyzer](https://github.com/rust-lang/rust-analyzer)
 
 <!--

--- a/docs/src/languages/scala.md
+++ b/docs/src/languages/scala.md
@@ -3,7 +3,7 @@
 Scala language support in Zed is provided by the community-maintained [Scala extension](https://github.com/scalameta/metals-zed).
 Report issues to: [https://github.com/scalameta/metals-zed/issues](https://github.com/scalameta/metals-zed/issues)
 
-- Tree Sitter: [tree-sitter/tree-sitter-scala](https://github.com/tree-sitter/tree-sitter-scala)
+- Tree-sitter: [tree-sitter/tree-sitter-scala](https://github.com/tree-sitter/tree-sitter-scala)
 - Language Server: [scalameta/metals](https://github.com/scalameta/metals)
 
 ## Setup

--- a/docs/src/languages/scheme.md
+++ b/docs/src/languages/scheme.md
@@ -2,4 +2,4 @@
 
 Scheme support is available through the [Scheme extension](https://github.com/zed-extensions/scheme).
 
-- Tree Sitter: [6cdh/tree-sitter-scheme](https://github.com/6cdh/tree-sitter-scheme)
+- Tree-sitter: [6cdh/tree-sitter-scheme](https://github.com/6cdh/tree-sitter-scheme)

--- a/docs/src/languages/sh.md
+++ b/docs/src/languages/sh.md
@@ -2,7 +2,7 @@
 
 Shell Scripts (bash, zsh, dash, sh) are supported natively by Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash)
+- Tree-sitter: [tree-sitter/tree-sitter-bash](https://github.com/tree-sitter/tree-sitter-bash)
 
 ## Settings
 

--- a/docs/src/languages/svelte.md
+++ b/docs/src/languages/svelte.md
@@ -2,7 +2,7 @@
 
 Svelte support is available through the [Svelte extension](https://github.com/zed-extensions/svelte).
 
-- Tree Sitter: [tree-sitter-grammars/tree-sitter-svelte](https://github.com/tree-sitter-grammars/tree-sitter-svelte)
+- Tree-sitter: [tree-sitter-grammars/tree-sitter-svelte](https://github.com/tree-sitter-grammars/tree-sitter-svelte)
 - Language Server: [sveltejs/language-tools](https://github.com/sveltejs/language-tools)
 
 ## Extra theme styling configuration

--- a/docs/src/languages/swift.md
+++ b/docs/src/languages/swift.md
@@ -3,7 +3,7 @@
 Swift language support in Zed is provided by the community-maintained [Swift extension](https://github.com/zed-extensions/swift).
 Report issues to: [https://github.com/zed-extensions/swift/issues](https://github.com/zed-extensions/swift/issues)
 
-- Tree Sitter: [alex-pinkus/tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift)
+- Tree-sitter: [alex-pinkus/tree-sitter-swift](https://github.com/alex-pinkus/tree-sitter-swift)
 - Language Server: [swiftlang/sourcekit-lsp](https://github.com/swiftlang/sourcekit-lsp)
 
 ## Configuration

--- a/docs/src/languages/terraform.md
+++ b/docs/src/languages/terraform.md
@@ -2,7 +2,7 @@
 
 Terraform support is available through the [Terraform extension](https://github.com/zed-industries/zed/tree/main/extensions/terraform).
 
-- Tree sitter: [MichaHoffmann/tree-sitter-hcl](https://github.com/MichaHoffmann/tree-sitter-hcl)
+- Tree-sitter: [MichaHoffmann/tree-sitter-hcl](https://github.com/MichaHoffmann/tree-sitter-hcl)
 - Language Server: [hashicorp/terraform-ls](https://github.com/hashicorp/terraform-ls)
 
 ## Configuration

--- a/docs/src/languages/toml.md
+++ b/docs/src/languages/toml.md
@@ -2,7 +2,7 @@
 
 TOML support is available through the [TOML extension](https://github.com/zed-industries/zed/tree/main/extensions/toml).
 
-- Tree Sitter: [tree-sitter/tree-sitter-toml](https://github.com/tree-sitter/tree-sitter-toml)
+- Tree-sitter: [tree-sitter/tree-sitter-toml](https://github.com/tree-sitter/tree-sitter-toml)
 - Language Server: [tamasfe/taplo](https://github.com/tamasfe/taplo)
 
 ## Configuration

--- a/docs/src/languages/typescript.md
+++ b/docs/src/languages/typescript.md
@@ -2,7 +2,7 @@
 
 TypeScript and TSX support are available natively in Zed.
 
-- Tree Sitter: [tree-sitter/tree-sitter-typescript](https://github.com/tree-sitter/tree-sitter-typescript)
+- Tree-sitter: [tree-sitter/tree-sitter-typescript](https://github.com/tree-sitter/tree-sitter-typescript)
 - Language Server: [yioneko/vtsls](https://github.com/yioneko/vtsls)
 - Alternate Language Server: [typescript-language-server/typescript-language-server](https://github.com/typescript-language-server/typescript-language-server)
 

--- a/docs/src/languages/uiua.md
+++ b/docs/src/languages/uiua.md
@@ -4,5 +4,5 @@
 
 Uiua support is available through the [Uiua extension](https://github.com/zed-industries/zed/tree/main/extensions/uiua).
 
-- Tree Sitter: [shnarazk/tree-sitter-uiua](https://github.com/shnarazk/tree-sitter-uiua)
+- Tree-sitter: [shnarazk/tree-sitter-uiua](https://github.com/shnarazk/tree-sitter-uiua)
 - Language Server: [uiua-lang/uiua](https://github.com/uiua-lang/uiua/)

--- a/docs/src/languages/vue.md
+++ b/docs/src/languages/vue.md
@@ -2,7 +2,7 @@
 
 Vue support is available through the [Vue extension](https://github.com/zed-extensions/vue).
 
-- Tree Sitter: [tree-sitter-grammars/tree-sitter-vue](https://github.com/tree-sitter-grammars/tree-sitter-vue)
+- Tree-sitter: [tree-sitter-grammars/tree-sitter-vue](https://github.com/tree-sitter-grammars/tree-sitter-vue)
 - Language Server: [vuejs/language-tools/](https://github.com/vuejs/language-tools/)
 
 > `@vue/language-server` is pinned to v1.8 due to some issues in v2.x [#9846](https://github.com/zed-industries/zed/pull/9846)

--- a/docs/src/languages/xml.md
+++ b/docs/src/languages/xml.md
@@ -2,7 +2,7 @@
 
 XML support is available through the [XML extension](https://github.com/sweetppro/zed-xml/).
 
-- Tree Sitter: [tree-sitter-grammars/tree-sitter-xml](https://github.com/tree-sitter-grammars/tree-sitter-xml)
+- Tree-sitter: [tree-sitter-grammars/tree-sitter-xml](https://github.com/tree-sitter-grammars/tree-sitter-xml)
 
 ## Configuration
 

--- a/docs/src/languages/yaml.md
+++ b/docs/src/languages/yaml.md
@@ -2,7 +2,7 @@
 
 YAML support is available natively in Zed.
 
-- Tree Sitter: [zed-industries/tree-sitter-yaml](https://github.com/zed-industries/tree-sitter-yaml)
+- Tree-sitter: [zed-industries/tree-sitter-yaml](https://github.com/zed-industries/tree-sitter-yaml)
 - Language Server: [redhat-developer/yaml-language-server](https://github.com/redhat-developer/yaml-language-server)
 
 ## Configuration

--- a/docs/src/languages/zig.md
+++ b/docs/src/languages/zig.md
@@ -2,5 +2,5 @@
 
 Zig support is available through the [Zig extension](https://github.com/zed-industries/zed/tree/main/extensions/zig).
 
-- Tree-Sitter: [tree-sitter-zig](https://github.com/tree-sitter-grammars/tree-sitter-zig)
+- Tree-sitter: [tree-sitter-zig](https://github.com/tree-sitter-grammars/tree-sitter-zig)
 - Language Server: [zls](https://github.com/zigtools/zls)


### PR DESCRIPTION
This PR fixes the casing of "Tree-sitter" in the docs.

It is "Tree-sitter", not "Tree Sitter" or "Tree-Sitter".

Release Notes:

- N/A
