### PR TITLE
vim: Allow left/right (h/l) motions to change lines + up/down (k/j) to move the cursor to the start/end

### DIFF
--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -81,12 +81,12 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &DeleteLeft, window, cx| {
         vim.record_current_action(cx);
         let times = Vim::take_count(cx);
-        vim.delete_motion(Motion::Left, times, window, cx);
+        vim.delete_motion(Motion::Left { wrap: true }, times, window, cx);
     });
     Vim::action(editor, cx, |vim, _: &DeleteRight, window, cx| {
         vim.record_current_action(cx);
         let times = Vim::take_count(cx);
-        vim.delete_motion(Motion::Right, times, window, cx);
+        vim.delete_motion(Motion::Right { wrap: true }, times, window, cx);
     });
     Vim::action(editor, cx, |vim, _: &ChangeToEndOfLine, window, cx| {
         vim.start_recording(cx);
@@ -284,7 +284,9 @@ impl Vim {
         self.switch_mode(Mode::Insert, false, window, cx);
         self.update_editor(window, cx, |_, editor, window, cx| {
             editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
-                s.move_cursors_with(|map, cursor, _| (right(map, cursor, 1), SelectionGoal::None));
+                s.move_cursors_with(|map, cursor, _| {
+                    (right(map, cursor, 1, false), SelectionGoal::None)
+                });
             });
         });
     }

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -24,8 +24,8 @@ impl Vim {
         // Some motions ignore failure when switching to normal mode
         let mut motion_succeeded = matches!(
             motion,
-            Motion::Left
-                | Motion::Right
+            Motion::Left { .. }
+                | Motion::Right { .. }
                 | Motion::EndOfLine { .. }
                 | Motion::Backspace
                 | Motion::StartOfLine { .. }

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -39,7 +39,7 @@ impl Vim {
                 editor.change_selections(None, window, cx, |s| {
                     s.move_with(|map, selection| {
                         if selection.start == selection.end {
-                            Motion::Right.expand_selection(
+                            Motion::Right { wrap: true }.expand_selection(
                                 map,
                                 selection,
                                 count,

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -583,7 +583,7 @@ fn in_word(
         .ignore_punctuation(ignore_punctuation);
     let start = movement::find_preceding_boundary_display_point(
         map,
-        right(map, relative_to, 1),
+        right(map, relative_to, 1, false),
         movement::FindRange::SingleLine,
         |left, right| classifier.kind(left) != classifier.kind(right),
     );
@@ -621,7 +621,7 @@ fn in_subword(
     let start = if in_subword {
         movement::find_preceding_boundary_display_point(
             map,
-            right(map, relative_to, 1),
+            right(map, relative_to, 1, false),
             movement::FindRange::SingleLine,
             |left, right| {
                 let is_word_start = classifier.kind(left) != classifier.kind(right);
@@ -775,7 +775,7 @@ fn around_subword(
         .ignore_punctuation(ignore_punctuation);
     let start = movement::find_preceding_boundary_display_point(
         map,
-        right(map, relative_to, 1),
+        right(map, relative_to, 1, false),
         movement::FindRange::SingleLine,
         |left, right| {
             let is_word_start = classifier.kind(left) != classifier.kind(right);
@@ -835,7 +835,7 @@ fn around_next_word(
     // Get the start of the word
     let start = movement::find_preceding_boundary_display_point(
         map,
-        right(map, relative_to, 1),
+        right(map, relative_to, 1, false),
         FindRange::SingleLine,
         |left, right| classifier.kind(left) != classifier.kind(right),
     );

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1641,12 +1641,42 @@ pub enum UseSystemClipboard {
     OnYank,
 }
 
+#[derive(Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundaryMovementsLeftRight {
+    /// Disable.
+    #[default]
+    Off,
+    /// Enable for both `h`/`l` and the arrows.
+    On,
+}
+
+#[derive(Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum BoundaryMovementsUpDown {
+    /// Disable.
+    #[default]
+    Off,
+    /// Enable for both `j`/`k` and the arrows.
+    On,
+}
+
+#[derive(Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+pub struct BoundaryMovements {
+    #[serde(default)]
+    left_right: BoundaryMovementsLeftRight,
+    #[serde(default)]
+    up_down: BoundaryMovementsUpDown,
+}
+
 #[derive(Deserialize)]
 struct VimSettings {
     pub toggle_relative_line_numbers: bool,
     pub use_system_clipboard: UseSystemClipboard,
     pub use_multiline_find: bool,
     pub use_smartcase_find: bool,
+    #[serde(default)]
+    pub boundary_movements: BoundaryMovements,
     pub custom_digraphs: HashMap<String, Arc<str>>,
     pub highlight_on_yank_duration: u64,
 }
@@ -1657,6 +1687,7 @@ struct VimSettingsContent {
     pub use_system_clipboard: Option<UseSystemClipboard>,
     pub use_multiline_find: Option<bool>,
     pub use_smartcase_find: Option<bool>,
+    pub boundary_movements: Option<BoundaryMovements>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_yank_duration: Option<u64>,
 }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/25510.

This pull request adds two config options:
- `"vim.boundary_movements.left_right"` (`"off" | "on"`)
- `"vim.boundary_movements.up_down"` (`"off" | "on"`)

They allow to toggle “wrapping” of the left/right and up/down motions in Vim mode (details in the [discussion](https://github.com/zed-industries/zed/discussions/25510)).

Potentially, this feature may be exapnded to only allow wrappings for the arrow/letter keys. That’s the reason why I chose to use strings (`"off"`, `"on"`) instead of booleans.

The changes are not breaking, so users aren’t required to modify their configuration files.

This is my first real open-source PR, so the implementation may not be the cleanest, but it works. I’ll be glad to hear feedback on how to improve code quality.

Also, I’m not a native English speaker, so the naming of the config options (and variables in the code) may not be accurate, I’m open to suggestions.