### PR TITLE
Fix regex search colors

### DIFF
--- a/crates/languages/src/regex/highlights.scm
+++ b/crates/languages/src/regex/highlights.scm
@@ -9,7 +9,7 @@
   "]"
   "{"
   "}"
-] @punctuation.bracket
+] @string
 
 (group_name) @property
 
@@ -31,6 +31,7 @@
   "|"
   "="
   "!"
+  (any_character)
 ] @operator
 
 (count_quantifier
@@ -44,7 +45,3 @@
     "^" @operator
     (class_range "-" @operator)
   ])
-
-(class_character) @constant.character
-
-(pattern_character) @string


### PR DESCRIPTION
In #25005 we added regex syntax highlighting to search; but the existing regex grammar highlighted every character as a string which was hard to read.

This flips so that characters are not highlighted, and brackets, etc. are.
<img width="346" alt="Screenshot 2025-03-03 at 14 39 35" src="https://github.com/user-attachments/assets/f7d3ae9c-fb5c-45eb-a5e9-41a330fbe940" />


Release Notes:

- Fixed regex search box being overly green