### PR TITLE
nix: Fix LDFLAGS rpath

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -145,7 +145,7 @@ let
         ZED_UPDATE_EXPLANATION = "Zed has been installed using Nix. Auto-updates have thus been disabled.";
         RELEASE_VERSION = version;
         RUSTFLAGS = if withGLES then "--cfg gles" else "";
-        # TODO: why are these not handled by the linker given that they're in buildInputs?
+        # these libraries are used with dlopen so putting them in buildInputs isn't enough
         NIX_LDFLAGS = "-rpath ${
           lib.makeLibraryPath [
             gpu-lib
@@ -154,6 +154,9 @@ let
         }";
         LK_CUSTOM_WEBRTC = livekit-libwebrtc;
       };
+
+      # prevent nix from removing the "unused" wayland/gpu-lib rpaths
+      dontPatchELF = true;
 
       cargoVendorDir = craneLib.vendorCargoDeps {
         inherit src cargoLock;


### PR DESCRIPTION
By default stdenv strips all unused rpaths, but we use a few libraries that are `dlopen`'d so we need to stop it from removing those. The [`dontPatchELF` flag](https://ryantm.github.io/nixpkgs/stdenv/stdenv/#var-stdenv-dontPatchELF) disables that and makes the nix build work on wayland again.

Fix #26905
Close #26864

Release Notes:

- N/A
