### PR TITLE
Remove cmd-g for `git::Commit`

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -157,8 +157,7 @@
       "cmd->": "assistant::QuoteSelection",
       "cmd-<": "assistant::InsertIntoEditor",
       "cmd-alt-e": "editor::SelectEnclosingSymbol",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer",
-      "cmd-g": "git::Commit"
+      "alt-enter": "editor::OpenSelectionsInMultibuffer"
     }
   },
   {


### PR DESCRIPTION
Conflicts with `search::SelectNextMatch`

Release Notes:

- N/A
