### PR TITLE
Use proper order of `Completion::Source` field to have sane default

### DIFF
--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -1,6 +1,5 @@
 syntax = "proto3";
 package zed.messages;
-import "google/protobuf/wrappers.proto";
 
 // Looking for a number? Search "// current max"
 
@@ -1003,8 +1002,8 @@ message Completion {
     optional bytes lsp_defaults = 8;
 
     enum Source {
-        Custom = 0;
-        Lsp = 1;
+        Lsp = 0;
+        Custom = 1;
     }
 }
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/26300

Release Notes:

- N/A
