### PR TITLE
assistant2: Fix saving database called on every stream item

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -438,7 +438,6 @@ impl Thread {
                         }
 
                         thread.touch_updated_at();
-                        cx.emit(ThreadEvent::StreamedCompletion);
                         cx.notify();
                     })?;
 
@@ -446,6 +445,7 @@ impl Thread {
                 }
 
                 thread.update(&mut cx, |thread, cx| {
+                    cx.emit(ThreadEvent::StreamedCompletion);
                     thread
                         .pending_completions
                         .retain(|completion| completion.id != pending_completion_id);


### PR DESCRIPTION
emit StreamedCompletion at every stream item lead to lots of database save threads. but it is even worse, because database is sync it completely chokes the executor and blocks the markdown parsing. all this made streaming on assistant2 very slow.

some discord chat: https://discord.com/channels/869392257814519848/1199799855007158352/1346167187311824986

Release Notes:

- N/A