### PR TITLE
git: Add `shift-escape` in gitcommit 

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -818,6 +818,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "editor::Newline",
+      "shift-escape": "menu::Cancel",
       "escape": "menu::Cancel",
       "cmd-enter": "git::Commit",
       "alt-tab": "git::GenerateCommitMessage"


### PR DESCRIPTION
Closes #ISSUE

You can zoom in using `shift-escape`, I think by feel you should be `shift-escape` to zoom out

Release Notes:

- N/A