### PR TITLE
git_ui: Do not show commit message editor with no changes

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1905,15 +1905,11 @@ impl GitPanel {
                     .trim_end_matches("/"),
             ));
             let branches = branch_picker::popover(self.project.clone(), window, cx);
+            let has_entries = self.entries.len() > 0;
             let footer = v_flex()
-                .child(PanelRepoFooter::new(
-                    "footer-button",
-                    display_name,
-                    Some(branch),
-                    Some(git_panel),
-                    Some(branches),
-                ))
-                .child(
+                .child(if !has_entries {
+                    h_flex().id("commit-editor-container")
+                } else {
                     panel_editor_container(window, cx)
                         .id("commit-editor-container")
                         .relative()
@@ -1978,8 +1974,15 @@ impl GitPanel {
                                             }
                                         })),
                                 ),
-                        ),
-                );
+                        )
+                })
+                .child(PanelRepoFooter::new(
+                    "footer-button",
+                    display_name,
+                    Some(branch),
+                    Some(git_panel),
+                    Some(branches),
+                ));
 
             Some(footer)
         } else {


### PR DESCRIPTION
| Before the pr No changes | After the pr No changes |After the pr Changes |
|--------|--------|--------|
| <img width="368" alt="Screenshot 2025-03-01 alle 10 34 50" src="https://github.com/user-attachments/assets/0aa6c63c-eb6b-433e-9d41-1edd3c044161" /> | <img width="374" alt="Screenshot 2025-03-01 alle 10 27 30" src="https://github.com/user-attachments/assets/8a4c83d7-8c9a-4440-8ef2-faf19c1a850e" /> | <img width="373" alt="Screenshot 2025-03-01 alle 10 26 47" src="https://github.com/user-attachments/assets/4cbb1c7e-dd9e-4abb-bb1d-967ca84dccd2" /> | 


Release Notes:

- Do not show commit message editor with no changes
