### PR TITLE
Fix pane magnification causing mouse to drag tabs unexpectedly

### DIFF
--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1948,6 +1948,13 @@ impl Interactivity {
                             if pending_mouse_down.is_some() && hitbox.is_hovered(window) {
                                 captured_mouse_down = pending_mouse_down.take();
                                 window.refresh();
+                            } else if pending_mouse_down.is_some() {
+                                // Clear the pending mouse (without fire click handlers) if the
+                                // hitbox is not being hovered.
+                                // This avoid dragging elements that changed its position
+                                // immediately after being clicked.
+                                let _capt = pending_mouse_down.take();
+                                window.refresh();
                             }
                         }
                         // Fire click handlers during the bubble phase.

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -1949,11 +1949,12 @@ impl Interactivity {
                                 captured_mouse_down = pending_mouse_down.take();
                                 window.refresh();
                             } else if pending_mouse_down.is_some() {
-                                // Clear the pending mouse (without fire click handlers) if the
-                                // hitbox is not being hovered.
-                                // This avoid dragging elements that changed its position
+                                // Clear the pending mouse down event (without firing click handlers)
+                                // if the hitbox is not being hovered.
+                                // This avoids dragging elements that changed their position
                                 // immediately after being clicked.
-                                let _capt = pending_mouse_down.take();
+                                // See https://github.com/zed-industries/zed/issues/24600 for more details
+                                pending_mouse_down.take();
                                 window.refresh();
                             }
                         }


### PR DESCRIPTION
Previously, if a user clicked a button and moved the cursor out before releasing, the click event was correctly prevented, but the pending mouse-down state remained.
This caused unintended drags when the UI shifted due to magnification settings.

Now, mouse-up clears the pending state:
- If over the button → clear state and trigger click handlers.
- If outside the button → clear state without triggering a click.

This avoids accidental drags while preserving expected click behavior.

Closes #24600

Release Notes:

- N/A
