### PR TITLE
Fold git merge messages into commit editor placeholder text

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -136,7 +136,7 @@ impl CommitModal {
         cx: &mut Context<Self>,
     ) -> Self {
         let panel = git_panel.read(cx);
-        let suggested_commit_message = panel.suggest_commit_message();
+        let suggested_commit_message = panel.suggest_commit_message(cx);
 
         let commit_editor = git_panel.update(cx, |git_panel, cx| {
             git_panel.set_modal_open(true, cx);

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1720,19 +1720,6 @@ impl GitPanel {
         }));
     }
 
-    fn update_editor_placeholder(&mut self, cx: &mut Context<Self>) {
-        let suggested_commit_message = self.suggest_commit_message(cx);
-        let placeholder_text = suggested_commit_message
-            .as_deref()
-            .unwrap_or("Enter commit message");
-
-        self.commit_editor.update(cx, |editor, cx| {
-            editor.set_placeholder_text(Arc::from(placeholder_text), cx)
-        });
-
-        cx.notify();
-    }
-
     pub(crate) fn fetch(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.can_push_and_pull(cx) {
             return;
@@ -2189,7 +2176,6 @@ impl GitPanel {
                             git_panel.clear_pending();
                         }
                         git_panel.update_visible_entries(cx);
-                        git_panel.update_editor_placeholder(cx);
                         git_panel.update_scrollbar_properties(window, cx);
                     })
                     .ok();
@@ -2245,6 +2231,7 @@ impl GitPanel {
     fn update_visible_entries(&mut self, cx: &mut Context<Self>) {
         self.entries.clear();
         self.single_staged_entry.take();
+        self.single_tracked_entry.take();
         self.conflicted_count = 0;
         self.conflicted_staged_count = 0;
         self.new_count = 0;
@@ -2403,6 +2390,15 @@ impl GitPanel {
         self.update_counts(repo);
 
         self.select_first_entry_if_none(cx);
+
+        let suggested_commit_message = self.suggest_commit_message(cx);
+        let placeholder_text = suggested_commit_message
+            .as_deref()
+            .unwrap_or("Enter commit message");
+
+        self.commit_editor.update(cx, |editor, cx| {
+            editor.set_placeholder_text(Arc::from(placeholder_text), cx)
+        });
 
         cx.notify();
     }

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -2177,7 +2177,6 @@ impl Repository {
         buffer_store: Entity<BufferStore>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
-        let merge_message = self.merge_message.clone();
         cx.spawn(|repository, mut cx| async move {
             let buffer = buffer_store
                 .update(&mut cx, |buffer_store, cx| buffer_store.create_buffer(cx))?

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -605,20 +605,9 @@ impl GitStore {
                             }
                             // Update the statuses and merge message but keep everything else.
                             let existing_handle = handle.clone();
-                            existing_handle.update(cx, |existing_handle, cx| {
+                            existing_handle.update(cx, |existing_handle, _| {
                                 existing_handle.repository_entry = repo.clone();
-                                if matches!(git_repo, GitRepo::Local { .. })
-                                    && existing_handle.merge_message != merge_message
-                                {
-                                    if let (Some(merge_message), Some(buffer)) =
-                                        (&merge_message, &existing_handle.commit_message_buffer)
-                                    {
-                                        buffer.update(cx, |buffer, cx| {
-                                            if buffer.is_empty() {
-                                                buffer.set_text(merge_message.as_str(), cx);
-                                            }
-                                        })
-                                    }
+                                if matches!(git_repo, GitRepo::Local { .. }) {
                                     existing_handle.merge_message = merge_message;
                                 }
                             });

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -2190,12 +2190,6 @@ impl Repository {
                 })?;
             }
 
-            if let Some(merge_message) = merge_message {
-                buffer.update(&mut cx, |buffer, cx| {
-                    buffer.set_text(merge_message.as_str(), cx)
-                })?;
-            }
-
             repository.update(&mut cx, |repository, _| {
                 repository.commit_message_buffer = Some(buffer.clone());
             })?;


### PR DESCRIPTION
This PR changes the git commit message editors to surface git's suggested merge message, if any, as placeholder text, as opposed to "real" buffer text as was previously the case.

Release Notes:

- Changed git commit message editors to use placeholder text for git's suggested merge messages
