### PR TITLE
git: Adjust rendering of git hunks

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4337,6 +4337,8 @@ impl EditorElement {
     }
 
     fn paint_diff_hunks(layout: &mut EditorLayout, window: &mut Window, cx: &mut App) {
+        let is_light = cx.theme().appearance().is_light();
+
         if layout.display_hunks.is_empty() {
             return;
         }
@@ -4401,7 +4403,7 @@ impl EditorElement {
                     hunk_to_paint
                 {
                     let background_color = if secondary_status != DiffHunkSecondaryStatus::None {
-                        background_color.opacity(0.3)
+                        background_color.opacity(if is_light { 0.2 } else { 0.32 })
                     } else {
                         background_color.opacity(1.0)
                     };
@@ -5095,9 +5097,15 @@ impl EditorElement {
                                             end_display_row.0 -= 1;
                                         }
                                         let color = match &hunk.status().kind {
-                                            DiffHunkStatusKind::Added => theme.status().created,
-                                            DiffHunkStatusKind::Modified => theme.status().modified,
-                                            DiffHunkStatusKind::Deleted => theme.status().deleted,
+                                            DiffHunkStatusKind::Added => {
+                                                theme.colors().version_control_added
+                                            }
+                                            DiffHunkStatusKind::Modified => {
+                                                theme.colors().version_control_modified
+                                            }
+                                            DiffHunkStatusKind::Deleted => {
+                                                theme.colors().version_control_deleted
+                                            }
                                         };
                                         ColoredRange {
                                             start: start_display_row,
@@ -6693,12 +6701,14 @@ impl Element for EditorElement {
                         .editor
                         .update(cx, |editor, cx| editor.highlighted_display_rows(window, cx));
 
+                    let is_light = cx.theme().appearance().is_light();
+
                     for (ix, row_info) in row_infos.iter().enumerate() {
                         let Some(diff_status) = row_info.diff_status else {
                             continue;
                         };
 
-                        let staged_opacity = 0.10;
+                        let staged_opacity = if is_light { 0.14 } else { 0.10 };
                         let unstaged_opacity = 0.04;
 
                         let background_color = match diff_status.kind {


### PR DESCRIPTION
- Light themes get their own values (creating better contrast and a better distinction between staged and unstaged hunks in light themes.)
- Scrollbar git hunks indicators now use the correct colors

Before:

![CleanShot 2025-02-28 at 14 31 29@2x](https://github.com/user-attachments/assets/038fe11c-7163-4f1b-92b8-56b24c8e9443)

After:

![CleanShot 2025-02-28 at 14 32 04@2x](https://github.com/user-attachments/assets/869d33d9-d925-4cbe-84bd-e54caf971431)


Release Notes:

- Fixed an issue where git hunk indicators in editor scrollbars used the incorrect colors.
