### PR TITLE
Show debug console evaluation response

### DIFF
--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1694,6 +1694,7 @@ impl Session {
             },
             |this, response, cx| {
                 let response = response.log_err()?;
+                this.output_token.0 += 1;
                 this.output.push_back(dap::OutputEvent {
                     category: None,
                     output: response.result.clone(),


### PR DESCRIPTION
We weren't incrementing the output token when getting responses from the debug evaluation request which caused some output to not be displayed. (Usually the evaluation response, but that could cascade into other output events not showing)


Release Notes:

- N/A 
