### PR TITLE
bash tool: Rename `working_directory` to `cd` and improve command wrap

### DIFF
--- a/crates/assistant_tools/src/bash_tool/description.md
+++ b/crates/assistant_tools/src/bash_tool/description.md
@@ -1,7 +1,7 @@
 Executes a bash one-liner and returns the combined output.
 
-This tool spawns a bash process IN THE SPECIFIED WORKING DIRECTORY, combines stdout and stderr into one interleaved stream as they are produced (preserving the order of writes), and captures that stream into a string which is returned.
+This tool spawns a bash process, combines stdout and stderr into one interleaved stream as they are produced (preserving the order of writes), and captures that stream into a string which is returned.
 
-WARNING: **NEVER** use 'cd' commands to navigate to the working directory - this is automatically handled by the 'working_directory' parameter. Only use 'cd' to navigate to subdirectories within the specified working directory.
+Make sure you use the `cd` parameter to navigate to one of the root directories of the project. NEVER do it as part of the `command` itself, otherwise it will error.
 
 Remember that each invocation of this tool will spawn a new bash process, so you can't rely on any state from previous invocations.


### PR DESCRIPTION
This helps its do the right thing

Release Notes:

- N/A
