### PR TITLE
Disable tests in nix and remove crane workaround

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1741148495,
-        "narHash": "sha256-EV8KUaIZ2/CdBXlutXrHoZYbWPeB65p5kKZk71gvDRI=",
+        "lastModified": 1741481578,
+        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "75390a36cd0c2cdd5f1aafd8a9f827d7107f2e53",
+        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741246872,
-        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
+        "lastModified": 1741379970,
+        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
+        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741314698,
-        "narHash": "sha256-6Yp0CTwAY/jq/F81Sa8NM0Zi1EwxAdASO6y4A5neGuc=",
+        "lastModified": 1741573199,
+        "narHash": "sha256-A2sln1GdCf+uZ8yrERSCZUCqZ3JUlOv1WE2VFqqfaLQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4e9af61c1a631886cdc7e13032af4fc9e75bb76b",
+        "rev": "c777dc8a1e35407b0e80ec89817fe69970f4e81a",
         "type": "github"
       },
       "original": {

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -213,12 +213,9 @@ craneLib.buildPackage (
       echo nightly > crates/zed/RELEASE_CHANNEL
     '';
 
-    # TODO: try craneLib.cargoNextest separate output and doCheck=false
-    # do we even care about running our test suite in the nix sandbox?
-
-    # see crane bug: https://github.com/ipetkov/crane/issues/808
-    doNotRemoveReferencesToRustToolchain = true;
-    doNotRemoveReferencesToVendorDir = true;
+    # TODO: try craneLib.cargoNextest separate output
+    # for now we're not worried about running our test suite in the nix sandbox
+    doCheck = false;
 
     installPhase =
       if stdenv.hostPlatform.isDarwin then


### PR DESCRIPTION
The checkPhase was failing for me in darwin so I turned it off. I think eventually we'll want to use a separate derivation for tests (which crane has a helper for).

Crane also solved our issue with spaces in paths so I bumped the flake to pick up that fix and removed our workaround: ipetkov/crane#808.

Release Notes:

- N/A
