### PR TITLE
Fix buffer search options not resetting when dismissed after Vim mode search then reopened with `buffer: deploy search`

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -814,7 +814,10 @@ impl BufferSearchBar {
 
         self.configured_options =
             SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
-        if self.dismissed && self.configured_options != self.default_options {
+        if self.dismissed
+            && (self.configured_options != self.default_options
+                || self.configured_options != self.search_options)
+        {
             self.search_options = self.configured_options;
             self.default_options = self.configured_options;
         }


### PR DESCRIPTION
Closes #25315

Release Notes:

- Fixes an issue where the buffer search options would not be reset when using `buffer: deploy search` after using Vim search (`*` & `#`) which enable all search options
