### PR TITLE
editor: Fix panic when `editor::SelectLargerSyntaxNode` overflows excerpt in multi buffer

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -132,7 +132,7 @@ pub use multi_buffer::{
 };
 use multi_buffer::{
     ExcerptInfo, ExpandExcerptDirection, MultiBufferDiffHunk, MultiBufferPoint, MultiBufferRow,
-    ToOffsetUtf16,
+    MultiOrSingleBufferOffsetRange, ToOffsetUtf16,
 };
 use project::{
     lsp_store::{CompletionDocumentation, FormatTrigger, LspFormatTarget, OpenLspBufferHandle},
@@ -10727,7 +10727,10 @@ impl Editor {
                 while let Some((node, containing_range)) = buffer.syntax_ancestor(new_range.clone())
                 {
                     new_node = Some(node);
-                    new_range = containing_range;
+                    new_range = match containing_range {
+                        MultiOrSingleBufferOffsetRange::Single(_) => break,
+                        MultiOrSingleBufferOffsetRange::Multi(range) => range,
+                    };
                     if !display_map.intersects_fold(new_range.start)
                         && !display_map.intersects_fold(new_range.end)
                     {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -15,7 +15,7 @@ use itertools::Itertools;
 use language::{DiagnosticEntry, Language, LanguageRegistry};
 use lsp::DiagnosticSeverity;
 use markdown::{Markdown, MarkdownStyle};
-use multi_buffer::ToOffset;
+use multi_buffer::{MultiOrSingleBufferOffsetRange, ToOffset};
 use project::{HoverBlock, HoverBlockKind, InlayHintLabelPart};
 use settings::Settings;
 use std::{borrow::Cow, cell::RefCell};
@@ -447,11 +447,13 @@ fn show_hover(
                     })
                     .or_else(|| {
                         let snapshot = &snapshot.buffer_snapshot;
-                        let offset_range = snapshot.syntax_ancestor(anchor..anchor)?.1;
-                        Some(
-                            snapshot.anchor_before(offset_range.start)
-                                ..snapshot.anchor_after(offset_range.end),
-                        )
+                        match snapshot.syntax_ancestor(anchor..anchor)?.1 {
+                            MultiOrSingleBufferOffsetRange::Multi(range) => Some(
+                                snapshot.anchor_before(range.start)
+                                    ..snapshot.anchor_after(range.end),
+                            ),
+                            MultiOrSingleBufferOffsetRange::Single(_) => None,
+                        }
                     })
                     .unwrap_or_else(|| anchor..anchor);
 


### PR DESCRIPTION
Closes #25513

This PR handles case when  `editor::SelectLargerSyntaxNode` expands across excerpt boundaries and eventually crashes in multi buffer. 

Release Notes:

- Fixed panic caused when `editor::SelectLargerSyntaxNode` is called repetedly in multi buffer.
