### PR TITLE
macOS: Disable fullscreen window tabbing (take 2)

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -512,6 +512,8 @@ impl MacWindow {
         unsafe {
             let pool = NSAutoreleasePool::new(nil);
 
+            let () = msg_send![class!(NSWindow), setAllowsAutomaticWindowTabbing: NO];
+
             let mut style_mask;
             if let Some(titlebar) = titlebar.as_ref() {
                 style_mask = NSWindowStyleMask::NSClosableWindowMask


### PR DESCRIPTION
Take 2 on https://github.com/zed-industries/zed/pull/26600. Now, it doesn't break remote development. 

Instead of using it in `build_classes`, it's now used in the `open` method while creating a window.  I found similar usage in other places over internet.

Release Notes:

- Fixed issue where Zed would show mac native tabs when opening new fullscreen windows on macOS.
