### PR TITLE
editor: Change order of format and timeout futures

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12820,11 +12820,11 @@ impl Editor {
 
         cx.spawn_in(window, |_, mut cx| async move {
             let transaction = futures::select_biased! {
+                transaction = format.log_err().fuse() => transaction,
                 () = timeout => {
                     log::warn!("timed out waiting for formatting");
                     None
                 }
-                transaction = format.log_err().fuse() => transaction,
             };
 
             buffer


### PR DESCRIPTION
Very small change, simply changing the order of the futures we pass to `select_biased!` so that if the format request and the timeout resolve at the same time (highly unlikely) we choose the format request instead of choosing the timeout and throwing away our work!

Release Notes:

- N/A
