### PR TITLE
Allow the keybinding context to detect the terminal vi_mode

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1911,6 +1911,10 @@ impl Terminal {
             }
         }
     }
+
+    pub fn vi_mode_enabled(&self) -> bool {
+        self.vi_mode_enabled
+    }
 }
 
 // Helper function to convert a grid row to a string

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -590,6 +590,10 @@ impl TerminalView {
         let mut dispatch_context = KeyContext::new_with_defaults();
         dispatch_context.add("Terminal");
 
+        if self.terminal.read(cx).vi_mode_enabled() {
+            dispatch_context.add("vi_mode");
+        }
+
         let mode = self.terminal.read(cx).last_content.mode;
         dispatch_context.set(
             "screen",


### PR DESCRIPTION
Release Notes:

- Added support for detecting the vi_mode in the keybinding context. Now we can define and use the keybinding when the terminal is in vi_mode.

https://github.com/user-attachments/assets/a927b6c9-c634-4739-9502-8457614d9a90

