### PR TITLE
Fix search skipping in vim mode

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -467,7 +467,6 @@ impl Clone for ReplayableAction {
 pub struct SearchState {
     pub direction: Direction,
     pub count: usize,
-    pub initial_query: String,
 
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,

--- a/crates/vim/test_data/test_search_skipping.json
+++ b/crates/vim/test_data/test_search_skipping.json
@@ -1,0 +1,12 @@
+{"Put":{"state":"ˇaa aa aa"}}
+{"Key":"/"}
+{"Key":"a"}
+{"Key":"a"}
+{"Key":"enter"}
+{"Get":{"state":"aa ˇaa aa","mode":"Normal"}}
+{"Key":"left"}
+{"Key":"/"}
+{"Key":"a"}
+{"Key":"a"}
+{"Key":"enter"}
+{"Get":{"state":"aa ˇaa aa","mode":"Normal"}}

--- a/crates/vim/test_data/test_v_search_aa.json
+++ b/crates/vim/test_data/test_v_search_aa.json
@@ -1,0 +1,7 @@
+{"Put":{"state":"ˇaa aa"}}
+{"Key":"v"}
+{"Key":"/"}
+{"Key":"a"}
+{"Key":"a"}
+{"Key":"enter"}
+{"Get":{"state":"«aa aˇ»a","mode":"Visual"}}


### PR DESCRIPTION
Closes #8049

Co-authored-by: nilehmann <nico.lehmannm@gmail.com>
Co-authored-by: Anthony Eid <hello@anthonyeid.me>

Release Notes:

- vim: Fix skipping of search results occasionally
