### PR TITLE
assistant2: Prevent sending messages when the button is disabled

### DIFF
--- a/crates/assistant2/src/message_editor.rs
+++ b/crates/assistant2/src/message_editor.rs
@@ -150,6 +150,14 @@ impl MessageEditor {
     }
 
     fn chat(&mut self, _: &Chat, window: &mut Window, cx: &mut Context<Self>) {
+        if self.is_editor_empty(cx) {
+            return;
+        }
+
+        if self.thread.read(cx).is_streaming() {
+            return;
+        }
+
         self.send_to_model(RequestKind::Chat, window, cx);
     }
 


### PR DESCRIPTION
This PR updates the `Chat` action handler to prevent sending messages in the states when the submit button is disabled.

Release Notes:

- N/A
