### PR TITLE
Revert "Improve Rust syntax highlighting (#25333)"

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -1,4 +1,3 @@
-(identifier) @variable
 (type_identifier) @type
 (primitive_type) @type.builtin
 (self) @variable.special


### PR DESCRIPTION
This reverts commit 3e75a661dd6d5837b4c4b15f10b5fcfc19306beb.

Categorizing all identifiers as `@variable` seems like too broad a brush to paint with.

While it doesn't make a difference in many themes, it does produce some stark changes in some of the base themes:

| Zed Nightly                                                                                                                         | Zed Preview                                                                                                                        |
| ----------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1138" alt="Gruvbox - Nightly" src="https://github.com/user-attachments/assets/5432ec68-c5b0-4574-af5d-0d21634c791e" />  | <img width="998" alt="Gruvbox - Preview" src="https://github.com/user-attachments/assets/0955e9f0-3b5a-4787-9599-83071a9c7168" />  |
| <img width="1138" alt="One Dark - Nightly" src="https://github.com/user-attachments/assets/801cf088-a9e9-46cc-96ac-b7bb5d33d35d" /> | <img width="998" alt="One Dark - Preview" src="https://github.com/user-attachments/assets/3fdeb327-c2ef-40c7-a925-c4e4aaf7913d" /> |


Release Notes:

- Community: This is a revert of #25333, so remove those notes from the release notes.
