### PR TITLE
[workaround] Fix closing all assistant panel pickers with `esc`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2700,23 +2700,29 @@ impl Editor {
     }
 
     pub fn cancel(&mut self, _: &Cancel, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.try_cancel(window, cx) {
+            cx.propagate();
+        }
+    }
+
+    pub fn try_cancel(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         self.selection_mark_mode = false;
 
         if self.clear_expanded_diff_hunks(cx) {
             cx.notify();
-            return;
+            return true;
         }
         if self.dismiss_menus_and_popups(true, window, cx) {
-            return;
+            return true;
         }
 
         if self.mode == EditorMode::Full
             && self.change_selections(Some(Autoscroll::fit()), window, cx, |s| s.try_cancel())
         {
-            return;
+            return true;
         }
 
-        cx.propagate();
+        return false;
     }
 
     pub fn dismiss_menus_and_popups(

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -425,6 +425,26 @@ impl<D: PickerDelegate> Picker<D> {
         cx.notify();
     }
 
+    pub fn editor_cancel(
+        &mut self,
+        _: &editor::actions::Cancel,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        match &self.head {
+            Head::Editor(editor) => {
+                let should_cancel = editor.update(cx, |editor, cx| !editor.try_cancel(window, cx));
+
+                if should_cancel {
+                    self.cancel(&menu::Cancel, window, cx);
+                }
+            }
+            Head::Empty(_) => {
+                self.cancel(&menu::Cancel, window, cx);
+            }
+        }
+    }
+
     pub fn cancel(&mut self, _: &menu::Cancel, window: &mut Window, cx: &mut Context<Self>) {
         if self.delegate.should_dismiss() {
             self.delegate.dismissed(window, cx);
@@ -790,6 +810,7 @@ impl<D: PickerDelegate> Render for Picker<D> {
             .on_action(cx.listener(Self::select_first))
             .on_action(cx.listener(Self::select_last))
             .on_action(cx.listener(Self::cancel))
+            .on_action(cx.listener(Self::editor_cancel))
             .on_action(cx.listener(Self::confirm))
             .on_action(cx.listener(Self::secondary_confirm))
             .on_action(cx.listener(Self::confirm_completion))


### PR DESCRIPTION
NOTE: This might not be the right solution. Investigating.

The cancel event doesn't propagate from the editor for some pickers

Release Notes:

- N/A
