### PR TITLE
edit predictions: Add `enabled_in_assistant` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -844,7 +844,10 @@
     //     "mode": "eager"
     // 2. Display predictions inline only when holding a modifier key (alt by default).
     //     "mode": "subtle"
-    "mode": "eager"
+    "mode": "eager",
+    // Whether edit predictions are enabled in the assistant prompt editor.
+    // This setting has no effect if globally disabled.
+    "enabled_in_assistant": true
   },
   // Settings specific to journaling
   "journal": {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1999,7 +1999,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.show_inline_completions_override = show_edit_predictions;
+        self.show_inline_completions_override = dbg!(show_edit_predictions);
         self.update_edit_prediction_settings(cx);
 
         if let Some(false) = show_edit_predictions {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1999,7 +1999,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.show_inline_completions_override = dbg!(show_edit_predictions);
+        self.show_inline_completions_override = show_edit_predictions;
         self.update_edit_prediction_settings(cx);
 
         if let Some(false) = show_edit_predictions {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1110,11 +1110,11 @@ impl settings::Settings for AllLanguageSettings {
             })
             .unwrap_or_default();
 
-        let mut edit_predictions_enabled_in_assistant = dbg!(default_value
+        let mut edit_predictions_enabled_in_assistant = default_value
             .edit_predictions
             .as_ref()
-            .map(|settings| settings.enabled_in_assistant))
-        .unwrap_or(true);
+            .map(|settings| settings.enabled_in_assistant)
+            .unwrap_or(true);
 
         let mut file_types: HashMap<Arc<str>, GlobSet> = HashMap::default();
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -236,6 +236,9 @@ pub struct EditPredictionSettings {
     pub mode: EditPredictionsMode,
     /// Settings specific to GitHub Copilot.
     pub copilot: CopilotSettings,
+    /// Whether edit predictions are enabled in the assistant prompt editor.
+    /// This setting has no effect if globally disabled.
+    pub enabled_in_assistant: bool,
 }
 
 /// The mode in which edit predictions should be displayed.
@@ -480,6 +483,10 @@ pub struct EditPredictionSettingsContent {
     /// Settings specific to GitHub Copilot.
     #[serde(default)]
     pub copilot: CopilotSettingsContent,
+    /// Whether edit predictions are enabled in the assistant prompt editor.
+    /// This has no effect if globally disabled.
+    #[serde(default = "default_true")]
+    pub enabled_in_assistant: bool,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq)]
@@ -1103,6 +1110,12 @@ impl settings::Settings for AllLanguageSettings {
             })
             .unwrap_or_default();
 
+        let mut edit_predictions_enabled_in_assistant = dbg!(default_value
+            .edit_predictions
+            .as_ref()
+            .map(|settings| settings.enabled_in_assistant))
+        .unwrap_or(true);
+
         let mut file_types: HashMap<Arc<str>, GlobSet> = HashMap::default();
 
         for (language, suffixes) in &default_value.file_types {
@@ -1129,6 +1142,7 @@ impl settings::Settings for AllLanguageSettings {
 
             if let Some(edit_predictions) = user_settings.edit_predictions.as_ref() {
                 edit_predictions_mode = edit_predictions.mode;
+                edit_predictions_enabled_in_assistant = edit_predictions.enabled_in_assistant;
 
                 if let Some(disabled_globs) = edit_predictions.disabled_globs.as_ref() {
                     completion_globs.extend(disabled_globs.iter());
@@ -1203,6 +1217,7 @@ impl settings::Settings for AllLanguageSettings {
                     .collect(),
                 mode: edit_predictions_mode,
                 copilot: copilot_settings,
+                enabled_in_assistant: edit_predictions_enabled_in_assistant,
             },
             defaults,
             languages,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -406,6 +406,12 @@ There are two options to choose from:
 
 List of `string` values.
 
+### Enabled in Assistant
+
+- Description: Whether to show edit predictions in the assistant's prompt editor.
+- Setting: `enabled_in_assistant`
+- Default: `true`
+
 ## Edit Predictions Disabled in
 
 - Description: A list of language scopes in which edit predictions should be disabled.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/16787

Release Notes:

- edit predictions: Add `enabled_in_assistant` setting 
