### PR TITLE
Fix "Open a file or project to get started" placeholder text not always shown

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3245,7 +3245,7 @@ impl Render for Pane {
                 pane.child(self.render_tab_bar(window, cx))
             })
             .child({
-                let has_worktrees = project.read(cx).worktrees(cx).next().is_some();
+                let has_worktrees = project.read(cx).visible_worktrees(cx).next().is_some();
                 // main content
                 div()
                     .flex_1()


### PR DESCRIPTION
Check that there are no `visible_worktrees` rather than checking `worktrees` when deciding whether to display the "Open a file or project to get started" text

Closes #25395

Release Notes:

- Fixed the "Open a file or project to get started" message not always showing after all buffers have been closed
