### PR TITLE
scripting tool: Use project buffers in `io.open` 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11918,6 +11918,7 @@ dependencies = [
  "collections",
  "futures 0.3.31",
  "gpui",
+ "language",
  "log",
  "mlua",
  "parking_lot",

--- a/crates/scripting_tool/Cargo.toml
+++ b/crates/scripting_tool/Cargo.toml
@@ -17,6 +17,7 @@ anyhow.workspace = true
 collections.workspace = true
 futures.workspace = true
 gpui.workspace = true
+language.workspace = true
 log.workspace = true
 mlua.workspace = true
 parking_lot.workspace = true
@@ -31,6 +32,7 @@ util.workspace = true
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
+language = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 rand.workspace = true
 settings = { workspace = true, features = ["test-support"] }

--- a/crates/scripting_tool/src/sandbox_preamble.lua
+++ b/crates/scripting_tool/src/sandbox_preamble.lua
@@ -8,9 +8,9 @@ local sandbox = {}
 -- to our in-memory log rather than to stdout, we will delete this loop (and re-enable
 -- the I/O module being sandboxed below) to have things be sandboxed again.
 for k, v in pairs(_G) do
-  if sandbox[k] == nil then
-    sandbox[k] = v
-  end
+    if sandbox[k] == nil then
+        sandbox[k] = v
+    end
 end
 
 -- Allow access to standard libraries (safe subset)
@@ -29,24 +29,27 @@ sandbox.search = search
 sandbox.outline = outline
 
 -- Create a sandboxed version of LuaFileIO
-local io = {}
+-- local io = {};
+--
+-- For now we are using unsandboxed io
+local io = _G.io;
 
 -- File functions
 io.open = sb_io_open
 
 -- Add the sandboxed io library to the sandbox environment
--- sandbox.io = io -- Uncomment this line to re-enable sandboxed file I/O.
+sandbox.io = io
 
 -- Load the script with the sandbox environment
 local user_script_fn, err = load(user_script, nil, "t", sandbox)
 
 if not user_script_fn then
-  error("Failed to load user script: " .. tostring(err))
+    error("Failed to load user script: " .. tostring(err))
 end
 
 -- Execute the user script within the sandbox
 local success, result = pcall(user_script_fn)
 
 if not success then
-  error("Error executing user script: " .. tostring(result))
+    error("Error executing user script: " .. tostring(result))
 end

--- a/crates/scripting_tool/src/scripting_tool.rs
+++ b/crates/scripting_tool/src/scripting_tool.rs
@@ -36,7 +36,7 @@ impl ScriptingTool {
         };
 
         // TODO: Store a session per thread
-        let session = cx.new(|cx| ScriptSession::new(project, cx));
+        let session = cx.new(|cx| ScriptingSession::new(project, cx));
         let lua_script = input.lua_script;
 
         let (script_id, script_task) =

--- a/crates/scripting_tool/src/session.rs
+++ b/crates/scripting_tool/src/session.rs
@@ -343,8 +343,10 @@ impl ScriptingSession {
             // When closing a writable file, record the content
             let content = file_userdata.get::<mlua::AnyUserData>("__content")?;
             let content_ref = content.borrow::<FileContent>()?;
-            let content_vec = content_ref.0.lock();
-            let text = String::from_utf8(content_vec.to_vec()).into_lua_err()?;
+            let text = {
+                let content_vec = content_ref.0.lock().to_vec();
+                String::from_utf8(content_vec).into_lua_err()?
+            };
 
             Self::write_to_buffer(project_path, text, foreground_tx)
                 .await

--- a/crates/scripting_tool/src/session.rs
+++ b/crates/scripting_tool/src/session.rs
@@ -344,7 +344,8 @@ impl ScriptingSession {
             let content = file_userdata.get::<mlua::AnyUserData>("__content")?;
             let content_ref = content.borrow::<FileContent>()?;
             let text = {
-                let content_vec = content_ref.0.lock().to_vec();
+                let mut content_vec = content_ref.0.lock();
+                let content_vec = std::mem::take(&mut *content_vec);
                 String::from_utf8(content_vec).into_lua_err()?
             };
 

--- a/crates/scripting_tool/src/session.rs
+++ b/crates/scripting_tool/src/session.rs
@@ -15,19 +15,19 @@ use std::{
 };
 use util::{paths::PathMatcher, ResultExt};
 
-struct ForegroundFn(Box<dyn FnOnce(WeakEntity<ScriptSession>, AsyncApp) + Send>);
+struct ForegroundFn(Box<dyn FnOnce(WeakEntity<ScriptingSession>, AsyncApp) + Send>);
 
-pub struct ScriptSession {
+pub struct ScriptingSession {
     project: Entity<Project>,
     foreground_fns_tx: mpsc::Sender<ForegroundFn>,
     _invoke_foreground_fns: Task<()>,
     scripts: Vec<Script>,
 }
 
-impl ScriptSession {
+impl ScriptingSession {
     pub fn new(project: Entity<Project>, cx: &mut Context<Self>) -> Self {
         let (foreground_fns_tx, mut foreground_fns_rx) = mpsc::channel(128);
-        ScriptSession {
+        ScriptingSession {
             project,
             foreground_fns_tx,
             _invoke_foreground_fns: cx.spawn(|this, cx| async move {
@@ -1041,7 +1041,7 @@ mod tests {
         .await;
 
         let project = Project::test(fs, [Path::new("/")], cx).await;
-        let session = cx.new(|cx| ScriptSession::new(project, cx));
+        let session = cx.new(|cx| ScriptingSession::new(project, cx));
 
         let (script_id, task) =
             session.update(cx, |session, cx| session.run_script(source.to_string(), cx));

--- a/crates/scripting_tool/src/session.rs
+++ b/crates/scripting_tool/src/session.rs
@@ -953,6 +953,32 @@ mod tests {
     }
 
     #[gpui::test]
+    async fn test_multiple_writes(cx: &mut TestAppContext) {
+        let script = r#"
+                -- Test writing to a file multiple times
+                local file = io.open("multiwrite.txt", "w")
+                file:write("First line\n")
+                file:write("Second line\n")
+                file:write("Third line")
+                file:close()
+
+                -- Read back to verify
+                local read_file = io.open("multiwrite.txt", "r")
+                if read_file then
+                    local content = read_file:read("*a")
+                    print("Full content:", content)
+                    read_file:close()
+                end
+            "#;
+
+        let output = test_script(script, cx).await.unwrap();
+        assert_eq!(
+            output,
+            "Full content:\tFirst line\nSecond line\nThird line\n"
+        );
+    }
+
+    #[gpui::test]
     async fn test_read_formats(cx: &mut TestAppContext) {
         let script = r#"
             local file = io.open("multiline.txt", "w")


### PR DESCRIPTION
This PR makes `io.open` use our own implementation again, but instead of the real filesystem, it will now use the project's to check file metadata and perform read and writes using project buffers.

This also cleans up the `io.open` implementation by splitting it into multiple methods, adds tests for various File I/O patterns, and fixes a few bugs in read formats. 

Release Notes:

- N/A