### PR TITLE
edit predictions: Remove `enabled_in_assistant` docs for now

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -406,12 +406,6 @@ There are two options to choose from:
 
 List of `string` values.
 
-### Enabled in Assistant
-
-- Description: Whether to show edit predictions in the assistant panel.
-- Setting: `enabled_in_assistant`
-- Default: `true`
-
 ## Edit Predictions Disabled in
 
 - Description: A list of language scopes in which edit predictions should be disabled.


### PR DESCRIPTION
I shouldn't have added this because it's not out yet

Release Notes:

- N/A