### PR TITLE
Reset buffer language on buffer search redeploy

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -820,6 +820,7 @@ impl BufferSearchBar {
         }
 
         self.dismissed = false;
+        self.adjust_query_regex_language(cx);
         handle.search_bar_visibility_changed(true, window, cx);
         cx.notify();
         cx.emit(Event::UpdateLocation);


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/25005
Closes https://github.com/zed-industries/zed/issues/25792

Release Notes:

- Fixed search input regex highlight not going away after redeploy
