### PR TITLE
Add optional soft wrap based on .editorconfig file

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -752,6 +752,9 @@
   // The column at which to soft-wrap lines, for buffers where soft-wrap
   // is enabled.
   "preferred_line_length": 80,
+  /// Whether to use soft-wrap settings from .editorconfig files and rewrite
+  /// `preferred_line_length` setting.
+  "editorconfig_soft_wrap": false,
   // Whether to indent lines using tab characters, as opposed to multiple
   // spaces.
   "hard_tabs": false,

--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -55,6 +55,7 @@ You can customize a wide range of settings for each language, including:
 - [`enable_language_server`](./configuring-zed.md#enable-language-server): Toggle language server support
 - [`hard_tabs`](./configuring-zed.md#hard-tabs): Use tabs instead of spaces for indentation
 - [`preferred_line_length`](./configuring-zed.md#preferred-line-length): The recommended maximum line length
+- [`editorconfig_soft_wrap`](./configuring-zed.md#editorconfig_soft_wrap): Whether to use soft wrapping based on the .edtitorconfig file
 - [`soft_wrap`](./configuring-zed.md#soft-wrap): How to wrap long lines of code
 - [`show_completions_on_input`](./configuring-zed.md#show-completions-on-input): Whether or not to show completions as you type
 - [`show_completion_documentation`](./configuring-zed.md#show-completion-documentation): Whether to display inline and alongside documentation for items in the completions menu

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1634,6 +1634,7 @@ The following settings can be overridden for each specific language:
 - [`formatter`](#formatter)
 - [`hard_tabs`](#hard-tabs)
 - [`preferred_line_length`](#preferred-line-length)
+- [`editorconfig_soft_wrap`](#editorconfig-soft-wrap)
 - [`remove_trailing_whitespace_on_save`](#remove-trailing-whitespace-on-save)
 - [`show_edit_predictions`](#show-edit-predictions)
 - [`show_whitespaces`](#show-whitespaces)
@@ -1739,6 +1740,12 @@ Or to set a `socks5` proxy:
 - Description: The column at which to soft-wrap lines, for buffers where soft-wrap is enabled.
 - Setting: `preferred_line_length`
 - Default: `80`
+
+## Editorconfig Soft Wrap
+
+- Description: Whether to soft-wrap lines according to the .editorconfig column `max_line_length` specification.
+- Setting: `editorconfig_soft_wrap`
+- Default: `false`
 
 **Options**
 


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/25888

Release Notes:

- Added setting `editorconfig_soft_wrap` by default set to `false`, which allows .editorconfig `max_line_length` to wrap `preferred_line_length` and `soft_wrap` optionally
