### PR TITLE
Do not indent on enter in python comments ending in colon

### DIFF
--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -15,5 +15,5 @@ brackets = [
 ]
 
 auto_indent_using_last_non_empty_line = false
-increase_indent_pattern = ":\\s*$"
+increase_indent_pattern = "^[^#].*:\\s*$"
 decrease_indent_pattern = "^\\s*(else|elif|except|finally)\\b.*:"


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/25416

Release Notes:

- Python: Fixed a bug where indentation was applied when adding a newline to a comment ending in `:`.
