### PR TITLE
go: Do not fill out root_uri in initialization params to prevent stale notifications

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -5,7 +5,7 @@ use futures::StreamExt;
 use gpui::{App, AsyncApp, Task};
 use http_client::github::latest_github_release;
 pub use language::*;
-use lsp::{LanguageServerBinary, LanguageServerName};
+use lsp::{InitializeParams, LanguageServerBinary, LanguageServerName};
 use project::Fs;
 use regex::Regex;
 use serde_json::json;
@@ -372,6 +372,14 @@ impl super::LspAdapter for GoLspAdapter {
             text: text[display_range].to_string(),
             filter_range,
         })
+    }
+    fn prepare_initialize_params(
+        &self,
+        mut original: InitializeParams,
+    ) -> Result<InitializeParams> {
+        #[allow(deprecated)]
+        let _ = original.root_uri.take();
+        Ok(original)
     }
 }
 


### PR DESCRIPTION
Closes #25381

Release Notes:

- N/A
