### PR TITLE
Dismiss git commit modal when it's out of focus

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -149,6 +149,13 @@ impl CommitModal {
             }
         }
 
+        let focus_handle = commit_editor.focus_handle(cx);
+
+        cx.on_focus_out(&focus_handle, window, |this, _, window, cx| {
+            cx.emit(DismissEvent);
+        })
+        .detach();
+
         Self {
             git_panel,
             commit_editor,


### PR DESCRIPTION
Release Notes:

- Fix git commit modal not being dismissed when pressing esc key or clicking outside the modal