### PR TITLE
Revert "Use multi-line regex for '\s'"

### DIFF
--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -137,7 +137,7 @@ impl SearchQuery {
             query = word_query
         }
 
-        let multiline = query.contains('\n') || query.contains("\\n") || query.contains("\\s");
+        let multiline = query.contains('\n') || query.contains("\\n");
         let regex = RegexBuilder::new(&query)
             .case_insensitive(!case_sensitive)
             .build()?;


### PR DESCRIPTION
Reverts zed-industries/zed#19241
Closes: https://github.com/zed-industries/zed/issues/25901

Although `\s` contains `\n` it is widely used in non-multiline regexes (unlike `\n`).

See also:
- https://github.com/zed-industries/zed/issues/25901#issuecomment-2692996651
- https://github.com/zed-industries/zed/issues/25925
- https://github.com/zed-industries/zed/issues/19184

Release Notes:

- N/A