### PR TITLE
Fix a panic on Linux theme appearance change

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1020,7 +1020,7 @@ fn eager_load_active_theme_and_icon_theme(fs: Arc<dyn Fs>, cx: &App) {
     let extension_store = ExtensionStore::global(cx);
     let theme_registry = ThemeRegistry::global(cx);
     let theme_settings = ThemeSettings::get_global(cx);
-    let appearance = cx.window_appearance().into();
+    let appearance = SystemAppearance::global(cx).0;
 
     if let Some(theme_selection) = theme_settings.theme_selection.as_ref() {
         let theme_name = theme_selection.theme(appearance);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/26009

https://github.com/zed-industries/zed/blob/21484a2e9d07b6285f112ba49ca413cdb8e360e4/crates/gpui/src/platform/linux/platform.rs#L517-L519

`with_common` panicked at `borrow_mut` which is the way it's implemented for X11, Wayland and Headless Linux counterparts.

https://github.com/zed-industries/zed/blob/21484a2e9d07b6285f112ba49ca413cdb8e360e4/crates/gpui/src/platform/linux/wayland/client.rs#L722-L724

By accessing the appearance global instead of a `RefCell` with it, the panic goes away with one notable side-effect, on Linux only: the first global's value on `Dark` appearance would be `Light`: it becomes normal instantly, thanks to 

https://github.com/zed-industries/zed/blob/21484a2e9d07b6285f112ba49ca413cdb8e360e4/crates/workspace/src/workspace.rs#L1083-L1090

Things work without flickering:

[linux_theme_toggle.webm](https://github.com/user-attachments/assets/0e39ddc0-b4ff-4475-93ff-7b2bd7233628)


Release Notes:

- Fixed a panic on Linux theme appearance change
