### PR TITLE
docs: Fix wrong html-like tags shortcut for Vim

### DIFF
--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -105,8 +105,8 @@ Treesitter is a powerful tool that Zed uses to understand the structure of your 
 | A comment                                                  | `g c`            |
 | An argument, or list item, etc.                            | `i a`            |
 | An argument, or list item, etc. (including trailing comma) | `a a`            |
-| Around an HTML-like tag                                    | `i a`            |
-| Inside an HTML-like tag                                    | `i a`            |
+| Around an HTML-like tag                                    | `a t`            |
+| Inside an HTML-like tag                                    | `i t`            |
 | The current indent level, and one line before and after    | `a I`            |
 | The current indent level, and one line before              | `a i`            |
 | The current indent level                                   | `i i`            |


### PR DESCRIPTION
Release Notes:

- N/A