### PR TITLE
Add language scope for highlights

### DIFF
--- a/crates/language/src/highlight_map.rs
+++ b/crates/language/src/highlight_map.rs
@@ -11,10 +11,10 @@ pub struct HighlightId(pub u32);
 const DEFAULT_SYNTAX_HIGHLIGHT_ID: HighlightId = HighlightId(u32::MAX);
 
 impl HighlightMap {
-    pub(crate) fn new(capture_names: &[&str], theme: &SyntaxTheme) -> Self {
+    pub(crate) fn new(capture_names: &[&str], language_name: &str, theme: &SyntaxTheme) -> Self {
         // For each capture name in the highlight query, find the longest
         // key in the theme's syntax styles that matches all of the
-        // dot-separated components of the capture name.
+        // dot-separated components of the capture name and the language name.
         HighlightMap(
             capture_names
                 .iter()
@@ -27,7 +27,9 @@ impl HighlightMap {
                             let mut len = 0;
                             let capture_parts = capture_name.split('.');
                             for key_part in key.split('.') {
-                                if capture_parts.clone().any(|part| part == key_part) {
+                                if language_name == key_part
+                                    || capture_parts.clone().any(|part| part == key_part)
+                                {
                                     len += 1;
                                 } else {
                                     return None;
@@ -88,9 +90,10 @@ mod tests {
                 ("function", rgba(0x100000ff)),
                 ("function.method", rgba(0x200000ff)),
                 ("function.async", rgba(0x300000ff)),
-                ("variable.builtin.self.rust", rgba(0x400000ff)),
-                ("variable.builtin", rgba(0x500000ff)),
-                ("variable", rgba(0x600000ff)),
+                ("variable.builtin.self.python", rgba(0x400000ff)),
+                ("variable.builtin.rust", rgba(0x500000ff)),
+                ("variable.builtin", rgba(0x600000ff)),
+                ("variable", rgba(0x700000ff)),
             ]
             .iter()
             .map(|(name, color)| (name.to_string(), (*color).into()))
@@ -103,9 +106,9 @@ mod tests {
             "variable.builtin.self",
         ];
 
-        let map = HighlightMap::new(capture_names, &theme);
+        let map = HighlightMap::new(capture_names, "rust", &theme);
         assert_eq!(map.get(0).name(&theme), Some("function"));
         assert_eq!(map.get(1).name(&theme), Some("function.async"));
-        assert_eq!(map.get(2).name(&theme), Some("variable.builtin"));
+        assert_eq!(map.get(2).name(&theme), Some("variable.builtin.rust"));
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1579,8 +1579,11 @@ impl Language {
     pub fn set_theme(&self, theme: &SyntaxTheme) {
         if let Some(grammar) = self.grammar.as_ref() {
             if let Some(highlights_query) = &grammar.highlights_query {
-                *grammar.highlight_map.lock() =
-                    HighlightMap::new(highlights_query.capture_names(), theme);
+                *grammar.highlight_map.lock() = HighlightMap::new(
+                    highlights_query.capture_names(),
+                    self.config.name.lsp_id().as_ref(),
+                    theme,
+                );
             }
         }
     }


### PR DESCRIPTION
Release Notes:

  - Allow themes to target languages

---

This PR effectively adds the language name as a scope for highlights, which gives more flexibility to themes:

```json
{
  "syntax": {
    "punctuation": {
      "color": "#acb2beff"
    },
    "punctuation.regex": {
      "color": "#b477cfff"
    }
  }
}
```

Which can improve legibility for injected grammars:

| Zed 0.174.7 | Example with this PR |
| -- | -- |
| ![](https://github.com/user-attachments/assets/806fd7f7-7be7-4696-b689-6d5b704de701) | ![](https://github.com/user-attachments/assets/3e0bbc6e-05cb-41a7-a508-95ac0da35740) |

```js
/** @todo javascript regex jsdoc **/
function test() {
  string = "this is a string"
  regex = /^(?:this )?is{3,}[a-z]+(regex)$/
}
```
