### PR TITLE
Add --user-data-dir CLI flag and propose renaming support_dir to data_dir

### DIFF
--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -491,7 +491,7 @@ impl ThreadsDatabase {
         let database_future = executor
             .spawn({
                 let executor = executor.clone();
-                let database_path = paths::support_dir().join("threads/threads-db.1.mdb");
+                let database_path = paths::data_dir().join("threads/threads-db.1.mdb");
                 async move { ThreadsDatabase::new(database_path, executor) }
             })
             .then(|result| future::ready(result.map(Arc::new).map_err(Arc::new)))

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -16,6 +16,7 @@ pub enum CliRequest {
         wait: bool,
         open_new_workspace: Option<bool>,
         env: Option<HashMap<String, String>>,
+        user_data_dir: Option<String>,
     },
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -26,7 +26,11 @@ struct Detect;
 trait InstalledApp {
     fn zed_version_string(&self) -> String;
     fn launch(&self, ipc_url: String) -> anyhow::Result<()>;
-    fn run_foreground(&self, ipc_url: String, user_data_dir: Option<&str>) -> io::Result<ExitStatus>;
+    fn run_foreground(
+        &self,
+        ipc_url: String,
+        user_data_dir: Option<&str>,
+    ) -> io::Result<ExitStatus>;
     fn path(&self) -> PathBuf;
 }
 
@@ -58,7 +62,11 @@ struct Args {
     /// Create a new workspace
     #[arg(short, long, overrides_with = "add")]
     new: bool,
-    /// Sets a custom directory for all user data
+    /// Sets a custom directory for all user data (e.g., database, extensions, logs).
+    /// This overrides the default platform-specific data directory location.
+    /// On macOS, the default is `~/Library/Application Support/Zed`.
+    /// On Linux/FreeBSD, the default is `$XDG_DATA_HOME/zed`.
+    /// On Windows, the default is `%LOCALAPPDATA%\Zed`.
     #[arg(long, value_name = "DIR")]
     user_data_dir: Option<String>,
     /// The paths to open in Zed (space-separated).
@@ -458,7 +466,11 @@ mod linux {
             Ok(())
         }
 
-        fn run_foreground(&self, ipc_url: String, user_data_dir: Option<&str>) -> io::Result<ExitStatus> {
+        fn run_foreground(
+            &self,
+            ipc_url: String,
+            user_data_dir: Option<&str>,
+        ) -> io::Result<ExitStatus> {
             let mut cmd = std::process::Command::new(self.0.clone());
             cmd.arg(ipc_url);
             if let Some(dir) = user_data_dir {
@@ -702,7 +714,11 @@ mod windows {
             Ok(())
         }
 
-        fn run_foreground(&self, ipc_url: String, user_data_dir: Option<&str>) -> io::Result<ExitStatus> {
+        fn run_foreground(
+            &self,
+            ipc_url: String,
+            user_data_dir: Option<&str>,
+        ) -> io::Result<ExitStatus> {
             let mut cmd = std::process::Command::new(self.0.clone());
             cmd.arg(ipc_url).arg("--foreground");
             if let Some(dir) = user_data_dir {
@@ -890,7 +906,11 @@ mod mac_os {
             Ok(())
         }
 
-        fn run_foreground(&self, ipc_url: String, user_data_dir: Option<&str>) -> io::Result<ExitStatus> {
+        fn run_foreground(
+            &self,
+            ipc_url: String,
+            user_data_dir: Option<&str>,
+        ) -> io::Result<ExitStatus> {
             let path = match self {
                 Bundle::App { app_bundle, .. } => app_bundle.join("Contents/MacOS/zed"),
                 Bundle::LocalPath { executable, .. } => executable.clone(),

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -702,12 +702,13 @@ mod windows {
             Ok(())
         }
 
-        fn run_foreground(&self, ipc_url: String) -> io::Result<ExitStatus> {
-            std::process::Command::new(self.0.clone())
-                .arg(ipc_url)
-                .arg("--foreground")
-                .spawn()?
-                .wait()
+        fn run_foreground(&self, ipc_url: String, user_data_dir: Option<&str>) -> io::Result<ExitStatus> {
+            let mut cmd = std::process::Command::new(self.0.clone());
+            cmd.arg(ipc_url).arg("--foreground");
+            if let Some(dir) = user_data_dir {
+                cmd.arg("--user-data-dir").arg(dir);
+            }
+            cmd.spawn()?.wait()
         }
 
         fn path(&self) -> PathBuf {
@@ -889,13 +890,18 @@ mod mac_os {
             Ok(())
         }
 
-        fn run_foreground(&self, ipc_url: String) -> io::Result<ExitStatus> {
+        fn run_foreground(&self, ipc_url: String, user_data_dir: Option<&str>) -> io::Result<ExitStatus> {
             let path = match self {
                 Bundle::App { app_bundle, .. } => app_bundle.join("Contents/MacOS/zed"),
                 Bundle::LocalPath { executable, .. } => executable.clone(),
             };
 
-            std::process::Command::new(path).arg(ipc_url).status()
+            let mut cmd = std::process::Command::new(path);
+            cmd.arg(ipc_url);
+            if let Some(dir) = user_data_dir {
+                cmd.arg("--user-data-dir").arg(dir);
+            }
+            cmd.status()
         }
 
         fn path(&self) -> PathBuf {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -448,7 +448,7 @@ mod linux {
         }
 
         fn launch(&self, ipc_url: String) -> anyhow::Result<()> {
-            let sock_path = paths::support_dir().join(format!("zed-{}.sock", *RELEASE_CHANNEL));
+            let sock_path = paths::data_dir().join(format!("zed-{}.sock", *RELEASE_CHANNEL));
             let sock = UnixDatagram::unbound()?;
             if sock.connect(&sock_path).is_err() {
                 self.boot_background(ipc_url)?;

--- a/crates/indexed_docs/src/providers/rustdoc.rs
+++ b/crates/indexed_docs/src/providers/rustdoc.rs
@@ -53,7 +53,7 @@ impl IndexedDocsProvider for LocalRustdocProvider {
     }
 
     fn database_path(&self) -> PathBuf {
-        paths::support_dir().join("docs/rust/rustdoc-db.1.mdb")
+        paths::data_dir().join("docs/rust/rustdoc-db.1.mdb")
     }
 
     async fn suggest_packages(&self) -> Result<Vec<PackageName>> {
@@ -144,7 +144,7 @@ impl IndexedDocsProvider for DocsDotRsProvider {
     }
 
     fn database_path(&self) -> PathBuf {
-        paths::support_dir().join("docs/rust/docs-rs-db.1.mdb")
+        paths::data_dir().join("docs/rust/docs-rs-db.1.mdb")
     }
 
     async fn suggest_packages(&self) -> Result<Vec<PackageName>> {

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -312,7 +312,7 @@ impl ManagedNodeRuntime {
 
         let version = Self::VERSION;
         let folder_name = format!("node-{version}-{os}-{arch}");
-        let node_containing_dir = paths::support_dir().join("node");
+        let node_containing_dir = paths::data_dir().join("node");
         let node_dir = node_containing_dir.join(folder_name);
         let node_binary = node_dir.join(Self::NODE_PATH);
         let npm_file = node_dir.join(Self::NPM_PATH);
@@ -498,7 +498,7 @@ impl SystemNodeRuntime {
             )
         }
 
-        let scratch_dir = paths::support_dir().join("node");
+        let scratch_dir = paths::data_dir().join("node");
         fs::create_dir(&scratch_dir).await.ok();
         fs::create_dir(scratch_dir.join("cache")).await.ok();
 

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -64,9 +64,9 @@ pub fn config_dir() -> &'static PathBuf {
 }
 
 /// Returns the path to the support directory used by Zed.
-pub fn support_dir() -> &'static PathBuf {
-    static SUPPORT_DIR: OnceLock<PathBuf> = OnceLock::new();
-    SUPPORT_DIR.get_or_init(|| {
+pub fn data_dir() -> &'static PathBuf {
+    static DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
+    DATA_DIR.get_or_init(|| {
         if let Some(custom_dir) = CUSTOM_DATA_DIR.get() {
             return custom_dir.clone();
         }
@@ -130,7 +130,7 @@ pub fn logs_dir() -> &'static PathBuf {
         if cfg!(target_os = "macos") {
             home_dir().join("Library/Logs/Zed")
         } else {
-            support_dir().join("logs")
+            data_dir().join("logs")
         }
     })
 }
@@ -138,7 +138,7 @@ pub fn logs_dir() -> &'static PathBuf {
 /// Returns the path to the Zed server directory on this SSH host.
 pub fn remote_server_state_dir() -> &'static PathBuf {
     static REMOTE_SERVER_STATE: OnceLock<PathBuf> = OnceLock::new();
-    REMOTE_SERVER_STATE.get_or_init(|| support_dir().join("server_state"))
+    REMOTE_SERVER_STATE.get_or_init(|| data_dir().join("server_state"))
 }
 
 /// Returns the path to the `Zed.log` file.
@@ -156,7 +156,7 @@ pub fn old_log_file() -> &'static PathBuf {
 /// Returns the path to the database directory.
 pub fn database_dir() -> &'static PathBuf {
     static DATABASE_DIR: OnceLock<PathBuf> = OnceLock::new();
-    DATABASE_DIR.get_or_init(|| support_dir().join("db"))
+    DATABASE_DIR.get_or_init(|| data_dir().join("db"))
 }
 
 /// Returns the path to the crashes directory, if it exists for the current platform.
@@ -214,7 +214,7 @@ pub fn debug_tasks_file() -> &'static PathBuf {
 /// This is where installed extensions are stored.
 pub fn extensions_dir() -> &'static PathBuf {
     static EXTENSIONS_DIR: OnceLock<PathBuf> = OnceLock::new();
-    EXTENSIONS_DIR.get_or_init(|| support_dir().join("extensions"))
+    EXTENSIONS_DIR.get_or_init(|| data_dir().join("extensions"))
 }
 
 /// Returns the path to the extensions directory.
@@ -222,7 +222,7 @@ pub fn extensions_dir() -> &'static PathBuf {
 /// This is where installed extensions are stored on a remote.
 pub fn remote_extensions_dir() -> &'static PathBuf {
     static EXTENSIONS_DIR: OnceLock<PathBuf> = OnceLock::new();
-    EXTENSIONS_DIR.get_or_init(|| support_dir().join("remote_extensions"))
+    EXTENSIONS_DIR.get_or_init(|| data_dir().join("remote_extensions"))
 }
 
 /// Returns the path to the extensions directory.
@@ -256,7 +256,7 @@ pub fn contexts_dir() -> &'static PathBuf {
         if cfg!(target_os = "macos") {
             config_dir().join("conversations")
         } else {
-            support_dir().join("conversations")
+            data_dir().join("conversations")
         }
     })
 }
@@ -270,7 +270,7 @@ pub fn prompts_dir() -> &'static PathBuf {
         if cfg!(target_os = "macos") {
             config_dir().join("prompts")
         } else {
-            support_dir().join("prompts")
+            data_dir().join("prompts")
         }
     })
 }
@@ -296,7 +296,7 @@ pub fn prompt_overrides_dir(repo_path: Option<&Path>) -> PathBuf {
             if cfg!(target_os = "macos") {
                 config_dir().join("prompt_overrides")
             } else {
-                support_dir().join("prompt_overrides")
+                data_dir().join("prompt_overrides")
             }
         })
         .clone()
@@ -311,7 +311,7 @@ pub fn embeddings_dir() -> &'static PathBuf {
         if cfg!(target_os = "macos") {
             config_dir().join("embeddings")
         } else {
-            support_dir().join("embeddings")
+            data_dir().join("embeddings")
         }
     })
 }
@@ -321,7 +321,7 @@ pub fn embeddings_dir() -> &'static PathBuf {
 /// This is where language servers are downloaded to for languages built-in to Zed.
 pub fn languages_dir() -> &'static PathBuf {
     static LANGUAGES_DIR: OnceLock<PathBuf> = OnceLock::new();
-    LANGUAGES_DIR.get_or_init(|| support_dir().join("languages"))
+    LANGUAGES_DIR.get_or_init(|| data_dir().join("languages"))
 }
 
 /// Returns the path to the debug adapters directory
@@ -335,25 +335,25 @@ pub fn debug_adapters_dir() -> &'static PathBuf {
 /// Returns the path to the Copilot directory.
 pub fn copilot_dir() -> &'static PathBuf {
     static COPILOT_DIR: OnceLock<PathBuf> = OnceLock::new();
-    COPILOT_DIR.get_or_init(|| support_dir().join("copilot"))
+    COPILOT_DIR.get_or_init(|| data_dir().join("copilot"))
 }
 
 /// Returns the path to the Supermaven directory.
 pub fn supermaven_dir() -> &'static PathBuf {
     static SUPERMAVEN_DIR: OnceLock<PathBuf> = OnceLock::new();
-    SUPERMAVEN_DIR.get_or_init(|| support_dir().join("supermaven"))
+    SUPERMAVEN_DIR.get_or_init(|| data_dir().join("supermaven"))
 }
 
 /// Returns the path to the default Prettier directory.
 pub fn default_prettier_dir() -> &'static PathBuf {
     static DEFAULT_PRETTIER_DIR: OnceLock<PathBuf> = OnceLock::new();
-    DEFAULT_PRETTIER_DIR.get_or_init(|| support_dir().join("prettier"))
+    DEFAULT_PRETTIER_DIR.get_or_init(|| data_dir().join("prettier"))
 }
 
 /// Returns the path to the remote server binaries directory.
 pub fn remote_servers_dir() -> &'static PathBuf {
     static REMOTE_SERVERS_DIR: OnceLock<PathBuf> = OnceLock::new();
-    REMOTE_SERVERS_DIR.get_or_init(|| support_dir().join("remote_servers"))
+    REMOTE_SERVERS_DIR.get_or_init(|| data_dir().join("remote_servers"))
 }
 
 /// Returns the relative path to a `.zed` folder within a project.

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -19,18 +19,7 @@ pub fn remote_server_dir_relative() -> &'static Path {
 /// Sets a custom directory for all user data, overriding the default support directory.
 pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
     CUSTOM_DATA_DIR.get_or_init(|| {
-        let path = if cfg!(target_os = "windows") && (dir.contains(r"\") || dir.starts_with(r"\\")) {
-            // Windows absolute path (e.g., "C:\path" or "\\network\path")
-            PathBuf::from(dir)
-        } else if dir.starts_with("./") || dir.starts_with("../") || (!dir.starts_with("/") && !cfg!(target_os = "windows")) {
-            // Relative path on any OS (Linux/macOS: no leading "/", Windows: no drive letter or UNC)
-            std::env::current_dir()
-                .expect("failed to determine current directory")
-                .join(dir)
-        } else {
-            // Absolute path (Linux/macOS: "/path", Windows: assumed relative unless drive letter/UNC)
-            PathBuf::from(dir)
-        };
+        let path = PathBuf::from(dir);
         std::fs::create_dir_all(&path).expect("failed to create custom data directory");
         path
     })

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -61,7 +61,6 @@ pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
     })
 }
 
