### PR TITLE
assistant: Adjust slash command picker

### DIFF
--- a/crates/assistant_context_editor/src/slash_command_picker.rs
+++ b/crates/assistant_context_editor/src/slash_command_picker.rs
@@ -314,7 +314,7 @@ where
                         )
                         .child(
                             Label::new("Create your custom command")
-                                .size(LabelSize::XSmall)
+                                .size(LabelSize::Small)
                                 .color(Color::Muted),
                         )
                         .into_any_element()

--- a/crates/assistant_context_editor/src/slash_command_picker.rs
+++ b/crates/assistant_context_editor/src/slash_command_picker.rs
@@ -207,24 +207,31 @@ impl PickerDelegate for SlashCommandDelegate {
                             .child(
                                 h_flex()
                                     .gap_1p5()
-                                    .child(Icon::new(info.icon).size(IconSize::XSmall))
-                                    .child(div().font_buffer(cx).child({
+                                    .child(
+                                        Icon::new(info.icon)
+                                            .size(IconSize::XSmall)
+                                            .color(Color::Muted),
+                                    )
+                                    .child({
                                         let mut label = format!("{}", info.name);
                                         if let Some(args) = info.args.as_ref().filter(|_| selected)
                                         {
                                             label.push_str(&args);
                                         }
-                                        Label::new(label).single_line().size(LabelSize::Small)
-                                    }))
+                                        Label::new(label)
+                                            .single_line()
+                                            .size(LabelSize::Small)
+                                            .buffer_font(cx)
+                                    })
                                     .children(info.args.clone().filter(|_| !selected).map(
                                         |args| {
                                             div()
-                                                .font_buffer(cx)
                                                 .child(
                                                     Label::new(args)
                                                         .single_line()
                                                         .size(LabelSize::Small)
-                                                        .color(Color::Muted),
+                                                        .color(Color::Muted)
+                                                        .buffer_font(cx),
                                                 )
                                                 .visible_on_hover(format!(
                                                     "command-entry-label-{ix}"
@@ -294,10 +301,9 @@ where
                                         .gap_1p5()
                                         .child(Icon::new(IconName::Plus).size(IconSize::XSmall))
                                         .child(
-                                            div().font_buffer(cx).child(
-                                                Label::new("create-your-command")
-                                                    .size(LabelSize::Small),
-                                            ),
+                                            Label::new("create-your-command")
+                                                .size(LabelSize::Small)
+                                                .buffer_font(cx),
                                         ),
                                 )
                                 .child(
@@ -308,7 +314,7 @@ where
                         )
                         .child(
                             Label::new("Create your custom command")
-                                .size(LabelSize::Small)
+                                .size(LabelSize::XSmall)
                                 .color(Color::Muted),
                         )
                         .into_any_element()
@@ -341,7 +347,7 @@ where
             .anchor(gpui::Corner::BottomLeft)
             .offset(gpui::Point {
                 x: px(0.0),
-                y: px(-16.0),
+                y: px(-2.0),
             })
             .when_some(handle, |this, handle| this.with_handle(handle))
     }


### PR DESCRIPTION
Mostly just fine-tuning its positioning. Other changes are mainly using the Label's `buffer_font` method instead of using a div for that.

Release Notes:

- N/A
