### PR TITLE
Disable flaky file status test again

### DIFF
--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2430,7 +2430,9 @@ async fn test_git_repository_for_path(cx: &mut TestAppContext) {
 // you can't rename a directory which some program has already open. This is a
 // limitation of the Windows. See:
 // https://stackoverflow.com/questions/41365318/access-is-denied-when-renaming-folder
-#[gpui::test]
+// TODO: re-enable flaky test.
+//#[gpui::test]
+#[allow(dead_code)]
 #[cfg_attr(target_os = "windows", ignore)]
 async fn test_file_status(cx: &mut TestAppContext) {
     init_test(cx);
@@ -3533,6 +3535,8 @@ fn git_cherry_pick(commit: &git2::Commit<'_>, repo: &git2::Repository) {
     repo.cherrypick(commit, None).expect("Failed to cherrypick");
 }
 
+// TODO remove this once flaky test is fixed
+#[allow(dead_code)]
 #[track_caller]
 fn git_stash(repo: &mut git2::Repository) {
     use git2::Signature;
@@ -3542,6 +3546,8 @@ fn git_stash(repo: &mut git2::Repository) {
         .expect("Failed to stash");
 }
 
+// TODO remove this once flaky test is fixed
+#[allow(dead_code)]
 #[track_caller]
 fn git_reset(offset: usize, repo: &git2::Repository) {
     let head = repo.head().expect("Couldn't get repo head");
@@ -3574,6 +3580,7 @@ fn git_checkout(name: &str, repo: &git2::Repository) {
     repo.checkout_head(None).expect("Failed to check out head");
 }
 
+// TODO remove this once flaky test is fixed
 #[allow(dead_code)]
 #[track_caller]
 fn git_status(repo: &git2::Repository) -> collections::HashMap<String, git2::Status> {


### PR DESCRIPTION
Failure on an unrelated commit: https://github.com/zed-industries/zed/actions/runs/13903012863/job/38899239052

Release Notes:

- N/A