### PR TITLE
Revert "assistant_context_editor: Close menus on send (#25440)"

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -336,14 +336,10 @@ impl ContextEditor {
     }
 
     fn assist(&mut self, _: &Assist, window: &mut Window, cx: &mut Context<Self>) {
-        self.slash_menu_handle.hide(cx);
-        self.language_model_selector_menu_handle.hide(cx);
         self.send_to_model(RequestType::Chat, window, cx);
     }
 
     fn edit(&mut self, _: &Edit, window: &mut Window, cx: &mut Context<Self>) {
-        self.slash_menu_handle.hide(cx);
-        self.language_model_selector_menu_handle.hide(cx);
         self.send_to_model(RequestType::SuggestEdits, window, cx);
     }
 


### PR DESCRIPTION
Reverting https://github.com/zed-industries/zed/pull/25440

This is a good change, but given the PR was open for a while, I guess it didn't catch conflicts with main, and so it broke it. Will revert it for now, to keep main fresh, but will look into adding this behavior back again.

Release Notes:

- N/A
