### PR TITLE
edit predictions: Fix docs for `enabled_in_assistant`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -847,7 +847,7 @@
     // 2. Display predictions inline only when holding a modifier key (alt by default).
     //     "mode": "subtle"
     "mode": "eager",
-    // Whether edit predictions are enabled in the assistant prompt editor.
+    // Whether edit predictions are enabled in the assistant panel.
     // This setting has no effect if globally disabled.
     "enabled_in_assistant": true
   },

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -236,7 +236,7 @@ pub struct EditPredictionSettings {
     pub mode: EditPredictionsMode,
     /// Settings specific to GitHub Copilot.
     pub copilot: CopilotSettings,
-    /// Whether edit predictions are enabled in the assistant prompt editor.
+    /// Whether edit predictions are enabled in the assistant panel.
     /// This setting has no effect if globally disabled.
     pub enabled_in_assistant: bool,
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -408,7 +408,7 @@ List of `string` values.
 
 ### Enabled in Assistant
 
-- Description: Whether to show edit predictions in the assistant's prompt editor.
+- Description: Whether to show edit predictions in the assistant panel.
 - Setting: `enabled_in_assistant`
 - Default: `true`
 


### PR DESCRIPTION
Remove mention of "prompt editor" since that feature isn't out yet.

Release Notes:

- N/A 