### PR TITLE
Disable clangd's inactiveRegions support

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -273,15 +273,16 @@ impl super::LspAdapter for CLspAdapter {
         &self,
         mut original: InitializeParams,
     ) -> Result<InitializeParams> {
-        // enable clangd's dot-to-arrow feature.
         let experimental = json!({
             "textDocument": {
                 "completion" : {
+                    // enable clangd's dot-to-arrow feature.
                     "editsNearCursor": true
                 },
-                "inactiveRegionsCapabilities": {
-                    "inactiveRegions": true,
-                }
+                // TODO: inactiveRegions support needs an implementation in clangd_ext.rs
+                // "inactiveRegionsCapabilities": {
+                //     "inactiveRegions": true,
+                // }
             }
         });
         if let Some(ref mut original_experimental) = original.capabilities.experimental {

--- a/crates/project/src/lsp_store/clangd_ext.rs
+++ b/crates/project/src/lsp_store/clangd_ext.rs
@@ -35,6 +35,10 @@ pub fn register_notifications(
     }
     let server_id = language_server.server_id();
 
+    // TODO: inactiveRegions support needs do add diagnostics, not replace them as `this.update_diagnostics` call below does
+    if true {
+        return;
+    }
     language_server
         .on_notification::<InactiveRegions, _>({
             let adapter = adapter.clone();


### PR DESCRIPTION
Disables https://github.com/zed-industries/zed/pull/26146 until a better way to add diagnostics is found.
Overall, the PR had made changes that are worth keeping instead of reverting, such as finally extracting out r-a's language server logic into an `_ext.rs` file.

Release Notes:

- N/A 
