### PR TITLE
assistant_context_editor: Try to fix crash when trying to view patch

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -1122,7 +1122,7 @@ impl ContextEditor {
             }
         })?;
         this.read_with(&cx, |this, _| this.workspace)?
-            .update(&mut cx, |workspace, cx| {
+            .update_in(&mut cx, |workspace, window, cx| {
                 workspace.add_item_to_active_pane(Box::new(editor.clone()), None, false, window, cx)
             })
             .log_err();

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -1087,7 +1087,7 @@ impl ContextEditor {
         patch: AssistantPatch,
         mut cx: AsyncWindowContext,
     ) -> Result<()> {
-        let project = this.update(&mut cx, |this, _| this.project.clone())?;
+        let project = this.read_with(&cx, |this, _| this.project.clone())?;
         let resolved_patch = patch.resolve(project.clone(), &mut cx).await;
 
         let editor = cx.new_window_entity(|window, cx| {
@@ -1120,19 +1120,12 @@ impl ContextEditor {
                 });
                 patch_state.update_task.take();
             }
-
-            this.workspace
-                .update(cx, |workspace, cx| {
-                    workspace.add_item_to_active_pane(
-                        Box::new(editor.clone()),
-                        None,
-                        false,
-                        window,
-                        cx,
-                    )
-                })
-                .log_err();
         })?;
+        this.read_with(&cx, |this, _| this.workspace)?
+            .update(&mut cx, |workspace, cx| {
+                workspace.add_item_to_active_pane(Box::new(editor.clone()), None, false, window, cx)
+            })
+            .log_err();
 
         Ok(())
     }

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -1112,7 +1112,7 @@ impl ContextEditor {
             editor
         })?;
 
-        this.update_in(&mut cx, |this, window, cx| {
+        this.update(&mut cx, |this, _| {
             if let Some(patch_state) = this.patches.get_mut(&patch.range) {
                 patch_state.editor = Some(PatchEditorState {
                     editor: editor.downgrade(),
@@ -1121,7 +1121,7 @@ impl ContextEditor {
                 patch_state.update_task.take();
             }
         })?;
-        this.read_with(&cx, |this, _| this.workspace)?
+        this.read_with(&cx, |this, _| this.workspace.clone())?
             .update_in(&mut cx, |workspace, window, cx| {
                 workspace.add_item_to_active_pane(Box::new(editor.clone()), None, false, window, cx)
             })


### PR DESCRIPTION
Closes #24571

Attempts to fix crash described in #24571 based on the panic trace provided by the user. In short, the panic seemed to be caused by attempting to read an `Entity<ContextEditor>` while it was being updated. My assumption is that at some point in `workspace.add_item_to_current_pane` the `ContextEditor` is read. Therefore, I moved the workspace update outside of the ContextEditor update, and replaced another `update` call with a `read` call to clean it up and just in case that was actually the issue.

Release Notes:

- N/A
