### PR TITLE
Fix editor's outline view confirm not working before any queries have

### DIFF
--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -277,6 +277,7 @@ impl PickerDelegate for OutlineViewDelegate {
         cx: &mut Context<Picker<OutlineViewDelegate>>,
     ) {
         self.prev_scroll_position.take();
+        self.set_selected_index(self.selected_match_index, true, cx);
 
         self.active_editor.update(cx, |active_editor, cx| {
             let highlight = active_editor
@@ -381,12 +382,13 @@ mod tests {
             path!("/dir"),
             json!({
                 "a.rs": indoc!{"
-                    struct SingleLine; // display line 0
-                                       // display line 1
-                    struct MultiLine { // display line 2
-                        field_1: i32,  // display line 3
-                        field_2: i32,  // display line 4
-                    }                  // display line 5
+                                       // display line 0
+                    struct SingleLine; // display line 1
+                                       // display line 2
+                    struct MultiLine { // display line 3
+                        field_1: i32,  // display line 4
+                        field_2: i32,  // display line 5
+                    }                  // display line 6
                 "}
             }),
         )
@@ -439,23 +441,29 @@ mod tests {
         );
         assert_single_caret_at_row(&editor, 0, cx);
 
+        cx.dispatch_action(menu::Confirm);
+        // Ensures that outline still goes to entry even if no queries have been made
+        assert_single_caret_at_row(&editor, 1, cx);
+
+        let outline_view = open_outline_view(&workspace, cx);
+
         cx.dispatch_action(menu::SelectNext);
         ensure_outline_view_contents(&outline_view, cx);
         assert_eq!(
             highlighted_display_rows(&editor, cx),
-            vec![2, 3, 4, 5],
+            vec![3, 4, 5, 6],
             "Second struct's rows should be highlighted"
         );
-        assert_single_caret_at_row(&editor, 0, cx);
+        assert_single_caret_at_row(&editor, 1, cx);
 
         cx.dispatch_action(menu::SelectPrevious);
         ensure_outline_view_contents(&outline_view, cx);
         assert_eq!(
             highlighted_display_rows(&editor, cx),
-            vec![0],
+            vec![1],
             "First struct's row should be highlighted"
         );
-        assert_single_caret_at_row(&editor, 0, cx);
+        assert_single_caret_at_row(&editor, 1, cx);
 
         cx.dispatch_action(menu::Cancel);
         ensure_outline_view_contents(&outline_view, cx);
@@ -464,7 +472,7 @@ mod tests {
             Vec::<u32>::new(),
             "No rows should be highlighted after outline view is cancelled and closed"
         );
-        assert_single_caret_at_row(&editor, 0, cx);
+        assert_single_caret_at_row(&editor, 1, cx);
 
         let outline_view = open_outline_view(&workspace, cx);
         ensure_outline_view_contents(&outline_view, cx);
@@ -473,16 +481,16 @@ mod tests {
             Vec::<u32>::new(),
             "Reopened outline view should have no highlights"
         );
-        assert_single_caret_at_row(&editor, 0, cx);
+        assert_single_caret_at_row(&editor, 1, cx);
 
-        let expected_first_highlighted_row = 2;
+        let expected_first_highlighted_row = 3;
         cx.dispatch_action(menu::SelectNext);
         ensure_outline_view_contents(&outline_view, cx);
         assert_eq!(
             highlighted_display_rows(&editor, cx),
-            vec![expected_first_highlighted_row, 3, 4, 5]
+            vec![expected_first_highlighted_row, 4, 5, 6]
         );
-        assert_single_caret_at_row(&editor, 0, cx);
+        assert_single_caret_at_row(&editor, 1, cx);
         cx.dispatch_action(menu::Confirm);
         ensure_outline_view_contents(&outline_view, cx);
         assert_eq!(


### PR DESCRIPTION
## Summary
This PR fixes a minor bug where editor's outline view wouldn't move the cursor on confirm before any outline queries have been made.

### Before 

https://github.com/user-attachments/assets/6ccca0c1-c0fa-46cb-b700-28a666d62ce8

### After

https://github.com/user-attachments/assets/d508e20b-90fb-471a-b974-431205501c89

Release Notes:

- Fixes bug where editor's outline view wouldn't move cursor on confirm action
