### PR TITLE
Check if additional git provider is not the original git provider

### DIFF
--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -35,9 +35,9 @@ pub fn register_additional_providers(
         return;
     };
 
-    if let Ok(gitlab_self_hosted) = Gitlab::from_remote_url(&origin_url) {
+    if let Ok(gitlab_self_hosted) = Gitlab::from_self_hosted_remote_url(&origin_url) {
         provider_registry.register_hosting_provider(Arc::new(gitlab_self_hosted));
-    } else if let Ok(github_self_hosted) = Github::from_remote_url(&origin_url) {
+    } else if let Ok(github_self_hosted) = Github::from_self_hosted_remote_url(&origin_url) {
         provider_registry.register_hosting_provider(Arc::new(github_self_hosted));
     }
 }

--- a/crates/git_hosting_providers/src/git_hosting_providers.rs
+++ b/crates/git_hosting_providers/src/git_hosting_providers.rs
@@ -35,9 +35,9 @@ pub fn register_additional_providers(
         return;
     };
 
-    if let Ok(gitlab_self_hosted) = Gitlab::from_self_hosted_remote_url(&origin_url) {
+    if let Ok(gitlab_self_hosted) = Gitlab::from_remote_url(&origin_url) {
         provider_registry.register_hosting_provider(Arc::new(gitlab_self_hosted));
-    } else if let Ok(github_self_hosted) = Github::from_self_hosted_remote_url(&origin_url) {
+    } else if let Ok(github_self_hosted) = Github::from_remote_url(&origin_url) {
         provider_registry.register_hosting_provider(Arc::new(github_self_hosted));
     }
 }

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -58,11 +58,10 @@ impl Github {
         }
     }
 
