### PR TITLE
Fix auto-indent when pasting multi-line content that was copied start…

### DIFF
--- a/crates/assistant_context_editor/src/patch.rs
+++ b/crates/assistant_context_editor/src/patch.rs
@@ -140,7 +140,7 @@ impl ResolvedPatch {
             buffer.edit(
                 edits,
                 Some(AutoindentMode::Block {
-                    original_start_columns: Vec::new(),
+                    original_indent_columns: Vec::new(),
                 }),
                 cx,
             );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4931,6 +4931,34 @@ async fn test_paste_multiline(cx: &mut TestAppContext) {
             )
         );
     "});
+
+    // Copy an indented block, starting mid-line
+    cx.set_state(indoc! {"
+        const a: B = (
+            c(),
+            somethin«g(
+                e,
+                f
+            )ˇ»
+        );
+    "});
+    cx.update_editor(|e, window, cx| e.copy(&Copy, window, cx));
+
+    // Paste it on a line with a lower indent level
+    cx.update_editor(|e, window, cx| e.move_to_end(&Default::default(), window, cx));
+    cx.update_editor(|e, window, cx| e.paste(&Paste, window, cx));
+    cx.assert_editor_state(indoc! {"
+        const a: B = (
+            c(),
+            something(
+                e,
+                f
+            )
+        );
+        g(
+            e,
+            f
+        )ˇ"});
 }
 
 #[gpui::test]

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1643,7 +1643,7 @@ fn test_autoindent_block_mode(cx: &mut App) {
         // indent level, but the indentation of the first line was not included in
         // the copied text. This information is retained in the
         // 'original_indent_columns' vector.
-        let original_indent_columns = vec![4];
+        let original_indent_columns = vec![Some(4)];
         let inserted_text = r#"
             "
                   c
@@ -1658,7 +1658,7 @@ fn test_autoindent_block_mode(cx: &mut App) {
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), inserted_text.clone())],
             Some(AutoindentMode::Block {
-                original_start_columns: original_indent_columns.clone(),
+                original_indent_columns: original_indent_columns.clone(),
             }),
             cx,
         );
@@ -1686,7 +1686,7 @@ fn test_autoindent_block_mode(cx: &mut App) {
         buffer.edit(
             [(Point::new(2, 8)..Point::new(2, 8), inserted_text)],
             Some(AutoindentMode::Block {
-                original_start_columns: original_indent_columns.clone(),
+                original_indent_columns: original_indent_columns.clone(),
             }),
             cx,
         );
@@ -1735,7 +1735,7 @@ fn test_autoindent_block_mode_without_original_indent_columns(cx: &mut App) {
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), inserted_text)],
             Some(AutoindentMode::Block {
-                original_start_columns: original_indent_columns.clone(),
+                original_indent_columns: original_indent_columns.clone(),
             }),
             cx,
         );
@@ -1766,7 +1766,7 @@ fn test_autoindent_block_mode_without_original_indent_columns(cx: &mut App) {
         buffer.edit(
             [(Point::new(2, 12)..Point::new(2, 12), inserted_text)],
             Some(AutoindentMode::Block {
-                original_start_columns: Vec::new(),
+                original_indent_columns: Vec::new(),
             }),
             cx,
         );
@@ -1822,7 +1822,7 @@ fn test_autoindent_block_mode_multiple_adjacent_ranges(cx: &mut App) {
                 (ranges_to_replace[2].clone(), "fn three() {\n    103\n}\n"),
             ],
             Some(AutoindentMode::Block {
-                original_start_columns: vec![0, 0, 0],
+                original_indent_columns: vec![Some(0), Some(0), Some(0)],
             }),
             cx,
         );

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -81,32 +81,32 @@ impl Vim {
                     }
                 }
 
-                let first_selection_start_column =
+                let first_selection_indent_column =
                     clipboard_selections.as_ref().and_then(|zed_selections| {
                         zed_selections
                             .first()
-                            .map(|selection| selection.start_column)
+                            .map(|selection| selection.first_line_indent)
                     });
                 let before = action.before || vim.mode == Mode::VisualLine;
 
                 let mut edits = Vec::new();
                 let mut new_selections = Vec::new();
-                let mut original_start_columns = Vec::new();
+                let mut original_indent_columns = Vec::new();
                 let mut start_offset = 0;
 
                 for (ix, (selection, preserve)) in selections_to_process.iter().enumerate() {
-                    let (mut to_insert, original_start_column) =
+                    let (mut to_insert, original_indent_column) =
                         if let Some(clipboard_selections) = &clipboard_selections {
                             if let Some(clipboard_selection) = clipboard_selections.get(ix) {
                                 let end_offset = start_offset + clipboard_selection.len;
                                 let text = text[start_offset..end_offset].to_string();
                                 start_offset = end_offset + 1;
-                                (text, Some(clipboard_selection.start_column))
+                                (text, Some(clipboard_selection.first_line_indent))
                             } else {
-                                ("".to_string(), first_selection_start_column)
+                                ("".to_string(), first_selection_indent_column)
                             }
                         } else {
-                            (text.to_string(), first_selection_start_column)
+                            (text.to_string(), first_selection_indent_column)
                         };
                     let line_mode = to_insert.ends_with('\n');
                     let is_multiline = to_insert.contains('\n');
@@ -152,7 +152,7 @@ impl Vim {
                         new_selections.push((anchor, line_mode, is_multiline));
                     }
                     edits.push((point_range, to_insert.repeat(count)));
-                    original_start_columns.extend(original_start_column);
+                    original_indent_columns.push(original_indent_column);
                 }
 
                 let cursor_offset = editor.selections.last::<usize>(cx).head();
@@ -163,7 +163,7 @@ impl Vim {
                     .language_settings_at(cursor_offset, cx)
                     .auto_indent_on_paste
                 {
-                    editor.edit_with_block_indent(edits, original_start_columns, cx);
+                    editor.edit_with_block_indent(edits, original_indent_columns, cx);
                 } else {
                     editor.edit(edits, cx);
                 }

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -188,7 +188,7 @@ impl Vim {
                 clipboard_selections.push(ClipboardSelection {
                     len: text.len() - initial_len,
                     is_entire_line: linewise,
-                    start_column: start.column,
+                    first_line_indent: buffer.indent_size_for_line(MultiBufferRow(start.row)).len,
                 });
             }
         }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/24914 (again)

Release Notes:

- Fixed an issue where multi-line pasted content was auto-indented incorrectly if copied from the middle of an existing line.
