### PR TITLE
Provide a default name for an unnamed app in the `get_name` method

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1586,7 +1586,7 @@ impl App {
     /// Get the name for this App.
     #[cfg(any(test, feature = "test-support", debug_assertions))]
     pub fn get_name(&self) -> &'static str {
-        self.name.as_ref().unwrap()
+        self.name.unwrap_or("Unnamed App")
     }
 
     /// Returns `true` if the platform file picker supports selecting a mix of files and directories.


### PR DESCRIPTION
```
thread 'main' panicked at /Users/justjavac/.cargo/git/checkouts/zed-a70e2ad075855582/4da6dfa/crates/gpui/src/app.rs:1584:28:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace

thread 'main' panicked at library/core/src/panicking.rs:218:5:
panic in a function that cannot unwind
stack backtrace:
...
```

Release Notes:

- Fixed
