### PR TITLE
git_panel: Apply tooltip to checkbox instead of container

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2193,16 +2193,18 @@ impl GitPanel {
                 })
             });
 
-        let start_slot = h_flex()
-            .id(("start-slot", ix))
-            .gap(DynamicSpacing::Base04.rems(cx))
-            .child(checkbox)
-            .tooltip(|window, cx| Tooltip::for_action("Stage File", &ToggleStaged, window, cx))
-            .child(git_status_icon(status, cx))
-            .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                // prevent the list item active state triggering when toggling checkbox
-                cx.stop_propagation();
-            });
+        let start_slot =
+            h_flex()
+                .id(("start-slot", ix))
+                .gap(DynamicSpacing::Base04.rems(cx))
+                .child(checkbox.tooltip(|window, cx| {
+                    Tooltip::for_action("Stage File", &ToggleStaged, window, cx)
+                }))
+                .child(git_status_icon(status, cx))
+                .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                    // prevent the list item active state triggering when toggling checkbox
+                    cx.stop_propagation();
+                });
 
         div()
             .w_full()


### PR DESCRIPTION
Closes #ISSUE

Small tweak: The tooltip was activating on the icon

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/a1a5b4a7-f949-402e-a038-5f1b4445f068)|![image](https://github.com/user-attachments/assets/cb55f193-e665-4e88-b8d8-a437a7200eea)|

Release Notes:

- N/A
