### PR TITLE
Remove --frozen flag for cargo-about

### DIFF
--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -30,7 +30,6 @@ if [ -z "${ALLOW_MISSING_LICENSES-}" ]; then FAIL_FLAG=--fail; else FAIL_FLAG=""
 set -x
 cargo about generate \
     $FAIL_FLAG \
-    --frozen \
     -c script/licenses/zed-licenses.toml \
     "$TEMPLATE_FILE" >>"$OUTPUT_FILE"
 set +x

--- a/script/generate-licenses-csv
+++ b/script/generate-licenses-csv
@@ -17,7 +17,6 @@ echo "Generating cargo licenses"
 set -x
 cargo about generate \
     --fail \
-    --frozen \
     -c script/licenses/zed-licenses.toml \
     $TEMPLATE_FILE \
     | awk 'NR==1{print;next} NF{print | "sort"}' \


### PR DESCRIPTION
This was added to support the nix build but accidentally broke our bundling. I'll try to re-add it in a way that works for both in the future.

Release Notes:

- N/A
