### PR TITLE
Ensure search input always has regex language synced with search_options state

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -924,7 +924,7 @@ impl BufferSearchBar {
                     query_buffer.edit([(0..len, query)], None, cx);
                 });
             });
-            self.search_options = options;
+            self.set_search_options(options, cx);
             self.clear_matches(window, cx);
             cx.notify();
         }
@@ -978,6 +978,7 @@ impl BufferSearchBar {
 
     pub fn set_search_options(&mut self, search_options: SearchOptions, cx: &mut Context<Self>) {
         self.search_options = search_options;
+        self.adjust_query_regex_language(cx);
         cx.notify();
     }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -894,6 +894,7 @@ impl ProjectSearchView {
                             editor.set_text(old_query.as_str(), window, cx);
                         });
                         search_view.search_options = SearchOptions::from_query(&old_query);
+                        search_view.adjust_query_regex_language(cx);
                     }
                 }
                 new_query


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/25797

Release Notes:

- N/A
