### PR TITLE
ci: Use smaller windows runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,8 @@ jobs:
     if: |
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
-    runs-on: windows-2025-64
+    # Use bigger runners for PRs (speed); smaller for async (cost)
+    runs-on: ${{ github.event_name == 'pull_request' && 'windows-2025-32' || 'windows-2025-16' }}
     steps:
       # more info here:- https://github.com/rust-lang/cargo/issues/13020
       - name: Enable longer pathnames for git


### PR DESCRIPTION
Let's see if the speed of `windows-2025-32` for `windows_tests` is fast-enough for PRs and everywhere else use `windows-2025-16`.  Leaving `windows_clippy` unchanged with `windows-2025-16`.

observed: 
windows-2025-64 is 7m30s - 10m49s ($4-$5.60/run)

predictions:
windows-2025-32 will be 10m30s - 13m30s ($2.80-$3.60/run)
windows-2025-16 will be 12m30s - 15m30s ($1.65-$2.05/run)

Conservatively, switching main from `windows-2025-64` to `windows-2025-16` multiplied by ~210 commits per week could save ~$400/wk (assuming $4/run vs $2/run).  I don't have a count for commits on PRs, but assuming ~500 commits per week switching from `windows-2025-64` to `windows-2025-32` would save another ~$500/wk (assuming $4/run vs $3/run). If that's too slow we can always go back to `windows-2025-64` for PRs.

I still want to get PR times down for Windows runners too.  For me the variance ~2mins (largely due to cache restore times varying widely based regional instance placement) is bonkers.

Release Notes:

- N/A