### PR TITLE
Support `workspace/executeCommand` for actions' data

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -3569,10 +3569,10 @@ impl CodeActionProvider for AssistantCodeActionProvider {
             Task::ready(Ok(vec![CodeAction {
                 server_id: language::LanguageServerId(0),
                 range: snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end),
-                lsp_action: ActionVariant::Action(lsp::CodeAction {
+                lsp_action: ActionVariant::Action(Box::new(lsp::CodeAction {
                     title: "Fix with Assistant".into(),
                     ..Default::default()
-                }),
+                })),
             }]))
         } else {
             Task::ready(Ok(Vec::new()))

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -38,7 +38,7 @@ use language_model::{
 use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
-use project::{CodeAction, ProjectTransaction};
+use project::{ActionVariant, CodeAction, ProjectTransaction};
 use prompt_store::PromptBuilder;
 use rope::Rope;
 use settings::{update_settings_file, Settings, SettingsStore};
@@ -3569,10 +3569,10 @@ impl CodeActionProvider for AssistantCodeActionProvider {
             Task::ready(Ok(vec![CodeAction {
                 server_id: language::LanguageServerId(0),
                 range: snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end),
-                lsp_action: lsp::CodeAction {
+                lsp_action: ActionVariant::Action(lsp::CodeAction {
                     title: "Fix with Assistant".into(),
                     ..Default::default()
-                },
+                }),
             }]))
         } else {
             Task::ready(Ok(Vec::new()))

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -27,6 +27,7 @@ use language::{Buffer, Point, Selection, TransactionId};
 use language_model::{report_assistant_event, LanguageModelRegistry};
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
+use project::ActionVariant;
 use project::{CodeAction, ProjectTransaction};
 use prompt_store::PromptBuilder;
 use settings::{Settings, SettingsStore};
@@ -1727,10 +1728,10 @@ impl CodeActionProvider for AssistantCodeActionProvider {
             Task::ready(Ok(vec![CodeAction {
                 server_id: language::LanguageServerId(0),
                 range: snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end),
-                lsp_action: lsp::CodeAction {
+                lsp_action: ActionVariant::Action(lsp::CodeAction {
                     title: "Fix with Assistant".into(),
                     ..Default::default()
-                },
+                }),
             }]))
         } else {
             Task::ready(Ok(Vec::new()))

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -1728,10 +1728,10 @@ impl CodeActionProvider for AssistantCodeActionProvider {
             Task::ready(Ok(vec![CodeAction {
                 server_id: language::LanguageServerId(0),
                 range: snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end),
-                lsp_action: ActionVariant::Action(lsp::CodeAction {
+                lsp_action: ActionVariant::Action(Box::new(lsp::CodeAction {
                     title: "Fix with Assistant".into(),
                     ..Default::default()
-                }),
+                })),
             }]))
         } else {
             Task::ready(Ok(Vec::new()))

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -851,7 +851,7 @@ impl CodeActionsItem {
 
     pub fn label(&self) -> String {
         match self {
-            Self::CodeAction { action, .. } => action.lsp_action.title.clone(),
+            Self::CodeAction { action, .. } => action.lsp_action.title().to_owned(),
             Self::Task(_, task) => task.resolved_label.clone(),
         }
     }
@@ -984,7 +984,7 @@ impl CodeActionsMenu {
                                             .overflow_hidden()
                                             .child(
                                                 // TASK: It would be good to make lsp_action.title a SharedString to avoid allocating here.
-                                                action.lsp_action.title.replace("\n", ""),
+                                                action.lsp_action.title().replace("\n", ""),
                                             )
                                             .when(selected, |this| {
                                                 this.text_color(colors.text_accent)
@@ -1029,7 +1029,7 @@ impl CodeActionsMenu {
                 .max_by_key(|(_, action)| match action {
                     CodeActionsItem::Task(_, task) => task.resolved_label.chars().count(),
                     CodeActionsItem::CodeAction { action, .. } => {
-                        action.lsp_action.title.chars().count()
+                        action.lsp_action.title().chars().count()
                     }
                 })
                 .map(|(ix, _)| ix),

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -679,6 +679,9 @@ impl LanguageServer {
                         ..Default::default()
                     }),
                     apply_edit: Some(true),
+                    execute_command: Some(ExecuteCommandClientCapabilities {
+                        dynamic_registration: Some(false),
+                    }),
                     ..Default::default()
                 }),
                 text_document: Some(TextDocumentClientCapabilities {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2239,15 +2239,12 @@ impl LspCommand for GetCodeActions {
                 })
         })??;
 
-        let no_commands = Vec::new();
         let server_capabilities = language_server.capabilities();
         let available_commands = server_capabilities
             .execute_command_provider
             .as_ref()
-            .map(|options| &options.commands)
-            .unwrap_or(&no_commands)
-            .as_slice();
-
+            .map(|options| options.commands.as_slice())
+            .unwrap_or_default();
         Ok(actions
             .unwrap_or_default()
             .into_iter()

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2256,7 +2256,7 @@ impl LspCommand for GetCodeActions {
                                 return None;
                             }
                         }
-                        ActionVariant::Action(lsp_action)
+                        ActionVariant::Action(Box::new(lsp_action))
                     }
                     lsp::CodeActionOrCommand::Command(command) => {
                         if available_commands.contains(&command.command) {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1503,6 +1503,7 @@ impl LocalLspStore {
             let mut edits = None;
             for range in lsp_ranges {
                 if let Some(mut edit) = language_server
+                    // TODO kb check if any of these `.request::<lsp` needs capabilities before
                     .request::<lsp::request::RangeFormatting>(lsp::DocumentRangeFormattingParams {
                         text_document: text_document.clone(),
                         range,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1672,9 +1672,11 @@ impl LocalLspStore {
                     && lsp_action.data.is_some()
                     && (lsp_action.command.is_none() || lsp_action.edit.is_none())
                 {
-                    *lsp_action = lang_server
-                        .request::<lsp::request::CodeActionResolveRequest>(lsp_action.clone())
-                        .await?;
+                    *lsp_action = Box::new(
+                        lang_server
+                            .request::<lsp::request::CodeActionResolveRequest>(*lsp_action.clone())
+                            .await?,
+                    );
                 }
             }
             ActionVariant::Command(_) => {}

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -415,10 +415,13 @@ pub struct CodeAction {
     pub lsp_action: ActionVariant,
 }
 
-/// TODO kb docs
+/// An action sent back by a language server.
 #[derive(Clone, Debug)]
 pub enum ActionVariant {
+    /// An action with the full data, may have a command or may not.
+    /// May require resolving.
     Action(lsp::CodeAction),
+    /// A command data to run as an action.
     Command(lsp::Command),
 }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -411,7 +411,45 @@ pub struct CodeAction {
     /// The range of the buffer where this code action is applicable.
     pub range: Range<Anchor>,
     /// The raw code action provided by the language server.
-    pub lsp_action: lsp::CodeAction,
+    /// Can be either an action or a command.
+    pub lsp_action: ActionVariant,
+}
+
+/// TODO kb docs
+#[derive(Clone, Debug)]
+pub enum ActionVariant {
+    Action(lsp::CodeAction),
+    Command(lsp::Command),
+}
+
+impl ActionVariant {
+    pub fn title(&self) -> &str {
+        match self {
+            Self::Action(action) => &action.title,
+            Self::Command(command) => &command.title,
+        }
+    }
+
+    fn action_kind(&self) -> Option<lsp::CodeActionKind> {
+        match self {
+            Self::Action(action) => action.kind.clone(),
+            Self::Command(_) => Some(lsp::CodeActionKind::new("command")),
+        }
+    }
+
+    fn edit(&self) -> Option<&lsp::WorkspaceEdit> {
+        match self {
+            Self::Action(action) => action.edit.as_ref(),
+            Self::Command(_) => None,
+        }
+    }
+
+    fn command(&self) -> Option<&lsp::Command> {
+        match self {
+            Self::Action(action) => action.command.as_ref(),
+            Self::Command(command) => Some(command),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -420,7 +420,7 @@ pub struct CodeAction {
 pub enum ActionVariant {
     /// An action with the full data, may have a command or may not.
     /// May require resolving.
-    Action(lsp::CodeAction),
+    Action(Box<lsp::CodeAction>),
     /// A command data to run as an action.
     Command(lsp::Command),
 }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2951,6 +2951,10 @@ async fn test_apply_code_actions_with_commands(cx: &mut gpui::TestAppContext) {
                         ..lsp::CodeActionOptions::default()
                     },
                 )),
+                execute_command_provider: Some(lsp::ExecuteCommandOptions {
+                    commands: vec!["_the/command".to_string()],
+                    ..lsp::ExecuteCommandOptions::default()
+                }),
                 ..lsp::ServerCapabilities::default()
             },
             ..FakeLspAdapter::default()

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -5372,7 +5372,7 @@ async fn test_code_actions_only_kinds(cx: &mut gpui::TestAppContext) {
     let code_actions = code_actions_task.await.unwrap();
     assert_eq!(code_actions.len(), 1);
     assert_eq!(
-        code_actions[0].lsp_action.kind,
+        code_actions[0].lsp_action.action_kind(),
         Some(CodeActionKind::SOURCE_ORGANIZE_IMPORTS)
     );
 }
@@ -5529,7 +5529,7 @@ async fn test_multiple_language_server_actions(cx: &mut gpui::TestAppContext) {
             .await
             .unwrap()
             .into_iter()
-            .map(|code_action| code_action.lsp_action.title)
+            .map(|code_action| code_action.lsp_action.title().to_owned())
             .sorted()
             .collect::<Vec<_>>(),
         "Should receive code actions responses from all related servers with hover capabilities"

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1286,6 +1286,11 @@ message CodeAction {
     Anchor start = 2;
     Anchor end = 3;
     bytes lsp_action = 4;
+    Kind kind = 5;
+    enum Kind {
+        Action = 0;
+        Command = 1;
+    }
 }
 
 message ProjectTransaction {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/16746
Part of https://github.com/zed-extensions/deno/issues/2

Changes the action-related code so, that

* `lsp::Command` as actions are supported, if server replies with them
* actions with commands are filtered out based on servers' `executeCommandOptions` (https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#executeCommandOptions) — commands that are not listed won't be executed and the corresponding actions will be hidden in Zed

Release Notes:

- Added support of `workspace/executeCommand` for actions' data
