### PR TITLE
assistant2: Add "running" status feedback in the disclosure

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -811,6 +811,34 @@ impl ActiveThread {
                                                 .buffer_font(cx),
                                         ),
                                 ),
+                                ToolUseStatus::Running => container.child(
+                                    content_container().child(
+                                        h_flex()
+                                            .gap_1()
+                                            .pb_1()
+                                            .child(
+                                                Icon::new(IconName::ArrowCircle)
+                                                    .size(IconSize::Small)
+                                                    .color(Color::Accent)
+                                                    .with_animation(
+                                                        "arrow-circle",
+                                                        Animation::new(Duration::from_secs(2))
+                                                            .repeat(),
+                                                        |icon, delta| {
+                                                            icon.transform(Transformation::rotate(
+                                                                percentage(delta),
+                                                            ))
+                                                        },
+                                                    ),
+                                            )
+                                            .child(
+                                                Label::new("Running…")
+                                                    .size(LabelSize::XSmall)
+                                                    .color(Color::Muted)
+                                                    .buffer_font(cx),
+                                            ),
+                                    ),
+                                ),
                                 ToolUseStatus::Error(err) => container.child(
                                     content_container()
                                         .child(
@@ -823,7 +851,7 @@ impl ActiveThread {
                                             Label::new(err).size(LabelSize::Small).buffer_font(cx),
                                         ),
                                 ),
-                                ToolUseStatus::Pending | ToolUseStatus::Running => container,
+                                ToolUseStatus::Pending => container,
                             }),
                     )
                 }),


### PR DESCRIPTION
Just a tiny bit of polish here, so that if the user expands the disclosure, an equivalent loading state is at the response container.

<img src="https://github.com/user-attachments/assets/a2ecb7f4-c9ea-4a14-8a60-9f7f2983a1a1" width="600px" />

Release Notes:

- N/A
