### PR TITLE
Revert "Highlight `super` and `this` as keywords in JS/TS/TSX"

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -62,8 +62,8 @@
 
 ; Literals
 
-(this) @keyword
-(super) @keyword
+(this) @variable.special
+(super) @variable.special
 
 [
   (null)

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -62,8 +62,8 @@
 
 ; Literals
 
-(this) @keyword
-(super) @keyword
+(this) @variable.special
+(super) @variable.special
 
 [
   (null)

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -80,8 +80,8 @@
 
 ; Literals
 
-(this) @keyword
-(super) @keyword
+(this) @variable.special
+(super) @variable.special
 
 [
   (null)


### PR DESCRIPTION
Reverts zed-industries/zed#25135

This approach was not the best as explained in the response to the original PR. Likely, the better approach is to create a newer specific scope for these kinds of variables under the `@variable` prefix so that themes can control these pseudo-keywords specifically

Release Notes:
- N/A