### PR TITLE
ci: Move other Linux binaries to remote_server CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,12 +186,6 @@ jobs:
       - name: Run tests
         uses: ./.github/actions/run_tests
 
-      - name: Build other binaries and features
-        run: |
-          cargo build -p zed
-          cargo check -p workspace
-          cargo check -p gpui --examples
-
       # Even the Linux runner is not stateful, in theory there is no need to do this cleanup.
       # But, to avoid potential issues in the future if we choose to use a stateful Linux runner and forget to add code
       # to clean up the config file, I’ve included the cleanup code here as a precaution.
@@ -231,6 +225,12 @@ jobs:
 
       - name: Build Remote Server
         run: cargo build -p remote_server
+
+      - name: Build other binaries and features
+        run: |
+          cargo build -p zed
+          cargo check -p workspace
+          cargo check -p gpui --examples
 
       - name: Clean CI config file
         if: always()


### PR DESCRIPTION
Linux "build remote server" currently takes ~83 seconds.
The "Build other binaries and features" takes 2m15s of the "(Linux) Run clippy and tests". 
Hopefully this will run in parallel and shave 2mins off the main linux tests.

Release Notes:

- N/A
