### PR TITLE
Add support for opening local terminal in SSH remoting

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -270,7 +270,7 @@ impl Project {
             }
             TerminalKind::LocalShell(_) => {
                 terminal_title_override =
-                    Some(SharedString::new("Host Machine - Terminal".to_string()));
+                    Some(SharedString::new("Host Machine — Terminal".to_string()));
                 (None, settings.shell.clone())
             }
             TerminalKind::Task(spawn_task) => {
@@ -373,6 +373,10 @@ impl Project {
 
             if let Some(activate_command) = python_venv_activate_command {
                 this.activate_python_virtual_environment(activate_command, &terminal_handle, cx);
+            }
+
+            if is_local_shell && ssh_details.is_some() {
+                this.print_local_terminal_warning(&terminal_handle, cx);
             }
             terminal_handle
         })
@@ -519,6 +523,19 @@ impl Project {
         cx: &mut App,
     ) {
         terminal_handle.update(cx, |terminal, _| terminal.input_bytes(command.into_bytes()));
+    }
+
+    fn print_local_terminal_warning(&self, terminal_handle: &Entity<Terminal>, cx: &mut App) {
+        let line_ending = match std::env::consts::OS {
+            "windows" => "\r",
+            _ => "\n",
+        };
+
+        let warning = format!(
+            "clear; echo \"WARNING: This terminal is running on your local host, not the remote host.\" {line_ending}",
+        );
+
+        terminal_handle.update(cx, |terminal, _| terminal.input(warning));
     }
 
     pub fn local_terminal_handles(&self) -> &Vec<WeakEntity<terminal::Terminal>> {

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -280,8 +280,6 @@ pub enum Shell {
         program: String,
         /// The arguments to pass to the program.
         args: Vec<String>,
-        /// An optional string to override the title of the terminal tab
-        title_override: Option<SharedString>,
     },
 }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -302,6 +302,7 @@ impl Display for TerminalError {
     }
 }
 
