### PR TITLE
git_ui: Fix overflowing repo and branch labels in panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "aws-config"
-version = "1.5.17"
+version = "1.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490aa7465ee685b2ced076bb87ef654a47724a7844e2c7d3af4e749ce5b875dd"
+checksum = "50236e4d60fe8458de90a71c0922c761e41755adf091b1b03de1cef537179915"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1271,9 +1271,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-bedrockruntime"
-version = "1.75.0"
+version = "1.74.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ddf7475b6f50a1a5be8edb1bcdf6e4ae00feed5b890d14a3f1f0e14d76f5a16"
+checksum = "6938541d1948a543bca23303fec4cff9c36bf0e63b8fa3ae1b337bcb9d5b81af"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1295,9 +1295,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-kinesis"
-version = "1.62.0"
+version = "1.61.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31622345afd0c35d33c1cbba73ccf9fb88e09857413d8963dea2c493e00704d"
+checksum = "89f2163d8704e8fdcd51ec6c2e0441c418471e422ee9690451b17a1c46344e1a"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1317,9 +1317,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-s3"
-version = "1.77.0"
+version = "1.76.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34e87342432a3de0e94e82c99a7cbd9042f99de029ae1f4e368160f9e9929264"
+checksum = "66e83401ad7287ad15244d557e35502c2a94105ca5b41d656c391f1a4fc04ca2"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1351,9 +1351,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sso"
-version = "1.60.0"
+version = "1.58.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60186fab60b24376d3e33b9ff0a43485f99efd470e3b75a9160c849741d63d56"
+checksum = "16ff718c9ee45cc1ebd4774a0e086bb80a6ab752b4902edf1c9f56b86ee1f770"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1373,9 +1373,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-ssooidc"
-version = "1.61.0"
+version = "1.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7033130ce1ee13e6018905b7b976c915963755aef299c1521897679d6cd4f8ef"
+checksum = "5183e088715cc135d8d396fdd3bc02f018f0da4c511f53cb8d795b6a31c55809"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1395,9 +1395,9 @@ dependencies = [
 
 [[package]]
 name = "aws-sdk-sts"
-version = "1.61.0"
+version = "1.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5c1cac7677179d622b4448b0d31bcb359185295dc6fca891920cfb17e2b5156"
+checksum = "c9f944ef032717596639cea4a2118a3a457268ef51bbb5fde9637e54c465da00"
 dependencies = [
  "aws-credential-types",
  "aws-runtime",
@@ -1458,9 +1458,9 @@ dependencies = [
 
 [[package]]
 name = "aws-smithy-checksums"
-version = "0.63.0"
+version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2dc8d842d872529355c72632de49ef8c5a2949a4472f10e802f28cf925770c"
+checksum = "f2f45a1c384d7a393026bc5f5c177105aa9fa68e4749653b985707ac27d77295"
 dependencies = [
  "aws-smithy-http",
  "aws-smithy-types",
@@ -1810,7 +1810,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "log",
@@ -1833,7 +1833,7 @@ dependencies = [
  "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "prettyplease",
  "proc-macro2",
@@ -2406,6 +2406,25 @@ dependencies = [
 
 [[package]]
 name = "cbindgen"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
+dependencies = [
+ "clap",
+ "heck 0.4.1",
+ "indexmap",
+ "log",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "syn 2.0.90",
+ "tempfile",
+ "toml 0.8.20",
+]
+
+[[package]]
+name = "cbindgen"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eadd868a2ce9ca38de7eeafdcec9c7065ef89b42b32f0839278d55f35c54d1ff"
@@ -2501,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.40"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a7964611d71df112cb1730f2ee67324fcf4d0fc6606acbbe9bfe06df124637c"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -2511,7 +2530,7 @@ dependencies = [
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3508,10 +3527,11 @@ dependencies = [
 
 [[package]]
 name = "crc64fast-nvme"
-version = "1.2.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4955638f00a809894c947f85a024020a20815b65a5eea633798ea7924edab2b3"
+checksum = "d5e2ee08013e3f228d6d2394116c4549a6df77708442c62d887d83f68ef2ee37"
 dependencies = [
+ "cbindgen 0.27.0",
  "crc",
 ]
 
@@ -5563,7 +5583,7 @@ dependencies = [
  "bytemuck",
  "calloop",
  "calloop-wayland-source",
- "cbindgen",
+ "cbindgen 0.28.0",
  "cocoa 0.26.0",
  "collections",
  "core-foundation 0.9.4",
@@ -7236,9 +7256,9 @@ checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.169"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
 
 [[package]]
 name = "libdbus-sys"
@@ -9766,15 +9786,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pgvector"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0e8871b6d7ca78348c6cd29b911b94851f3429f0cd403130ca17f26c1fb91a6"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "phf"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10413,7 +10424,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes 1.10.0",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap 0.10.0",
  "once_cell",
@@ -10446,7 +10457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -11474,9 +11485,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed"
-version = "8.6.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3aba5104622db5c9fc61098de54708feb732e7763d7faa2fa625899f00bf6f"
+checksum = "fa66af4a4fdd5e7ebc276f115e895611a34739a9c1c01028383d612d550953c0"
 dependencies = [
  "rust-embed-impl",
  "rust-embed-utils",
@@ -11485,9 +11496,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-impl"
-version = "8.6.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f198c73be048d2c5aa8e12f7960ad08443e56fd39cc26336719fdb4ea0ebaae"
+checksum = "6125dbc8867951125eec87294137f4e9c2c96566e61bf72c45095a7c77761478"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11498,9 +11509,9 @@ dependencies = [
 
 [[package]]
 name = "rust-embed-utils"
-version = "8.6.0"
+version = "8.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a2fcdc9f40c8dc2922842ca9add611ad19f332227fc651d015881ad1552bd9a"
+checksum = "2e5347777e9aacb56039b0e1f28785929a8a3b709e87482e7442c72e7c12529d"
 dependencies = [
  "globset",
  "sha2",
@@ -11775,9 +11786,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "indexmap",
@@ -11788,9 +11799,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11853,18 +11864,17 @@ dependencies = [
 
 [[package]]
 name = "sea-orm"
-version = "1.1.6"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fba7b2c749b2d0a00303d5cb13e6761e39a4172554bdf930852cac4e7aeabd"
+checksum = "00733e5418e8ae3758cdb988c3654174e716230cc53ee2cb884207cf86a23029"
 dependencies = [
  "async-stream",
  "async-trait",
  "bigdecimal",
  "chrono",
- "futures-util",
+ "futures 0.3.31",
  "log",
  "ouroboros",
- "pgvector",
  "rust_decimal",
  "sea-orm-macros",
  "sea-query",
@@ -11882,9 +11892,9 @@ dependencies = [
 
 [[package]]
 name = "sea-orm-macros"
-version = "1.1.6"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2568cff8d35d5150b4276cc0dd766192a587f64b6ece60ae3706e0872c4eb209"
+checksum = "a98408f82fb4875d41ef469a79944a7da29767c7b3e4028e22188a3dd613b10f"
 dependencies = [
  "heck 0.4.1",
  "proc-macro2",
@@ -14804,9 +14814,9 @@ dependencies = [
 
 [[package]]
 name = "uuid"
-version = "1.15.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0f540e3240398cce6128b64ba83fdbdd86129c16a3aa1a3a252efd66eb3d587"
+checksum = "8c1f41ffb7cf259f1ecc2876861a17e7142e63ead296f671f81f6ae85903e0d6"
 dependencies = [
  "getrandom 0.3.1",
  "serde",
@@ -15928,12 +15938,6 @@ dependencies = [
  "quote",
  "syn 2.0.90",
 ]
-
-[[package]]
-name = "windows-link"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dccfd733ce2b1753b03b6d3c65edf020262ea35e20ccdf3e288043e6dd620e3"
 
 [[package]]
 name = "windows-registry"

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -609,7 +609,7 @@ impl AssistantPanel {
                     .id("title")
                     .overflow_x_scroll()
                     .px(DynamicSpacing::Base08.rems(cx))
-                    .child(Label::new(title).text_ellipsis()),
+                    .child(Label::new(title).truncate()),
             )
             .child(
                 h_flex()

--- a/crates/assistant2/src/thread_history.rs
+++ b/crates/assistant2/src/thread_history.rs
@@ -260,7 +260,7 @@ impl RenderOnce for PastThread {
             .start_slot(
                 div()
                     .max_w_4_5()
-                    .child(Label::new(summary).size(LabelSize::Small).text_ellipsis()),
+                    .child(Label::new(summary).size(LabelSize::Small).truncate()),
             )
             .end_slot(
                 h_flex()
@@ -356,7 +356,7 @@ impl RenderOnce for PastContext {
         .start_slot(
             div()
                 .max_w_4_5()
-                .child(Label::new(summary).size(LabelSize::Small).text_ellipsis()),
+                .child(Label::new(summary).size(LabelSize::Small).truncate()),
         )
         .end_slot(
             h_flex()

--- a/crates/assistant_context_editor/src/slash_command_picker.rs
+++ b/crates/assistant_context_editor/src/slash_command_picker.rs
@@ -243,7 +243,7 @@ impl PickerDelegate for SlashCommandDelegate {
                                 Label::new(info.description.clone())
                                     .size(LabelSize::Small)
                                     .color(Color::Muted)
-                                    .text_ellipsis(),
+                                    .truncate(),
                             ),
                     ),
             ),

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -226,3 +226,7 @@ impl Item for ComponentPreview {
         f(*event)
     }
 }
+
+// TODO: impl serializable item for component preview so it will restore with the workspace
+// ref: https://github.com/zed-industries/zed/blob/32201ac70a501e63dfa2ade9c00f85aea2d4dd94/crates/image_viewer/src/image_viewer.rs#L199
+// Use `ImageViewer` as a model for how to do it, except it'll be even simpler

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -522,7 +522,7 @@ impl ExtensionsPage {
                             extension.authors.join(", ")
                         ))
                         .size(LabelSize::Small)
-                        .text_ellipsis(),
+                        .truncate(),
                     )
                     .child(Label::new("<>").size(LabelSize::Small)),
             )
@@ -534,7 +534,7 @@ impl ExtensionsPage {
                         Label::new(description.clone())
                             .size(LabelSize::Small)
                             .color(Color::Default)
-                            .text_ellipsis()
+                            .truncate()
                     }))
                     .children(repository_url.map(|repository_url| {
                         IconButton::new(
@@ -665,7 +665,7 @@ impl ExtensionsPage {
                             extension.manifest.authors.join(", ")
                         ))
                         .size(LabelSize::Small)
-                        .text_ellipsis(),
+                        .truncate(),
                     )
                     .child(
                         Label::new(format!(
@@ -683,7 +683,7 @@ impl ExtensionsPage {
                         Label::new(description.clone())
                             .size(LabelSize::Small)
                             .color(Color::Default)
-                            .text_ellipsis()
+                            .truncate()
                     }))
                     .child(
                         h_flex()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3462,94 +3462,204 @@ impl ComponentPreview for PanelRepoFooter {
             }
         }
 
+        fn custom(branch_name: &str, upstream: Option<UpstreamTracking>) -> Branch {
+            Branch {
+                is_head: true,
+                name: branch_name.to_string().into(),
+                upstream: upstream.map(|tracking| Upstream {
+                    ref_name: format!("zed/{}", branch_name).into(),
+                    tracking,
+                }),
+                most_recent_commit: Some(CommitSummary {
+                    sha: "abc123".into(),
+                    subject: "Modify stuff".into(),
+                    commit_timestamp: 1710932954,
+                }),
+            }
+        }
+
         fn active_repository(id: usize) -> SharedString {
             format!("repo-{}", id).into()
         }
 
+        let example_width = px(340.);
+
         v_flex()
             .gap_6()
+            .w_full()
+            .flex_none()
             .children(vec![example_group_with_title(
                 "Action Button States",
                 vec![
                     single_example(
                         "No Branch",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "no-branch",
                                 active_repository(1).clone(),
                                 None,
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                     single_example(
                         "Remote status unknown",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "unknown-upstream",
                                 active_repository(2).clone(),
                                 Some(branch(unknown_upstream)),
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                     single_example(
                         "No Remote Upstream",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "no-remote-upstream",
                                 active_repository(3).clone(),
                                 Some(branch(no_remote_upstream)),
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                     single_example(
                         "Not Ahead or Behind",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "not-ahead-or-behind",
                                 active_repository(4).clone(),
                                 Some(branch(not_ahead_or_behind_upstream)),
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                     single_example(
                         "Behind remote",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "behind-remote",
                                 active_repository(5).clone(),
                                 Some(branch(behind_upstream)),
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                     single_example(
                         "Ahead of remote",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "ahead-of-remote",
                                 active_repository(6).clone(),
                                 Some(branch(ahead_of_upstream)),
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                     single_example(
                         "Ahead and behind remote",
                         div()
-                            .w(px(180.))
+                            .w(example_width)
+                            .overflow_hidden()
                             .child(PanelRepoFooter::new_preview(
                                 "ahead-and-behind",
                                 active_repository(7).clone(),
                                 Some(branch(ahead_and_behind_upstream)),
                             ))
                             .into_any_element(),
-                    ),
+                    )
+                    .grow(),
                 ],
             )
+            .grow()
+            .vertical()])
+            .children(vec![example_group_with_title(
+                "Labels",
+                vec![
+                    single_example(
+                        "Short Branch & Repo",
+                        div()
+                            .w(example_width)
+                            .overflow_hidden()
+                            .child(PanelRepoFooter::new_preview(
+                                "short-branch",
+                                SharedString::from("zed"),
+                                Some(custom("main", behind_upstream)),
+                            ))
+                            .into_any_element(),
+                    )
+                    .grow(),
+                    single_example(
+                        "Long Branch",
+                        div()
+                            .w(example_width)
+                            .overflow_hidden()
+                            .child(PanelRepoFooter::new_preview(
+                                "long-branch",
+                                SharedString::from("zed"),
+                                Some(custom(
+                                    "redesign-and-update-git-ui-list-entry-style",
+                                    behind_upstream,
+                                )),
+                            ))
+                            .into_any_element(),
+                    )
+                    .grow(),
+                    single_example(
+                        "Long Repo",
+                        div()
+                            .w(example_width)
+                            .overflow_hidden()
+                            .child(PanelRepoFooter::new_preview(
+                                "long-repo",
+                                SharedString::from("zed-industries-community-examples"),
+                                Some(custom("gpui", ahead_of_upstream)),
+                            ))
+                            .into_any_element(),
+                    )
+                    .grow(),
+                    single_example(
+                        "Uppercase Repo",
+                        div()
+                            .w(example_width)
+                            .overflow_hidden()
+                            .child(PanelRepoFooter::new_preview(
+                                "uppercase-repo",
+                                SharedString::from("LICENSES"),
+                                Some(custom("main", ahead_of_upstream)),
+                            ))
+                            .into_any_element(),
+                    )
+                    .grow(),
+                    single_example(
+                        "Uppercase Branch",
+                        div()
+                            .w(example_width)
+                            .overflow_hidden()
+                            .child(PanelRepoFooter::new_preview(
+                                "uppercase-branch",
+                                SharedString::from("zed"),
+                                Some(custom("update-README", behind_upstream)),
+                            ))
+                            .into_any_element(),
+                    )
+                    .grow(),
+                ],
+            )
+            .grow()
             .vertical()])
             .into_any_element()
     }

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -402,7 +402,7 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                         .w(px(240.))
                         .child(
                             div().max_w_40().child(
-                                Label::new(model_info.model.name().0.clone()).text_ellipsis(),
+                                Label::new(model_info.model.name().0.clone()).truncate(),
                             ),
                         )
                         .child(

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -401,7 +401,7 @@ impl TitleBar {
                         .child(
                             Label::new(nickname.clone())
                                 .size(LabelSize::Small)
-                                .text_ellipsis(),
+                                .truncate(),
                         ),
                 )
                 .tooltip(move |window, cx| {

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -97,6 +97,7 @@ pub struct Button {
     key_binding: Option<KeyBinding>,
     key_binding_position: KeybindingPosition,
     alpha: Option<f32>,
+    truncate: bool,
 }
 
 impl Button {
@@ -123,6 +124,7 @@ impl Button {
             key_binding: None,
             key_binding_position: KeybindingPosition::default(),
             alpha: None,
+            truncate: false,
         }
     }
 
@@ -204,6 +206,15 @@ impl Button {
     /// Sets the alpha property of the color of label.
     pub fn alpha(mut self, alpha: f32) -> Self {
         self.alpha = Some(alpha);
+        self
+    }
+
+    /// Truncates overflowing labels with an ellipsis (`…`) if needed.
+    ///
+    /// Buttons with static labels should _never_ be truncated, ensure
+    /// this is only used when the label is dynamic and may overflow.
+    pub fn truncate(mut self, truncate: bool) -> Self {
+        self.truncate = truncate;
         self
     }
 }
@@ -437,7 +448,8 @@ impl RenderOnce for Button {
                                 .color(label_color)
                                 .size(self.label_size.unwrap_or_default())
                                 .when_some(self.alpha, |this, alpha| this.alpha(alpha))
-                                .line_height_style(LineHeightStyle::UiLabel),
+                                .line_height_style(LineHeightStyle::UiLabel)
+                                .when(self.truncate, |this| this.truncate()),
                         )
                         .children(self.key_binding),
                 )

--- a/crates/ui/src/components/label/highlighted_label.rs
+++ b/crates/ui/src/components/label/highlighted_label.rs
@@ -64,8 +64,8 @@ impl LabelCommon for HighlightedLabel {
         self
     }
 
-    fn text_ellipsis(mut self) -> Self {
-        self.base = self.base.text_ellipsis();
+    fn truncate(mut self) -> Self {
+        self.base = self.base.truncate();
         self
     }
 

--- a/crates/ui/src/components/label/label.rs
+++ b/crates/ui/src/components/label/label.rs
@@ -171,8 +171,9 @@ impl LabelCommon for Label {
         self
     }
 
-    fn text_ellipsis(mut self) -> Self {
-        self.base = self.base.text_ellipsis();
+    /// Truncates overflowing text with an ellipsis (`…`) if needed.
+    fn truncate(mut self) -> Self {
+        self.base = self.base.truncate();
         self
     }
 
@@ -240,7 +241,7 @@ mod label_preview {
                         "Special Cases",
                         vec![
                             single_example("Single Line", Label::new("Line 1\nLine 2\nLine 3").single_line().into_any_element()),
-                            single_example("Text Ellipsis", div().max_w_24().child(Label::new("This is a very long file name that should be truncated: very_long_file_name_with_many_words.rs").text_ellipsis()).into_any_element()),
+                            single_example("Text Ellipsis", div().max_w_24().child(Label::new("This is a very long file name that should be truncated: very_long_file_name_with_many_words.rs").truncate()).into_any_element()),
                         ],
                     ),
                 ])

--- a/crates/ui/src/components/label/label_like.rs
+++ b/crates/ui/src/components/label/label_like.rs
@@ -57,7 +57,7 @@ pub trait LabelCommon {
     fn alpha(self, alpha: f32) -> Self;
 
     /// Truncates overflowing text with an ellipsis (`…`) if needed.
-    fn text_ellipsis(self) -> Self;
+    fn truncate(self) -> Self;
 
     /// Sets the label to render as a single line.
     fn single_line(self) -> Self;
@@ -84,7 +84,7 @@ pub struct LabelLike {
     alpha: Option<f32>,
     underline: bool,
     single_line: bool,
-    text_ellipsis: bool,
+    truncate: bool,
 }
 
 impl Default for LabelLike {
@@ -109,7 +109,7 @@ impl LabelLike {
             alpha: None,
             underline: false,
             single_line: false,
-            text_ellipsis: false,
+            truncate: false,
         }
     }
 }
@@ -166,8 +166,9 @@ impl LabelCommon for LabelLike {
         self
     }
 
-    fn text_ellipsis(mut self) -> Self {
-        self.text_ellipsis = true;
+    /// Truncates overflowing text with an ellipsis (`…`) if needed.
+    fn truncate(mut self) -> Self {
+        self.truncate = true;
         self
     }
 
@@ -220,7 +221,7 @@ impl RenderOnce for LabelLike {
             })
             .when(self.strikethrough, |this| this.line_through())
             .when(self.single_line, |this| this.whitespace_nowrap())
-            .when(self.text_ellipsis, |this| {
+            .when(self.truncate, |this| {
                 this.overflow_x_hidden().text_ellipsis()
             })
             .text_color(color)


### PR DESCRIPTION
This PR fixes one of the two issues related below: Constrain the space the repo/branch pickers are allow to fill

Truncation is a bit more complicated due to the nature of two buttons flexed in a row, and the issue fixed here at least makes the right side buttons not broken.

Where we are now:

![CleanShot 2025-03-03 at 12 08 38@2x](https://github.com/user-attachments/assets/7df7fa58-4a1e-4215-a3ca-d61c80ad4441)

---

Problem: 

![CleanShot 2025-03-03 at 10 29 04@2x](https://github.com/user-attachments/assets/f95e5314-fb73-491d-823d-0108f6d3e1fd)

Two fixes are needed:

- Constrain the space the repo/branch pickers are allow to fill
- Truncate long names in each when needed

Release Notes:

- N/A *or* Added/Fixed/Improved ...
