### PR TITLE
Change `@variable` color in Gruvbox themes to be less intense

### DIFF
--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -379,7 +379,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#fbf1c7ff",
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -767,7 +767,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#fbf1c7ff",
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1155,7 +1155,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#fbf1c7ff",
+            "color": "#ebdbb2ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -379,7 +379,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#83a598ff",
+            "color": "#fbf1c7ff",
             "font_style": null,
             "font_weight": null
           },
@@ -767,7 +767,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#83a598ff",
+            "color": "#fbf1c7ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1155,7 +1155,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#83a598ff",
+            "color": "#fbf1c7ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1543,7 +1543,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#066578ff",
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1931,7 +1931,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#066578ff",
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2319,7 +2319,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#066578ff",
+            "color": "#282828ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
This PR changes the color used for `@variable` syntax highlights in the Gruvbox themes to be less intense.

We now use the same color as `editor.foreground`.

| Language | Before                                                                                                                                                | After                                                                                                                                                 |
| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
| Rust     | <img width="1410" alt="Screenshot 2025-02-24 at 10 08 41 AM" src="https://github.com/user-attachments/assets/9a34964d-9fdc-4deb-ac30-4a1c9e6fb531" /> | <img width="1410" alt="Screenshot 2025-02-24 at 10 55 18 AM" src="https://github.com/user-attachments/assets/c245d0fd-28af-42b8-93f6-48cb14671d94" /> |
| Python   | <img width="1410" alt="Screenshot 2025-02-24 at 10 08 38 AM" src="https://github.com/user-attachments/assets/8f8d111e-1d50-4229-a333-eb29b6ce9f4f" /> | <img width="1410" alt="Screenshot 2025-02-24 at 10 55 20 AM" src="https://github.com/user-attachments/assets/010b661e-dc9e-4ccb-8e52-ee10c8eb8342" /> |

In #25333 and #25331 the highlight used for identifiers in Rust and Python, respectively, was changed to `@variable`, which resulted in the intense colors you see in the "Before" screenshots above.

We considered reverting the highlight query changes to those languages, but after taking a look at our other languages, they already use similar queries. Instead we're adjusting the theme to make these cases less visually intense.

Release Notes:

- Gruvbox themes: Changed the color used for `@variable` syntax highlights to be less intense.
