### PR TITLE
Add file icon for `wgsl` (WebGPU Shading Language)

### DIFF
--- a/assets/icons/file_icons/wgsl.svg
+++ b/assets/icons/file_icons/wgsl.svg
@@ -1,0 +1,7 @@
+<svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.5 13L1.5 5H11.5L6.5 13Z" fill="black"/>
+<path d="M14 9H9L11.5 5L14 9Z" fill="black" fill-opacity="0.75"/>
+<path d="M9 9L14 9L11.5 13L9 9Z" fill="black" fill-opacity="0.65"/>
+<path d="M14 5L15.25 7L12.75 7L14 5Z" fill="black" fill-opacity="0.5"/>
+<path d="M14 9L12.75 7H15.25L14 9Z" fill="black" fill-opacity="0.55"/>
+</svg>

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -264,6 +264,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ("vs_sln", &["sln"]),
     ("vs_suo", &["suo"]),
     ("vue", &["vue"]),
+    ("wgsl", &["wgsl"]),
     ("zig", &["zig"]),
 ];
 
@@ -348,6 +349,7 @@ const FILE_ICONS: &[(&str, &str)] = &[
     ("vs_sln", "icons/file_icons/file.svg"),
     ("vs_suo", "icons/file_icons/file.svg"),
     ("vue", "icons/file_icons/vue.svg"),
+    ("wgsl", "icons/file_icons/wgsl.svg"),
     ("zig", "icons/file_icons/zig.svg"),
 ];
 


### PR DESCRIPTION
Was dabbling on the shaders these past few days and missed having the WGSL file icon, so here it is. This is based on the logo found on the GPU Web repository: https://github.com/gpuweb/gpuweb/tree/main/logo

Release Notes:

- N/A
