### PR TITLE
collab: Clean up LLM token creation

### DIFF
--- a/crates/collab/src/db/tables/user.rs
+++ b/crates/collab/src/db/tables/user.rs
@@ -43,6 +43,20 @@ pub enum Relation {
     Contributor,
 }
 
+impl Model {
+    /// Returns the timestamp of when the user's account was created.
+    ///
+    /// This will be the earlier of the `created_at` and `github_user_created_at` timestamps.
+    pub fn account_created_at(&self) -> NaiveDateTime {
+        let mut account_created_at = self.created_at;
+        if let Some(github_created_at) = self.github_user_created_at {
+            account_created_at = account_created_at.min(github_created_at);
+        }
+
+        account_created_at
+    }
+}
+
 impl Related<super::access_token::Entity> for Entity {
     fn to() -> RelationDef {
         Relation::AccessToken.def()

--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -37,8 +37,7 @@ impl LlmTokenClaims {
         user: &user::Model,
         is_staff: bool,
         billing_preferences: Option<billing_preference::Model>,
-        has_llm_closed_beta_feature_flag: bool,
-        has_predict_edits_feature_flag: bool,
+        feature_flags: &Vec<String>,
         has_llm_subscription: bool,
         plan: rpc::proto::Plan,
         system_id: Option<String>,
@@ -59,8 +58,12 @@ impl LlmTokenClaims {
             metrics_id: user.metrics_id,
             github_user_login: user.github_login.clone(),
             is_staff,
-            has_llm_closed_beta_feature_flag,
-            has_predict_edits_feature_flag,
+            has_llm_closed_beta_feature_flag: feature_flags
+                .iter()
+                .any(|flag| flag == "llm-closed-beta"),
+            has_predict_edits_feature_flag: feature_flags
+                .iter()
+                .any(|flag| flag == "predict-edits"),
             has_llm_subscription,
             max_monthly_spend_in_cents: billing_preferences
                 .map_or(DEFAULT_MAX_MONTHLY_SPEND.0, |preferences| {


### PR DESCRIPTION
This PR cleans up the LLM token creation a bit.

We now pass in the entire list of feature flags to the `LlmTokenClaims::create` method to prevent having a bunch of confusable `bool` parameters.

Release Notes:

- N/A
