### PR TITLE
Document why `ForegroundExecutor` is `!Send`

### DIFF
--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -35,6 +35,11 @@ pub struct BackgroundExecutor {
 
 /// A pointer to the executor that is currently running,
 /// for spawning tasks on the main thread.
+///
+/// This is intentionally `!Send` via the `not_send` marker field. This is because
+/// `ForegroundExecutor::spawn` does not require `Send` but checks at runtime that the future is
+/// only polled from the same thread it was spawned from. These checks would fail when spawning
+/// foreground tasks from from background threads.
 #[derive(Clone)]
 pub struct ForegroundExecutor {
     #[doc(hidden)]


### PR DESCRIPTION
Release Notes:

- N/A