### PR TITLE
extension_host: Remove restriction of extension API v0.3.0 to development builds

### DIFF
--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -108,8 +108,6 @@ impl Extension {
         let _ = release_channel;
 
         if version >= latest::MIN_VERSION {
-            authorize_access_to_unreleased_wasm_api_version(release_channel)?;
-
             let extension =
                 latest::Extension::instantiate_async(store, component, latest::linker())
                     .await


### PR DESCRIPTION
Forgot to do this in #26495.

Release Notes:

- N/A
