### PR TITLE
chore: Do not bust Rust build cache when opening projects with dev build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -26,3 +26,6 @@ rustflags = [
     "-C",
     "target-feature=+crt-static", # This fixes the linking issue when compiling livekit on Windows
 ]
+
+[env]
+MACOSX_DEPLOYMENT_TARGET = "10.15.7"

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -277,6 +277,17 @@ fn main() {
                 load_login_shell_environment().log_err();
             })
             .detach()
+    } else {
+        if cfg!(target_os = "macos")
+            && std::env::var("CARGO_PKG_NAME").is_ok_and(|name| name == "zed")
+        {
+            // We're running under `cargo run`. This can lead to a problem where the `cargo run` build of Zed invalidates
+            // all caches of Rust projects it's ran on, because cargo propagates `MACOSX_DEPLOYMENT_TARGET` env variable.
+            // This then has a cascading effect on how RA builds these projects - as it busts the cache.
+            //
+            // Remove `MACOSX_DEPLOYMENT_TARGET` from the environment.
+            std::env::remove_var("MACOSX_DEPLOYMENT_TARGET");
+        }
     };
 
     app.on_open_urls({
@@ -326,6 +337,7 @@ fn main() {
             .or_else(read_proxy_from_env);
         let http = {
             let _guard = Tokio::handle(cx).enter();
+
             ReqwestClient::proxy_and_user_agent(proxy_url, &user_agent)
                 .expect("could not start HTTP client")
         };

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -277,17 +277,6 @@ fn main() {
                 load_login_shell_environment().log_err();
             })
             .detach()
-    } else {
-        if cfg!(target_os = "macos")
-            && std::env::var("CARGO_PKG_NAME").is_ok_and(|name| name == "zed")
-        {
-            // We're running under `cargo run`. This can lead to a problem where the `cargo run` build of Zed invalidates
-            // all caches of Rust projects it's ran on, because cargo propagates `MACOSX_DEPLOYMENT_TARGET` env variable.
-            // This then has a cascading effect on how RA builds these projects - as it busts the cache.
-            //
-            // Remove `MACOSX_DEPLOYMENT_TARGET` from the environment.
-            std::env::remove_var("MACOSX_DEPLOYMENT_TARGET");
-        }
     };
 
     app.on_open_urls({

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -70,7 +70,6 @@ export ZED_RELEASE_CHANNEL="${channel}"
 popd
 
 export ZED_BUNDLE=true
-export MACOSX_DEPLOYMENT_TARGET=10.15.7
 
 cargo_bundle_version=$(cargo -q bundle --help 2>&1 | head -n 1 || echo "")
 if [ "$cargo_bundle_version" != "cargo-bundle v0.6.0-zed" ]; then


### PR DESCRIPTION
## Problem
Running `cargo run .` twice in Zed repository required a rebuild two times in a row. The second rebuild was triggered around libz-sys, which in practice caused a rebuild of the ~entire project.

Some concrete examples:
```
cargo test -p project # Requires a rebuild (warranted)
cargo run . # Requires a rebuild (warranted)
cargo test -p project # Requires a rebuild (unwarranted)
```
or
```
cargo run . # Requires a rebuild (warranted)
cargo run . # Requires a rebuild (unwarranted)
```

## What's going on
Zed build script on MacOS sets MACOSX_DEPLOYMENT_TARGET to 10.15. This is fine. However, **cargo propagates all environment variables to child processes during `cargo run`**. This then affects Rust Analyzer spawned by dev Zed - it clobbers build cache of whatever package it touches, because it's behavior is not same between running it with `cargo run` (where MACOS_DEPLOYMENT_TARGET gets propagated to child Zed) and running it directly via `target/debug/zed` or whatever (where the env variable is not set, so that build behaves roughly like Zed Dev.app).


## Solution
~We'll unset that env variable from user environment when we're reasonably confident that we're running under `cargo run` by exploiting other env variables set by cargo: https://doc.rust-lang.org/cargo/reference/environment-variables.html CARGO_PKG_NAME is always set to `zed` when running it via `cargo run`, as it's the value propagated from the build.~

~The alternative I've considered is running [via a custom runner](https://doc.rust-lang.org/cargo/reference/config.html#targetcfgrunner), though the problem here is that we'd have to use a shell script to unset the env variable - that could be problematic with e.g. fish. I just didn't want to deal with that, though admittedly it would've been cleaner in other aspects.~

Redact all above. We'll just set MACOSX_DEPLOYMENT_TARGET regardless of whether you have it in your OG shell environment or not. This means that `target/debug/zed` is now the one that can run into the same problem, but.. 🤷 

Release Notes:

- N/A
