### PR TITLE
Update to suggest commit message based on file staging

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1267,11 +1267,7 @@ impl GitPanel {
             .find(|entry| match entry.status_entry() {
                 Some(entry) => entry.is_staged.unwrap_or(false),
                 _ => false,
-            });
-
-        let Some(entry) = entry else {
-            return None;
-        };
+            })?;
 
         let GitListEntry::GitStatusEntry(git_status_entry) = entry.clone() else {
             return None;
@@ -1287,17 +1283,13 @@ impl GitPanel {
             None
         };
 
-        let Some(action_text) = action_text else {
-            return None;
-        };
-
         let file_name = git_status_entry
             .repo_path
             .file_name()
             .unwrap_or_default()
             .to_string_lossy();
 
-        Some(format!("{} {}", action_text, file_name))
+        Some(format!("{} {}", action_text?, file_name))
     }
 
     fn update_editor_placeholder(&mut self, cx: &mut Context<Self>) {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1257,40 +1257,47 @@ impl GitPanel {
 
     /// Suggests a commit message based on the changed files and their statuses
     pub fn suggest_commit_message(&self) -> Option<String> {
-        let entries = self
+        if self.total_staged_count() != 1 {
+            return None;
+        }
+
+        let entry = self
             .entries
             .iter()
-            .filter_map(|entry| {
-                if let GitListEntry::GitStatusEntry(status_entry) = entry {
-                    Some(status_entry)
-                } else {
-                    None
-                }
-            })
-            .collect::<Vec<&GitStatusEntry>>();
+            .find(|entry| match entry.status_entry() {
+                Some(entry) => entry.is_staged.unwrap_or(false),
+                _ => false,
+            });
 
-        if entries.is_empty() {
-            None
-        } else if entries.len() == 1 {
-            let entry = &entries[0];
-            let file_name = entry
-                .repo_path
-                .file_name()
-                .unwrap_or_default()
-                .to_string_lossy();
+        let Some(entry) = entry else {
+            return None;
+        };
 
-            if entry.status.is_deleted() {
-                Some(format!("Delete {}", file_name))
-            } else if entry.status.is_created() {
-                Some(format!("Create {}", file_name))
-            } else if entry.status.is_modified() {
-                Some(format!("Update {}", file_name))
-            } else {
-                None
-            }
+        let GitListEntry::GitStatusEntry(git_status_entry) = entry.clone() else {
+            return None;
+        };
+
+        let action_text = if git_status_entry.status.is_deleted() {
+            Some("Delete")
+        } else if git_status_entry.status.is_created() {
+            Some("Create")
+        } else if git_status_entry.status.is_modified() {
+            Some("Update")
         } else {
             None
-        }
+        };
+
+        let Some(action_text) = action_text else {
+            return None;
+        };
+
+        let file_name = git_status_entry
+            .repo_path
+            .file_name()
+            .unwrap_or_default()
+            .to_string_lossy();
+
+        Some(format!("{} {}", action_text, file_name))
     }
 
     fn update_editor_placeholder(&mut self, cx: &mut Context<Self>) {


### PR DESCRIPTION
Currently, you only get a suggested commit message if you have a single changed file in the repository. After the PR, the suggest happens per single-staged file.

https://github.com/user-attachments/assets/4cc19fe6-099c-4690-967d-898b8ca7540b

Release Notes:

- N/A
