### PR TITLE
Fix panel not resizing after external file deletion

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1880,7 +1880,7 @@ impl Pane {
                     }
                     Ok(1) => {
                         pane.update_in(cx, |pane, window, cx| {
-                            pane.remove_item(item.item_id(), false, false, window, cx)
+                            pane.remove_item(item.item_id(), false, true, window, cx)
                         })?;
                     }
                     _ => return Ok(false),


### PR DESCRIPTION
Previously, when a file was deleted externally and the warning prompt was dismissed with "Close", the panel remained but was empty, leaving an unused split space.

This happened because pane.remove_item(...) was being called with close_pane_if_empty set to false, preventing the panel from being removed even when it had no remaining items.

This fix changes the third boolean parameter to true, ensuring that the panel is removed if it becomes empty, allowing the layout to properly resize.

Closes #23904

Release Notes:

- N/A
