### PR TITLE
markdown: Add initial support for tables

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1,6 +1,12 @@
 pub mod parser;
 
-use crate::parser::CodeBlockKind;
+use std::collections::HashMap;
+use std::iter;
+use std::mem;
+use std::ops::Range;
+use std::rc::Rc;
+use std::sync::Arc;
+
 use gpui::{
     actions, point, quad, AnyElement, App, Bounds, ClipboardItem, CursorStyle, DispatchPhase,
     Edges, Entity, FocusHandle, Focusable, FontStyle, FontWeight, GlobalElementId, Hitbox, Hsla,
@@ -11,11 +17,11 @@ use gpui::{
 use language::{Language, LanguageRegistry, Rope};
 use parser::{parse_links_only, parse_markdown, MarkdownEvent, MarkdownTag, MarkdownTagEnd};
 use pulldown_cmark::Alignment;
-
-use std::{collections::HashMap, iter, mem, ops::Range, rc::Rc, sync::Arc};
 use theme::SyntaxTheme;
 use ui::{prelude::*, Tooltip};
 use util::{ResultExt, TryFutureExt};
+
+use crate::parser::CodeBlockKind;
 
 #[derive(Clone)]
 pub struct MarkdownStyle {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -654,6 +654,12 @@ impl Element for MarkdownElement {
                             }
                         }
                         MarkdownTag::MetadataBlock(_) => {}
+                        MarkdownTag::Table(_alignments) => {}
+                        MarkdownTag::TableHead => {}
+                        MarkdownTag::TableRow => {}
+                        MarkdownTag::TableCell => {
+                            builder.push_text("|", range.start);
+                        }
                         _ => log::error!("unsupported markdown tag {:?}", tag),
                     }
                 }
@@ -723,6 +729,12 @@ impl Element for MarkdownElement {
                             builder.pop_text_style()
                         }
                     }
+                    MarkdownTagEnd::Table => {}
+                    MarkdownTagEnd::TableHead => {}
+                    MarkdownTagEnd::TableRow => {
+                        builder.push_text("|\n", range.start);
+                    }
+                    MarkdownTagEnd::TableCell => {}
                     _ => log::error!("unsupported markdown tag end: {:?}", tag),
                 },
                 MarkdownEvent::Text(parsed) => {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -659,7 +659,6 @@ impl Element for MarkdownElement {
                                 div()
                                     .id(("table", range.start))
                                     .flex()
-                                    .px_0p5()
                                     .border_1()
                                     .border_color(cx.theme().colors().border)
                                     .rounded_md()
@@ -671,7 +670,10 @@ impl Element for MarkdownElement {
                         }
                         MarkdownTag::TableHead => {
                             builder.push_div(
-                                div().border_b_1().border_color(cx.theme().colors().border),
+                                div()
+                                    .flex()
+                                    .border_b_1()
+                                    .border_color(cx.theme().colors().border),
                                 range,
                                 markdown_end,
                             );
@@ -681,10 +683,14 @@ impl Element for MarkdownElement {
                             });
                         }
                         MarkdownTag::TableRow => {
-                            builder.push_text("\n", range.start);
+                            builder.push_div(
+                                div().h_flex().justify_between().px_1().py_0p5(),
+                                range,
+                                markdown_end,
+                            );
                         }
                         MarkdownTag::TableCell => {
-                            builder.push_text("|", range.start);
+                            builder.push_div(div().flex().px_1(), range, markdown_end);
                         }
                         _ => log::error!("unsupported markdown tag {:?}", tag),
                     }
@@ -764,9 +770,11 @@ impl Element for MarkdownElement {
                         builder.pop_text_style();
                     }
                     MarkdownTagEnd::TableRow => {
-                        builder.push_text("|", range.start);
+                        builder.pop_div();
                     }
