### PR TITLE
git_ui: horizontal is not vertical

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2274,7 +2274,7 @@ impl GitPanel {
     ) -> impl IntoElement {
         let entry_count = self.entries.len();
 
-        v_flex()
+        h_flex()
             .size_full()
             .flex_grow()
             .overflow_hidden()

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3365,6 +3365,7 @@ impl RenderOnce for PanelRepoFooter {
             .child(
                 h_flex()
                     .flex_1()
+                    .overflow_hidden()
                     .items_center()
                     .child(
                         div().child(

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3365,7 +3365,6 @@ impl RenderOnce for PanelRepoFooter {
             .child(
                 h_flex()
                     .flex_1()
-                    .overflow_hidden()
                     .items_center()
                     .child(
                         div().child(


### PR DESCRIPTION
Fixes an issue where I was missing some brain cells and changed the git panel's `render_entries` to a `v_flex` instead of an `h_flex`.

But actually, fixes the git panel entries from disappearing when a scrollbar is rendered.

**Before**

![CleanShot 2025-03-03 at 16 36 52@2x](https://github.com/user-attachments/assets/9dca7b9c-318d-4b3f-ab3e-e7242fa7f73a)

**After**

![CleanShot 2025-03-03 at 16 35 59@2x](https://github.com/user-attachments/assets/c1fe5fb1-ad57-4bca-ace4-365e70a74066)


Closes #25955

Release Notes:

- Git Beta: Fixed an issue where when the git panel would need to scroll all the items are pushed off the screen.