-
 /// Returns the path to the configuration directory used by Zed.
 pub fn config_dir() -> &'static PathBuf {
     CONFIG_DIR.get_or_init(|| {

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -8,13 +8,23 @@ pub use util::paths::home_dir;
 /// A default editorconfig file name to use when resolving project settings.
 pub const EDITORCONFIG_NAME: &str = ".editorconfig";
 
-// Custom data directory override, set only by set_custom_data_dir.
+/// A custom data directory override, set only by `set_custom_data_dir`.
+/// This is used to override the default data directory location.
+/// The directory will be created if it doesn't exist when set.
 static CUSTOM_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 
-// Resolved data directory, combining custom or platform defaults, set once.
+/// The resolved data directory, combining custom override or platform defaults.
+/// This is set once and cached for subsequent calls.
+/// On macOS, this is `~/Library/Application Support/Zed`.
+/// On Linux/FreeBSD, this is `$XDG_DATA_HOME/zed`.
+/// On Windows, this is `%LOCALAPPDATA%\Zed`.
 static CURRENT_DATA_DIR: OnceLock<PathBuf> = OnceLock::new();
 
-// Resolved config directory, combining custom or platform defaults, set once.
+/// The resolved config directory, combining custom override or platform defaults.
+/// This is set once and cached for subsequent calls.
+/// On macOS, this is `~/.config/zed`.
+/// On Linux/FreeBSD, this is `$XDG_CONFIG_HOME/zed`.
+/// On Windows, this is `%APPDATA%\Zed`.
 static CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
 
 /// Returns the relative path to the zed_server directory on the ssh host.
@@ -23,8 +33,23 @@ pub fn remote_server_dir_relative() -> &'static Path {
 }
 
 /// Sets a custom directory for all user data, overriding the default data directory.
+/// This function must be called before any other path operations that depend on the data directory.
+/// The directory will be created if it doesn't exist.
 ///
-/// Panics if called after the data directory has been initialized (e.g., via `data_dir` or `config_dir`).
+/// # Arguments
+///
+/// * `dir` - The path to use as the custom data directory. This will be used as the base
+///           directory for all user data, including databases, extensions, and logs.
+///
+/// # Returns
+///
+/// A reference to the static `PathBuf` containing the custom data directory path.
+///
+/// # Panics
+///
+/// Panics if:
+/// * Called after the data directory has been initialized (e.g., via `data_dir` or `config_dir`)
+/// * The directory cannot be created
 pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
     if CURRENT_DATA_DIR.get().is_some() || CONFIG_DIR.get().is_some() {
         panic!("set_custom_data_dir called after data_dir or config_dir was initialized");
@@ -35,6 +60,7 @@ pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
         path
     })
 }
