### PR TITLE
assistant2: Add ability to open the active thread as Markdown

### DIFF
--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -54,7 +54,7 @@ actions!(
         FocusRight,
         RemoveFocusedContext,
         AcceptSuggestedContext,
-        OpenAsMarkdown
+        OpenActiveThreadAsMarkdown
     ]
 );
 

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -53,7 +53,8 @@ actions!(
         FocusLeft,
         FocusRight,
         RemoveFocusedContext,
-        AcceptSuggestedContext
+        AcceptSuggestedContext,
+        OpenAsMarkdown
     ]
 );
 

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -11,7 +11,7 @@ use assistant_slash_command::SlashCommandWorkingSet;
 use assistant_tool::ToolWorkingSet;
 
 use client::zed_urls;
-use editor::Editor;
+use editor::{Editor, MultiBuffer};
 use fs::Fs;
 use gpui::{
     prelude::*, Action, AnyElement, App, AsyncWindowContext, Corner, Entity, EventEmitter,
@@ -39,7 +39,8 @@ use crate::thread::{Thread, ThreadError, ThreadId};
 use crate::thread_history::{PastContext, PastThread, ThreadHistory};
 use crate::thread_store::ThreadStore;
 use crate::{
-    InlineAssistant, NewPromptEditor, NewThread, OpenAsMarkdown, OpenConfiguration, OpenHistory,
+    InlineAssistant, NewPromptEditor, NewThread, OpenActiveThreadAsMarkdown, OpenConfiguration,
+    OpenHistory,
 };
 
 pub fn init(cx: &mut App) {
@@ -411,6 +412,70 @@ impl AssistantPanel {
 
             configuration.focus_handle(cx).focus(window);
         }
+    }
+
+    pub(crate) fn open_active_thread_as_markdown(
+        &mut self,
+        _: &OpenActiveThreadAsMarkdown,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let Some(workspace) = self
+            .workspace
+            .upgrade()
+            .ok_or_else(|| anyhow!("workspace dropped"))
+            .log_err()
+        else {
+            return;
+        };
+
+        let markdown_language_task = workspace
+            .read(cx)
+            .app_state()
+            .languages
+            .language_for_name("Markdown");
+        let thread = self.active_thread(cx);
+        cx.spawn_in(window, |_this, mut cx| async move {
+            let markdown_language = markdown_language_task.await?;
+
+            workspace.update_in(&mut cx, |workspace, window, cx| {
+                let thread = thread.read(cx);
+                let markdown = thread.to_markdown()?;
+                let thread_summary = thread
+                    .summary()
+                    .map(|summary| summary.to_string())
+                    .unwrap_or_else(|| "Thread".to_string());
+
+                let project = workspace.project().clone();
+                let buffer = project.update(cx, |project, cx| {
+                    project.create_local_buffer(&markdown, Some(markdown_language), cx)
+                });
+                let buffer = cx.new(|cx| {
+                    MultiBuffer::singleton(buffer, cx).with_title(thread_summary.clone())
+                });
+
+                workspace.add_item_to_active_pane(
+                    Box::new(cx.new(|cx| {
+                        let mut editor = Editor::for_multibuffer(
+                            buffer,
+                            Some(project.clone()),
+                            true,
+                            window,
+                            cx,
+                        );
+                        editor.set_breadcrumb_header(thread_summary);
+                        editor
+                    })),
+                    None,
+                    true,
+                    window,
+                    cx,
+                );
+
+                anyhow::Ok(())
+            })
+        })
+        .detach_and_log_err(cx);
     }
 
     fn handle_assistant_configuration_event(
@@ -1013,13 +1078,7 @@ impl Render for AssistantPanel {
             .on_action(cx.listener(|this, _: &OpenHistory, window, cx| {
                 this.open_history(window, cx);
             }))
-            .on_action(cx.listener(|this, _: &OpenAsMarkdown, window, cx| {
-                let Some(markdown) = this.active_thread(cx).read(cx).to_markdown().log_err() else {
-                    return;
-                };
-
-                dbg!(markdown);
-            }))
+            .on_action(cx.listener(Self::open_active_thread_as_markdown))
             .on_action(cx.listener(Self::deploy_prompt_library))
             .child(self.render_toolbar(cx))
             .map(|parent| match self.active_view {

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -38,7 +38,9 @@ use crate::message_editor::MessageEditor;
 use crate::thread::{Thread, ThreadError, ThreadId};
 use crate::thread_history::{PastContext, PastThread, ThreadHistory};
 use crate::thread_store::ThreadStore;
-use crate::{InlineAssistant, NewPromptEditor, NewThread, OpenConfiguration, OpenHistory};
+use crate::{
+    InlineAssistant, NewPromptEditor, NewThread, OpenAsMarkdown, OpenConfiguration, OpenHistory,
+};
 
 pub fn init(cx: &mut App) {
     cx.observe_new(
@@ -1010,6 +1012,13 @@ impl Render for AssistantPanel {
             }))
             .on_action(cx.listener(|this, _: &OpenHistory, window, cx| {
                 this.open_history(window, cx);
+            }))
+            .on_action(cx.listener(|this, _: &OpenAsMarkdown, window, cx| {
+                let Some(markdown) = this.active_thread(cx).read(cx).to_markdown().log_err() else {
+                    return;
+                };
+
+                dbg!(markdown);
             }))
             .on_action(cx.listener(Self::deploy_prompt_library))
             .child(self.render_toolbar(cx))

--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -800,15 +800,23 @@ impl Thread {
         let mut markdown = Vec::new();
 
         for message in self.messages() {
-            match message.role {
-                Role::User => writeln!(markdown, "## User")?,
-                Role::Assistant => writeln!(markdown, "## Assistant")?,
-                Role::System => writeln!(markdown, "## System")?,
-            }
-
-            write!(markdown, "{}", message.text)?;
+            writeln!(
+                markdown,
+                "## {role}\n",
+                role = match message.role {
+                    Role::User => "User",
+                    Role::Assistant => "Assistant",
+                    Role::System => "System",
+                }
+            )?;
+            writeln!(markdown, "{}\n", message.text)?;
 
             for tool_use in self.tool_uses_for_message(message.id) {
+                writeln!(
+                    markdown,
+                    "**Use Tool: {} ({})**",
+                    tool_use.name, tool_use.id
+                )?;
                 writeln!(markdown, "```json")?;
                 writeln!(
                     markdown,
@@ -819,7 +827,13 @@ impl Thread {
             }
 
             for tool_result in self.tool_results_for_message(message.id) {
-                write!(markdown, "{}", tool_result.content)?;
+                write!(markdown, "**Tool Results: {}", tool_result.tool_use_id)?;
+                if tool_result.is_error {
+                    write!(markdown, " (Error)")?;
+                }
+
+                writeln!(markdown, "**\n")?;
+                writeln!(markdown, "{}", tool_result.content)?;
             }
         }
 


### PR DESCRIPTION
This PR adds a new `assistant2: open active thread as markdown` action that opens up the active thread in a Markdown representation:

<img width="1394" alt="Screenshot 2025-03-13 at 12 25 33 PM" src="https://github.com/user-attachments/assets/363baaaa-c74b-4e93-af36-a3e04a114af0" />

Release Notes:

- N/A
