### PR TITLE
vim: Fix `insert before` in visual modes

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1623,6 +1623,7 @@ mod test {
         cx.simulate_shared_keystrokes("p p").await;
         cx.shared_state().await.assert_eq("\nhello\nˇhello");
     }
+
     #[gpui::test]
     async fn test_visual_mode_insert_before_after(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
@@ -1636,23 +1637,6 @@ mod test {
         cx.shared_state().await.assert_eq("helloˇ");
 
         cx.set_shared_state(indoc! {"
-            The ˇquick brown
-            fox jumps over
-            the lazy dog"})
-            .await;
-        cx.simulate_shared_keystrokes("ctrl-v e j j").await;
-        cx.set_shared_state(indoc! {"
-            The «quickˇ» brown
-            fox «jumpsˇ» over
-            the «lazy ˇ»dog"})
-            .await;
-        cx.simulate_shared_keystrokes("shift-i").await;
-        cx.shared_state().await.assert_eq(indoc! {"
-            The ˇquick brown
-            fox ˇjumps over
-            the ˇlazy dog"});
-
-        cx.set_shared_state(indoc! {"
             The quick brown
             fox ˇjumps over
             the lazy dog"})
@@ -1661,17 +1645,6 @@ mod test {
         cx.shared_state().await.assert_eq(indoc! {"
             The quick brown
             ˇfox jumps over
-            the lazy dog"});
-
-        cx.set_shared_state(indoc! {"
-            The quick brown
-            fox ˇjumps over
-            the lazy dog"})
-            .await;
-        cx.simulate_shared_keystrokes("shift-v shift-a").await;
-        cx.shared_state().await.assert_eq(indoc! {"
-            The quick brown
-            fox jumps overˇ
             the lazy dog"});
     }
 }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1628,9 +1628,11 @@ mod test {
     #[gpui::test]
     async fn test_visual_mode_insert_before_after(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
+
         cx.set_shared_state("heˇllo").await;
         cx.simulate_shared_keystrokes("v i w shift-i").await;
         cx.shared_state().await.assert_eq("ˇhello");
+
         cx.set_shared_state("heˇllo").await;
         cx.simulate_shared_keystrokes("v i w shift-a").await;
         cx.shared_state().await.assert_eq("helloˇ");
@@ -1657,7 +1659,18 @@ mod test {
             fox ˇjumps over
             the lazy dog"})
             .await;
-        cx.simulate_shared_keystrokes("shift-a").await;
+        cx.simulate_shared_keystrokes("shift-v shift-i").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            The quick brown
+            ˇfox jumps over
+            the lazy dog"});
+
+        cx.set_shared_state(indoc! {"
+            The quick brown
+            fox ˇjumps over
+            the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("shift-v shift-a").await;
         cx.shared_state().await.assert_eq(indoc! {"
             The quick brown
             fox jumps overˇ

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1625,4 +1625,42 @@ mod test {
         cx.simulate_shared_keystrokes("p p").await;
         cx.shared_state().await.assert_eq("\nhello\nˇhello");
     }
+    #[gpui::test]
+    async fn test_visual_mode_insert_before_after(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.set_shared_state("heˇllo").await;
+        cx.simulate_shared_keystrokes("v i w shift-i").await;
+        cx.shared_state().await.assert_eq("ˇhello");
+        cx.set_shared_state("heˇllo").await;
+        cx.simulate_shared_keystrokes("v i w shift-a").await;
+        cx.shared_state().await.assert_eq("helloˇ");
+
+        cx.set_shared_state(indoc! {"
+            The ˇquick brown
+            fox jumps over
+            the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("ctrl-v e j j").await;
+        cx.set_shared_state(indoc! {"
+            The «quickˇ» brown
+            fox «jumpsˇ» over
+            the «lazy ˇ»dog"})
+            .await;
+        cx.simulate_shared_keystrokes("shift-i").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            The ˇquick brown
+            fox ˇjumps over
+            the ˇlazy dog"});
+
+        cx.set_shared_state(indoc! {"
+            The quick brown
+            fox ˇjumps over
+            the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("shift-a").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            The quick brown
+            fox jumps overˇ
+            the lazy dog"});
+    }
 }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -1613,10 +1613,6 @@ mod test {
         cx.simulate_shared_keystrokes("v i w shift-i").await;
         cx.shared_state().await.assert_eq("ˇhello");
 
-        cx.set_shared_state("heˇllo").await;
-        cx.simulate_shared_keystrokes("v i w shift-a").await;
-        cx.shared_state().await.assert_eq("helloˇ");
-
         cx.set_shared_state(indoc! {"
             The quick brown
             fox ˇjumps over

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -324,10 +324,8 @@ impl Vim {
                     });
                 });
             });
-            self.switch_mode(Mode::Insert, false, window, cx);
-        } else {
-            self.switch_mode(Mode::Insert, false, window, cx);
         }
+        self.switch_mode(Mode::Insert, false, window, cx);
     }
 
     fn insert_first_non_whitespace(

--- a/crates/vim/test_data/test_visual_mode_insert_before_after.json
+++ b/crates/vim/test_data/test_visual_mode_insert_before_after.json
@@ -10,19 +10,7 @@
 {"Key":"w"}
 {"Key":"shift-a"}
 {"Get":{"state":"helloˇ","mode":"Insert"}}
-{"Put": {"state": "The ˇquick brown\nfox jumps over\nthe lazy dog"}}
-{"Key": "ctrl-v"}
-{"Key": "e"}
-{"Key": "j"}
-{"Key": "j"}
-{"Put": {"state": "The «quickˇ» brown\nfox «jumpsˇ» over\nthe «lazy ˇ»dog"}}
-{"Key": "shift-i"}
-{"Get": {"state": "The ˇquick brown\nfox ˇjumps over\nthe ˇlazy dog", "mode": "Insert"}}
-{"Put": {"state": "The quick brown\nfox ˇjumps over\nthe lazy dog"}}
-{"Key": "shift-v"}
-{"Key": "shift-i"}
-{"Get": {"state": "The quick brown\nˇfox jumps over\nthe lazy dog", "mode": "Insert"}}
-{"Put": {"state": "The quick brown\nfox ˇjumps over\nthe lazy dog"}}
-{"Key": "shift-v"}
-{"Key": "shift-a"}
-{"Get": {"state": "The quick brown\nfox jumps overˇ\nthe lazy dog", "mode": "Insert"}}
+{"Put":{"state":"The quick brown\nfox ˇjumps over\nthe lazy dog"}}
+{"Key":"shift-v"}
+{"Key":"shift-i"}
+{"Get":{"state":"The quick brown\nˇfox jumps over\nthe lazy dog","mode":"Insert"}}

--- a/crates/vim/test_data/test_visual_mode_insert_before_after.json
+++ b/crates/vim/test_data/test_visual_mode_insert_before_after.json
@@ -19,5 +19,10 @@
 {"Key": "shift-i"}
 {"Get": {"state": "The ˇquick brown\nfox ˇjumps over\nthe ˇlazy dog", "mode": "Insert"}}
 {"Put": {"state": "The quick brown\nfox ˇjumps over\nthe lazy dog"}}
+{"Key": "shift-v"}
+{"Key": "shift-i"}
+{"Get": {"state": "The quick brown\nˇfox jumps over\nthe lazy dog", "mode": "Insert"}}
+{"Put": {"state": "The quick brown\nfox ˇjumps over\nthe lazy dog"}}
+{"Key": "shift-v"}
 {"Key": "shift-a"}
 {"Get": {"state": "The quick brown\nfox jumps overˇ\nthe lazy dog", "mode": "Insert"}}

--- a/crates/vim/test_data/test_visual_mode_insert_before_after.json
+++ b/crates/vim/test_data/test_visual_mode_insert_before_after.json
@@ -1,0 +1,23 @@
+{"Put":{"state":"heˇllo"}}
+{"Key":"v"}
+{"Key":"i"}
+{"Key":"w"}
+{"Key":"shift-i"}
+{"Get":{"state":"ˇhello","mode":"Insert"}}
+{"Put":{"state":"heˇllo"}}
+{"Key":"v"}
+{"Key":"i"}
+{"Key":"w"}
+{"Key":"shift-a"}
+{"Get":{"state":"helloˇ","mode":"Insert"}}
+{"Put": {"state": "The ˇquick brown\nfox jumps over\nthe lazy dog"}}
+{"Key": "ctrl-v"}
+{"Key": "e"}
+{"Key": "j"}
+{"Key": "j"}
+{"Put": {"state": "The «quickˇ» brown\nfox «jumpsˇ» over\nthe «lazy ˇ»dog"}}
+{"Key": "shift-i"}
+{"Get": {"state": "The ˇquick brown\nfox ˇjumps over\nthe ˇlazy dog", "mode": "Insert"}}
+{"Put": {"state": "The quick brown\nfox ˇjumps over\nthe lazy dog"}}
+{"Key": "shift-a"}
+{"Get": {"state": "The quick brown\nfox jumps overˇ\nthe lazy dog", "mode": "Insert"}}

--- a/crates/vim/test_data/test_visual_mode_insert_before_after.json
+++ b/crates/vim/test_data/test_visual_mode_insert_before_after.json
@@ -14,3 +14,7 @@
 {"Key":"shift-v"}
 {"Key":"shift-i"}
 {"Get":{"state":"The quick brown\nˇfox jumps over\nthe lazy dog","mode":"Insert"}}
+{"Put":{"state":"The quick brown\nfox ˇjumps over\nthe lazy dog"}}
+{"Key":"shift-v"}
+{"Key":"shift-a"}
+{"Get":{"state":"The quick brown\nfox jˇumps over\nthe lazy dog","mode":"Insert"}}

--- a/crates/vim/test_data/test_visual_mode_insert_before_after.json
+++ b/crates/vim/test_data/test_visual_mode_insert_before_after.json
@@ -4,12 +4,6 @@
 {"Key":"w"}
 {"Key":"shift-i"}
 {"Get":{"state":"ˇhello","mode":"Insert"}}
-{"Put":{"state":"heˇllo"}}
-{"Key":"v"}
-{"Key":"i"}
-{"Key":"w"}
-{"Key":"shift-a"}
-{"Get":{"state":"helloˇ","mode":"Insert"}}
 {"Put":{"state":"The quick brown\nfox ˇjumps over\nthe lazy dog"}}
 {"Key":"shift-v"}
 {"Key":"shift-i"}


### PR DESCRIPTION
Closes #22536

Changes:
- Visual and visual block: Cursor at start of selection.
- Visual line: Cursor at start on line.
  - Uses different handling since the selection does not actually change in vline.

Release Notes:

- vim: Fixed insert before (`shift-i`) in visual modes.