### PR TITLE
go_to_line: Fix goto line + mouse click jumps to previous scroll position

### DIFF
--- a/crates/go_to_line/src/go_to_line.rs
+++ b/crates/go_to_line/src/go_to_line.rs
@@ -152,7 +152,10 @@ impl GoToLine {
         cx: &mut Context<Self>,
     ) {
         match event {
-            editor::EditorEvent::Blurred => cx.emit(DismissEvent),
+            editor::EditorEvent::Blurred => {
+                self.prev_scroll_position.take();
+                cx.emit(DismissEvent)
+            }
             editor::EditorEvent::BufferEdited { .. } => self.highlight_current_line(cx),
             _ => {}
         }


### PR DESCRIPTION
Closes #20658

Now, when the "Go to Line" palette is open:  
- Clicking on the editor will dismiss the palette without changing the scroll position.  (PR change)
- Pressing Enter will jump to the line number entered in the palette. (Unchanged)  
- Pressing Escape will jump back to the previous cursor location. (Unchanged)  

Release Notes:

- Fixed an issue where clicking the editor with the mouse while the "Go to Line" palette is open would cause it to jump to the previous scroll position.
