### PR TITLE
Remove worktree and project notifies

### DIFF
--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -104,49 +104,53 @@ impl ContextStore {
             const CONTEXT_WATCH_DURATION: Duration = Duration::from_millis(100);
             let (mut events, _) = fs.watch(contexts_dir(), CONTEXT_WATCH_DURATION).await;
 
-            let this = cx.new(|cx: &mut Context<Self>| {
-                let context_server_factory_registry =
-                    ContextServerFactoryRegistry::default_global(cx);
-                let context_server_manager = cx.new(|cx| {
-                    ContextServerManager::new(context_server_factory_registry, project.clone(), cx)
-                });
-                let mut this = Self {
-                    contexts: Vec::new(),
-                    contexts_metadata: Vec::new(),
-                    context_server_manager,
-                    context_server_slash_command_ids: HashMap::default(),
-                    host_contexts: Vec::new(),
-                    fs,
-                    languages,
-                    slash_commands,
-                    telemetry,
-                    _watch_updates: cx.spawn(|this, mut cx| {
-                        async move {
-                            while events.next().await.is_some() {
-                                this.update(&mut cx, |this, cx| this.reload(cx))?
-                                    .await
-                                    .log_err();
+            let this =
+                cx.new(|cx: &mut Context<Self>| {
+                    let context_server_factory_registry =
+                        ContextServerFactoryRegistry::default_global(cx);
+                    let context_server_manager = cx.new(|cx| {
+                        ContextServerManager::new(
+                            context_server_factory_registry,
+                            project.clone(),
+                            cx,
+                        )
+                    });
+                    let mut this = Self {
+                        contexts: Vec::new(),
+                        contexts_metadata: Vec::new(),
+                        context_server_manager,
+                        context_server_slash_command_ids: HashMap::default(),
+                        host_contexts: Vec::new(),
+                        fs,
+                        languages,
+                        slash_commands,
+                        telemetry,
+                        _watch_updates: cx.spawn(|this, mut cx| {
+                            async move {
+                                while events.next().await.is_some() {
+                                    this.update(&mut cx, |this, cx| this.reload(cx))?
+                                        .await
+                                        .log_err();
+                                }
+                                anyhow::Ok(())
                             }
-                            anyhow::Ok(())
-                        }
-                        .log_err()
-                    }),
-                    client_subscription: None,
-                    _project_subscriptions: vec![
-                        cx.observe(&project, Self::handle_project_changed),
-                        cx.subscribe(&project, Self::handle_project_event),
-                    ],
-                    project_is_shared: false,
-                    client: project.read(cx).client(),
-                    project: project.clone(),
-                    prompt_builder,
-                };
-                this.handle_project_changed(project.clone(), cx);
-                this.synchronize_contexts(cx);
-                this.register_context_server_handlers(cx);
-                this.reload(cx).detach_and_log_err(cx);
-                this
-            })?;
+                            .log_err()
+                        }),
+                        client_subscription: None,
+                        _project_subscriptions: vec![
+                            cx.subscribe(&project, Self::handle_project_event)
+                        ],
+                        project_is_shared: false,
+                        client: project.read(cx).client(),
+                        project: project.clone(),
+                        prompt_builder,
+                    };
+                    this.handle_project_shared(project.clone(), cx);
+                    this.synchronize_contexts(cx);
+                    this.register_context_server_handlers(cx);
+                    this.reload(cx).detach_and_log_err(cx);
+                    this
+                })?;
 
             Ok(this)
         })
@@ -288,7 +292,7 @@ impl ContextStore {
         })?
     }
 
