### PR TITLE
Fix . repeat for remapping surrounds/exchange actions

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -561,4 +561,41 @@ impl Operator {
             | Operator::ToggleComments => false,
         }
     }
+
+    pub fn starts_dot_recording(&self) -> bool {
+        match self {
+            Operator::Change
+            | Operator::Delete
+            | Operator::Replace
+            | Operator::Indent
+            | Operator::Outdent
+            | Operator::AutoIndent
+            | Operator::Lowercase
+            | Operator::Uppercase
+            | Operator::OppositeCase
+            | Operator::ToggleComments
+            | Operator::ReplaceWithRegister
+            | Operator::Rewrap
+            | Operator::ShellCommand
+            | Operator::AddSurrounds { target: None }
+            | Operator::ChangeSurrounds { target: None }
+            | Operator::DeleteSurrounds
+            | Operator::Exchange => true,
+            Operator::Yank
+            | Operator::Object { .. }
+            | Operator::FindForward { .. }
+            | Operator::FindBackward { .. }
+            | Operator::Sneak { .. }
+            | Operator::SneakBackward { .. }
+            | Operator::Mark
+            | Operator::Digraph { .. }
+            | Operator::Literal { .. }
+            | Operator::AddSurrounds { .. }
+            | Operator::ChangeSurrounds { .. }
+            | Operator::Jump { .. }
+            | Operator::Register
+            | Operator::RecordRegister
+            | Operator::ReplayRegister => false,
+        }
+    }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -827,22 +827,9 @@ impl Vim {
     }
 
     fn push_operator(&mut self, operator: Operator, window: &mut Window, cx: &mut Context<Self>) {
-        if matches!(
-            operator,
-            Operator::Change
-                | Operator::Delete
-                | Operator::Replace
-                | Operator::Indent
-                | Operator::Outdent
-                | Operator::AutoIndent
-                | Operator::Lowercase
-                | Operator::Uppercase
-                | Operator::OppositeCase
-                | Operator::ToggleComments
-                | Operator::ReplaceWithRegister
-        ) {
-            self.start_recording(cx)
-        };
+        if operator.starts_dot_recording() {
+            self.start_recording(cx);
+        }
         // Since these operations can only be entered with pre-operators,
         // we need to clear the previous operators when pushing,
         // so that the current stack is the most correct
@@ -853,9 +840,6 @@ impl Vim {
                 | Operator::DeleteSurrounds
         ) {
             self.operator_stack.clear();
-            if let Operator::AddSurrounds { target: None } = operator {
-                self.start_recording(cx);
-            }
         };
         self.operator_stack.push(operator);
         self.sync_vim_settings(window, cx);


### PR DESCRIPTION
Closes #ISSUE

cc @thomasheartman

Release Notes:

- vim: Fixes `.` repeat for remapped surrounds/exchange actions
