### PR TITLE
gpui: Fix scrolling in image example

### DIFF
--- a/crates/gpui/examples/image/image.rs
+++ b/crates/gpui/examples/image/image.rs
@@ -80,7 +80,7 @@ impl Render for ImageShowcase {
             .size_full()
             .flex()
             .flex_col()
-            .justify_center()
+            .justify_start()
             .items_center()
             .gap_8()
             .bg(rgb(0xffffff))


### PR DESCRIPTION
In image example, the scrollable area is limited. When content is higher than the window, justify_center makes the top areas unscrollable.

Release Notes:

- N/A
