### PR TITLE
Fix cursor position when navigating to a multibuffer's first excerpt

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -7,7 +7,7 @@ use collections::HashSet;
 use editor::{
     actions::{GoToHunk, GoToPrevHunk},
     scroll::Autoscroll,
-    Editor, EditorEvent, ToPoint,
+    Editor, EditorEvent, ToOffset, ToPoint,
 };
 use feature_flags::FeatureFlagViewExt;
 use futures::StreamExt;
@@ -927,6 +927,8 @@ impl Render for ProjectDiffToolbar {
 
 #[cfg(test)]
 mod tests {
+    use std::path::Path;
+
     use collections::HashMap;
     use editor::test::editor_test_context::assert_state_with_diff;
     use git::status::{StatusCode, TrackedStatus};
@@ -1012,5 +1014,99 @@ mod tests {
 
         let text = String::from_utf8(fs.read_file_sync("/project/foo").unwrap()).unwrap();
         assert_eq!(text, "foo\n");
+    }
+
+    #[gpui::test]
+    async fn test_scroll_to_beginning_with_deletion(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree(
+            path!("/project"),
+            json!({
+                ".git": {},
+                "bar": "BAR\n",
+                "foo": "FOO\n",
+            }),
+        )
+        .await;
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let diff = cx.new_window_entity(|window, cx| {
+            ProjectDiff::new(project.clone(), workspace, window, cx)
+        });
+        cx.run_until_parked();
+
+        fs.set_head_for_repo(
+            path!("/project/.git").as_ref(),
+            &[
+                ("bar".into(), "bar\n".into()),
+                ("foo".into(), "foo\n".into()),
+            ],
+        );
+        fs.with_git_state(path!("/project/.git").as_ref(), true, |state| {
+            state.statuses = HashMap::from_iter([
+                (
+                    "bar".into(),
+                    TrackedStatus {
+                        index_status: StatusCode::Unmodified,
+                        worktree_status: StatusCode::Modified,
+                    }
+                    .into(),
+                ),
+                (
+                    "foo".into(),
+                    TrackedStatus {
+                        index_status: StatusCode::Unmodified,
+                        worktree_status: StatusCode::Modified,
+                    }
+                    .into(),
+                ),
+            ]);
+        });
+        cx.run_until_parked();
+
+        let editor = cx.update_window_entity(&diff, |diff, window, cx| {
+            diff.scroll_to_path(
+                PathKey::namespaced(TRACKED_NAMESPACE, Path::new("foo").into()),
+                window,
+                cx,
+            );
+            diff.editor.clone()
+        });
+        assert_state_with_diff(
+            &editor,
+            cx,
+            &"
+                - bar
+                + BAR
+
+                - ˇfoo
+                + FOO
+            "
+            .unindent(),
+        );
+
+        let editor = cx.update_window_entity(&diff, |diff, window, cx| {
+            diff.scroll_to_path(
+                PathKey::namespaced(TRACKED_NAMESPACE, Path::new("bar").into()),
+                window,
+                cx,
+            );
+            diff.editor.clone()
+        });
+        assert_state_with_diff(
+            &editor,
+            cx,
+            &"
+                - ˇbar
+                + BAR
+
+                - foo
+                + FOO
+            "
+            .unindent(),
+        );
     }
 }

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -7,7 +7,7 @@ use collections::HashSet;
 use editor::{
     actions::{GoToHunk, GoToPrevHunk},
     scroll::Autoscroll,
-    Editor, EditorEvent, ToOffset, ToPoint,
+    Editor, EditorEvent, ToPoint,
 };
 use feature_flags::FeatureFlagViewExt;
 use futures::StreamExt;

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4528,7 +4528,6 @@ impl MultiBufferSnapshot {
                     base_text_byte_range,
                     ..
                 }) => {
-                    let mut in_deleted_hunk = false;
                     if let Some(diff_base_anchor) = &anchor.diff_base_anchor {
                         if let Some(base_text) =
                             self.diffs.get(buffer_id).and_then(|diff| diff.base_text())
@@ -4543,16 +4542,12 @@ impl MultiBufferSnapshot {
                                             base_text_byte_range.start..base_text_offset,
                                         );
                                     position.add_assign(&position_in_hunk);
-                                    in_deleted_hunk = true;
                                 } else if at_transform_end {
                                     diff_transforms.next(&());
                                     continue;
                                 }
                             }
                         }
-                    }
-                    if !in_deleted_hunk {
-                        position = diff_transforms.end(&()).1 .0;
                     }
                 }
                 _ => {


### PR DESCRIPTION
This PR fixes an unexpected cursor position when jumping to the beginning of the project diff editor's first excerpt if that excerpt starts with a deleted region. Previously, the cursor would end up in the *following* region in this situation; now it ends up at the start of the deleted region, as happens already for excerpts that are not the first.

Release Notes:

- N/A
