### PR TITLE
Cap the number of paths shown in the project diff

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -875,7 +875,20 @@ impl GitPanel {
                 }
             };
 
-            if entry.worktree_path.starts_with("..") {
+            let should_open_single_path = entry.worktree_path.starts_with("..")
+                || self
+                    .workspace
+                    .update(cx, |workspace, cx| {
+                        workspace
+                            .item_of_type::<ProjectDiff>(cx)
+                            .map_or(false, |project_diff| {
+                                project_diff
+                                    .read(cx)
+                                    .has_excerpt_for_path(&entry.repo_path.0, cx)
+                            })
+                    })
+                    .unwrap_or(false);
+            if should_open_single_path {
                 self.workspace
                     .update(cx, |workspace, cx| {
                         workspace

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1596,6 +1596,10 @@ impl MultiBuffer {
         self.update_path_excerpts(path, buffer, &buffer_snapshot, new, cx)
     }
 
+    pub fn has_excerpt_for_path(&self, path: &PathKey) -> bool {
+        self.excerpts_by_path.get(path).is_some()
+    }
+
     fn update_path_excerpts(
         &mut self,
         path: PathKey,

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1597,7 +1597,7 @@ impl MultiBuffer {
     }
 
     pub fn has_excerpt_for_path(&self, path: &PathKey) -> bool {
-        self.excerpts_by_path.get(path).is_some()
+        self.excerpts_by_path.contains_key(path)
     }
 
     fn update_path_excerpts(


### PR DESCRIPTION
This PR implements a cap on the number of paths that will be shown in the project diff, similar to the one we already have for project search. This is intended to improve the experience in repos with an enormous number of untracked or changed files---especially in the case of directories like `target/` or `node_modules/` that were inadvertently not added to `.gitignore`, or a git repository in some parent directory that sees a large number of untracked files that aren't logically part of the project.

I've implemented separate caps on new/added files and tracked files, because the case of a large number of new files and a modest number of tracked files seems likely to be common, and we might as well show all the tracked files in that situation.

We still show all the paths in the git panel. If you activate a path from the panel that's not included in the project diff due to the cap, we open the file itself in its own singleton buffer, so you can still see its diff.

Release Notes:

- Limited the number of paths that are shown in the project diff.
