### PR TITLE
migrator: Fix case where users see migration banner despite no diff changes

### DIFF
--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -77,7 +77,7 @@ fn run_migrations(
             result = Some(migrated_text);
         }
     }
-    Ok(result)
+    Ok(result.filter(|new_text| text != new_text))
 }
 
 pub fn migrate_keymap(text: &str) -> Result<Option<String>> {


### PR DESCRIPTION
Fixes edge case where after carrying out all migrations if final text is same as existing text, we don't need to ask user to do anything, despite migrations edits are being applied internally. E.g. A -> B - > C -> A

Release Notes:

- N/A
