### PR TITLE
vim: Fix key navigation on folded buffer headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14908,6 +14908,7 @@ dependencies = [
  "multi_buffer",
  "nvim-rs",
  "parking_lot",
+ "project",
  "project_panel",
  "regex",
  "release_channel",

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1124,6 +1124,11 @@ impl DisplaySnapshot {
         self.block_snapshot.is_block_line(BlockRow(display_row.0))
     }
 
+    pub fn is_folded_buffer_header(&self, display_row: DisplayRow) -> bool {
+        self.block_snapshot
+            .is_folded_buffer_header(BlockRow(display_row.0))
+    }
+
     pub fn soft_wrap_indent(&self, display_row: DisplayRow) -> Option<u32> {
         let wrap_row = self
             .block_snapshot

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1618,6 +1618,15 @@ impl BlockSnapshot {
         cursor.item().map_or(false, |t| t.block.is_some())
     }
 
+    pub(super) fn is_folded_buffer_header(&self, row: BlockRow) -> bool {
+        let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
+        cursor.seek(&row, Bias::Right, &());
+        let Some(transform) = cursor.item() else {
+            return false;
+        };
+        matches!(transform.block, Some(Block::FoldedBuffer { .. }))
+    }
+
     pub(super) fn is_line_replaced(&self, row: MultiBufferRow) -> bool {
         let wrap_point = self
             .wrap_snapshot

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -12,7 +12,7 @@ use gpui::{
 };
 use itertools::Itertools;
 use language::{Buffer, BufferSnapshot, LanguageRegistry};
-use multi_buffer::{ExcerptRange, MultiBufferRow, ToOffset};
+use multi_buffer::{ExcerptRange, MultiBufferRow};
 use parking_lot::RwLock;
 use project::{FakeFs, Project};
 use std::{
@@ -24,7 +24,6 @@ use std::{
         Arc,
     },
 };
-use unicode_script::script_extensions::MULT;
 use util::{
     assert_set_eq,
     test::{generate_marked_text, marked_text_ranges},
@@ -88,6 +87,15 @@ impl EditorTestContext {
     #[cfg(not(target_os = "windows"))]
     fn root_path() -> &'static Path {
         Path::new("/root")
+    }
+
+    pub async fn for_editor_in(editor: Entity<Editor>, cx: &mut gpui::VisualTestContext) -> Self {
+        Self {
+            window: cx.windows()[0].clone(),
+            cx: cx.clone(),
+            editor,
+            assertion_cx: AssertionContextManager::new(),
+        }
     }
 
     pub async fn for_editor(editor: WindowHandle<Editor>, cx: &mut gpui::TestAppContext) -> Self {
@@ -390,63 +398,66 @@ impl EditorTestContext {
             .split("[EXCERPT]\n")
             .collect::<Vec<_>>();
 
-        let actual = self.update_editor(|editor, _, cx| {
+        let (selections, excerpts) = self.update_editor(|editor, _, cx| {
             let multibuffer_snapshot = editor.buffer.read(cx).snapshot(cx);
+
+            let selections = editor.selections.disjoint_anchors();
+            let excerpts = multibuffer_snapshot
+                .excerpts()
+                .map(|(e_id, snapshot, range)| (e_id, snapshot.clone(), range))
+                .collect::<Vec<_>>();
+
+            (selections, excerpts)
+        });
+
+        assert_eq!(excerpts.len(), expected_excerpts.len());
+
+        for (ix, (excerpt_id, snapshot, range)) in excerpts.into_iter().enumerate() {
+            let is_folded = self
+                .update_editor(|editor, _, cx| editor.is_buffer_folded(snapshot.remote_id(), cx));
+            let (expected_text, expected_selections) =
+                marked_text_ranges(expected_excerpts[ix], true);
+            if expected_text == "[FOLDED]\n" {
+                assert!(is_folded, "excerpt {} should be folded", ix);
+                let is_selected = selections.iter().any(|s| s.head().excerpt_id == excerpt_id);
+                if expected_selections.len() > 0 {
+                    assert!(
+                        is_selected,
+                        "excerpt {} should be selected. Got {:?}",
+                        ix,
+                        self.editor_state()
+                    );
+                } else {
+                    assert!(!is_selected, "excerpt {} should not be selected", ix);
+                }
+                continue;
+            }
+            assert!(!is_folded, "excerpt {} should not be folded", ix);
             assert_eq!(
-                multibuffer_snapshot.excerpts().count(),
-                expected_excerpts.len()
+                snapshot
+                    .text_for_range(range.context.clone())
+                    .collect::<String>(),
+                expected_text
             );
 
-            for (ix, (excerpt_id, snapshot, range)) in multibuffer_snapshot.excerpts().enumerate() {
-                let (expected_text, expected_selections) =
-                    marked_text_ranges(expected_excerpts[ix], true);
-                if expected_text == "[FOLDED]\n" {
-                    assert!(
-                        editor.is_buffer_folded(snapshot.remote_id(), cx),
-                        "excerpt {} should be folded",
-                        ix
-                    );
-                    let selections = editor.selections.disjoint_anchors();
-                    let is_selected = selections.iter().any(|s| s.head().excerpt_id == excerpt_id);
-                    if expected_selections.len() > 0 {
-                        assert!(is_selected, "excerpt {} should be selected", ix);
-                    } else {
-                        assert!(!is_selected, "excerpt {} should not be selected", ix);
-                    }
-                    continue;
-                }
-                assert!(
-                    !editor.is_buffer_folded(snapshot.remote_id(), cx),
-                    "excerpt {} should not be folded",
-                    ix
-                );
-                assert_eq!(
-                    snapshot
-                        .text_for_range(range.context.clone())
-                        .collect::<String>(),
-                    expected_text
-                );
-
-                let selections = editor.selections.disjoint_anchors();
-                let selections = selections
-                    .iter()
-                    .filter(|s| s.head().excerpt_id == excerpt_id)
-                    .map(|s| {
-                        let head = text::ToOffset::to_offset(&s.head().text_anchor, snapshot)
-                            - text::ToOffset::to_offset(&range.context.start, snapshot);
-                        let tail = text::ToOffset::to_offset(&s.head().text_anchor, snapshot)
-                            - text::ToOffset::to_offset(&range.context.start, snapshot);
-                        tail..head
-                    })
-                    .collect::<Vec<_>>();
-                // todo: selections that cross excerpt boundaries..
-                assert_eq!(
-                    selections, expected_selections,
-                    "excerpt {} has incorrect selections",
-                    ix,
-                );
-            }
-        });
+            let selections = selections
+                .iter()
+                .filter(|s| s.head().excerpt_id == excerpt_id)
+                .map(|s| {
+                    let head = text::ToOffset::to_offset(&s.head().text_anchor, &snapshot)
+                        - text::ToOffset::to_offset(&range.context.start, &snapshot);
+                    let tail = text::ToOffset::to_offset(&s.head().text_anchor, &snapshot)
+                        - text::ToOffset::to_offset(&range.context.start, &snapshot);
+                    tail..head
+                })
+                .collect::<Vec<_>>();
+            // todo: selections that cross excerpt boundaries..
+            assert_eq!(
+                selections, expected_selections,
+                "excerpt {} has incorrect selections",
+                ix,
+            );
+        }
     }
 
     /// Make an assertion about the editor's text and the ranges and directions

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -90,8 +90,9 @@ impl EditorTestContext {
     }
 
     pub async fn for_editor_in(editor: Entity<Editor>, cx: &mut gpui::VisualTestContext) -> Self {
+        cx.focus(&editor);
         Self {
-            window: cx.windows()[0].clone(),
+            window: cx.windows()[0],
             cx: cx.clone(),
             editor,
             assertion_cx: AssertionContextManager::new(),

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -55,6 +55,7 @@ git_ui.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
 language = { workspace = true, features = ["test-support"] }
+project = { workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features = ["test-support"] }
 parking_lot.workspace = true
 project_panel.workspace = true

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1329,12 +1329,25 @@ pub(crate) fn start_of_relative_buffer_row(
 
 fn up_down_buffer_rows(
     map: &DisplaySnapshot,
-    point: DisplayPoint,
+    mut point: DisplayPoint,
     mut goal: SelectionGoal,
-    times: isize,
+    mut times: isize,
     text_layout_details: &TextLayoutDetails,
 ) -> (DisplayPoint, SelectionGoal) {
     let bias = if times < 0 { Bias::Left } else { Bias::Right };
+
+    while map.is_folded_buffer_header(point.row()) {
+        if times < 0 {
+            (point, _) = movement::up(map, point, goal, true, text_layout_details);
+            times += 1;
+        } else if times > 0 {
+            (point, _) = movement::down(map, point, goal, true, text_layout_details);
+            times -= 1;
+        } else {
+            break;
+        }
+    }
+
     let start = map.display_point_to_fold_point(point, Bias::Left);
     let begin_folded_line = map.fold_point_to_display_point(
         map.fold_snapshot

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -15,7 +15,6 @@ use gpui::{KeyBinding, Modifiers, MouseButton, TestAppContext};
 use language::Point;
 pub use neovim_backed_test_context::*;
 use settings::SettingsStore;
-use ui::VisualContext;
 pub use vim_test_context::*;
 
 use indoc::indoc;
@@ -1749,7 +1748,6 @@ async fn test_folded_multibuffer_excerpts(cx: &mut gpui::TestAppContext) {
         editor
     });
     let mut cx = EditorTestContext::for_editor_in(editor.clone(), cx).await;
-    cx.focus(&editor);
 
     cx.assert_excerpts_with_selections(indoc! {"
         [EXCERPT]


### PR DESCRIPTION
Closes #24243

Release Notes:

- vim: Fix j/k on folded multibuffer headers
