### PR TITLE
Capitalize default slash command description

### DIFF
--- a/crates/assistant_slash_commands/src/default_command.rs
+++ b/crates/assistant_slash_commands/src/default_command.rs
@@ -21,11 +21,11 @@ impl SlashCommand for DefaultSlashCommand {
     }
 
     fn description(&self) -> String {
-        "insert default prompt".into()
+        "Insert default prompt".into()
     }
 
     fn menu_text(&self) -> String {
-        "Insert Default Prompt".into()
+        self.description()
     }
 
     fn requires_argument(&self) -> bool {


### PR DESCRIPTION
Update default slash command to use description constant format from https://github.com/zed-industries/zed/pull/18595.

|Before|After|
|---|---|
|![image](https://github.com/user-attachments/assets/107a321e-0e91-40dd-8c38-4d55fd4f6d28)|![image](https://github.com/user-attachments/assets/f487a518-15bb-45c4-b524-25e6373a5886)|

^ This is when you type slash in the assistant panel.

Release Notes:

- N/A
