### PR TITLE
Fix enter binding in git panel's commit editor on Linux

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -787,6 +787,7 @@
       "escape": "git_panel::FocusChanges",
       "tab": "git_panel::FocusChanges",
       "shift-tab": "git_panel::FocusChanges",
+      "enter": "editor::Newline",
       "ctrl-enter": "git::Commit",
       "alt-up": "git_panel::FocusChanges",
       "alt-l": "git::GenerateCommitMessage"


### PR DESCRIPTION
Closes #26110 

Release Notes:

- Git Beta: fixed being unable to enter newline in the git panel's commit editor on Linux