### PR TITLE
Git commit modal command

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -746,6 +746,7 @@
   {
     "context": "GitCommit > Editor",
     "bindings": {
+      "escape": "menu::Cancel",
       "enter": "editor::Newline",
       "ctrl-enter": "git::Commit",
       "alt-l": "git::GenerateCommitMessage"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -31,13 +31,13 @@
       "enter": "menu::Confirm",
       "ctrl-enter": "menu::SecondaryConfirm",
       "cmd-enter": "menu::SecondaryConfirm",
+      "cmd-escape": "menu::Cancel",
       "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "escape": "menu::Cancel",
       "alt-shift-enter": "menu::Restart",
       "cmd-shift-w": "workspace::CloseWindow",
       "shift-escape": "workspace::ToggleZoom",
-      "cmd-escape": "menu::Cancel",
       "cmd-o": "workspace::Open",
       "cmd-=": ["zed::IncreaseBufferFontSize", { "persist": false }],
       "cmd-+": ["zed::IncreaseBufferFontSize", { "persist": false }],
@@ -817,6 +817,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "editor::Newline",
+      "escape": "menu::Cancel",
       "cmd-enter": "git::Commit",
       "alt-tab": "git::GenerateCommitMessage"
     }

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -232,8 +232,6 @@ impl CommitModal {
     }
 
     pub fn render_footer(&self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let git_panel = self.git_panel.clone();
-
         let (branch, can_commit, tooltip, commit_label, co_authors, generate_commit_message) =
             self.git_panel.update(cx, |git_panel, cx| {
                 let branch = git_panel
@@ -289,6 +287,7 @@ impl CommitModal {
                 x: px(0.0),
                 y: px(-2.0),
             });
+        let focus_handle = self.focus_handle(cx);
 
         let close_kb_hint =
             if let Some(close_kb) = ui::KeyBinding::for_action(&menu::Cancel, window, cx) {
@@ -300,12 +299,9 @@ impl CommitModal {
                 None
             };
 
-        let panel_editor_focus_handle =
-            git_panel.update(cx, |git_panel, cx| git_panel.editor_focus_handle(cx));
-
         let commit_button = panel_filled_button(commit_label)
             .tooltip({
-                let panel_editor_focus_handle = panel_editor_focus_handle.clone();
+                let panel_editor_focus_handle = focus_handle.clone();
                 move |window, cx| {
                     Tooltip::for_action_in(tooltip, &Commit, &panel_editor_focus_handle, window, cx)
                 }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -694,10 +694,6 @@ impl GitPanel {
         }
     }
 
-    pub(crate) fn editor_focus_handle(&self, cx: &mut Context<Self>) -> FocusHandle {
-        self.commit_editor.focus_handle(cx).clone()
-    }
-
     fn focus_editor(&mut self, _: &FocusEditor, window: &mut Window, cx: &mut Context<Self>) {
         self.commit_editor.update(cx, |editor, cx| {
             window.focus(&editor.focus_handle(cx));

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -29,6 +29,9 @@ impl KeyBinding {
     /// Returns the highest precedence keybinding for an action. This is the last binding added to
     /// the keymap. User bindings are added after built-in bindings so that they take precedence.
     pub fn for_action(action: &dyn Action, window: &mut Window, cx: &App) -> Option<Self> {
+        if let Some(focused) = window.focused(cx) {
+            return Self::for_action_in(action, &focused, window, cx);
+        }
         let key_binding =
             gpui::Keymap::binding_to_display_from_bindings(&window.bindings_for_action(action))
                 .cloned()?;


### PR DESCRIPTION
Fix KeyBinding::for_action() to use the active focus handle instead of what was
rendered last.

This makes the UI consistently chose the cmd-escape binding for close (because escape in the editor is editor::Cancel?),
so force it to be "escape"

Release Notes:

- git: Fixed escape tooltip in commit modal
