### PR TITLE
ci: Less Windows CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,7 +297,7 @@ jobs:
         if: always()
         run: Remove-Item -Path "${{ env.CARGO_HOME }}/config.toml"  -Force
 
-  # Windows CI takes twice as long as our other platforms and fast github runners are expensive.
+  # Windows CI takes twice as long as our other platforms and fast github hosted runners are expensive.
   # But we still want to do CI, so let's only run tests on main and come back to this when we're
   # ready to self host our Windows CI (e.g. during the push for full Windows support)
   windows_tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
   windows_tests:
     timeout-minutes: 60
     name: (Windows) Run Tests
-    if: (github.repository_owner == 'zed-industries' && (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'windows'))
+    if: ${{ github.repository_owner == 'zed-industries' && (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'windows')) }}
     runs-on: hosted-windows-2
     steps:
       # Temporarily Collect some metadata about the hardware behind our runners.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,18 @@ jobs:
     if: github.repository_owner == 'zed-industries'
     runs-on: hosted-windows-2
     steps:
+      # Temporarily Collect some metadata about the hardware behind our runners.
+      - name: GHA Runner Info
+        run: |
+          Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -Uri "http://169.254.169.254/metadata/instance/compute?api-version=2023-07-01" |
+            ConvertTo-Json -Depth 10 |
+            jq "{ vm_size: .vmSize, location: .location, os_disk_gb: (.storageProfile.osDisk.diskSizeGB | tonumber), rs_disk_gb: (.storageProfile.resourceDisk.size | tonumber / 1024) }"
+          @{
+              Cores = (Get-CimInstance Win32_Processor).NumberOfCores
+              vCPUs = (Get-CimInstance Win32_Processor).NumberOfLogicalProcessors
+              RamGb = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB, 2)
+              cpuid = (Get-CimInstance Win32_Processor).Name.Trim()
+          } | ConvertTo-Json
       # more info here:- https://github.com/rust-lang/cargo/issues/13020
       - name: Enable longer pathnames for git
         run: git config --system core.longpaths true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -236,9 +236,9 @@ jobs:
         if: always()
         run: rm -rf ./../.cargo
 
-  windows_tests:
+  windows_clippy:
     timeout-minutes: 60
-    name: (Windows) Run Clippy and tests
+    name: (Windows) Run Clippy
     if: github.repository_owner == 'zed-industries'
     runs-on: hosted-windows-2
     steps:
@@ -286,6 +286,66 @@ jobs:
       - name: cargo clippy
         working-directory: ${{ env.ZED_WORKSPACE }}
         run: ./script/clippy.ps1
+
+      - name: Check dev drive space
+        working-directory: ${{ env.ZED_WORKSPACE }}
+        # `setup-dev-driver.ps1` creates a 100GB drive, with CI taking up ~45GB of the drive.
+        run: ./script/exit-ci-if-dev-drive-is-full.ps1 95
+
+      # Since the Windows runners are stateful, so we need to remove the config file to prevent potential bug.
+      - name: Clean CI config file
+        if: always()
+        run: Remove-Item -Path "${{ env.CARGO_HOME }}/config.toml"  -Force
+
+  # Windows CI takes twice as long as our other platforms and fast github runners are expensive.
+  # But we still want to do CI, so let's only run tests on main and come back to this when we're
+  # ready to self host our Windows CI (e.g. during the push for full Windows support)
+  windows_tests:
+    timeout-minutes: 60
+    name: (Windows) Run Tests
+    if: (github.repository_owner == 'zed-industries' && (github.ref == 'refs/heads/main' || contains(github.event.pull_request.labels.*.name, 'windows'))
+    runs-on: hosted-windows-2
+    steps:
+      # Temporarily Collect some metadata about the hardware behind our runners.
+      - name: GHA Runner Info
+        run: |
+          Invoke-RestMethod -Headers @{"Metadata"="true"} -Method GET -Uri "http://169.254.169.254/metadata/instance/compute?api-version=2023-07-01" |
+            ConvertTo-Json -Depth 10 |
+            jq "{ vm_size: .vmSize, location: .location, os_disk_gb: (.storageProfile.osDisk.diskSizeGB | tonumber), rs_disk_gb: (.storageProfile.resourceDisk.size | tonumber / 1024) }"
+          @{
+              Cores = (Get-CimInstance Win32_Processor).NumberOfCores
+              vCPUs = (Get-CimInstance Win32_Processor).NumberOfLogicalProcessors
+              RamGb = [math]::Round((Get-CimInstance Win32_ComputerSystem).TotalPhysicalMemory / 1GB, 2)
+              cpuid = (Get-CimInstance Win32_Processor).Name.Trim()
+          } | ConvertTo-Json
+      # more info here:- https://github.com/rust-lang/cargo/issues/13020
+      - name: Enable longer pathnames for git
+        run: git config --system core.longpaths true
+
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          clean: false
+
+      - name: Create Dev Drive using ReFS
+        run: ./script/setup-dev-driver.ps1
+
+      # actions/checkout does not let us clone into anywhere outside ${{ github.workspace }}, so we have to copy the clone...
+      - name: Copy Git Repo to Dev Drive
+        run: |
+          Copy-Item -Path "${{ github.workspace }}" -Destination "${{ env.ZED_WORKSPACE }}" -Recurse
+
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@f0deed1e0edfc6a9be95417288c0e1099b1eeec3 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          workspaces: ${{ env.ZED_WORKSPACE }}
+          cache-provider: "github"
+
+      - name: Configure CI
+        run: |
+          mkdir -p ${{ env.CARGO_HOME }} -ErrorAction Ignore
+          cp ./.cargo/ci-config.toml ${{ env.CARGO_HOME }}/config.toml
 
       - name: Run tests
         uses: ./.github/actions/run_tests_windows


### PR DESCRIPTION
Split Windows GHA CI job into `windows_clippy` and `windows_tests` (`cargo test` and `cargo build`). `windows_clippy` will continue to run on every PR commit, but `windows_tests` will only be run on main. Tag a PR `windows` if you would like to run windows tests.

Added a call to the Azure metadata service to detect the Azure hardware used by the GitHub hosted Windows runners. This is temporary and I'll remove once I've gathered some data (adds 5-15secs to Windows CI times)

Release Notes:

- N/A