### PR TITLE
Return back a proper `resolved` value

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16980,7 +16980,8 @@ fn snippet_completions(
                     new_text: snippet.body.clone(),
                     source: CompletionSource::Lsp {
                         server_id: LanguageServerId(usize::MAX),
-                        resolved: true,
+                        // Despite usize::MAX server_id above, snippets may need to be resolved
+                        resolved: false,
                         lsp_completion: Box::new(lsp::CompletionItem {
                             label: snippet.prefix.first().unwrap().clone(),
                             kind: Some(CompletionItemKind::SNIPPET),


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/26300

https://github.com/zed-industries/zed/pull/26300/files#diff-a3da3181e4ab4f73aa1697d7b6dc0caa0c17b2a187fb83b076dfc0234ec91f54L16900 changed the snippets' `resolved` value but it should have not.

Release Notes:

- N/A
