### PR TITLE
assistant2: Rework how tool results are stored and referred to

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -255,12 +255,7 @@ impl ActiveThread {
                         let task = tool.run(tool_use.input, self.workspace.clone(), window, cx);
 
                         self.thread.update(cx, |thread, cx| {
-                            thread.insert_tool_output(
-                                tool_use.assistant_message_id,
-                                tool_use.id.clone(),
-                                task,
-                                cx,
-                            );
+                            thread.insert_tool_output(tool_use.id.clone(), task, cx);
                         });
                     }
                 }


### PR DESCRIPTION
This PR reworks how we store tool results and refer to them later.

We now maintain a mapping of the tool uses to their corresponding results, with separate mappings for the messages and the tool uses they correspond to.

Release Notes:

- N/A
