### PR TITLE
git_hosting_providers: Fix incorrect name for SourceHut

### DIFF
--- a/crates/git_hosting_providers/src/providers/sourcehut.rs
+++ b/crates/git_hosting_providers/src/providers/sourcehut.rs
@@ -11,7 +11,7 @@ pub struct Sourcehut;
 
 impl GitHostingProvider for Sourcehut {
     fn name(&self) -> String {
-        "Gitee".to_string()
+        "SourceHut".to_string()
     }
 
     fn base_url(&self) -> Url {


### PR DESCRIPTION
This PR fixes an issue where the SourceHut Git hosting provider was using the wrong name.

Release Notes:

- N/A
