### PR TITLE
macOS: Add support for external file managers to open directory in Zed

### DIFF
--- a/crates/zed/resources/info/DocumentTypes.plist
+++ b/crates/zed/resources/info/DocumentTypes.plist
@@ -9,8 +9,9 @@
         <string>Alternate</string>
         <key>LSItemContentTypes</key>
         <array>
-            <string>public.text</string>
+            <string>public.folder</string>
             <string>public.plain-text</string>
+            <string>public.text</string>
             <string>public.utf8-plain-text</string>
         </array>
     </dict>


### PR DESCRIPTION
Closes #25421

This PR adds support for external file managers to show Zed as an option in the "Open With" context menu for directories on macOS.

<img width="350" alt="image" src="https://github.com/user-attachments/assets/c52acd48-73c4-47be-8683-6950e0371b73" />


Release Notes:

- Added support for opening folders in Zed from third-party macOS file managers like Path Finder and Super Charge through their "Open With" menu.
