### PR TITLE
Use carriage return instead of newline symbol for single line text

### DIFF
--- a/crates/breadcrumbs/src/breadcrumbs.rs
+++ b/crates/breadcrumbs/src/breadcrumbs.rs
@@ -81,7 +81,7 @@ impl Render for Breadcrumbs {
             }
             text_style.color = Color::Muted.color(cx);
 
-            StyledText::new(segment.text.replace('\n', "␤"))
+            StyledText::new(segment.text.replace('\n', "⏎"))
                 .with_highlights(&text_style, segment.highlights.unwrap_or_default())
                 .into_any()
         });

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -177,7 +177,7 @@ impl LabelCommon for Label {
     }
 
     fn single_line(mut self) -> Self {
-        self.label = SharedString::from(self.label.replace('\n', "␤"));
+        self.label = SharedString::from(self.label.replace('\n', "⏎"));
         self.base = self.base.single_line();
         self
     }


### PR DESCRIPTION
I think this is clearer in the cases where it does appear.  Use of NL symbol was added in #10231

Release Notes:

- N/A