### PR TITLE
Unified more state in buttons between Git panel and Git commit editor

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -115,15 +115,15 @@ impl CommitModal {
                 return;
             };
 
-            let (can_commit, conflict) = git_panel.update(cx, |git_panel, cx| {
-                let can_commit = git_panel.can_commit();
+            let (can_open_commit_editor, conflict) = git_panel.update(cx, |git_panel, cx| {
+                let can_open_commit_editor = git_panel.can_open_commit_editor();
                 let conflict = git_panel.has_unstaged_conflicts();
-                if can_commit {
+                if can_open_commit_editor {
                     git_panel.set_modal_open(true, cx);
                 }
-                (can_commit, conflict)
+                (can_open_commit_editor, conflict)
             });
-            if !can_commit {
+            if !can_open_commit_editor {
                 let message = if conflict {
                     "There are still conflicts. You must stage these before committing."
                 } else {
@@ -250,7 +250,7 @@ impl CommitModal {
     pub fn render_footer(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let git_panel = self.git_panel.clone();
 
-        let (branch, tooltip, commit_label, co_authors) =
+        let (branch, can_commit, tooltip, commit_label, co_authors) =
             self.git_panel.update(cx, |git_panel, cx| {
                 let branch = git_panel
                     .active_repository
@@ -262,10 +262,10 @@ impl CommitModal {
                             .map(|b| b.name.clone())
                     })
                     .unwrap_or_else(|| "<no branch>".into());
-                let (_, tooltip) = git_panel.configure_commit_button(cx);
+                let (can_commit, tooltip) = git_panel.configure_commit_button(cx);
                 let title = git_panel.commit_button_title();
                 let co_authors = git_panel.render_co_authors(cx);
-                (branch, tooltip, title, co_authors)
+                (branch, can_commit, tooltip, title, co_authors)
             });
 
         let branch_picker_button = panel_button(branch)
@@ -300,9 +300,8 @@ impl CommitModal {
                 None
             };
 
-        let (panel_editor_focus_handle, can_commit) = git_panel.update(cx, |git_panel, cx| {
-            (git_panel.editor_focus_handle(cx), git_panel.can_commit())
-        });
+        let panel_editor_focus_handle =
+            git_panel.update(cx, |git_panel, cx| git_panel.editor_focus_handle(cx));
 
         let commit_button = panel_filled_button(commit_label)
             .tooltip(move |window, cx| {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1917,7 +1917,7 @@ impl GitPanel {
         })
     }
 
-    pub fn can_commit(&self) -> bool {
+    pub fn can_open_commit_editor(&self) -> bool {
         (self.has_staged_changes() || self.has_tracked_changes()) && !self.has_unstaged_conflicts()
     }
 
@@ -2000,6 +2000,7 @@ impl GitPanel {
         let panel_editor_style = panel_editor_style(true, window, cx);
 
         if let Some(active_repo) = active_repository {
+            let can_open_commit_editor = self.can_open_commit_editor();
             let (can_commit, tooltip) = self.configure_commit_button(cx);
 
             let enable_coauthors = self.render_co_authors(cx);
@@ -2092,6 +2093,7 @@ impl GitPanel {
                                         .icon_size(IconSize::Small)
                                         .style(ButtonStyle::Transparent)
                                         .width(expand_button_size.into())
+                                        .disabled(!can_open_commit_editor)
                                         .on_click(cx.listener({
                                             move |_, _, window, cx| {
                                                 window.dispatch_action(

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -257,14 +257,14 @@ impl ProjectDiff {
                 }
             }
         }
-        let mut commit = false;
+        let mut can_open_commit_editor = false;
         let mut stage_all = false;
         let mut unstage_all = false;
         self.workspace
             .read_with(cx, |workspace, cx| {
                 if let Some(git_panel) = workspace.panel::<GitPanel>(cx) {
                     let git_panel = git_panel.read(cx);
-                    commit = git_panel.can_commit();
+                    can_open_commit_editor = git_panel.can_open_commit_editor();
                     stage_all = git_panel.can_stage_all();
                     unstage_all = git_panel.can_unstage_all();
                 }
@@ -276,7 +276,7 @@ impl ProjectDiff {
             unstage: has_staged_hunks,
             prev_next,
             selection,
-            commit,
+            can_open_commit_editor,
             stage_all,
             unstage_all,
         };
@@ -773,7 +773,7 @@ struct ButtonStates {
     selection: bool,
     stage_all: bool,
     unstage_all: bool,
-    commit: bool,
+    can_open_commit_editor: bool,
 }
 
 impl Render for ProjectDiffToolbar {
@@ -949,7 +949,7 @@ impl Render for ProjectDiffToolbar {
                     )
                     .child(
                         Button::new("commit", "Commit")
-                            .disabled(!button_states.commit)
+                            .disabled(!button_states.can_open_commit_editor)
                             .tooltip(Tooltip::for_action_title_in(
                                 "Commit",
                                 &ShowCommitEditor,

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -6,10 +6,7 @@ use client::ProjectId;
 use futures::channel::{mpsc, oneshot};
 use futures::StreamExt as _;
 use git::repository::{Branch, CommitDetails, PushOptions, Remote, RemoteCommandOutput, ResetMode};
-use git::{
-    repository::{GitRepository, RepoPath},
-    status::{GitSummary, TrackedSummary},
-};
+use git::repository::{GitRepository, RepoPath};
 use gpui::{
     App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Subscription, Task,
     WeakEntity,
@@ -1071,18 +1068,6 @@ impl Repository {
     /// untracked files.
     pub fn entry_count(&self) -> usize {
         self.repository_entry.status_len()
-    }
-
-    fn have_changes(&self) -> bool {
-        self.repository_entry.status_summary() != GitSummary::UNCHANGED
-    }
-
-    fn have_staged_changes(&self) -> bool {
-        self.repository_entry.status_summary().index != TrackedSummary::UNCHANGED
-    }
-
-    pub fn can_commit(&self, commit_all: bool) -> bool {
-        return self.have_changes() && (commit_all || self.have_staged_changes());
     }
 
     pub fn commit(


### PR DESCRIPTION
Also:

- Internally renames a bit of code to make it easy to identify between when we are disabling the buttons that open and close the modal editor (in Git Panel and Project Diff) vs when we are disabling the commit buttons (in Git Panel and Git commit editor modal).
- Deletes some unused code.

Release Notes:

- Unified disabling / enabling the button to open the Git commit editor modal in the Git panel with the Project Diff commit button.
- Unified disabling / enabling the commit buttons, for the same cases, between the Git panel and Git commit editor modal.
