### PR TITLE
worktree: Fix tracking of git status scans and re-enable tests

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5464,6 +5464,7 @@ impl BackgroundScanner {
                     }
                 };
 
+                inc_scans_running(&self.scans_running);
                 status_updates
                     .push(self.schedule_git_statuses_update(&mut state, local_repository));
             }
@@ -5496,9 +5497,12 @@ impl BackgroundScanner {
             });
         }
 
+        let scans_running = self.scans_running.clone();
         self.executor.spawn(async move {
-            let _updates_finished: Vec<Result<(), oneshot::Canceled>> =
+            let updates_finished: Vec<Result<(), oneshot::Canceled>> =
                 join_all(status_updates).await;
+            let n = updates_finished.len();
+            dec_scans_running(&scans_running, n as i32);
         })
     }
 

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -845,9 +845,7 @@ async fn test_update_gitignore(cx: &mut TestAppContext) {
     });
 }
 
-// TODO fix flaky test
-#[allow(dead_code)]
-//#[gpui::test]
+#[gpui::test]
 async fn test_write_file(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();
@@ -2625,9 +2623,7 @@ async fn test_file_status(cx: &mut TestAppContext) {
     });
 }
 
-// TODO fix flaky test
-#[allow(unused)]
-//#[gpui::test]
+#[gpui::test]
 async fn test_git_repository_status(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();
@@ -2741,9 +2737,7 @@ async fn test_git_repository_status(cx: &mut TestAppContext) {
     });
 }
 
-// TODO fix flaky test
-#[allow(unused)]
-//#[gpui::test]
+#[gpui::test]
 async fn test_git_status_postprocessing(cx: &mut TestAppContext) {
     init_test(cx);
     cx.executor().allow_parking();
@@ -3539,8 +3533,6 @@ fn git_cherry_pick(commit: &git2::Commit<'_>, repo: &git2::Repository) {
     repo.cherrypick(commit, None).expect("Failed to cherrypick");
 }
 
-// TODO remove this once flaky test is fixed
-#[allow(dead_code)]
 #[track_caller]
 fn git_stash(repo: &mut git2::Repository) {
     use git2::Signature;
@@ -3550,8 +3542,6 @@ fn git_stash(repo: &mut git2::Repository) {
         .expect("Failed to stash");
 }
 
-// TODO remove this once flaky test is fixed
-#[allow(dead_code)]
 #[track_caller]
 fn git_reset(offset: usize, repo: &git2::Repository) {
     let head = repo.head().expect("Couldn't get repo head");
@@ -3584,8 +3574,6 @@ fn git_checkout(name: &str, repo: &git2::Repository) {
     repo.checkout_head(None).expect("Failed to check out head");
 }
 
-// TODO remove this once flaky test is fixed
-#[allow(dead_code)]
 #[track_caller]
 fn git_status(repo: &git2::Repository) -> collections::HashMap<String, git2::Status> {
     repo.statuses(None)

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2430,9 +2430,7 @@ async fn test_git_repository_for_path(cx: &mut TestAppContext) {
 // you can't rename a directory which some program has already open. This is a
 // limitation of the Windows. See:
 // https://stackoverflow.com/questions/41365318/access-is-denied-when-renaming-folder
-// TODO: re-enable flaky test.
-//#[gpui::test]
-#[allow(dead_code)]
+#[gpui::test]
 #[cfg_attr(target_os = "windows", ignore)]
 async fn test_file_status(cx: &mut TestAppContext) {
     init_test(cx);


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- N/A