### PR TITLE
Use same commit button text in panel and modal

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -267,11 +267,7 @@ impl CommitModal {
                 } else {
                     "Commit changes to tracked files"
                 };
-                let title = if git_panel.has_staged_changes() {
-                    "Commit"
-                } else {
-                    "Commit All"
-                };
+                let title = git_panel.commit_button_title();
                 let co_authors = git_panel.render_co_authors(cx);
                 (branch, tooltip, title, co_authors)
             });

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1985,6 +1985,14 @@ impl GitPanel {
         }
     }
 
+    pub fn commit_button_title(&self) -> &'static str {
+        if self.has_staged_changes() {
+            "Commit"
+        } else {
+            "Commit Tracked"
+        }
+    }
+
     pub fn render_footer(
         &self,
         window: &mut Window,
@@ -1999,11 +2007,7 @@ impl GitPanel {
 
             let enable_coauthors = self.render_co_authors(cx);
 
-            let title = if self.has_staged_changes() {
-                "Commit"
-            } else {
-                "Commit Tracked"
-            };
+            let title = self.commit_button_title();
             let editor_focus_handle = self.commit_editor.focus_handle(cx);
 
             let branch = active_repo.read(cx).current_branch().cloned();


### PR DESCRIPTION
Release Notes:

- Fixed inconsistencies in commit button text between Git panel and modal.
