### PR TITLE
vim: Fix search submit panic

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -187,13 +187,13 @@ impl Vim {
                 let direction = self.search.direction;
                 search_bar.has_active_match();
                 let new_head = new_selections.last().unwrap().start;
-                let old_head = self
+                let is_new_selection = self
                     .search
                     .prior_selections
                     .last()
-                    .is_some_and(|range| range.start != new_head);
+                    .map_or(true, |old_range| old_range.start != new_head);
 
-                if old_head && self.search.direction == Direction::Next {
+                if is_new_selection && self.search.direction == Direction::Next {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -187,13 +187,13 @@ impl Vim {
                 let direction = self.search.direction;
                 search_bar.has_active_match();
                 let new_head = new_selections.last().unwrap().start;
-                let is_new_selection = self
+                let is_different_head = self
                     .search
                     .prior_selections
                     .last()
-                    .map_or(true, |old_range| old_range.start != new_head);
+                    .map_or(true, |range| range.start != new_head);
 
-                if is_new_selection && self.search.direction == Direction::Next {
+                if is_different_head && self.search.direction == Direction::Next {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -187,9 +187,13 @@ impl Vim {
                 let direction = self.search.direction;
                 search_bar.has_active_match();
                 let new_head = new_selections.last().unwrap().start;
-                let old_head = self.search.prior_selections.last().unwrap().start;
+                let old_head = self
+                    .search
+                    .prior_selections
+                    .last()
+                    .is_some_and(|range| range.start != new_head);
 
-                if new_head != old_head && self.search.direction == Direction::Next {
+                if old_head && self.search.direction == Direction::Next {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;


### PR DESCRIPTION
In file search submit action, handle unwrap when there are no prior selection.

Fix is for recently made commits, hence no release notes.

Release Notes:

- vim: Fixed a panic when submitting a search.
