### PR TITLE
lsp: Add support for Clang `inactiveRegions` extension

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -838,18 +838,21 @@ impl LanguageServer {
             const METHOD: &'static str = Initialize::METHOD;
         }
         let mut params = serde_json::to_value(params).unwrap();
-        merge_non_null_json_value_into(
-            serde_json::json!({
-                "capabilities": {
-                    "textDocument": {
-                        "inactiveRegionsCapabilities": {
-                            "inactiveRegions": true,
+
+        if self.name().0 == "clangd" {
+            merge_non_null_json_value_into(
+                serde_json::json!({
+                    "capabilities": {
+                        "textDocument": {
+                            "inactiveRegionsCapabilities": {
+                                "inactiveRegions": true,
+                            }
                         }
                     }
-                }
-            }),
-            &mut params,
-        );
+                }),
+                &mut params,
+            );
+        }
 
         cx.spawn(|_| async move {
             let response = self.request::<InitializeExtended>(params).await?;


### PR DESCRIPTION
Closes #13089 

Notes:
1. I was not sure where to place language specific lsp notifications, I couldn't find any language specific notifications in the codebase.
2. I had to create a `lsp_types::Initialize` newtype since the `lsp_types` crate doesn't allow inserting arbitrary objects into `InitializeParams` object.

Release Notes:

- Added support for clangd's inactiveRegions extension