### PR TITLE
Support busybox wget for downloading zed-remote-server

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1910,7 +1910,6 @@ impl SshRemoteConnection {
                     .run_command(
                         "wget",
                         &[
-                            "--max-redirect=5",
                             "--method=GET",
                             "--header=Content-Type: application/json",
                             "--body-data",


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/22380

Alpine linux ships busybox wget not gnu wget.
BusyBox wget does not support `--max-redirect`.

Release Notes:

- ssh: Add support for downloading `zed-remote-server` with busybox wget (Alpine, etc)