### PR TITLE
git_ui: Branch picker improvements

### DIFF
--- a/crates/assistant2/src/context_picker/fetch_context_picker.rs
+++ b/crates/assistant2/src/context_picker/fetch_context_picker.rs
@@ -167,8 +167,8 @@ impl PickerDelegate for FetchContextPickerDelegate {
         }
     }
 
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        "Enter the URL that you would like to fetch".into()
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("Enter the URL that you would like to fetch".into())
     }
 
     fn selected_index(&self) -> usize {

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6770,7 +6770,7 @@ async fn test_remote_git_branches(
 
     assert_eq!(branches_b, branches_set);
 
-    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch.to_string()))
+    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch))
         .await
         .unwrap()
         .unwrap();
@@ -6790,23 +6790,15 @@ async fn test_remote_git_branches(
     assert_eq!(host_branch.name, branches[2]);
 
     // Also try creating a new branch
-    cx_b.update(|cx| {
-        repo_b
-            .read(cx)
-            .create_branch("totally-new-branch".to_string())
-    })
-    .await
-    .unwrap()
-    .unwrap();
+    cx_b.update(|cx| repo_b.read(cx).create_branch("totally-new-branch"))
+        .await
+        .unwrap()
+        .unwrap();
 
-    cx_b.update(|cx| {
-        repo_b
-            .read(cx)
-            .change_branch("totally-new-branch".to_string())
-    })
-    .await
-    .unwrap()
-    .unwrap();
+    cx_b.update(|cx| repo_b.read(cx).change_branch("totally-new-branch"))
+        .await
+        .unwrap()
+        .unwrap();
 
     executor.run_until_parked();
 

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -294,7 +294,7 @@ async fn test_ssh_collaboration_git_branches(
 
     assert_eq!(&branches_b, &branches_set);
 
-    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch.to_string()))
+    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch))
         .await
         .unwrap()
         .unwrap();
