### PR TITLE
Add a missing notify when updating the project diff

### DIFF
--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -472,7 +472,10 @@ impl ProjectDiff {
                     })?;
                 }
             }
-            this.update(&mut cx, |this, _| this.pending_scroll.take())?;
+            this.update(&mut cx, |this, cx| {
+                this.pending_scroll.take();
+                cx.notify();
+            })?;
         }
 
         Ok(())


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Git Beta: Fixed a bug that caused the project diff not to update in response to git-related events