### PR TITLE
assistant2: Truncate context pill labels

### DIFF
--- a/crates/assistant2/src/ui/context_pill.rs
+++ b/crates/assistant2/src/ui/context_pill.rs
@@ -126,7 +126,13 @@ impl RenderOnce for ContextPill {
                     h_flex()
                         .id("context-data")
                         .gap_1()
-                        .child(Label::new(context.name.clone()).size(LabelSize::Small))
+                        .child(
+                            div().max_w_64().child(
+                                Label::new(context.name.clone())
+                                    .size(LabelSize::Small)
+                                    .truncate(),
+                            ),
+                        )
                         .when_some(context.parent.as_ref(), |element, parent_name| {
                             if *dupe_name {
                                 element.child(
@@ -174,21 +180,22 @@ impl RenderOnce for ContextPill {
                 })
                 .hover(|style| style.bg(color.element_hover.opacity(0.5)))
                 .child(
-                    Label::new(name.clone())
-                        .size(LabelSize::Small)
-                        .color(Color::Muted),
+                    div().px_0p5().max_w_64().child(
+                        Label::new(name.clone())
+                            .size(LabelSize::Small)
+                            .color(Color::Muted)
+                            .truncate(),
+                    ),
                 )
                 .child(
-                    div().px_0p5().child(
-                        Label::new(match kind {
-                            ContextKind::File => "Active Tab",
-                            ContextKind::Thread
-                            | ContextKind::Directory
-                            | ContextKind::FetchedUrl => "Active",
-                        })
-                        .size(LabelSize::XSmall)
-                        .color(Color::Muted),
-                    ),
+                    Label::new(match kind {
+                        ContextKind::File => "Active Tab",
+                        ContextKind::Thread | ContextKind::Directory | ContextKind::FetchedUrl => {
+                            "Active"
+                        }
+                    })
+                    .size(LabelSize::XSmall)
+                    .color(Color::Muted),
                 )
                 .child(
                     Icon::new(IconName::Plus)


### PR DESCRIPTION
To solve a problem that mostly happens if the pill is of kind `Thread` and the corresponding thread has a super long title.

<img src="https://github.com/user-attachments/assets/4ee8038d-9467-41a9-9b30-76019d0b9c0b" width="500px"/>

Release Notes:

- N/A
