### PR TITLE
node_runtime: Use user/global configuration when using system node installation

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -499,12 +499,6 @@ impl SystemNodeRuntime {
         let scratch_dir = paths::support_dir().join("node");
         fs::create_dir(&scratch_dir).await.ok();
         fs::create_dir(scratch_dir.join("cache")).await.ok();
-        fs::write(scratch_dir.join("blank_user_npmrc"), [])
-            .await
-            .ok();
-        fs::write(scratch_dir.join("blank_global_npmrc"), [])
-            .await
-            .ok();
 
         let mut this = Self {
             node,

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -551,14 +551,6 @@ impl NodeRuntimeTrait for SystemNodeRuntime {
             .env(NODE_CA_CERTS_ENV_VAR, node_ca_certs)
             .arg(subcommand)
             .args(["--cache".into(), self.scratch_dir.join("cache")])
-            .args([
-                "--userconfig".into(),
-                self.scratch_dir.join("blank_user_npmrc"),
-            ])
-            .args([
-                "--globalconfig".into(),
-                self.scratch_dir.join("blank_global_npmrc"),
-            ])
             .args(args);
         configure_npm_command(&mut command, directory, proxy);
         let output = command.output().await?;


### PR DESCRIPTION
This partially reverts https://github.com/zed-industries/zed/pull/3324
We will still blank out user/global config when running managed NPM, to keep to the spirit of #3324 (which was made at the time we did not allow user-provided NPM builds - the intent of the change was to make the behavior of NPM as consistent as possible).

I tested this change by:
1. Setting up a custom NPM registry via Versaccio
2. Adding this new registry to my .npmrc
3. Mirroring `vscode-langservers-extracted` to it 
4. Blocking access to `registry.npmjs.org`
5. Opening up settings.json file in Zed Nightly
- Verifying that language server update fails for it
6. Opening up Zed Dev build of this branch
- Confirming that language server update check goes through for it

Closes #19806
Closes #20749
Closes #9422

Release Notes:

- User and global .npmrc configuration is now respected when running user-provided NPM binary (which also happens automatically when `npm` from PATH is newer than 18.0.0)