+
 
 /// Returns the path to the configuration directory used by Zed.
 pub fn config_dir() -> &'static PathBuf {

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -17,7 +17,12 @@ pub fn remote_server_dir_relative() -> &'static Path {
 }
 
 /// Sets a custom directory for all user data, overriding the default support directory.
+/// 
+/// Panics if called after paths have been initialized (e.g., via `support_dir` or `config_dir`).
 pub fn set_custom_data_dir(dir: &str) -> &'static PathBuf {
+    if CUSTOM_DATA_DIR.get().is_some() {
+        panic!("set_custom_data_dir called after data_dir was initialized");
+    }
     CUSTOM_DATA_DIR.get_or_init(|| {
         let path = PathBuf::from(dir);
         std::fs::create_dir_all(&path).expect("failed to create custom data directory");

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -967,7 +967,11 @@ struct Args {
     /// URLs can either be `file://` or `zed://` scheme, or relative to <https://zed.dev>.
     paths_or_urls: Vec<String>,
 
-    /// Sets a custom directory for all user data
+    /// Sets a custom directory for all user data (e.g., database, extensions, logs).
+    /// This overrides the default platform-specific data directory location.
+    /// On macOS, the default is `~/Library/Application Support/Zed`.
+    /// On Linux/FreeBSD, the default is `$XDG_DATA_HOME/zed`.
+    /// On Windows, the default is `%LOCALAPPDATA%\Zed`.
     #[arg(long, value_name = "DIR")]
     user_data_dir: Option<String>,
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -172,6 +172,11 @@ fn fail_to_open_window(e: anyhow::Error, _cx: &mut App) {
 fn main() {
     let args = Args::parse();
 
+    // Set custom data directory.
+    if let Some(dir) = &args.user_data_dir {
+        paths::set_custom_data_dir(dir);
+    }
+    
     #[cfg(all(not(debug_assertions), target_os = "windows"))]
     unsafe {
         use windows::Win32::System::Console::{ATTACH_PARENT_PROCESS, AttachConsole};
@@ -961,6 +966,10 @@ struct Args {
     ///
     /// URLs can either be `file://` or `zed://` scheme, or relative to <https://zed.dev>.
     paths_or_urls: Vec<String>,
+
+    /// Sets a custom directory for all user data
+    #[arg(long, value_name = "DIR")]
+    user_data_dir: Option<String>,
 
     /// Instructs zed to run as a dev server on this machine. (not implemented)
     #[arg(long)]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -176,7 +176,7 @@ fn main() {
     if let Some(dir) = &args.user_data_dir {
         paths::set_custom_data_dir(dir);
     }
-    
+
     #[cfg(all(not(debug_assertions), target_os = "windows"))]
     unsafe {
         use windows::Win32::System::Console::{ATTACH_PARENT_PROCESS, AttachConsole};

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -151,7 +151,7 @@ pub fn listen_for_cli_connections(opener: OpenListener) -> Result<()> {
     use release_channel::RELEASE_CHANNEL_NAME;
     use std::os::unix::net::UnixDatagram;
 
-    let sock_path = paths::support_dir().join(format!("zed-{}.sock", *RELEASE_CHANNEL_NAME));
+    let sock_path = paths::data_dir().join(format!("zed-{}.sock", *RELEASE_CHANNEL_NAME));
     // remove the socket if the process listening on it has died
     if let Err(e) = UnixDatagram::unbound()?.connect(&sock_path) {
         if e.kind() == std::io::ErrorKind::ConnectionRefused {
@@ -266,7 +266,7 @@ pub async fn handle_cli_connection(
                 if let Some(dir) = user_data_dir {
                     paths::set_custom_data_dir(&dir);
                 }
-                
+
                 if !urls.is_empty() {
                     cx.update(|cx| {
                         match OpenRequest::parse(urls, cx) {

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -261,7 +261,12 @@ pub async fn handle_cli_connection(
                 wait,
                 open_new_workspace,
                 env,
+                user_data_dir,
             } => {
+                if let Some(dir) = user_data_dir {
+                    paths::set_custom_data_dir(&dir);
+                }
+                
                 if !urls.is_empty() {
                     cx.update(|cx| {
                         match OpenRequest::parse(urls, cx) {

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -261,12 +261,8 @@ pub async fn handle_cli_connection(
                 wait,
                 open_new_workspace,
                 env,
-                user_data_dir,
+                user_data_dir: _, // Ignore user_data_dir
             } => {
-                if let Some(dir) = user_data_dir {
-                    paths::set_custom_data_dir(&dir);
-                }
-
                 if !urls.is_empty() {
                     cx.update(|cx| {
                         match OpenRequest::parse(urls, cx) {

--- a/crates/zed/src/zed/windows_only_instance.rs
+++ b/crates/zed/src/zed/windows_only_instance.rs
@@ -130,7 +130,7 @@ fn send_args_to_instance(args: &Args) -> anyhow::Result<()> {
             wait: false,
             open_new_workspace: None,
             env: None,
-            user_data_dir: None,
+            user_data_dir: args.user_data_dir.clone(),
         }
     };
 

--- a/crates/zed/src/zed/windows_only_instance.rs
+++ b/crates/zed/src/zed/windows_only_instance.rs
@@ -130,6 +130,7 @@ fn send_args_to_instance(args: &Args) -> anyhow::Result<()> {
             wait: false,
             open_new_workspace: None,
             env: None,
+            user_data_dir: None,
         }
     };
 


### PR DESCRIPTION
This PR introduces support for a `--user-data-dir` CLI flag to override Zed's data directory and proposes renaming `support_dir` to `data_dir` for better cross-platform clarity. It builds on the discussion in #25349 about custom data directories, aiming to provide a flexible cross-platform solution.

### Changes

The PR is split into two commits:
1. **[feat(cli): add --user-data-dir to override data directory](https://github.com/zed-industries/zed/pull/26886/commits/28e8889105847401e783d1739722d0998459fe5a)**
2. **[refactor(paths): rename support_dir to data_dir for cross-platform clarity](https://github.com/zed-industries/zed/pull/26886/commits/affd2fc606b39af1b25432a688a9006229a8fc3a)**


### Context
Inspired by the need for custom data directories discussed in #25349, this PR provides an immediate implementation in the first commit, while the second commit suggests a naming improvement for broader appeal. @mikayla-maki, I’d appreciate your feedback, especially on the rename proposal, given your involvement in the original discussion!

### Testing
- `cargo build `
- `./target/debug/zed --user-data-dir ~/custom-data-dir`

Release Notes:
- Added --user-data-dir CLI flag