### PR TITLE
Add typescript-language-server and vtsls to list of available language servers

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -272,6 +272,17 @@ pub fn init(languages: Arc<LanguageRegistry>, node_runtime: NodeRuntime, cx: &mu
         let node_runtime = node_runtime.clone();
         move || Arc::new(typescript::EsLintLspAdapter::new(node_runtime.clone()))
     });
+    languages.register_available_lsp_adapter(LanguageServerName("vtsls".into()), {
+        let node_runtime = node_runtime.clone();
+        move || Arc::new(vtsls::VtslsLspAdapter::new(node_runtime.clone()))
+    });
+    languages.register_available_lsp_adapter(
+        LanguageServerName("typescript-language-server".into()),
+        {
+            let node_runtime = node_runtime.clone();
+            move || Arc::new(typescript::TypeScriptLspAdapter::new(node_runtime.clone()))
+        },
+    );
 
     // Register Tailwind for the existing languages that should have it by default.
     //


### PR DESCRIPTION
Add the typescript language severs as lsp adapters.
This would allow language extensions to use them.
For example using on vue files to be able to run the vue-language-server in [hybridMode](https://github.com/vuejs/language-tools?tab=readme-ov-file#hybrid-mode-configuration-requires-vuelanguage-server-version-200).

Release Notes:

- Added `vtsls` and `typescript-language-server` to the list of available language servers.
