### PR TITLE
Refine word completions

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -362,6 +362,7 @@
       "ctrl-k ctrl-0": "editor::FoldAll",
       "ctrl-k ctrl-j": "editor::UnfoldAll",
       "ctrl-space": "editor::ShowCompletions",
+      "ctrl-shift-space": "editor::ShowWordCompletions",
       "ctrl-.": "editor::ToggleCodeActions",
       "ctrl-k r": "editor::RevealInFileManager",
       "ctrl-k p": "editor::CopyPath",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -466,6 +466,7 @@
       // Using `ctrl-space` in Zed requires disabling the macOS global shortcut.
       // System Preferences->Keyboard->Keyboard Shortcuts->Input Sources->Select the previous input source (uncheck)
       "ctrl-space": "editor::ShowCompletions",
+      "ctrl-shift-space": "editor::ShowWordCompletions",
       "cmd-.": "editor::ToggleCodeActions",
       "cmd-k r": "editor::RevealInFileManager",
       "cmd-k p": "editor::CopyPath",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1092,11 +1092,12 @@
     //
     // May take 3 values:
     // 1. "enabled"
-    //   Always fetch document's words for completions.
+    //   Always fetch document's words for completions along with LSP completions.
     // 2. "fallback"
-    //   Only if LSP response errors/times out/is empty, use document's words to show completions.
+    //   Only if LSP response errors or times out, use document's words to show completions.
     // 3. "disabled"
     //   Never fetch or complete document's words for completions.
+    //   (Word-based completions can still be queried via a separate action)
     //
     // Default: fallback
     "words": "fallback",
@@ -1107,8 +1108,8 @@
     // When fetching LSP completions, determines how long to wait for a response of a particular server.
     // When set to 0, waits indefinitely.
     //
