### PR TITLE
vim: Fix increment step error

### DIFF
--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -27,7 +27,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, action: &Increment, window, cx| {
         vim.record_current_action(cx);
         let count = Vim::take_count(cx).unwrap_or(1);
-        let step = if action.step { 1 * count as i32 } else { 0 };
+        let step = if action.step { count as i32 } else { 0 };
         vim.increment(count as i64, step, window, cx)
     });
     Vim::action(editor, cx, |vim, action: &Decrement, window, cx| {

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -27,13 +27,13 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, action: &Increment, window, cx| {
         vim.record_current_action(cx);
         let count = Vim::take_count(cx).unwrap_or(1);
-        let step = if action.step { 1 } else { 0 };
+        let step = if action.step { 1 * count as i32 } else { 0 };
         vim.increment(count as i64, step, window, cx)
     });
     Vim::action(editor, cx, |vim, action: &Decrement, window, cx| {
         vim.record_current_action(cx);
         let count = Vim::take_count(cx).unwrap_or(1);
-        let step = if action.step { -1 } else { 0 };
+        let step = if action.step { -1 * (count as i32) } else { 0 };
         vim.increment(-(count as i64), step, window, cx)
     });
 }
@@ -590,5 +590,13 @@ mod test {
             0  2
             0
             0"});
+        cx.simulate_shared_keystrokes("v shift-g g ctrl-a").await;
+        cx.simulate_shared_keystrokes("v shift-g 5 g ctrl-a").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            ˇ6
+            12
+            18  2
+            24
+            30"});
     }
 }

--- a/crates/vim/test_data/test_increment_steps.json
+++ b/crates/vim/test_data/test_increment_steps.json
@@ -13,3 +13,13 @@
 {"Key":"g"}
 {"Key":"ctrl-x"}
 {"Get":{"state":"ˇ0\n0\n0  2\n0\n0","mode":"Normal"}}
+{"Key":"v"}
+{"Key":"shift-g"}
+{"Key":"g"}
+{"Key":"ctrl-a"}
+{"Key":"v"}
+{"Key":"shift-g"}
+{"Key":"5"}
+{"Key":"g"}
+{"Key":"ctrl-a"}
+{"Get":{"state":"ˇ6\n12\n18  2\n24\n30","mode":"Normal"}}


### PR DESCRIPTION
Closes #12887

Release Notes:

- Fixed `x g ctrl-a` step
