### PR TITLE
Adjust `@variable` color in One Dark theme

### DIFF
--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -365,7 +365,7 @@
             "font_weight": null
           },
           "variable": {
-            "color": "#dce0e5ff",
+            "color": "#acb2beff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
This PR adjusts the color used for `@variable`s in One Dark to use the `editor.foreground` color.

| Language | Before                                                                                                                                                | After                                                                                                                                                 |
| -------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
| Rust     | <img width="1410" alt="Screenshot 2025-02-24 at 10 46 04 AM" src="https://github.com/user-attachments/assets/3e1de7d2-03f6-45cc-87bb-93b86b5b1cb2" /> | <img width="1410" alt="Screenshot 2025-02-24 at 10 46 15 AM" src="https://github.com/user-attachments/assets/da6129aa-6886-4655-b305-c283e23bfd1e" /> |
| Python   | <img width="1410" alt="Screenshot 2025-02-24 at 10 46 10 AM" src="https://github.com/user-attachments/assets/f60833f9-d306-44b6-a0b0-42b447e60498" /> | <img width="1410" alt="Screenshot 2025-02-24 at 10 46 19 AM" src="https://github.com/user-attachments/assets/256aa6b3-b798-46e4-9943-f21469e7d8bb" /> |

Release Notes:

- One Dark theme: Adjusted the color used for `@variable` syntax highlights.
