### PR TITLE
extension_cli: Make use of `scrollbar_thumb.background` a hard error

### DIFF
--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -339,6 +339,20 @@ async fn test_themes(
         let theme_path = extension_path.join(relative_theme_path);
         let theme_family = theme::read_user_theme(&theme_path, fs.clone()).await?;
         log::info!("loaded theme family {}", theme_family.name);
+
+        for theme in &theme_family.themes {
+            if theme
+                .style
+                .colors
+                .deprecated_scrollbar_thumb_background
+                .is_some()
+            {
+                bail!(
+                    r#"Theme "{theme_name}" is using a deprecated style property: scrollbar_thumb.background. Use `scrollbar.thumb.background` instead."#,
+                    theme_name = theme.name
+                )
+            }
+        }
     }
 
     Ok(())


### PR DESCRIPTION
This PR updates the extension CLI to make the use of `scrollbar_thumb.background` in a theme a hard error.

We're working to eradicate usage of this theme property, so this will prevent new extensions from being published that use it.

Release Notes:

- N/A
