### PR TITLE
vim: Combine match arms in `Mode::is_visual`

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -45,9 +45,8 @@ impl Display for Mode {
 impl Mode {
     pub fn is_visual(&self) -> bool {
         match self {
-            Mode::Normal | Mode::Insert | Mode::Replace => false,
-            Mode::Visual | Mode::VisualLine | Mode::VisualBlock => true,
-            Mode::HelixNormal => false,
+            Self::Visual | Self::VisualLine | Self::VisualBlock => true,
+            Self::Normal | Self::Insert | Self::Replace | Self::HelixNormal => false,
         }
     }
 }


### PR DESCRIPTION
This PR refactors the `Mode::is_visual` implementation to combine some of the `match` arms.

Release Notes:

- N/A
