### PR TITLE
Update bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -2,15 +2,18 @@ name: Bug Report
 description: |
   Something is broken in Zed (exclude crashing).
 type: "Bug"
+labels: ["triage"]
 body:
   - type: textarea
     attributes:
       label: Summary
-      description: Describe the bug with a one line summary, and provide detailed reproduction steps
+      description: Include all steps necessary to reproduce from a clean Zed installation.
       value: |
         <!-- Please insert a one line summary of the issue below -->
 
-        <!-- Include all steps necessary to reproduce from a clean Zed installation. Be verbose -->
+        <!-- Include all steps necessary to reproduce from a clean Zed installation. -->
+        <!-- Be verbose: we rather get a minimal code snippet than an image, or a link to a repository to reproduce the issue -->
+
         Steps to trigger the problem:
         1.
         2.
@@ -22,6 +25,27 @@ body:
 
     validations:
       required: true
+
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Configuration Details
+      description: Include any relevant configuration or related logs that might affect this issue.
+      placeholder: If applicable, share relevant parts of your settings.json or keymap.json, zed:logs, lanaguage server:logs
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Add any other context about the problem here.
+      placeholder: |
+        - Does it happen consistently or intermittently?
+        - Does it happen with specific file types or projects?
+        - Any other relevant details, do you have a workaround, does turning a specific setting off make the issue disappear?
+    validations:
+      required: false
 
   - type: textarea
     id: environment

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -31,7 +31,7 @@ body:
     attributes:
       label: Configuration Details
       description: Include any relevant configuration or related logs that might affect this issue.
-      placeholder: If applicable, share relevant parts of your settings.json or keymap.json, zed:logs, lanaguage server:logs
+      placeholder: If applicable, share relevant parts of your settings.json or keymap.json, zed:logs, language server:logs
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -6,7 +6,7 @@ body:
   - type: textarea
     attributes:
       label: Summary
-      description: Include all steps necessary to reproduce from a clean Zed installation.
+      description: Describe the bug with a one line summary, and provide detailed reproduction steps
       value: |
         <!-- Please insert a one line summary of the issue below -->
 

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -10,41 +10,41 @@ body:
       value: |
         <!-- Please insert a one line summary of the issue below -->
 
-        <!-- Include all steps necessary to reproduce from a clean Zed installation. -->
-        <!-- Be verbose: we rather get a minimal code snippet than an image, or a link to a repository to reproduce the issue -->
+        SUMMARY_SENTENCE_HERE
+
+        <!-- Be verbose: Include all steps necessary to reproduce from a clean Zed installation. -->
+        <!-- Code snippets are better than images, a repository link that reproduces the issue is ideal. -->
 
         Steps to trigger the problem:
         1.
         2.
         3.
+        4.
 
         Actual Behavior:
 
         Expected Behavior:
 
+        <!--
+          Is there anything additional necessary to reproduce this issue?
+            - settings.json, keymap.json, .editorconfig etc?
+            - Does it happen intermittently or only with specific projects / file types?
+            - Have you found a workaround?
+
+          Did you check your Zed.log to see if there is any relevant details there?
+            - When including large items (videos, screenshots, logs, configs) please wrap with:
+
+          <details><summary>See inside for XXXXYYY</summary>
+
+          ```shell
+          code
+          ```
+
+          </details>
+        -->
+
     validations:
       required: true
-
-  - type: textarea
-    id: configuration
-    attributes:
-      label: Configuration Details
-      description: Include any relevant configuration or related logs that might affect this issue.
-      placeholder: If applicable, share relevant parts of your settings.json or keymap.json, zed:logs, language server:logs
-    validations:
-      required: false
-
-  - type: textarea
-    id: additional-context
-    attributes:
-      label: Additional Context
-      description: Add any other context about the problem here.
-      placeholder: |
-        - Does it happen consistently or intermittently?
-        - Does it happen with specific file types or projects?
-        - Any other relevant details, do you have a workaround, does turning a specific setting off make the issue disappear?
-    validations:
-      required: false
 
   - type: textarea
     id: environment

--- a/.github/ISSUE_TEMPLATE/1_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/1_bug_report.yml
@@ -2,7 +2,6 @@ name: Bug Report
 description: |
   Something is broken in Zed (exclude crashing).
 type: "Bug"
-labels: ["triage"]
 body:
   - type: textarea
     attributes:


### PR DESCRIPTION
1. The first thing is to add the triage label automatically for each new bug report, anybody can then press on the triage label to check new incoming issues, so issues that come in don't stay without an answer for to long. 

2. Summary: make it clear that we rather get code snippets than images of code, because if we have to reproduce it, we have to type the code from the image(s) ourselves, thats wasted time when we have 3k issues. (required)

3. To many times we have to ask for settings, keymaps, logs, language server logs etc. I've added a Configuration Details section which isn't required. (should it be?)

4. Additional context that might be needed (isn't required)


Release Notes:

- N/A 
