### PR TITLE
ci: Remove `migration_checks` as a required check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,6 @@ jobs:
     needs:
       - job_spec
       - style
-      - migration_checks
       - linux_tests
       - build_remote_server
       - macos_tests
@@ -453,7 +452,6 @@ jobs:
             [[ "${{ needs.linux_tests.result }}"          != 'success' ]] && { RET_CODE=1; echo "Linux tests failed"; }
             [[ "${{ needs.windows_tests.result }}"        != 'success' ]] && { RET_CODE=1; echo "Windows tests failed"; }
             [[ "${{ needs.windows_clippy.result }}"       != 'success' ]] && { RET_CODE=1; echo "Windows clippy failed"; }
-            [[ "${{ needs.migration_checks.result }}"     != 'success' ]] && { RET_CODE=1; echo "Migration checks failed"; }
             [[ "${{ needs.build_remote_server.result }}"  != 'success' ]] && { RET_CODE=1; echo "Remote server build failed"; }
           fi
           if [[ "$RET_CODE" -eq 0 ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,6 +432,7 @@ jobs:
     needs:
       - job_spec
       - style
+      - migration_checks
       - linux_tests
       - build_remote_server
       - macos_tests


### PR DESCRIPTION
This PR removes the `migration_checks` job as a required check.

This was not required before, and we shouldn't make it required, as there are cases where we need to bypass it, as is the case in https://github.com/zed-industries/zed/pull/26832.

Release Notes:

- N/A
