### PR TITLE
assistant2: Remove "Tools" switch

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -447,7 +447,7 @@ impl ActiveThread {
         };
 
         self.thread.update(cx, |thread, cx| {
-            thread.send_to_model(model, RequestKind::Chat, false, cx)
+            thread.send_to_model(model, RequestKind::Chat, cx)
         });
         cx.notify();
     }

--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -17,7 +17,7 @@ use text::Bias;
 use theme::ThemeSettings;
 use ui::{
     prelude::*, ButtonLike, Disclosure, KeyBinding, PlatformStyle, PopoverMenu, PopoverMenuHandle,
-    Switch, Tooltip,
+    Tooltip,
 };
 use vim_mode_setting::VimModeSetting;
 use workspace::Workspace;
@@ -41,7 +41,6 @@ pub struct MessageEditor {
     inline_context_picker_menu_handle: PopoverMenuHandle<ContextPicker>,
     model_selector: Entity<AssistantModelSelector>,
     tool_selector: Entity<ToolSelector>,
-    use_tools: bool,
     edits_expanded: bool,
     _subscriptions: Vec<Subscription>,
 }
@@ -122,14 +121,12 @@ impl MessageEditor {
                 )
             }),
             tool_selector: cx.new(|cx| ToolSelector::new(tools, cx)),
-            use_tools: false,
             edits_expanded: false,
             _subscriptions: subscriptions,
         }
     }
 
     fn toggle_chat_mode(&mut self, _: &ChatMode, _window: &mut Window, cx: &mut Context<Self>) {
-        self.use_tools = !self.use_tools;
         cx.notify();
     }
 
@@ -196,14 +193,13 @@ impl MessageEditor {
 
         let thread = self.thread.clone();
         let context_store = self.context_store.clone();
-        let use_tools = self.use_tools;
         cx.spawn(move |_, mut cx| async move {
             refresh_task.await;
             thread
                 .update(&mut cx, |thread, cx| {
                     let context = context_store.read(cx).snapshot(cx).collect::<Vec<_>>();
                     thread.insert_user_message(user_message, context, cx);
-                    thread.send_to_model(model, request_kind, use_tools, cx);
+                    thread.send_to_model(model, request_kind, cx);
                 })
                 .ok();
         })
@@ -541,27 +537,7 @@ impl Render for MessageEditor {
                             .child(
                                 h_flex()
                                     .justify_between()
-                                    .child(
-                                        h_flex().gap_2().child(self.tool_selector.clone()).child(
-                                            Switch::new("use-tools", self.use_tools.into())
-                                                .label("Tools")
-                                                .on_click(cx.listener(
-                                                    |this, selection, _window, _cx| {
-                                                        this.use_tools = match selection {
-                                                            ToggleState::Selected => true,
-                                                            ToggleState::Unselected
-                                                            | ToggleState::Indeterminate => false,
-                                                        };
-                                                    },
-                                                ))
-                                                .key_binding(KeyBinding::for_action_in(
-                                                    &ChatMode,
-                                                    &focus_handle,
-                                                    window,
-                                                    cx,
-                                                )),
-                                        ),
-                                    )
+                                    .child(h_flex().gap_2().child(self.tool_selector.clone()))
                                     .child(
                                         h_flex().gap_1().child(self.model_selector.clone()).child(
                                             ButtonLike::new("submit-message")

--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -342,12 +342,10 @@ impl Thread {
         &mut self,
         model: Arc<dyn LanguageModel>,
         request_kind: RequestKind,
-        use_tools: bool,
         cx: &mut Context<Self>,
     ) {
         let mut request = self.to_completion_request(request_kind, cx);
-
-        if use_tools {
+        request.tools = {
             let mut tools = Vec::new();
 
             if self.tools.is_scripting_tool_enabled() {
@@ -366,8 +364,8 @@ impl Thread {
                 }
             }));
 
-            request.tools = tools;
-        }
+            tools
+        };
 
         self.stream_completion(request, model, cx);
     }
@@ -753,7 +751,7 @@ impl Thread {
             Vec::new(),
             cx,
         );
-        self.send_to_model(model, RequestKind::Chat, true, cx);
+        self.send_to_model(model, RequestKind::Chat, cx);
     }
 
     /// Cancels the last pending completion, if there are any pending.


### PR DESCRIPTION
This PR removes the "Tools" switch from Assistant 2, as we can manage tools from the tool selector now.

Release Notes:

- N/A
