### PR TITLE
Refactor Completions to allow non-LSP ones better

### DIFF
--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -38,7 +38,7 @@ use language_model::{
 use language_model_selector::{LanguageModelSelector, LanguageModelSelectorPopoverMenu};
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
-use project::{ActionVariant, CodeAction, ProjectTransaction};
+use project::{CodeAction, LspAction, ProjectTransaction};
 use prompt_store::PromptBuilder;
 use rope::Rope;
 use settings::{update_settings_file, Settings, SettingsStore};
@@ -3569,7 +3569,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
             Task::ready(Ok(vec![CodeAction {
                 server_id: language::LanguageServerId(0),
                 range: snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end),
-                lsp_action: ActionVariant::Action(Box::new(lsp::CodeAction {
+                lsp_action: LspAction::Action(Box::new(lsp::CodeAction {
                     title: "Fix with Assistant".into(),
                     ..Default::default()
                 })),

--- a/crates/assistant2/src/inline_assistant.rs
+++ b/crates/assistant2/src/inline_assistant.rs
@@ -27,7 +27,7 @@ use language::{Buffer, Point, Selection, TransactionId};
 use language_model::{report_assistant_event, LanguageModelRegistry};
 use multi_buffer::MultiBufferRow;
 use parking_lot::Mutex;
-use project::ActionVariant;
+use project::LspAction;
 use project::{CodeAction, ProjectTransaction};
 use prompt_store::PromptBuilder;
 use settings::{Settings, SettingsStore};
@@ -1728,7 +1728,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
             Task::ready(Ok(vec![CodeAction {
                 server_id: language::LanguageServerId(0),
                 range: snapshot.anchor_before(range.start)..snapshot.anchor_after(range.end),
-                lsp_action: ActionVariant::Action(Box::new(lsp::CodeAction {
+                lsp_action: LspAction::Action(Box::new(lsp::CodeAction {
                     title: "Fix with Assistant".into(),
                     ..Default::default()
                 })),

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -5,9 +5,9 @@ use assistant_slash_command::{AfterCompletion, SlashCommandLine, SlashCommandWor
 use editor::{CompletionProvider, Editor};
 use fuzzy::{match_strings, StringMatchCandidate};
 use gpui::{App, AppContext as _, Context, Entity, Task, WeakEntity, Window};
-use language::{Anchor, Buffer, LanguageServerId, ToPoint};
+use language::{Anchor, Buffer, ToPoint};
 use parking_lot::Mutex;
-use project::{lsp_store::CompletionDocumentation, CompletionIntent};
+use project::{lsp_store::CompletionDocumentation, CompletionIntent, CompletionSource};
 use rope::Point;
 use std::{
     cell::RefCell,
@@ -125,10 +125,8 @@ impl SlashCommandCompletionProvider {
                             )),
                             new_text,
                             label: command.label(cx),
-                            server_id: LanguageServerId(0),
-                            lsp_completion: Default::default(),
                             confirm,
-                            resolved: true,
+                            source: CompletionSource::Custom,
                         })
                     })
                     .collect()
@@ -225,10 +223,8 @@ impl SlashCommandCompletionProvider {
                             label: new_argument.label,
                             new_text,
                             documentation: None,
-                            server_id: LanguageServerId(0),
-                            lsp_completion: Default::default(),
                             confirm,
-                            resolved: true,
+                            source: CompletionSource::Custom,
                         }
                     })
                     .collect())

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -10,9 +10,9 @@ use gpui::{
 };
 use language::{
     language_settings::SoftWrap, Anchor, Buffer, BufferSnapshot, CodeLabel, LanguageRegistry,
-    LanguageServerId, ToOffset,
+    ToOffset,
 };
-use project::{search::SearchQuery, Completion};
+use project::{search::SearchQuery, Completion, CompletionSource};
 use settings::Settings;
 use std::{
     cell::RefCell,
@@ -309,11 +309,9 @@ impl MessageEditor {
                     old_range: range.clone(),
                     new_text,
                     label,
-                    documentation: None,
-                    server_id: LanguageServerId(0), // TODO: Make this optional or something?
-                    lsp_completion: Default::default(), // TODO: Make this optional or something?
                     confirm: None,
-                    resolved: true,
+                    documentation: None,
+                    source: CompletionSource::Custom,
                 }
             })
             .collect()

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -6,11 +6,11 @@ use gpui::{
 };
 use language::Buffer;
 use language::CodeLabel;
-use lsp::LanguageServerId;
 use markdown::Markdown;
 use multi_buffer::{Anchor, ExcerptId};
 use ordered_float::OrderedFloat;
 use project::lsp_store::CompletionDocumentation;
+use project::CompletionSource;
 use project::{CodeAction, Completion, TaskSourceKind};
 
 use std::{
@@ -233,11 +233,9 @@ impl CompletionsMenu {
                     runs: Default::default(),
                     filter_range: Default::default(),
                 },
-                server_id: LanguageServerId(usize::MAX),
                 documentation: None,
-                lsp_completion: Default::default(),
                 confirm: None,
-                resolved: true,
+                source: CompletionSource::Custom,
             })
             .collect();
 
@@ -500,7 +498,12 @@ impl CompletionsMenu {
                                     // Ignore font weight for syntax highlighting, as we'll use it
                                     // for fuzzy matches.
                                     highlight.font_weight = None;
-                                    if completion.lsp_completion.deprecated.unwrap_or(false) {
+                                    if completion
+                                        .source
+                                        .lsp_completion()
+                                        .and_then(|lsp_completion| lsp_completion.deprecated)
+                                        .unwrap_or(false)
+                                    {
                                         highlight.strikethrough = Some(StrikethroughStyle {
                                             thickness: 1.0.into(),
                                             ..Default::default()
@@ -708,7 +711,10 @@ impl CompletionsMenu {
 
                 let completion = &completions[mat.candidate_id];
                 let sort_key = completion.sort_key();
-                let sort_text = completion.lsp_completion.sort_text.as_deref();
+                let sort_text = completion
+                    .source
+                    .lsp_completion()
+                    .and_then(|lsp_completion| lsp_completion.sort_text.as_deref());
                 let score = Reverse(OrderedFloat(mat.score));
 
                 if mat.score >= 0.2 {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -138,8 +138,9 @@ use multi_buffer::{
 use project::{
     lsp_store::{CompletionDocumentation, FormatTrigger, LspFormatTarget, OpenLspBufferHandle},
     project_settings::{GitGutterSetting, ProjectSettings},
-    CodeAction, Completion, CompletionIntent, DocumentHighlight, InlayHint, Location, LocationLink,
-    PrepareRenameResponse, Project, ProjectItem, ProjectTransaction, TaskSourceKind,
+    CodeAction, Completion, CompletionIntent, CompletionSource, DocumentHighlight, InlayHint,
+    Location, LocationLink, PrepareRenameResponse, Project, ProjectItem, ProjectTransaction,
+    TaskSourceKind,
 };
 use rand::prelude::*;
 use rpc::{proto::*, ErrorExt};
@@ -16897,38 +16898,40 @@ fn snippet_completions(
                 Some(Completion {
                     old_range: range,
                     new_text: snippet.body.clone(),
-                    resolved: false,
+                    source: CompletionSource::Lsp {
+                        server_id: LanguageServerId(usize::MAX),
+                        resolved: true,
+                        lsp_completion: lsp::CompletionItem {
+                            label: snippet.prefix.first().unwrap().clone(),
+                            kind: Some(CompletionItemKind::SNIPPET),
+                            label_details: snippet.description.as_ref().map(|description| {
+                                lsp::CompletionItemLabelDetails {
+                                    detail: Some(description.clone()),
+                                    description: None,
+                                }
+                            }),
+                            insert_text_format: Some(InsertTextFormat::SNIPPET),
+                            text_edit: Some(lsp::CompletionTextEdit::InsertAndReplace(
+                                lsp::InsertReplaceEdit {
+                                    new_text: snippet.body.clone(),
+                                    insert: lsp_range,
+                                    replace: lsp_range,
+                                },
+                            )),
+                            filter_text: Some(snippet.body.clone()),
+                            sort_text: Some(char::MAX.to_string()),
+                            ..lsp::CompletionItem::default()
+                        },
+                    },
                     label: CodeLabel {
                         text: matching_prefix.clone(),
-                        runs: vec![],
+                        runs: Vec::new(),
                         filter_range: 0..matching_prefix.len(),
                     },
-                    server_id: LanguageServerId(usize::MAX),
                     documentation: snippet
                         .description
                         .clone()
                         .map(|description| CompletionDocumentation::SingleLine(description.into())),
-                    lsp_completion: lsp::CompletionItem {
-                        label: snippet.prefix.first().unwrap().clone(),
-                        kind: Some(CompletionItemKind::SNIPPET),
-                        label_details: snippet.description.as_ref().map(|description| {
-                            lsp::CompletionItemLabelDetails {
-                                detail: Some(description.clone()),
-                                description: None,
-                            }
-                        }),
-                        insert_text_format: Some(InsertTextFormat::SNIPPET),
-                        text_edit: Some(lsp::CompletionTextEdit::InsertAndReplace(
-                            lsp::InsertReplaceEdit {
-                                new_text: snippet.body.clone(),
-                                insert: lsp_range,
-                                replace: lsp_range,
-                            },
-                        )),
-                        filter_text: Some(snippet.body.clone()),
-                        sort_text: Some(char::MAX.to_string()),
-                        ..Default::default()
-                    },
                     confirm: None,
                 })
             })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16901,7 +16901,7 @@ fn snippet_completions(
                     source: CompletionSource::Lsp {
                         server_id: LanguageServerId(usize::MAX),
                         resolved: true,
-                        lsp_completion: lsp::CompletionItem {
+                        lsp_completion: Box::new(lsp::CompletionItem {
                             label: snippet.prefix.first().unwrap().clone(),
                             kind: Some(CompletionItemKind::SNIPPET),
                             label_details: snippet.description.as_ref().map(|description| {
@@ -16921,7 +16921,7 @@ fn snippet_completions(
                             filter_text: Some(snippet.body.clone()),
                             sort_text: Some(char::MAX.to_string()),
                             ..lsp::CompletionItem::default()
-                        },
+                        }),
                     },
                     label: CodeLabel {
                         text: matching_prefix.clone(),

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2,10 +2,10 @@ mod signature_help;
 
 use crate::{
     lsp_store::{LocalLspStore, LspStore},
-    ActionVariant, CodeAction, CoreCompletion, DocumentHighlight, Hover, HoverBlock,
-    HoverBlockKind, InlayHint, InlayHintLabel, InlayHintLabelPart, InlayHintLabelPartTooltip,
-    InlayHintTooltip, Location, LocationLink, MarkupContent, PrepareRenameResponse,
-    ProjectTransaction, ResolveState,
+    ActionVariant, CodeAction, CompletionSource, CoreCompletion, DocumentHighlight, Hover,
+    HoverBlock, HoverBlockKind, InlayHint, InlayHintLabel, InlayHintLabelPart,
+    InlayHintLabelPartTooltip, InlayHintTooltip, Location, LocationLink, MarkupContent,
+    PrepareRenameResponse, ProjectTransaction, ResolveState,
 };
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
@@ -2011,9 +2011,11 @@ impl LspCommand for GetCompletions {
                 CoreCompletion {
                     old_range,
                     new_text,
-                    server_id,
-                    lsp_completion,
-                    resolved: false,
+                    source: CompletionSource::Lsp {
+                        server_id,
+                        lsp_completion,
+                        resolved: false,
+                    },
                 }
             })
             .collect())

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2013,7 +2013,7 @@ impl LspCommand for GetCompletions {
                     new_text,
                     source: CompletionSource::Lsp {
                         server_id,
-                        lsp_completion,
+                        lsp_completion: Box::new(lsp_completion),
                         resolved: false,
                     },
                 }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2,10 +2,10 @@ mod signature_help;
 
 use crate::{
     lsp_store::{LocalLspStore, LspStore},
-    ActionVariant, CodeAction, CompletionSource, CoreCompletion, DocumentHighlight, Hover,
-    HoverBlock, HoverBlockKind, InlayHint, InlayHintLabel, InlayHintLabelPart,
-    InlayHintLabelPartTooltip, InlayHintTooltip, Location, LocationLink, MarkupContent,
-    PrepareRenameResponse, ProjectTransaction, ResolveState,
+    CodeAction, CompletionSource, CoreCompletion, DocumentHighlight, Hover, HoverBlock,
+    HoverBlockKind, InlayHint, InlayHintLabel, InlayHintLabelPart, InlayHintLabelPartTooltip,
+    InlayHintTooltip, Location, LocationLink, LspAction, MarkupContent, PrepareRenameResponse,
+    ProjectTransaction, ResolveState,
 };
 use anyhow::{anyhow, Context as _, Result};
 use async_trait::async_trait;
@@ -2258,11 +2258,11 @@ impl LspCommand for GetCodeActions {
                                 return None;
                             }
                         }
-                        ActionVariant::Action(Box::new(lsp_action))
+                        LspAction::Action(Box::new(lsp_action))
                     }
                     lsp::CodeActionOrCommand::Command(command) => {
                         if available_commands.contains(&command.command) {
-                            ActionVariant::Command(command)
+                            LspAction::Command(command)
                         } else {
                             return None;
                         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -443,12 +443,12 @@ pub struct CodeAction {
     pub range: Range<Anchor>,
     /// The raw code action provided by the language server.
     /// Can be either an action or a command.
-    pub lsp_action: ActionVariant,
+    pub lsp_action: LspAction,
 }
 
 /// An action sent back by a language server.
 #[derive(Clone, Debug)]
-pub enum ActionVariant {
+pub enum LspAction {
     /// An action with the full data, may have a command or may not.
     /// May require resolving.
     Action(Box<lsp::CodeAction>),
@@ -456,7 +456,7 @@ pub enum ActionVariant {
     Command(lsp::Command),
 }
 
-impl ActionVariant {
+impl LspAction {
     pub fn title(&self) -> &str {
         match self {
             Self::Action(action) => &action.title,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -381,7 +381,7 @@ pub enum CompletionSource {
         /// The id of the language server that produced this completion.
         server_id: LanguageServerId,
         /// The raw completion provided by the language server.
-        lsp_completion: lsp::CompletionItem,
+        lsp_completion: Box<lsp::CompletionItem>,
         /// Whether this completion has been resolved, to ensure it happens once per completion.
         resolved: bool,
     },

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -364,19 +364,54 @@ pub struct Completion {
     pub new_text: String,
     /// A label for this completion that is shown in the menu.
     pub label: CodeLabel,
-    /// The id of the language server that produced this completion.
-    pub server_id: LanguageServerId,
     /// The documentation for this completion.
     pub documentation: Option<CompletionDocumentation>,
-    /// The raw completion provided by the language server.
-    pub lsp_completion: lsp::CompletionItem,
-    /// Whether this completion has been resolved, to ensure it happens once per completion.
-    pub resolved: bool,
+    /// Completion data source which it was constructed from.
+    pub source: CompletionSource,
     /// An optional callback to invoke when this completion is confirmed.
     /// Returns, whether new completions should be retriggered after the current one.
     /// If `true` is returned, the editor will show a new completion menu after this completion is confirmed.
     /// if no confirmation is provided or `false` is returned, the completion will be committed.
     pub confirm: Option<Arc<dyn Send + Sync + Fn(CompletionIntent, &mut Window, &mut App) -> bool>>,
+}
+
+#[derive(Debug, Clone)]
+pub enum CompletionSource {
+    Lsp {
+        /// The id of the language server that produced this completion.
+        server_id: LanguageServerId,
+        /// The raw completion provided by the language server.
+        lsp_completion: lsp::CompletionItem,
+        /// Whether this completion has been resolved, to ensure it happens once per completion.
+        resolved: bool,
+    },
+    Custom,
+}
+
+impl CompletionSource {
+    pub fn server_id(&self) -> Option<LanguageServerId> {
+        if let CompletionSource::Lsp { server_id, .. } = self {
+            Some(*server_id)
+        } else {
+            None
+        }
+    }
+
+    pub fn lsp_completion(&self) -> Option<&lsp::CompletionItem> {
+        if let Self::Lsp { lsp_completion, .. } = self {
+            Some(lsp_completion)
+        } else {
+            None
+        }
+    }
+
+    fn lsp_completion_mut(&mut self) -> Option<&mut lsp::CompletionItem> {
+        if let Self::Lsp { lsp_completion, .. } = self {
+            Some(lsp_completion)
+        } else {
+            None
+        }
+    }
 }
 
 impl std::fmt::Debug for Completion {
@@ -385,9 +420,8 @@ impl std::fmt::Debug for Completion {
             .field("old_range", &self.old_range)
             .field("new_text", &self.new_text)
             .field("label", &self.label)
-            .field("server_id", &self.server_id)
             .field("documentation", &self.documentation)
-            .field("lsp_completion", &self.lsp_completion)
+            .field("source", &self.source)
             .finish()
     }
 }
@@ -397,9 +431,7 @@ impl std::fmt::Debug for Completion {
 pub(crate) struct CoreCompletion {
     old_range: Range<Anchor>,
     new_text: String,
-    server_id: LanguageServerId,
-    lsp_completion: lsp::CompletionItem,
-    resolved: bool,
+    source: CompletionSource,
 }
 
 /// A code action provided by a language server.
@@ -4605,27 +4637,38 @@ impl Completion {
     /// A key that can be used to sort completions when displaying
     /// them to the user.
     pub fn sort_key(&self) -> (usize, &str) {
-        let kind_key = match self.lsp_completion.kind {
-            Some(lsp::CompletionItemKind::KEYWORD) => 0,
-            Some(lsp::CompletionItemKind::VARIABLE) => 1,
-            _ => 2,
-        };
+        const DEFAULT_KIND_KEY: usize = 2;
+        let kind_key = self
+            .source
+            .lsp_completion()
+            .and_then(|lsp_completion| lsp_completion.kind)
+            .and_then(|lsp_completion_kind| match lsp_completion_kind {
+                lsp::CompletionItemKind::KEYWORD => Some(0),
+                lsp::CompletionItemKind::VARIABLE => Some(1),
+                _ => None,
+            })
+            .unwrap_or(DEFAULT_KIND_KEY);
         (kind_key, &self.label.text[self.label.filter_range.clone()])
     }
 
     /// Whether this completion is a snippet.
     pub fn is_snippet(&self) -> bool {
-        self.lsp_completion.insert_text_format == Some(lsp::InsertTextFormat::SNIPPET)
+        self.source
+            .lsp_completion()
+            .map_or(false, |lsp_completion| {
+                lsp_completion.insert_text_format == Some(lsp::InsertTextFormat::SNIPPET)
+            })
     }
 
     /// Returns the corresponding color for this completion.
     ///
     /// Will return `None` if this completion's kind is not [`CompletionItemKind::COLOR`].
     pub fn color(&self) -> Option<Hsla> {
-        match self.lsp_completion.kind {
-            Some(CompletionItemKind::COLOR) => color_extractor::extract_color(&self.lsp_completion),
-            _ => None,
+        let lsp_completion = self.source.lsp_completion()?;
+        if lsp_completion.kind? == CompletionItemKind::COLOR {
+            return color_extractor::extract_color(lsp_completion);
         }
+        None
     }
 }
 

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1,6 +1,6 @@
-
 syntax = "proto3";
 package zed.messages;
+import "google/protobuf/wrappers.proto";
 
 // Looking for a number? Search "// current max"
 
@@ -996,9 +996,15 @@ message Completion {
     Anchor old_start = 1;
     Anchor old_end = 2;
     string new_text = 3;
-    optional uint64 server_id = 4;
-    optional bytes lsp_completion = 5;
-    optional bool resolved = 6;
+    uint64 server_id = 4;
+    bytes lsp_completion = 5;
+    bool resolved = 6;
+    Source source = 7;
+
+    enum Source {
+        Custom = 0;
+        Lsp = 1;
+    }
 }
 
 message GetCodeActions {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -996,9 +996,9 @@ message Completion {
     Anchor old_start = 1;
     Anchor old_end = 2;
     string new_text = 3;
-    uint64 server_id = 4;
-    bytes lsp_completion = 5;
-    bool resolved = 6;
+    optional uint64 server_id = 4;
+    optional bytes lsp_completion = 5;
+    optional bool resolved = 6;
 }
 
 message GetCodeActions {


### PR DESCRIPTION
A preparation for https://github.com/zed-industries/zed/issues/4957 that pushes all LSP-related data out from the basic completion item, so that it's possible to create completion items without any trace of LSP clearly.

Release Notes:

- N/A
