### PR TITLE
docs: Remove duplicate `indent_guides` setting in Project panel options

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2576,7 +2576,6 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "folder_icons": true,
     "git_status": true,
     "indent_size": 20,
-    "indent_guides": true,
     "auto_reveal_entries": true,
     "auto_fold_dirs": true,
     "scrollbar": {


### PR DESCRIPTION
Just a small docs pull request to remove the duplicate `indent_guides` setting in the Project panel options section of the docs. There is also another `indent_guides` on [L2585](https://github.com/zed-industries/zed/pull/26927/files#diff-c2decf822f3085926bd23bdf175700222dfd8193d48ea39908d4bb1d1a7c6240R2584). ~~Let me know if you prefer to remove the other instance, thank you!~~

Edit: I just realized it's the old setting, `indent_guides` now expects an object.