### PR TITLE
Don't open the commit editor when staging last hunk

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -14020,8 +14020,6 @@ impl Editor {
             self.change_selections(Some(autoscroll), window, cx, |s| {
                 s.select_ranges([destination..destination]);
             });
-        } else if all_diff_hunks_expanded {
-            window.dispatch_action(::git::ExpandCommitEditor.boxed_clone(), cx);
         }
     }
 

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -806,6 +806,7 @@ impl ProjectDiffToolbar {
     fn project_diff(&self, _: &App) -> Option<Entity<ProjectDiff>> {
         self.project_diff.as_ref()?.upgrade()
     }
+
     fn dispatch_action(&self, action: &dyn Action, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(project_diff) = self.project_diff(cx) {
             project_diff.focus_handle(cx).focus(window);


### PR DESCRIPTION
Closes #26880

Release Notes:

- Removed a behavior where staging the last hunk in the project diff would open the commit modal.
