### PR TITLE
assistant2: Fix keyboard navigation issues when a picker is open

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -779,6 +779,8 @@
   {
     "context": "Picker > Editor",
     "bindings": {
+      "up": "menu::SelectPrev",
+      "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }]
     }

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -779,6 +779,7 @@
   {
     "context": "Picker > Editor",
     "bindings": {
+      "escape": "menu::Cancel",
       "up": "menu::SelectPrev",
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -780,7 +780,7 @@
     "context": "Picker > Editor",
     "bindings": {
       "escape": "menu::Cancel",
-      "up": "menu::SelectPrev",
+      "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -798,7 +798,7 @@
     "context": "Picker > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "up": "menu::SelectPrev",
+      "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -798,6 +798,7 @@
     "context": "Picker > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "escape": "menu::Cancel",
       "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -798,6 +798,8 @@
     "context": "Picker > Editor",
     "use_key_equivalents": true,
     "bindings": {
+      "up": "menu::SelectPrev",
+      "down": "menu::SelectNext",
       "tab": "picker::ConfirmCompletion",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "cmd-alt-enter": ["picker::ConfirmInput", { "secondary": true }]


### PR DESCRIPTION
This fixes:
- Bug: Using "up" in model selector triggers assistant2::FocusUp not menu::SelectPrev
- Bug: Pressing arrow up/down in the model selector opened in the inline assistant doesn't work
- Bug: Dismissing the model selector with Esc is not working
- Bug: Dismissing context pickers with Esc no longer working

Release Notes:

- N/A