-                    MarkdownTagEnd::TableCell => {}
+                    MarkdownTagEnd::TableCell => {
+                        builder.pop_div();
+                    }
                     _ => log::error!("unsupported markdown tag end: {:?}", tag),
                 },
                 MarkdownEvent::Text(parsed) => {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -666,7 +666,8 @@ impl Element for MarkdownElement {
                                 range,
                                 markdown_end,
                             );
-                            builder.push_div(div().v_flex(), range, markdown_end);
+                            // This inner `v_flex` is so the table rows will stack vertically without disrupting the `overflow_x_scroll`.
+                            builder.push_div(div().v_flex().flex_grow(), range, markdown_end);
                         }
                         MarkdownTag::TableHead => {
                             builder.push_div(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -667,8 +667,14 @@ impl Element for MarkdownElement {
                                 range,
                                 markdown_end,
                             );
+                            builder.push_div(div().v_flex(), range, markdown_end);
                         }
                         MarkdownTag::TableHead => {
+                            builder.push_div(
+                                div().border_b_1().border_color(cx.theme().colors().border),
+                                range,
+                                markdown_end,
+                            );
                             builder.push_text_style(TextStyleRefinement {
                                 font_weight: Some(FontWeight::BOLD),
                                 ..Default::default()
@@ -751,8 +757,10 @@ impl Element for MarkdownElement {
                     }
                     MarkdownTagEnd::Table => {
                         builder.pop_div();
+                        builder.pop_div();
                     }
                     MarkdownTagEnd::TableHead => {
+                        builder.pop_div();
                         builder.pop_text_style();
                     }
                     MarkdownTagEnd::TableRow => {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -654,9 +654,29 @@ impl Element for MarkdownElement {
                             }
                         }
                         MarkdownTag::MetadataBlock(_) => {}
-                        MarkdownTag::Table(_alignments) => {}
-                        MarkdownTag::TableHead => {}
-                        MarkdownTag::TableRow => {}
+                        MarkdownTag::Table(_alignments) => {
+                            builder.push_div(
+                                div()
+                                    .id(("table", range.start))
+                                    .flex()
+                                    .px_0p5()
+                                    .border_1()
+                                    .border_color(cx.theme().colors().border)
+                                    .rounded_md()
+                                    .overflow_x_scroll(),
+                                range,
+                                markdown_end,
+                            );
+                        }
+                        MarkdownTag::TableHead => {
+                            builder.push_text_style(TextStyleRefinement {
+                                font_weight: Some(FontWeight::BOLD),
+                                ..Default::default()
+                            });
+                        }
+                        MarkdownTag::TableRow => {
+                            builder.push_text("\n", range.start);
+                        }
                         MarkdownTag::TableCell => {
                             builder.push_text("|", range.start);
                         }
@@ -729,10 +749,14 @@ impl Element for MarkdownElement {
                             builder.pop_text_style()
                         }
                     }
-                    MarkdownTagEnd::Table => {}
-                    MarkdownTagEnd::TableHead => {}
+                    MarkdownTagEnd::Table => {
+                        builder.pop_div();
+                    }
+                    MarkdownTagEnd::TableHead => {
+                        builder.pop_text_style();
+                    }
                     MarkdownTagEnd::TableRow => {
-                        builder.push_text("|\n", range.start);
+                        builder.push_text("|", range.start);
                     }
                     MarkdownTagEnd::TableCell => {}
                     _ => log::error!("unsupported markdown tag end: {:?}", tag),

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -673,6 +673,7 @@ impl Element for MarkdownElement {
                             builder.push_div(
                                 div()
                                     .flex()
+                                    .justify_between()
                                     .border_b_1()
                                     .border_color(cx.theme().colors().border),
                                 range,


### PR DESCRIPTION
This PR adds initial support for displaying tables to the `markdown` crate.

This allows us to render tables in Assistant 2:

| Before                                                                                                                                               | After                                                                                                                                                |
| ---------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
| <img width="1309" alt="Screenshot 2025-03-03 at 1 39 39 PM" src="https://github.com/user-attachments/assets/ad7ada01-f35d-4fcf-a20c-deb42b55b34e" /> | <img width="1297" alt="Screenshot 2025-03-03 at 3 38 21 PM" src="https://github.com/user-attachments/assets/9b771126-30a0-479b-8c29-f5f572936f56" /> |

There are a few known issues that should be addressed as follow-ups:

- The horizontal scrolling within a table is linked with the scrolling of the parent container (e.g., the Assistant 2 thread)
- Cells are currently cut off entirely when they are too wide, would be nice to truncate them with an ellipsis

Release Notes:

- N/A
