### PR TITLE
Don't clobber the user's upstream settings

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1705,10 +1705,18 @@ impl GitPanel {
         };
         telemetry::event!("Git Pushed");
         let branch = branch.clone();
+
         let options = if force_push {
-            PushOptions::Force
+            Some(PushOptions::Force)
         } else {
-            PushOptions::SetUpstream
+            match branch.upstream {
+                Some(Upstream {
+                    tracking: UpstreamTracking::Gone,
+                    ..
+                })
+                | None => Some(PushOptions::SetUpstream),
+                _ => None,
+            }
         };
         let remote = self.get_current_remote(window, cx);
 
@@ -1738,7 +1746,7 @@ impl GitPanel {
                 repo.push(
                     branch.name.clone(),
                     remote.name.clone(),
-                    Some(options),
+                    options,
                     askpass_delegate,
                     cx,
                 )


### PR DESCRIPTION
It's not clobbering time :(

Release Notes:

- Git Beta: Fixed a bug where our push button would always overwrite the current branch's upstream
