### PR TITLE
Set default memory limit for vtsls lsp to 8gb to increase performance

### DIFF
--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -253,7 +253,10 @@ impl LspAdapter for VtslsLspAdapter {
                         "entriesLimit": 5000,
                     }
                 },
-               "autoUseWorkspaceTsdk": true
+               "autoUseWorkspaceTsdk": true,
+               "tsserver": {
+                   "maxTsServerMemory": 8092
+               },
             }
         });
 


### PR DESCRIPTION
Closes #19387, #18698 

Release Notes:

- vtsls lsp memory limit is 8gb now, increased performance on big repos and monorepos