-    pub fn from_self_hosted_remote_url(remote_url: &str) -> Result<Self> {
+    pub fn from_remote_url(remote_url: &str) -> Result<Self> {
         let host = get_host_from_git_remote_url(remote_url)?;
-
         if host == "github.com" {
-            bail!("the GitHub instance is not self-hosted")
+            bail!("the GitHub instance is not self-hosted");
         }
 
         // TODO: detecting self hosted instances by checking whether "github" is in the url or not
@@ -243,14 +242,14 @@ mod tests {
     #[test]
     fn test_invalid_self_hosted_remote_url() {
         let remote_url = "git@github.com:zed-industries/zed.git";
-        let github = Github::from_self_hosted_remote_url(remote_url);
+        let github = Github::from_remote_url(remote_url);
         assert!(github.is_err());
     }
 
     #[test]
-    fn test_from_self_hosted_remote_url_ssh() {
+    fn test_from_remote_url_ssh() {
         let remote_url = "git@github.my-enterprise.com:zed-industries/zed.git";
-        let github = Github::from_self_hosted_remote_url(remote_url).unwrap();
+        let github = Github::from_remote_url(remote_url).unwrap();
 
         assert!(!github.supports_avatars());
         assert_eq!(github.name, "GitHub Self-Hosted".to_string());
@@ -261,9 +260,9 @@ mod tests {
     }
 
     #[test]
-    fn test_from_self_hosted_remote_url_https() {
+    fn test_from_remote_url_https() {
         let remote_url = "https://github.my-enterprise.com/zed-industries/zed.git";
-        let github = Github::from_self_hosted_remote_url(remote_url).unwrap();
+        let github = Github::from_remote_url(remote_url).unwrap();
 
         assert!(!github.supports_avatars());
         assert_eq!(github.name, "GitHub Self-Hosted".to_string());
@@ -276,7 +275,7 @@ mod tests {
     #[test]
     fn test_parse_remote_url_given_self_hosted_ssh_url() {
         let remote_url = "git@github.my-enterprise.com:zed-industries/zed.git";
-        let parsed_remote = Github::from_self_hosted_remote_url(remote_url)
+        let parsed_remote = Github::from_remote_url(remote_url)
             .unwrap()
             .parse_remote_url(remote_url)
             .unwrap();
@@ -293,7 +292,7 @@ mod tests {
     #[test]
     fn test_parse_remote_url_given_self_hosted_https_url_with_subgroup() {
         let remote_url = "https://github.my-enterprise.com/zed-industries/zed.git";
-        let parsed_remote = Github::from_self_hosted_remote_url(remote_url)
+        let parsed_remote = Github::from_remote_url(remote_url)
             .unwrap()
             .parse_remote_url(remote_url)
             .unwrap();

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -58,8 +58,12 @@ impl Github {
         }
     }
 
-    pub fn from_remote_url(remote_url: &str) -> Result<Self> {
+    pub fn from_self_hosted_remote_url(remote_url: &str) -> Result<Self> {
         let host = get_host_from_git_remote_url(remote_url)?;
+
+        if host == "github.com" {
+            bail!("the GitHub instance is not self-hosted")
+        }
 
         // TODO: detecting self hosted instances by checking whether "github" is in the url or not
         // is not very reliable. See https://github.com/zed-industries/zed/issues/26393 for more
@@ -237,9 +241,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_from_remote_url_ssh() {
+    fn test_invalid_self_hosted_remote_url() {
+        let remote_url = "git@github.com:zed-industries/zed.git";
+        let github = Github::from_self_hosted_remote_url(remote_url);
+        assert!(github.is_err());
+    }
+
+    #[test]
+    fn test_from_self_hosted_remote_url_ssh() {
         let remote_url = "git@github.my-enterprise.com:zed-industries/zed.git";
-        let github = Github::from_remote_url(remote_url).unwrap();
+        let github = Github::from_self_hosted_remote_url(remote_url).unwrap();
 
         assert!(!github.supports_avatars());
         assert_eq!(github.name, "GitHub Self-Hosted".to_string());
@@ -250,9 +261,9 @@ mod tests {
     }
 
     #[test]
-    fn test_from_remote_url_https() {
+    fn test_from_self_hosted_remote_url_https() {
         let remote_url = "https://github.my-enterprise.com/zed-industries/zed.git";
-        let github = Github::from_remote_url(remote_url).unwrap();
+        let github = Github::from_self_hosted_remote_url(remote_url).unwrap();
 
         assert!(!github.supports_avatars());
         assert_eq!(github.name, "GitHub Self-Hosted".to_string());
@@ -265,7 +276,7 @@ mod tests {
     #[test]
     fn test_parse_remote_url_given_self_hosted_ssh_url() {
         let remote_url = "git@github.my-enterprise.com:zed-industries/zed.git";
-        let parsed_remote = Github::from_remote_url(remote_url)
+        let parsed_remote = Github::from_self_hosted_remote_url(remote_url)
             .unwrap()
             .parse_remote_url(remote_url)
             .unwrap();
@@ -282,7 +293,7 @@ mod tests {
     #[test]
     fn test_parse_remote_url_given_self_hosted_https_url_with_subgroup() {
         let remote_url = "https://github.my-enterprise.com/zed-industries/zed.git";
-        let parsed_remote = Github::from_remote_url(remote_url)
+        let parsed_remote = Github::from_self_hosted_remote_url(remote_url)
             .unwrap()
             .parse_remote_url(remote_url)
             .unwrap();

--- a/crates/git_hosting_providers/src/providers/gitlab.rs
+++ b/crates/git_hosting_providers/src/providers/gitlab.rs
@@ -24,9 +24,8 @@ impl Gitlab {
         }
     }
 
-    pub fn from_self_hosted_remote_url(remote_url: &str) -> Result<Self> {
+    pub fn from_remote_url(remote_url: &str) -> Result<Self> {
         let host = get_host_from_git_remote_url(remote_url)?;
-
         if host == "gitlab.com" {
             bail!("the GitLab instance is not self-hosted");
         }
@@ -130,7 +129,7 @@ mod tests {
     #[test]
     fn test_invalid_self_hosted_remote_url() {
         let remote_url = "https://gitlab.com/zed-industries/zed.git";
-        let github = Gitlab::from_self_hosted_remote_url(remote_url);
+        let github = Gitlab::from_remote_url(remote_url);
         assert!(github.is_err());
     }
 
@@ -168,7 +167,7 @@ mod tests {
     fn test_parse_remote_url_given_self_hosted_ssh_url() {
         let remote_url = "git@gitlab.my-enterprise.com:zed-industries/zed.git";
 
-        let parsed_remote = Gitlab::from_self_hosted_remote_url(remote_url)
+        let parsed_remote = Gitlab::from_remote_url(remote_url)
             .unwrap()
             .parse_remote_url(remote_url)
             .unwrap();
@@ -185,7 +184,7 @@ mod tests {
     #[test]
     fn test_parse_remote_url_given_self_hosted_https_url_with_subgroup() {
         let remote_url = "https://gitlab.my-enterprise.com/group/subgroup/zed.git";
-        let parsed_remote = Gitlab::from_self_hosted_remote_url(remote_url)
+        let parsed_remote = Gitlab::from_remote_url(remote_url)
             .unwrap()
             .parse_remote_url(remote_url)
             .unwrap();
@@ -255,10 +254,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_self_hosted_permalink_from_ssh_url() {
-        let gitlab = Gitlab::from_self_hosted_remote_url(
-            "git@gitlab.some-enterprise.com:zed-industries/zed.git",
-        )
-        .unwrap();
+        let gitlab =
+            Gitlab::from_remote_url("git@gitlab.some-enterprise.com:zed-industries/zed.git")
+                .unwrap();
         let permalink = gitlab.build_permalink(
             ParsedGitRemote {
                 owner: "zed-industries".into(),
@@ -277,10 +275,9 @@ mod tests {
 
     #[test]
     fn test_build_gitlab_self_hosted_permalink_from_https_url() {
-        let gitlab = Gitlab::from_self_hosted_remote_url(
-            "https://gitlab-instance.big-co.com/zed-industries/zed.git",
-        )
-        .unwrap();
+        let gitlab =
+            Gitlab::from_remote_url("https://gitlab-instance.big-co.com/zed-industries/zed.git")
+                .unwrap();
         let permalink = gitlab.build_permalink(
             ParsedGitRemote {
                 owner: "zed-industries".into(),


### PR DESCRIPTION
Release Notes:

- N/A

Yesterday I worked on https://github.com/zed-industries/zed/pull/26482 and noticed afterwards that we have duplicated hosting providers if the git remote host is "gitlab.com" and after the PR also for "github.com". This is not a big problem, since the original providers are registered first and therefore we first find a match with the original providers, but I think we should address this nevertheless.

We initialize every hosting provider with the defaults here:
https://github.com/zed-industries/zed/blob/b008b2863ee015a9dc6ecdcd6dedbc708983f8b3/crates/git_hosting_providers/src/git_hosting_providers.rs#L15-L24

After that, we also register additional hosting providers:
https://github.com/zed-industries/zed/blob/b008b2863ee015a9dc6ecdcd6dedbc708983f8b3/crates/git_hosting_providers/src/git_hosting_providers.rs#L30-L43

If we do not check if the additional provider is not the original provider, we will register the same provider twice.