### PR TITLE
Update bundled JSON schemas (2025-02-28)

### DIFF
--- a/crates/languages/src/json/schemas/package.json
+++ b/crates/languages/src/json/schemas/package.json
@@ -32,6 +32,41 @@
         "type": "string"
       }
     },
+    "devDependency": {
+      "description": "Specifies dependencies that are required for the development and testing of the project. These dependencies are not needed in the production environment.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "optionalDependency": {
+      "description": "Specifies dependencies that are optional for your project. These dependencies are attempted to be installed during the npm install process, but if they fail to install, the installation process will not fail.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "peerDependency": {
+      "description": "Specifies dependencies that are required by the package but are expected to be provided by the consumer of the package.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "string"
+      }
+    },
+    "peerDependencyMeta": {
+      "description": "When a user installs your package, warnings are emitted if packages specified in \"peerDependencies\" are not already installed. The \"peerDependenciesMeta\" field serves to provide more information on how your peer dependencies are utilized. Most commonly, it allows peer dependencies to be marked as optional. Metadata for this field is specified with a simple hash of the package name to a metadata object.",
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": true,
+        "properties": {
+          "optional": {
+            "description": "Specifies that this peer dependency is optional and should not be installed automatically.",
+            "type": "boolean"
+          }
+        }
+      }
+    },
     "license": {
       "anyOf": [
         {
@@ -135,13 +170,17 @@
         },
         "types": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
-          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions."
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
         }
       },
       "patternProperties": {
         "^[^.0-9]+$": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment matches the property name."
+        },
+        "^types@.+$": {
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
         }
       },
       "additionalProperties": false
@@ -170,6 +209,77 @@
         },
         {
           "$ref": "#/definitions/packageExportsFallback"
+        }
+      ]
+    },
+    "packageImportsEntryPath": {
+      "type": [
+        "string",
+        "null"
+      ],
+      "description": "The module path that is resolved when this specifier is imported. Set to `null` to disallow importing this module."
+    },
+    "packageImportsEntryObject": {
+      "type": "object",
+      "description": "Used to specify conditional exports, note that Conditional exports are unsupported in older environments, so it's recommended to use the fallback array option if support for those environments is a concern.",
+      "properties": {
+        "require": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this specifier is imported as a CommonJS module using the `require(...)` function."
+        },
+        "import": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this specifier is imported as an ECMAScript module using an `import` declaration or the dynamic `import(...)` function."
+        },
+        "node": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this environment is Node.js."
+        },
+        "default": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when no other export type matches."
+        },
+        "types": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
+        }
+      },
+      "patternProperties": {
+        "^[^.0-9]+$": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this environment matches the property name."
+        },
+        "^types@.+$": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved for TypeScript types when this specifier is imported. Should be listed before other conditions. Additionally, versioned \"types\" condition in the form \"types@{selector}\" are supported."
+        }
+      },
+      "additionalProperties": false
+    },
+    "packageImportsEntry": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/packageImportsEntryPath"
+        },
+        {
+          "$ref": "#/definitions/packageImportsEntryObject"
+        }
+      ]
+    },
+    "packageImportsFallback": {
+      "type": "array",
+      "description": "Used to allow fallbacks in case this environment doesn't support the preceding entries.",
+      "items": {
+        "$ref": "#/definitions/packageImportsEntry"
+      }
+    },
+    "packageImportsEntryOrFallback": {
+      "oneOf": [
+        {
+          "$ref": "#/definitions/packageImportsEntry"
+        },
+        {
+          "$ref": "#/definitions/packageImportsFallback"
         }
       ]
     },
@@ -212,7 +322,7 @@
       "pattern": "^(?:(?:@(?:[a-z0-9-*~][a-z0-9-*._~]*)?/[a-z0-9-._~])|[a-z0-9-~])[a-z0-9-._~]*$"
     },
     "version": {
-      "description": "Version must be parseable by node-semver, which is bundled with npm as a dependency.",
+      "description": "Version must be parsable by node-semver, which is bundled with npm as a dependency.",
       "type": "string"
     },
     "description": {
@@ -329,6 +439,17 @@
           "description": "The module path that is resolved when the module specifier matches \"name\", shadows the \"main\" field."
         }
       ]
