### PR TITLE
assistant2: Include the thread summary in the Markdown representation

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -799,6 +799,10 @@ impl Thread {
     pub fn to_markdown(&self) -> Result<String> {
         let mut markdown = Vec::new();
 
+        if let Some(summary) = self.summary() {
+            writeln!(markdown, "# {summary}\n")?;
+        };
+
         for message in self.messages() {
             writeln!(
                 markdown,


### PR DESCRIPTION
This PR adds the thread's summary (if it has one) as a heading in the Markdown representation.

Release Notes:

- N/A
