### PR TITLE
Use current upstream for permalink to line

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -1983,7 +1983,6 @@ async fn test_git_blame_is_forwarded(cx_a: &mut TestAppContext, cx_b: &mut TestA
             blame_entry("3a3a3a", 2..3),
             blame_entry("4c4c4c", 3..4),
         ],
-        permalinks: HashMap::default(), // This field is deprecrated
         messages: [
             ("1b1b1b", "message for idx-0"),
             ("0d0d0d", "message for idx-1"),

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -57,6 +57,14 @@ pub struct Upstream {
     pub tracking: UpstreamTracking,
 }
 
+impl Upstream {
+    pub fn remote_name(&self) -> Option<&str> {
+        self.ref_name
+            .strip_prefix("refs/remotes/")
+            .and_then(|stripped| stripped.split("/").next())
+    }
+}
+
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
 pub enum UpstreamTracking {
     /// Remote ref not present in local repository.

--- a/crates/project/src/buffer_store.rs
+++ b/crates/project/src/buffer_store.rs
@@ -1705,11 +1705,17 @@ impl BufferStore {
                     Err(e) => return Task::ready(Err(e)),
                 };
 
+                let remote = repo_entry
+                    .branch()
+                    .and_then(|b| b.upstream.as_ref())
+                    .and_then(|b| b.remote_name())
+                    .unwrap_or("origin")
+                    .to_string();
+
                 cx.spawn(|cx| async move {
-                    const REMOTE_NAME: &str = "origin";
                     let origin_url = repo
-                        .remote_url(REMOTE_NAME)
-                        .ok_or_else(|| anyhow!("remote \"{REMOTE_NAME}\" not found"))?;
+                        .remote_url(&remote)
+                        .ok_or_else(|| anyhow!("remote \"{remote}\" not found"))?;
 
                     let sha = repo
                         .head_sha()


### PR DESCRIPTION
Release Notes:

- git: Copy permalink to line now uses the upstream of the current branch instead of "origin"
