### PR TITLE
assistant2: Use `cmd-n` to create a new prompt editor when already in a prompt editor

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -613,6 +613,14 @@
     }
   },
   {
+    "context": "AssistantPanel2 && prompt_editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-n": "assistant2::NewPromptEditor",
+      "cmd-alt-p": "assistant2::NewThread"
+    }
+  },
+  {
     "context": "MessageEditor > Editor",
     "bindings": {
       "enter": "assistant2::Chat"

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -617,7 +617,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "assistant2::NewPromptEditor",
-      "cmd-alt-p": "assistant2::NewThread"
+      "cmd-alt-t": "assistant2::NewThread"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -257,6 +257,14 @@
     }
   },
   {
+    "context": "AssistantPanel2 && prompt_editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "cmd-n": "assistant2::NewPromptEditor",
+      "cmd-alt-p": "assistant2::NewThread"
+    }
+  },
+  {
     "context": "MessageEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -261,7 +261,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "assistant2::NewPromptEditor",
-      "cmd-alt-p": "assistant2::NewThread"
+      "cmd-alt-t": "assistant2::NewThread"
     }
   },
   {

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -15,7 +15,8 @@ use editor::Editor;
 use fs::Fs;
 use gpui::{
     prelude::*, Action, AnyElement, App, AsyncWindowContext, Corner, Entity, EventEmitter,
-    FocusHandle, Focusable, FontWeight, Pixels, Subscription, Task, UpdateGlobal, WeakEntity,
+    FocusHandle, Focusable, FontWeight, KeyContext, Pixels, Subscription, Task, UpdateGlobal,
+    WeakEntity,
 };
 use language::LanguageRegistry;
 use language_model::{LanguageModelProviderTosView, LanguageModelRegistry};
@@ -993,12 +994,21 @@ impl AssistantPanel {
             )
             .into_any()
     }
+
+    fn key_context(&self) -> KeyContext {
+        let mut key_context = KeyContext::new_with_defaults();
+        key_context.add("AssistantPanel2");
+        if matches!(self.active_view, ActiveView::PromptEditor) {
+            key_context.add("prompt_editor");
+        }
+        key_context
+    }
 }
 
 impl Render for AssistantPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
-            .key_context("AssistantPanel2")
+            .key_context(self.key_context())
             .justify_between()
             .size_full()
             .on_action(cx.listener(Self::cancel))


### PR DESCRIPTION
This flips the keybindings that are used to create a new thread/prompt editor (only when you're already in a prompt editor)

Release Notes:

- N/A
