### PR TITLE
Allow auto-update in the nix devshell

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -46,8 +46,10 @@ mkShell' {
           passthru = { inherit (attrs) env; };
         })).env; # exfil `env`; it's not in drvAttrs
     in
-    # unsetting this var so we download the staticlib during the build
-    (removeAttrs baseEnvs [ "LK_CUSTOM_WEBRTC" ])
+    (removeAttrs baseEnvs [
+      "LK_CUSTOM_WEBRTC" # download the staticlib during the build as usual
+      "ZED_UPDATE_EXPLANATION" # allow auto-updates
+    ])
     // {
       # note: different than `$FONTCONFIG_FILE` in `build.nix` – this refers to relative paths
       # outside the nix store instead of to `$src`


### PR DESCRIPTION
Our direnv integration was making zed refuse to auto-update when you had the zed repo open with the devshell active. This was happening even when you used a non-nix build of zed, which actually should be able to auto-update. 

I'm a bit unsure of why we check for the `ZED_UPDATE_EXPLANATION` env var [both at build time _and_ at runtime](https://github.com/zed-industries/zed/blob/2828dcb67b0427bb64dd7c350896673ff6a14782/crates/auto_update/src/auto_update.rs#L149), but I can see an argument for why people might want that so I'll just do the less intrusive change for now and leave the var out of the devshell.

Release Notes:

- N/A