### PR TITLE
docs: Use correct name for Intelephense license file

### DIFF
--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -27,7 +27,7 @@ which php
 
 ## Intelephense
 
-[Intelephense](https://intelephense.com/) is a [proprietary](https://github.com/bmewburn/vscode-intelephense/blob/master/LICENSE.txt#L29) language server for PHP operating under a freemium model. Certain features require purchase of a [premium license](https://intelephense.com/). To use these features you must place your [license.txt file](https://intelephense.com/faq.html) at `~/intelephense/licence.txt` inside your home directory.
+[Intelephense](https://intelephense.com/) is a [proprietary](https://github.com/bmewburn/vscode-intelephense/blob/master/LICENSE.txt#L29) language server for PHP operating under a freemium model. Certain features require purchase of a [premium license](https://intelephense.com/). To use these features you must place your [licence.txt file](https://intelephense.com/faq.html) at `~/intelephense/licence.txt` inside your home directory.
 
 To switch to `intelephense`, add the following to your `settings.json`:
 


### PR DESCRIPTION
This PR updates the Intelephense section of the PHP docs to use the correct name for the license file.

Intelephense uses British English:

<img width="1185" alt="Screenshot 2025-03-18 at 8 30 20 AM" src="https://github.com/user-attachments/assets/a675e854-bedf-4f70-bf8f-90488d196242" />

Release Notes:

- N/A
