### PR TITLE
assistant2: Consider tool use as part of the "streaming" state

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -200,7 +200,7 @@ impl Thread {
     }
 
     pub fn is_streaming(&self) -> bool {
-        !self.pending_completions.is_empty()
+        !self.pending_completions.is_empty() || !self.all_tools_finished()
     }
 
     pub fn tools(&self) -> &Arc<ToolWorkingSet> {


### PR DESCRIPTION
This PR updates the `Thread::is_streaming` method so that it includes tool use in the "streaming" state.

This will prevent the streaming indicator from disappearing when we're doing tool use.

Release Notes:

- N/A
