### PR TITLE
Add lua script access to code using `cx` + reuse project search logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8134,6 +8134,7 @@ checksum = "d3f763c1041eff92ffb5d7169968a327e1ed2ebfe425dac0ee5a35f29082534b"
 dependencies = [
  "bstr",
  "either",
+ "futures-util",
  "mlua-sys",
  "num-traits",
  "parking_lot",
@@ -11915,12 +11916,17 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "assistant_tool",
+ "futures 0.3.31",
  "gpui",
  "mlua",
+ "parking_lot",
+ "project",
  "regex",
  "schemars",
  "serde",
  "serde_json",
+ "smol",
+ "util",
  "workspace",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -452,7 +452,7 @@ livekit = { git = "https://github.com/zed-industries/livekit-rust-sdks", rev = "
 ], default-features = false }
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
 markup5ever_rcdom = "0.3.0"
-mlua = { version = "0.10", features = ["lua54", "vendored"] }
+mlua = { version = "0.10", features = ["lua54", "vendored", "async", "send"] }
 nanoid = "0.4"
 nbformat = { version = "0.10.0" }
 nix = "0.29"

--- a/crates/scripting_tool/Cargo.toml
+++ b/crates/scripting_tool/Cargo.toml
@@ -15,10 +15,15 @@ doctest = false
 [dependencies]
 anyhow.workspace = true
 assistant_tool.workspace = true
+futures.workspace = true
 gpui.workspace = true
 mlua.workspace = true
+parking_lot.workspace = true
+project.workspace = true
+regex.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+smol.workspace = true
+util.workspace = true
 workspace.workspace = true
-regex.workspace = true


### PR DESCRIPTION
Access to `cx` will be needed for anything that queries entities. In this commit this is use of `WorktreeStore::find_search_candidates`. In the future it will be things like access to LSP / tree-sitter outlines / etc.

Changes to support access to `cx` from functions provided to the Lua script:

* Adds a channel of requests that require a `cx`. Work enqueued to this channel is run on the foreground thread.

* Adds `async` and `send` features to `mlua` crate so that async rust functions can be used from Lua.

* Changes uses of `Rc<RefCell<...>>` to `Arc<Mutex<...>>` so that the futures are `Send`.

One benefit of reusing project search logic for search candidates is that it properly ignores paths.

Release Notes:

- N/A