### PR TITLE
Revert "Return back a proper `resolved` value (#26406)"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16980,8 +16980,7 @@ fn snippet_completions(
                     new_text: snippet.body.clone(),
                     source: CompletionSource::Lsp {
                         server_id: LanguageServerId(usize::MAX),
-                        // Despite usize::MAX server_id above, snippets may need to be resolved
-                        resolved: false,
+                        resolved: true,
                         lsp_completion: Box::new(lsp::CompletionItem {
                             label: snippet.prefix.first().unwrap().clone(),
                             kind: Some(CompletionItemKind::SNIPPET),


### PR DESCRIPTION
This reverts commit 1f8b14f4f11e0aab9cd6754690b8315af3ab4757.

Release Notes:

- N/A 
