### PR TITLE
ssh: Allow `ssh -F ssh_config`

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -146,7 +146,8 @@ impl SshConnectionOptions {
             "-4", "-6", "-A", "-a", "-C", "-K", "-k", "-X", "-x", "-Y", "-y",
         ];
         const ALLOWED_ARGS: &[&str] = &[
-            "-B", "-b", "-c", "-D", "-I", "-i", "-J", "-l", "-m", "-o", "-P", "-p", "-R", "-w",
+            "-B", "-b", "-c", "-D", "-F", "-I", "-i", "-J", "-l", "-m", "-o", "-P", "-p", "-R",
+            "-w",
         ];
 
         let mut tokens = shlex::split(input)

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -195,7 +195,8 @@ Supported options:
 - `-i` - to use a specific key file
 - `-o` - to set custom options
 - `-J` / `-w` - to proxy the SSH connection
-- And also... `-4`, `-6`, `-A`, `-a`, `-C`, `-K`, `-k`, `-X`, `-x`, `-Y`, `-y`, `-B`, `-b`, `-c`, `-D`, `-I`, `-i`, `-J`, `-l`, `-m`, `-o`, `-P`, `-p`, `-w`
+- `-F` for specifying an `ssh_config`
+- And also... `-4`, `-6`, `-A`, `-B`, `-C`, `-D`, `-I`, `-K`, `-P`, `-X`, `-Y`, `-a`, `-b`, `-c`, `-i`, `-k`, `-l`, `-m`, `-o`, `-p`, `-w`, `-x`, `-y`
 
 Note that we deliberately disallow some options (for example `-t` or `-T`) that Zed will set for you.
 
@@ -203,7 +204,6 @@ Note that we deliberately disallow some options (for example `-t` or `-T`) that 
 
 - Zed extensions are not yet supported on remotes, so languages that need them for support do not work.
 - You can't open files from the remote Terminal by typing the `zed` command.
-- Zed does not yet support automatic port-forwarding. You can use `-R` and `-L` in your SSH arguments for now.
 
 ## Feedback
 


### PR DESCRIPTION
- Closes https://github.com/zed-industries/zed/issues/22818

Usage: `ssh -F ssh_config user@host.tld`

```
-F configfile
    Specifies an alternative per-user configuration file. If a configuration file
    is given on the command line, the system-wide configuration file
    (/etc/ssh/ssh_config) will be ignored. The default for the per-user
    configuration file is ~/.ssh/config. If set to “none”, no configuration files
    will be read.
```

Release Notes:

- ssh: Added support for specifying ssh_config files (`ssh -F ssh_config`) in connection string