### PR TITLE
editor: Disable selection highlights for single line editor

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4937,6 +4937,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) {
+        if matches!(self.mode, EditorMode::SingleLine { .. }) {
+            return;
+        }
         self.selection_highlight_task.take();
         if !EditorSettings::get_global(cx).selection_highlight {
             self.clear_background_highlights::<SelectedTextHighlight>(cx);


### PR DESCRIPTION
Fixes the selection highlight appearing in single-line editors like the file picker, command palette, etc.

Release Notes:

- Fixed selection highlight appearing in input fields like the file picker, command palette, etc.
