### PR TITLE
worktree: Disable flaky `test_file_status` test 

### DIFF
--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2432,6 +2432,7 @@ async fn test_git_repository_for_path(cx: &mut TestAppContext) {
 // https://stackoverflow.com/questions/41365318/access-is-denied-when-renaming-folder
 // TODO: Fix flaky test.
 // #[gpui::test]
+#[allow(unused)]
 #[cfg_attr(target_os = "windows", ignore)]
 async fn test_file_status(cx: &mut TestAppContext) {
     init_test(cx);
@@ -3536,6 +3537,8 @@ fn git_cherry_pick(commit: &git2::Commit<'_>, repo: &git2::Repository) {
     repo.cherrypick(commit, None).expect("Failed to cherrypick");
 }
 
+// TODO: Remove allow(unused) once flaky tests are reinstated
+#[allow(unused)]
 #[track_caller]
 fn git_stash(repo: &mut git2::Repository) {
     use git2::Signature;
@@ -3545,6 +3548,8 @@ fn git_stash(repo: &mut git2::Repository) {
         .expect("Failed to stash");
 }
 
+// TODO: Remove allow(unused) once flaky tests are reinstated
+#[allow(unused)]
 #[track_caller]
 fn git_reset(offset: usize, repo: &git2::Repository) {
     let head = repo.head().expect("Couldn't get repo head");

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2426,12 +2426,12 @@ async fn test_git_repository_for_path(cx: &mut TestAppContext) {
     });
 }
 
-// NOTE:
-// This test always fails on Windows, because on Windows, unlike on Unix, you can't rename
-// a directory which some program has already open.
-// This is a limitation of the Windows.
-// See: https://stackoverflow.com/questions/41365318/access-is-denied-when-renaming-folder
-#[gpui::test]
+// NOTE: This test always fails on Windows, because on Windows, unlike on Unix,
+// you can't rename a directory which some program has already open. This is a
+// limitation of the Windows. See:
+// https://stackoverflow.com/questions/41365318/access-is-denied-when-renaming-folder
+// TODO: Fix flaky test.
+// #[gpui::test]
 #[cfg_attr(target_os = "windows", ignore)]
 async fn test_file_status(cx: &mut TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
See also:
- https://github.com/zed-industries/zed/pull/26684
- https://github.com/zed-industries/zed/pull/26710

Example of failing:
- macOS: https://github.com/zed-industries/zed/actions/runs/13843672736/job/38737047196

Release Notes:

- N/A