### PR TITLE
Support absolute `disabled_globs`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -829,7 +829,8 @@
     // A list of globs representing files that edit predictions should be disabled for.
     // There's a sensible default list of globs already included.
     // Any addition to this list will be merged with the default list.
-    // Note: File path globs are matched relative to the worktree root, except when starting with a slash (/) or equivalent.
+    // Globs are matched relative to the worktree root,
+    // except when starting with a slash (/) or equivalent in Windows.
     "disabled_globs": [
       "**/.env*",
       "**/*.pem",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -829,6 +829,7 @@
     // A list of globs representing files that edit predictions should be disabled for.
     // There's a sensible default list of globs already included.
     // Any addition to this list will be merged with the default list.
+    // Note: File path globs are matched relative to the worktree root, except when starting with a slash (/) or equivalent.
     "disabled_globs": [
       "**/.env*",
       "**/*.pem",

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -192,7 +192,7 @@ impl EditPredictionProvider for CopilotCompletionProvider {
     fn discard(&mut self, cx: &mut Context<Self>) {
         let settings = AllLanguageSettings::get_global(cx);
 
-        let copilot_enabled = settings.show_inline_completions(None, cx);
+        let copilot_enabled = settings.show_edit_predictions(None, cx);
 
         if !copilot_enabled {
             return;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5005,7 +5005,7 @@ impl Editor {
                 return Some(true);
             };
             let settings = all_language_settings(Some(file), cx);
-            Some(settings.inline_completions_enabled_for_path(file.path()))
+            Some(settings.inline_completions_enabled_for_file(file, cx))
         })
         .unwrap_or(false)
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5005,7 +5005,7 @@ impl Editor {
                 return Some(true);
             };
             let settings = all_language_settings(Some(file), cx);
-            Some(settings.inline_completions_enabled_for_file(file, cx))
+            Some(settings.edit_predictions_enabled_for_file(file, cx))
         })
         .unwrap_or(false)
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1739,6 +1739,7 @@ mod tests {
         let file = TestFile {
             path: Path::new("").into(),
             root_name: String::new(),
+            local_root: None,
         };
         assert_eq!(path_for_file(&file, 0, false, cx), None);
     }

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -456,7 +456,7 @@ impl InlineCompletionButton {
         }
 
         let settings = AllLanguageSettings::get_global(cx);
-        let globally_enabled = settings.show_inline_completions(None, cx);
+        let globally_enabled = settings.show_edit_predictions(None, cx);
         menu = menu.toggleable_entry("All Files", globally_enabled, IconPosition::Start, None, {
             let fs = fs.clone();
             move |_, cx| toggle_inline_completions_globally(fs.clone(), cx)
@@ -702,7 +702,7 @@ impl InlineCompletionButton {
             Some(
                 file.map(|file| {
                     all_language_settings(Some(file), cx)
-                        .inline_completions_enabled_for_file(file, cx)
+                        .edit_predictions_enabled_for_file(file, cx)
                 })
                 .unwrap_or(true),
             )
@@ -825,7 +825,7 @@ async fn open_disabled_globs_setting_in_editor(
 }
 
 fn toggle_inline_completions_globally(fs: Arc<dyn Fs>, cx: &mut App) {
-    let show_edit_predictions = all_language_settings(None, cx).show_inline_completions(None, cx);
+    let show_edit_predictions = all_language_settings(None, cx).show_edit_predictions(None, cx);
     update_settings_file::<AllLanguageSettings>(fs, cx, move |file, _| {
         file.defaults.show_edit_predictions = Some(!show_edit_predictions)
     });
@@ -845,7 +845,7 @@ fn toggle_show_inline_completions_for_language(
     cx: &mut App,
 ) {
     let show_edit_predictions =
-        all_language_settings(None, cx).show_inline_completions(Some(&language), cx);
+        all_language_settings(None, cx).show_edit_predictions(Some(&language), cx);
     update_settings_file::<AllLanguageSettings>(fs, cx, move |file, _| {
         file.languages
             .entry(language.name())

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -702,7 +702,7 @@ impl InlineCompletionButton {
             Some(
                 file.map(|file| {
                     all_language_settings(Some(file), cx)
-                        .inline_completions_enabled_for_path(file.path())
+                        .inline_completions_enabled_for_file(file, cx)
                 })
                 .unwrap_or(true),
             )

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4478,6 +4478,7 @@ impl IndentSize {
 pub struct TestFile {
     pub path: Arc<Path>,
     pub root_name: String,
+    pub local_root: Option<PathBuf>,
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -4491,7 +4492,11 @@ impl File for TestFile {
     }
 
     fn as_local(&self) -> Option<&dyn LocalFile> {
-        None
+        if self.local_root.is_some() {
+            Some(self)
+        } else {
+            None
+        }
     }
 
     fn disk_state(&self) -> DiskState {
@@ -4516,6 +4521,23 @@ impl File for TestFile {
 
     fn is_private(&self) -> bool {
         false
+    }
+}
+
+#[cfg(any(test, feature = "test-support"))]
+impl LocalFile for TestFile {
+    fn abs_path(&self, _cx: &App) -> PathBuf {
+        PathBuf::from(self.local_root.as_ref().unwrap())
+            .join(&self.root_name)
+            .join(self.path.as_ref())
+    }
+
+    fn load(&self, _cx: &App) -> Task<Result<String>> {
+        unimplemented!()
+    }
+
+    fn load_bytes(&self, _cx: &App) -> Task<Result<Vec<u8>>> {
+        unimplemented!()
     }
 }
 

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -254,6 +254,7 @@ fn file(path: &str) -> Arc<dyn File> {
     Arc::new(TestFile {
         path: Path::new(path).into(),
         root_name: "zed".into(),
+        local_root: None,
     })
 }
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1489,6 +1489,14 @@ mod tests {
         // Test directory/** glob
         let settings = build_settings(&["src/**"]);
         assert!(!settings.enabled_for_file(&test_file, &cx));
+
+        let test_file_root: Arc<dyn File> = Arc::new(TestFile {
+            path: PathBuf::from("file.rs").as_path().into(),
+            root_name: WORKTREE_NAME.to_string(),
+            local_root: Some(PathBuf::from("/absolute/")),
+        });
+        assert!(settings.enabled_for_file(&test_file_root, &cx));
+
         let settings = build_settings(&["other/**"]);
         assert!(settings.enabled_for_file(&test_file, &cx));
 
@@ -1510,7 +1518,7 @@ mod tests {
             root_name: WORKTREE_NAME.to_string(),
             local_root: Some(PathBuf::from("/abs/")),
         });
-        let settings = build_settings(&[".*", "**/.config/*"]);
+        let settings = build_settings(&[".*"]);
         assert!(!settings.enabled_for_file(&dot_file, &cx));
 
         let dot_env_file: Arc<dyn File> = Arc::new(TestFile {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1423,7 +1423,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_inline_completions_enabled_for_file(cx: &mut TestAppContext) {
+    fn test_edit_predictions_enabled_for_file(cx: &mut TestAppContext) {
         use crate::TestFile;
         use std::path::PathBuf;
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -983,13 +983,12 @@ impl AllLanguageSettings {
     }
 
     /// Returns whether edit predictions are enabled for the given path.
-    ///  todo! az rename
-    pub fn inline_completions_enabled_for_file(&self, file: &Arc<dyn File>, cx: &App) -> bool {
+    pub fn edit_predictions_enabled_for_file(&self, file: &Arc<dyn File>, cx: &App) -> bool {
         self.edit_predictions.enabled_for_file(file, cx)
     }
 
     /// Returns whether edit predictions are enabled for the given language and path.
-    pub fn show_inline_completions(&self, language: Option<&Arc<Language>>, cx: &App) -> bool {
+    pub fn show_edit_predictions(&self, language: Option<&Arc<Language>>, cx: &App) -> bool {
         self.language(None, language.map(|l| l.name()).as_ref(), cx)
             .show_edit_predictions
     }
@@ -1446,7 +1445,7 @@ mod tests {
         const WORKTREE_NAME: &str = "project";
 
         let test_file: Arc<dyn File> = Arc::new(TestFile {
-            path: PathBuf::from(format!("src/test/file.rs")).as_path().into(),
+            path: PathBuf::from("src/test/file.rs").as_path().into(),
             root_name: WORKTREE_NAME.to_string(),
             local_root: Some(PathBuf::from("/absolute/")),
         });


### PR DESCRIPTION
Closes: #25556

We were always comparing `disabled_globs` against the relative file path, we'll now use the absolute path if the glob is also absolute.

Release Notes:

- Support absolute globs in `edit_predictions.disabled_globs`
