### PR TITLE
vim: Fix `auto_indent_on_paste` not being respected

### DIFF
--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -155,7 +155,18 @@ impl Vim {
                     original_start_columns.extend(original_start_column);
                 }
 
-                editor.edit_with_block_indent(edits, original_start_columns, cx);
+                let cursor_offset = editor.selections.last::<usize>(cx).head();
+                let auto_indent_on_paste = editor.buffer().update(cx, |buffer, cx| {
+                    buffer
+                        .read(cx)
+                        .settings_at(cursor_offset, cx)
+                        .auto_indent_on_paste
+                });
+                if auto_indent_on_paste {
+                    editor.edit_with_block_indent(edits, original_start_columns, cx);
+                } else {
+                    editor.edit(edits, cx);
+                }
 
                 // in line_mode vim will insert the new text on the next (or previous if before) line
                 // and put the cursor on the first non-blank character of the first inserted line (or at the end if the first line is blank).

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -1,5 +1,5 @@
 use editor::{display_map::ToDisplayPoint, movement, scroll::Autoscroll, DisplayPoint, RowExt};
-use gpui::{impl_actions, Context, Window};
+use gpui::{impl_actions, Context, Point, Window};
 use language::{Bias, SelectionGoal};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -156,13 +156,13 @@ impl Vim {
                 }
 
                 let cursor_offset = editor.selections.last::<usize>(cx).head();
-                let auto_indent_on_paste = editor.buffer().update(cx, |buffer, cx| {
-                    buffer
-                        .read(cx)
-                        .settings_at(cursor_offset, cx)
-                        .auto_indent_on_paste
-                });
-                if auto_indent_on_paste {
+                if editor
+                    .buffer()
+                    .read(cx)
+                    .snapshot(cx)
+                    .settings_at(cursor_offset, cx)
+                    .auto_indent_on_paste
+                {
                     editor.edit_with_block_indent(edits, original_start_columns, cx);
                 } else {
                     editor.edit(edits, cx);


### PR DESCRIPTION
Closes #12236

This PR fixes an issue where the `auto_indent_on_paste` setting was not being applied for pasting in Vim mode. It was correctly used for normal paste behavior.  

Also includes tests.  


Release Notes:

- Fixed yank + paste indenting incorrectly when `auto_indent_on_paste` is set to `false` in certain languages.