### PR TITLE
paths: Add support for clickable file paths in the Odin language format

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -165,9 +165,7 @@ pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
 const ROW_COL_CAPTURE_REGEX: &str = r"(?x)
     ([^\(]+)(?:
-        \((\d+),(\d+)\) # filename(row,column)
-        |
-        \((\d+):(\d+)\) # filename(row:column)
+        \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column)
         |
         \((\d+)\)()     # filename(row)
     )

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -167,6 +167,8 @@ const ROW_COL_CAPTURE_REGEX: &str = r"(?x)
     ([^\(]+)(?:
         \((\d+),(\d+)\) # filename(row,column)
         |
+        \((\d+):(\d+)\) # filename(row:column)
+        |
         \((\d+)\)()     # filename(row)
     )
     |
@@ -647,6 +649,14 @@ mod tests {
                 path: PathBuf::from("crate/utils/src/test:today.log"),
                 row: Some(34),
                 column: None,
+            }
+        );
+        assert_eq!(
+            PathWithPosition::parse_str("/testing/out/src/file_finder.odin(7:15)"),
+            PathWithPosition {
+                path: PathBuf::from("/testing/out/src/file_finder.odin"),
+                row: Some(7),
+                column: Some(15),
             }
         );
     }


### PR DESCRIPTION
This PR adds support for clickable file paths in the Odin language format. 

The odin compiler errors use the format `/path/to/file.odin(1:1)`. We didn't recognize this format, making these paths non-clickable in the terminal. 

Also added tests for this. 


Release Notes:

- Added support for clickable file paths in the Odin language format. 
