### PR TITLE
Make python's file, line output clickable in terminal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13751,7 +13751,6 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "libc",
- "log",
  "rand 0.8.5",
  "regex",
  "release_channel",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13751,6 +13751,7 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "libc",
+ "log",
  "rand 0.8.5",
  "regex",
  "release_channel",

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -31,10 +31,11 @@ task.workspace = true
 theme.workspace = true
 thiserror.workspace = true
 util.workspace = true
+log.workspace = true
+regex.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true
 
 [dev-dependencies]
 rand.workspace = true
-regex.workspace = true

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -31,7 +31,6 @@ task.workspace = true
 theme.workspace = true
 thiserror.workspace = true
 util.workspace = true
-log.workspace = true
 regex.workspace = true
 
 [target.'cfg(windows)'.dependencies]

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -946,22 +946,23 @@ impl Terminal {
                 } else if let Some(python_match) =
                     regex_match_at(term, point, &mut self.python_file_line_regex)
                 {
-                    let file_line =
+                    let matching_line =
                         term.bounds_to_string(*python_match.start(), *python_match.end());
 
-                    let p: Result<_, _> = python_extract_path_and_line(file_line.as_str())
-                        .map(|(file_path, line_number)| {
-                            (
-                                format!("{}:{}", file_path, line_number),
-                                false,
-                                python_match,
-                            )
-                        })
-                        .ok_or_else(|| {
-                            "Could not parse python file, line number reference".to_string()
-                        });
+                    let file_and_line: Result<_, _> =
+                        python_extract_path_and_line(matching_line.as_str())
+                            .map(|(file_path, line_number)| {
+                                (
+                                    format!("{}:{}", file_path, line_number),
+                                    false,
+                                    python_match,
+                                )
+                            })
+                            .ok_or_else(|| {
+                                "Could not parse python file, line number reference".to_string()
+                            });
 
-                    p.log_err()
+                    file_and_line.log_err()
                 } else if let Some(word_match) = regex_match_at(term, point, &mut self.word_regex) {
                     let file_path = term.bounds_to_string(*word_match.start(), *word_match.end());
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2312,6 +2312,16 @@ mod tests {
     }
 
     #[test]
+    fn test_python_file_line_regex() {
+        re_test(
+            crate::PYTHON_FILE_LINE_REGEX,
+            "hay File \"/zed/bad_py.py\", line 8 stack",
+            vec!["File \"/zed/bad_py.py\", line 8"],
+        );
+        re_test(crate::PYTHON_FILE_LINE_REGEX, "unrelated", vec![]);
+    }
+
+    #[test]
     fn test_python_file_line() {
         let inputs: Vec<(&str, Option<(&str, u32)>)> = vec![
             (

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -318,7 +318,7 @@ const URL_REGEX: &str = r#"(ipfs:|ipns:|magnet:|mailto:|gemini://|gopher://|http
 // https://learn.microsoft.com/en-us/visualstudio/msbuild/msbuild-diagnostic-format-for-tasks
 const WORD_REGEX: &str =
     r#"[\$\+\w.\[\]:/\\@\-~()]+(?:\((?:\d+|\d+,\d+)\))|[\$\+\w.\[\]:/\\@\-~()]+"#;
-const PYTHON_FILE_LINE_REGEX: &str = r#"File "(?P<file_path>[^"]+)", line (?P<line_number>\d+)"#;
+const PYTHON_FILE_LINE_REGEX: &str = r#"File "(?P<file>[^"]+)", line (?P<line>\d+)"#;
 
 fn python_extract_path_and_line(input: &str) -> Option<(&str, u32)> {
     // assumes a match from the PYTHON_FILE_LINE_REGEX

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -46,7 +46,7 @@ use smol::channel::{Receiver, Sender};
 use task::{HideStrategy, Shell, TaskId};
 use terminal_settings::{AlternateScroll, CursorShape, TerminalSettings};
 use theme::{ActiveTheme, Theme};
-use util::{paths::home_dir, truncate_and_trailoff, ResultExt};
+use util::{paths::home_dir, truncate_and_trailoff};
 
 use std::{
     cmp::{self, min},
@@ -948,21 +948,9 @@ impl Terminal {
                 {
                     let matching_line =
                         term.bounds_to_string(*python_match.start(), *python_match.end());
-
-                    let file_and_line: Result<_, _> =
-                        python_extract_path_and_line(matching_line.as_str())
-                            .map(|(file_path, line_number)| {
-                                (
-                                    format!("{}:{}", file_path, line_number),
-                                    false,
-                                    python_match,
-                                )
-                            })
-                            .ok_or_else(|| {
-                                "Could not parse python file, line number reference".to_string()
-                            });
-
-                    file_and_line.log_err()
+                    python_extract_path_and_line(&matching_line).map(|(file_path, line_number)| {
+                        (format!("{file_path}:{line_number}"), false, python_match)
+                    })
                 } else if let Some(word_match) = regex_match_at(term, point, &mut self.word_regex) {
                     let file_path = term.bounds_to_string(*word_match.start(), *word_match.end());
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -950,12 +950,12 @@ impl Terminal {
                         term.bounds_to_string(*python_match.start(), *python_match.end());
 
                     let p: Result<_, _> = python_extract_path_and_line(file_line.as_str())
-                        .and_then(|(file_path, line_number)| {
-                            Some((
+                        .map(|(file_path, line_number)| {
+                            (
                                 format!("{}:{}", file_path, line_number),
                                 false,
                                 python_match,
-                            ))
+                            )
                         })
                         .ok_or_else(|| {
                             "Could not parse python file, line number reference".to_string()


### PR DESCRIPTION
Closes #16004.

![image](https://github.com/user-attachments/assets/73cfe9da-5575-4616-9ed0-99fcb3ab61f5)

Python formats file and line number references in the form `File "file.py", line 8"`
I'm not a CPython expert, but from a quick look, they appear to come from:
- https://github.com/python/cpython/blob/80e00ecc399db8aeaa9f3a1c87a2cfb34517d7be/Python/traceback.c#L613
- https://github.com/python/cpython/blob/80e00ecc399db8aeaa9f3a1c87a2cfb34517d7be/Python/traceback.c#L927
I am not aware of the possiblity to also encode the column information.

Release Notes:

- File, line references from Python, like 'File "file.py", line 8' are now clickable in the terminal
