### PR TITLE
collab: Defer account age check to `POST /completion` endpoint

### DIFF
--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -5,6 +5,7 @@ mod token;
 use crate::api::events::SnowflakeRow;
 use crate::api::CloudflareIpCountryHeader;
 use crate::build_kinesis_client;
+use crate::rpc::MIN_ACCOUNT_AGE_FOR_LLM_USE;
 use crate::{db::UserId, executor::Executor, Cents, Config, Error, Result};
 use anyhow::{anyhow, Context as _};
 use authorization::authorize_access_to_language_model;
@@ -216,6 +217,15 @@ async fn perform_completion(
         state.db.model_names_for_provider(params.provider),
         params.model,
     );
+
+    let bypass_account_age_check = claims.has_llm_subscription || claims.bypass_account_age_check;
+    if !bypass_account_age_check {
+        if let Some(account_created_at) = claims.account_created_at {
+            if Utc::now().naive_utc() - account_created_at < MIN_ACCOUNT_AGE_FOR_LLM_USE {
+                Err(anyhow!("account too young"))?
+            }
+        }
+    }
 
     authorize_access_to_language_model(
         &state.config,

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4036,7 +4036,7 @@ async fn accept_terms_of_service(
 }
 
 /// The minimum account age an account must have in order to use the LLM service.
-const MIN_ACCOUNT_AGE_FOR_LLM_USE: chrono::Duration = chrono::Duration::days(30);
+pub const MIN_ACCOUNT_AGE_FOR_LLM_USE: chrono::Duration = chrono::Duration::days(30);
 
 async fn get_llm_api_token(
     _request: proto::GetLlmToken,
@@ -4066,6 +4066,8 @@ async fn get_llm_api_token(
 
     let has_llm_subscription = session.has_llm_subscription(&db).await?;
 
+    // This check is now handled in the `perform_completion` endpoint. We can remove the check here once the tokens have
+    // had ~1 hour to cycle.
     let bypass_account_age_check =
         has_llm_subscription || has_bypass_account_age_check_feature_flag;
     if !bypass_account_age_check {


### PR DESCRIPTION
This PR defers the account age check to the `POST /completion` endpoint instead of doing it when an LLM token is generated.

This will allow us to lift the account age restriction for using Edit Prediction.

Note: We're still temporarily performing the account age check when issuing the LLM token until this change is deployed and the LLM tokens have had a chance to cycle.

Release Notes:

- N/A
