### PR TITLE
Address out-of-bounds panic in inline completion button

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4176,7 +4176,9 @@ impl MultiBufferSnapshot {
         let region = cursor.region()?;
         let overshoot = offset - region.range.start;
         let buffer_offset = region.buffer_range.start + overshoot;
-        let buffer_offset = buffer_offset.min(region.buffer.len());
+        if buffer_offset > region.buffer.len() {
+            return None;
+        }
         Some((region.buffer, buffer_offset))
     }
 
@@ -4185,8 +4187,11 @@ impl MultiBufferSnapshot {
         cursor.seek(&point);
         let region = cursor.region()?;
         let overshoot = point - region.range.start;
-        let buffer_offset = region.buffer_range.start + overshoot;
-        Some((region.buffer, buffer_offset, region.is_main_buffer))
+        let buffer_point = region.buffer_range.start + overshoot;
+        if buffer_point > region.buffer.max_point() {
+            return None;
+        }
+        Some((region.buffer, buffer_point, region.is_main_buffer))
     }
 
     pub fn suggested_indents(

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4176,6 +4176,7 @@ impl MultiBufferSnapshot {
         let region = cursor.region()?;
         let overshoot = offset - region.range.start;
         let buffer_offset = region.buffer_range.start + overshoot;
+        let buffer_offset = buffer_offset.min(region.buffer.len());
         Some((region.buffer, buffer_offset))
     }
 

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -3378,6 +3378,17 @@ fn assert_position_translation(snapshot: &MultiBufferSnapshot) {
             }
         }
     }
+
+    let point = snapshot.max_point();
+    let Some((buffer, offset)) = snapshot.point_to_buffer_offset(point) else {
+        return;
+    };
+    assert!(offset <= buffer.len(),);
+
+    let Some((buffer, point, _)) = snapshot.point_to_buffer_point(point) else {
+        return;
+    };
+    assert!(point <= buffer.max_point(),);
 }
 
 fn assert_line_indents(snapshot: &MultiBufferSnapshot) {


### PR DESCRIPTION
Closes #26350

Release Notes:

- Git Beta: Fixed a panic that could occur when using the project diff
