### PR TITLE
Keep and filter word completions on input, if the menu is open

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -180,6 +180,7 @@ pub struct CompletionsMenu {
     scroll_handle: UniformListScrollHandle,
     resolve_completions: bool,
     show_completion_documentation: bool,
+    pub(super) ignore_completion_provider: bool,
     last_rendered_range: Rc<RefCell<Option<Range<usize>>>>,
     markdown_element: Option<Entity<Markdown>>,
 }
@@ -189,6 +190,7 @@ impl CompletionsMenu {
         id: CompletionId,
         sort_completions: bool,
         show_completion_documentation: bool,
+        ignore_completion_provider: bool,
         initial_position: Anchor,
         buffer: Entity<Buffer>,
         completions: Box<[Completion]>,
@@ -205,6 +207,7 @@ impl CompletionsMenu {
             initial_position,
             buffer,
             show_completion_documentation,
+            ignore_completion_provider,
             completions: RefCell::new(completions).into(),
             match_candidates,
             entries: RefCell::new(Vec::new()).into(),
@@ -266,6 +269,7 @@ impl CompletionsMenu {
             scroll_handle: UniformListScrollHandle::new(),
             resolve_completions: false,
             show_completion_documentation: false,
+            ignore_completion_provider: false,
             last_rendered_range: RefCell::new(None).into(),
             markdown_element: None,
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3546,7 +3546,21 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.is_completion_trigger(text, trigger_in_words, cx) {
+        let ignore_completion_provider = self
+            .context_menu
+            .borrow()
+            .as_ref()
+            .map(|menu| match menu {
+                CodeContextMenu::Completions(completions_menu) => {
+                    completions_menu.ignore_completion_provider
+                }
+                CodeContextMenu::CodeActions(_) => false,
+            })
+            .unwrap_or(false);
+
+        if ignore_completion_provider {
+            self.show_word_completions(&ShowWordCompletions, window, cx);
+        } else if self.is_completion_trigger(text, trigger_in_words, cx) {
             self.show_completions(
                 &ShowCompletions {
                     trigger: Some(text.to_owned()).filter(|x| !x.is_empty()),
@@ -4183,6 +4197,7 @@ impl Editor {
                         id,
                         sort_completions,
                         show_completion_documentation,
+                        ignore_completion_provider,
                         position,
                         buffer.clone(),
                         completions.into(),


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/26410

Release Notes:

- N/A
