### PR TITLE
git: Prevent up and down motions leaking out of the commit editor

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2596,6 +2596,12 @@ impl GitPanel {
                     .child(
                         div()
                             .pr_2p5()
+                            .on_action(|&editor::actions::MoveUp, _, cx| {
+                                cx.stop_propagation();
+                            })
+                            .on_action(|&editor::actions::MoveDown, _, cx| {
+                                cx.stop_propagation();
+                            })
                             .child(EditorElement::new(&self.commit_editor, panel_editor_style)),
                     )
                     .child(


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Git Beta: fixed an issue where pressing `up` or `down` in the git panel's commit message editor would change the selected status entry