### PR TITLE
project_panel: Fix entry not being marked when triggered via keyboard

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1095,6 +1095,7 @@ impl ProjectPanel {
         if let Some((_, entry)) = self.selected_entry(cx) {
             if entry.is_file() {
                 self.open_entry(entry.id, focus_opened_item, allow_preview, cx);
+                cx.notify();
             } else {
                 self.toggle_expanded(entry.id, window, cx);
             }


### PR DESCRIPTION
This is follow-up for https://github.com/zed-industries/zed/pull/25457

If you open a project without any open buffer, focus on the project panel, navigate with arrows to a given entry, and hit space, you will mark and open the file in the buffer. This is all correct. If you then hit `escape` to clear the marked entries, nothing happens to the open buffer, and the marked styled in the project panel entry go away. This is all correct. The wrong behavior happens if you now hit space again on the active entry. That should mark it, and thus change its styles, but it doesn't happen. You just see it upon moving to a different entry with arrow up/down.

Release Notes:

- Fixed project panel entry not being marked when triggering open action via keyboard.
