### PR TITLE
Fix early return when reaching end excerpt in `lift_buffer_metadata`

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -3825,6 +3825,11 @@ impl MultiBufferSnapshot {
             // When there are no more metadata items for this excerpt, move to the next excerpt.
             else {
                 current_excerpt_metadata.take();
+                if let Some((end_excerpt_id, _)) = range_end {
+                    if excerpt.id == end_excerpt_id {
+                        return None;
+                    }
+                }
                 cursor.next_excerpt();
             }
         })


### PR DESCRIPTION
Release Notes:

- Fixed a bug causing slowness when viewing multi buffers with lots of excerpts
