### PR TITLE
lsp: Fix buffer snapshots sometimes going missing

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1921,20 +1921,20 @@ impl LocalLspStore {
                     version: 0,
                     snapshot: initial_snapshot.clone(),
                 };
-                let previous_snapshots = self
-                    .buffer_snapshots
+                self.buffer_snapshots
                     .entry(buffer_id)
                     .or_default()
-                    .insert(server.server_id(), vec![snapshot]);
+                    .entry(server.server_id())
+                    .or_insert_with(|| {
+                        server.register_buffer(
+                            uri.clone(),
+                            adapter.language_id(&language.name()),
+                            0,
+                            initial_snapshot.text(),
+                        );
 
-                if previous_snapshots.is_none() {
-                    server.register_buffer(
-                        uri.clone(),
-                        adapter.language_id(&language.name()),
-                        0,
-                        initial_snapshot.text(),
-                    );
-                }
+                        vec![snapshot]
+                    });
             }
         }
     }


### PR DESCRIPTION
A call to register_buffer_with_language_servers could nuke existing snapshots, even when the buffer was already registered with a server.

Essentially, had we had the else branch in place, this would have been detected.

Closes #ISSUE

Release Notes:

- Fixed Rust analyzer renames sometimes failing. (Preview only)
