### PR TITLE
python: Don't highlight all identifiers as `@variable`s

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -8,7 +8,6 @@
 ((identifier) @constant
   (#match? @constant "^_*[A-Z][A-Z0-9_]*$"))
 
-(identifier) @variable
 (attribute attribute: (identifier) @property)
 (type (identifier) @type)
 (generic_type (identifier) @type)


### PR DESCRIPTION
This PR is a partial revert of https://github.com/zed-industries/zed/pull/25331.

Categorizing all identifiers as @variable seems like too broad a brush to paint with.

No release notes, as the original change was never released.

Release Notes:

- N/A
