### PR TITLE
Fix issues with .git FS events handling

### DIFF
--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -26,6 +26,7 @@ pub static DOT_GIT: LazyLock<&'static OsStr> = LazyLock::new(|| OsStr::new(".git
 pub static GITIGNORE: LazyLock<&'static OsStr> = LazyLock::new(|| OsStr::new(".gitignore"));
 pub static FSMONITOR_DAEMON: LazyLock<&'static OsStr> =
     LazyLock::new(|| OsStr::new("fsmonitor--daemon"));
+pub static LFS_DIR: LazyLock<&'static OsStr> = LazyLock::new(|| OsStr::new("lfs"));
 pub static COMMIT_MESSAGE: LazyLock<&'static OsStr> =
     LazyLock::new(|| OsStr::new("COMMIT_EDITMSG"));
 pub static INDEX_LOCK: LazyLock<&'static OsStr> = LazyLock::new(|| OsStr::new("index.lock"));

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -25,6 +25,7 @@ use git::{
         FileStatus, GitSummary, StatusCode, TrackedStatus, UnmergedStatus, UnmergedStatusCode,
     },
     GitHostingProviderRegistry, COMMIT_MESSAGE, DOT_GIT, FSMONITOR_DAEMON, GITIGNORE, INDEX_LOCK,
+    LFS_DIR,
 };
 use gpui::{
     App, AppContext as _, AsyncApp, BackgroundExecutor, Context, Entity, EventEmitter, Task,
@@ -4513,7 +4514,7 @@ impl BackgroundScanner {
         // Certain directories may have FS changes, but do not lead to git data changes that Zed cares about.
         // Ignore these, to avoid Zed unnecessarily rescanning git metadata.
         let skipped_files_in_dot_git = HashSet::from_iter([*COMMIT_MESSAGE, *INDEX_LOCK]);
-        let skipped_dirs_in_dot_git = [*FSMONITOR_DAEMON];
+        let skipped_dirs_in_dot_git = [*FSMONITOR_DAEMON, *LFS_DIR];
 
         let mut relative_paths = Vec::with_capacity(abs_paths.len());
         let mut dot_git_abs_paths = Vec::new();

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2766,7 +2766,7 @@ async fn test_repository_subfolder_git_status(cx: &mut TestAppContext) {
     .unwrap();
 
     tree.flush_fs_events(cx).await;
-    tree.flush_fs_events_in_root_git_repository(cx).await;
+    tree.flush_fs_events_in_root_git_repository(false, cx).await;
     cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
         .await;
     cx.executor().run_until_parked();
@@ -2798,7 +2798,7 @@ async fn test_repository_subfolder_git_status(cx: &mut TestAppContext) {
     // Meaning: we don't produce any FS events for files inside the project.
     git_add(E_TXT, &repo);
     git_commit("Second commit", &repo);
-    tree.flush_fs_events_in_root_git_repository(cx).await;
+    tree.flush_fs_events_in_root_git_repository(false, cx).await;
     cx.executor().run_until_parked();
 
     tree.read_with(cx, |tree, _cx| {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/25865

In the issue, Zed had caused `.git/lfs/tmp/466102258`-like files to appear in the directory, which lead to background FS event listener to handle this as an update, incrementing snapshot's `scan_id`, which lead to git status rescan, which caused another increment to `status_scan_id` — incrementing either of the IDs causes the related repo data to be considered "changed:

https://github.com/zed-industries/zed/blob/41b45eaba798a56e596857fa497c862050788bc7/crates/worktree/src/worktree.rs#L1590-L1605

hence propagating events to the other parts of the system (e.g. git blame, which was also active in the issue's case)

```
[2025-03-01T20:01:08+01:00 DEBUG worktree] ignoring event ".git/lfs/tmp/466102258" within unloaded directory
[2025-03-01T20:01:08+01:00 DEBUG worktree] received fs events []
[2025-03-01T20:01:08+01:00 DEBUG worktree] reloading repositories: ["/Users/alex/dev/monorepo/.git"]
[2025-03-01T20:01:08+01:00 DEBUG editor::git::blame] Status of git repositories updated. Regenerating blame data...
[2025-03-01T20:01:08+01:00 DEBUG editor::git::blame] Status of git repositories updated. Regenerating blame data...
[2025-03-01T20:01:08+01:00 DEBUG editor::git::blame] Status of git repositories updated. Regenerating blame data...
```

Due to repo update events sent, another `.git/lfs/tmp/` entry is created, things start over...

To fix this, two commits are done in the PR:

1. `.git/lfs/` directory's FS events are not related to git statuses, the PR makes Zed to skip git status updates on such changes
2. Avoid `scan_id` and `status_scan_id` increments if nothing new was discovered

Both parts were tested separately by the issue owner and were reported as fixing the issue; my manual testing shows the same: I have not experienced the issue myself, but ran Zed and 
```
while true; do
    touch "$file_path"
    echo "Touched $file_path at $(date +%H:%M:%S.%N | cut -c 1-12)"
    sleep 0.5
done
```

loop inside the project's `/git/foo/bar` directory, precreated upfront.
This was enough to notice the same debug logs provided and fix these.

I have tried to create a test in `worktree_tests.rs` but 
* `flush_fs_events*` test methods create and remove `fs-event-sentinel` file to trigger the event handling, but to test `received fs events []` case, I need to alter files within `.git` subdirectory only
* doing that in tests did not trigger anything related, I'm not sure what else can I do about it at this point

Release Notes:

- Fixed issues with .git FS events handling
