### PR TITLE
Remove unused AssistantThreadFeedback event

### DIFF
--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -660,10 +660,6 @@ fn for_snowflake(
                 e.event_type.clone(),
                 serde_json::to_value(&e.event_properties).unwrap(),
             ),
-            Event::AssistantThreadFeedback(e) => (
-                "Assistant Feedback".to_string(),
-                serde_json::to_value(&e).unwrap(),
-            ),
         };
 
         if let serde_json::Value::Object(ref mut map) = event_properties {

--- a/crates/telemetry_events/src/telemetry_events.rs
+++ b/crates/telemetry_events/src/telemetry_events.rs
@@ -97,7 +97,6 @@ pub enum Event {
     InlineCompletionRating(InlineCompletionRatingEvent),
     Call(CallEvent),
     Assistant(AssistantEvent),
-    AssistantThreadFeedback(AssistantThreadFeedbackEvent),
     Cpu(CpuEvent),
     Memory(MemoryEvent),
     App(AppEvent),
@@ -229,26 +228,6 @@ pub struct ReplEvent {
     pub kernel_language: String,
     pub kernel_status: String,
     pub repl_session_id: String,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub enum ThreadFeedbackRating {
-    Positive,
-    Negative,
-}
-
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct AssistantThreadFeedbackEvent {
-    /// Unique identifier for the thread
-    pub thread_id: String,
-    /// The feedback rating (thumbs up or thumbs down)
-    pub rating: ThreadFeedbackRating,
-    /// The serialized thread data containing messages, tool calls, etc.
-    pub thread_data: serde_json::Value,
-    /// The initial project snapshot taken when the thread was created
-    pub initial_project_snapshot: serde_json::Value,
-    /// The final project snapshot taken when the thread was first saved
-    pub final_project_snapshot: serde_json::Value,
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
It looks like:

- https://github.com/zed-industries/zed/pull/26780

accidentally added a new event type, `AssistantThreadFeedback`, using the old event system, that it didn't end up actually using, as [the code actually relies on using the newer (preferred) `telemetry::event!()`](https://github.com/zed-industries/zed/blob/4a39fc264405a1e7f1c319a513c62d330a1f644d/crates/assistant2/src/thread.rs#L964).

Release Notes:

- N/A
