### PR TITLE
Use consistent comment style in `default.json`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -176,8 +176,8 @@
   "show_completion_documentation": true,
   // Show method signatures in the editor, when inside parentheses.
   "auto_signature_help": false,
-  /// Whether to show the signature help after completion or a bracket pair inserted.
-  /// If `auto_signature_help` is enabled, this setting will be treated as enabled also.
+  // Whether to show the signature help after completion or a bracket pair inserted.
+  // If `auto_signature_help` is enabled, this setting will be treated as enabled also.
   "show_signature_help_after_edits": false,
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
@@ -298,11 +298,11 @@
     //  - "information": show only errors, warnings, and information
     //  - "all" or true: show all diagnostics
     "diagnostics": "all",
-    /// Forcefully enable or disable the scrollbar for each axis
+    // Forcefully enable or disable the scrollbar for each axis
     "axes": {
-      /// When false, forcefully disables the horizontal scrollbar. Otherwise, obey other settings.
+      // When false, forcefully disables the horizontal scrollbar. Otherwise, obey other settings.
       "horizontal": true,
-      /// When false, forcefully disables the vertical scrollbar. Otherwise, obey other settings.
+      // When false, forcefully disables the vertical scrollbar. Otherwise, obey other settings.
       "vertical": true
     }
   },
@@ -328,24 +328,24 @@
     "folds": true
   },
   "indent_guides": {
-    /// Whether to show indent guides in the editor.
+    // Whether to show indent guides in the editor.
     "enabled": true,
-    /// The width of the indent guides in pixels, between 1 and 10.
+    // The width of the indent guides in pixels, between 1 and 10.
     "line_width": 1,
-    /// The width of the active indent guide in pixels, between 1 and 10.
+    // The width of the active indent guide in pixels, between 1 and 10.
     "active_line_width": 1,
-    /// Determines how indent guides are colored.
-    /// This setting can take the following three values:
+    // Determines how indent guides are colored.
+    // This setting can take the following three values:
     ///
-    /// 1. "disabled"
-    /// 2. "fixed"
-    /// 3. "indent_aware"
+    // 1. "disabled"
+    // 2. "fixed"
+    // 3. "indent_aware"
     "coloring": "fixed",
-    /// Determines how indent guide backgrounds are colored.
-    /// This setting can take the following two values:
+    // Determines how indent guide backgrounds are colored.
+    // This setting can take the following two values:
     ///
-    /// 1. "disabled"
-    /// 2. "indent_aware"
+    // 1. "disabled"
+    // 2. "indent_aware"
     "background_coloring": "disabled"
   },
   // Whether the editor will scroll beyond the last line.
@@ -424,32 +424,32 @@
     // Whether to fold directories automatically and show compact folders
     // (e.g. "a/b/c" ) when a directory has only one subdirectory inside.
     "auto_fold_dirs": true,
-    /// Scrollbar-related settings
+    // Scrollbar-related settings
     "scrollbar": {
-      /// When to show the scrollbar in the project panel.
-      /// This setting can take five values:
+      // When to show the scrollbar in the project panel.
+      // This setting can take five values:
       ///
-      /// 1. null (default): Inherit editor settings
-      /// 2. Show the scrollbar if there's important information or
-      ///    follow the system's configured behavior (default):
-      ///   "auto"
-      /// 3. Match the system's configured behavior:
-      ///    "system"
-      /// 4. Always show the scrollbar:
-      ///    "always"
-      /// 5. Never show the scrollbar:
-      ///    "never"
+      // 1. null (default): Inherit editor settings
+      // 2. Show the scrollbar if there's important information or
+      //    follow the system's configured behavior (default):
+      //   "auto"
+      // 3. Match the system's configured behavior:
+      //    "system"
+      // 4. Always show the scrollbar:
+      //    "always"
+      // 5. Never show the scrollbar:
+      //    "never"
       "show": null
     },
-    /// Which files containing diagnostic errors/warnings to mark in the project panel.
-    /// This setting can take the following three values:
+    // Which files containing diagnostic errors/warnings to mark in the project panel.
+    // This setting can take the following three values:
     ///
-    /// 1. Do not mark any files:
-    ///    "off"
-    /// 2. Only mark files with errors:
-    ///    "errors"
-    /// 3. Mark files with errors and warnings:
-    ///    "all"
+    // 1. Do not mark any files:
+    //    "off"
+    // 2. Only mark files with errors:
+    //    "errors"
+    // 3. Mark files with errors and warnings:
+    //    "all"
     "show_diagnostics": "all",
     // Settings related to indent guides in the project panel.
     "indent_guides": {
@@ -482,8 +482,8 @@
     // when a corresponding outline entry becomes active.
     // Gitignored entries are never auto revealed.
     "auto_reveal_entries": true,
-    /// Whether to fold directories automatically
-    /// when a directory has only one directory inside.
+    // Whether to fold directories automatically
+    // when a directory has only one directory inside.
     "auto_fold_dirs": true,
     // Settings related to indent guides in the outline panel.
     "indent_guides": {
@@ -496,21 +496,21 @@
       //    "never"
       "show": "always"
     },
-    /// Scrollbar-related settings
+    // Scrollbar-related settings
     "scrollbar": {
-      /// When to show the scrollbar in the project panel.
-      /// This setting can take five values:
+      // When to show the scrollbar in the project panel.
+      // This setting can take five values:
       ///
-      /// 1. null (default): Inherit editor settings
-      /// 2. Show the scrollbar if there's important information or
-      ///    follow the system's configured behavior (default):
-      ///   "auto"
-      /// 3. Match the system's configured behavior:
-      ///    "system"
-      /// 4. Always show the scrollbar:
-      ///    "always"
-      /// 5. Never show the scrollbar:
-      ///    "never"
+      // 1. null (default): Inherit editor settings
+      // 2. Show the scrollbar if there's important information or
+      //    follow the system's configured behavior (default):
+      //   "auto"
+      // 3. Match the system's configured behavior:
+      //    "system"
+      // 4. Always show the scrollbar:
+      //    "always"
+      // 5. Never show the scrollbar:
+      //    "never"
       "show": null
     }
   },
