### PR TITLE
git: Use worktree paths in the panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5439,6 +5439,7 @@ dependencies = [
  "panel",
  "picker",
  "postage",
+ "pretty_assertions",
  "project",
  "schemars",
  "serde",

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -61,6 +61,7 @@ ctor.workspace = true
 env_logger.workspace = true
 editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
+pretty_assertions.workspace = true
 project = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 unindent.workspace = true

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -22,6 +22,7 @@ use editor::ProposedChangesEditorToolbar;
 use editor::{scroll::Autoscroll, Editor, MultiBuffer};
 use feature_flags::{FeatureFlagAppExt, FeatureFlagViewExt, GitUiFeatureFlag};
 use futures::{channel::mpsc, select_biased, StreamExt};
+use git_ui::git_panel::GitPanel;
 use git_ui::project_diff::ProjectDiffToolbar;
 use gpui::{
     actions, point, px, Action, App, AppContext as _, AsyncApp, Context, DismissEvent, Element,
@@ -429,7 +430,10 @@ fn initialize_panels(
             workspace.add_panel(chat_panel, window, cx);
             workspace.add_panel(notification_panel, window, cx);
             cx.when_flag_enabled::<GitUiFeatureFlag>(window, |workspace, window, cx| {
-                let git_panel = git_ui::git_panel::GitPanel::new(workspace, window, cx);
+                let entity = cx.entity();
+                let project = workspace.project().clone();
+                let app_state = workspace.app_state().clone();
+                let git_panel = cx.new(|cx| GitPanel::new(entity, project, app_state, window, cx));
                 workspace.add_panel(git_panel, window, cx);
             });
         })?;


### PR DESCRIPTION
This PR changes the git panel to use worktree-relative paths for its entries, instead of repository-relative paths as before. Paths that lie outside the active repository's worktree are no longer shown in the panel. Note that in both respects this is how the project diff editor already works, so this PR brings those two pieces of UI into harmony.

Release Notes:

- N/A
