### PR TITLE
Fix fold button appearing on empty blocks

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -17341,6 +17341,10 @@ impl EditorSnapshot {
         let folded = self.is_line_folded(buffer_row);
         let mut is_foldable = false;
 
+        if self.is_empty_block(buffer_row) {
+            return None;
+        }
+
         if let Some(crease) = self
             .crease_snapshot
             .query_row(buffer_row, &self.buffer_snapshot)


### PR DESCRIPTION
Fold button was appearing on empty functions but doing nothing. Now it doesn't show on empty functions.
Working on different programming languages.

Closes #25773 

Release Notes:

- Fixed the fold button rendering next to functions which are empty blocks.
