### PR TITLE
git: Add missing migrations for git.hunk_style

### DIFF
--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -25,3 +25,9 @@ pub(crate) mod m_2025_03_06 {
 
     pub(crate) use keymap::KEYMAP_PATTERNS;
 }
+
+pub(crate) mod m_2025_03_18 {
+    mod settings;
+
+    pub(crate) use settings::SETTINGS_PATTERNS;
+}

--- a/crates/migrator/src/migrations/m_2025_03_18/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_03_18/settings.rs
@@ -1,0 +1,51 @@
+use std::ops::Range;
+
+use tree_sitter::{Query, QueryMatch};
+
+use crate::{patterns::SETTINGS_NESTED_KEY_VALUE_PATTERN, MigrationPatterns};
+
+pub const SETTINGS_PATTERNS: MigrationPatterns = &[(
+    SETTINGS_NESTED_KEY_VALUE_PATTERN,
+    replace_hunk_style_setting_key,
+)];
+
+fn replace_hunk_style_setting_key(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let parent_object_capture_ix = query.capture_index_for_name("parent_key")?;
+    let parent_object_range = mat
+        .nodes_for_capture_index(parent_object_capture_ix)
+        .next()?
+        .byte_range();
+    let parent_object_name = contents.get(parent_object_range.clone())?;
+
+    let setting_name_ix = query.capture_index_for_name("setting_name")?;
+    let setting_name_range = mat
+        .nodes_for_capture_index(setting_name_ix)
+        .next()?
+        .byte_range();
+    let setting_name = contents.get(setting_name_range.clone())?;
+
+    let setting_value_ix = query.capture_index_for_name("setting_value")?;
+    let setting_value_range = mat
+        .nodes_for_capture_index(setting_value_ix)
+        .next()?
+        .byte_range();
+    let setting_value = contents.get(setting_value_range.clone())?;
+
+    if parent_object_name == "git" && setting_name == "hunk_style" {
+        match setting_value {
+            "\"transparent\"" | "\"pattern\"" | "\"border\"" => {
+                return Some((setting_value_range, "\"unstaged_hollow\"".to_string()))
+            }
+            "\"staged_transparent\"" | "\"staged_pattern\"" | "\"staged_border\"" => {
+                return Some((setting_value_range, "\"staged_hollow\"".to_string()))
+            }
+            _ => {}
+        }
+    }
+
+    None
+}

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -112,6 +112,10 @@ pub fn migrate_settings(text: &str) -> Result<Option<String>> {
             migrations::m_2025_01_30::SETTINGS_PATTERNS,
             &SETTINGS_QUERY_2025_01_30,
         ),
+        (
+            migrations::m_2025_03_18::SETTINGS_PATTERNS,
+            &SETTINGS_QUERY_2025_03_18,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -173,6 +177,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_01_30,
     migrations::m_2025_01_30::SETTINGS_PATTERNS
+);
+define_query!(
+    SETTINGS_QUERY_2025_03_18,
+    migrations::m_2025_03_18::SETTINGS_PATTERNS
 );
 
 // custom query


### PR DESCRIPTION
Follow up to #26816, adding missing settings migrations for the `git.hunk_style` setting.

I'm migrating the original `transparent`, `pattern` and `border` variants to `unstaged_hollow`, and their `staged`-prefixed counterparts to `staged_hollow`. I feel like for people who set one of these options, this is how they would map closest to the current options, whilst retaining the default of `staged_hollow`.

In the implementation I basically just copied out the settings replacements from one of the older migrations. I feel like this might become a common pattern in the future, so I will follow up with another PR to refactor out some common logic.

Release Notes:

- N/A
