### PR TITLE
worktree: Disable flaky `test_git_repository_status` test

### DIFF
--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2624,7 +2624,9 @@ async fn test_file_status(cx: &mut TestAppContext) {
     });
 }
 
-#[gpui::test]
+// TODO: Fix flaky test.
+// #[gpui::test]
+#[allow(unused)]
 async fn test_git_repository_status(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();


### PR DESCRIPTION
This PR disables the flaky `test_git_repository_status` test.

Release Notes:

- N/A
