### PR TITLE
Fix inline diagnostics in the project diff

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1691,7 +1691,7 @@ impl EditorElement {
             let pos_y = content_origin.y
                 + line_height * (row.0 as f32 - scroll_pixel_position.y / line_height);
 
-            let window_ix = row.minus(start_row) as usize;
+            let window_ix = row.0.saturating_sub(start_row.0) as usize;
             let pos_x = {
                 let crease_trailer_layout = &crease_trailers[window_ix];
                 let line_layout = &line_layouts[window_ix];

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -138,6 +138,7 @@ impl ProjectDiff {
                 window,
                 cx,
             );
+            diff_display_editor.disable_inline_diagnostics();
             diff_display_editor.set_expand_all_diff_hunks(cx);
             diff_display_editor.register_addon(GitPanelAddon {
                 workspace: workspace.downgrade(),


### PR DESCRIPTION
https://github.com/zed-industries/zed/blob/205f9a9f0391da47a87cac45a41f67d2a23f5a95/crates/editor/src/element.rs#L1643

Due to the snippet above, Zed is supposed to have `row` larger or equal to `start_row` here:

https://github.com/zed-industries/zed/blob/205f9a9f0391da47a87cac45a41f67d2a23f5a95/crates/editor/src/element.rs#L1694

yet the panic were reported when clicking in the project diff.

That project diff has a lot of highlighting happening already, so the PR disables inline diagnostics within a git diff view.


Release Notes:

- N/A
