### PR TITLE
terminal: Don't consider ']' at the end of URLs

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -313,7 +313,7 @@ impl Display for TerminalError {
 // https://github.com/alacritty/alacritty/blob/cb3a79dbf6472740daca8440d5166c1d4af5029e/extra/man/alacritty.5.scd?plain=1#L207-L213
 const DEFAULT_SCROLL_HISTORY_LINES: usize = 10_000;
 const MAX_SCROLL_HISTORY_LINES: usize = 100_000;
-const URL_REGEX: &str = r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩`]+"#;
+const URL_REGEX: &str = r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|https://|http://|news:|file://|git://|ssh:|ftp://)[^\u{0000}-\u{001F}\u{007F}-\u{009F}<>"\s{-}\^⟨⟩\]`]+"#;
 // Optional suffix matches MSBuild diagnostic suffixes for path parsing in PathLikeWithPosition
 // https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks
 const WORD_REGEX: &str =
@@ -2158,8 +2158,13 @@ mod tests {
     fn test_url_regex() {
         re_test(
             crate::URL_REGEX,
-            "test http://example.com test mailto:bob@example.com train",
-            vec!["http://example.com", "mailto:bob@example.com"],
+            "test http://example.com test mailto:bob@example.com train
+            [http://example2.com].",
+            vec![
+                "http://example.com",
+                "mailto:bob@example.com",
+                "http://example2.com",
+            ],
         );
     }
     #[test]


### PR DESCRIPTION
For this PR, I'm trying to fix the following issue with terminal panes:
<img width="523" alt="image" src="https://github.com/user-attachments/assets/df5bf822-c1ef-4464-9f95-21357acf6567" />


That would be the expected behaviour:
<img width="380" alt="image" src="https://github.com/user-attachments/assets/81a26b3c-c7a5-484b-a2f0-3e1114103e58" />

So with this, it would open `http://example.com/example].` but `http://example.com/example`.

Release Notes:

- Improved URL Regex on terminal pane
