### PR TITLE
Fix panic in commit editor selections syncing

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2247,6 +2247,10 @@ impl Editor {
             cx.subscribe(&other, |this, other, other_evt, cx| match other_evt {
                 EditorEvent::SelectionsChanged { local: true } => {
                     let other_selections = other.read(cx).selections.disjoint.to_vec();
+                    if other_selections.is_empty() {
+                        eprintln!("no selections");
+                        return;
+                    }
                     this.selections.change_with(cx, |selections| {
                         selections.select_anchors(other_selections);
                     });
@@ -2258,6 +2262,9 @@ impl Editor {
             cx.subscribe_self::<EditorEvent>(move |this, this_evt, cx| match this_evt {
                 EditorEvent::SelectionsChanged { local: true } => {
                     let these_selections = this.selections.disjoint.to_vec();
+                    if these_selections.is_empty() {
+                        return;
+                    }
                     other.update(cx, |other_editor, cx| {
                         other_editor.selections.change_with(cx, |selections| {
                             selections.select_anchors(these_selections);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2248,7 +2248,6 @@ impl Editor {
                 EditorEvent::SelectionsChanged { local: true } => {
                     let other_selections = other.read(cx).selections.disjoint.to_vec();
                     if other_selections.is_empty() {
-                        eprintln!("no selections");
                         return;
                     }
                     this.selections.change_with(cx, |selections| {


### PR DESCRIPTION
Closes #26183 

Release Notes:

- Git Beta: Fixed a panic when selecting text in one of the commit message editors when the other is open
