### PR TITLE
Allow tools to read unsaved buffers

### DIFF
--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -78,29 +78,20 @@ impl Tool for ReadFileTool {
                 .await?;
 
             let result = buffer.read_with(cx, |buffer, _cx| {
-                if buffer
-                    .file()
-                    .map_or(false, |file| file.disk_state().exists())
-                {
-                    let text = buffer.text();
-                    let string = if input.start_line.is_some() || input.end_line.is_some() {
-                        let start = input.start_line.unwrap_or(1);
-                        let lines = text.split('\n').skip(start - 1);
-                        if let Some(end) = input.end_line {
-                            let count = end.saturating_sub(start);
-                            Itertools::intersperse(lines.take(count), "\n").collect()
-                        } else {
-                            Itertools::intersperse(lines, "\n").collect()
-                        }
+                let text = buffer.text();
+                if input.start_line.is_some() || input.end_line.is_some() {
+                    let start = input.start_line.unwrap_or(1);
+                    let lines = text.split('\n').skip(start - 1);
+                    if let Some(end) = input.end_line {
+                        let count = end.saturating_sub(start);
+                        Itertools::intersperse(lines.take(count), "\n").collect()
                     } else {
-                        text
-                    };
-
-                    Ok(string)
+                        Itertools::intersperse(lines, "\n").collect()
+                    }
                 } else {
-                    Err(anyhow!("File does not exist"))
+                    text
                 }
-            })??;
+            })?;
 
             action_log.update(cx, |log, cx| {
                 log.buffer_read(buffer, cx);


### PR DESCRIPTION
If the tool asks to read a path, we don't need to verify whether that path exists on disk; an unsaved buffer with that path is fine.

Release Notes:

- N/A
