### PR TITLE
docs: Add marker to signal which languages are built into Zed

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -75,6 +75,7 @@
 - [CSS](./languages/css.md)
 - [Dart](./languages/dart.md)
 - [Deno](./languages/deno.md)
+- [Diff](./languages/diff.md)
 - [Docker](./languages/docker.md)
 - [Elixir](./languages/elixir.md)
 - [Elm](./languages/elm.md)

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -3,7 +3,7 @@
 Zed supports hundreds of programming languages and text formats.
 Some work out-of-the box and others rely on 3rd party extensions.
 
-> The ones included out-of-the-box, natively built into Zed, are marked *.
+> The ones included out-of-the-box, natively built into Zed, are marked with *.
 
 ## Languages with Documentation
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -1,6 +1,8 @@
 # Language Support in Zed
 
-Zed supports hundreds of programming languages and text formats. Some work out-of-the box and others rely on 3rd party extensions.
+Zed supports hundreds of programming languages and text formats.
+
+> Note that those marked with * are natively built into Zed, and available without having to install additional extensions.
 
 ## Languages with Documentation
 
@@ -9,13 +11,14 @@ Zed supports hundreds of programming languages and text formats. Some work out-o
 - [Astro](./languages/astro.md)
 - [Bash](./languages/bash.md)
 - [Biome](./languages/biome.md)