@@ -316,23 +316,15 @@ async fn test_ssh_collaboration_git_branches(
     assert_eq!(server_branch.name, branches[2]);
 
     // Also try creating a new branch
-    cx_b.update(|cx| {
-        repo_b
-            .read(cx)
-            .create_branch("totally-new-branch".to_string())
-    })
-    .await
-    .unwrap()
-    .unwrap();
+    cx_b.update(|cx| repo_b.read(cx).create_branch("totally-new-branch"))
+        .await
+        .unwrap()
+        .unwrap();
 
-    cx_b.update(|cx| {
-        repo_b
-            .read(cx)
-            .change_branch("totally-new-branch".to_string())
-    })
-    .await
-    .unwrap()
-    .unwrap();
+    cx_b.update(|cx| repo_b.read(cx).change_branch("totally-new-branch"))
+        .await
+        .unwrap()
+        .unwrap();
 
     executor.run_until_parked();
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6763,8 +6763,7 @@ impl Element for EditorElement {
                         let unstaged_background = if use_pattern {
                             pattern_slash(
                                 background_color.opacity(hunk_opacity),
-                                dbg!(window.line_height().0 * 0.5),
-                                //window.rem_size().0 * 1.125, // ~18 by default
+                                window.rem_size().0 * 1.125, // ~18 by default
                             )
                         } else {
                             solid_background(background_color.opacity(if is_light {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6763,7 +6763,8 @@ impl Element for EditorElement {
                         let unstaged_background = if use_pattern {
                             pattern_slash(
                                 background_color.opacity(hunk_opacity),
-                                window.rem_size().0 * 1.125, // ~18 by default
+                                dbg!(window.line_height().0 * 0.5),
+                                //window.rem_size().0 * 1.125, // ~18 by default
                             )
                         } else {
                             solid_background(background_color.opacity(if is_light {

--- a/crates/file_finder/src/new_path_prompt.rs
+++ b/crates/file_finder/src/new_path_prompt.rs
@@ -436,8 +436,8 @@ impl PickerDelegate for NewPathDelegate {
         )
     }
 
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        "Type a path...".into()
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("Type a path...".into())
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {

--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -347,12 +347,14 @@ impl PickerDelegate for OpenPathDelegate {
         )
     }
 
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        if let Some(error) = self.directory_state.as_ref().and_then(|s| s.error.clone()) {
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        let text = if let Some(error) = self.directory_state.as_ref().and_then(|s| s.error.clone())
+        {
             error
         } else {
             "No such file or directory".into()
-        }
+        };
+        Some(text)
     }
 
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -31,7 +31,7 @@ pub fn open(
     let repository = workspace.project().read(cx).active_repository(cx).clone();
     let style = BranchListStyle::Modal;
     workspace.toggle_modal(window, cx, |window, cx| {
-        BranchList::new(repository, style, 34., window, cx)
+        BranchList::new(repository, style, rems(34.), window, cx)
     })
 }
 
@@ -41,7 +41,7 @@ pub fn popover(
     cx: &mut App,
 ) -> Entity<BranchList> {
     cx.new(|cx| {
-        let list = BranchList::new(repository, BranchListStyle::Popover, 15., window, cx);
+        let list = BranchList::new(repository, BranchListStyle::Popover, rems(15.), window, cx);
         list.focus_handle(cx).focus(window);
         list
     })
@@ -54,7 +54,7 @@ enum BranchListStyle {
 }
 
 pub struct BranchList {
-    rem_width: f32,
+    width: Rems,
     pub popover_handle: PopoverMenuHandle<Self>,
     pub picker: Entity<Picker<BranchListDelegate>>,
     _subscription: Subscription,
@@ -64,7 +64,7 @@ impl BranchList {
     fn new(
         repository: Option<Entity<Repository>>,
         style: BranchListStyle,
-        rem_width: f32,
+        width: Rems,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -89,7 +89,7 @@ impl BranchList {
         })
         .detach_and_log_err(cx);
 
-        let delegate = BranchListDelegate::new(repository.clone(), style, 20);
+        let delegate = BranchListDelegate::new(repository.clone(), style, (1.6 * width.0) as usize);
         let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
 
         let _subscription = cx.subscribe(&picker, |_, _, _, cx| {
@@ -98,7 +98,7 @@ impl BranchList {
 
         Self {
             picker,
-            rem_width,
+            width,
             popover_handle,
             _subscription,
         }
@@ -116,7 +116,7 @@ impl Focusable for BranchList {
 impl Render for BranchList {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
-            .w(rems(self.rem_width))
+            .w(self.width)
             .child(self.picker.clone())
             .on_mouse_down_out({
                 cx.listener(move |this, _, window, cx| {

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -10,7 +10,9 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use project::git::Repository;
 use std::sync::Arc;
-use ui::{prelude::*, HighlightedLabel, ListItem, ListItemSpacing, PopoverMenuHandle, Tooltip};
+use ui::{
+    prelude::*, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, PopoverMenuHandle, Tooltip,
+};
 use util::ResultExt;
 use workspace::notifications::DetachAndPromptErr;
 use workspace::{ModalView, Workspace};
@@ -419,7 +421,11 @@ impl PickerDelegate for BranchListDelegate {
         )
     }
 
-    fn render_footer(&self, _: &mut Window, cx: &mut Context<Picker<Self>>) -> Option<AnyElement> {
+    fn render_footer(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> Option<AnyElement> {
         let new_branch_name = SharedString::from(self.last_query.trim().replace(" ", "-"));
         let handle = cx.weak_entity();
         Some(
@@ -437,6 +443,11 @@ impl PickerDelegate for BranchListDelegate {
                                 "create-branch",
                                 format!("Create branch '{new_branch_name}'",),
                             )
+                            .key_binding(KeyBinding::for_action(
+                                &menu::SecondaryConfirm,
+                                window,
+                                cx,
+                            ))
                             .toggle_state(
                                 self.modifiers.secondary()
                                     || (self.selected_index == 0 && self.matches.len() == 0),

--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -661,11 +661,11 @@ impl Default for Background {
 }
 
 /// Creates a hash pattern background
-pub fn pattern_slash(color: Hsla, thickness: f32) -> Background {
+pub fn pattern_slash(color: Hsla, height: f32) -> Background {
     Background {
         tag: BackgroundTag::PatternSlash,
         solid: color,
-        gradient_angle_or_pattern_height: thickness,
+        gradient_angle_or_pattern_height: height,
         ..Default::default()
     }
 }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -96,8 +96,8 @@ pub trait PickerDelegate: Sized + 'static {
         None
     }
     fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str>;
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        "No matches".into()
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("No matches".into())
     }
     fn update_matches(
         &mut self,
@@ -844,18 +844,17 @@ impl<D: PickerDelegate> Render for Picker<D> {
                 )
             })
             .when(self.delegate.match_count() == 0, |el| {
-                el.child(
-                    v_flex().flex_grow().py_2().child(
-                        ListItem::new("empty_state")
-                            .inset(true)
-                            .spacing(ListItemSpacing::Sparse)
-                            .disabled(true)
-                            .child(
-                                Label::new(self.delegate.no_matches_text(window, cx))
-                                    .color(Color::Muted),
-                            ),
-                    ),
-                )
+                el.when_some(self.delegate.no_matches_text(window, cx), |el, text| {
+                    el.child(
+                        v_flex().flex_grow().py_2().child(
+                            ListItem::new("empty_state")
+                                .inset(true)
+                                .spacing(ListItemSpacing::Sparse)
+                                .disabled(true)
+                                .child(Label::new(text).color(Color::Muted)),
+                        ),
+                    )
+                })
             })
             .children(self.delegate.render_footer(window, cx))
             .children(match &self.head {

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -636,7 +636,7 @@ impl GitStore {
 
         repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.create_branch(branch_name)
+                repository_handle.create_branch(&branch_name)
             })?
             .await??;
 
@@ -656,7 +656,7 @@ impl GitStore {
 
         repository_handle
             .update(&mut cx, |repository_handle, _| {
-                repository_handle.change_branch(branch_name)
+                repository_handle.change_branch(&branch_name)
             })?
             .await??;
 
@@ -1695,7 +1695,8 @@ impl Repository {
         })
     }
 
-    pub fn create_branch(&self, branch_name: String) -> oneshot::Receiver<Result<()>> {
+    pub fn create_branch(&self, branch_name: &str) -> oneshot::Receiver<Result<()>> {
+        let branch_name = branch_name.to_owned();
         self.send_job(|repo| async move {
             match repo {
                 GitRepo::Local(git_repository) => git_repository.create_branch(&branch_name),
@@ -1720,7 +1721,8 @@ impl Repository {
         })
     }
 
-    pub fn change_branch(&self, branch_name: String) -> oneshot::Receiver<Result<()>> {
+    pub fn change_branch(&self, branch_name: &str) -> oneshot::Receiver<Result<()>> {
+        let branch_name = branch_name.to_owned();
         self.send_job(|repo| async move {
             match repo {
                 GitRepo::Local(git_repository) => git_repository.change_branch(&branch_name),

--- a/crates/prompt_library/src/prompt_library.rs
+++ b/crates/prompt_library/src/prompt_library.rs
@@ -179,12 +179,13 @@ impl PickerDelegate for PromptPickerDelegate {
         self.matches.len()
     }
 
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        if self.store.prompt_count() == 0 {
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        let text = if self.store.prompt_count() == 0 {
             "No prompts.".into()
         } else {
             "No prompts found matching your search.".into()
-        }
+        };
+        Some(text)
     }
 
     fn selected_index(&self) -> usize {

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -351,12 +351,13 @@ impl PickerDelegate for RecentProjectsDelegate {
 
     fn dismissed(&mut self, _window: &mut Window, _: &mut Context<Picker<Self>>) {}
 
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        if self.workspaces.is_empty() {
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        let text = if self.workspaces.is_empty() {
             "Recently opened projects will show up here".into()
         } else {
             "No matches".into()
-        }
+        };
+        Some(text)
     }
 
     fn render_match(

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -1361,7 +1361,7 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
 
     assert_eq!(&remote_branches, &branches_set);
 
-    cx.update(|cx| repository.read(cx).change_branch(new_branch.to_string()))
+    cx.update(|cx| repository.read(cx).change_branch(new_branch))
         .await
         .unwrap()
         .unwrap();
@@ -1383,23 +1383,15 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     assert_eq!(server_branch.name, branches[2]);
 
     // Also try creating a new branch
-    cx.update(|cx| {
-        repository
-            .read(cx)
-            .create_branch("totally-new-branch".to_string())
-    })
-    .await
-    .unwrap()
-    .unwrap();
+    cx.update(|cx| repository.read(cx).create_branch("totally-new-branch"))
+        .await
+        .unwrap()
+        .unwrap();
 
-    cx.update(|cx| {
-        repository
-            .read(cx)
-            .change_branch("totally-new-branch".to_string())
-    })
-    .await
-    .unwrap()
-    .unwrap();
+    cx.update(|cx| repository.read(cx).change_branch("totally-new-branch"))
+        .await
+        .unwrap()
+        .unwrap();
 
     cx.run_until_parked();
 

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -325,8 +325,8 @@ impl PickerDelegate for TabSwitcherDelegate {
         Arc::default()
     }
 
-    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> SharedString {
-        "No tabs".into()
+    fn no_matches_text(&self, _window: &mut Window, _cx: &mut App) -> Option<SharedString> {
+        Some("No tabs".into())
     }
 
     fn match_count(&self) -> usize {


### PR DESCRIPTION
- Truncate branch names based on the width of the picker
- Use a footer for "Create branch" instead of a picker entry

Still to do:

- [x] Select the footer button when no matches and run the create logic on `enter`
- [x] Make it possible to quickly select the footer button from the keyboard when there are matches

Release Notes:

- Git Beta: Removed limitation that made it impossible to create a branch from the branch picker when it too closely resembled an existing branch name
