### PR TITLE
vim: View Marks

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -39,7 +39,7 @@ use crate::{
     object::Object,
     state::{Mark, Mode},
     visual::VisualDeleteLine,
-    ToggleRegistersView, Vim,
+    ToggleMarksView, ToggleRegistersView, Vim,
 };
 
 #[derive(Clone, Debug, PartialEq)]
@@ -860,6 +860,7 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
             )
         }),
         VimCommand::new(("reg", "isters"), ToggleRegistersView).bang(ToggleRegistersView),
+        VimCommand::new(("marks", ""), ToggleMarksView).bang(ToggleMarksView),
         VimCommand::new(("sor", "t"), SortLinesCaseSensitive).range(select_range),
         VimCommand::new(("sort i", ""), SortLinesCaseInsensitive).range(select_range),
         VimCommand::str(("E", "xplore"), "project_panel::ToggleFocus"),

--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -183,10 +183,13 @@ impl Vim {
         &mut self,
         text: Arc<str>,
         line: bool,
+        should_pop_operator: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.pop_operator(window, cx);
+        if should_pop_operator {
+            self.pop_operator(window, cx);
+        }
         let mark = self
             .update_editor(window, cx, |vim, editor, window, cx| {
                 vim.get_mark(&text, editor, window, cx)

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -144,6 +144,7 @@ actions!(
         PushReplace,
         PushDeleteSurrounds,
         PushMark,
+        ToggleMarksView,
         PushIndent,
         PushOutdent,
         PushAutoIndent,
@@ -1599,7 +1600,7 @@ impl Vim {
                     self.select_register(text, window, cx);
                 }
             },
-            Some(Operator::Jump { line }) => self.jump(text, line, window, cx),
+            Some(Operator::Jump { line }) => self.jump(text, line, true, window, cx),
             _ => {
                 if self.mode == Mode::Replace {
                     self.multi_replace(text, window, cx)


### PR DESCRIPTION
Closes #26884

Release Notes:

- vim: Added `:marks` which brings up list of current marks.