### PR TITLE
ci: Run stalebot checks multiple times to ensure completion

### DIFF
--- a/.github/workflows/community_close_stale_issues.yml
+++ b/.github/workflows/community_close_stale_issues.yml
@@ -1,7 +1,7 @@
 name: "Close Stale Issues"
 on:
   schedule:
-    - cron: "0 11 * * 2"
+    - cron: "0 7,9,11 * * 2"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Stalebot has a maximum operations-per-run which is set at 1000. As a result it may require multiple runs to successfully complete.

This morning it took [three runs](https://github.com/zed-industries/zed/actions/runs/13921563707/attempts/1) so set it to run three times two hours apart to avoid hitting github API limits.

Release Notes:

- N/A
