### PR TITLE
assistant edit tool: Track read buffers and notify model of user edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,7 @@ name = "assistant_tool"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "clock",
  "collections",
  "derive_more",
  "gpui",

--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -361,7 +361,7 @@ impl ActiveThread {
                 if self.thread.read(cx).all_tools_finished() {
                     let pending_refresh_buffers = self.thread.update(cx, |thread, cx| {
                         thread.action_log().update(cx, |action_log, _cx| {
-                            action_log.take_pending_refresh_buffers()
+                            action_log.take_stale_buffers_in_context()
                         })
                     });
 

--- a/crates/assistant_tool/Cargo.toml
+++ b/crates/assistant_tool/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/assistant_tool.rs"
 [dependencies]
 anyhow.workspace = true
 collections.workspace = true
+clock.workspace = true
 derive_more.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -4,7 +4,7 @@ mod tool_working_set;
 use std::sync::Arc;
 
 use anyhow::Result;
-use collections::HashSet;
+use collections::{HashMap, HashSet};
 use gpui::Context;
 use gpui::{App, Entity, SharedString, Task};
 use language::Buffer;
@@ -58,31 +58,53 @@ pub trait Tool: 'static + Send + Sync {
 /// Tracks actions performed by tools in a thread
 #[derive(Debug)]
 pub struct ActionLog {
-    changed_buffers: HashSet<Entity<Buffer>>,
-    pending_refresh: HashSet<Entity<Buffer>>,
+    /// Buffers that user manually added to the context, and whose content has
+    /// changed since the model last saw them.
+    stale_buffers_in_context: HashSet<Entity<Buffer>>,
+    /// Buffers that we want to notify the model about when they change.
+    tracked_buffers: HashMap<Entity<Buffer>, TrackedBuffer>,
+}
+
+#[derive(Debug, Default)]
+struct TrackedBuffer {
+    version: clock::Global,
 }
 
 impl ActionLog {
     /// Creates a new, empty action log.
     pub fn new() -> Self {
         Self {
-            changed_buffers: HashSet::default(),
-            pending_refresh: HashSet::default(),
+            stale_buffers_in_context: HashSet::default(),
+            tracked_buffers: HashMap::default(),
         }
     }
 
-    /// Registers buffers that have changed and need refreshing.
-    pub fn notify_buffers_changed(
-        &mut self,
-        buffers: HashSet<Entity<Buffer>>,
-        _cx: &mut Context<Self>,
-    ) {
-        self.changed_buffers.extend(buffers.clone());
-        self.pending_refresh.extend(buffers);
+    /// Track a buffer as read, so we can notify the model about user edits.
+    pub fn buffer_read(&mut self, buffer: Entity<Buffer>, cx: &mut Context<Self>) {
+        let tracked_buffer = self.tracked_buffers.entry(buffer.clone()).or_default();
+        tracked_buffer.version = buffer.read(cx).version();
+    }
+
+    /// Mark a buffer as edited, so we can refresh it in the context
+    pub fn buffer_edited(&mut self, buffers: HashSet<Entity<Buffer>>, cx: &mut Context<Self>) {
+        for buffer in &buffers {
+            let tracked_buffer = self.tracked_buffers.entry(buffer.clone()).or_default();
+            tracked_buffer.version = buffer.read(cx).version();
+        }
+
+        self.stale_buffers_in_context.extend(buffers);
+    }
+
+    /// Iterate over buffers changed since last read or edited by the model
+    pub fn stale_buffers<'a>(&'a self, cx: &'a App) -> impl Iterator<Item = &'a Entity<Buffer>> {
+        self.tracked_buffers
+            .iter()
+            .filter(|(buffer, tracked)| tracked.version != buffer.read(cx).version)
+            .map(|(buffer, _)| buffer)
     }
 
     /// Takes and returns the set of buffers pending refresh, clearing internal state.
-    pub fn take_pending_refresh_buffers(&mut self) -> HashSet<Entity<Buffer>> {
-        std::mem::take(&mut self.pending_refresh)
+    pub fn take_stale_buffers_in_context(&mut self) -> HashSet<Entity<Buffer>> {
+        std::mem::take(&mut self.stale_buffers_in_context)
     }
 }

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -309,9 +309,7 @@ impl EditToolRequest {
         }
 
         self.action_log
-            .update(cx, |log, cx| {
-                log.notify_buffers_changed(self.changed_buffers, cx)
-            })
+            .update(cx, |log, cx| log.buffer_edited(self.changed_buffers, cx))
             .log_err();
 
         let errors = self.parser.errors();


### PR DESCRIPTION
When the model reads file, we'll track the version it read, and let it know if the user makes edits to the buffer. This helps prevent edit failures because it'll know to re-read the file before.

Release Notes:

- N/A
