### PR TITLE
Fix active pane modifiers applying to parent pane axis if child pane is active

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -214,13 +214,6 @@ impl Member {
         Member::Axis(PaneAxis::new(axis, members))
     }
 
-    fn contains(&self, needle: &Entity<Pane>) -> bool {
-        match self {
-            Member::Axis(axis) => axis.members.iter().any(|member| member.contains(needle)),
-            Member::Pane(pane) => pane == needle,
-        }
-    }
-
     fn first_pane(&self) -> Entity<Pane> {
         match self {
             Member::Axis(axis) => axis.members[0].first_pane(),
@@ -702,7 +695,7 @@ impl PaneAxis {
             cx.entity().downgrade(),
         )
         .children(self.members.iter().enumerate().map(|(ix, member)| {
-            if member.contains(active_pane) {
+            if matches!(member, Member::Pane(pane) if pane == active_pane) {
                 active_pane_ix = Some(ix);
             }
             member


### PR DESCRIPTION
Closes #25304

Release Notes:

- Fixed an issue where `active_pane_modifiers` settings would be applied to a parent pane if one of it's child panes was active
