### PR TITLE
Bring back our CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: ./script/clippy
 
       - name: Check unused dependencies
-        uses: bnjbvr/cargo-machete@0.7.0
+        uses: bnjbvr/cargo-machete@v0.7.0
 
       - name: Check licenses
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,8 +109,16 @@ jobs:
       - name: cargo clippy
         run: ./script/clippy
 
+      - name: Install cargo-machete
+        uses: clechasseur/rs-cargo@v2
+        with:
+          command: install
+          args: cargo-machete@0.7.0
+
       - name: Check unused dependencies
-        uses: bnjbvr/cargo-machete@v0.7.0
+        uses: clechasseur/rs-cargo@v2
+        with:
+          command: machete
 
       - name: Check licenses
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: ./script/clippy
 
       - name: Check unused dependencies
-        uses: bnjbvr/cargo-machete@929a77bed5046af583806eb91f257f1bbdba2f56
+        uses: bnjbvr/cargo-machete@0.7.0
 
       - name: Check licenses
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         run: ./script/clippy
 
       - name: Check unused dependencies
-        uses: bnjbvr/cargo-machete@main
+        uses: bnjbvr/cargo-machete@929a77bed5046af583806eb91f257f1bbdba2f56
 
       - name: Check licenses
         run: |


### PR DESCRIPTION
Closes #ISSUE

Fix `The package requires the Cargo feature called edition2024, but that feature is not stabilized in this version of Cargo (1.81.0`

Release Notes:

- N/A
