### PR TITLE
Ensure inlay hint toggling with modifiers happens fast

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3691,6 +3691,7 @@ impl Editor {
             InlayHintRefreshReason::SettingsChange(_)
                 | InlayHintRefreshReason::Toggle(_)
                 | InlayHintRefreshReason::ExcerptsRemoved(_)
+                | InlayHintRefreshReason::ModifiersChanged(_)
         );
         let (invalidate_cache, required_languages) = match reason {
             InlayHintRefreshReason::ModifiersChanged(enabled) => {

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -581,6 +581,7 @@ impl InlayHintCache {
             self.version += 1;
         }
         self.update_tasks.clear();
+        self.refresh_task = Task::ready(());
         self.hints.clear();
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/25766 
Fixes the bugs found:

* modifier toggle not happening instantly due to `edit_debounce_ms` considered
* hint update race that ignored the cache clear

Release Notes:

- N/A 