### PR TITLE
assistant2: Fix keyboard navigation issues when a picker is open

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -231,12 +231,8 @@ impl AssistantPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // If the context picker is deployed, we do not want to interfere with the dismiss event
-        if self
-            .message_editor
-            .read(cx)
-            .is_any_context_picker_deployed()
-        {
+        // If the context picker is deployed, we do not want to interfere with the cancel event
+        if self.message_editor.read(cx).is_any_picker_deployed(cx) {
             cx.propagate();
             return;
         }

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -232,7 +232,11 @@ impl AssistantPanel {
         cx: &mut Context<Self>,
     ) {
         // If the context picker is deployed, we do not want to interfere with the dismiss event
-        if self.message_editor.read(cx).is_context_picker_deployed() {
+        if self
+            .message_editor
+            .read(cx)
+            .is_any_context_picker_deployed()
+        {
             cx.propagate();
             return;
         }

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -231,6 +231,11 @@ impl AssistantPanel {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // If the context picker is deployed, we do not want to interfere with the dismiss event
+        if self.message_editor.read(cx).is_context_picker_deployed() {
+            cx.propagate();
+            return;
+        }
         self.thread
             .update(cx, |thread, cx| thread.cancel_last_completion(cx));
     }

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -140,6 +140,10 @@ impl MessageEditor {
         self.send_to_model(RequestKind::Chat, window, cx);
     }
 
+    pub fn is_context_picker_deployed(&self) -> bool {
+        self.context_picker_menu_handle.is_deployed()
+    }
+
     fn is_editor_empty(&self, cx: &App) -> bool {
         self.editor.read(cx).text(cx).is_empty()
     }

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -140,8 +140,9 @@ impl MessageEditor {
         self.send_to_model(RequestKind::Chat, window, cx);
     }
 
-    pub fn is_context_picker_deployed(&self) -> bool {
+    pub fn is_any_context_picker_deployed(&self) -> bool {
         self.context_picker_menu_handle.is_deployed()
+            || self.inline_context_picker_menu_handle.is_deployed()
     }
 
     fn is_editor_empty(&self, cx: &App) -> bool {

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -140,9 +140,10 @@ impl MessageEditor {
         self.send_to_model(RequestKind::Chat, window, cx);
     }
 
-    pub fn is_any_context_picker_deployed(&self) -> bool {
+    pub fn is_any_picker_deployed(&self, cx: &App) -> bool {
         self.context_picker_menu_handle.is_deployed()
             || self.inline_context_picker_menu_handle.is_deployed()
+            || self.model_selector.read(cx).selector.read(cx).is_deployed()
     }
 
     fn is_editor_empty(&self, cx: &App) -> bool {
@@ -257,9 +258,7 @@ impl MessageEditor {
     }
 
     fn move_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
-        if self.context_picker_menu_handle.is_deployed()
-            || self.inline_context_picker_menu_handle.is_deployed()
-        {
+        if self.is_any_picker_deployed(cx) {
             cx.propagate();
         } else {
             self.context_strip.focus_handle(cx).focus(window);

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -755,7 +755,7 @@ pub trait InteractiveElement: Sized {
     }
 
     /// Capture the given action, before normal action dispatch can fire
-    /// The fluent API equivalent to [`Interactivity::on_scroll_wheel`]
+    /// The fluent API equivalent to [`Interactivity::capture_action`]
     ///
     /// See [`Context::listener`](crate::Context::listener) to get access to a view's state from this callback.
     fn capture_action<A: Action>(

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -73,6 +73,10 @@ impl LanguageModelSelector {
         }
     }
 
+    pub fn is_deployed(&self) -> bool {
+        self.popover_menu_handle.is_deployed()
+    }
+
     pub fn toggle_model_selector(
         &mut self,
         _: &ToggleModelSelector,


### PR DESCRIPTION
This fixes:
- Bug: Using "up" in model selector triggers `assistant2::FocusUp` not `menu::SelectPrev`
- Bug: Pressing arrow up/down in the model selector opened in the inline assistant doesn't work
- Bug: Dismissing the model selector with `Esc` is not working
- Bug: Dismissing context pickers with `Esc` no longer working

Release Notes:

- N/A
