### PR TITLE
rust: Restore and update attribute highlighting

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -190,5 +190,9 @@ operator: "/" @operator
 
 (parameter (identifier) @variable.parameter)
 
-(attribute_item) @attribute
-(inner_attribute_item) @attribute
+(attribute_item (attribute (identifier) @attribute))
+(inner_attribute_item (attribute (identifier) @attribute))
+; Match nested snake case identifiers in attribute items.
+(token_tree (identifier) @attribute (#match? @attribute "^[a-z\\d_]*$"))
+; Override the attribute match for paths in scoped identifiers.
+(token_tree (identifier) @variable "::")


### PR DESCRIPTION
#25333 added broader highlighting for identifiers, which broke the generic query for attribute queries, resulting in these being highlighted the same as identifiers. 

To accomodate for this change, this PR updates the attribute matches to be more specific. 

Additionally, path matches in scoped identifiers are no longer highlighted as attributes, as seen in the comparison screenshot. Can revert this if requested.

| Zed Preview | <img width="750" alt="preview" src="https://github.com/user-attachments/assets/2cd2e830-f510-4adf-8ce9-c41ed6fb157c" /> | 
| --- | --- | 
| `main` | <img width="750" alt="main" src="https://github.com/user-attachments/assets/cbe93186-9afd-4515-bc06-e519fd4ee6af" /> | 
| This PR | <img width="750" alt="pr" src="https://github.com/user-attachments/assets/68270de8-e083-4fc6-a45e-25d3151acd87" /> |

The generic match for `token_tree` is needed to recursively match patterns like `#[cfg(any(test, feature = "test-support"))]` (or at least I was unable to find a better query here). I tried to validate that this does not break any other highlights and I believe it does not. However, I might have still missed something. 

Release Notes:

- N/A
