### PR TITLE
copilot: Handle sign out when copilot language server is not running

### DIFF
--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -654,6 +654,10 @@ impl Copilot {
                     anyhow::Ok(())
                 })
             }
+            CopilotServer::Disabled => cx.background_spawn(async {
+                clear_copilot_config_dir().await;
+                anyhow::Ok(())
+            }),
             _ => Task::ready(Err(anyhow!("copilot hasn't started yet"))),
         }
     }
@@ -1045,6 +1049,10 @@ fn uri_for_buffer(buffer: &Entity<Buffer>, cx: &App) -> lsp::Url {
 
 async fn clear_copilot_dir() {
     remove_matching(paths::copilot_dir(), |_| true).await
+}
+
+async fn clear_copilot_config_dir() {
+    remove_matching(copilot_chat::copilot_chat_config_dir(), |_| true).await
 }
 
 async fn get_copilot_lsp(http: Arc<dyn HttpClient>) -> anyhow::Result<PathBuf> {


### PR DESCRIPTION
When copilot is not being used as the edit prediction provider and you open a fresh Zed instance, we don’t run the copilot language server. This is because copilot chat is purely handled via oauth token and doesn’t require the language server.  

In this case, if you click sign out, instead of asking the language server to sign out (which isn’t running), we can manually clear the config directory, which contains the oauth tokens. We already watch this directory, and if the token is not found, we update the sign-in status. 

Release Notes:

- N/A
