### PR TITLE
docs: Add note about `path` in `extensions.toml`

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -111,6 +111,8 @@ submodule = "extensions/my-extension"
 version = "0.0.1"
 ```
 
+> If your extension is in a subdirectory within the submodule you can use the `path` field to point to where the extension resides.
+
 3. Run `pnpm sort-extensions` to ensure `extensions.toml` and `.gitmodules` are sorted
 
 Once your PR is merged, the extension will be packaged and published to the Zed extension registry.


### PR DESCRIPTION
This PR adds a note about the `path` field in `extensions.toml` and how to use it.

Suggested in https://github.com/zed-industries/extensions/pull/2128.

Release Notes:

- N/A
