### PR TITLE
assistant2: Remove unneeded `pub` on field

### DIFF
--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -25,7 +25,7 @@ use crate::{
 
 pub struct ContextStrip {
     context_store: Entity<ContextStore>,
-    pub context_picker: Entity<ContextPicker>,
+    context_picker: Entity<ContextPicker>,
     context_picker_menu_handle: PopoverMenuHandle<ContextPicker>,
     focus_handle: FocusHandle,
     suggest_context_kind: SuggestContextKind,


### PR DESCRIPTION
This PR removes an unneeded `pub` on a field in the `ContextStrip`, as it was never accessed externally.

Release Notes:

- N/A
