### PR TITLE
vim: Fix tab title when using `!!` and disable rerun button for terminal tasks

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -273,6 +273,7 @@ impl Project {
                     status: TaskStatus::Running,
                     show_summary: spawn_task.show_summary,
                     show_command: spawn_task.show_command,
+                    show_rerun: spawn_task.show_rerun,
                     completion_rx,
                 });
 

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -58,6 +58,8 @@ pub struct SpawnInTerminal {
     pub show_summary: bool,
     /// Whether to show the command line in the task output.
     pub show_command: bool,
+    /// Whether to show the rerun button in the terminal tab.
+    pub show_rerun: bool,
 }
 
 /// A final form of the [`TaskTemplate`], that got resolved with a particular [`TaskContext`] and now is ready to spawn the actual task.

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -255,6 +255,7 @@ impl TaskTemplate {
                 shell: self.shell.clone(),
                 show_summary: self.show_summary,
                 show_command: self.show_command,
+                show_rerun: true,
             }),
         })
     }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -643,6 +643,7 @@ pub struct TaskState {
     pub hide: HideStrategy,
     pub show_summary: bool,
     pub show_command: bool,
+    pub show_rerun: bool,
 }
 
 /// A status of the current terminal tab's task.

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1417,11 +1417,11 @@ impl ShellExec {
                 cx.emit(workspace::Event::SpawnTask {
                     action: Box::new(SpawnInTerminal {
                         id: TaskId("vim".to_string()),
-                        full_label: self.command.clone(),
-                        label: self.command.clone(),
+                        full_label: command.clone(),
+                        label: command.clone(),
                         command: command.clone(),
                         args: Vec::new(),
-                        command_label: self.command.clone(),
+                        command_label: command.clone(),
                         cwd,
                         env: HashMap::default(),
                         use_new_terminal: true,

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1432,6 +1432,7 @@ impl ShellExec {
                         shell,
                         show_summary: false,
                         show_command: false,
+                        show_rerun: false,
                     }),
                 });
             });


### PR DESCRIPTION
These changes tackle two issues with running terminal commands via vim mode:

- When using `!!` the tab's title was set to `!!` instead of the previous command that was run and these changes fix that in order to always display the previous command in the tab's title when re-running the command with `!!`
- For a terminal command, pressing the rerun button would actually bring up the task palette, so this has been updated in order to disable the rerun button when the terminal tab was spawned via a vim command

Closes #25800 

Release Notes:

- Fixed the terminal tab title when using `!!` to rerun the last command
- Improved the terminal tab for when command is run via vim mode, in order to disable the rerun button, seeing as Zed does not support it