### PR TITLE
Omit `json-language-server` from the `scope_opt_in_language_servers`

### DIFF
--- a/crates/editor/src/persistence.rs
+++ b/crates/editor/src/persistence.rs
@@ -83,7 +83,7 @@ define_connection!(
     //   scroll_top_row: usize,
     //   scroll_vertical_offset: f32,
     //   scroll_horizontal_offset: f32,
-    //   content: Option<String>,
+    //   contents: Option<String>,
     //   language: Option<String>,
     //   mtime_seconds: Option<i64>,
     //   mtime_nanos: Option<i32>,

--- a/crates/languages/src/json/config.toml
+++ b/crates/languages/src/json/config.toml
@@ -10,8 +10,6 @@ brackets = [
 ]
 tab_size = 2
 prettier_parser_name = "json"
-scope_opt_in_language_servers = ["json-language-server"]
 
 [overrides.string]
 word_characters = [":"]
-opt_into_language_servers = ["json-language-server"]

--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -11,7 +11,5 @@ brackets = [
 tab_size = 2
 prettier_parser_name = "jsonc"
 
-scope_opt_in_language_servers = ["json-language-server"]
 [overrides.string]
 word_characters = [":"]
-opt_into_language_servers = ["json-language-server"]


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/26574

After that PR, settings.json stopped giving completions when `"` was typed as a key: 

https://github.com/user-attachments/assets/5ff03863-024c-4c28-a7cd-8ef48a1695d8

This goes down to 

https://github.com/zed-industries/zed/blob/fb12863999e601c4ffc9afbded036e4f1f064369/crates/language/src/language.rs#L1736-L1748

which was empty before the PR, hence leading to lower `true` branch.
Now, when typing `"`, there's no scope according to 

https://github.com/zed-industries/zed/blob/fb12863999e601c4ffc9afbded036e4f1f064369/crates/project/src/lsp_store.rs#L4529-L4532

return result.

Removing `json-language-server` from `scope_opt_in_language_servers` seems to preserve the `:` fix and restore the completions behavior.


Release Notes:

- N/A 
