### PR TITLE
title_bar: Fix the order of the collab buttons

### DIFF
--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -350,42 +350,6 @@ impl TitleBar {
                 .into_any_element(),
         );
 
-        children.push(
-            IconButton::new(
-                "mute-sound",
-                if is_deafened {
-                    ui::IconName::AudioOff
-                } else {
-                    ui::IconName::AudioOn
-                },
-            )
-            .style(ButtonStyle::Subtle)
-            .selected_style(ButtonStyle::Tinted(TintColor::Error))
-            .icon_size(IconSize::Small)
-            .toggle_state(is_deafened)
-            .tooltip(move |window, cx| {
-                if is_deafened {
-                    let label = "Unmute Audio";
-
-                    if !muted_by_user {
-                        Tooltip::with_meta(label, None, "Microphone will be unmuted", window, cx)
-                    } else {
-                        Tooltip::simple(label, cx)
-                    }
-                } else {
-                    let label = "Mute Audio";
-
-                    if !muted_by_user {
-                        Tooltip::with_meta(label, None, "Microphone will be muted", window, cx)
-                    } else {
-                        Tooltip::simple(label, cx)
-                    }
-                }
-            })
-            .on_click(move |_, _, cx| toggle_deafen(&Default::default(), cx))
-            .into_any_element(),
-        );
-
         if can_use_microphone {
             children.push(
                 IconButton::new(
@@ -422,25 +386,61 @@ impl TitleBar {
                 })
                 .into_any_element(),
             );
+        }
 
-            if screen_sharing_supported {
-                children.push(
-                    IconButton::new("screen-share", ui::IconName::Screen)
-                        .style(ButtonStyle::Subtle)
-                        .icon_size(IconSize::Small)
-                        .toggle_state(is_screen_sharing)
-                        .selected_style(ButtonStyle::Tinted(TintColor::Accent))
-                        .tooltip(Tooltip::text(if is_screen_sharing {
-                            "Stop Sharing Screen"
-                        } else {
-                            "Share Screen"
-                        }))
-                        .on_click(move |_, window, cx| {
-                            toggle_screen_sharing(&Default::default(), window, cx)
-                        })
-                        .into_any_element(),
-                );
-            }
+        children.push(
+            IconButton::new(
+                "mute-sound",
+                if is_deafened {
+                    ui::IconName::AudioOff
+                } else {
+                    ui::IconName::AudioOn
+                },
+            )
+            .style(ButtonStyle::Subtle)
+            .selected_style(ButtonStyle::Tinted(TintColor::Error))
+            .icon_size(IconSize::Small)
+            .toggle_state(is_deafened)
+            .tooltip(move |window, cx| {
+                if is_deafened {
+                    let label = "Unmute Audio";
+
+                    if !muted_by_user {
+                        Tooltip::with_meta(label, None, "Microphone will be unmuted", window, cx)
+                    } else {
+                        Tooltip::simple(label, cx)
+                    }
+                } else {
+                    let label = "Mute Audio";
+
+                    if !muted_by_user {
+                        Tooltip::with_meta(label, None, "Microphone will be muted", window, cx)
+                    } else {
+                        Tooltip::simple(label, cx)
+                    }
+                }
+            })
+            .on_click(move |_, _, cx| toggle_deafen(&Default::default(), cx))
+            .into_any_element(),
+        );
+
+        if can_use_microphone && screen_sharing_supported {
+            children.push(
+                IconButton::new("screen-share", ui::IconName::Screen)
+                    .style(ButtonStyle::Subtle)
+                    .icon_size(IconSize::Small)
+                    .toggle_state(is_screen_sharing)
+                    .selected_style(ButtonStyle::Tinted(TintColor::Accent))
+                    .tooltip(Tooltip::text(if is_screen_sharing {
+                        "Stop Sharing Screen"
+                    } else {
+                        "Share Screen"
+                    }))
+                    .on_click(move |_, window, cx| {
+                        toggle_screen_sharing(&Default::default(), window, cx)
+                    })
+                    .into_any_element(),
+            );
         }
 
         children.push(div().pr_2().into_any_element());


### PR DESCRIPTION
My previous #24761 and #25192 PR's changed the order of the buttons in the title_bar for collab, the logic is kept the same but the order is now as it was previously.

Release Notes:

- N/A
