### PR TITLE
Update git panel entry checked box tooltip to say Stage/Unstage

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2486,6 +2486,7 @@ impl GitPanel {
 
         let id: ElementId = ElementId::Name(format!("entry_{}", display_name).into());
 
+        let is_entry_staged = self.entry_is_staged(entry);
         let mut is_staged: ToggleState = self.entry_is_staged(entry).into();
 
         if !self.has_staged_changes() && !self.has_conflicts() && !entry.status.is_created() {
@@ -2509,18 +2510,23 @@ impl GitPanel {
                 })
             });
 
-        let start_slot =
-            h_flex()
-                .id(("start-slot", ix))
-                .gap(DynamicSpacing::Base04.rems(cx))
-                .child(checkbox.tooltip(|window, cx| {
-                    Tooltip::for_action("Stage File", &ToggleStaged, window, cx)
-                }))
-                .child(git_status_icon(status, cx))
-                .on_mouse_down(MouseButton::Left, |_, _, cx| {
-                    // prevent the list item active state triggering when toggling checkbox
-                    cx.stop_propagation();
-                });
+        let start_slot = h_flex()
+            .id(("start-slot", ix))
+            .gap(DynamicSpacing::Base04.rems(cx))
+            .child(checkbox.tooltip(move |window, cx| {
+                let tooltip_name = if is_entry_staged.unwrap_or(false) {
+                    "Unstage"
+                } else {
+                    "Stage"
+                };
+
+                Tooltip::for_action(tooltip_name, &ToggleStaged, window, cx)
+            }))
+            .child(git_status_icon(status, cx))
+            .on_mouse_down(MouseButton::Left, |_, _, cx| {
+                // prevent the list item active state triggering when toggling checkbox
+                cx.stop_propagation();
+            });
 
         div()
             .w_full()


### PR DESCRIPTION
Before it would always say staged when a user hovered over the check box. Now it will show the correct hover message depending on the state of the entry

Release Notes:

- N/A
