### PR TITLE
Show git panel footer even when on a detached HEAD

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1991,7 +1991,7 @@ impl GitPanel {
             };
             let editor_focus_handle = self.commit_editor.focus_handle(cx);
 
-            let branch = active_repo.read(cx).current_branch()?.clone();
+            let branch = active_repo.read(cx).current_branch().cloned();
 
             let footer_size = px(32.);
             let gap = px(8.0);
@@ -2012,7 +2012,7 @@ impl GitPanel {
                 .child(PanelRepoFooter::new(
                     "footer-button",
                     display_name,
-                    Some(branch),
+                    branch,
                     Some(git_panel),
                     Some(branches),
                 ))


### PR DESCRIPTION
Previously, the git panel footer would accidentally hide when not on a branch.

Release Notes:

- N/A
