### PR TITLE
Fix message on push

### DIFF
--- a/crates/git_ui/src/remote_output.rs
+++ b/crates/git_ui/src/remote_output.rs
@@ -143,7 +143,7 @@ pub fn format_output(action: &RemoteAction, output: RemoteCommandOutput) -> Succ
                 }
             } else {
                 SuccessMessage {
-                    message: "Successfully pushed new branch".to_owned(),
+                    message: format!("Pushed {} to {}", branch_name, remote_ref.name),
                     style: SuccessStyle::ToastWithLog { output },
                 }
             }


### PR DESCRIPTION
Instead of saying "Successfully pushed new branch" we say "Pushed x to y"

Release Notes:

- N/A
