### PR TITLE
Add back default binding for copilot partial completions

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -575,6 +575,13 @@
       "cmd-k right": "pane::SplitRight"
     }
   },
+  // Allow user to trigger partial copilot completions
+  {
+    "context": "Editor && mode == full && copilot_suggestion",
+    "bindings": {
+      "cmd-right": "editor::AcceptPartialCopilotSuggestion"
+    }
+  },
   // Bindings that should be unified with bindings for more general actions
   {
     "context": "Editor && renaming",


### PR DESCRIPTION
Closes #26007

Release Notes:

- Added default keybinding for copilot partial completions
