### PR TITLE
Add `variable.special` color to Gruvbox themes

### DIFF
--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -383,6 +383,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.special": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variant": {
             "color": "#83a598ff",
             "font_style": null,
@@ -768,6 +773,11 @@
           },
           "variable": {
             "color": "#ebdbb2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1159,6 +1169,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.special": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variant": {
             "color": "#83a598ff",
             "font_style": null,
@@ -1544,6 +1559,11 @@
           },
           "variable": {
             "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1935,6 +1955,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "variable.special": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "variant": {
             "color": "#0b6678ff",
             "font_style": null,
@@ -2320,6 +2345,11 @@
           },
           "variable": {
             "color": "#282828ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "variable.special": {
+            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
This adds the `variable.special` color to the Gruvbox family of themes, which colors special variables (in Rust's case `self`) differently than normal ones. The colors were taken from the old Gruvbox `variable` highlighting (see https://github.com/zed-industries/zed/pull/25464).

before:
![image](https://github.com/user-attachments/assets/3f329ac0-fbdf-480c-9074-5db99591f4e1)
![image](https://github.com/user-attachments/assets/43efdddd-7daf-440f-8c11-d6279330912a)

after:
![image](https://github.com/user-attachments/assets/052c05b8-55c5-495a-a9cc-a5f73aa5aa00)
![image](https://github.com/user-attachments/assets/f598b75f-8d2d-4710-b804-9282de9f8d15)

fixes half of https://github.com/zed-industries/zed/issues/26206. Since I don't use the Ayu themes I'd prefer someone who knows what looks good there does those changes.

Release Notes:

- Gruvbox themes: Added a color for `@variable.special` syntax highlights.