### PR TITLE
component_preview: Enable scrolling in preview pages

### DIFF
--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -1,8 +1,8 @@
-#[allow(unused, dead_code)]
-
 //! # Component Preview
 //!
 //! A view for exploring Zed components.
+
+#![allow(unused, dead_code)]
 
 use std::iter::Iterator;
 use std::sync::Arc;

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -1,3 +1,5 @@
+#[allow(unused, dead_code)]
+
 //! # Component Preview
 //!
 //! A view for exploring Zed components.
@@ -14,7 +16,7 @@ use gpui::{
 
 use collections::HashMap;
 
-use gpui::{ListState, ScrollHandle, UniformListScrollHandle};
+use gpui::{ListState, UniformListScrollHandle};
 use languages::LanguageRegistry;
 use notifications::status_toast::{StatusToast, ToastIcon};
 use project::Project;

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -88,7 +88,6 @@ enum PreviewPage {
 
 struct ComponentPreview {
     focus_handle: FocusHandle,
-    _view_scroll_handle: ScrollHandle,
     nav_scroll_handle: UniformListScrollHandle,
     component_map: HashMap<ComponentId, ComponentMetadata>,
     active_page: PreviewPage,
@@ -130,7 +129,6 @@ impl ComponentPreview {
 
         let mut component_preview = Self {
             focus_handle: cx.focus_handle(),
-            _view_scroll_handle: ScrollHandle::new(),
             nav_scroll_handle: UniformListScrollHandle::new(),
             language_registry,
             user_store,
@@ -401,10 +399,12 @@ impl ComponentPreview {
         let component = self.component_map.get(&component_id);
 
         if let Some(component) = component {
-            v_flex()
-                .w_full()
-                .flex_initial()
-                .min_h_full()
+            div()
+                .id("component-page-container")
+                .flex_1()
+                .size_full()
+                .overflow_x_hidden()
+                .overflow_y_scroll()
                 .child(self.render_preview(component, window, cx))
                 .into_any_element()
         } else {
@@ -412,6 +412,7 @@ impl ComponentPreview {
                 .size_full()
                 .items_center()
                 .justify_center()
+                .text_center()
                 .child("Component not found")
                 .into_any_element()
         }


### PR DESCRIPTION
This PR fixes an issue in Component Preview where individual pages wouldn't scroll.

Release Notes:

- N/A
