### PR TITLE
windows: Fix terminal inline assistant not clearing input

### DIFF
--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -1084,7 +1084,7 @@ pub fn clear_input(terminal: &mut Terminal) {
         } else {
             terminal.input(CLEAR_INPUT.to_string());
         }
-    };
+    }
 }
 
 struct TerminalTransaction {

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -1079,7 +1079,10 @@ const CARRIAGE_RETURN: &str = "\x0d";
 
 pub fn clear_input(terminal: &mut Terminal) {
     if let Some(process) = terminal.pty_info.current.as_ref() {
-        if process.name.ends_with("cmd.exe") || process.name.ends_with("pwsh.exe") {
+        if process.name.ends_with("cmd.exe")
+            || process.name.ends_with("pwsh.exe")
+            || process.name.ends_with("powershell.exe")
+        {
             terminal.input(CLEAR_WINDOWS_INPUT.to_string());
         } else {
             terminal.input(CLEAR_INPUT.to_string());

--- a/crates/assistant2/src/terminal_codegen.rs
+++ b/crates/assistant2/src/terminal_codegen.rs
@@ -156,7 +156,18 @@ pub enum CodegenEvent {
 }
 
 pub const CLEAR_INPUT: &str = "\x15";
+pub const CLEAR_WINDOWS_INPUT: &str = "\x1b";
 const CARRIAGE_RETURN: &str = "\x0d";
+
+pub fn clear_input(terminal: &mut Terminal) {
+    if let Some(process) = terminal.pty_info.current.as_ref() {
+        if process.name.ends_with("cmd.exe") || process.name.ends_with("pwsh.exe") {
+            terminal.input(CLEAR_WINDOWS_INPUT.to_string());
+        } else {
+            terminal.input(CLEAR_INPUT.to_string());
+        }
+    };
+}
 
 struct TerminalTransaction {
     terminal: Entity<Terminal>,
@@ -176,7 +187,7 @@ impl TerminalTransaction {
 
     pub fn undo(&self, cx: &mut App) {
         self.terminal
-            .update(cx, |terminal, _| terminal.input(CLEAR_INPUT.to_string()));
+            .update(cx, |terminal, _| clear_input(terminal));
     }
 
     pub fn complete(&self, cx: &mut App) {

--- a/crates/assistant2/src/terminal_codegen.rs
+++ b/crates/assistant2/src/terminal_codegen.rs
@@ -161,7 +161,10 @@ const CARRIAGE_RETURN: &str = "\x0d";
 
 pub fn clear_input(terminal: &mut Terminal) {
     if let Some(process) = terminal.pty_info.current.as_ref() {
-        if process.name.ends_with("cmd.exe") || process.name.ends_with("pwsh.exe") {
+        if process.name.ends_with("cmd.exe")
+            || process.name.ends_with("pwsh.exe")
+            || process.name.ends_with("powershell.exe")
+        {
             terminal.input(CLEAR_WINDOWS_INPUT.to_string());
         } else {
             terminal.input(CLEAR_INPUT.to_string());

--- a/crates/assistant2/src/terminal_codegen.rs
+++ b/crates/assistant2/src/terminal_codegen.rs
@@ -166,7 +166,7 @@ pub fn clear_input(terminal: &mut Terminal) {
         } else {
             terminal.input(CLEAR_INPUT.to_string());
         }
-    };
+    }
 }
 
 struct TerminalTransaction {

--- a/crates/assistant2/src/terminal_inline_assistant.rs
+++ b/crates/assistant2/src/terminal_inline_assistant.rs
@@ -3,7 +3,7 @@ use crate::context_store::ContextStore;
 use crate::inline_prompt_editor::{
     CodegenStatus, PromptEditor, PromptEditorEvent, TerminalInlineAssistId,
 };
-use crate::terminal_codegen::{CodegenEvent, TerminalCodegen, CLEAR_INPUT};
+use crate::terminal_codegen::{clear_input, CodegenEvent, TerminalCodegen};
 use crate::thread_store::ThreadStore;
 use anyhow::{Context as _, Result};
 use client::telemetry::Telemetry;
@@ -189,7 +189,7 @@ impl TerminalInlineAssistant {
             .update(cx, |terminal, cx| {
                 terminal
                     .terminal()
-                    .update(cx, |terminal, _| terminal.input(CLEAR_INPUT.to_string()));
+                    .update(cx, |terminal, _| clear_input(terminal));
             })
             .log_err();
 


### PR DESCRIPTION
Closes #18518
Closes #20546

There isn't <kbd>Ctrl</kbd>+<kbd>U</kbd> neither in CMD nor in PowerShell to clear the prompt input, but pressing <kbd>Esc</kbd> has the same effect.
Not sure if there's a better way to check what shell is currently being used in the terminal, and due to that, if you change the shell directly from the terminal (for example, when typing `wsl` in a `cmd.exe` terminal), it will still recognize it as CMD/PowerShell.

Release Notes:

- N/A 