+    },
+    "imports": {
+      "description": "The \"imports\" field is used to create private mappings that only apply to import specifiers from within the package itself.",
+      "type": "object",
+      "patternProperties": {
+        "^#.+$": {
+          "$ref": "#/definitions/packageImportsEntryOrFallback",
+          "description": "The module path that is resolved when this environment matches the property name."
+        }
+      },
+      "additionalProperties": false
     },
     "bin": {
       "type": [
@@ -487,7 +608,7 @@
         },
         "prepare": {
           "type": "string",
-          "description": "Run both BEFORE the package is packed and published, and on local npm install without any arguments. This is run AFTER prepublish, but BEFORE prepublishOnly."
+          "description": "Runs BEFORE the package is packed, i.e. during \"npm publish\" and \"npm pack\", and on local \"npm install\" without any arguments. This is run AFTER \"prepublish\", but BEFORE \"prepublishOnly\"."
         },
         "prepublishOnly": {
           "type": "string",
@@ -594,27 +715,16 @@
       "$ref": "#/definitions/dependency"
     },
     "devDependencies": {
-      "$ref": "#/definitions/dependency"
+      "$ref": "#/definitions/devDependency"
     },
     "optionalDependencies": {
-      "$ref": "#/definitions/dependency"
+      "$ref": "#/definitions/optionalDependency"
     },
     "peerDependencies": {
-      "$ref": "#/definitions/dependency"
+      "$ref": "#/definitions/peerDependency"
     },
     "peerDependenciesMeta": {
-      "description": "When a user installs your package, warnings are emitted if packages specified in \"peerDependencies\" are not already installed. The \"peerDependenciesMeta\" field serves to provide more information on how your peer dependencies are utilized. Most commonly, it allows peer dependencies to be marked as optional. Metadata for this field is specified with a simple hash of the package name to a metadata object.",
-      "type": "object",
-      "additionalProperties": {
-        "type": "object",
-        "additionalProperties": true,
-        "properties": {
-          "optional": {
-            "description": "Specifies that this peer dependency is optional and should not be installed automatically.",
-            "type": "boolean"
-          }
-        }
-      }
+      "$ref": "#/definitions/peerDependencyMeta"
     },
     "bundleDependencies": {
       "description": "Array of package names that will be bundled when publishing the package.",
@@ -828,6 +938,190 @@
     },
     "jscpd": {
       "$ref": "https://json.schemastore.org/jscpd.json"
+    },
+    "pnpm": {
+      "description": "Defines pnpm specific configuration.",
+      "type": "object",
+      "properties": {
+        "overrides": {
+          "description": "Used to override any dependency in the dependency graph.",
+          "type": "object"
+        },
+        "packageExtensions": {
+          "description": "Used to extend the existing package definitions with additional information.",
+          "type": "object",
+          "patternProperties": {
+            "^.+$": {
+              "type": "object",
+              "properties": {
+                "dependencies": {
+                  "$ref": "#/definitions/dependency"
+                },
+                "optionalDependencies": {
+                  "$ref": "#/definitions/optionalDependency"
+                },
+                "peerDependencies": {
+                  "$ref": "#/definitions/peerDependency"
+                },
+                "peerDependenciesMeta": {
+                  "$ref": "#/definitions/peerDependencyMeta"
+                }
+              },
+              "additionalProperties": false
+            }
+          },
+          "additionalProperties": false
+        },
+        "peerDependencyRules": {
+          "properties": {
+            "ignoreMissing": {
+              "description": "pnpm will not print warnings about missing peer dependencies from this list.",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "allowedVersions": {
+              "description": "Unmet peer dependency warnings will not be printed for peer dependencies of the specified range.",
+              "type": "object"
+            },
+            "allowAny": {
+              "description": "Any peer dependency matching the pattern will be resolved from any version, regardless of the range specified in \"peerDependencies\".",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "neverBuiltDependencies": {
+          "description": "A list of dependencies to run builds for.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onlyBuiltDependencies": {
+          "description": "A list of package names that are allowed to be executed during installation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onlyBuiltDependenciesFile": {
+          "description": "Specifies a JSON file that lists the only packages permitted to run installation scripts during the pnpm install process.",
+          "type": "string"
+        },
+        "ignoredBuiltDependencies": {
+          "description": "A list of package names that should not be built during installation.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "allowedDeprecatedVersions": {
+          "description": "A list of deprecated versions that the warnings are suppressed.",
+          "type": "object"
+        },
+        "patchedDependencies": {
+          "description": "A list of dependencies that are patched.",
+          "type": "object"
+        },
+        "allowNonAppliedPatches": {
+          "description": "When true, installation won't fail if some of the patches from the \"patchedDependencies\" field were not applied.",
+          "type": "boolean"
+        },
+        "updateConfig": {
+          "type": "object",
+          "properties": {
+            "ignoreDependencies": {
+              "description": "A list of packages that should be ignored when running \"pnpm outdated\" or \"pnpm update --latest\".",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "configDependencies": {
+          "type": "object",
+          "description": "Configurational dependencies are installed before all the other types of dependencies (before 'dependencies', 'devDependencies', 'optionalDependencies')."
+        },
+        "auditConfig": {
+          "type": "object",
+          "properties": {
+            "ignoreCves": {
+              "description": "A list of CVE IDs that will be ignored by \"pnpm audit\".",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^CVE-\\d{4}-\\d{4,7}$"
+              }
+            },
+            "ignoreGhsas": {
+              "description": "A list of GHSA Codes that will be ignored by \"pnpm audit\".",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^GHSA(-[23456789cfghjmpqrvwx]{4}){3}$"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "requiredScripts": {
+          "description": "A list of scripts that must exist in each project.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "supportedArchitectures": {
+          "description": "Specifies architectures for which you'd like to install optional dependencies, even if they don't match the architecture of the system running the install.",
+          "type": "object",
+          "properties": {
+            "os": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "cpu": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "libc": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          },
+          "additionalProperties": false
+        },
+        "ignoredOptionalDependencies": {
+          "description": "A list of optional dependencies that the install should be skipped.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "executionEnv": {
+          "type": "object",
+          "properties": {
+            "nodeVersion": {
+              "description": "Specifies which exact Node.js version should be used for the project's runtime.",
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
     }
   },
   "anyOf": [

--- a/crates/languages/src/json/schemas/tsconfig.json
+++ b/crates/languages/src/json/schemas/tsconfig.json
@@ -452,6 +452,7 @@
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Set the newline character for emitting files.",
               "type": ["string", "null"],
+              "default": "lf",
               "anyOf": [
                 {
                   "enum": ["crlf", "lf"]
@@ -663,11 +664,12 @@
                     "ES2021",
                     "ES2022",
                     "ES2023",
+                    "ES2024",
                     "ESNext"
                   ]
                 },
                 {
-                  "pattern": "^([Ee][Ss]([356]|(20(1[56789]|2[0123]))|[Nn][Ee][Xx][Tt]))$"
+                  "pattern": "^([Ee][Ss]([356]|(20(1[56789]|2[01234]))|[Nn][Ee][Xx][Tt]))$"
                 }
               ],
               "markdownDescription": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.\n\nSee more: https://www.typescriptlang.org/tsconfig#target"
@@ -772,7 +774,7 @@
               "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Ensure that casing is correct in imports.",
               "type": ["boolean", "null"],
-              "default": false,
+              "default": true,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
@@ -928,6 +930,7 @@
                       "ES2017.SharedMemory",
                       "ES2017.String",
                       "ES2017.TypedArrays",
+                      "ES2017.ArrayBuffer",
                       "ES2018",
                       "ES2018.AsyncGenerator",
                       "ES2018.AsyncIterable",
@@ -985,6 +988,14 @@
                       "ES2022.RegExp",
                       "ES2023",
                       "ES2023.Array",
+                      "ES2024",
+                      "ES2024.ArrayBuffer",
+                      "ES2024.Collection",
+                      "ES2024.Object",
+                      "ES2024.Promise",
+                      "ES2024.Regexp",
+                      "ES2024.SharedMemory",
+                      "ES2024.String",
                       "Decorators",
                       "Decorators.Legacy",
                       "ES2017.Date",
@@ -1003,7 +1014,7 @@
                     "pattern": "^[Ee][Ss]2016(\\.[Aa][Rr][Rr][Aa][Yy]\\.[Ii][Nn][Cc][Ll][Uu][Dd][Ee])?$"
                   },
                   {
-                    "pattern": "^[Ee][Ss]2017(\\.([Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Hh][Aa][Rr][Ee][Dd][Mm][Ee][Mm][Oo][Rr][Yy]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Tt][Yy][Pp][Ee][Dd][Aa][Rr][Rr][Aa][Yy][Ss]|[Dd][Aa][Tt][Ee]))?$"
+                    "pattern": "^[Ee][Ss]2017(\\.([Ii][Nn][Tt][Ll]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Ss][Hh][Aa][Rr][Ee][Dd][Mm][Ee][Mm][Oo][Rr][Yy]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Tt][Yy][Pp][Ee][Dd][Aa][Rr][Rr][Aa][Yy][Ss]|[Dd][Aa][Tt][Ee]|[Aa][Rr][Rr][Aa][Yy][Bb][Uu][Ff][Ff][Ee][Rr]))?$"
                   },
                   {
                     "pattern": "^[Ee][Ss]2018(\\.([Aa][Ss][Yy][Nn][Cc][Gg][Ee][Nn][Ee][Rr][Aa][Tt][Oo][Rr]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Rr][Ee][Gg][Ee][Xx][Pp]))?$"
@@ -1022,6 +1033,9 @@
                   },
                   {
                     "pattern": "^[Ee][Ss]2023(\\.([Aa][Rr][Rr][Aa][Yy]|[Cc][Oo][Ll][Ll][Ee][Cc][Tt][Ii][Oo][Nn]))?$"
+                  },
+                  {
+                    "pattern": "^[Ee][Ss]2024(\\.([Aa][Rr][Rr][Aa][Yy][Bb][Uu][Ff][Ff][Ee][Rr]|[Cc][Oo][Ll][Ll][Ee][Cc][Tt][Ii][Oo][Nn]|[Oo][Bb][Jj][Ee][Cc][Tt]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Rr][Ee][Gg][Ee][Xx][Pp]|[Ss][Hh][Aa][Rr][Ee][Dd][Mm][Ee][Mm][Oo][Rr][Yy]|[Ss][Tt][Rr][Ii][Nn][Gg]))?$"
                   },
                   {
                     "pattern": "^[Ee][Ss][Nn][Ee][Xx][Tt](\\.([Aa][Rr][Rr][Aa][Yy]|[Aa][Ss][Yy][Nn][Cc][Ii][Tt][Ee][Rr][Aa][Bb][Ll][Ee]|[Bb][Ii][Gg][Ii][Nn][Tt]|[Ii][Nn][Tt][Ll]|[Pp][Rr][Oo][Mm][Ii][Ss][Ee]|[Ss][Tt][Rr][Ii][Nn][Gg]|[Ss][Yy][Mm][Bb][Oo][Ll]|[Ww][Ee][Aa][Kk][Rr][Ee][Ff]|[Dd][Ee][Cc][Oo][Rr][Aa][Tt][Oo][Rr][Ss]|[Dd][Ii][Ss][Pp][Oo][Ss][Aa][Bb][Ll][Ee]))?$"


### PR DESCRIPTION
Updated JSON schemas to [SchemaStore/schemastore@b107b83](https://github.com/SchemaStore/schemastore/tree/b107b83a50bad9ac06dd171201dc870901f92ca8) (2025-02-28)

- [tsconfig.json](https://github.com/SchemaStore/schemastore/commits/master/src/schemas/json/tsconfig.json) @ [b107b83](https://raw.githubusercontent.com/SchemaStore/schemastore/b107b83a50bad9ac06dd171201dc870901f92ca8/src/schemas/json/tsconfig.json)
- [package.json](https://github.com/SchemaStore/schemastore/commits/master/src/schemas/json/package.json) @ [b107b83](https://raw.githubusercontent.com/SchemaStore/schemastore/b107b83a50bad9ac06dd171201dc870901f92ca8/src/schemas/json/package.json)

Previously:
- https://github.com/zed-industries/zed/pull/20910

Release Notes:

- Updated bundled JSON schemas for package.json and tsconfig.json
