### PR TITLE
Try adding the get-task-allow entitlement

### DIFF
--- a/crates/zed/resources/zed.entitlements
+++ b/crates/zed/resources/zed.entitlements
@@ -22,5 +22,7 @@
 	<true/>
 	<key>com.apple.security.personal-information.photos-library</key>
 	<true/>
+	<key>com.apple.security.get-task-allow</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Right now it doesn't seem to be possible to use the Allocations instrument on macOS against nightly Zed, possibly due to lacking this entitlement. Let's try out adding it to the list and see if the resulting bundle behaves better.

Release Notes:

- N/A
