### PR TITLE
terminal: Fix issues with highlighted ranges of paths

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -935,12 +935,19 @@ impl Terminal {
 
                         if is_path_surrounded_by_common_symbols(&file_path) {
                             word_match = Match::new(
-                                word_match.start().add(term, Boundary::Cursor, 1),
-                                word_match.end().sub(term, Boundary::Cursor, 1),
+                                word_match.start().add(term, Boundary::Grid, 1),
+                                word_match.end().sub(term, Boundary::Grid, 1),
                             );
                             file_path = file_path[1..file_path.len() - 1].to_owned();
                         }
 
+                        while file_path.ends_with(':') {
+                            file_path.pop();
+                            word_match = Match::new(
+                                *word_match.start(),
+                                word_match.end().sub(term, Boundary::Grid, 1),
+                            );
+                        }
                         let mut colon_count = 0;
                         for c in file_path.chars() {
                             if c == ':' {
@@ -966,7 +973,7 @@ impl Terminal {
                                 let stripped_len = file_path.len() - last_index;
                                 word_match = Match::new(
                                     *word_match.start(),
-                                    word_match.end().sub(term, Boundary::Cursor, stripped_len),
+                                    word_match.end().sub(term, Boundary::Grid, stripped_len),
                                 );
                                 file_path = file_path[0..last_index].to_owned();
                             }


### PR DESCRIPTION
Fixes a few problems,

- Uses `Boundary::Grid` instead of `Boundary::Cursor` for highlighted range adjustments.

This fixes quite a few wierd behaviors around highlighting paths that had to be scrolled into view (i.e. were in the terminal history) including the issue described in the release notes as well as a regression caused by #26401 where the highlight range would span from the start of the path to the cursor location in the shell prompt

- Strips all trailing `:`s from the paths, updating the highlighted range accordingly.

This worked fine before and is just a visual improvement.



Release Notes:

- Fixed an issue where file paths in the terminal surrounded by `()` or `[]` would not be highlighted properly
