### PR TITLE
Fix being unable to put a cursor after trailing deletion hunks

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4176,7 +4176,12 @@ impl MultiBufferSnapshot {
         let region = cursor.region()?;
         let overshoot = offset - region.range.start;
         let buffer_offset = region.buffer_range.start + overshoot;
-        if buffer_offset > region.buffer.len() {
+        if buffer_offset == region.buffer.len() + 1
+            && region.has_trailing_newline
+            && !region.is_main_buffer
+        {
+            return Some((&cursor.excerpt()?.buffer, cursor.main_buffer_position()?));
+        } else if buffer_offset > region.buffer.len() {
             return None;
         }
         Some((region.buffer, buffer_offset))
@@ -4188,7 +4193,16 @@ impl MultiBufferSnapshot {
         let region = cursor.region()?;
         let overshoot = point - region.range.start;
         let buffer_point = region.buffer_range.start + overshoot;
-        if buffer_point > region.buffer.max_point() {
+        if buffer_point == region.buffer.max_point() + Point::new(1, 0)
+            && region.has_trailing_newline
+            && !region.is_main_buffer
+        {
+            return Some((
+                &cursor.excerpt()?.buffer,
+                cursor.main_buffer_position()?,
+                true,
+            ));
+        } else if buffer_point > region.buffer.max_point() {
             return None;
         }
         Some((region.buffer, buffer_point, region.is_main_buffer))

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -2007,22 +2007,17 @@ impl MultiBuffer {
         cx: &App,
     ) -> Option<(Entity<Buffer>, Point, ExcerptId)> {
         let snapshot = self.read(cx);
-        let point = point.to_point(&snapshot);
-        let mut cursor = snapshot.cursor::<Point>();
-        cursor.seek(&point);
-
-        cursor.region().and_then(|region| {
-            if !region.is_main_buffer {
-                return None;
-            }
-
-            let overshoot = point - region.range.start;
-            let buffer_point = region.buffer_range.start + overshoot;
-            let buffer = self.buffers.borrow()[&region.buffer.remote_id()]
+        let (buffer, point, is_main_buffer) =
+            snapshot.point_to_buffer_point(point.to_point(&snapshot))?;
+        Some((
+            self.buffers
+                .borrow()
+                .get(&buffer.remote_id())?
                 .buffer
-                .clone();
-            Some((buffer, buffer_point, region.excerpt.id))
-        })
+                .clone(),
+            point,
+            is_main_buffer,
+        ))
     }
 
     pub fn buffer_point_to_anchor(
@@ -4187,25 +4182,25 @@ impl MultiBufferSnapshot {
         Some((region.buffer, buffer_offset))
     }
 
-    pub fn point_to_buffer_point(&self, point: Point) -> Option<(&BufferSnapshot, Point, bool)> {
+    pub fn point_to_buffer_point(
+        &self,
+        point: Point,
+    ) -> Option<(&BufferSnapshot, Point, ExcerptId)> {
         let mut cursor = self.cursor::<Point>();
         cursor.seek(&point);
         let region = cursor.region()?;
         let overshoot = point - region.range.start;
         let buffer_point = region.buffer_range.start + overshoot;
+        let excerpt = cursor.excerpt()?;
         if buffer_point == region.buffer.max_point() + Point::new(1, 0)
             && region.has_trailing_newline
             && !region.is_main_buffer
         {
-            return Some((
-                &cursor.excerpt()?.buffer,
-                cursor.main_buffer_position()?,
-                true,
-            ));
+            return Some((&excerpt.buffer, cursor.main_buffer_position()?, excerpt.id));
         } else if buffer_point > region.buffer.max_point() {
             return None;
         }
-        Some((region.buffer, buffer_point, region.is_main_buffer))
+        Some((region.buffer, buffer_point, excerpt.id))
     }
 
     pub fn suggested_indents(

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -4733,6 +4733,9 @@ impl MultiBufferSnapshot {
                         .buffer
                         .text_summary_for_range(region.buffer_range.start.key..buffer_point),
                 );
+                if point == region.range.end.key && region.has_trailing_newline {
+                    position.add_assign(&D::from_text_summary(&TextSummary::newline()));
+                }
                 return Some(position);
             } else {
                 return Some(D::from_text_summary(&self.text_summary()));

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -3158,58 +3158,18 @@ fn test_trailing_deletion_without_newline(cx: &mut TestAppContext) {
     assert_eq!(snapshot.len(), 8);
 
     assert_eq!(
-        snapshot.clip_point(Point::new(2, 0), Bias::Left),
-        Point::new(2, 0)
-    );
-    assert_eq!(
-        snapshot.clip_point(Point::new(2, 0), Bias::Right),
-        Point::new(2, 0)
-    );
-    assert_eq!(
-        snapshot.clip_point(Point::new(2, 1), Bias::Right),
-        Point::new(2, 0)
-    );
-    assert_eq!(
-        snapshot.clip_point(Point::new(2, 1), Bias::Left),
-        Point::new(2, 0)
-    );
-    assert_eq!(
-        snapshot.clip_point(Point::new(3, 0), Bias::Left),
-        Point::new(2, 0)
-    );
-    assert_eq!(
-        snapshot.clip_point(Point::new(3, 0), Bias::Right),
-        Point::new(2, 0)
-    );
-
-    let anchor = snapshot.anchor_before(Point::new(2, 0));
-    assert_eq!(
-        snapshot.summary_for_anchor::<Point>(&anchor),
-        Point::new(2, 0)
-    );
-    let anchor = snapshot.anchor_after(Point::new(2, 0));
-    assert_eq!(
-        snapshot.summary_for_anchor::<Point>(&anchor),
-        Point::new(2, 0)
-    );
-    assert_eq!(
-        snapshot.summary_for_anchor::<usize>(&anchor),
-        "one\ntwo\n".len()
-    );
-
-    assert_eq!(
         snapshot
             .dimensions_from_points::<Point>([Point::new(2, 0)])
             .collect::<Vec<_>>(),
         vec![Point::new(2, 0)]
     );
 
+    let (_, translated_offset) = snapshot.point_to_buffer_offset(Point::new(2, 0)).unwrap();
+    assert_eq!(translated_offset, "one\n".len());
     let (_, translated_point, is_main_buffer) =
         snapshot.point_to_buffer_point(Point::new(2, 0)).unwrap();
     assert_eq!(translated_point, Point::new(1, 0));
     assert!(is_main_buffer);
-    let (_, translated_offset) = snapshot.point_to_buffer_offset(Point::new(2, 0)).unwrap();
-    assert_eq!(translated_offset, "one\n".len());
 }
 
 fn format_diff(


### PR DESCRIPTION
Closes #26541

Release Notes:

- Fixed a bug that prevented putting the cursor after a deletion hunk at the end of a file, in the absence of trailing newlines