### PR TITLE
Ensure emacs undo (ctrl-_) works by default in terminal on macOS

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -831,6 +831,7 @@
       "cmd-k": "terminal::Clear",
       "cmd-n": "workspace::NewTerminal",
       "ctrl-enter": "assistant::InlineAssist",
+      "ctrl-_": null, // emacs undo
       // Some nice conveniences
       "cmd-backspace": ["terminal::SendText", "\u0015"],
       "cmd-right": ["terminal::SendText", "\u0005"],


### PR DESCRIPTION
Release Notes:

- Fixed undo in emacs (`ctrl-_`) not working by default in Terminal on macOS
