### PR TITLE
macOS: Remove multi-keystroke rendering in title of menu item

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -347,20 +347,7 @@ impl MacPlatform {
                                 msg_send![item, setAllowsAutomaticKeyEquivalentLocalization: NO];
                         }
                         item.setKeyEquivalentModifierMask_(mask);
-                    }
-                    // For multi-keystroke bindings, render the keystroke as part of the title.
-                    else {
-                        use std::fmt::Write;
-
-                        let mut name = format!("{name} [");
-                        for (i, keystroke) in keystrokes.iter().enumerate() {
-                            if i > 0 {
-                                name.push(' ');
-                            }
-                            write!(&mut name, "{}", keystroke).unwrap();
-                        }
-                        name.push(']');
-
+                    } else {
                         item = NSMenuItem::alloc(nil)
                             .initWithTitle_action_keyEquivalent_(
                                 ns_string(&name),


### PR DESCRIPTION
Closes #25483

Currently, macOS doesn't support showing multi-keystroke shortcuts in menu items. We can use an attributed string to differentiate them, but that breaks consistency with traditional shortcuts.  

This PR removes the hack of concatenating the multi-keystroke shortcut to the title, as it looked a bit janky.

Release Notes:

- N/A
