### PR TITLE
assistant2: Fix submit button width depending on certain conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,7 @@ dependencies = [
  "ui",
  "util",
  "uuid",
+ "vim_mode_setting",
  "workspace",
  "zed_actions",
 ]

--- a/crates/assistant2/Cargo.toml
+++ b/crates/assistant2/Cargo.toml
@@ -73,6 +73,7 @@ time_format.workspace = true
 ui.workspace = true
 util.workspace = true
 uuid.workspace = true
+vim_mode_setting.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -14,8 +14,10 @@ use std::time::Duration;
 use text::Bias;
 use theme::ThemeSettings;
 use ui::{
-    prelude::*, ButtonLike, KeyBinding, PopoverMenu, PopoverMenuHandle, Switch, TintColor, Tooltip,
+    prelude::*, ButtonLike, KeyBinding, PlatformStyle, PopoverMenu, PopoverMenuHandle, Switch,
+    TintColor, Tooltip,
 };
+use vim_mode_setting::VimModeSetting;
 use workspace::Workspace;
 
 use crate::assistant_model_selector::AssistantModelSelector;
@@ -274,13 +276,22 @@ impl Render for MessageEditor {
         let inline_context_picker = self.inline_context_picker.clone();
         let bg_color = cx.theme().colors().editor_background;
         let is_streaming_completion = self.thread.read(cx).is_streaming();
-        let button_width = px(64.);
         let is_model_selected = self.is_model_selected(cx);
         let is_editor_empty = self.is_editor_empty(cx);
         let submit_label_color = if is_editor_empty {
             Color::Muted
         } else {
             Color::Default
+        };
+
+        let vim_mode_enabled = VimModeSetting::get_global(cx).0;
+        let platform = PlatformStyle::platform();
+        let linux = platform == PlatformStyle::Linux;
+        let windows = platform == PlatformStyle::Windows;
+        let button_width = if linux || windows || vim_mode_enabled {
+            px(92.)
+        } else {
+            px(64.)
         };
 
         v_flex()


### PR DESCRIPTION
This PR makes the Assistant 2 submit button have a different width if the platform is Linux or Windows, or if Vim mode is turned on. That's because we now use written out words instead of icons for keybindings when in those conditions.

| Before | After |
|--------|--------|
| ![CleanShot 2025-02-27 at 9  59 10@2x](https://github.com/user-attachments/assets/f1f8e27c-71c2-402c-8f7b-f9ed91e8e3bf) | ![CleanShot 2025-02-27 at 9  56 59@2x](https://github.com/user-attachments/assets/ad13b179-daf7-4b38-83e8-1511deb97d96) | 

Release Notes:

- N/A
