### PR TITLE
language_settings: Add `auto` alias for subtle edit prediction mode

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -244,6 +244,7 @@ pub struct EditPredictionSettings {
 pub enum EditPredictionsMode {
     /// If provider supports it, display inline when holding modifier key (e.g., alt).
     /// Otherwise, eager preview is used.
+    #[serde(alias = "auto")]
     Subtle,
     /// Display inline when there are no language server completions available.
     #[default]


### PR DESCRIPTION
This PR makes `auto` an alias for the `subtle` edit prediction mode.

Right now I'm in a state where I can't have valid settings in both development and Nightly because the settings values are disparate.

Release Notes:

- N/A
