### PR TITLE
file_finder: Fix panic when file name contains new line

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -169,7 +169,7 @@ impl<T: AsRef<Path>> From<T> for SanitizedPath {
 /// A delimiter to use in `path_query:row_number:column_number` strings parsing.
 pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
-const ROW_COL_CAPTURE_REGEX: &str = r"(?x)
+const ROW_COL_CAPTURE_REGEX: &str = r"(?xs)
     ([^\(]+)(?:
         \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column)
         |
@@ -621,6 +621,24 @@ mod tests {
             PathWithPosition {
                 path: PathBuf::from("test_file.rs"),
                 row: Some(1),
+                column: None
+            }
+        );
+
+        assert_eq!(
+            PathWithPosition::parse_str("ab\ncd"),
+            PathWithPosition {
+                path: PathBuf::from("ab\ncd"),
+                row: None,
+                column: None
+            }
+        );
+
+        assert_eq!(
+            PathWithPosition::parse_str("👋\nab"),
+            PathWithPosition {
+                path: PathBuf::from("👋\nab"),
+                row: None,
                 column: None
             }
         );


### PR DESCRIPTION
Closes #26777

This PR fixes a panic when a file name contains a newline and a multi-byte character like 👋 (4 bytes in UTF-8). The issue was in the regex not considering newlines in file names, causing it to match only the latter part of the file name.

For example:

```
 left: PathWithPosition { path: "ab", row: None, column: None } // matched
 right: PathWithPosition { path: "ab\ncd", row: None, column: None } // actual file name
```


This resulted in incorrect index calculation later in the code, which went unnoticed until now due to the lack of tests with file names containing newlines. 

We discovered this issue when a panic occurred due to incorrect index calculation while trying to get the index of a multi-byte character. After the newline fix, the index calculation is always correct, even in the case of multi-byte characters.

Release Notes:

- Fixed an issue where file names with newlines and multi-byte characters could cause a crash in certain cases.
