### PR TITLE
assistant: Rename action from New Context to New Chat

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -184,9 +184,9 @@
       "ctrl-alt-/": "assistant::ToggleModelSelector",
       "ctrl-k h": "assistant::DeployHistory",
       "ctrl-k l": "assistant::DeployPromptLibrary",
-      "new": "assistant::NewContext",
-      "ctrl-t": "assistant::NewContext",
-      "ctrl-n": "assistant::NewContext"
+      "new": "assistant::NewChat",
+      "ctrl-t": "assistant::NewChat",
+      "ctrl-n": "assistant::NewChat"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -211,8 +211,8 @@
       "cmd-alt-/": "assistant::ToggleModelSelector",
       "cmd-k h": "assistant::DeployHistory",
       "cmd-k l": "assistant::DeployPromptLibrary",
-      "cmd-t": "assistant::NewContext",
-      "cmd-n": "assistant::NewContext"
+      "cmd-t": "assistant::NewChat",
+      "cmd-n": "assistant::NewChat"
     }
   },
   {

--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -33,7 +33,7 @@ actions!(
     [
         InsertActivePrompt,
         DeployHistory,
-        NewContext,
+        NewChat,
         CycleNextInlineAssist,
         CyclePreviousInlineAssist
     ]

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,6 +1,6 @@
 use crate::assistant_configuration::{ConfigurationView, ConfigurationViewEvent};
 use crate::{
-    terminal_inline_assistant::TerminalInlineAssistant, DeployHistory, InlineAssistant, NewContext,
+    terminal_inline_assistant::TerminalInlineAssistant, DeployHistory, InlineAssistant, NewChat,
 };
 use anyhow::{anyhow, Result};
 use assistant_context_editor::{
@@ -129,7 +129,7 @@ impl AssistantPanel {
                 workspace.project().clone(),
                 Default::default(),
                 None,
-                NewContext.boxed_clone(),
+                NewChat.boxed_clone(),
                 window,
                 cx,
             );
@@ -228,12 +228,12 @@ impl AssistantPanel {
                         IconButton::new("new-chat", IconName::Plus)
                             .icon_size(IconSize::Small)
                             .on_click(cx.listener(|_, _, window, cx| {
-                                window.dispatch_action(NewContext.boxed_clone(), cx)
+                                window.dispatch_action(NewChat.boxed_clone(), cx)
                             }))
                             .tooltip(move |window, cx| {
                                 Tooltip::for_action_in(
                                     "New Chat",
-                                    &NewContext,
+                                    &NewChat,
                                     &focus_handle,
                                     window,
                                     cx,
@@ -256,7 +256,7 @@ impl AssistantPanel {
                                 let focus_handle = _pane.focus_handle(cx);
                                 Some(ContextMenu::build(window, cx, move |menu, _, _| {
                                     menu.context(focus_handle.clone())
-                                        .action("New Chat", Box::new(NewContext))
+                                        .action("New Chat", Box::new(NewChat))
                                         .action("History", Box::new(DeployHistory))
                                         .action("Prompt Library", Box::new(DeployPromptLibrary))
                                         .action("Configure", Box::new(ShowConfiguration))
@@ -760,7 +760,7 @@ impl AssistantPanel {
 
     pub fn create_new_context(
         workspace: &mut Workspace,
-        _: &NewContext,
+        _: &NewChat,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
@@ -1206,7 +1206,7 @@ impl Render for AssistantPanel {
         v_flex()
             .key_context("AssistantPanel")
             .size_full()
-            .on_action(cx.listener(|this, _: &NewContext, window, cx| {
+            .on_action(cx.listener(|this, _: &NewChat, window, cx| {
                 this.new_context(window, cx);
             }))
             .on_action(cx.listener(|this, _: &ShowConfiguration, window, cx| {


### PR DESCRIPTION
If you looked that up via the Command Palette, we were showing an outdated action name ("new context") which causes confusion given the panel says "New Chat".

Release Notes:

- N/A
