### PR TITLE
Use system git for committing

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -795,9 +795,8 @@ impl GitRepository for RealGitRepository {
         cx: AsyncApp,
     ) -> BoxFuture<Result<()>> {
         let working_directory = self.working_directory();
-        let git_binary_path = self.git_binary_path.clone();
         cx.background_spawn(async move {
-            let mut cmd = new_smol_command(&git_binary_path);
+            let mut cmd = new_smol_command("git");
             cmd.current_dir(&working_directory?)
                 .envs(env)
                 .args(["commit", "--quiet", "-m"])


### PR DESCRIPTION
Closes #26472

Release Notes:

- On macOS, switched to using the system's git binary to create commits. This fixes issues that some users were seeing with pre-commit hooks. Compatibility note: after this change, it is no longer possible to commit from Zed unless git is installed.