### PR TITLE
Git on main thread

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6770,7 +6770,7 @@ async fn test_remote_git_branches(
 
     assert_eq!(branches_b, branches_set);
 
-    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch))
+    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch.to_string()))
         .await
         .unwrap()
         .unwrap();
@@ -6790,15 +6790,23 @@ async fn test_remote_git_branches(
     assert_eq!(host_branch.name, branches[2]);
 
     // Also try creating a new branch
-    cx_b.update(|cx| repo_b.read(cx).create_branch("totally-new-branch"))
-        .await
-        .unwrap()
-        .unwrap();
+    cx_b.update(|cx| {
+        repo_b
+            .read(cx)
+            .create_branch("totally-new-branch".to_string())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
-    cx_b.update(|cx| repo_b.read(cx).change_branch("totally-new-branch"))
-        .await
-        .unwrap()
-        .unwrap();
+    cx_b.update(|cx| {
+        repo_b
+            .read(cx)
+            .change_branch("totally-new-branch".to_string())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
     executor.run_until_parked();
 

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -294,7 +294,7 @@ async fn test_ssh_collaboration_git_branches(
 
     assert_eq!(&branches_b, &branches_set);
 
-    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch))
+    cx_b.update(|cx| repo_b.read(cx).change_branch(new_branch.to_string()))
         .await
         .unwrap()
         .unwrap();
@@ -316,15 +316,23 @@ async fn test_ssh_collaboration_git_branches(
     assert_eq!(server_branch.name, branches[2]);
 
     // Also try creating a new branch
-    cx_b.update(|cx| repo_b.read(cx).create_branch("totally-new-branch"))
-        .await
-        .unwrap()
-        .unwrap();
+    cx_b.update(|cx| {
+        repo_b
+            .read(cx)
+            .create_branch("totally-new-branch".to_string())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
-    cx_b.update(|cx| repo_b.read(cx).change_branch("totally-new-branch"))
-        .await
-        .unwrap()
-        .unwrap();
+    cx_b.update(|cx| {
+        repo_b
+            .read(cx)
+            .change_branch("totally-new-branch".to_string())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
     executor.run_until_parked();
 

--- a/crates/git/src/commit.rs
+++ b/crates/git/src/commit.rs
@@ -3,20 +3,21 @@ use anyhow::{anyhow, Result};
 use collections::HashMap;
 use std::path::Path;
 
-pub fn get_messages(working_directory: &Path, shas: &[Oid]) -> Result<HashMap<Oid, String>> {
+pub async fn get_messages(working_directory: &Path, shas: &[Oid]) -> Result<HashMap<Oid, String>> {
     if shas.is_empty() {
         return Ok(HashMap::default());
     }
 
     const MARKER: &str = "<MARKER>";
 
-    let output = util::command::new_std_command("git")
+    let output = util::command::new_smol_command("git")
         .current_dir(working_directory)
         .arg("show")
         .arg("-s")
         .arg(format!("--format=%B{}", MARKER))
         .args(shas.iter().map(ToString::to_string))
         .output()
+        .await
         .map_err(|e| anyhow!("Failed to start git blame process: {}", e))?;
 
     anyhow::ensure!(

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -5,15 +5,14 @@ use anyhow::{anyhow, Context, Result};
 use askpass::{AskPassResult, AskPassSession};
 use collections::{HashMap, HashSet};
 use futures::future::BoxFuture;
-use futures::{select_biased, FutureExt as _};
+use futures::{select_biased, AsyncWriteExt, FutureExt as _};
 use git2::BranchType;
-use gpui::SharedString;
+use gpui::{AppContext, AsyncApp, SharedString};
 use parking_lot::Mutex;
 use rope::Rope;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use std::borrow::Borrow;
-use std::io::Write as _;
 use std::process::Stdio;
 use std::sync::LazyLock;
 use std::{
@@ -22,7 +21,7 @@ use std::{
     sync::Arc,
 };
 use sum_tree::MapSeekTarget;
-use util::command::{new_smol_command, new_std_command};
+use util::command::new_smol_command;
 use util::ResultExt;
 
 pub const REMOTE_CANCELLED_BY_USER: &str = "Operation cancelled by user";
@@ -157,19 +156,20 @@ pub trait GitRepository: Send + Sync {
     /// Returns the contents of an entry in the repository's index, or None if there is no entry for the given path.
     ///
     /// Also returns `None` for symlinks.
-    fn load_index_text(&self, path: &RepoPath) -> Option<String>;
+    fn load_index_text(&self, path: RepoPath, cx: AsyncApp) -> BoxFuture<Option<String>>;
 
     /// Returns the contents of an entry in the repository's HEAD, or None if HEAD does not exist or has no entry for the given path.
     ///
     /// Also returns `None` for symlinks.
-    fn load_committed_text(&self, path: &RepoPath) -> Option<String>;
+    fn load_committed_text(&self, path: RepoPath, cx: AsyncApp) -> BoxFuture<Option<String>>;
 
     fn set_index_text(
         &self,
-        path: &RepoPath,
+        path: RepoPath,
         content: Option<String>,
-        env: &HashMap<String, String>,
-    ) -> anyhow::Result<()>;
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<anyhow::Result<()>>;
 
     /// Returns the URL of the remote with the given name.
     fn remote_url(&self, name: &str) -> Option<String>;
@@ -179,15 +179,21 @@ pub trait GitRepository: Send + Sync {
 
     fn merge_head_shas(&self) -> Vec<String>;
 
-    /// Returns the list of git statuses, sorted by path
+    // Note: this method blocks the current thread!
     fn status(&self, path_prefixes: &[RepoPath]) -> Result<GitStatus>;
 
-    fn branches(&self) -> Result<Vec<Branch>>;
-    fn change_branch(&self, _: &str) -> Result<()>;
-    fn create_branch(&self, _: &str) -> Result<()>;
-    fn branch_exits(&self, _: &str) -> Result<bool>;
+    fn branches(&self) -> BoxFuture<Result<Vec<Branch>>>;
 
-    fn reset(&self, commit: &str, mode: ResetMode, env: &HashMap<String, String>) -> Result<()>;
+    fn change_branch(&self, _: String, _: AsyncApp) -> BoxFuture<Result<()>>;
+    fn create_branch(&self, _: String, _: AsyncApp) -> BoxFuture<Result<()>>;
+
+    fn reset(
+        &self,
+        commit: String,
+        mode: ResetMode,
+        env: HashMap<String, String>,
+    ) -> BoxFuture<Result<()>>;
+
     fn checkout_files(
         &self,
         commit: String,
@@ -195,9 +201,14 @@ pub trait GitRepository: Send + Sync {
         env: HashMap<String, String>,
     ) -> BoxFuture<Result<()>>;
 
-    fn show(&self, commit: &str) -> Result<CommitDetails>;
+    fn show(&self, commit: String, cx: AsyncApp) -> BoxFuture<Result<CommitDetails>>;
 
-    fn blame(&self, path: &Path, content: Rope) -> Result<crate::blame::Blame>;
+    fn blame(
+        &self,
+        path: RepoPath,
+        content: Rope,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<crate::blame::Blame>>;
 
     /// Returns the absolute path to the repository. For worktrees, this will be the path to the
     /// worktree's gitdir within the main repository (typically `.git/worktrees/<name>`).
@@ -214,18 +225,29 @@ pub trait GitRepository: Send + Sync {
     /// Updates the index to match the worktree at the given paths.
     ///
     /// If any of the paths have been deleted from the worktree, they will be removed from the index if found there.
-    fn stage_paths(&self, paths: &[RepoPath], env: &HashMap<String, String>) -> Result<()>;
+    fn stage_paths(
+        &self,
+        paths: Vec<RepoPath>,
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<()>>;
     /// Updates the index to match HEAD at the given paths.
     ///
     /// If any of the paths were previously staged but do not exist in HEAD, they will be removed from the index.
-    fn unstage_paths(&self, paths: &[RepoPath], env: &HashMap<String, String>) -> Result<()>;
+    fn unstage_paths(
+        &self,
+        paths: Vec<RepoPath>,
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<()>>;
 
     fn commit(
         &self,
-        message: &str,
-        name_and_email: Option<(&str, &str)>,
-        env: &HashMap<String, String>,
-    ) -> Result<()>;
+        message: SharedString,
+        name_and_email: Option<(SharedString, SharedString)>,
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<()>>;
 
     fn push(
         &self,
@@ -234,29 +256,36 @@ pub trait GitRepository: Send + Sync {
         options: Option<PushOptions>,
         askpass: AskPassSession,
         env: HashMap<String, String>,
+        cx: AsyncApp,
     ) -> BoxFuture<Result<RemoteCommandOutput>>;
 
     fn pull(
         &self,
-        branch_name: &str,
-        upstream_name: &str,
+        branch_name: String,
+        upstream_name: String,
         askpass: AskPassSession,
-        env: &HashMap<String, String>,
-    ) -> Result<RemoteCommandOutput>;
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<RemoteCommandOutput>>;
 
     fn fetch(
         &self,
         askpass: AskPassSession,
-        env: &HashMap<String, String>,
-    ) -> Result<RemoteCommandOutput>;
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<RemoteCommandOutput>>;
 
-    fn get_remotes(&self, branch_name: Option<&str>) -> Result<Vec<Remote>>;
+    fn get_remotes(
+        &self,
+        branch_name: Option<String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<Vec<Remote>>>;
 
     /// returns a list of remote branches that contain HEAD
-    fn check_for_pushed_commit(&self) -> Result<Vec<SharedString>>;
+    fn check_for_pushed_commit(&self, cx: AsyncApp) -> BoxFuture<Result<Vec<SharedString>>>;
 
     /// Run git diff
-    fn diff(&self, diff: DiffType) -> Result<String>;
+    fn diff(&self, diff: DiffType, cx: AsyncApp) -> BoxFuture<Result<String>>;
 }
 
 pub enum DiffType {
@@ -277,14 +306,14 @@ impl std::fmt::Debug for dyn GitRepository {
 }
 
 pub struct RealGitRepository {
-    pub repository: Mutex<git2::Repository>,
+    pub repository: Arc<Mutex<git2::Repository>>,
     pub git_binary_path: PathBuf,
 }
 
 impl RealGitRepository {
     pub fn new(repository: git2::Repository, git_binary_path: Option<PathBuf>) -> Self {
         Self {
-            repository: Mutex::new(repository),
+            repository: Arc::new(Mutex::new(repository)),
             git_binary_path: git_binary_path.unwrap_or_else(|| PathBuf::from("git")),
         }
     }
@@ -318,47 +347,60 @@ impl GitRepository for RealGitRepository {
         repo.commondir().into()
     }
 
-    fn show(&self, commit: &str) -> Result<CommitDetails> {
-        let repo = self.repository.lock();
-        let Ok(commit) = repo.revparse_single(commit)?.into_commit() else {
-            anyhow::bail!("{} is not a commit", commit);
-        };
-        let details = CommitDetails {
-            sha: commit.id().to_string().into(),
-            message: String::from_utf8_lossy(commit.message_raw_bytes())
-                .to_string()
-                .into(),
-            commit_timestamp: commit.time().seconds(),
-            committer_email: String::from_utf8_lossy(commit.committer().email_bytes())
-                .to_string()
-                .into(),
-            committer_name: String::from_utf8_lossy(commit.committer().name_bytes())
-                .to_string()
-                .into(),
-        };
-        Ok(details)
+    fn show(&self, commit: String, cx: AsyncApp) -> BoxFuture<Result<CommitDetails>> {
+        let repo = self.repository.clone();
+        cx.background_spawn(async move {
+            let repo = repo.lock();
+            let Ok(commit) = repo.revparse_single(&commit)?.into_commit() else {
+                anyhow::bail!("{} is not a commit", commit);
+            };
+            let details = CommitDetails {
+                sha: commit.id().to_string().into(),
+                message: String::from_utf8_lossy(commit.message_raw_bytes())
+                    .to_string()
+                    .into(),
+                commit_timestamp: commit.time().seconds(),
+                committer_email: String::from_utf8_lossy(commit.committer().email_bytes())
+                    .to_string()
+                    .into(),
+                committer_name: String::from_utf8_lossy(commit.committer().name_bytes())
+                    .to_string()
+                    .into(),
+            };
+            Ok(details)
+        })
+        .boxed()
     }
 
-    fn reset(&self, commit: &str, mode: ResetMode, env: &HashMap<String, String>) -> Result<()> {
-        let working_directory = self.working_directory()?;
+    fn reset(
+        &self,
+        commit: String,
+        mode: ResetMode,
+        env: HashMap<String, String>,
+    ) -> BoxFuture<Result<()>> {
+        async move {
+            let working_directory = self.working_directory();
 
-        let mode_flag = match mode {
-            ResetMode::Mixed => "--mixed",
-            ResetMode::Soft => "--soft",
-        };
+            let mode_flag = match mode {
+                ResetMode::Mixed => "--mixed",
+                ResetMode::Soft => "--soft",
+            };
 
-        let output = new_std_command(&self.git_binary_path)
-            .envs(env)
-            .current_dir(&working_directory)
-            .args(["reset", mode_flag, commit])
-            .output()?;
-        if !output.status.success() {
-            return Err(anyhow!(
-                "Failed to reset:\n{}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
+            let output = new_smol_command(&self.git_binary_path)
+                .envs(env)
+                .current_dir(&working_directory?)
+                .args(["reset", mode_flag, &commit])
+                .output()
+                .await?;
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "Failed to reset:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Ok(())
         }
-        Ok(())
+        .boxed()
     }
 
     fn checkout_files(
@@ -369,7 +411,7 @@ impl GitRepository for RealGitRepository {
     ) -> BoxFuture<Result<()>> {
         let working_directory = self.working_directory();
         let git_binary_path = self.git_binary_path.clone();
-        async {
+        async move {
             if paths.is_empty() {
                 return Ok(());
             }
@@ -392,93 +434,113 @@ impl GitRepository for RealGitRepository {
         .boxed()
     }
 
-    fn load_index_text(&self, path: &RepoPath) -> Option<String> {
-        fn logic(repo: &git2::Repository, path: &RepoPath) -> Result<Option<String>> {
-            const STAGE_NORMAL: i32 = 0;
-            let index = repo.index()?;
+    fn load_index_text(&self, path: RepoPath, cx: AsyncApp) -> BoxFuture<Option<String>> {
+        let repo = self.repository.clone();
+        cx.background_spawn(async move {
+            fn logic(repo: &git2::Repository, path: &RepoPath) -> Result<Option<String>> {
+                const STAGE_NORMAL: i32 = 0;
+                let index = repo.index()?;
 
-            // This check is required because index.get_path() unwraps internally :(
-            check_path_to_repo_path_errors(path)?;
+                // This check is required because index.get_path() unwraps internally :(
+                check_path_to_repo_path_errors(path)?;
 
-            let oid = match index.get_path(path, STAGE_NORMAL) {
-                Some(entry) if entry.mode != GIT_MODE_SYMLINK => entry.id,
-                _ => return Ok(None),
-            };
+                let oid = match index.get_path(path, STAGE_NORMAL) {
+                    Some(entry) if entry.mode != GIT_MODE_SYMLINK => entry.id,
+                    _ => return Ok(None),
+                };
 
-            let content = repo.find_blob(oid)?.content().to_owned();
-            Ok(Some(String::from_utf8(content)?))
-        }
-
-        match logic(&self.repository.lock(), path) {
-            Ok(value) => return value,
-            Err(err) => log::error!("Error loading index text: {:?}", err),
-        }
-        None
+                let content = repo.find_blob(oid)?.content().to_owned();
+                Ok(Some(String::from_utf8(content)?))
+            }
+            match logic(&repo.lock(), &path) {
+                Ok(value) => return value,
+                Err(err) => log::error!("Error loading index text: {:?}", err),
+            }
+            None
+        })
+        .boxed()
     }
 
-    fn load_committed_text(&self, path: &RepoPath) -> Option<String> {
-        let repo = self.repository.lock();
-        let head = repo.head().ok()?.peel_to_tree().log_err()?;
-        let entry = head.get_path(path).ok()?;
-        if entry.filemode() == i32::from(git2::FileMode::Link) {
-            return None;
-        }
-        let content = repo.find_blob(entry.id()).log_err()?.content().to_owned();
-        let content = String::from_utf8(content).log_err()?;
-        Some(content)
+    fn load_committed_text(&self, path: RepoPath, cx: AsyncApp) -> BoxFuture<Option<String>> {
+        let repo = self.repository.clone();
+        cx.background_spawn(async move {
+            let repo = repo.lock();
+            let head = repo.head().ok()?.peel_to_tree().log_err()?;
+            let entry = head.get_path(&path).ok()?;
+            if entry.filemode() == i32::from(git2::FileMode::Link) {
+                return None;
+            }
+            let content = repo.find_blob(entry.id()).log_err()?.content().to_owned();
+            let content = String::from_utf8(content).log_err()?;
+            Some(content)
+        })
+        .boxed()
     }
 
     fn set_index_text(
         &self,
-        path: &RepoPath,
+        path: RepoPath,
         content: Option<String>,
-        env: &HashMap<String, String>,
-    ) -> anyhow::Result<()> {
-        let working_directory = self.working_directory()?;
-        if let Some(content) = content {
-            let mut child = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .envs(env)
-                .args(["hash-object", "-w", "--stdin"])
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .spawn()?;
-            child.stdin.take().unwrap().write_all(content.as_bytes())?;
-            let output = child.wait_with_output()?.stdout;
-            let sha = String::from_utf8(output)?;
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<anyhow::Result<()>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        cx.background_spawn(async move {
+            let working_directory = working_directory?;
+            if let Some(content) = content {
+                let mut child = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .envs(&env)
+                    .args(["hash-object", "-w", "--stdin"])
+                    .stdin(Stdio::piped())
+                    .stdout(Stdio::piped())
+                    .spawn()?;
+                child
+                    .stdin
+                    .take()
+                    .unwrap()
+                    .write_all(content.as_bytes())
+                    .await?;
+                let output = child.output().await?.stdout;
+                let sha = String::from_utf8(output)?;
 
-            log::debug!("indexing SHA: {sha}, path {path:?}");
+                log::debug!("indexing SHA: {sha}, path {path:?}");
 
-            let output = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .envs(env)
-                .args(["update-index", "--add", "--cacheinfo", "100644", &sha])
-                .arg(path.as_ref())
-                .output()?;
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .envs(env)
+                    .args(["update-index", "--add", "--cacheinfo", "100644", &sha])
+                    .arg(path.as_ref())
+                    .output()
+                    .await?;
 
-            if !output.status.success() {
-                return Err(anyhow!(
-                    "Failed to stage:\n{}",
-                    String::from_utf8_lossy(&output.stderr)
-                ));
+                if !output.status.success() {
+                    return Err(anyhow!(
+                        "Failed to stage:\n{}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+            } else {
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .envs(env)
+                    .args(["update-index", "--force-remove"])
+                    .arg(path.as_ref())
+                    .output()
+                    .await?;
+
+                if !output.status.success() {
+                    return Err(anyhow!(
+                        "Failed to unstage:\n{}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
             }
-        } else {
-            let output = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .envs(env)
-                .args(["update-index", "--force-remove"])
-                .arg(path.as_ref())
-                .output()?;
 
-            if !output.status.success() {
-                return Err(anyhow!(
-                    "Failed to unstage:\n{}",
-                    String::from_utf8_lossy(&output.stderr)
-                ));
-            }
-        }
-
-        Ok(())
+            Ok(())
+        })
+        .boxed()
     }
 
     fn remote_url(&self, name: &str) -> Option<String> {
@@ -522,211 +584,241 @@ impl GitRepository for RealGitRepository {
         GitStatus::new(&self.git_binary_path, &working_directory, path_prefixes)
     }
 
-    fn branch_exits(&self, name: &str) -> Result<bool> {
-        let repo = self.repository.lock();
-        let branch = repo.find_branch(name, BranchType::Local);
-        match branch {
-            Ok(_) => Ok(true),
-            Err(e) => match e.code() {
-                git2::ErrorCode::NotFound => Ok(false),
-                _ => Err(anyhow!(e)),
-            },
-        }
-    }
-
-    fn branches(&self) -> Result<Vec<Branch>> {
-        let working_directory = self
-            .repository
-            .lock()
-            .workdir()
-            .context("failed to read git work directory")?
-            .to_path_buf();
-        let fields = [
-            "%(HEAD)",
-            "%(objectname)",
-            "%(parent)",
-            "%(refname)",
-            "%(upstream)",
-            "%(upstream:track)",
-            "%(committerdate:unix)",
-            "%(contents:subject)",
-        ]
-        .join("%00");
-        let args = vec!["for-each-ref", "refs/heads/**/*", "--format", &fields];
-
-        let output = new_std_command(&self.git_binary_path)
-            .current_dir(&working_directory)
-            .args(args)
-            .output()?;
-
-        if !output.status.success() {
-            return Err(anyhow!(
-                "Failed to git git branches:\n{}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
-        }
-
-        let input = String::from_utf8_lossy(&output.stdout);
-
-        let mut branches = parse_branch_input(&input)?;
-        if branches.is_empty() {
-            let args = vec!["symbolic-ref", "--quiet", "--short", "HEAD"];
-
-            let output = new_std_command(&self.git_binary_path)
+    fn branches(&self) -> BoxFuture<Result<Vec<Branch>>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        async move {
+            let fields = [
+                "%(HEAD)",
+                "%(objectname)",
+                "%(parent)",
+                "%(refname)",
+                "%(upstream)",
+                "%(upstream:track)",
+                "%(committerdate:unix)",
+                "%(contents:subject)",
+            ]
+            .join("%00");
+            let args = vec!["for-each-ref", "refs/heads/**/*", "--format", &fields];
+            let working_directory = working_directory?;
+            let output = new_smol_command(&git_binary_path)
                 .current_dir(&working_directory)
                 .args(args)
-                .output()?;
+                .output()
+                .await?;
 
-            // git symbolic-ref returns a non-0 exit code if HEAD points
-            // to something other than a branch
-            if output.status.success() {
-                let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
-
-                branches.push(Branch {
-                    name: name.into(),
-                    is_head: true,
-                    upstream: None,
-                    most_recent_commit: None,
-                });
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "Failed to git git branches:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
             }
+
+            let input = String::from_utf8_lossy(&output.stdout);
+
+            let mut branches = parse_branch_input(&input)?;
+            if branches.is_empty() {
+                let args = vec!["symbolic-ref", "--quiet", "--short", "HEAD"];
+
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .args(args)
+                    .output()
+                    .await?;
+
+                // git symbolic-ref returns a non-0 exit code if HEAD points
+                // to something other than a branch
+                if output.status.success() {
+                    let name = String::from_utf8_lossy(&output.stdout).trim().to_string();
+
+                    branches.push(Branch {
+                        name: name.into(),
+                        is_head: true,
+                        upstream: None,
+                        most_recent_commit: None,
+                    });
+                }
+            }
+
+            Ok(branches)
         }
-
-        Ok(branches)
+        .boxed()
     }
 
-    fn change_branch(&self, name: &str) -> Result<()> {
-        let repo = self.repository.lock();
-        let revision = repo.find_branch(name, BranchType::Local)?;
-        let revision = revision.get();
-        let as_tree = revision.peel_to_tree()?;
-        repo.checkout_tree(as_tree.as_object(), None)?;
-        repo.set_head(
-            revision
-                .name()
-                .ok_or_else(|| anyhow!("Branch name could not be retrieved"))?,
-        )?;
-        Ok(())
+    fn change_branch(&self, name: String, cx: AsyncApp) -> BoxFuture<Result<()>> {
+        let repo = self.repository.clone();
+        cx.background_spawn(async move {
+            let repo = repo.lock();
+            let revision = repo.find_branch(&name, BranchType::Local)?;
+            let revision = revision.get();
+            let as_tree = revision.peel_to_tree()?;
+            repo.checkout_tree(as_tree.as_object(), None)?;
+            repo.set_head(
+                revision
+                    .name()
+                    .ok_or_else(|| anyhow!("Branch name could not be retrieved"))?,
+            )?;
+            Ok(())
+        })
+        .boxed()
     }
 
-    fn create_branch(&self, name: &str) -> Result<()> {
-        let repo = self.repository.lock();
-        let current_commit = repo.head()?.peel_to_commit()?;
-        repo.branch(name, &current_commit, false)?;
-        Ok(())
+    fn create_branch(&self, name: String, cx: AsyncApp) -> BoxFuture<Result<()>> {
+        let repo = self.repository.clone();
+        cx.background_spawn(async move {
+            let repo = repo.lock();
+            let current_commit = repo.head()?.peel_to_commit()?;
+            repo.branch(&name, &current_commit, false)?;
+            Ok(())
+        })
+        .boxed()
     }
 
-    fn blame(&self, path: &Path, content: Rope) -> Result<crate::blame::Blame> {
-        let working_directory = self
-            .repository
-            .lock()
-            .workdir()
-            .with_context(|| format!("failed to get git working directory for file {:?}", path))?
-            .to_path_buf();
+    fn blame(
+        &self,
+        path: RepoPath,
+        content: Rope,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<crate::blame::Blame>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
 
         const REMOTE_NAME: &str = "origin";
         let remote_url = self.remote_url(REMOTE_NAME);
 
-        crate::blame::Blame::for_path(
-            &self.git_binary_path,
-            &working_directory,
-            path,
-            &content,
-            remote_url,
-        )
+        cx.background_spawn(async move {
+            crate::blame::Blame::for_path(
+                &git_binary_path,
+                &working_directory?,
+                &path,
+                &content,
+                remote_url,
+            )
+            .await
+        })
+        .boxed()
     }
 
-    fn diff(&self, diff: DiffType) -> Result<String> {
-        let working_directory = self.working_directory()?;
-        let args = match diff {
-            DiffType::HeadToIndex => Some("--staged"),
-            DiffType::HeadToWorktree => None,
-        };
+    fn diff(&self, diff: DiffType, cx: AsyncApp) -> BoxFuture<Result<String>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        cx.background_spawn(async move {
+            let args = match diff {
+                DiffType::HeadToIndex => Some("--staged"),
+                DiffType::HeadToWorktree => None,
+            };
 
-        let output = new_std_command(&self.git_binary_path)
-            .current_dir(&working_directory)
-            .args(["diff"])
-            .args(args)
-            .output()?;
-
-        if !output.status.success() {
-            return Err(anyhow!(
-                "Failed to run git diff:\n{}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
-        }
-        Ok(String::from_utf8_lossy(&output.stdout).to_string())
-    }
-
-    fn stage_paths(&self, paths: &[RepoPath], env: &HashMap<String, String>) -> Result<()> {
-        let working_directory = self.working_directory()?;
-
-        if !paths.is_empty() {
-            let output = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .envs(env)
-                .args(["update-index", "--add", "--remove", "--"])
-                .args(paths.iter().map(|p| p.as_ref()))
-                .output()?;
+            let output = new_smol_command(&git_binary_path)
+                .current_dir(&working_directory?)
+                .args(["diff"])
+                .args(args)
+                .output()
+                .await?;
 
             if !output.status.success() {
                 return Err(anyhow!(
-                    "Failed to stage paths:\n{}",
+                    "Failed to run git diff:\n{}",
                     String::from_utf8_lossy(&output.stderr)
                 ));
             }
-        }
-        Ok(())
+            Ok(String::from_utf8_lossy(&output.stdout).to_string())
+        })
+        .boxed()
     }
 
-    fn unstage_paths(&self, paths: &[RepoPath], env: &HashMap<String, String>) -> Result<()> {
-        let working_directory = self.working_directory()?;
+    fn stage_paths(
+        &self,
+        paths: Vec<RepoPath>,
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<()>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        cx.background_spawn(async move {
+            if !paths.is_empty() {
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory?)
+                    .envs(env)
+                    .args(["update-index", "--add", "--remove", "--"])
+                    .args(paths.iter().map(|p| p.as_ref()))
+                    .output()
+                    .await?;
 
-        if !paths.is_empty() {
-            let output = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .envs(env)
-                .args(["reset", "--quiet", "--"])
-                .args(paths.iter().map(|p| p.as_ref()))
-                .output()?;
-
-            if !output.status.success() {
-                return Err(anyhow!(
-                    "Failed to unstage:\n{}",
-                    String::from_utf8_lossy(&output.stderr)
-                ));
+                if !output.status.success() {
+                    return Err(anyhow!(
+                        "Failed to stage paths:\n{}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
             }
-        }
-        Ok(())
+            Ok(())
+        })
+        .boxed()
+    }
+
+    fn unstage_paths(
+        &self,
+        paths: Vec<RepoPath>,
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<()>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+
+        cx.background_spawn(async move {
+            if !paths.is_empty() {
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory?)
+                    .envs(env)
+                    .args(["reset", "--quiet", "--"])
+                    .args(paths.iter().map(|p| p.as_ref()))
+                    .output()
+                    .await?;
+
+                if !output.status.success() {
+                    return Err(anyhow!(
+                        "Failed to unstage:\n{}",
+                        String::from_utf8_lossy(&output.stderr)
+                    ));
+                }
+            }
+            Ok(())
+        })
+        .boxed()
     }
 
     fn commit(
         &self,
-        message: &str,
-        name_and_email: Option<(&str, &str)>,
-        env: &HashMap<String, String>,
-    ) -> Result<()> {
-        let working_directory = self.working_directory()?;
+        message: SharedString,
+        name_and_email: Option<(SharedString, SharedString)>,
+        env: HashMap<String, String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<()>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        cx.background_spawn(async move {
+            let mut cmd = new_smol_command(&git_binary_path);
+            cmd.current_dir(&working_directory?)
+                .envs(env)
+                .args(["commit", "--quiet", "-m"])
+                .arg(&message.to_string())
+                .arg("--cleanup=strip");
 
-        let mut cmd = new_std_command(&self.git_binary_path);
-        cmd.current_dir(&working_directory)
-            .envs(env)
-            .args(["commit", "--quiet", "-m"])
-            .arg(message)
-            .arg("--cleanup=strip");
+            if let Some((name, email)) = name_and_email {
+                cmd.arg("--author").arg(&format!("{name} <{email}>"));
+            }
 
-        if let Some((name, email)) = name_and_email {
-            cmd.arg("--author").arg(&format!("{name} <{email}>"));
-        }
+            let output = cmd.output().await?;
 
-        let output = cmd.output()?;
-
-        if !output.status.success() {
-            return Err(anyhow!(
-                "Failed to commit:\n{}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
-        }
-        Ok(())
+            if !output.status.success() {
+                return Err(anyhow!(
+                    "Failed to commit:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+            Ok(())
+        })
+        .boxed()
     }
 
     fn push(
@@ -736,6 +828,9 @@ impl GitRepository for RealGitRepository {
         options: Option<PushOptions>,
         ask_pass: AskPassSession,
         env: HashMap<String, String>,
+        // note: git push *must* be started on the main thread for
+        // git-credentials manager to work (hence taking an AsyncApp)
+        _cx: AsyncApp,
     ) -> BoxFuture<Result<RemoteCommandOutput>> {
         let working_directory = self.working_directory();
         async move {
@@ -770,142 +865,165 @@ impl GitRepository for RealGitRepository {
 
     fn pull(
         &self,
-        branch_name: &str,
-        remote_name: &str,
+        branch_name: String,
+        remote_name: String,
         ask_pass: AskPassSession,
-        env: &HashMap<String, String>,
-    ) -> Result<RemoteCommandOutput> {
-        todo!();
-        // let working_directory = self.working_directory()?;
+        env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<RemoteCommandOutput>> {
+        let working_directory = self.working_directory();
+        async {
+            let mut command = new_smol_command("git");
+            command
+                .envs(env)
+                .env("GIT_ASKPASS", ask_pass.script_path())
+                .env("SSH_ASKPASS", ask_pass.script_path())
+                .env("SSH_ASKPASS_REQUIRE", "force")
+                .current_dir(&working_directory?)
+                .args(["pull"])
+                .arg(remote_name)
+                .arg(branch_name)
+                .stdout(smol::process::Stdio::piped())
+                .stderr(smol::process::Stdio::piped());
+            let git_process = command.spawn()?;
 
-        // let mut command = new_smol_command("git");
-        // command
-        //     .envs(env)
-        //     .env("GIT_ASKPASS", ask_pass.script_path())
-        //     .env("SSH_ASKPASS", ask_pass.script_path())
-        //     .env("SSH_ASKPASS_REQUIRE", "force")
-        //     .current_dir(&working_directory)
-        //     .args(["pull"])
-        //     .arg(remote_name)
-        //     .arg(branch_name)
-        //     .stdout(smol::process::Stdio::piped())
-        //     .stderr(smol::process::Stdio::piped());
-        // let git_process = command.spawn()?;
-
-        // run_remote_command(ask_pass, git_process)
+            run_remote_command(ask_pass, git_process).await
+        }
+        .boxed()
     }
 
     fn fetch(
         &self,
         ask_pass: AskPassSession,
-        env: &HashMap<String, String>,
-    ) -> Result<RemoteCommandOutput> {
-        todo!();
-        // let working_directory = self.working_directory()?;
+        env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<RemoteCommandOutput>> {
+        let working_directory = self.working_directory();
+        async {
+            let mut command = new_smol_command("git");
+            command
+                .envs(env)
+                .env("GIT_ASKPASS", ask_pass.script_path())
+                .env("SSH_ASKPASS", ask_pass.script_path())
+                .env("SSH_ASKPASS_REQUIRE", "force")
+                .current_dir(&working_directory?)
+                .args(["fetch", "--all"])
+                .stdout(smol::process::Stdio::piped())
+                .stderr(smol::process::Stdio::piped());
+            let git_process = command.spawn()?;
 
-        // let mut command = new_smol_command("git");
-        // command
-        //     .envs(env)
-        //     .env("GIT_ASKPASS", ask_pass.script_path())
-        //     .env("SSH_ASKPASS", ask_pass.script_path())
-        //     .env("SSH_ASKPASS_REQUIRE", "force")
-        //     .current_dir(&working_directory)
-        //     .args(["fetch", "--all"])
-        //     .stdout(smol::process::Stdio::piped())
-        //     .stderr(smol::process::Stdio::piped());
-        // let git_process = command.spawn()?;
-
-        // run_remote_command(ask_pass, git_process)
+            run_remote_command(ask_pass, git_process).await
+        }
+        .boxed()
     }
 
-    fn get_remotes(&self, branch_name: Option<&str>) -> Result<Vec<Remote>> {
-        let working_directory = self.working_directory()?;
+    fn get_remotes(
+        &self,
+        branch_name: Option<String>,
+        cx: AsyncApp,
+    ) -> BoxFuture<Result<Vec<Remote>>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        cx.background_spawn(async move {
+            let working_directory = working_directory?;
+            if let Some(branch_name) = branch_name {
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .args(["config", "--get"])
+                    .arg(format!("branch.{}.remote", branch_name))
+                    .output()
+                    .await?;
 
-        if let Some(branch_name) = branch_name {
-            let output = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .args(["config", "--get"])
-                .arg(format!("branch.{}.remote", branch_name))
-                .output()?;
+                if output.status.success() {
+                    let remote_name = String::from_utf8_lossy(&output.stdout);
 
-            if output.status.success() {
-                let remote_name = String::from_utf8_lossy(&output.stdout);
-
-                return Ok(vec![Remote {
-                    name: remote_name.trim().to_string().into(),
-                }]);
-            }
-        }
-
-        let output = new_std_command(&self.git_binary_path)
-            .current_dir(&working_directory)
-            .args(["remote"])
-            .output()?;
-
-        if output.status.success() {
-            let remote_names = String::from_utf8_lossy(&output.stdout)
-                .split('\n')
-                .filter(|name| !name.is_empty())
-                .map(|name| Remote {
-                    name: name.trim().to_string().into(),
-                })
-                .collect();
-
-            return Ok(remote_names);
-        } else {
-            return Err(anyhow!(
-                "Failed to get remotes:\n{}",
-                String::from_utf8_lossy(&output.stderr)
-            ));
-        }
-    }
-
-    fn check_for_pushed_commit(&self) -> Result<Vec<SharedString>> {
-        let working_directory = self.working_directory()?;
-        let git_cmd = |args: &[&str]| -> Result<String> {
-            let output = new_std_command(&self.git_binary_path)
-                .current_dir(&working_directory)
-                .args(args)
-                .output()?;
-            if output.status.success() {
-                Ok(String::from_utf8(output.stdout)?)
-            } else {
-                Err(anyhow!(String::from_utf8_lossy(&output.stderr).to_string()))
-            }
-        };
-
-        let head = git_cmd(&["rev-parse", "HEAD"])
-            .context("Failed to get HEAD")?
-            .trim()
-            .to_owned();
-
-        let mut remote_branches = vec![];
-        let mut add_if_matching = |remote_head: &str| {
-            if let Ok(merge_base) = git_cmd(&["merge-base", &head, remote_head]) {
-                if merge_base.trim() == head {
-                    if let Some(s) = remote_head.strip_prefix("refs/remotes/") {
-                        remote_branches.push(s.to_owned().into());
-                    }
+                    return Ok(vec![Remote {
+                        name: remote_name.trim().to_string().into(),
+                    }]);
                 }
             }
-        };
 
-        // check the main branch of each remote
-        let remotes = git_cmd(&["remote"]).context("Failed to get remotes")?;
-        for remote in remotes.lines() {
-            if let Ok(remote_head) =
-                git_cmd(&["symbolic-ref", &format!("refs/remotes/{remote}/HEAD")])
-            {
-                add_if_matching(remote_head.trim());
+            let output = new_smol_command(&git_binary_path)
+                .current_dir(&working_directory)
+                .args(["remote"])
+                .output()
+                .await?;
+
+            if output.status.success() {
+                let remote_names = String::from_utf8_lossy(&output.stdout)
+                    .split('\n')
+                    .filter(|name| !name.is_empty())
+                    .map(|name| Remote {
+                        name: name.trim().to_string().into(),
+                    })
+                    .collect();
+
+                return Ok(remote_names);
+            } else {
+                return Err(anyhow!(
+                    "Failed to get remotes:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
             }
-        }
+        })
+        .boxed()
+    }
 
-        // ... and the remote branch that the checked-out one is tracking
-        if let Ok(remote_head) = git_cmd(&["rev-parse", "--symbolic-full-name", "@{u}"]) {
-            add_if_matching(remote_head.trim());
-        }
+    fn check_for_pushed_commit(&self, cx: AsyncApp) -> BoxFuture<Result<Vec<SharedString>>> {
+        let working_directory = self.working_directory();
+        let git_binary_path = self.git_binary_path.clone();
+        cx.background_spawn(async move {
+            let working_directory = working_directory?;
+            let git_cmd = async |args: &[&str]| -> Result<String> {
+                let output = new_smol_command(&git_binary_path)
+                    .current_dir(&working_directory)
+                    .args(args)
+                    .output()
+                    .await?;
+                if output.status.success() {
+                    Ok(String::from_utf8(output.stdout)?)
+                } else {
+                    Err(anyhow!(String::from_utf8_lossy(&output.stderr).to_string()))
+                }
+            };
 
-        Ok(remote_branches)
+            let head = git_cmd(&["rev-parse", "HEAD"])
+                .await
+                .context("Failed to get HEAD")?
+                .trim()
+                .to_owned();
+
+            let mut remote_branches = vec![];
+            let mut add_if_matching = async |remote_head: &str| {
+                if let Ok(merge_base) = git_cmd(&["merge-base", &head, remote_head]).await {
+                    if merge_base.trim() == head {
+                        if let Some(s) = remote_head.strip_prefix("refs/remotes/") {
+                            remote_branches.push(s.to_owned().into());
+                        }
+                    }
+                }
+            };
+
+            // check the main branch of each remote
+            let remotes = git_cmd(&["remote"])
+                .await
+                .context("Failed to get remotes")?;
+            for remote in remotes.lines() {
+                if let Ok(remote_head) =
+                    git_cmd(&["symbolic-ref", &format!("refs/remotes/{remote}/HEAD")]).await
+                {
+                    add_if_matching(remote_head.trim()).await;
+                }
+            }
+
+            // ... and the remote branch that the checked-out one is tracking
+            if let Ok(remote_head) = git_cmd(&["rev-parse", "--symbolic-full-name", "@{u}"]).await {
+                add_if_matching(remote_head.trim()).await;
+            }
+
+            Ok(remote_branches)
+        })
+        .boxed()
     }
 }
 
@@ -984,36 +1102,39 @@ impl FakeGitRepositoryState {
 impl GitRepository for FakeGitRepository {
     fn reload_index(&self) {}
 
-    fn load_index_text(&self, path: &RepoPath) -> Option<String> {
+    fn load_index_text(&self, path: RepoPath, _: AsyncApp) -> BoxFuture<Option<String>> {
         let state = self.state.lock();
-        state.index_contents.get(path.as_ref()).cloned()
+        let content = state.index_contents.get(path.as_ref()).cloned();
+        async { content }.boxed()
     }
 
-    fn load_committed_text(&self, path: &RepoPath) -> Option<String> {
+    fn load_committed_text(&self, path: RepoPath, _: AsyncApp) -> BoxFuture<Option<String>> {
         let state = self.state.lock();
-        state.head_contents.get(path.as_ref()).cloned()
+        let content = state.head_contents.get(path.as_ref()).cloned();
+        async { content }.boxed()
     }
 
     fn set_index_text(
         &self,
-        path: &RepoPath,
+        path: RepoPath,
         content: Option<String>,
-        _env: &HashMap<String, String>,
-    ) -> anyhow::Result<()> {
+        _env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<anyhow::Result<()>> {
         let mut state = self.state.lock();
         if let Some(message) = state.simulated_index_write_error_message.clone() {
-            return Err(anyhow::anyhow!(message));
+            return async { Err(anyhow::anyhow!(message)) }.boxed();
         }
         if let Some(content) = content {
             state.index_contents.insert(path.clone(), content);
         } else {
-            state.index_contents.remove(path);
+            state.index_contents.remove(&path);
         }
         state
             .event_emitter
             .try_send(state.path.clone())
             .expect("Dropped repo change event");
-        Ok(())
+        async { Ok(()) }.boxed()
     }
 
     fn remote_url(&self, _name: &str) -> Option<String> {
@@ -1028,11 +1149,11 @@ impl GitRepository for FakeGitRepository {
         vec![]
     }
 
-    fn show(&self, _: &str) -> Result<CommitDetails> {
+    fn show(&self, _: String, _: AsyncApp) -> BoxFuture<Result<CommitDetails>> {
         unimplemented!()
     }
 
-    fn reset(&self, _: &str, _: ResetMode, _: &HashMap<String, String>) -> Result<()> {
+    fn reset(&self, _: String, _: ResetMode, _: HashMap<String, String>) -> BoxFuture<Result<()>> {
         unimplemented!()
     }
 
@@ -1078,10 +1199,10 @@ impl GitRepository for FakeGitRepository {
         })
     }
 
-    fn branches(&self) -> Result<Vec<Branch>> {
+    fn branches(&self) -> BoxFuture<Result<Vec<Branch>>> {
         let state = self.state.lock();
         let current_branch = &state.current_branch_name;
-        Ok(state
+        let result = Ok(state
             .branches
             .iter()
             .map(|branch_name| Branch {
@@ -1090,57 +1211,71 @@ impl GitRepository for FakeGitRepository {
                 most_recent_commit: None,
                 upstream: None,
             })
-            .collect())
+            .collect());
+
+        async { result }.boxed()
     }
 
-    fn branch_exits(&self, name: &str) -> Result<bool> {
-        let state = self.state.lock();
-        Ok(state.branches.contains(name))
-    }
-
-    fn change_branch(&self, name: &str) -> Result<()> {
+    fn change_branch(&self, name: String, _: AsyncApp) -> BoxFuture<Result<()>> {
         let mut state = self.state.lock();
         state.current_branch_name = Some(name.to_owned());
         state
             .event_emitter
             .try_send(state.path.clone())
             .expect("Dropped repo change event");
-        Ok(())
+        async { Ok(()) }.boxed()
     }
 
-    fn create_branch(&self, name: &str) -> Result<()> {
+    fn create_branch(&self, name: String, _: AsyncApp) -> BoxFuture<Result<()>> {
         let mut state = self.state.lock();
         state.branches.insert(name.to_owned());
         state
             .event_emitter
             .try_send(state.path.clone())
             .expect("Dropped repo change event");
-        Ok(())
+        async { Ok(()) }.boxed()
     }
 
-    fn blame(&self, path: &Path, _content: Rope) -> Result<crate::blame::Blame> {
+    fn blame(
+        &self,
+        path: RepoPath,
+        _content: Rope,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<crate::blame::Blame>> {
         let state = self.state.lock();
-        state
+        let result = state
             .blames
-            .get(path)
+            .get(&path)
             .with_context(|| format!("failed to get blame for {:?}", path))
-            .cloned()
+            .cloned();
+        async { result }.boxed()
     }
 
-    fn stage_paths(&self, _paths: &[RepoPath], _env: &HashMap<String, String>) -> Result<()> {
+    fn stage_paths(
+        &self,
+        _paths: Vec<RepoPath>,
+        _env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<()>> {
         unimplemented!()
     }
 
-    fn unstage_paths(&self, _paths: &[RepoPath], _env: &HashMap<String, String>) -> Result<()> {
+    fn unstage_paths(
+        &self,
+        _paths: Vec<RepoPath>,
+        _env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<()>> {
         unimplemented!()
     }
 
     fn commit(
         &self,
-        _message: &str,
-        _name_and_email: Option<(&str, &str)>,
-        _env: &HashMap<String, String>,
-    ) -> Result<()> {
+        _message: SharedString,
+        _name_and_email: Option<(SharedString, SharedString)>,
+        _env: HashMap<String, String>,
+        _: AsyncApp,
+    ) -> BoxFuture<Result<()>> {
         unimplemented!()
     }
 
@@ -1151,37 +1286,44 @@ impl GitRepository for FakeGitRepository {
         _options: Option<PushOptions>,
         _ask_pass: AskPassSession,
         _env: HashMap<String, String>,
+        _cx: AsyncApp,
     ) -> BoxFuture<Result<RemoteCommandOutput>> {
         unimplemented!()
     }
 
     fn pull(
         &self,
-        _branch: &str,
-        _remote: &str,
+        _branch: String,
+        _remote: String,
         _ask_pass: AskPassSession,
-        _env: &HashMap<String, String>,
-    ) -> Result<RemoteCommandOutput> {
+        _env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<RemoteCommandOutput>> {
         unimplemented!()
     }
 
     fn fetch(
         &self,
         _ask_pass: AskPassSession,
-        _env: &HashMap<String, String>,
-    ) -> Result<RemoteCommandOutput> {
+        _env: HashMap<String, String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<RemoteCommandOutput>> {
         unimplemented!()
     }
 
-    fn get_remotes(&self, _branch: Option<&str>) -> Result<Vec<Remote>> {
+    fn get_remotes(
+        &self,
+        _branch: Option<String>,
+        _cx: AsyncApp,
+    ) -> BoxFuture<Result<Vec<Remote>>> {
         unimplemented!()
     }
 
-    fn check_for_pushed_commit(&self) -> Result<Vec<SharedString>> {
+    fn check_for_pushed_commit(&self, _cx: AsyncApp) -> BoxFuture<Result<Vec<SharedString>>> {
         unimplemented!()
     }
 
-    fn diff(&self, _diff: DiffType) -> Result<String> {
+    fn diff(&self, _diff: DiffType, _cx: AsyncApp) -> BoxFuture<Result<String>> {
         unimplemented!()
     }
 }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1244,7 +1244,7 @@ impl GitRepository for FakeGitRepository {
         let result = state
             .blames
             .get(&path)
-            .with_context(|| format!("failed to get blame for {:?}", path))
+            .with_context(|| format!("failed to get blame for {:?}", path.0))
             .cloned();
         async { result }.boxed()
     }

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -842,8 +842,6 @@ impl GitRepository for RealGitRepository {
                 .env("GIT_ASKPASS", ask_pass.script_path())
                 .env("SSH_ASKPASS", ask_pass.script_path())
                 .env("SSH_ASKPASS_REQUIRE", "force")
-                .env("GIT_TRACE", "/Users/max/.git_trace")
-                .env("GCM_TRACE", "/Users/max/.git_trace")
                 .env("GIT_HTTP_USER_AGENT", "Zed")
                 .current_dir(&working_directory)
                 .args(["push"])

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -205,9 +205,9 @@ impl BranchListDelegate {
             return;
         };
         cx.spawn(|_, cx| async move {
-            cx.update(|cx| repo.read(cx).create_branch(&new_branch_name))?
+            cx.update(|cx| repo.read(cx).create_branch(new_branch_name.to_string()))?
                 .await??;
-            cx.update(|cx| repo.read(cx).change_branch(&new_branch_name))?
+            cx.update(|cx| repo.read(cx).change_branch(new_branch_name.to_string()))?
                 .await??;
             Ok(())
         })
@@ -358,7 +358,7 @@ impl PickerDelegate for BranchListDelegate {
                     let cx = cx.to_async();
 
                     anyhow::Ok(async move {
-                        cx.update(|cx| repo.read(cx).change_branch(&branch.name))?
+                        cx.update(|cx| repo.read(cx).change_branch(branch.name.to_string()))?
                             .await?
                     })
                 })??;

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1504,15 +1504,17 @@ impl GitPanel {
         telemetry::event!("Git Uncommitted");
 
         let confirmation = self.check_for_pushed_commits(window, cx);
-        let prior_head = self.load_commit_details("HEAD", cx);
+        let prior_head = self.load_commit_details("HEAD".to_string(), cx);
 
         let task = cx.spawn_in(window, |this, mut cx| async move {
             let result = maybe!(async {
                 if let Ok(true) = confirmation.await {
                     let prior_head = prior_head.await?;
 
-                    repo.update(&mut cx, |repo, cx| repo.reset("HEAD^", ResetMode::Soft, cx))?
-                        .await??;
+                    repo.update(&mut cx, |repo, cx| {
+                        repo.reset("HEAD^".to_string(), ResetMode::Soft, cx)
+                    })?
+                    .await??;
 
                     Ok(Some(prior_head))
                 } else {
@@ -3404,7 +3406,7 @@ impl GitPanel {
 
     fn load_commit_details(
         &self,
-        sha: &str,
+        sha: String,
         cx: &mut Context<Self>,
     ) -> Task<anyhow::Result<CommitDetails>> {
         let Some(repo) = self.active_repository.clone() else {
@@ -3910,7 +3912,7 @@ impl GitPanelMessageTooltip {
             cx.spawn_in(window, |this, mut cx| async move {
                 let details = git_panel
                     .update(&mut cx, |git_panel, cx| {
-                        git_panel.load_commit_details(&sha, cx)
+                        git_panel.load_commit_details(sha.to_string(), cx)
                     })?
                     .await?;
 

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -1361,7 +1361,7 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
 
     assert_eq!(&remote_branches, &branches_set);
 
-    cx.update(|cx| repository.read(cx).change_branch(new_branch))
+    cx.update(|cx| repository.read(cx).change_branch(new_branch.to_string()))
         .await
         .unwrap()
         .unwrap();
@@ -1383,15 +1383,23 @@ async fn test_remote_git_branches(cx: &mut TestAppContext, server_cx: &mut TestA
     assert_eq!(server_branch.name, branches[2]);
 
     // Also try creating a new branch
-    cx.update(|cx| repository.read(cx).create_branch("totally-new-branch"))
-        .await
-        .unwrap()
-        .unwrap();
+    cx.update(|cx| {
+        repository
+            .read(cx)
+            .create_branch("totally-new-branch".to_string())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
-    cx.update(|cx| repository.read(cx).change_branch("totally-new-branch"))
-        .await
-        .unwrap()
-        .unwrap();
+    cx.update(|cx| {
+        repository
+            .read(cx)
+            .change_branch("totally-new-branch".to_string())
+    })
+    .await
+    .unwrap()
+    .unwrap();
 
     cx.run_until_parked();
 


### PR DESCRIPTION
Closes #26558

This moves spawning of the git subprocess to the main thread. We're not yet
sure why, but when we spawn a process using GCD's background queues,
sub-processes like git-credential-manager fail to open windows.

This seems to be fixable either by using the main thread, or by using a standard background thread,
but for now we use the main thread.


Release Notes:

- Git: Fix git-credential-manager
