### PR TITLE
docs: Specify the command for activating prompt library from the command palette

### DIFF
--- a/docs/src/assistant/prompting.md
+++ b/docs/src/assistant/prompting.md
@@ -27,7 +27,7 @@ You can use the inline assistant right in the prompt editor, allowing you to aut
 2. Click on the menu in the top right corner.
 3. Select "Prompt Library" from the dropdown.
 
-You can also use the `prompt-library: toggle` command.
+You can also use the `assistant: deploy prompt library` command while in the assistant panel.
 
 ### Managing Prompts
 


### PR DESCRIPTION
Quickfix of the docs as I read through and get familiar with the assistant interface.
`prompt-library: toggle` does not appear to be a live command in `cmd-shift-p` - instead I see `assistant: deploy prompt library`. This change to the docs reflects that. It also notes that this command can only be activated from within the assistant panel (the command is not accessible from a standard editor panel).

Release Notes:

- N/A