### PR TITLE
worktree: Disable flaky tests (`test_write_file`, `test_git_status_postprocessing`)

### DIFF
--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -845,7 +845,9 @@ async fn test_update_gitignore(cx: &mut TestAppContext) {
     });
 }
 
-#[gpui::test]
+// TODO: Fix flaky test.
+// #[gpui::test]
+#[allow(unused)]
 async fn test_write_file(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2740,7 +2740,9 @@ async fn test_git_repository_status(cx: &mut TestAppContext) {
     });
 }
 
-#[gpui::test]
+// TODO: Fix flaky test.
+// #[gpui::test]
+#[allow(unused)]
 async fn test_git_status_postprocessing(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();


### PR DESCRIPTION
Comment out flaky tests:
- `worktree_tests::test_write_file`
- `worktree_tests::test_git_status_postprocessing`

Job links:
- windows fail: https://github.com/zed-industries/zed/actions/runs/13841766606/job/38730766252
- macos fail: https://github.com/zed-industries/zed/actions/runs/13841766606/job/38730764118

That [commit](https://github.com/zed-industries/zed/commit/85384fb9c67614795a82f5b0a09895875beb16d0) was a non-op script change, but in the [prior commit](https://github.com/zed-industries/zed/commit/00359271d11b6ba865fe81f04f675bf588a17335) [windows/macos pass](https://github.com/zed-industries/zed/actions/runs/13841135221).

Similar experience with `worktree_tests::test_write_file` on both macOS windows too.

- See also: https://github.com/zed-industries/zed/pull/26684

Release Notes:

- N/A