### PR TITLE
Remove flake-compat

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,17 @@
-(import (
-  let
-    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  in
-  fetchTarball {
-    url =
-      lock.nodes.flake-compat.locked.url
-        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-    sha256 = lock.nodes.flake-compat.locked.narHash;
-  }
-) { src = ./.; }).defaultNix
+{ 
+  system ? builtins.currentSystem,
+  lock ? builtins.fromJSON (builtins.readFile ./flake.lock),
+  rust-overlay ? import (builtins.fetchTarball {
+    url = "github:oxalica/rust-overlay/${lock.nodes.rust-overlay.locked.rev}";
+    sha256 = lock.nodes.rust-overlay.locked.narHash;
+  }),
+  pkgs ? import <nixpkgs> { inherit system; overlays = [ rust-overlay ]; }, 
+  crane ? import (builtins.fetchTarball {
+    url = "github:ipetkov/crane/${lock.nodes.crane.locked.rev}";
+    sha256 = lock.nodes.crane.locked.narHash;
+  }) { inherit pkgs; }
+}:
+pkgs.callPackage ./nix/build.nix {
+  inherit crane;
+  rustToolchain = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
+}

--- a/default.nix
+++ b/default.nix
@@ -1,15 +1,24 @@
-{ 
+{
   system ? builtins.currentSystem,
   lock ? builtins.fromJSON (builtins.readFile ./flake.lock),
-  rust-overlay ? import (builtins.fetchTarball {
-    url = "github:oxalica/rust-overlay/${lock.nodes.rust-overlay.locked.rev}";
-    sha256 = lock.nodes.rust-overlay.locked.narHash;
-  }),
-  pkgs ? import <nixpkgs> { inherit system; overlays = [ rust-overlay ]; }, 
+  rust-overlay ? import (
+    builtins.fetchTarball {
+      url = "github:oxalica/rust-overlay/${lock.nodes.rust-overlay.locked.rev}";
+      sha256 = lock.nodes.rust-overlay.locked.narHash;
+    }
+  ),
+  nixpkgs ? builtins.fetchTarball {
+    url = "github:NixOS/nixpkgs/${lock.nodes.nixpkgs.locked.rev}";
+    sha256 = lock.nodes.nixpkgs.locked.narHash;
+  },
+  pkgs ? import nixpkgs {
+    inherit system;
+    overlays = [ rust-overlay ];
+  },
   crane ? import (builtins.fetchTarball {
     url = "github:ipetkov/crane/${lock.nodes.crane.locked.rev}";
     sha256 = lock.nodes.crane.locked.narHash;
-  }) { inherit pkgs; }
+  }) { inherit pkgs; },
 }:
 pkgs.callPackage ./nix/build.nix {
   inherit crane;

--- a/flake.lock
+++ b/flake.lock
@@ -15,21 +15,6 @@
         "type": "github"
       }
     },
-    "flake-compat": {
-      "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1741379970,
@@ -49,7 +34,6 @@
     "root": {
       "inputs": {
         "crane": "crane",
-        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "rust-overlay": "rust-overlay"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
       inputs.nixpkgs.follows = "nixpkgs";
     };
     crane.url = "github:ipetkov/crane";
-    flake-compat.url = "github:edolstra/flake-compat";
   };
 
   outputs =

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,11 @@
       sha256 = lock.nodes.rust-overlay.locked.narHash;
     }
   ),
-  pkgs ? import <nixpkgs> {
+  nixpkgs ? builtins.fetchTarball {
+    url = "github:NixOS/nixpkgs/${lock.nodes.nixpkgs.locked.rev}";
+    sha256 = lock.nodes.nixpkgs.locked.narHash;
+  },
+  pkgs ? import nixpkgs {
     inherit system;
     overlays = [ rust-overlay ];
   },

--- a/shell.nix
+++ b/shell.nix
@@ -1,11 +1,24 @@
-(import (
-  let
-    lock = builtins.fromJSON (builtins.readFile ./flake.lock);
-  in
-  fetchTarball {
-    url =
-      lock.nodes.flake-compat.locked.url
-        or "https://github.com/edolstra/flake-compat/archive/${lock.nodes.flake-compat.locked.rev}.tar.gz";
-    sha256 = lock.nodes.flake-compat.locked.narHash;
-  }
-) { src = ./.; }).shellNix
+{
+  system ? builtins.currentSystem,
+  lock ? builtins.fromJSON (builtins.readFile ./flake.lock),
+  rust-overlay ? import (
+    builtins.fetchTarball {
+      url = "github:oxalica/rust-overlay/${lock.nodes.rust-overlay.locked.rev}";
+      sha256 = lock.nodes.rust-overlay.locked.narHash;
+    }
+  ),
+  pkgs ? import <nixpkgs> {
+    inherit system;
+    overlays = [ rust-overlay ];
+  },
+  crane ? import (builtins.fetchTarball {
+    url = "github:ipetkov/crane/${lock.nodes.crane.locked.rev}";
+    sha256 = lock.nodes.crane.locked.narHash;
+  }) { inherit pkgs; },
+}:
+let
+  zed-editor = import ./default.nix { inherit pkgs crane; };
+in
+pkgs.callPackage ./nix/shell.nix {
+  inherit zed-editor;
+}


### PR DESCRIPTION
This allows non-flake users to pass their own instances of rust-overlay/pkgs/crane and avoid duplication

Release Notes:

- N/A

cc @P1n3appl3 