### PR TITLE
Optimize JSON merging by removing redundant key clones in serde_json operations

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -332,7 +332,7 @@ pub fn merge_json_value_into(source: serde_json::Value, target: &mut serde_json:
                 if let Some(target) = target.get_mut(&key) {
                     merge_json_value_into(value, target);
                 } else {
-                    target.insert(key.clone(), value);
+                    target.insert(key, value);
                 }
             }
         }
@@ -360,7 +360,7 @@ pub fn merge_non_null_json_value_into(source: serde_json::Value, target: &mut se
             if let Some(target) = target_object.get_mut(&key) {
                 merge_non_null_json_value_into(value, target);
             } else if !value.is_null() {
-                target_object.insert(key.clone(), value);
+                target_object.insert(key, value);
             }
         }
     } else if !source.is_null() {


### PR DESCRIPTION
Hi Zed team! 👋
As a fan of Zed Editor who's excited to contribute, I noticed a small optimization opportunity in the JSON merging utilities.

<b>Changes:</b>
Removed redundant key.clone() calls in insert() operations within 2 functions:
1. merge_json_value_into
2. merge_non_null_json_value_into

<b>Why:</b>
Since we're already moving ownership of `source_object` 's contents and key is no longer used further, we could directly pass `key` to `insert` without cloning.
Eliminates redundant allocations, improving performance slightly for JSON-heavy operations.

<b>Testing:</b>
I have tested this locally and all existing tests passed. The change preserves behavior while removing redundancy.

Love using Zed and happy to contribute! Let me know if any adjustments are needed!

Release Notes:

- N/A
