### PR TITLE
Enable soft-wrap by default in markdown

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1175,6 +1175,7 @@
       "format_on_save": "off",
       "use_on_type_format": false,
       "allow_rewrap": "anywhere",
+      "soft_wrap": "bounded",
       "prettier": {
         "allowed": true
       }


### PR DESCRIPTION
Release Notes:

- Enabled soft-wrap by default in markdown
