### PR TITLE
docs: Add documentation for use_smartcase_search

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -379,6 +379,9 @@
   // 3. Never populate the search query
   //    "never"
   "seed_search_query_from_cursor": "always",
+  // When enabled, automatically adjusts search case sensitivity based on your query.
+  // If your search query contains any uppercase letters, the search becomes case-sensitive;
+  // if it contains only lowercase letters, the search becomes case-insensitive.
   "use_smartcase_search": false,
   // Inlay hint related settings
   "inlay_hints": {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1762,6 +1762,22 @@ Or to set a `socks5` proxy:
 },
 ```
 
+## Use Smartcase Search
+
+- Description: When enabled, automatically adjusts search case sensitivity based on your query. If your search query contains any uppercase letters, the search becomes case-sensitive; if it contains only lowercase letters, the search becomes case-insensitive. \
+  This applies to both in-file searches and project-wide searches.
+
+  Examples:
+    - Searching for "function" would match "function", "Function", "FUNCTION", etc.
+    - Searching for "Function" would only match "Function", not "function" or "FUNCTION"
+
+- Setting: `use_smartcase_search`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
 ## Show Call Status Icon
 
 - Description: Whether or not to show the call status icon in the status bar.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1768,8 +1768,9 @@ Or to set a `socks5` proxy:
   This applies to both in-file searches and project-wide searches.
 
   Examples:
-    - Searching for "function" would match "function", "Function", "FUNCTION", etc.
-    - Searching for "Function" would only match "Function", not "function" or "FUNCTION"
+
+  - Searching for "function" would match "function", "Function", "FUNCTION", etc.
+  - Searching for "Function" would only match "Function", not "function" or "FUNCTION"
 
 - Setting: `use_smartcase_search`
 - Default: `false`


### PR DESCRIPTION
Closes #24795

Added missing documentation for `use_smartcase_search`. 

Release Notes:

- N/A 
