### PR TITLE
Fix bad `cd` sometimes used by `BashTool` and set edit model temperature to 0

### DIFF
--- a/crates/assistant_tools/src/bash_tool.rs
+++ b/crates/assistant_tools/src/bash_tool.rs
@@ -11,6 +11,9 @@ use util::command::new_smol_command;
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct BashToolInput {
     /// The bash command to execute as a one-liner.
+    ///
+    /// WARNING: you must not `cd` into the working directory, as that's already
+    /// taken care of automatically. Doing so will cause the command to fail!
     command: String,
     /// Working directory for the command. This must be one of the root directories of the project.
     working_directory: String,

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -151,7 +151,7 @@ impl EditFilesTool {
                 messages,
                 tools: vec![],
                 stop: vec![],
-                temperature: None,
+                temperature: Some(0.0),
             };
 
             let mut parser = EditActionParser::new();


### PR DESCRIPTION
Release Notes:

- N/A
