### PR TITLE
git: Use font size to determine pattern slash width

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6779,7 +6779,7 @@ impl Element for EditorElement {
 
                         let unstaged = diff_status.has_secondary_hunk();
                         let hunk_opacity = if is_light { 0.16 } else { 0.12 };
-                        let slash_width = line_height.0 / 1.5; // ~16 by default
+                        let slash_width = font_size.0 / 1.5; // 10 by default
 
                         let staged_highlight: LineHighlight = match hunk_style {
                             GitHunkStyleSetting::Transparent


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/26038#issuecomment-2699024540

The slash and text display should have a fixed proportional relationship and should not change because of line height, which is now 2 character across 3 slashes

use line_height

![image](https://github.com/user-attachments/assets/5523e8cb-9e98-479f-8b64-93bedfc0b664)

use font_size

![image](https://github.com/user-attachments/assets/2d18585c-e816-4e94-b359-f2d5011f73cb)


Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
