### PR TITLE
markdown_preview: Refresh images when they change on disk

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2082,6 +2082,12 @@ impl Window {
             None
         })
     }
+
+    /// Remove asset from GPUIs cache
+    pub fn remove_asset<A: Asset>(&mut self, source: &A::Source, cx: &mut App) {
+        cx.remove_asset::<A>(source);
+    }
+    
     /// Obtain the current element offset. This method should only be called during the
     /// prepaint phase of element drawing.
     pub fn element_offset(&self) -> Point<Pixels> {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2082,7 +2082,6 @@ impl Window {
             None
         })
     }
-
     /// Obtain the current element offset. This method should only be called during the
     /// prepaint phase of element drawing.
     pub fn element_offset(&self) -> Point<Pixels> {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2083,11 +2083,6 @@ impl Window {
         })
     }
 
-    /// Remove asset from GPUIs cache
-    pub fn remove_asset<A: Asset>(&mut self, source: &A::Source, cx: &mut App) {
-        cx.remove_asset::<A>(source);
-    }
-    
     /// Obtain the current element offset. This method should only be called during the
     /// prepaint phase of element drawing.
     pub fn element_offset(&self) -> Point<Pixels> {

--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -25,6 +25,7 @@ linkify.workspace = true
 log.workspace = true
 pretty_assertions.workspace = true
 pulldown-cmark.workspace = true
+regex.workspace = true
 settings.workspace = true
 theme.workspace = true
 ui.workspace = true

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -11,6 +11,7 @@ use gpui::{
     WeakEntity, Window,
 };
 use language::LanguageRegistry;
+use regex::Regex;
 use ui::prelude::*;
 use workspace::item::{Item, ItemHandle};
 use workspace::{Pane, Workspace};
@@ -368,7 +369,7 @@ impl MarkdownPreviewView {
     fn clear_image_caches(
         &self,
         editor: Entity<Editor>,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         let Some(folder_path) = Self::get_folder_for_active_editor(&editor.read(cx), cx) else {


### PR DESCRIPTION
Closes #26359

Release Notes:

- **Fixed:** Markdown preview now updates images when they change on disk