+#[derive(Debug, Clone, Copy)]
 pub enum TerminalRunLocation {
     Host,
     Remote,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -622,7 +622,7 @@ pub struct Terminal {
     word_regex: RegexSearch,
     task: Option<TaskState>,
     vi_mode_enabled: bool,
-    run_location: TerminalRunLocation,
+    pub run_location: TerminalRunLocation,
 }
 
 pub struct TaskState {

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -3,7 +3,10 @@ use async_recursion::async_recursion;
 use collections::HashSet;
 use futures::{stream::FuturesUnordered, StreamExt as _};
 use gpui::{AppContext as _, AsyncWindowContext, Axis, Entity, Task, WeakEntity};
-use project::{terminals::TerminalKind, Project};
+use project::{
+    terminals::{ShellOptions, TerminalKind},
+    Project,
+};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use ui::{App, Context, Pixels, Window};
@@ -240,9 +243,10 @@ async fn deserialize_pane_group(
                             .update(cx, |workspace, cx| default_working_directory(workspace, cx))
                             .ok()
                             .flatten();
-                        let kind = TerminalKind::Shell(
-                            working_directory.as_deref().map(Path::to_path_buf),
-                        );
+                        let kind = TerminalKind::Shell(ShellOptions {
+                            path: working_directory.as_deref().map(Path::to_path_buf),
+                            run_locally: None,
+                        });
                         let window = window.window_handle();
                         let terminal = project
                             .update(cx, |project, cx| project.create_terminal(kind, window, cx));

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -3,10 +3,7 @@ use async_recursion::async_recursion;
 use collections::HashSet;
 use futures::{stream::FuturesUnordered, StreamExt as _};
 use gpui::{AppContext as _, AsyncWindowContext, Axis, Entity, Task, WeakEntity};
-use project::{
-    terminals::{ShellOptions, TerminalKind},
-    Project,
-};
+use project::{terminals::TerminalKind, Project};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 use ui::{App, Context, Pixels, Window};
@@ -243,10 +240,9 @@ async fn deserialize_pane_group(
                             .update(cx, |workspace, cx| default_working_directory(workspace, cx))
                             .ok()
                             .flatten();
-                        let kind = TerminalKind::Shell(ShellOptions {
-                            path: working_directory.as_deref().map(Path::to_path_buf),
-                            run_locally: None,
-                        });
+                        let kind = TerminalKind::Shell(
+                            working_directory.as_deref().map(Path::to_path_buf),
+                        );
                         let window = window.window_handle();
                         let terminal = project
                             .update(cx, |project, cx| project.create_terminal(kind, window, cx));

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -403,7 +403,8 @@ define_connection! {
             DROP TABLE terminals;
 
             ALTER TABLE terminals2 RENAME TO terminals;
-        )];
+        ),
+        sql!(ALTER TABLE terminals ADD COLUMN is_local_shell INTEGER NOT NULL DEFAULT 0)];
 }
 
 impl TerminalDb {
@@ -420,19 +421,28 @@ impl TerminalDb {
     }
 
     query! {
-        pub async fn save_working_directory(
+        pub async fn save_terminal_view(
             item_id: ItemId,
             workspace_id: WorkspaceId,
-            working_directory: PathBuf
+            working_directory: PathBuf,
+            is_local_shell: bool
         ) -> Result<()> {
-            INSERT OR REPLACE INTO terminals(item_id, workspace_id, working_directory)
-            VALUES (?, ?, ?)
+            INSERT OR REPLACE INTO terminals(item_id, workspace_id, working_directory, is_local_shell)
+            VALUES (?, ?, ?, ?)
         }
     }
 
     query! {
         pub fn get_working_directory(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<PathBuf>> {
             SELECT working_directory
+            FROM terminals
+            WHERE item_id = ? AND workspace_id = ?
+        }
+    }
+
+    query! {
+        pub fn get_is_local_shell(item_id: ItemId, workspace_id: WorkspaceId) -> Result<Option<bool>> {
+            SELECT is_local_shell
             FROM terminals
             WHERE item_id = ? AND workspace_id = ?
         }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -156,32 +156,31 @@ impl TerminalPanel {
                             .menu(move |window, cx| {
                                 let focus_handle = focus_handle.clone();
                                 let menu = ContextMenu::build(window, cx, |menu, _, cx| {
-                                    let context_menu = menu
-                                        .context(focus_handle.clone())
-                                        .action(
-                                            "New Terminal",
-                                            workspace::NewTerminal.boxed_clone(),
-                                        )
-                                        // We want the focus to go back to terminal panel once task modal is dismissed,
-                                        // hence we focus that first. Otherwise, we'd end up without a focused element, as
-                                        // context menu will be gone the moment we spawn the modal.
-                                        .action(
-                                            "Spawn task",
-                                            zed_actions::Spawn::modal().boxed_clone(),
-                                        );
+                                    let mut menu = menu.context(focus_handle.clone()).action(
+                                        "New Terminal",
+                                        workspace::NewTerminal.boxed_clone(),
+                                    );
+
                                     if workspace
                                         .read_with(cx, |workspace, cx| {
                                             workspace.project().read(cx).is_via_ssh()
                                         })
                                         .is_ok_and(|f| f)
                                     {
-                                        context_menu.action(
+                                        menu = menu.context(focus_handle.clone()).action(
                                             "New Local Terminal",
                                             workspace::NewLocalTerminal.boxed_clone(),
-                                        )
-                                    } else {
-                                        context_menu
+                                        );
                                     }
+                                    // We want the focus to go back to terminal panel once task modal is dismissed,
+                                    // hence we focus that first. Otherwise, we'd end up without a focused element, as
+                                    // context menu will be gone the moment we spawn the modal.
+                                    menu = menu.context(focus_handle.clone()).action(
+                                        "Spawn Task",
+                                        zed_actions::Spawn::modal().boxed_clone(),
+                                    );
+
+                                    menu
                                 });
 
                                 Some(menu)

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -13,7 +13,11 @@ use gpui::{
     Pixels, Render, ScrollWheelEvent, Stateful, Styled, Subscription, Task, WeakEntity,
 };
 use persistence::TERMINAL_DB;
-use project::{search::SearchQuery, terminals::TerminalKind, Fs, Metadata, Project};
+use project::{
+    search::SearchQuery,
+    terminals::{ShellOptions, TerminalKind},
+    Fs, Metadata, Project,
+};
 use schemars::JsonSchema;
 use terminal::{
     alacritty_terminal::{
@@ -152,7 +156,10 @@ impl TerminalView {
         let working_directory = default_working_directory(workspace, cx);
         TerminalPanel::add_center_terminal(
             workspace,
-            TerminalKind::Shell(working_directory),
+            TerminalKind::Shell(ShellOptions {
+                path: working_directory,
+                run_locally: None,
+            }),
             window,
             cx,
         )
@@ -1310,7 +1317,10 @@ impl Item for TerminalView {
                     .or_else(|| Some(project.active_project_directory(cx)?.to_path_buf()));
                 let python_venv_directory = terminal.python_venv_directory.clone();
                 project.create_terminal_with_venv(
-                    TerminalKind::Shell(working_directory),
+                    TerminalKind::Shell(ShellOptions {
+                        path: working_directory,
+                        run_locally: None,
+                    }),
                     python_venv_directory,
                     window_handle,
                     cx,
@@ -1470,7 +1480,14 @@ impl SerializableItem for TerminalView {
 
             let terminal = project
                 .update(&mut cx, |project, cx| {
-                    project.create_terminal(TerminalKind::Shell(cwd), window_handle, cx)
+                    project.create_terminal(
+                        TerminalKind::Shell(ShellOptions {
+                            path: cwd,
+                            run_locally: None,
+                        }),
+                        window_handle,
+                        cx,
+                    )
                 })?
                 .await?;
             cx.update(|window, cx| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -13,11 +13,7 @@ use gpui::{
     Pixels, Render, ScrollWheelEvent, Stateful, Styled, Subscription, Task, WeakEntity,
 };
 use persistence::TERMINAL_DB;
-use project::{
-    search::SearchQuery,
-    terminals::{ShellOptions, TerminalKind},
-    Fs, Metadata, Project,
-};
+use project::{search::SearchQuery, terminals::TerminalKind, Fs, Metadata, Project};
 use schemars::JsonSchema;
 use terminal::{
     alacritty_terminal::{
@@ -156,10 +152,7 @@ impl TerminalView {
         let working_directory = default_working_directory(workspace, cx);
         TerminalPanel::add_center_terminal(
             workspace,
-            TerminalKind::Shell(ShellOptions {
-                path: working_directory,
-                run_locally: None,
-            }),
+            TerminalKind::Shell(working_directory),
             window,
             cx,
         )
@@ -1317,10 +1310,7 @@ impl Item for TerminalView {
                     .or_else(|| Some(project.active_project_directory(cx)?.to_path_buf()));
                 let python_venv_directory = terminal.python_venv_directory.clone();
                 project.create_terminal_with_venv(
-                    TerminalKind::Shell(ShellOptions {
-                        path: working_directory,
-                        run_locally: None,
-                    }),
+                    TerminalKind::Shell(working_directory),
                     python_venv_directory,
                     window_handle,
                     cx,
@@ -1480,14 +1470,7 @@ impl SerializableItem for TerminalView {
 
             let terminal = project
                 .update(&mut cx, |project, cx| {
-                    project.create_terminal(
-                        TerminalKind::Shell(ShellOptions {
-                            path: cwd,
-                            run_locally: None,
-                        }),
-                        window_handle,
-                        cx,
-                    )
+                    project.create_terminal(TerminalKind::Shell(cwd), window_handle, cx)
                 })?
                 .await?;
             cx.update(|window, cx| {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1473,7 +1473,7 @@ impl SerializableItem for TerminalView {
             let is_local_shell = cx
                 .update(|_, _| {
                     TERMINAL_DB
-                        .get_run_locally(item_id, workspace_id)
+                        .get_is_local_shell(item_id, workspace_id)
                         .log_err()
                         .flatten()
                         .is_some_and(|f| f)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -142,6 +142,7 @@ actions!(
         NewFileSplitHorizontal,
         NewSearch,
         NewTerminal,
+        NewLocalTerminal,
         NewWindow,
         Open,
         OpenFiles,


### PR DESCRIPTION
This pull request lets users open a local terminal while using remote development. Sometimes, you need access to your local terminal, for whatever reason, and it's nice to be able to stay in Zed. This is inspired by a very similar [VSCode feature](https://code.visualstudio.com/docs/terminal/advanced#_local-terminals-in-remote-windows).

https://github.com/user-attachments/assets/222b41e5-190b-4357-8a68-28eb03edf2b8

Release Notes:

- Added the ability to open a local terminal when using Zed's Remote Development feature.




