### PR TITLE
gpui: Add `on_button_click` / `on_any_click`

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2291,8 +2291,7 @@ impl Pane {
             .on_click(cx.listener(move |pane: &mut Self, _, window, cx| {
                 pane.activate_item(ix, true, true, window, cx)
             }))
-            // TODO: This should be a click listener with the middle mouse button instead of a mouse down listener.
-            .on_mouse_down(
+            .on_button_click(
                 MouseButton::Middle,
                 cx.listener(move |pane, _event, window, cx| {
                     pane.close_item_by_id(item_id, SaveIntent::Close, window, cx)
@@ -3147,11 +3146,12 @@ impl Render for Pane {
         let should_display_tab_bar = self.should_display_tab_bar.clone();
         let display_tab_bar = should_display_tab_bar(window, cx);
         let Some(project) = self.project.upgrade() else {
-            return div().track_focus(&self.focus_handle(cx));
+            return div().id("pane").track_focus(&self.focus_handle(cx));
         };
         let is_local = project.read(cx).is_local();
 
         v_flex()
+            .id("pane")
             .key_context(key_context)
             .track_focus(&self.focus_handle(cx))
             .size_full()
@@ -3378,7 +3378,7 @@ impl Render for Pane {
                             }),
                     )
             })
-            .on_mouse_down(
+            .on_button_click(
                 MouseButton::Navigate(NavigationDirection::Back),
                 cx.listener(|pane, _, window, cx| {
                     if let Some(workspace) = pane.workspace.upgrade() {
@@ -3391,7 +3391,7 @@ impl Render for Pane {
                     }
                 }),
             )
-            .on_mouse_down(
+            .on_button_click(
                 MouseButton::Navigate(NavigationDirection::Forward),
                 cx.listener(|pane, _, window, cx| {
                     if let Some(workspace) = pane.workspace.upgrade() {


### PR DESCRIPTION
`Interactivity::on_click` now accepts a `MouseButton`, indicating which button the handler is interested in.

The fluent API has two new functions: `on_button_click`, `on_any_click`. The behavior of `on_click` is preserved: meaning left-click only.

In particular, this resolves the TODO in `crates/workspace/src/pane.rs`. I'm working on a feature that adds a "middle-click to hide panel" feature, and it was blocked by the existing APIs:
- If I bound the event to `mouse_down`, it would hide the panel, but then the `mouse_up` event would get delivered to whatever was behind the panel.
- If I bound the event to `mouse_up`, middle-clicking a tab would close the tab, but then it would hide the panel when you released the mouse button.

This resolves those issues by allowing proper click handlers for any mouse button.

Release Notes:

- N/A
