### PR TITLE
image_viewer: Hide breadcrumb 

### DIFF
--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -145,8 +145,8 @@ impl Item for ImageView {
     }
 
     fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
-        let display_breadcrumb = EditorSettings::get_global(cx).toolbar.breadcrumbs;
-        if display_breadcrumb && self.show_toolbar() {
+        let show_breadcrumb = EditorSettings::get_global(cx).toolbar.breadcrumbs;
+        if show_breadcrumb {
             ToolbarItemLocation::PrimaryLeft
         } else {
             ToolbarItemLocation::Hidden

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -4,7 +4,7 @@ mod image_viewer_settings;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
-use editor::items::entry_git_aware_label_color;
+use editor::{items::entry_git_aware_label_color, EditorSettings};
 use file_icons::FileIcons;
 use gpui::{
     canvas, div, fill, img, opaque_grey, point, size, AnyElement, App, Bounds, Context, Entity,
@@ -144,8 +144,13 @@ impl Item for ImageView {
             .map(Icon::from_path)
     }
 
-    fn breadcrumb_location(&self, _: &App) -> ToolbarItemLocation {
-        ToolbarItemLocation::PrimaryLeft
+    fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
+        let display_breadcrumb = EditorSettings::get_global(cx).toolbar.breadcrumbs;
+        if display_breadcrumb && self.show_toolbar() {
+            ToolbarItemLocation::PrimaryLeft
+        } else {
+            ToolbarItemLocation::Hidden
+        }
     }
 
     fn breadcrumbs(&self, _theme: &Theme, cx: &App) -> Option<Vec<BreadcrumbText>> {


### PR DESCRIPTION
Closes #25279 

![image](https://github.com/user-attachments/assets/15a0b092-449b-493c-8eea-10a3d9d1a912)

Release Notes:

- Added the ability to hide breadcrumb showing image path 
