### PR TITLE
gpui: Fix text underline width

### DIFF
--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -196,14 +196,14 @@ fn paint_line(
         );
         let mut prev_glyph_position = Point::default();
         let mut max_glyph_size = size(px(0.), px(0.));
-        let mut glyph_start_x = origin.x;
+        let mut first_glyph_x = origin.x;
         for (run_ix, run) in layout.runs.iter().enumerate() {
             max_glyph_size = text_system.bounding_box(run.font_id, layout.font_size).size;
 
             for (glyph_ix, glyph) in run.glyphs.iter().enumerate() {
                 glyph_origin.x += glyph.position.x - prev_glyph_position.x;
                 if glyph_ix == 0 {
-                    glyph_start_x = glyph_origin.x;
+                    first_glyph_x = glyph_origin.x;
                 }
 
                 if wraps.peek() == Some(&&WrapBoundary { run_ix, glyph_ix }) {
@@ -359,7 +359,7 @@ fn paint_line(
             }
         }
 
-        let mut last_line_end_x = glyph_start_x + layout.width;
+        let mut last_line_end_x = first_glyph_x + layout.width;
         if let Some(boundary) = wrap_boundaries.last() {
             let run = &layout.runs[boundary.run_ix];
             let glyph = &run.glyphs[boundary.glyph_ix];

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -196,11 +196,15 @@ fn paint_line(
         );
         let mut prev_glyph_position = Point::default();
         let mut max_glyph_size = size(px(0.), px(0.));
+        let mut first_text_start_x = origin.x;
         for (run_ix, run) in layout.runs.iter().enumerate() {
             max_glyph_size = text_system.bounding_box(run.font_id, layout.font_size).size;
 
             for (glyph_ix, glyph) in run.glyphs.iter().enumerate() {
                 glyph_origin.x += glyph.position.x - prev_glyph_position.x;
+                if glyph_ix == 0 {
+                    first_text_start_x = glyph_origin.x;
+                }
 
                 if wraps.peek() == Some(&&WrapBoundary { run_ix, glyph_ix }) {
                     wraps.next();
@@ -355,7 +359,7 @@ fn paint_line(
             }
         }
 
-        let mut last_line_end_x = glyph_origin.x;
+        let mut last_line_end_x = first_text_start_x + layout.width;
         if let Some(boundary) = wrap_boundaries.last() {
             let run = &layout.runs[boundary.run_ix];
             let glyph = &run.glyphs[boundary.glyph_ix];

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -196,14 +196,14 @@ fn paint_line(
         );
         let mut prev_glyph_position = Point::default();
         let mut max_glyph_size = size(px(0.), px(0.));
-        let mut first_text_start_x = origin.x;
+        let mut glyph_start_x = origin.x;
         for (run_ix, run) in layout.runs.iter().enumerate() {
             max_glyph_size = text_system.bounding_box(run.font_id, layout.font_size).size;
 
             for (glyph_ix, glyph) in run.glyphs.iter().enumerate() {
                 glyph_origin.x += glyph.position.x - prev_glyph_position.x;
                 if glyph_ix == 0 {
-                    first_text_start_x = glyph_origin.x;
+                    glyph_start_x = glyph_origin.x;
                 }
 
                 if wraps.peek() == Some(&&WrapBoundary { run_ix, glyph_ix }) {
@@ -359,7 +359,7 @@ fn paint_line(
             }
         }
 
-        let mut last_line_end_x = first_text_start_x + layout.width;
+        let mut last_line_end_x = glyph_start_x + layout.width;
         if let Some(boundary) = wrap_boundaries.last() {
             let run = &layout.runs[boundary.run_ix];
             let glyph = &run.glyphs[boundary.glyph_ix];


### PR DESCRIPTION
Release Notes:

- N/A 

Fix #24721 mistake to make sure underline width same as the text.

## Before

![image](https://github.com/user-attachments/assets/1fe6a8c2-517f-41be-bdf0-0ee777b7f8aa)

## After

<img width="912" alt="image" src="https://github.com/user-attachments/assets/222b5dcb-c0fb-4ec1-8e23-d68247621375" />
