### PR TITLE
settings: Enable JSX tag auto-close by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1300,8 +1300,7 @@
   },
   // Settings for auto-closing of JSX tags.
   "jsx_tag_auto_close": {
-    // // Whether to auto-close JSX tags.
-    // "enabled": true
+    "enabled": true
   },
   // LSP Specific settings.
   "lsp": {


### PR DESCRIPTION
Based on conversation with @maxbrunsfeld. Enabling Tag auto closing by default so that it is discoverable for new and existing users

Release Notes:

- Made it so JSX tag auto-closing is automatically enabled in supported languages
