### PR TITLE
nix: Fix runtime dependencies not being found

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -145,13 +145,6 @@ let
         ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
         RELEASE_VERSION = version;
         RUSTFLAGS = if withGLES then "--cfg gles" else "";
-        # TODO: why are these not handled by the linker given that they're in buildInputs?
-        NIX_LDFLAGS = "-rpath ${
-          lib.makeLibraryPath [
-            gpu-lib
-            wayland
-          ]
-        }";
         LK_CUSTOM_WEBRTC = livekit-libwebrtc;
       };
 
@@ -271,7 +264,9 @@ craneLib.buildPackage (
 
     # TODO: why isn't this also done on macOS?
     postFixup = lib.optionalString stdenv.hostPlatform.isLinux ''
-      wrapProgram $out/libexec/zed-editor --suffix PATH : ${lib.makeBinPath [ nodejs_22 ]}
+      wrapProgram $out/libexec/zed-editor \
+        --suffix PATH : ${lib.makeBinPath [ nodejs_22 ]} \
+        --prefix LD_LIBRARY_PATH : ${lib.makeLibraryPath [ gpu-lib wayland ]}
     '';
 
     meta = {


### PR DESCRIPTION
(I’m going to follow the template for "Proposing Change". I’m not sure it’s supposed to apply to PR too, or just suggestion)

### Problem statment:

The nix build does not execute on a NixOS environment, as it can’t locate the wayland runtime dependancies
The -rpath in the file does not appear to work, at it doesn’t add it to either libraries (this can be checked with `patchelf --print-rpath <elf executable>`)

### solution proposal:

Add the LD_LIBRARY_PATH environment variable to the variable, serving the same purpose, but that work (it’s how I’m used to do that kind of stuff in NixPkgs.

### Release Notes:

- N/A *or* Fixed Linux Nix build

### Other

(I’m not sure it’s important enought to mention in the changelog)
(also, where does I agree to the contributor license agreement? Do I state it here? Yes, I agree to the contributor license agreement as shown here https://zed.dev/cla as of the date of 16/03/2025 at 08:40 UTC)