### PR TITLE
python: Fix and improve highlighting

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -1,4 +1,6 @@
 ; Identifier naming conventions; these "soft conventions" should stay at the top of the file as they're often overridden
+(identifier) @variable
+(attribute attribute: (identifier) @property)
 
 ; CamelCase for classes
 ((identifier) @type.class
@@ -8,8 +10,6 @@
 ((identifier) @constant
   (#match? @constant "^_*[A-Z][A-Z0-9_]*$"))
 
-(identifier) @variable
-(attribute attribute: (identifier) @property)
 (type (identifier) @type)
 (generic_type (identifier) @type)
 (comment) @comment
@@ -61,6 +61,8 @@
         (identifier) @function.arguments) ; Typed parameters
       (default_parameter
         name: (identifier) @function.arguments) ; Default parameters
+      (typed_default_parameter
+        name: (identifier) @function.arguments) ; Typed default parameters
   ]))
 
 ; Keyword arguments


### PR DESCRIPTION
Closes #25803
Closes #25707 

This PR fixes the highlighting regression described in #25803 by fixing the priorities of highlights as described in the [comment within the file itself](https://github.com/zed-industries/zed/blob/5b66ea15638b004c45bbf4e4dd0b576aa6cdcebc/crates/languages/src/python/highlights.scm#L1). A nice side-effect of this is that scoped constants or other identifiers are now also more accurately highlighted, as seen in the screenshots below.

While I was at it, I also adressed the highlighting issue for default typed idenfiers.

| This PR | <img width="575" alt="PR" src="https://github.com/user-attachments/assets/aed5cdd0-c31a-4794-8128-376944fddd2d" /> |
| --- | --- |
| Preview | <img width="575" alt="preview" src="https://github.com/user-attachments/assets/ae3fad35-d436-472c-aff0-16508304ccf7" /> |
| Stable |  <img width="575" alt="stable" src="https://github.com/user-attachments/assets/3836427c-f1cc-42ea-b1a7-8f5bbbadf210" /> |

Release Notes:

- Fixed constants not being highlighted in Python-files.
- Improved Python-highlighting for default function arguments and scoped identifiers.