-- [C](./languages/c.md)
-- [C++](./languages/cpp.md)
+- [C](./languages/c.md) *
+- [C++](./languages/cpp.md) *
 - [C#](./languages/csharp.md)
 - [Clojure](./languages/clojure.md)
-- [CSS](./languages/css.md)
+- [CSS](./languages/css.md) *
 - [Dart](./languages/dart.md)
 - [Deno](./languages/deno.md)
+- [Diff](./languages/diff.md) *
 - [Docker](./languages/docker.md)
 - [Elixir](./languages/elixir.md)
 - [Elm](./languages/elm.md)
@@ -25,48 +28,48 @@ Zed supports hundreds of programming languages and text formats. Some work out-o
 - [GDScript](./languages/gdscript.md)
 - [Gleam](./languages/gleam.md)
 - [GLSL](./languages/glsl.md)
-- [Go](./languages/go.md)
+- [Go](./languages/go.md) *
 - [Groovy](./languages/groovy.md)
 - [Haskell](./languages/haskell.md)
 - [Helm](./languages/helm.md)
 - [HTML](./languages/html.md)
 - [Java](./languages/java.md)
-- [JavaScript](./languages/javascript.md)
+- [JavaScript](./languages/javascript.md) *
 - [Julia](./languages/julia.md)
-- [JSON](./languages/json.md)
+- [JSON](./languages/json.md) *
 - [Jsonnet](./languages/jsonnet.md)
 - [Kotlin](./languages/kotlin.md)
 - [Lua](./languages/lua.md)
 - [Luau](./languages/luau.md)
 - [Makefile](./languages/makefile.md)
-- [Markdown](./languages/markdown.md)
+- [Markdown](./languages/markdown.md) *
 - [Nim](./languages/nim.md)
 - [OCaml](./languages/ocaml.md)
 - [PHP](./languages/php.md)
 - [Prisma](./languages/prisma.md)
 - [Proto](./languages/proto.md)
 - [PureScript](./languages/purescript.md)
-- [Python](./languages/python.md)
+- [Python](./languages/python.md) *
 - [R](./languages/r.md)
 - [Rego](./languages/rego.md)
 - [ReStructuredText](./languages/rst.md)
 - [Racket](./languages/racket.md)
 - [Roc](./languages/roc.md)
 - [Ruby](./languages/ruby.md)
-- [Rust](./languages/rust.md)
+- [Rust](./languages/rust.md) * (Zed's written in Rust)
 - [Scala](./languages/scala.md)
 - [Scheme](./languages/scheme.md)
 - [Shell Script](./languages/sh.md)
 - [Svelte](./languages/svelte.md)
 - [Swift](./languages/swift.md)
-- [Tailwind CSS](./languages/tailwindcss.md)
+- [Tailwind CSS](./languages/tailwindcss.md) *
 - [Terraform](./languages/terraform.md)
 - [TOML](./languages/toml.md)
-- [TypeScript](./languages/typescript.md)
+- [TypeScript](./languages/typescript.md) *
 - [Uiua](./languages/uiua.md)
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
-- [YAML](./languages/yaml.md)
+- [YAML](./languages/yaml.md) *
 - [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -3,7 +3,7 @@
 Zed supports hundreds of programming languages and text formats.
 Some work out-of-the box and others rely on 3rd party extensions.
 
-> The ones included out-of-the-box, natively built into Zed, are marked with *.
+> The ones included out-of-the-box, natively built into Zed, are marked with \*.
 
 ## Languages with Documentation
 
@@ -12,14 +12,14 @@ Some work out-of-the box and others rely on 3rd party extensions.
 - [Astro](./languages/astro.md)
 - [Bash](./languages/bash.md)
 - [Biome](./languages/biome.md)
-- [C](./languages/c.md) *
-- [C++](./languages/cpp.md) *
+- [C](./languages/c.md) \*
+- [C++](./languages/cpp.md) \*
 - [C#](./languages/csharp.md)
 - [Clojure](./languages/clojure.md)
-- [CSS](./languages/css.md) *
+- [CSS](./languages/css.md) \*
 - [Dart](./languages/dart.md)
 - [Deno](./languages/deno.md)
-- [Diff](./languages/diff.md) *
+- [Diff](./languages/diff.md) \*
 - [Docker](./languages/docker.md)
 - [Elixir](./languages/elixir.md)
 - [Elm](./languages/elm.md)
@@ -29,48 +29,48 @@ Some work out-of-the box and others rely on 3rd party extensions.
 - [GDScript](./languages/gdscript.md)
 - [Gleam](./languages/gleam.md)
 - [GLSL](./languages/glsl.md)
-- [Go](./languages/go.md) *
+- [Go](./languages/go.md) \*
 - [Groovy](./languages/groovy.md)
 - [Haskell](./languages/haskell.md)
 - [Helm](./languages/helm.md)
 - [HTML](./languages/html.md)
 - [Java](./languages/java.md)
-- [JavaScript](./languages/javascript.md) *
+- [JavaScript](./languages/javascript.md) \*
 - [Julia](./languages/julia.md)
-- [JSON](./languages/json.md) *
+- [JSON](./languages/json.md) \*
 - [Jsonnet](./languages/jsonnet.md)
 - [Kotlin](./languages/kotlin.md)
 - [Lua](./languages/lua.md)
 - [Luau](./languages/luau.md)
 - [Makefile](./languages/makefile.md)
-- [Markdown](./languages/markdown.md) *
+- [Markdown](./languages/markdown.md) \*
 - [Nim](./languages/nim.md)
 - [OCaml](./languages/ocaml.md)
 - [PHP](./languages/php.md)
 - [Prisma](./languages/prisma.md)
 - [Proto](./languages/proto.md)
 - [PureScript](./languages/purescript.md)
-- [Python](./languages/python.md) *
+- [Python](./languages/python.md) \*
 - [R](./languages/r.md)
 - [Rego](./languages/rego.md)
 - [ReStructuredText](./languages/rst.md)
 - [Racket](./languages/racket.md)
 - [Roc](./languages/roc.md)
 - [Ruby](./languages/ruby.md)
-- [Rust](./languages/rust.md) * (Zed's written in Rust)
+- [Rust](./languages/rust.md) \* (Zed's written in Rust)
 - [Scala](./languages/scala.md)
 - [Scheme](./languages/scheme.md)
 - [Shell Script](./languages/sh.md)
 - [Svelte](./languages/svelte.md)
 - [Swift](./languages/swift.md)
-- [Tailwind CSS](./languages/tailwindcss.md) *
+- [Tailwind CSS](./languages/tailwindcss.md) \*
 - [Terraform](./languages/terraform.md)
 - [TOML](./languages/toml.md)
-- [TypeScript](./languages/typescript.md) *
+- [TypeScript](./languages/typescript.md) \*
 - [Uiua](./languages/uiua.md)
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
-- [YAML](./languages/yaml.md) *
+- [YAML](./languages/yaml.md) \*
 - [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -1,8 +1,9 @@
 # Language Support in Zed
 
 Zed supports hundreds of programming languages and text formats.
+Some work out-of-the box and others rely on 3rd party extensions.
 
-> Note that those marked with * are natively built into Zed, and available without having to install additional extensions.
+> The ones included out-of-the-box, natively built into Zed, are marked *.
 
 ## Languages with Documentation
 


### PR DESCRIPTION
I saw over the weekend some social media posts that indicated people didn't know which languages are included in Zed by default. We do say that on each language-specific page, but I figured having this high-level view on the languages page wouldn't hurt.

Release Notes:

- N/A
