### PR TITLE
Remove unnecessary conditional definition of `FS_WATCH_LATENCY`

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -76,9 +76,6 @@ use util::{
 };
 pub use worktree_settings::WorktreeSettings;
 
-#[cfg(feature = "test-support")]
-pub const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
-#[cfg(not(feature = "test-support"))]
 pub const FS_WATCH_LATENCY: Duration = Duration::from_millis(100);
 
 /// A set of local or remote files that are being opened as part of a project.


### PR DESCRIPTION
This was added in #8343 to make it only visible for tests. #9189 then made it visible regardless of `test-support`, so the definitions became identical.

Release Notes:

- N/A