### PR TITLE
assistant_tool: Fix inaccurate parameter name

### DIFF
--- a/crates/assistant_tool/src/tool_working_set.rs
+++ b/crates/assistant_tool/src/tool_working_set.rs
@@ -45,15 +45,15 @@ impl ToolWorkingSet {
         tools
     }
 
-    pub fn insert(&self, command: Arc<dyn Tool>) -> ToolId {
+    pub fn insert(&self, tool: Arc<dyn Tool>) -> ToolId {
         let mut state = self.state.lock();
-        let command_id = state.next_tool_id;
+        let tool_id = state.next_tool_id;
         state.next_tool_id.0 += 1;
         state
             .context_server_tools_by_id
-            .insert(command_id, command.clone());
+            .insert(tool_id, tool.clone());
         state.tools_changed();
-        command_id
+        tool_id
     }
 
     pub fn remove(&self, command_ids_to_remove: &[ToolId]) {


### PR DESCRIPTION
This PR fixes an inaccurate parameter name in the `ToolWorkingSet::insert` method.

Release Notes:

- N/A
