### PR TITLE
git_ui: Try to prompt the model out of including the diff output

### DIFF
--- a/crates/git_ui/src/commit_message_prompt.txt
+++ b/crates/git_ui/src/commit_message_prompt.txt
@@ -4,7 +4,7 @@ If you can accurately express the change in just the subject line, don't include
 
 Don't repeat information from the subject line in the message body.
 
-Only return the commit message in your response. Do not include any additional meta-commentary about the task.
+Only return the commit message in your response. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the commit message.
 
 Follow good Git style:
 


### PR DESCRIPTION
This PR updates the prompt for generating commit messages to tell the model not to include the raw diff output in the message.

Release Notes:

- N/A
