### PR TITLE
git: Fix errors not showing in the toast notification

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -692,7 +692,9 @@ impl GitRepository for RealGitRepository {
                 PushOptions::Force => "--force-with-lease",
             }))
             .arg(remote_name)
-            .arg(format!("{}:{}", branch_name, branch_name));
+            .arg(format!("{}:{}", branch_name, branch_name))
+            .stdout(smol::process::Stdio::piped())
+            .stderr(smol::process::Stdio::piped());
         let git_process = command.spawn()?;
 
         run_remote_command(ask_pass, git_process)
@@ -714,7 +716,9 @@ impl GitRepository for RealGitRepository {
             .current_dir(&working_directory)
             .args(["pull"])
             .arg(remote_name)
-            .arg(branch_name);
+            .arg(branch_name)
+            .stdout(smol::process::Stdio::piped())
+            .stderr(smol::process::Stdio::piped());
         let git_process = command.spawn()?;
 
         run_remote_command(ask_pass, git_process)
@@ -729,7 +733,9 @@ impl GitRepository for RealGitRepository {
             .env("SSH_ASKPASS", ask_pass.script_path())
             .env("SSH_ASKPASS_REQUIRE", "force")
             .current_dir(&working_directory)
-            .args(["fetch", "--all"]);
+            .args(["fetch", "--all"])
+            .stdout(smol::process::Stdio::piped())
+            .stderr(smol::process::Stdio::piped());
         let git_process = command.spawn()?;
 
         run_remote_command(ask_pass, git_process)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1571,6 +1571,7 @@ impl GitPanel {
                         this.show_remote_output(RemoteAction::Fetch, remote_message, cx);
                     }
                     Err(e) => {
+                        log::error!("Error while fetching {:?}", e);
                         this.show_err_toast(e, cx);
                     }
                 }
@@ -1629,7 +1630,10 @@ impl GitPanel {
                 Ok(remote_message) => {
                     this.show_remote_output(RemoteAction::Pull, remote_message, cx)
                 }
-                Err(err) => this.show_err_toast(err, cx),
+                Err(err) => {
+                    log::error!("Error while pull {:?}", err);
+                    this.show_err_toast(err, cx)
+                }
             })
             .ok();
 
@@ -1697,6 +1701,7 @@ impl GitPanel {
                     this.show_remote_output(RemoteAction::Push(remote), remote_message, cx);
                 }
                 Err(e) => {
+                    log::error!("Error while pushing {:?}", e);
                     this.show_err_toast(e, cx);
                 }
             })?;


### PR DESCRIPTION
closes  #26285
Release Notes:

- Resolved an issue where error messages from Git were not being displayed in toast notifications.
<img width="1702" alt="Screenshot 2025-03-08 at 1 11 30 AM" src="https://github.com/user-attachments/assets/a46517db-4e64-4c5e-a64e-96e820ca9aec" />

