### PR TITLE
Avoid modifying the LSP message before resolving it

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -500,7 +500,7 @@ impl CompletionsMenu {
                                     highlight.font_weight = None;
                                     if completion
                                         .source
-                                        .lsp_completion()
+                                        .lsp_completion(false)
                                         .and_then(|lsp_completion| lsp_completion.deprecated)
                                         .unwrap_or(false)
                                     {
@@ -711,10 +711,12 @@ impl CompletionsMenu {
 
                 let completion = &completions[mat.candidate_id];
                 let sort_key = completion.sort_key();
-                let sort_text = completion
-                    .source
-                    .lsp_completion()
-                    .and_then(|lsp_completion| lsp_completion.sort_text.as_deref());
+                let sort_text =
+                    if let CompletionSource::Lsp { lsp_completion, .. } = &completion.source {
+                        lsp_completion.sort_text.as_deref()
+                    } else {
+                        None
+                    };
                 let score = Reverse(OrderedFloat(mat.score));
 
                 if mat.score >= 0.2 {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -17017,6 +17017,7 @@ fn snippet_completions(
                             sort_text: Some(char::MAX.to_string()),
                             ..lsp::CompletionItem::default()
                         }),
+                        lsp_defaults: None,
                     },
                     label: CodeLabel {
                         text: matching_prefix.clone(),

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1000,6 +1000,7 @@ message Completion {
     bytes lsp_completion = 5;
     bool resolved = 6;
     Source source = 7;
+    optional bytes lsp_defaults = 8;
 
     enum Source {
         Custom = 0;


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/21277

To the left is current Zed, right is the improved version.
3rd message, from Zed, to resolve the item, does not have `textEdit` on the right side, and has one on the left.
Seems to not influence the end result though, but at least Zed behaves more appropriate now.

<img width="1727" alt="image" src="https://github.com/user-attachments/assets/ca1236fd-9ce2-41ba-88fe-1f3178cdcbde" />


Instead of modifying the original LSP completion item, store completion list defaults and apply them when the item is requested (except `data` defaults, needed for resolve).

Now, the only place that can modify the completion items is this method, and Python impl seems to be the one doing it:

https://github.com/zed-industries/zed/blob/ca9c3af56ffb05a789c2b946489f4406af2c8281/crates/languages/src/python.rs#L182-L204

Seems ok to leave untouched for now.

Release Notes:

- Fixed LSP completion items modified before resolve request
