### PR TITLE
python: Fix incorrect highlighting of function parameters

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -56,13 +56,13 @@
 (function_definition
   parameters: (parameters
   [
-      (identifier) @function.arguments ; Simple parameters
+      (identifier) @variable.parameter; Simple parameters
       (typed_parameter
-        (identifier) @function.arguments) ; Typed parameters
+        (identifier) @variable.parameter) ; Typed parameters
       (default_parameter
-        name: (identifier) @function.arguments) ; Default parameters
+        name: (identifier) @variable.parameter) ; Default parameters
       (typed_default_parameter
-        name: (identifier) @function.arguments) ; Typed default parameters
+        name: (identifier) @variable.parameter) ; Typed default parameters
   ]))
 
 ; Keyword arguments

--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -88,9 +88,9 @@
 
 ((call
   function: (identifier) @function.builtin)
- (#match?
+ (#any-of?
    @function.builtin
-   "^(abs|all|any|ascii|bin|bool|breakpoint|bytearray|bytes|callable|chr|classmethod|compile|complex|delattr|dict|dir|divmod|enumerate|eval|exec|filter|float|format|frozenset|getattr|globals|hasattr|hash|help|hex|id|input|int|isinstance|issubclass|iter|len|list|locals|map|max|memoryview|min|next|object|oct|open|ord|pow|print|property|range|repr|reversed|round|set|setattr|slice|sorted|staticmethod|str|sum|super|tuple|type|vars|zip|__import__)$"))
+   "abs" "all" "any" "ascii" "bin" "bool" "breakpoint" "bytearray" "bytes" "callable" "chr" "classmethod" "compile" "complex" "delattr" "dict" "dir" "divmod" "enumerate" "eval" "exec" "filter" "float" "format" "frozenset" "getattr" "globals" "hasattr" "hash" "help" "hex" "id" "input" "int" "isinstance" "issubclass" "iter" "len" "list" "locals" "map" "max" "memoryview" "min" "next" "object" "oct" "open" "ord" "pow" "print" "property" "range" "repr" "reversed" "round" "set" "setattr" "slice" "sorted" "staticmethod" "str" "sum" "super" "tuple" "type" "vars" "zip" "__import__"))
 
 ((identifier) @type.builtin
     (#any-of? @type.builtin "int" "float" "complex" "bool" "list" "tuple" "range" "str" "bytes" "bytearray" "memoryview" "set" "frozenset" "dict"))
@@ -117,7 +117,7 @@
 [
   (parameters (identifier) @variable.special)
   (attribute (identifier) @variable.special)
-  (#match? @variable.special "^self|cls$")
+  (#any-of? @variable.special "self" "cls")
 ]
 
 [


### PR DESCRIPTION
This PR addresses the highlighting of function parameters in Python.

#21454 added various improvements to Python highlighting. However, some of the capture groups are missing corresponding colors in themes, which was also [noted on the PR](https://github.com/zed-industries/zed/pull/21454#pullrequestreview-2537510964).

Currently, this is especially bad for function parameters, which are not only missing corresponding colors, but are also captured incorrectly as `arguments` instead of `parameters`. Additionally, as not one theme defines `function.arguments` (I cheked this with the [extension surveyor](https://github.com/zed-industries/extension-surveyor), we instead always fall back to `function` here. Thus, parameters are always highlighted the same as functions, resulting in incorrect and inproper highlighting.

This PR resolves this issue by instead capturing parameters as `variable.parameter`, which has not perfect, but much better coverage among existing themes. 

| `main` | <img width="670" alt="main" src="https://github.com/user-attachments/assets/6942b494-fe0f-4537-8503-8de4e2c5a30e" /> |
| --- | --- |
| This PR | <img width="670" alt="PR" src="https://github.com/user-attachments/assets/f0d1d22a-c5f4-46b8-a22b-f18e0e55fa47" /> |

--- 

Following [this comment](https://github.com/zed-industries/zed/blob/7d9dbbe5feafb0135e05d29f950d5465203690c8/extensions/test-extension/languages/gleam/highlights.scm#L77-L78) and [the note on the other PR](https://github.com/zed-industries/zed/pull/21454#discussion_r1907012758), I also updated the last two matchs in the file to instead use `any-of` in the second commit (GitHub falsely shows `id` being removed despite it still being present). Should that not be wanted, I can revert this change.

Release Notes:

- Fixed improper highlighting of function parameters in Python.
