### PR TITLE
editor:  Fix cmd + click on a URL not working most of the time

### DIFF
--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -241,8 +241,10 @@ impl Editor {
                         }
                     })
                     .collect();
-
-                return self.navigate_to_hover_links(None, links, modifiers.alt, window, cx);
+                let navigate_task =
+                    self.navigate_to_hover_links(None, links, modifiers.alt, window, cx);
+                self.select(SelectPhase::End, window, cx);
+                return navigate_task;
             }
         }
 
@@ -258,7 +260,7 @@ impl Editor {
             cx,
         );
 
-        if point.as_valid().is_some() {
+        let navigate_task = if point.as_valid().is_some() {
             if modifiers.shift {
                 self.go_to_type_definition(&GoToTypeDefinition, window, cx)
             } else {
@@ -266,7 +268,9 @@ impl Editor {
             }
         } else {
             Task::ready(Ok(Navigated::No))
-        }
+        };
+        self.select(SelectPhase::End, window, cx);
+        return navigate_task;
     }
 }
 


### PR DESCRIPTION
Closes #25647

This PR fixes two issues related to cmd + click on URL:

1. Normally cmd + click on URL, it opens browser. Now, alt + tab back to Zed. If you cmd + click on link again it won't work, until you normal click some where else in buffer. It won't even show underline.

2. Again, cmd + click on URL, it opens browser. Now, alt + tab back to Zed. If you cmd + click, some where else in buffer like just normal text, and now try to hover on URL it won't show up underline and cmd + click on it won't work. Unless again, if you plain click somewhere else.

Problem:

Issue is when clicking we set pending anchor (for selection), and when we mouse up we clear those. This works for normal case without pressing any modifier.

But, in case of cmd modifier, we set pending anchor (set when `SelectPhase::Begin`), but we don't clear it once we use that data. 

Fix: 

Once we end up using selection, anchor, etc data to figure out where to navigate either URL/defination etc, we clear selection just like how we do it in normal click. This doesn't require to happen after navigate task, so we do it right after our usage of it.

Before:

https://github.com/user-attachments/assets/b33d93fc-f490-4fa4-ae22-1da1fd6b77a9

After:

https://github.com/user-attachments/assets/028f039a-cd13-4651-b461-3ba52f2526de


Release Notes:

- Fixed an issue where cmd + click on a URL was not working sometimes.
