### PR TITLE
copilot: Decouple copilot sign in from edit prediction settings

### DIFF
--- a/crates/copilot/src/sign_in.rs
+++ b/crates/copilot/src/sign_in.rs
@@ -195,7 +195,9 @@ impl CopilotCodeVerification {
                     .full_width()
                     .on_click(cx.listener(|this, _, _, cx| {
                         cx.emit(DismissEvent);
-                        this.copilot.update(cx, |copilot, cx| copilot.sign_out(cx));
+                        this.copilot
+                            .update(cx, |copilot, cx| copilot.sign_out(cx))
+                            .detach_and_log_err(cx);
                     })),
             )
     }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -580,8 +580,6 @@ pub struct CopilotSettingsContent {
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct FeaturesContent {
-    /// Whether the GitHub Copilot feature is enabled.
-    pub copilot: Option<bool>,
     /// Determines which edit prediction provider to use.
     pub edit_prediction_provider: Option<EditPredictionProvider>,
 }
@@ -1158,7 +1156,6 @@ impl settings::Settings for AllLanguageSettings {
             languages.insert(language_name.clone(), language_settings);
         }
 
-        let mut copilot_enabled = default_value.features.as_ref().and_then(|f| f.copilot);
         let mut edit_prediction_provider = default_value
             .features
             .as_ref()
@@ -1205,9 +1202,6 @@ impl settings::Settings for AllLanguageSettings {
         }
 
         for user_settings in sources.customizations() {
-            if let Some(copilot) = user_settings.features.as_ref().and_then(|f| f.copilot) {
-                copilot_enabled = Some(copilot);
-            }
             if let Some(provider) = user_settings
                 .features
                 .as_ref()
@@ -1282,8 +1276,6 @@ impl settings::Settings for AllLanguageSettings {
             edit_predictions: EditPredictionSettings {
                 provider: if let Some(provider) = edit_prediction_provider {
                     provider
-                } else if copilot_enabled.unwrap_or(true) {
-                    EditPredictionProvider::Copilot
                 } else {
                     EditPredictionProvider::None
                 },

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -366,7 +366,6 @@ impl Render for ConfigurationView {
 
             match &self.copilot_status {
                 Some(status) => match status {
-                    Status::Disabled => v_flex().gap_6().p_4().child(Label::new(ERROR_LABEL)),
                     Status::Starting { task: _ } => {
                         const LABEL: &str = "Starting Copilot...";
                         v_flex()

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -129,7 +129,7 @@ impl LanguageModelProvider for CopilotChatLanguageModelProvider {
             Status::Error(err) => anyhow!(format!("Received the following error while signing into Copilot: {err}")),
             Status::Starting { task: _ } => anyhow!("Copilot is still starting, please wait for Copilot to start then try again"),
             Status::Unauthorized => anyhow!("Unable to authorize with Copilot. Please make sure that you have an active Copilot and Copilot Chat subscription."),
-            Status::SignedOut => anyhow!("You have signed out of Copilot. Please sign in to Copilot and try again."),
+            Status::SignedOut {..} => anyhow!("You have signed out of Copilot. Please sign in to Copilot and try again."),
             Status::SigningIn { prompt: _ } => anyhow!("Still signing into Copilot..."),
         };
 
@@ -375,7 +375,10 @@ impl Render for ConfigurationView {
                             .child(Label::new(LABEL))
                             .child(loading_icon)
                     }
-                    Status::SigningIn { prompt: _ } => {
+                    Status::SigningIn { prompt: _ }
+                    | Status::SignedOut {
+                        awaiting_signing_in: true,
+                    } => {
                         const LABEL: &str = "Signing in to Copilot...";
                         v_flex()
                             .gap_6()


### PR DESCRIPTION
Closes #25883

This PR allows you to use copilot chat for assistant without setting copilot as the edit prediction provider.

[copilot.webm](https://github.com/user-attachments/assets/fecfbde1-d72c-4c0c-b080-a07671fb846e)

Todos:
- [x] Remove redudant "copilot" key from settings
- [x] Do not disable copilot LSP when `edit_prediction_provider` is not set to `copilot`
- [x] Start copilot LSP when:
  - [x]  `edit_prediction_provider` is set to `copilot`
  - [x] Copilot sign in clicked from assistant settings
- [x] Handle flicker for frame after starting LSP, but before signing in caused due to signed out status
  - [x] Fixed this by adding intermediate state for awaiting signing in in sign out enum 
- [x] Handle cancel button should sign out from `copilot` (existing bug)
- [x] Handle modal dismissal should sign out if not in signed in state (existing bug)

Release Notes:

- You can now sign into Copilot from assistant settings without making it your edit prediction provider. This is useful if you want to use Copilot chat while keeping a different provider, like Zed, for predictions.
- Removed the `copilot` key from `features` in settings. Use `edit_prediction_provider` instead.
