### PR TITLE
editor: Ensure correct tab icon is shown for files outside of the current project

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -618,11 +618,8 @@ impl Item for Editor {
         ItemSettings::get_global(cx)
             .file_icons
             .then(|| {
-                self.buffer
-                    .read(cx)
-                    .as_singleton()
-                    .and_then(|buffer| buffer.read(cx).project_path(cx))
-                    .and_then(|path| FileIcons::get_icon(path.path.as_ref(), cx))
+                path_for_buffer(&self.buffer, 0, true, cx)
+                    .and_then(|path| FileIcons::get_icon(path.as_ref(), cx))
             })
             .flatten()
             .map(Icon::from_path)


### PR DESCRIPTION
Closes #25885 

This PR improves the matching for file icons to tabs. 
Previously, the tab icon would be resolved based upon the relative path in the current project. However, this caused the default file icon being assigned to all files outside of the project, as the relative path for these files would be empty.

Instead, `path_for_buffer` is now used which always returns a proper file name even for paths outside the current project (as also stated [in this comment](https://github.com/zed-industries/zed/blob/fee9c677078ad5beebe151e8350e1fc353230dc9/crates/editor/src/items.rs#L1689)).
As the file name is sufficient for matching icons to files, this fixes the linked issue whilst not changing anything for previously properly matched icons.

| `main` | This PR |
| --- | --- | 
| <img width="296" alt="main" src="https://github.com/user-attachments/assets/e72b8b5d-aa1c-4a8e-903f-14239f5b8764" /> | <img width="296" alt="PR" src="https://github.com/user-attachments/assets/a736974a-ce41-4861-be3f-95448cc7ffd0" /> |

Release Notes:

- Fixed wrong file icons being shown for files outside of the current project.
