### PR TITLE
vim: Fix ignoring `cursor_shape` settings

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -23,7 +23,7 @@ use anyhow::Result;
 use collections::HashMap;
 use editor::{
     movement::{self, FindRange},
-    Anchor, Bias, Editor, EditorEvent, EditorMode, ToPoint,
+    Anchor, Bias, Editor, EditorEvent, EditorMode, EditorSettings, ToPoint,
 };
 use gpui::{
     actions, impl_actions, Action, App, AppContext as _, Axis, Context, Entity, EventEmitter,
@@ -996,7 +996,7 @@ impl Vim {
         count
     }
 
-    pub fn cursor_shape(&self) -> CursorShape {
+    pub fn cursor_shape(&self, cx: &mut App) -> CursorShape {
         match self.mode {
             Mode::Normal => {
                 if let Some(operator) = self.operator_stack.last() {
@@ -1022,7 +1022,10 @@ impl Vim {
             Mode::HelixNormal | Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
                 CursorShape::Block
             }
-            Mode::Insert => CursorShape::Bar,
+            Mode::Insert => {
+                let editor_settings = EditorSettings::get_global(cx);
+                editor_settings.cursor_shape.unwrap_or_default()
+            }
         }
     }
 
@@ -1161,7 +1164,7 @@ impl Vim {
         self.store_visual_marks(window, cx);
         self.clear_operator(window, cx);
         self.update_editor(window, cx, |vim, editor, _, cx| {
-            if vim.cursor_shape() == CursorShape::Block {
+            if vim.cursor_shape(cx) == CursorShape::Block {
                 editor.set_cursor_shape(CursorShape::Hollow, cx);
             }
         });
@@ -1169,7 +1172,7 @@ impl Vim {
 
     fn cursor_shape_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.update_editor(window, cx, |vim, editor, _, cx| {
-            editor.set_cursor_shape(vim.cursor_shape(), cx);
+            editor.set_cursor_shape(vim.cursor_shape(cx), cx);
         });
     }
 
@@ -1612,7 +1615,7 @@ impl Vim {
 
     fn sync_vim_settings(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.update_editor(window, cx, |vim, editor, window, cx| {
-            editor.set_cursor_shape(vim.cursor_shape(), cx);
+            editor.set_cursor_shape(vim.cursor_shape(cx), cx);
             editor.set_clip_at_line_ends(vim.clip_at_line_ends(), cx);
             editor.set_collapse_matches(true);
             editor.set_input_enabled(vim.editor_input_enabled());


### PR DESCRIPTION
Closes #ISSUE

[Block cursor in insert mode #25322](https://github.com/zed-industries/zed/discussions/25322)

Respect the `cursor_shape` setting in insert mode

Release Notes:

- Fixed vim ignoring `cursor_shape` settings
