### PR TITLE
migration: Add for `editor::GoToHunk` and `editor::GoToPrevHunk` actions

### DIFF
--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -90,7 +90,7 @@ const KEYMAP_MIGRATION_TRANSFORMATION_PATTERNS: MigrationPatterns = &[
         ACTION_ARGUMENT_OBJECT_PATTERN,
         replace_action_argument_object_with_single_value,
     ),
-    (ACTION_STRING_PATTERN, rename_string_action),
+    (ACTION_STRING_PATTERN, replace_string_action),
     (CONTEXT_PREDICATE_PATTERN, rename_context_key),
     (
         ACTION_STRING_OF_ARRAY_PATTERN,
@@ -433,19 +433,32 @@ const ACTION_STRING_PATTERN: &str = r#"(document
     (#eq? @name "bindings")
 )"#;
 
-fn rename_string_action(
+fn replace_string_action(
     contents: &str,
     mat: &QueryMatch,
     query: &Query,
 ) -> Option<(Range<usize>, String)> {
     let action_name_ix = query.capture_index_for_name("action_name")?;
-    let action_name_range = mat
-        .nodes_for_capture_index(action_name_ix)
-        .next()?
-        .byte_range();
+    let action_name_node = mat.nodes_for_capture_index(action_name_ix).next()?;
+    let action_name_range = action_name_node.byte_range();
     let action_name = contents.get(action_name_range.clone())?;
-    let new_action_name = STRING_REPLACE.get(&action_name)?;
-    Some((action_name_range, new_action_name.to_string()))
+
+    if let Some(new_action_name) = STRING_REPLACE.get(&action_name) {
+        return Some((action_name_range, new_action_name.to_string()));
+    }
+
+    if let Some((new_action_name, options)) = STRING_TO_ARRAY_REPLACE.get(action_name) {
+        let full_string_range = action_name_node.parent()?.byte_range();
+        let mut options_parts = Vec::new();
+        for (key, value) in options.iter() {
+            options_parts.push(format!("\"{}\": {}", key, value));
+        }
+        let options_str = options_parts.join(", ");
+        let replacement = format!("[\"{}\", {{ {} }}]", new_action_name, options_str);
+        return Some((full_string_range, replacement));
+    }
+
+    None
 }
 
 /// "ctrl-k ctrl-1": "inline_completion::ToggleMenu" -> "edit_prediction::ToggleMenu"
@@ -487,6 +500,27 @@ static STRING_REPLACE: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
         ("vim::MoveToPrevMatch", "vim::MoveToPreviousMatch"),
     ])
 });
+
+/// "editor::GoToPrevHunk" -> ["editor::GoToPreviousHunk", { "center_cursor": true }]
+static STRING_TO_ARRAY_REPLACE: LazyLock<HashMap<&str, (&str, HashMap<&str, bool>)>> =
+    LazyLock::new(|| {
+        HashMap::from_iter([
+            (
+                "editor::GoToHunk",
+                (
+                    "editor::GoToHunk",
+                    HashMap::from_iter([("center_cursor", true)]),
+                ),
+            ),
+            (
+                "editor::GoToPrevHunk",
+                (
+                    "editor::GoToPreviousHunk",
+                    HashMap::from_iter([("center_cursor", true)]),
+                ),
+            ),
+        ])
+    });
 
 const CONTEXT_PREDICATE_PATTERN: &str = r#"(document
     (array

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -1004,8 +1004,8 @@ mod tests {
                 [
                     {
                         "bindings": {
-                            "ctrl-q": ["editor::GoToHunk", { "center_cursor": true } ],
-                            "ctrl-w": ["editor::GoToPreviousHunk", { "center_cursor": true } ]
+                            "ctrl-q": ["editor::GoToHunk", { "center_cursor": true }],
+                            "ctrl-w": ["editor::GoToPreviousHunk", { "center_cursor": true }]
                         }
                     }
                 ]


### PR DESCRIPTION
We modified few actions in https://github.com/zed-industries/zed/pull/25846, which are:

`"editor::GoToHunk" -> ["editor::GoToHunk", { "center_cursor": true }]`
`"editor::GoToPrevHunk" -> ["editor::GoToPrevHunk", { "center_cursor": true }]`

Also, recently we changed and added migration for:

`["editor::GoToPrevHunk", { "center_cursor": true }] -> ["editor::GoToPreviousHunk", { "center_cursor": true }] `

This means:

1.  User that might still have `editor::GoToHunk` won't be automatically migrated to  `["editor::GoToHunk", { "center_cursor": true }]`. Note value of `center_cursor` is false, in first case (default), and true in second case.

2. User that might still have `editor::GoToPrevHunk` won't be automatically migrated to `["editor::GoToPreviousHunk", { "center_cursor": true }]`. Note,  `editor::GoToPrevHunk` is renamed since, it is now invalid action.

This PR adds those migrations.

cc: @marcospb19 

Release Notes:

- N/A