### PR TITLE
Fine tune the commit modal experience

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1358,7 +1358,10 @@ impl Editor {
             project,
             blink_manager: blink_manager.clone(),
             show_local_selections: true,
-            show_scrollbars: true,
+            show_scrollbars: match mode {
+                EditorMode::AutoHeight { .. } | EditorMode::SingleLine { .. } => false,
+                EditorMode::Full => true,
+            },
             mode,
             show_breadcrumbs: EditorSettings::get_global(cx).toolbar.breadcrumbs,
             show_gutter: mode == EditorMode::Full,
@@ -16776,7 +16779,8 @@ fn wrap_with_prefix(
         is_whitespace,
     } in tokenizer
     {
-        if current_line_len + grapheme_len > wrap_column && current_line_len != line_prefix_len {
+        if (current_line_len + grapheme_len) > wrap_column && (current_line_len != line_prefix_len)
+        {
             wrapped_text.push_str(current_line.trim_end());
             wrapped_text.push('\n');
             current_line.truncate(line_prefix.len());

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -35,6 +35,7 @@ use gpui::{
     Transformation, UniformListScrollHandle, WeakEntity,
 };
 use itertools::Itertools;
+use language::language_settings::SoftWrap;
 use language::{Buffer, File};
 use language_model::{
     LanguageModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
@@ -368,6 +369,8 @@ pub(crate) fn commit_message_editor(
     commit_editor.set_show_wrap_guides(false, cx);
     commit_editor.set_show_indent_guides(false, cx);
     commit_editor.set_hard_wrap(Some(72), cx);
+    commit_editor.set_soft_wrap_mode(SoftWrap::None, cx);
+    commit_editor.set_show_scrollbars(true, cx);
     let placeholder = placeholder.unwrap_or("Enter commit message");
     commit_editor.set_placeholder_text(placeholder, cx);
     commit_editor


### PR DESCRIPTION
TODO:

- [x] Disable soft wrap, so we're properly WYSIWYG 
- [ ] Add scrollbars to commit modal (part way)
- [ ] Allow selecting and scrolling in the full visual editor area, rather than just the lines that have text on them
- [ ] Fix hard wrap implementation to not collapse new lines

Release Notes:

- Git: Disabled soft wrap in the commit modal
