### PR TITLE
Fix panic when scrolling in project diff

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -281,6 +281,7 @@ impl ProjectDiff {
                 let snapshot = multibuffer.snapshot(cx);
                 let mut point = anchor.to_point(&snapshot);
                 point.row = (point.row + 1).min(snapshot.max_row().0);
+                point.column = 0;
 
                 let Some((_, buffer, _)) = self.multibuffer.read(cx).excerpt_containing(point, cx)
                 else {


### PR DESCRIPTION
It may happen that the column for the scroll anchor is nonzero, and the adjustment we're doing here could result in an invalid point in that case.

Release Notes:

- N/A