### PR TITLE
Add git branch switching aliases

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -18,8 +18,28 @@ use workspace::{ModalView, Workspace};
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {
         workspace.register_action(open);
+        workspace.register_action(switch);
+        workspace.register_action(checkout_branch);
     })
     .detach();
+}
+
+pub fn checkout_branch(
+    workspace: &mut Workspace,
+    _: &zed_actions::git::CheckoutBranch,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    open(workspace, &zed_actions::git::Branch, window, cx);
+}
+
+pub fn switch(
+    workspace: &mut Workspace,
+    _: &zed_actions::git::Switch,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
+    open(workspace, &zed_actions::git::Branch, window, cx);
 }
 
 pub fn open(

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -374,9 +374,17 @@ impl Render for CommitModal {
             .on_action(cx.listener(Self::commit))
             .on_action(
                 cx.listener(|this, _: &zed_actions::git::Branch, window, cx| {
-                    this.branch_list.update(cx, |branch_list, cx| {
-                        branch_list.popover_handle.toggle(window, cx);
-                    })
+                    toggle_branch_picker(this, window, cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|this, _: &zed_actions::git::CheckoutBranch, window, cx| {
+                    toggle_branch_picker(this, window, cx);
+                }),
+            )
+            .on_action(
+                cx.listener(|this, _: &zed_actions::git::Switch, window, cx| {
+                    toggle_branch_picker(this, window, cx);
                 }),
             )
             .elevation_3(cx)
@@ -414,4 +422,14 @@ impl Render for CommitModal {
                     .child(self.render_footer(window, cx)),
             )
     }
+}
+
+fn toggle_branch_picker(
+    this: &mut CommitModal,
+    window: &mut Window,
+    cx: &mut Context<'_, CommitModal>,
+) {
+    this.branch_list.update(cx, |branch_list, cx| {
+        branch_list.popover_handle.toggle(window, cx);
+    })
 }

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -114,8 +114,9 @@ pub mod workspace {
 }
 
 pub mod git {
-    use gpui::action_with_deprecated_aliases;
+    use gpui::{action_with_deprecated_aliases, actions};
 
+    actions!(git, [CheckoutBranch, Switch]);
     action_with_deprecated_aliases!(git, Branch, ["branches::OpenRecent"]);
 }
 


### PR DESCRIPTION
This gives us _very_ rudimentary support for `git switch` and `git checkout` now, by making them aliases for our existing `git::branch` call.

Release Notes:

- Git Beta: Added `git::Switch` and `git::CheckoutBranch` as aliases for the existing `git::Branch`
