### PR TITLE
anthropic: Use an empty object if no tool input is provided

### DIFF
--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -639,7 +639,9 @@ pub fn map_to_language_model_completion_events(
                                                 id: tool_use.id.into(),
                                                 name: tool_use.name.into(),
                                                 input: if tool_use.input_json.is_empty() {
-                                                    serde_json::Value::Null
+                                                    serde_json::Value::Object(
+                                                        serde_json::Map::default(),
+                                                    )
                                                 } else {
                                                     serde_json::Value::from_str(
                                                         &tool_use.input_json,


### PR DESCRIPTION
This PR changes the default value when no input is provided with a tool use from `null` to `{}`.

This fixes an issue I was seeing where tools that didn't accept input were not being called correctly.

Release Notes:

- N/A
