### PR TITLE
Fix tmux being broken by default on Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -813,6 +813,7 @@
       "pagedown": ["terminal::SendKeystroke", "pagedown"],
       "escape": ["terminal::SendKeystroke", "escape"],
       "enter": ["terminal::SendKeystroke", "enter"],
+      "ctrl-b": ["terminal::SendKeystroke", "ctrl-b"],
       "ctrl-c": ["terminal::SendKeystroke", "ctrl-c"],
       "shift-pageup": "terminal::ScrollPageUp",
       "shift-pagedown": "terminal::ScrollPageDown",


### PR DESCRIPTION
Tmux uses `ctrl-b` as default prefix.
Prior to this tmux was basically useless in the default zed configuration.
(ctrl-b would toggle the left dock).

Release Notes:

- Fixed tmux `ctrl-b` being broken in the Terminal on Linux by default.