### PR TITLE
gpui: Ensure hitbox is inserted when element has hover listener

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1509,6 +1509,7 @@ impl Interactivity {
             || self.tracked_focus_handle.is_some()
             || self.hover_style.is_some()
             || self.group_hover_style.is_some()
+            || self.hover_listener.is_some()
             || !self.mouse_up_listeners.is_empty()
             || !self.mouse_down_listeners.is_empty()
             || !self.mouse_move_listeners.is_empty()


### PR DESCRIPTION
Currently, when an element has only a hover listener, the attached listener will never trigger, because within the check for whether a hitbox has to be inserted for the given element, this case it not considered. 
That leads to the behaviour as described in https://github.com/zed-industries/zed/pull/25602#discussion_r1970720972, where another event listener has to be attached to the element in order for the hover listener to work.

This PR fixes the issue by ensuring that a hitbox is also inserted when only a hover listener is attached to the element.

Release Notes:

- N/A