-    // Default: 500
-    "lsp_fetch_timeout_ms": 500
+    // Default: 0
+    "lsp_fetch_timeout_ms": 0
   },
   // Different settings for specific languages.
   "languages": {

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -48,7 +48,7 @@ impl SlashCommandCompletionProvider {
         name_range: Range<Anchor>,
         window: &mut Window,
         cx: &mut App,
-    ) -> Task<Result<Vec<project::Completion>>> {
+    ) -> Task<Result<Option<Vec<project::Completion>>>> {
         let slash_commands = self.slash_commands.clone();
         let candidates = slash_commands
             .command_names(cx)
@@ -71,65 +71,67 @@ impl SlashCommandCompletionProvider {
             .await;
 
             cx.update(|_, cx| {
-                matches
-                    .into_iter()
-                    .filter_map(|mat| {
-                        let command = slash_commands.command(&mat.string, cx)?;
-                        let mut new_text = mat.string.clone();
-                        let requires_argument = command.requires_argument();
-                        let accepts_arguments = command.accepts_arguments();
-                        if requires_argument || accepts_arguments {
-                            new_text.push(' ');
-                        }
+                Some(
+                    matches
+                        .into_iter()
+                        .filter_map(|mat| {
+                            let command = slash_commands.command(&mat.string, cx)?;
+                            let mut new_text = mat.string.clone();
+                            let requires_argument = command.requires_argument();
+                            let accepts_arguments = command.accepts_arguments();
+                            if requires_argument || accepts_arguments {
+                                new_text.push(' ');
+                            }
 
-                        let confirm =
-                            editor
-                                .clone()
-                                .zip(workspace.clone())
-                                .map(|(editor, workspace)| {
-                                    let command_name = mat.string.clone();
-                                    let command_range = command_range.clone();
-                                    let editor = editor.clone();
-                                    let workspace = workspace.clone();
-                                    Arc::new(
-                                    move |intent: CompletionIntent,
-                                          window: &mut Window,
-                                          cx: &mut App| {
-                                        if !requires_argument
-                                            && (!accepts_arguments || intent.is_complete())
-                                        {
-                                            editor
-                                                .update(cx, |editor, cx| {
-                                                    editor.run_command(
-                                                        command_range.clone(),
-                                                        &command_name,
-                                                        &[],
-                                                        true,
-                                                        workspace.clone(),
-                                                        window,
-                                                        cx,
-                                                    );
-                                                })
-                                                .ok();
-                                            false
-                                        } else {
-                                            requires_argument || accepts_arguments
-                                        }
-                                    },
-                                ) as Arc<_>
-                                });
-                        Some(project::Completion {
-                            old_range: name_range.clone(),
-                            documentation: Some(CompletionDocumentation::SingleLine(
-                                command.description().into(),
-                            )),
-                            new_text,
-                            label: command.label(cx),
-                            confirm,
-                            source: CompletionSource::Custom,
+                            let confirm =
+                                editor
+                                    .clone()
+                                    .zip(workspace.clone())
+                                    .map(|(editor, workspace)| {
+                                        let command_name = mat.string.clone();
+                                        let command_range = command_range.clone();
+                                        let editor = editor.clone();
+                                        let workspace = workspace.clone();
+                                        Arc::new(
+                                            move |intent: CompletionIntent,
+                                            window: &mut Window,
+                                            cx: &mut App| {
+                                                if !requires_argument
+                                                && (!accepts_arguments || intent.is_complete())
+                                                {
+                                                    editor
+                                                        .update(cx, |editor, cx| {
+                                                            editor.run_command(
+                                                                command_range.clone(),
+                                                                &command_name,
+                                                                &[],
+                                                                true,
+                                                                workspace.clone(),
+                                                                window,
+                                                                cx,
+                                                            );
+                                                        })
+                                                        .ok();
+                                                    false
+                                                } else {
+                                                    requires_argument || accepts_arguments
+                                                }
+                                            },
+                                        ) as Arc<_>
+                                    });
+                            Some(project::Completion {
+                                old_range: name_range.clone(),
+                                documentation: Some(CompletionDocumentation::SingleLine(
+                                    command.description().into(),
+                                )),
+                                new_text,
+                                label: command.label(cx),
+                                confirm,
+                                source: CompletionSource::Custom,
+                            })
                         })
-                    })
-                    .collect()
+                        .collect(),
+                )
             })
         })
     }
@@ -143,7 +145,7 @@ impl SlashCommandCompletionProvider {
         last_argument_range: Range<Anchor>,
         window: &mut Window,
         cx: &mut App,
-    ) -> Task<Result<Vec<project::Completion>>> {
+    ) -> Task<Result<Option<Vec<project::Completion>>>> {
         let new_cancel_flag = Arc::new(AtomicBool::new(false));
         let mut flag = self.cancel_flag.lock();
         flag.store(true, SeqCst);
@@ -161,27 +163,28 @@ impl SlashCommandCompletionProvider {
             let workspace = self.workspace.clone();
             let arguments = arguments.to_vec();
             cx.background_spawn(async move {
-                Ok(completions
-                    .await?
-                    .into_iter()
-                    .map(|new_argument| {
-                        let confirm =
-                            editor
-                                .clone()
-                                .zip(workspace.clone())
-                                .map(|(editor, workspace)| {
-                                    Arc::new({
-                                        let mut completed_arguments = arguments.clone();
-                                        if new_argument.replace_previous_arguments {
-                                            completed_arguments.clear();
-                                        } else {
-                                            completed_arguments.pop();
-                                        }
-                                        completed_arguments.push(new_argument.new_text.clone());
+                Ok(Some(
+                    completions
+                        .await?
+                        .into_iter()
+                        .map(|new_argument| {
+                            let confirm =
+                                editor
+                                    .clone()
+                                    .zip(workspace.clone())
+                                    .map(|(editor, workspace)| {
+                                        Arc::new({
+                                            let mut completed_arguments = arguments.clone();
+                                            if new_argument.replace_previous_arguments {
+                                                completed_arguments.clear();
+                                            } else {
+                                                completed_arguments.pop();
+                                            }
+                                            completed_arguments.push(new_argument.new_text.clone());
 
-                                        let command_range = command_range.clone();
-                                        let command_name = command_name.clone();
-                                        move |intent: CompletionIntent,
+                                            let command_range = command_range.clone();
+                                            let command_name = command_name.clone();
+                                            move |intent: CompletionIntent,
                                               window: &mut Window,
                                               cx: &mut App| {
                                             if new_argument.after_completion.run()
@@ -205,31 +208,32 @@ impl SlashCommandCompletionProvider {
                                                 !new_argument.after_completion.run()
                                             }
                                         }
-                                    }) as Arc<_>
-                                });
+                                        }) as Arc<_>
+                                    });
 
-                        let mut new_text = new_argument.new_text.clone();
-                        if new_argument.after_completion == AfterCompletion::Continue {
-                            new_text.push(' ');
-                        }
+                            let mut new_text = new_argument.new_text.clone();
+                            if new_argument.after_completion == AfterCompletion::Continue {
+                                new_text.push(' ');
+                            }
 
-                        project::Completion {
-                            old_range: if new_argument.replace_previous_arguments {
-                                argument_range.clone()
-                            } else {
-                                last_argument_range.clone()
-                            },
-                            label: new_argument.label,
-                            new_text,
-                            documentation: None,
-                            confirm,
-                            source: CompletionSource::Custom,
-                        }
-                    })
-                    .collect())
+                            project::Completion {
+                                old_range: if new_argument.replace_previous_arguments {
+                                    argument_range.clone()
+                                } else {
+                                    last_argument_range.clone()
+                                },
+                                label: new_argument.label,
+                                new_text,
+                                documentation: None,
+                                confirm,
+                                source: CompletionSource::Custom,
+                            }
+                        })
+                        .collect(),
+                ))
             })
         } else {
-            Task::ready(Ok(Vec::new()))
+            Task::ready(Ok(Some(Vec::new())))
         }
     }
 }
@@ -242,7 +246,7 @@ impl CompletionProvider for SlashCommandCompletionProvider {
         _: editor::CompletionContext,
         window: &mut Window,
         cx: &mut Context<Editor>,
-    ) -> Task<Result<Vec<project::Completion>>> {
+    ) -> Task<Result<Option<Vec<project::Completion>>>> {
         let Some((name, arguments, command_range, last_argument_range)) =
             buffer.update(cx, |buffer, _cx| {
                 let position = buffer_position.to_point(buffer);
@@ -286,7 +290,7 @@ impl CompletionProvider for SlashCommandCompletionProvider {
                 Some((name, arguments, command_range, last_argument_range))
             })
         else {
-            return Task::ready(Ok(Vec::new()));
+            return Task::ready(Ok(Some(Vec::new())));
         };
 
         if let Some((arguments, argument_range)) = arguments {

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -1,6 +1,6 @@
 //! This module contains all actions supported by [`Editor`].
 use super::*;
-use gpui::{action_as, action_with_deprecated_aliases};
+use gpui::{action_as, action_with_deprecated_aliases, actions};
 use schemars::JsonSchema;
 use util::serde::default_true;
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
@@ -248,7 +248,7 @@ impl_actions!(
     ]
 );
 
-gpui::actions!(
+actions!(
     editor,
     [
         AcceptEditPrediction,
@@ -404,6 +404,7 @@ gpui::actions!(
         ShowCharacterPalette,
         ShowEditPrediction,
         ShowSignatureHelp,
+        ShowWordCompletions,
         ShuffleLines,
         SortLinesCaseInsensitive,
         SortLinesCaseSensitive,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -106,7 +106,7 @@ use language::{
     point_from_lsp, text_diff_with_options, AutoindentMode, BracketMatch, BracketPair, Buffer,
     Capability, CharKind, CodeLabel, CursorShape, Diagnostic, DiffOptions, EditPredictionsMode,
     EditPreview, HighlightedText, IndentKind, IndentSize, Language, OffsetRangeExt, Point,
-    Selection, SelectionGoal, TextObject, TransactionId, TreeSitterOptions,
+    Selection, SelectionGoal, TextObject, TransactionId, TreeSitterOptions, WordsQuery,
 };
 use language::{point_to_lsp, BufferRow, CharClassifier, Runnable, RunnableRange};
 use linked_editing_ranges::refresh_linked_ranges;
@@ -4095,7 +4095,11 @@ impl Editor {
                     WordsCompletionMode::Disabled => Task::ready(HashMap::default()),
                     WordsCompletionMode::Enabled | WordsCompletionMode::Fallback => cx
                         .background_spawn(async move {
-                            buffer_snapshot.words_in_range(None, word_search_range)
+                            buffer_snapshot.words_in_range(WordsQuery {
+                                fuzzy_contents: None,
+                                range: word_search_range,
+                                skip_digits: true,
+                            })
                         }),
                 };
 
@@ -4103,7 +4107,11 @@ impl Editor {
             }
             None => (
                 cx.background_spawn(async move {
-                    buffer_snapshot.words_in_range(None, word_search_range)
+                    buffer_snapshot.words_in_range(WordsQuery {
+                        fuzzy_contents: None,
+                        range: word_search_range,
+                        skip_digits: true,
+                    })
                 }),
                 Task::ready(Ok(Vec::new())),
             ),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -390,6 +390,7 @@ impl EditorElement {
         register_action(editor, window, Editor::set_mark);
         register_action(editor, window, Editor::swap_selection_ends);
         register_action(editor, window, Editor::show_completions);
+        register_action(editor, window, Editor::show_word_completions);
         register_action(editor, window, Editor::toggle_code_actions);
         register_action(editor, window, Editor::open_excerpts);
         register_action(editor, window, Editor::open_excerpts_in_split);

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -714,6 +714,7 @@ async fn test_extension_store_with_test_extension(cx: &mut TestAppContext) {
         })
         .await
         .unwrap()
+        .unwrap()
         .into_iter()
         .map(|c| c.label.text)
         .collect::<Vec<_>>();

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4189,10 +4189,14 @@ impl BufferSnapshot {
                 } else if let Some(word_start) = current_word_start_ix.take() {
                     if query_ix == query_len {
                         let word_range = self.anchor_before(word_start)..self.anchor_after(ix);
-                        words.insert(
-                            self.text_for_range(word_start..ix).collect::<String>(),
-                            word_range,
-                        );
+                        let mut word_text = self.text_for_range(word_start..ix).peekable();
+                        let first_char = word_text
+                            .peek()
+                            .and_then(|first_chunk| first_chunk.chars().next());
+                        // Skip empty and "words" starting with digits as a heuristic to reduce useless completions
+                        if !first_char.map_or(true, |first_char| first_char.is_digit(10)) {
+                            words.insert(word_text.collect(), word_range);
+                        }
                     }
                 }
                 query_ix = 0;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4146,12 +4146,9 @@ impl BufferSnapshot {
         }
     }
 
-    pub fn words_in_range(
-        &self,
-        query: Option<&str>,
-        range: Range<usize>,
-    ) -> HashMap<String, Range<Anchor>> {
-        if query.map_or(false, |query| query.is_empty()) {
+    pub fn words_in_range(&self, query: WordsQuery) -> HashMap<String, Range<Anchor>> {
+        let query_str = query.fuzzy_contents;
+        if query_str.map_or(false, |query| query.is_empty()) {
             return HashMap::default();
         }
 
@@ -4161,13 +4158,13 @@ impl BufferSnapshot {
         }));
 
         let mut query_ix = 0;
-        let query = query.map(|query| query.chars().collect::<Vec<_>>());
-        let query_len = query.as_ref().map_or(0, |query| query.len());
+        let query_chars = query_str.map(|query| query.chars().collect::<Vec<_>>());
+        let query_len = query_chars.as_ref().map_or(0, |query| query.len());
 
         let mut words = HashMap::default();
         let mut current_word_start_ix = None;
-        let mut chunk_ix = range.start;
-        for chunk in self.chunks(range, false) {
+        let mut chunk_ix = query.range.start;
+        for chunk in self.chunks(query.range, false) {
             for (i, c) in chunk.text.char_indices() {
                 let ix = chunk_ix + i;
                 if classifier.is_word(c) {
@@ -4175,12 +4172,9 @@ impl BufferSnapshot {
                         current_word_start_ix = Some(ix);
                     }
 
-                    if let Some(query) = &query {
+                    if let Some(query_chars) = &query_chars {
                         if query_ix < query_len {
-                            let query_c = query.get(query_ix).expect(
-                                "query_ix is a vec of chars, which we access only if before the end",
-                            );
-                            if c.to_lowercase().eq(query_c.to_lowercase()) {
+                            if c.to_lowercase().eq(query_chars[query_ix].to_lowercase()) {
                                 query_ix += 1;
                             }
                         }
@@ -4194,7 +4188,9 @@ impl BufferSnapshot {
                             .peek()
                             .and_then(|first_chunk| first_chunk.chars().next());
                         // Skip empty and "words" starting with digits as a heuristic to reduce useless completions
-                        if !first_char.map_or(true, |first_char| first_char.is_digit(10)) {
+                        if !query.skip_digits
+                            || first_char.map_or(true, |first_char| !first_char.is_digit(10))
+                        {
                             words.insert(word_text.collect(), word_range);
                         }
                     }
@@ -4206,6 +4202,15 @@ impl BufferSnapshot {
 
         words
     }
+}
+
+pub struct WordsQuery<'a> {
+    /// Only returns words with all chars from the fuzzy string in them.
+    pub fuzzy_contents: Option<&'a str>,
+    /// Skips words that start with a digit.
+    pub skip_digits: bool,
+    /// Buffer offset range, to look for words.
+    pub range: Range<usize>,
 }
 
 fn indent_size_for_line(text: &text::BufferSnapshot, row: u32) -> IndentSize {

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3145,7 +3145,11 @@ fn test_trailing_whitespace_ranges(mut rng: StdRng) {
 fn test_words_in_range(cx: &mut gpui::App) {
     init_settings(cx, |_| {});
 
-    let contents = r#"let word=öäpple.bar你 Öäpple word2-öÄpPlE-Pizza-word ÖÄPPLE word"#;
+    // The first line are words excluded from the results with heuristics, we do not expect them in the test assertions.
+    let contents = r#"
+0_isize 123 3.4 4  
+let word=öäpple.bar你 Öäpple word2-öÄpPlE-Pizza-word ÖÄPPLE word
+    "#;
 
     let buffer = cx.new(|cx| {
         let buffer = Buffer::local(contents, cx).with_language(Arc::new(rust_lang()), cx);

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3163,7 +3163,11 @@ let word=öäpple.bar你 Öäpple word2-öÄpPlE-Pizza-word ÖÄPPLE word
         assert_eq!(
             BTreeSet::from_iter(["Pizza".to_string()]),
             snapshot
-                .words_in_range(Some("piz"), 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: Some("piz"),
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                })
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );
@@ -3175,7 +3179,11 @@ let word=öäpple.bar你 Öäpple word2-öÄpPlE-Pizza-word ÖÄPPLE word
                 "ÖÄPPLE".to_string(),
             ]),
             snapshot
-                .words_in_range(Some("öp"), 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: Some("öp"),
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                })
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );
@@ -3187,28 +3195,44 @@ let word=öäpple.bar你 Öäpple word2-öÄpPlE-Pizza-word ÖÄPPLE word
                 "öäpple".to_string(),
             ]),
             snapshot
-                .words_in_range(Some("öÄ"), 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: Some("öÄ"),
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                })
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );
         assert_eq!(
             BTreeSet::default(),
             snapshot
-                .words_in_range(Some("öÄ好"), 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: Some("öÄ好"),
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                })
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );
         assert_eq!(
             BTreeSet::from_iter(["bar你".to_string(),]),
             snapshot
-                .words_in_range(Some("你"), 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: Some("你"),
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                })
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );
         assert_eq!(
             BTreeSet::default(),
             snapshot
-                .words_in_range(Some(""), 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: Some(""),
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                },)
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );
@@ -3225,7 +3249,36 @@ let word=öäpple.bar你 Öäpple word2-öÄpPlE-Pizza-word ÖÄPPLE word
                 "word2".to_string(),
             ]),
             snapshot
-                .words_in_range(None, 0..snapshot.len())
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: None,
+                    skip_digits: true,
+                    range: 0..snapshot.len(),
+                })
+                .into_keys()
+                .collect::<BTreeSet<_>>()
+        );
+        assert_eq!(
+            BTreeSet::from_iter([
+                "0_isize".to_string(),
+                "123".to_string(),
+                "3".to_string(),
+                "4".to_string(),
+                "bar你".to_string(),
+                "öÄpPlE".to_string(),
+                "Öäpple".to_string(),
+                "ÖÄPPLE".to_string(),
+                "öäpple".to_string(),
+                "let".to_string(),
+                "Pizza".to_string(),
+                "word".to_string(),
+                "word2".to_string(),
+            ]),
+            snapshot
+                .words_in_range(WordsQuery {
+                    fuzzy_contents: None,
+                    skip_digits: false,
+                    range: 0..snapshot.len(),
+                })
                 .into_keys()
                 .collect::<BTreeSet<_>>()
         );

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -326,8 +326,8 @@ pub struct CompletionSettings {
     /// When fetching LSP completions, determines how long to wait for a response of a particular server.
     /// When set to 0, waits indefinitely.
     ///
-    /// Default: 500
-    #[serde(default = "lsp_fetch_timeout_ms")]
+    /// Default: 0
+    #[serde(default = "default_lsp_fetch_timeout_ms")]
     pub lsp_fetch_timeout_ms: u64,
 }
 
@@ -335,12 +335,13 @@ pub struct CompletionSettings {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum WordsCompletionMode {
-    /// Always fetch document's words for completions.
+    /// Always fetch document's words for completions along with LSP completions.
     Enabled,
-    /// Only if LSP response errors/times out/is empty,
+    /// Only if LSP response errors or times out,
     /// use document's words to show completions.
     Fallback,
     /// Never fetch or complete document's words for completions.
+    /// (Word-based completions can still be queried via a separate action)
     Disabled,
 }
 
@@ -348,8 +349,8 @@ fn default_words_completion_mode() -> WordsCompletionMode {
     WordsCompletionMode::Fallback
 }
 
-fn lsp_fetch_timeout_ms() -> u64 {
-    500
+fn default_lsp_fetch_timeout_ms() -> u64 {
+    0
 }
 
 /// The settings for a particular language.

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -7299,14 +7299,6 @@ impl Iterator for MultiBufferRows<'_> {
 
         let overshoot = self.point - region.range.start;
         let buffer_point = region.buffer_range.start + overshoot;
-        // dbg!(
-        //     buffer_point.row,
-        //     region.range.end.column,
-        //     self.point.row,
-        //     region.range.end.row,
-        //     self.cursor.is_at_end_of_excerpt(),
-        //     region.buffer.max_point().row
-        // );
         let expand_info = if self.is_singleton {
             None
         } else {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -4402,7 +4402,7 @@ impl LspStore {
         position: PointUtf16,
         context: CompletionContext,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Vec<Completion>>> {
+    ) -> Task<Result<Option<Vec<Completion>>>> {
         let language_registry = self.languages.clone();
 
         if let Some((upstream_client, project_id)) = self.upstream_client() {
@@ -4430,7 +4430,7 @@ impl LspStore {
                 let mut result = Vec::new();
                 populate_labels_for_completions(completions, language, lsp_adapter, &mut result)
                     .await;
-                Ok(result)
+                Ok(Some(result))
             })
         } else if let Some(local) = self.as_local() {
             let snapshot = buffer.read(cx).snapshot();
@@ -4444,7 +4444,7 @@ impl LspStore {
             )
             .completions;
             if !completion_settings.lsp {
-                return Task::ready(Ok(Vec::new()));
+                return Task::ready(Ok(None));
             }
 
             let server_ids: Vec<_> = buffer.update(cx, |buffer, cx| {
@@ -4523,7 +4523,7 @@ impl LspStore {
                     }
                 }
 
-                Ok(completions)
+                Ok(Some(completions))
             })
         } else {
             Task::ready(Err(anyhow!("No upstream client or local language server")))

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3142,7 +3142,7 @@ impl Project {
         position: T,
         context: CompletionContext,
         cx: &mut Context<Self>,
-    ) -> Task<Result<Vec<Completion>>> {
+    ) -> Task<Result<Option<Vec<Completion>>>> {
         let position = position.to_point_utf16(buffer.read(cx));
         self.lsp_store.update(cx, |lsp_store, cx| {
             lsp_store.completions(buffer, position, context, cx)

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2825,7 +2825,7 @@ async fn test_completions_without_edit_ranges(cx: &mut gpui::TestAppContext) {
         })
         .next()
         .await;
-    let completions = completions.await.unwrap();
+    let completions = completions.await.unwrap().unwrap();
     let snapshot = buffer.update(cx, |buffer, _| buffer.snapshot());
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "fullyQualifiedName");
@@ -2851,7 +2851,7 @@ async fn test_completions_without_edit_ranges(cx: &mut gpui::TestAppContext) {
         })
         .next()
         .await;
-    let completions = completions.await.unwrap();
+    let completions = completions.await.unwrap().unwrap();
     let snapshot = buffer.update(cx, |buffer, _| buffer.snapshot());
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "component");
@@ -2919,7 +2919,7 @@ async fn test_completions_with_carriage_returns(cx: &mut gpui::TestAppContext) {
         })
         .next()
         .await;
-    let completions = completions.await.unwrap();
+    let completions = completions.await.unwrap().unwrap();
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "fully\nQualified\nName");
 }

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -506,7 +506,11 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
         .unwrap();
 
     assert_eq!(
-        result.into_iter().map(|c| c.label.text).collect::<Vec<_>>(),
+        result
+            .unwrap()
+            .into_iter()
+            .map(|c| c.label.text)
+            .collect::<Vec<_>>(),
         vec!["boop".to_string()]
     );
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/26410

* Extract word completions into their own, `editor::ShowWordCompletions` action so those could be triggered independently of completions
* Assign `ctrl-shift-space` binding to this new action
* Still keep words returned along the completions as in the original PR, but:
    * Tone down regular completions' fallback logic, skip words when the language server responds with empty list of completions, but keep on adding words if nothing or an error were returned instead
    * Adjust the defaults to wait for LSP completions infinitely
    * Skip "words" with digits such as `0_usize` or `2.f32` from completion items, unless a completion query has digits in it

Release Notes:

- N/A 
