### PR TITLE
Fix font sizes not reacting on settings change

### DIFF
--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -579,6 +579,22 @@ impl ThemeSettings {
         clamp_font_size(font_size)
     }
 
+    /// Returns the buffer font size, read from the settings.
+    ///
+    /// The real buffer font size is stored in-memory, to support temporary font size changes.
+    /// Use [`Self::buffer_font_size`] to get the real font size.
+    pub fn buffer_font_size_settings(&self) -> Pixels {
+        self.buffer_font_size
+    }
+
+    /// Returns the UI font size, read from the settings.
+    ///
+    /// The real UI font size is stored in-memory, to support temporary font size changes.
+    /// Use [`Self::ui_font_size`] to get the real font size.
+    pub fn ui_font_size_settings(&self) -> Pixels {
+        self.ui_font_size
+    }
+
     // TODO: Rename: `line_height` -> `buffer_line_height`
     /// Returns the buffer's line height.
     pub fn line_height(&self) -> f32 {

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -23,6 +23,7 @@ use std::path::Path;
 use std::sync::Arc;
 
 use ::settings::Settings;
+use ::settings::SettingsStore;
 use anyhow::Result;
 use fallback_themes::apply_status_color_defaults;
 use fs::Fs;
@@ -101,6 +102,24 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut App) {
 
     ThemeSettings::register(cx);
     FontFamilyCache::init_global(cx);
+
+    let mut prev_buffer_font_size_settings =
+        ThemeSettings::get_global(cx).buffer_font_size_settings();
+    let mut prev_ui_font_size_settings = ThemeSettings::get_global(cx).ui_font_size_settings();
+    cx.observe_global::<SettingsStore>(move |cx| {
+        let buffer_font_size_settings = ThemeSettings::get_global(cx).buffer_font_size_settings();
+        if buffer_font_size_settings != prev_buffer_font_size_settings {
+            prev_buffer_font_size_settings = buffer_font_size_settings;
+            reset_buffer_font_size(cx);
+        }
+
+        let ui_font_size_settings = ThemeSettings::get_global(cx).ui_font_size_settings();
+        if ui_font_size_settings != prev_ui_font_size_settings {
+            prev_ui_font_size_settings = ui_font_size_settings;
+            reset_ui_font_size(cx);
+        }
+    })
+    .detach();
 }
 
 /// Implementing this trait allows accessing the active theme.


### PR DESCRIPTION
Proper version of https://github.com/zed-industries/zed/pull/25425
When https://github.com/zed-industries/zed/pull/24857 returned font updates on settings changes, settings values, not in-memory ones should be compared.

This PR returns back the logic finally, and changes it to explicitly track the settings values, not the in-memory ones.
Also adds the same tracking for UI font changes, which had never been tracked before.

Release Notes:

- Fixed font sizes not reacting on settings change
