### PR TITLE
edit predictions: Rename edit prediction modes

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -843,7 +843,7 @@
     // 1. Display inline when there are no language server completions available.
     //     "mode": "eager_preview"
     // 2. Display inline when holding modifier key (alt by default).
-    //     "mode": "auto"
+    //     "mode": "stealth"
     "mode": "eager_preview"
   },
   // Settings specific to journaling

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -843,7 +843,7 @@
     // 1. Display predictions inline when there are no language server completions available.
     //     "mode": "eager"
     // 2. Display predictions inline only when holding a modifier key (alt by default).
-    //     "mode": "stealth"
+    //     "mode": "subtle"
     "mode": "eager"
   },
   // Settings specific to journaling

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -841,10 +841,10 @@
     // When to show edit predictions previews in buffer.
     // This setting takes two possible values:
     // 1. Display inline when there are no language server completions available.
-    //     "mode": "eager_preview"
+    //     "mode": "eager"
     // 2. Display inline when holding modifier key (alt by default).
     //     "mode": "stealth"
-    "mode": "eager_preview"
+    "mode": "eager"
   },
   // Settings specific to journaling
   "journal": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -840,9 +840,9 @@
     ],
     // When to show edit predictions previews in buffer.
     // This setting takes two possible values:
-    // 1. Display inline when there are no language server completions available.
+    // 1. Display predictions inline when there are no language server completions available.
     //     "mode": "eager"
-    // 2. Display inline when holding modifier key (alt by default).
+    // 2. Display predictions inline only when holding a modifier key (alt by default).
     //     "mode": "stealth"
     "mode": "eager"
   },

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4959,7 +4959,7 @@ impl Editor {
                 });
 
         let preview_requires_modifier =
-            all_language_settings(file, cx).edit_predictions_mode() == EditPredictionsMode::Stealth;
+            all_language_settings(file, cx).edit_predictions_mode() == EditPredictionsMode::Subtle;
 
         EditPredictionSettings::Enabled {
             show_in_menu,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4959,7 +4959,7 @@ impl Editor {
                 });
 
         let preview_requires_modifier =
-            all_language_settings(file, cx).edit_predictions_mode() == EditPredictionsMode::Auto;
+            all_language_settings(file, cx).edit_predictions_mode() == EditPredictionsMode::Stealth;
 
         EditPredictionSettings::Enabled {
             show_in_menu,

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -593,7 +593,7 @@ impl InlineCompletionButton {
         if cx.has_flag::<feature_flags::PredictEditsNonEagerModeFeatureFlag>() {
             let is_eager_preview_enabled = match settings.edit_predictions_mode() {
                 language::EditPredictionsMode::Stealth => false,
-                language::EditPredictionsMode::EagerPreview => true,
+                language::EditPredictionsMode::Eager => true,
             };
             menu = menu.separator().toggleable_entry(
                 "Eager Preview Mode",
@@ -609,7 +609,7 @@ impl InlineCompletionButton {
                             move |settings, _cx| {
                                 let new_mode = match is_eager_preview_enabled {
                                     true => language::EditPredictionsMode::Stealth,
-                                    false => language::EditPredictionsMode::EagerPreview,
+                                    false => language::EditPredictionsMode::Eager,
                                 };
 
                                 if let Some(edit_predictions) = settings.edit_predictions.as_mut() {

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -592,7 +592,7 @@ impl InlineCompletionButton {
 
         if cx.has_flag::<feature_flags::PredictEditsNonEagerModeFeatureFlag>() {
             let is_eager_preview_enabled = match settings.edit_predictions_mode() {
-                language::EditPredictionsMode::Stealth => false,
+                language::EditPredictionsMode::Subtle => false,
                 language::EditPredictionsMode::Eager => true,
             };
             menu = menu.separator().toggleable_entry(
@@ -608,7 +608,7 @@ impl InlineCompletionButton {
                             cx,
                             move |settings, _cx| {
                                 let new_mode = match is_eager_preview_enabled {
-                                    true => language::EditPredictionsMode::Stealth,
+                                    true => language::EditPredictionsMode::Subtle,
                                     false => language::EditPredictionsMode::Eager,
                                 };
 

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -592,7 +592,7 @@ impl InlineCompletionButton {
 
         if cx.has_flag::<feature_flags::PredictEditsNonEagerModeFeatureFlag>() {
             let is_eager_preview_enabled = match settings.edit_predictions_mode() {
-                language::EditPredictionsMode::Auto => false,
+                language::EditPredictionsMode::Stealth => false,
                 language::EditPredictionsMode::EagerPreview => true,
             };
             menu = menu.separator().toggleable_entry(
@@ -608,7 +608,7 @@ impl InlineCompletionButton {
                             cx,
                             move |settings, _cx| {
                                 let new_mode = match is_eager_preview_enabled {
-                                    true => language::EditPredictionsMode::Auto,
+                                    true => language::EditPredictionsMode::Stealth,
                                     false => language::EditPredictionsMode::EagerPreview,
                                 };
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -244,7 +244,7 @@ pub struct EditPredictionSettings {
 pub enum EditPredictionsMode {
     /// If provider supports it, display inline when holding modifier key (e.g., alt).
     /// Otherwise, eager preview is used.
-    Stealth,
+    Subtle,
     /// Display inline when there are no language server completions available.
     #[default]
     #[serde(alias = "eager_preview")]

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -247,7 +247,8 @@ pub enum EditPredictionsMode {
     Stealth,
     /// Display inline when there are no language server completions available.
     #[default]
-    EagerPreview,
+    #[serde(alias = "eager_preview")]
+    Eager,
 }
 
 #[derive(Clone, Debug, Default)]

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -244,7 +244,7 @@ pub struct EditPredictionSettings {
 pub enum EditPredictionsMode {
     /// If provider supports it, display inline when holding modifier key (e.g., alt).
     /// Otherwise, eager preview is used.
-    Auto,
+    Stealth,
     /// Display inline when there are no language server completions available.
     #[default]
     EagerPreview,


### PR DESCRIPTION
- `auto` -> `subtle`
- `eager_preview` -> `eager`

Release Notes:

- N/A
