### PR TITLE
Give Zed AI users access to Claude 3.7 Sonnet

### DIFF
--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -72,14 +72,13 @@ impl CloudModel {
     pub fn availability(&self) -> LanguageModelAvailability {
         match self {
             Self::Anthropic(model) => match model {
-                anthropic::Model::Claude3_5Sonnet => {
+                anthropic::Model::Claude3_5Sonnet | anthropic::Model::Claude3_7Sonnet => {
                     LanguageModelAvailability::RequiresPlan(Plan::Free)
                 }
                 anthropic::Model::Claude3Opus
                 | anthropic::Model::Claude3Sonnet
                 | anthropic::Model::Claude3Haiku
                 | anthropic::Model::Claude3_5Haiku
-                | anthropic::Model::Claude3_7Sonnet
                 | anthropic::Model::Custom { .. } => {
                     LanguageModelAvailability::RequiresPlan(Plan::ZedPro)
                 }

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -263,6 +263,10 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
                 anthropic::Model::Claude3_5Sonnet.id().to_string(),
                 CloudModel::Anthropic(anthropic::Model::Claude3_5Sonnet),
             );
+            models.insert(
+                anthropic::Model::Claude3_7Sonnet.id().to_string(),
+                CloudModel::Anthropic(anthropic::Model::Claude3_7Sonnet),
+            );
         }
 
         let llm_closed_beta_models = if cx.has_flag::<LlmClosedBeta>() {


### PR DESCRIPTION
This PR updates the client-side checks to give Zed AI users access to Claude 3.7 Sonnet.

Requires https://github.com/zed-industries/zed/pull/25576 to be deployed.

Release Notes:

- Added support for Claude 3.7 Sonnet to Zed AI.
