### PR TITLE
Allow parsing commits when we can't resolve the permalink

### DIFF
--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -488,7 +488,7 @@ async fn parse_commit_messages(
                 },
             ))
         } else {
-            continue;
+            None
         };
 
         let remote = parsed_remote_url


### PR DESCRIPTION
Closes #26577

Release Notes:

- git: Fix showing commit messages for all repos
