### PR TITLE
image_viewer: Hide breadcrumbs only in the image viewer

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -98,7 +98,9 @@
     // The unit for image file sizes.
     // By default we're setting it to binary.
     // The second option is decimal.
-    "unit": "binary"
+    "unit": "binary",
+    // Whether to show breadcrumbs in the image viewer
+    "breadcrumbs": true
   },
   // The key to use for adding multiple cursors
   // Currently "alt" or "cmd_or_ctrl"  (also aliased as

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -4,7 +4,7 @@ mod image_viewer_settings;
 use std::path::PathBuf;
 
 use anyhow::Context as _;
-use editor::{items::entry_git_aware_label_color, EditorSettings};
+use editor::items::entry_git_aware_label_color;
 use file_icons::FileIcons;
 use gpui::{
     canvas, div, fill, img, opaque_grey, point, size, AnyElement, App, Bounds, Context, Entity,

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -145,7 +145,7 @@ impl Item for ImageView {
     }
 
     fn breadcrumb_location(&self, cx: &App) -> ToolbarItemLocation {
-        let show_breadcrumb = EditorSettings::get_global(cx).toolbar.breadcrumbs;
+        let show_breadcrumb = ImageViewerSettings::get_global(cx).breadcrumbs;
         if show_breadcrumb {
             ToolbarItemLocation::PrimaryLeft
         } else {

--- a/crates/image_viewer/src/image_viewer_settings.rs
+++ b/crates/image_viewer/src/image_viewer_settings.rs
@@ -11,6 +11,10 @@ pub struct ImageViewerSettings {
     /// Default: "binary"
     #[serde(default)]
     pub unit: ImageFileSizeUnit,
+    /// Whether to show breadcrumbs in the image viewer
+    ///
+    /// Default: true
+    pub breadcrumbs: bool
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, Default)]

--- a/crates/image_viewer/src/image_viewer_settings.rs
+++ b/crates/image_viewer/src/image_viewer_settings.rs
@@ -14,7 +14,7 @@ pub struct ImageViewerSettings {
     /// Whether to show breadcrumbs in the image viewer
     ///
     /// Default: true
-    pub breadcrumbs: bool
+    pub breadcrumbs: bool,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, Default)]


### PR DESCRIPTION
The previous PR #25654 uses the editor setting for the toolbar, which is great, but we should confine this to the image viewer, unless otherwise specified, explicitly

When I disable breadcrumbs via my settings (for the image viewer, at least), I can't see most of the symbols or file paths. This is what it looks like: 

![breadcrumb-false](https://github.com/user-attachments/assets/93d64321-6b43-4f50-9df4-fb1fc04a5416)

And the original issue, if I'm not mistaken, expects this to be scoped to the image viewer, not the entire editor. This PR isolates the ability to enable/disable breadcrumbs in the image viewer alone

Expected UI irrespective of the choice in the image viewer 

![breadcrumb-true](https://github.com/user-attachments/assets/027c5965-e766-4550-9de5-a209c8069d85)
 
Closes #25279 

Release Notes:

- Added ability to enable/disable breadcrumbs in the image viewer alone