-    fn handle_project_changed(&mut self, _: Entity<Project>, cx: &mut Context<Self>) {
+    fn handle_project_shared(&mut self, _: Entity<Project>, cx: &mut Context<Self>) {
         let is_shared = self.project.read(cx).is_shared();
         let was_shared = mem::replace(&mut self.project_is_shared, is_shared);
         if is_shared == was_shared {
@@ -318,11 +322,14 @@ impl ContextStore {
 
     fn handle_project_event(
         &mut self,
-        _: Entity<Project>,
+        project: Entity<Project>,
         event: &project::Event,
         cx: &mut Context<Self>,
     ) {
         match event {
+            project::Event::RemoteIdChanged(_) => {
+                self.handle_project_shared(project, cx);
+            }
             project::Event::Reshared => {
                 self.advertise_contexts(cx);
             }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1249,11 +1249,6 @@ impl Editor {
         let mut project_subscriptions = Vec::new();
         if mode == EditorMode::Full {
             if let Some(project) = project.as_ref() {
-                if buffer.read(cx).is_singleton() {
-                    project_subscriptions.push(cx.observe_in(project, window, |_, _, _, cx| {
-                        cx.emit(EditorEvent::TitleChanged);
-                    }));
-                }
                 project_subscriptions.push(cx.subscribe_in(
                     project,
                     window,
@@ -15438,14 +15433,9 @@ impl Editor {
             }
             multi_buffer::Event::DirtyChanged => cx.emit(EditorEvent::DirtyChanged),
             multi_buffer::Event::Saved => cx.emit(EditorEvent::Saved),
-            multi_buffer::Event::FileHandleChanged | multi_buffer::Event::Reloaded => {
-                cx.emit(EditorEvent::TitleChanged)
-            }
-            // multi_buffer::Event::DiffBaseChanged => {
-            //     self.scrollbar_marker_state.dirty = true;
-            //     cx.emit(EditorEvent::DiffBaseChanged);
-            //     cx.notify();
-            // }
+            multi_buffer::Event::FileHandleChanged
+            | multi_buffer::Event::Reloaded
+            | multi_buffer::Event::BufferDiffChanged => cx.emit(EditorEvent::TitleChanged),
             multi_buffer::Event::Closed => cx.emit(EditorEvent::Closed),
             multi_buffer::Event::DiagnosticsUpdated => {
                 self.refresh_active_diagnostics(cx);

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -121,6 +121,7 @@ pub enum Event {
     Discarded,
     DirtyChanged,
     DiagnosticsUpdated,
+    BufferDiffChanged,
 }
 
 /// A diff hunk, representing a range of consequent lines in a multibuffer.
@@ -248,6 +249,7 @@ impl DiffState {
                     if let Some(changed_range) = changed_range.clone() {
                         this.buffer_diff_changed(diff, changed_range, cx)
                     }
+                    cx.emit(Event::BufferDiffChanged);
                 }
                 BufferDiffEvent::LanguageChanged => this.buffer_diff_language_changed(diff, cx),
                 _ => {}

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -307,7 +307,7 @@ impl TitleBar {
                 cx.notify()
             }),
         );
-        subscriptions.push(cx.observe(&project, |_, _, cx| cx.notify()));
+        subscriptions.push(cx.subscribe(&project, |_, _, _, cx| cx.notify()));
         subscriptions.push(cx.observe(&active_call, |this, _, cx| this.active_call_changed(cx)));
         subscriptions.push(cx.observe_window_activation(window, Self::window_activation_changed));
         subscriptions.push(cx.observe(&user_store, |_, _, cx| cx.notify()));

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -852,6 +852,7 @@ impl<T: Item> ItemHandle for Entity<T> {
             .detach();
 
             let item_id = self.item_id();
+            workspace.update_item_dirty_state(self, window, cx);
             cx.observe_release_in(self, window, move |workspace, _, _, _| {
                 workspace.panes_by_item.remove(&item_id);
                 event_subscription.take();

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -879,8 +879,6 @@ impl Workspace {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
-        cx.observe_in(&project, window, |_, _, _, cx| cx.notify())
-            .detach();
         cx.subscribe_in(&project, window, move |this, _, event, window, cx| {
             match event {
                 project::Event::RemoteIdChanged(_) => {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5855,7 +5855,7 @@ impl WorktreeModelHandle for Entity<Worktree> {
                 .await
                 .unwrap();
             while events.next().await.is_some() {
-                if tree.update(cx, |tree, _| !tree.entry_for_path(file_name).is_some()) {
+                if tree.update(cx, |tree, _| tree.entry_for_path(file_name).is_none()) {
                     break;
                 }
             }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1526,7 +1526,6 @@ impl LocalWorktree {
                             this.update_abs_path_and_refresh(new_path, cx);
                         }
                     }
-                    cx.notify();
                 })
                 .ok();
             }

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -12,6 +12,7 @@ use git::{
     },
     GITIGNORE,
 };
+use git2::RepositoryInitOptions;
 use gpui::{AppContext as _, BorrowAppContext, Context, Task, TestAppContext};
 use parking_lot::Mutex;
 use postage::stream::Stream;
@@ -855,7 +856,7 @@ async fn test_write_file(cx: &mut TestAppContext) {
         "ignored-dir": {}
     }));
 
-    let tree = Worktree::local(
+    let worktree = Worktree::local(
         dir.path(),
         true,
         Arc::new(RealFs::default()),
@@ -868,32 +869,34 @@ async fn test_write_file(cx: &mut TestAppContext) {
     #[cfg(not(target_os = "macos"))]
     fs::fs_watcher::global(|_| {}).unwrap();
 
-    cx.read(|cx| tree.read(cx).as_local().unwrap().scan_complete())
+    cx.read(|cx| worktree.read(cx).as_local().unwrap().scan_complete())
         .await;
-    tree.flush_fs_events(cx).await;
+    worktree.flush_fs_events(cx).await;
 
-    tree.update(cx, |tree, cx| {
-        tree.write_file(
-            Path::new("tracked-dir/file.txt"),
-            "hello".into(),
-            Default::default(),
-            cx,
-        )
-    })
-    .await
-    .unwrap();
-    tree.update(cx, |tree, cx| {
-        tree.write_file(
-            Path::new("ignored-dir/file.txt"),
-            "world".into(),
-            Default::default(),
-            cx,
-        )
-    })
-    .await
-    .unwrap();
+    worktree
+        .update(cx, |tree, cx| {
+            tree.write_file(
+                Path::new("tracked-dir/file.txt"),
+                "hello".into(),
+                Default::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
+    worktree
+        .update(cx, |tree, cx| {
+            tree.write_file(
+                Path::new("ignored-dir/file.txt"),
+                "world".into(),
+                Default::default(),
+                cx,
+            )
+        })
+        .await
+        .unwrap();
 
-    tree.read_with(cx, |tree, _| {
+    worktree.read_with(cx, |tree, _| {
         let tracked = tree.entry_for_path("tracked-dir/file.txt").unwrap();
         let ignored = tree.entry_for_path("ignored-dir/file.txt").unwrap();
         assert!(!tracked.is_ignored);
@@ -3349,7 +3352,7 @@ async fn test_conflicted_cherry_pick(cx: &mut TestAppContext) {
         .expect("Failed to get HEAD")
         .peel_to_commit()
         .expect("HEAD is not a commit");
-    git_checkout("refs/heads/master", &repo);
+    git_checkout("refs/heads/main", &repo);
     std::fs::write(root_path.join("project/a.txt"), "b").unwrap();
     git_add("a.txt", &repo);
     git_commit("improve letter", &repo);
@@ -3442,7 +3445,9 @@ const MODIFIED: GitSummary = GitSummary {
 
 #[track_caller]
 fn git_init(path: &Path) -> git2::Repository {
-    git2::Repository::init(path).expect("Failed to initialize git repository")
+    let mut init_opts = RepositoryInitOptions::new();
+    init_opts.initial_head("main");
+    git2::Repository::init_opts(path, &init_opts).expect("Failed to initialize git repository")
 }
 
 #[track_caller]


### PR DESCRIPTION
This reduces the number of multibuffer syncs from 100,000 to 20,000. Before this change each editor individually observed the project, so literally any project change was amplified by the number of editors you had open.

Now editors listen to their buffers instead of the project, and other users of `cx.observe` on the project have been updated to use specific events to reduce churn.

Follow up to #26237


Release Notes:

- Improved performance of Zed in large repos with lots of file system events.
