### PR TITLE
rust: Fix test/doctest tasks showing up outside of tests

### DIFF
--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -472,6 +472,12 @@ const RUST_BIN_KIND_TASK_VARIABLE: VariableName =
 const RUST_TEST_FRAGMENT_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("RUST_TEST_FRAGMENT"));
 
+const RUST_DOC_TEST_NAME_TASK_VARIABLE: VariableName =
+    VariableName::Custom(Cow::Borrowed("RUST_DOC_TEST_NAME"));
+
+const RUST_TEST_NAME_TASK_VARIABLE: VariableName =
+    VariableName::Custom(Cow::Borrowed("RUST_TEST_NAME"));
+
 impl ContextProvider for RustContextProvider {
     fn build_context(
         &self,
@@ -516,6 +522,16 @@ impl ContextProvider for RustContextProvider {
             let fragment = test_fragment(&variables, path, stem);
             variables.insert(RUST_TEST_FRAGMENT_TASK_VARIABLE, fragment);
         };
+        if let Some(test_name) =
+            task_variables.get(&VariableName::Custom(Cow::Borrowed("_test_name")))
+        {
+            variables.insert(RUST_TEST_NAME_TASK_VARIABLE, test_name.into());
+        }
+        if let Some(doc_test_name) =
+            task_variables.get(&VariableName::Custom(Cow::Borrowed("_doc_test_name")))
+        {
+            variables.insert(RUST_DOC_TEST_NAME_TASK_VARIABLE, doc_test_name.into());
+        }
 
         Task::ready(Ok(variables))
     }
@@ -569,7 +585,7 @@ impl ContextProvider for RustContextProvider {
             TaskTemplate {
                 label: format!(
                     "Test '{}' (package: {})",
-                    VariableName::Symbol.template_value(),
+                    RUST_TEST_NAME_TASK_VARIABLE.template_value(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),
                 command: "cargo".into(),
@@ -577,7 +593,7 @@ impl ContextProvider for RustContextProvider {
                     "test".into(),
                     "-p".into(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
-                    VariableName::Symbol.template_value(),
+                    RUST_TEST_NAME_TASK_VARIABLE.template_value(),
                     "--".into(),
                     "--nocapture".into(),
                 ],
@@ -587,8 +603,8 @@ impl ContextProvider for RustContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "DocTest '{}' (package: {})",
-                    VariableName::Symbol.template_value(),
+                    "Doc test '{}' (package: {})",
+                    RUST_DOC_TEST_NAME_TASK_VARIABLE.template_value(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),
                 command: "cargo".into(),
@@ -597,7 +613,7 @@ impl ContextProvider for RustContextProvider {
                     "--doc".into(),
                     "-p".into(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
-                    VariableName::Symbol.template_value(),
+                    RUST_DOC_TEST_NAME_TASK_VARIABLE.template_value(),
                     "--".into(),
                     "--nocapture".into(),
                 ],
@@ -607,7 +623,7 @@ impl ContextProvider for RustContextProvider {
             },
             TaskTemplate {
                 label: format!(
-                    "Test '{}' (package: {})",
+                    "Test mod '{}' (package: {})",
                     VariableName::Stem.template_value(),
                     RUST_PACKAGE_TASK_VARIABLE.template_value(),
                 ),

--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -22,7 +22,7 @@
         [(line_comment) (block_comment)] *
         .
         (function_item
-            name: (_) @run
+            name: (_) @run @_test_name
             body: _
         ) @_end
     )
@@ -35,34 +35,35 @@
         (line_comment) *
         (line_comment
             doc: (_) @_comment_content
-        ) @start
+        ) @_start @run
         (#match? @_comment_content "```")
+        .
         (line_comment) *
+        .
         (line_comment
             doc: (_) @_end_comment_content
         ) @_end_code_block
         (#match? @_end_comment_content "```")
         .
+        (line_comment) *
         (attribute_item) *
         .
-        [(line_comment) (block_comment)] *
-        .
         [(function_item
-            name: (_) @run
+            name: (_)  @_doc_test_name
             body: _
         ) (function_signature_item
-            name: (_) @run
+            name: (_) @_doc_test_name
         ) (struct_item
-            name: (_) @run
+            name: (_) @_doc_test_name
         ) (enum_item
-            name: (_) @run
+            name: (_) @_doc_test_name
             body: _
         ) (
             (attribute_item) ?
             (macro_definition
-                name: (_) @run)
+                name: (_) @_doc_test_name)
         ) (mod_item
-            name: (_) @run
+            name: (_) @_doc_test_name
         )] @_end
     )
     (#set! tag rust-doc-test)


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixes Rust test tasks showing up outside of tests