### PR TITLE
docs: Improve documentation of ensure final new line on save

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -720,8 +720,8 @@
   "remove_trailing_whitespace_on_save": true,
   // Whether to start a new line with a comment when a previous line is a comment as well.
   "extend_comment_on_newline": true,
-  // Whether or not to ensure there's a single newline at the end of a buffer
-  // when saving it.
+  // Removes any lines containing only whitespace at the end of the file and
+  // ensures just one newline at the end.
   "ensure_final_newline_on_save": true,
   // Whether or not to perform a buffer format before saving
   //

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -917,7 +917,7 @@ Each option controls displaying of a particular toolbar element. If all elements
 
 ## Ensure Final Newline On Save
 
-- Description: Whether or not to ensure there's a single newline at the end of a buffer when saving it.
+- Description: This will remove any lines containing only whitespace at the end of the file and ensure exactly one newline at the end.
 - Setting: `ensure_final_newline_on_save`
 - Default: `true`
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -917,7 +917,7 @@ Each option controls displaying of a particular toolbar element. If all elements
 
 ## Ensure Final Newline On Save
 
-- Description: This will remove any lines containing only whitespace at the end of the file and ensure exactly one newline at the end.
+- Description: Removes any lines containing only whitespace at the end of the file and ensures just one newline at the end.
 - Setting: `ensure_final_newline_on_save`
 - Default: `true`
 


### PR DESCRIPTION
The function ensure_final_newline in buffer.rs has this explanation:  Ensures that the buffer ends with a single newline character, no other whitespace.

The documentation wasn't explaining well that we actually remove any lines containing only whitespace and keep only 1 line at the end of a buffer. 

Release Notes:

- N/A
