### PR TITLE
workspace: Add hide status_bar option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -136,6 +136,8 @@
   // Whether to use the system provided dialogs for Open and Save As.
   // When set to false, Zed will use the built-in keyboard-first pickers.
   "use_system_path_prompts": true,
+  // Whether to show the status bar at the bottom of the window.
+  "show_status_bar": true,
   // Whether the cursor blinks in the editor.
   "cursor_blink": true,
   // Cursor shape for the default editor.

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5282,6 +5282,8 @@ impl Render for Workspace {
         let theme = cx.theme().clone();
         let colors = theme.colors();
 
+        let show_status_bar = WorkspaceSettings::get_global(cx).show_status_bar;
+
         client_side_decorations(
             self.actions(div(), window, cx)
                 .key_context(context)
@@ -5478,7 +5480,11 @@ impl Render for Workspace {
                                 }))
                                 .children(self.render_notifications(window, cx)),
                         )
-                        .child(self.status_bar.clone())
+                        .children(if show_status_bar {
+                            Some(self.status_bar.clone())
+                        } else {
+                            None
+                        })
                         .child(self.modal_layer.clone()),
                 ),
             window,

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -24,6 +24,7 @@ pub struct WorkspaceSettings {
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub on_last_window_closed: OnLastWindowClosed,
+    pub show_status_bar: bool,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -165,6 +166,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: auto (nothing on macOS, "app quit" otherwise)
     pub on_last_window_closed: Option<OnLastWindowClosed>,
+    /// Whether to show the status bar at the bottom of the window.
+    ///
+    /// Default: true
+    pub show_status_bar: Option<bool>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
Closes #8169

Add's the option to hide the status_bar under `show_status_bar` which by default is true. 

Release Notes:

- Added `show_status_bar` which gives the possibility to hide the status bar. 
