### PR TITLE
gruvbox: `version_control_` -> `version_control.`

### DIFF
--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -6,15 +6,7 @@
     {
       "name": "Gruvbox Dark",
       "appearance": "dark",
-      "accents": [
-        "#cc241dff",
-        "#98971aff",
-        "#d79921ff",
-        "#458588ff",
-        "#b16286ff",
-        "#689d6aff",
-        "#d65d0eff"
-      ],
+      "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
       "style": {
         "border": "#5b534dff",
         "border.variant": "#494340ff",
@@ -105,9 +97,9 @@
         "terminal.ansi.bright_white": "#fbf1c7ff",
         "terminal.ansi.dim_white": "#b0a189ff",
         "link_text.hover": "#83a598ff",
-        "version_control_added": "#b7bb26ff",
-        "version_control_modified": "#f9bd2fff",
-        "version_control_deleted": "#fb4a35ff",
+        "version_control.added": "#b7bb26ff",
+        "version_control.modified": "#f9bd2fff",
+        "version_control.deleted": "#fb4a35ff",
         "conflict": "#f9bd2fff",
         "conflict.background": "#572e10ff",
         "conflict.border": "#754916ff",
@@ -399,15 +391,7 @@
     {
       "name": "Gruvbox Dark Hard",
       "appearance": "dark",
-      "accents": [
-        "#cc241dff",
-        "#98971aff",
-        "#d79921ff",
-        "#458588ff",
-        "#b16286ff",
-        "#689d6aff",
-        "#d65d0eff"
-      ],
+      "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
       "style": {
         "border": "#5b534dff",
         "border.variant": "#494340ff",
@@ -498,9 +482,9 @@
         "terminal.ansi.bright_white": "#fbf1c7ff",
         "terminal.ansi.dim_white": "#b0a189ff",
         "link_text.hover": "#83a598ff",
-        "version_control_added": "#b7bb26ff",
-        "version_control_modified": "#f9bd2fff",
-        "version_control_deleted": "#fb4a35ff",
+        "version_control.added": "#b7bb26ff",
+        "version_control.modified": "#f9bd2fff",
+        "version_control.deleted": "#fb4a35ff",
         "conflict": "#f9bd2fff",
         "conflict.background": "#572e10ff",
         "conflict.border": "#754916ff",
@@ -792,15 +776,7 @@
     {
       "name": "Gruvbox Dark Soft",
       "appearance": "dark",
-      "accents": [
-        "#cc241dff",
-        "#98971aff",
-        "#d79921ff",
-        "#458588ff",
-        "#b16286ff",
-        "#689d6aff",
-        "#d65d0eff"
-      ],
+      "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
       "style": {
         "border": "#5b534dff",
         "border.variant": "#494340ff",
@@ -891,9 +867,9 @@
         "terminal.ansi.bright_white": "#fbf1c7ff",
         "terminal.ansi.dim_white": "#b0a189ff",
         "link_text.hover": "#83a598ff",
-        "version_control_added": "#b7bb26ff",
-        "version_control_modified": "#f9bd2fff",
-        "version_control_deleted": "#fb4a35ff",
+        "version_control.added": "#b7bb26ff",
+        "version_control.modified": "#f9bd2fff",
+        "version_control.deleted": "#fb4a35ff",
         "conflict": "#f9bd2fff",
         "conflict.background": "#572e10ff",
         "conflict.border": "#754916ff",
@@ -1185,15 +1161,7 @@
     {
       "name": "Gruvbox Light",
       "appearance": "light",
-      "accents": [
-        "#cc241dff",
-        "#98971aff",
-        "#d79921ff",
-        "#458588ff",
-        "#b16286ff",
-        "#689d6aff",
-        "#d65d0eff"
-      ],
+      "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
       "style": {
         "border": "#c8b899ff",
         "border.variant": "#ddcca7ff",
@@ -1284,9 +1252,9 @@
         "terminal.ansi.bright_white": "#282828ff",
         "terminal.ansi.dim_white": "#73675eff",
         "link_text.hover": "#0b6678ff",
-        "version_control_added": "#797410ff",
-        "version_control_modified": "#b57615ff",
-        "version_control_deleted": "#9d0308ff",
+        "version_control.added": "#797410ff",
+        "version_control.modified": "#b57615ff",
+        "version_control.deleted": "#9d0308ff",
         "conflict": "#b57615ff",
         "conflict.background": "#f5e2d0ff",
         "conflict.border": "#ebccabff",
@@ -1578,15 +1546,7 @@
     {
       "name": "Gruvbox Light Hard",
       "appearance": "light",
-      "accents": [
-        "#cc241dff",
-        "#98971aff",
-        "#d79921ff",
-        "#458588ff",
-        "#b16286ff",
-        "#689d6aff",
-        "#d65d0eff"
-      ],
+      "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
       "style": {
         "border": "#c8b899ff",
         "border.variant": "#ddcca7ff",
@@ -1677,9 +1637,9 @@
         "terminal.ansi.bright_white": "#282828ff",
         "terminal.ansi.dim_white": "#73675eff",
         "link_text.hover": "#0b6678ff",
-        "version_control_added": "#797410ff",
-        "version_control_modified": "#b57615ff",
-        "version_control_deleted": "#9d0308ff",
+        "version_control.added": "#797410ff",
+        "version_control.modified": "#b57615ff",
+        "version_control.deleted": "#9d0308ff",
         "conflict": "#b57615ff",
         "conflict.background": "#f5e2d0ff",
         "conflict.border": "#ebccabff",
@@ -1971,15 +1931,7 @@
     {
       "name": "Gruvbox Light Soft",
       "appearance": "light",
-      "accents": [
-        "#cc241dff",
-        "#98971aff",
-        "#d79921ff",
-        "#458588ff",
-        "#b16286ff",
-        "#689d6aff",
-        "#d65d0eff"
-      ],
+      "accents": ["#cc241dff", "#98971aff", "#d79921ff", "#458588ff", "#b16286ff", "#689d6aff", "#d65d0eff"],
       "style": {
         "border": "#c8b899ff",
         "border.variant": "#ddcca7ff",
@@ -2070,9 +2022,9 @@
         "terminal.ansi.bright_white": "#282828ff",
         "terminal.ansi.dim_white": "#73675eff",
         "link_text.hover": "#0b6678ff",
-        "version_control_added": "#797410ff",
-        "version_control_modified": "#b57615ff",
-        "version_control_deleted": "#9d0308ff",
+        "version_control.added": "#797410ff",
+        "version_control.modified": "#b57615ff",
+        "version_control.deleted": "#9d0308ff",
         "conflict": "#b57615ff",
         "conflict.background": "#f5e2d0ff",
         "conflict.border": "#ebccabff",


### PR DESCRIPTION
Missed this in PR #26606 

Before:

![CleanShot 2025-03-13 at 08 58 59@2x](https://github.com/user-attachments/assets/021df4b1-5a70-4fae-a109-9b8bb35949e3)

After:

![CleanShot 2025-03-13 at 08 59 22@2x](https://github.com/user-attachments/assets/01dca26d-77ec-4a54-8b7c-aa2fb160ff7d)

Release Notes:

- theme: Fixed an issue where version control colors weren't applying correctly. (again)
