### PR TITLE
Merge clangd's `inactiveRegions` with existing diagnostics

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1557,6 +1557,13 @@ impl Buffer {
         self.send_operation(op, true, cx);
     }
 
+    pub fn get_diagnostics(&self, server_id: LanguageServerId) -> Option<&DiagnosticSet> {
+        let Ok(idx) = self.diagnostics.binary_search_by_key(&server_id, |v| v.0) else {
+            return None;
+        };
+        Some(&self.diagnostics[idx].1)
+    }
+
     fn request_autoindent(&mut self, cx: &mut Context<Self>) {
         if let Some(indent_sizes) = self.compute_autoindents() {
             let indent_sizes = cx.background_spawn(indent_sizes);

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -225,8 +225,13 @@ impl CachedLspAdapter {
         self.adapter.code_action_kinds()
     }
 
-    pub fn process_diagnostics(&self, params: &mut lsp::PublishDiagnosticsParams) {
-        self.adapter.process_diagnostics(params)
+    pub fn process_diagnostics(
+        &self,
+        params: &mut lsp::PublishDiagnosticsParams,
+        existing_diagnostics: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+    ) {
+        self.adapter
+            .process_diagnostics(params, existing_diagnostics)
     }
 
     pub async fn process_completions(&self, completion_items: &mut [lsp::CompletionItem]) {
@@ -442,7 +447,12 @@ pub trait LspAdapter: 'static + Send + Sync {
         delegate: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary>;
 
-    fn process_diagnostics(&self, _: &mut lsp::PublishDiagnosticsParams) {}
+    fn process_diagnostics(
+        &self,
+        _: &mut lsp::PublishDiagnosticsParams,
+        _: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+    ) {
+    }
 
     /// Post-processes completions provided by the language server.
     async fn process_completions(&self, _: &mut [lsp::CompletionItem]) {}
@@ -2017,7 +2027,12 @@ impl LspAdapter for FakeLspAdapter {
         unreachable!();
     }
 
-    fn process_diagnostics(&self, _: &mut lsp::PublishDiagnosticsParams) {}
+    fn process_diagnostics(
+        &self,
+        _: &mut lsp::PublishDiagnosticsParams,
+        _: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+    ) {
+    }
 
     fn disk_based_diagnostic_sources(&self) -> Vec<String> {
         self.disk_based_diagnostics_sources.clone()

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -228,7 +228,7 @@ impl CachedLspAdapter {
     pub fn process_diagnostics(
         &self,
         params: &mut lsp::PublishDiagnosticsParams,
-        existing_diagnostics: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+        existing_diagnostics: Option<(LanguageServerId, &'_ Buffer)>,
     ) {
         self.adapter
             .process_diagnostics(params, existing_diagnostics)
@@ -450,7 +450,7 @@ pub trait LspAdapter: 'static + Send + Sync {
     fn process_diagnostics(
         &self,
         _: &mut lsp::PublishDiagnosticsParams,
-        _: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+        _: Option<(LanguageServerId, &'_ Buffer)>,
     ) {
     }
 
@@ -2030,7 +2030,7 @@ impl LspAdapter for FakeLspAdapter {
     fn process_diagnostics(
         &self,
         _: &mut lsp::PublishDiagnosticsParams,
-        _: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+        _: Option<(LanguageServerId, &'_ Buffer)>,
     ) {
     }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -228,10 +228,11 @@ impl CachedLspAdapter {
     pub fn process_diagnostics(
         &self,
         params: &mut lsp::PublishDiagnosticsParams,
-        existing_diagnostics: Option<(LanguageServerId, &'_ Buffer)>,
+        server_id: LanguageServerId,
+        existing_diagnostics: Option<&'_ Buffer>,
     ) {
         self.adapter
-            .process_diagnostics(params, existing_diagnostics)
+            .process_diagnostics(params, server_id, existing_diagnostics)
     }
 
     pub async fn process_completions(&self, completion_items: &mut [lsp::CompletionItem]) {
@@ -450,7 +451,8 @@ pub trait LspAdapter: 'static + Send + Sync {
     fn process_diagnostics(
         &self,
         _: &mut lsp::PublishDiagnosticsParams,
-        _: Option<(LanguageServerId, &'_ Buffer)>,
+        _: LanguageServerId,
+        _: Option<&'_ Buffer>,
     ) {
     }
 
@@ -2025,13 +2027,6 @@ impl LspAdapter for FakeLspAdapter {
         _: &dyn LspAdapterDelegate,
     ) -> Option<LanguageServerBinary> {
         unreachable!();
-    }
-
-    fn process_diagnostics(
-        &self,
-        _: &mut lsp::PublishDiagnosticsParams,
-        _: Option<(LanguageServerId, &'_ Buffer)>,
-    ) {
     }
 
     fn disk_based_diagnostic_sources(&self) -> Vec<String> {

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -296,9 +296,10 @@ impl super::LspAdapter for CLspAdapter {
     fn process_diagnostics(
         &self,
         params: &mut lsp::PublishDiagnosticsParams,
-        buffer_access: Option<(LanguageServerId, &'_ Buffer)>,
+        server_id: LanguageServerId,
+        buffer_access: Option<&'_ Buffer>,
     ) {
-        if let Some((server_id, buffer)) = buffer_access {
+        if let Some(buffer) = buffer_access {
             let snapshot = buffer.snapshot();
             let inactive_regions = buffer
                 .get_diagnostics(server_id)
@@ -306,7 +307,6 @@ impl super::LspAdapter for CLspAdapter {
                 .flat_map(|v| v.iter())
                 .filter(|diag| clangd_ext::is_inactive_region(&diag.diagnostic))
                 .map(move |diag| {
-                    // try to reconstruct inactiveRegion diagnostic messages...
                     let range =
                         language::range_to_lsp(diag.range.to_point_utf16(&snapshot)).unwrap();
                     let mut tags = vec![];

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -279,10 +279,9 @@ impl super::LspAdapter for CLspAdapter {
                     // enable clangd's dot-to-arrow feature.
                     "editsNearCursor": true
                 },
-                // TODO: inactiveRegions support needs an implementation in clangd_ext.rs
-                // "inactiveRegionsCapabilities": {
-                //     "inactiveRegions": true,
-                // }
+                "inactiveRegionsCapabilities": {
+                    "inactiveRegions": true,
+                }
             }
         });
         if let Some(ref mut original_experimental) = original.capabilities.experimental {

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -244,7 +244,7 @@ impl LspAdapter for RustLspAdapter {
     fn process_diagnostics(
         &self,
         params: &mut lsp::PublishDiagnosticsParams,
-        _: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+        _: Option<(LanguageServerId, &'_ Buffer)>,
     ) {
         static REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"(?m)`([^`]+)\n`$").expect("Failed to create REGEX"));

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -244,7 +244,8 @@ impl LspAdapter for RustLspAdapter {
     fn process_diagnostics(
         &self,
         params: &mut lsp::PublishDiagnosticsParams,
-        _: Option<(LanguageServerId, &'_ Buffer)>,
+        _: LanguageServerId,
+        _: Option<&'_ Buffer>,
     ) {
         static REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"(?m)`([^`]+)\n`$").expect("Failed to create REGEX"));
@@ -949,7 +950,7 @@ mod tests {
                 },
             ],
         };
-        RustLspAdapter.process_diagnostics(&mut params, None);
+        RustLspAdapter.process_diagnostics(&mut params, LanguageServerId(0), None);
 
         assert_eq!(params.diagnostics[0].message, "use of moved value `a`");
 

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -241,7 +241,11 @@ impl LspAdapter for RustLspAdapter {
         Some("rust-analyzer/flycheck".into())
     }
 
-    fn process_diagnostics(&self, params: &mut lsp::PublishDiagnosticsParams) {
+    fn process_diagnostics(
+        &self,
+        params: &mut lsp::PublishDiagnosticsParams,
+        _: Option<&'_ mut dyn Iterator<Item = lsp::Diagnostic>>,
+    ) {
         static REGEX: LazyLock<Regex> =
             LazyLock::new(|| Regex::new(r"(?m)`([^`]+)\n`$").expect("Failed to create REGEX"));
 
@@ -945,7 +949,7 @@ mod tests {
                 },
             ],
         };
-        RustLspAdapter.process_diagnostics(&mut params);
+        RustLspAdapter.process_diagnostics(&mut params, None);
 
         assert_eq!(params.diagnostics[0].message, "use of moved value `a`");
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1790,6 +1790,7 @@ impl LocalLspStore {
         });
 
         let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx)?;
+
         let edits_since_save = std::cell::LazyCell::new(|| {
             let saved_version = buffer.read(cx).saved_version();
             Patch::new(snapshot.edits_since::<PointUtf16>(saved_version).collect())

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -455,9 +455,8 @@ impl LocalLspStore {
                                     .to_file_path()
                                     .map(|file_path| this.get_buffer(&file_path, cx))
                                     .ok()
-                                    .flatten()
-                                    .map(|v| (server_id, v));
-                                adapter.process_diagnostics(&mut params, buffer);
+                                    .flatten();
+                                adapter.process_diagnostics(&mut params, server_id, buffer);
                             }
 
                             this.update_diagnostics(
@@ -5895,7 +5894,7 @@ impl LspStore {
         version: Option<i32>,
         diagnostics: Vec<DiagnosticEntry<Unclipped<PointUtf16>>>,
         cx: &mut Context<Self>,
-    ) -> Result<(), anyhow::Error> {
+    ) -> anyhow::Result<()> {
         self.merge_diagnostic_entries(server_id, abs_path, version, diagnostics, |_| false, cx)
     }
 
@@ -5935,9 +5934,8 @@ impl LspStore {
                         diag.iter().filter(|v| filter(&v.diagnostic)).map(|v| {
                             let start = Unclipped(v.range.start.to_point_utf16(&snapshot));
                             let end = Unclipped(v.range.end.to_point_utf16(&snapshot));
-                            let range = start..end;
                             DiagnosticEntry {
-                                range,
+                                range: start..end,
                                 diagnostic: v.diagnostic.clone(),
                             }
                         })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1772,8 +1772,6 @@ impl LocalLspStore {
                 .then_with(|| a.message.cmp(&b.message))
         }
 
-        let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx)?;
-
         diagnostics.sort_unstable_by(|a, b| {
             Ordering::Equal
                 .then_with(|| a.range.start.cmp(&b.range.start))
@@ -1781,6 +1779,7 @@ impl LocalLspStore {
                 .then_with(|| compare_diagnostics(&a.diagnostic, &b.diagnostic))
         });
 
+        let snapshot = self.buffer_snapshot_for_lsp_version(buffer, server_id, version, cx)?;
         let edits_since_save = std::cell::LazyCell::new(|| {
             let saved_version = buffer.read(cx).saved_version();
             Patch::new(snapshot.edits_since::<PointUtf16>(saved_version).collect())

--- a/crates/project/src/lsp_store/clangd_ext.rs
+++ b/crates/project/src/lsp_store/clangd_ext.rs
@@ -75,10 +75,7 @@ pub fn register_notifications(
                         server_id,
                         mapped_diagnostics,
                         &adapter.disk_based_diagnostic_sources,
-                        |diag| {
-                            // we want to retain anything that isn't `inactiveRegions`.
-                            !is_inactive_region(diag)
-                        },
+                        |diag| !is_inactive_region(diag),
                         cx,
                     )
                     .log_err();

--- a/crates/project/src/lsp_store/clangd_ext.rs
+++ b/crates/project/src/lsp_store/clangd_ext.rs
@@ -9,6 +9,7 @@ use util::ResultExt as _;
 use crate::LspStore;
 
 pub const CLANGD_SERVER_NAME: &str = "clangd";
+const INACTIVE_REGION_MESSAGE: &str = "inactive region";
 
 #[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -26,8 +27,9 @@ impl lsp::notification::Notification for InactiveRegions {
 }
 
 pub fn is_inactive_region(diag: &Diagnostic) -> bool {
-    diag.severity == lsp::DiagnosticSeverity::INFORMATION
-        && diag.is_unnecessary
+    diag.is_unnecessary
+        && diag.severity == lsp::DiagnosticSeverity::INFORMATION
+        && diag.message == INACTIVE_REGION_MESSAGE
         && diag
             .source
             .as_ref()
@@ -59,7 +61,7 @@ pub fn register_notifications(
                             range,
                             severity: Some(lsp::DiagnosticSeverity::INFORMATION),
                             source: Some(CLANGD_SERVER_NAME.to_string()),
-                            message: "inactive region".to_string(),
+                            message: INACTIVE_REGION_MESSAGE.to_string(),
                             tags: Some(vec![lsp::DiagnosticTag::UNNECESSARY]),
                             ..Default::default()
                         })


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/13089

This PR attempts to resolve the issues discussed in my previous PR #26146.

TODOs:
- [X] merge`inactiveRegions` with existing diagnostics.
- [x] save `inactiveRegions` aside and merge in the `CLspAdapter`s `process_diagnostics` to avoid blinking of `inactiveRegions`.

Release Notes:

- Fixed: `inactiveRegions` doesn't replace existing diagnostics anymore
