### PR TITLE
Fix syntax highlighting of git commit messages

### DIFF
--- a/crates/languages/src/gitcommit/config.toml
+++ b/crates/languages/src/gitcommit/config.toml
@@ -1,5 +1,5 @@
 name = "Git Commit"
-grammar = "git_commit"
+grammar = "gitcommit"
 path_suffixes = [
   "TAG_EDITMSG",
   "MERGE_MSG",

--- a/crates/languages/src/gitcommit/highlights.scm
+++ b/crates/languages/src/gitcommit/highlights.scm
@@ -4,6 +4,7 @@
 (commit) @constant
 (item) @markup.link.url
 (header) @tag
+(comment) @comment
 
 (change kind: "new file" @diff.plus)
 (change kind: "deleted" @diff.minus)
@@ -15,4 +16,3 @@
   value: (trailer_value) @string)
 
 [":" "=" "->" (scissors)] @punctuation.delimiter
-(comment) @comment

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -204,7 +204,6 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
         },
         LanguageInfo {
             name: "gitcommit",
-            adapters: vec![],
             ..Default::default()
         },
     ];

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -202,6 +202,11 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
             adapters: vec![yaml_lsp_adapter],
             ..Default::default()
         },
+        LanguageInfo {
+            name: "gitcommit",
+            adapters: vec![],
+            ..Default::default()
+        },
     ];
 
     for registration in built_in_languages {

--- a/crates/panel/src/panel.rs
+++ b/crates/panel/src/panel.rs
@@ -113,6 +113,7 @@ pub fn panel_editor_style(monospace: bool, window: &Window, cx: &App) -> EditorS
             line_height: line_height.into(),
             ..Default::default()
         },
+        syntax: cx.theme().syntax().clone(),
         ..Default::default()
     }
 }


### PR DESCRIPTION
- Load syntax colors into commit message editors
- Fix name mismatches that were preventing the git commit grammar and language config from being matched up

Release Notes:

- Fixed git commit messages not being syntax-highlighted
