### PR TITLE
docs: Improve introduction to Edit Prediction

### DIFF
--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -28,13 +28,11 @@ Edit predictions appear as you type, and most of the time, you can accept them b
 ### Configuring Zeta
 
 Zed's Edit Prediction was initially introduced via a banner on the title bar.
-Clicking on it would take you to a modal with a button to set `zed` as your `edit_prediction_provider`.
+Clicking on it would take you to a modal with a button ("Enable Edit Prediction") that sets `zed` as your `edit_prediction_provider`.
 
-<!-- I'll still swap the image -->
+![Onboarding banner and modal](https://zed.dev/img/edit-prediction/docs.webp)
 
-![Asking a question](https://zed.dev/img/assistant/ask-a-question.png)
-
-If you haven't come across the banner, start using Zed's Edit Prediction by adding this to your settings:
+But, if you haven't come across the banner, start using Zed's Edit Prediction by adding this to your settings:
 
 ```json
 "features": {

--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -34,7 +34,7 @@ Clicking on it would take you to a modal with a button to set `zed` as your `edi
 
 ![Asking a question](https://zed.dev/img/assistant/ask-a-question.png)
 
-If haven't come across the banner, start using Zed's Edit Prediction by adding this to your settings:
+If you haven't come across the banner, start using Zed's Edit Prediction by adding this to your settings:
 
 ```json
 "features": {

--- a/docs/src/completions.md
+++ b/docs/src/completions.md
@@ -22,9 +22,25 @@ For more information, see:
 
 ## Edit Predictions {#edit-predictions}
 
-Zed has built-in support for predicting multiple edits at a time via its [Zeta model](https://huggingface.co/zed-industries/zeta). Clicking "Introducing: Edit Prediction" on the top right will open a brief prompt setting up this feature.
-
+Zed has built-in support for predicting multiple edits at a time [via Zeta](https://huggingface.co/zed-industries/zeta), Zed's open-source and open-data model.
 Edit predictions appear as you type, and most of the time, you can accept them by pressing `tab`.
+
+### Configuring Zeta
+
+Zed's Edit Prediction was initially introduced via a banner on the title bar.
+Clicking on it would take you to a modal with a button to set `zed` as your `edit_prediction_provider`.
+
+<!-- I'll still swap the image -->
+
+![Asking a question](https://zed.dev/img/assistant/ask-a-question.png)
+
+If haven't come across the banner, start using Zed's Edit Prediction by adding this to your settings:
+
+```json
+"features": {
+  "edit_prediction_provider": "zed"
+},
+```
 
 ### Conflict With Other `tab` Actions {#edit-predictions-conflict}
 


### PR DESCRIPTION
As I was writing a blog post about Edit Prediction, I realized we didn't have a great section in the docs I could link to talking about configuring it. We weren't: 1) explicitly exposing the settings code to add Zed as the edit prediction provider, and 2) not showing an image of the title bar banner. 

Release Notes:

- N/A
