### PR TITLE
markdown_preview: Fix markdown preview not updating on `AcceptEditPrediction`

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -317,7 +317,9 @@ impl MarkdownPreviewView {
             window,
             |this, editor, event: &EditorEvent, window, cx| {
                 match event {
-                    EditorEvent::Edited { .. } | EditorEvent::DirtyChanged => {
+                    EditorEvent::Edited { .. }
+                    | EditorEvent::DirtyChanged
+                    | EditorEvent::ExcerptsEdited { .. } => {
                         this.parse_markdown_from_active_editor(true, window, cx);
                     }
                     EditorEvent::SelectionsChanged { .. } => {


### PR DESCRIPTION
Closes #25384

Markdown preview now subscribes to `ExcerptsEdited` event which is emited when edit prediction is accepted.

Release Notes:

- Fixed markdown preview not updating when edit prediction is accepted.
