### PR TITLE
assistant_tool: Add a `source` to the `Tool` trait

### DIFF
--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -4,7 +4,7 @@ mod tool_working_set;
 use std::sync::Arc;
 
 use anyhow::Result;
-use gpui::{App, Entity, Task};
+use gpui::{App, Entity, SharedString, Task};
 use project::Project;
 
 pub use crate::tool_registry::*;
@@ -14,6 +14,14 @@ pub fn init(cx: &mut App) {
     ToolRegistry::default_global(cx);
 }
 
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum ToolSource {
+    /// A native tool built-in to Zed.
+    Native,
+    /// A tool provided by a context server.
+    ContextServer { id: SharedString },
+}
+
 /// A tool that can be used by a language model.
 pub trait Tool: 'static + Send + Sync {
     /// Returns the name of the tool.
@@ -21,6 +29,11 @@ pub trait Tool: 'static + Send + Sync {
 
     /// Returns the description of the tool.
     fn description(&self) -> String;
+
+    /// Returns the source of the tool.
+    fn source(&self) -> ToolSource {
+        ToolSource::Native
+    }
 
     /// Returns the JSON schema that describes the tool's input.
     fn input_schema(&self) -> serde_json::Value {

--- a/crates/context_server/src/context_server_tool.rs
+++ b/crates/context_server/src/context_server_tool.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::{anyhow, bail, Result};
-use assistant_tool::Tool;
+use assistant_tool::{Tool, ToolSource};
 use gpui::{App, Entity, Task};
 use project::Project;
 
@@ -35,6 +35,12 @@ impl Tool for ContextServerTool {
 
     fn description(&self) -> String {
         self.tool.description.clone().unwrap_or_default()
+    }
+
+    fn source(&self) -> ToolSource {
+        ToolSource::ContextServer {
+            id: self.server_id.clone().into(),
+        }
     }
 
     fn input_schema(&self) -> serde_json::Value {


### PR DESCRIPTION
This PR adds a `source` method to the `Tool` trait.

This will allow us to track where a tool is coming from.

Release Notes:

- N/A
