### PR TITLE
language_model: Use `LanguageModelToolUseId` instead of a `String`

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -518,7 +518,7 @@ impl Thread {
                         match output {
                             Ok(output) => {
                                 tool_results.push(LanguageModelToolResult {
-                                    tool_use_id: tool_use_id.to_string(),
+                                    tool_use_id: tool_use_id.clone(),
                                     content: output,
                                     is_error: false,
                                 });
@@ -527,7 +527,7 @@ impl Thread {
                             }
                             Err(err) => {
                                 tool_results.push(LanguageModelToolResult {
-                                    tool_use_id: tool_use_id.to_string(),
+                                    tool_use_id: tool_use_id.clone(),
                                     content: err.to_string(),
                                     is_error: true,
                                 });

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -1,7 +1,7 @@
 use std::io::{Cursor, Write};
 
 use crate::role::Role;
-use crate::LanguageModelToolUse;
+use crate::{LanguageModelToolUse, LanguageModelToolUseId};
 use base64::write::EncoderWriter;
 use gpui::{
     point, size, App, AppContext as _, DevicePixels, Image, ObjectFit, RenderImage, Size, Task,
@@ -165,7 +165,7 @@ impl LanguageModelImage {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq, Hash)]
 pub struct LanguageModelToolResult {
-    pub tool_use_id: String,
+    pub tool_use_id: LanguageModelToolUseId,
     pub is_error: bool,
     pub content: String,
 }

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -513,7 +513,7 @@ pub fn into_anthropic(
                         }
                         MessageContent::ToolResult(tool_result) => {
                             Some(anthropic::RequestContent::ToolResult {
-                                tool_use_id: tool_result.tool_use_id,
+                                tool_use_id: tool_result.tool_use_id.to_string(),
                                 is_error: tool_result.is_error,
                                 content: tool_result.content,
                                 cache_control,


### PR DESCRIPTION
This PR updates the `LanguageModelToolResult` type to use a `LanguageModelToolUseId` for the tool use ID instead of a `String`.

Release Notes:

- N/A