@@ -628,7 +628,7 @@
     "show": true,
     // Whether or not to show the navigation history buttons.
     "show_nav_history_buttons": true,
-    /// Whether or not to show the tab bar buttons.
+    // Whether or not to show the tab bar buttons.
     "show_tab_bar_buttons": true
   },
   // Settings related to the editor's tabs
@@ -650,16 +650,16 @@
     // 3. Activate the left neighbour tab if present
     //     "left_neighbour"
     "activate_on_close": "history",
-    /// Which files containing diagnostic errors/warnings to mark in the tabs.
-    /// Diagnostics are only shown when file icons are also active.
-    /// This setting only works when can take the following three values:
+    // Which files containing diagnostic errors/warnings to mark in the tabs.
+    // Diagnostics are only shown when file icons are also active.
+    // This setting only works when can take the following three values:
     ///
-    /// 1. Do not mark any files:
-    ///    "off"
-    /// 2. Only mark files with errors:
-    ///    "errors"
-    /// 3. Mark files with errors and warnings:
-    ///    "all"
+    // 1. Do not mark any files:
+    //    "off"
+    // 2. Only mark files with errors:
+    //    "errors"
+    // 3. Mark files with errors and warnings:
+    //    "all"
     "show_diagnostics": "off"
   },
   // Settings related to preview tabs.
@@ -985,21 +985,21 @@
       // Example: `echo -e "\e]2;New Title\007";`
       "breadcrumbs": true
     },
-    /// Scrollbar-related settings
+    // Scrollbar-related settings
     "scrollbar": {
-      /// When to show the scrollbar in the terminal.
-      /// This setting can take five values:
+      // When to show the scrollbar in the terminal.
+      // This setting can take five values:
       ///
-      /// 1. null (default): Inherit editor settings
-      /// 2. Show the scrollbar if there's important information or
-      ///    follow the system's configured behavior (default):
-      ///   "auto"
-      /// 3. Match the system's configured behavior:
-      ///    "system"
-      /// 4. Always show the scrollbar:
-      ///    "always"
-      /// 5. Never show the scrollbar:
-      ///    "never"
+      // 1. null (default): Inherit editor settings
+      // 2. Show the scrollbar if there's important information or
+      //    follow the system's configured behavior (default):
+      //   "auto"
+      // 3. Match the system's configured behavior:
+      //    "system"
+      // 4. Always show the scrollbar:
+      //    "always"
+      // 5. Never show the scrollbar:
+      //    "never"
       "show": null
     }
     // Set the terminal's font size. If this option is not included,
@@ -1018,7 +1018,7 @@
     // "max_scroll_history_lines": 10000,
   },
   "code_actions_on_format": {},
-  /// Settings related to running tasks.
+  // Settings related to running tasks.
   "tasks": {
     "variables": {}
   },
@@ -1039,20 +1039,20 @@
     "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "**/.vscode/**/*.json"],
     "Shell Script": [".env.*"]
   },
-  /// By default use a recent system version of node, or install our own.
-  /// You can override this to use a version of node that is not in $PATH with:
-  /// {
-  ///   "node": {
-  ///     "path": "/path/to/node"
-  ///     "npm_path": "/path/to/npm" (defaults to node_path/../npm)
-  ///   }
-  /// }
-  /// or to ensure Zed always downloads and installs an isolated version of node:
-  /// {
-  ///   "node": {
-  ///     "ignore_system_version": true,
-  ///   }
-  /// NOTE: changing this setting currently requires restarting Zed.
+  // By default use a recent system version of node, or install our own.
+  // You can override this to use a version of node that is not in $PATH with:
+  // {
+  //   "node": {
+  //     "path": "/path/to/node"
+  //     "npm_path": "/path/to/npm" (defaults to node_path/../npm)
+  //   }
+  // }
+  // or to ensure Zed always downloads and installs an isolated version of node:
+  // {
+  //   "node": {
+  //     "ignore_system_version": true,
+  //   }
+  // NOTE: changing this setting currently requires restarting Zed.
   "node": {},
   // The extensions that Zed should automatically install on startup.
   //


### PR DESCRIPTION
This PR updates the comments in the `default.json` file consistently use `//`.

Some comments were using `///`, which doesn't make sense in JSONC.

Release Notes:

- N/A
