### PR TITLE
recent_projects: Use keybinding text instead of symbol

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -21,7 +21,9 @@ use std::{
     path::{Path, PathBuf},
     sync::Arc,
 };
-use ui::{prelude::*, tooltip_container, KeyBinding, ListItem, ListItemSpacing, Tooltip};
+use ui::{
+    prelude::*, text_for_action, tooltip_container, KeyBinding, ListItem, ListItemSpacing, Tooltip,
+};
 use util::{paths::PathExt, ResultExt};
 use workspace::{
     CloseIntent, ModalView, OpenOptions, SerializedWorkspaceLocation, Workspace, WorkspaceId,
@@ -180,13 +182,13 @@ impl PickerDelegate for RecentProjectsDelegate {
     fn placeholder_text(&self, window: &mut Window, cx: &mut App) -> Arc<str> {
         let (create_window, reuse_window) = if self.create_new_window {
             (
-                ui::text_for_action(&menu::Confirm, window, cx).unwrap_or_default(),
-                ui::text_for_action(&menu::SecondaryConfirm, window, cx).unwrap_or_default(),
+                text_for_action(&menu::Confirm, window, cx).unwrap_or_default(),
+                text_for_action(&menu::SecondaryConfirm, window, cx).unwrap_or_default(),
             )
         } else {
             (
-                ui::text_for_action(&menu::SecondaryConfirm, window, cx).unwrap_or_default(),
-                ui::text_for_action(&menu::Confirm, window, cx).unwrap_or_default(),
+                text_for_action(&menu::SecondaryConfirm, window, cx).unwrap_or_default(),
+                text_for_action(&menu::Confirm, window, cx).unwrap_or_default(),
             )
         };
         Arc::from(format!(

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -177,16 +177,16 @@ impl EventEmitter<DismissEvent> for RecentProjectsDelegate {}
 impl PickerDelegate for RecentProjectsDelegate {
     type ListItem = ListItem;
 
-    fn placeholder_text(&self, window: &mut Window, _: &mut App) -> Arc<str> {
+    fn placeholder_text(&self, window: &mut Window, cx: &mut App) -> Arc<str> {
         let (create_window, reuse_window) = if self.create_new_window {
             (
-                window.keystroke_text_for(&menu::Confirm),
-                window.keystroke_text_for(&menu::SecondaryConfirm),
+                ui::text_for_action(&menu::Confirm, window, cx).unwrap_or_default(),
+                ui::text_for_action(&menu::SecondaryConfirm, window, cx).unwrap_or_default(),
             )
         } else {
             (
-                window.keystroke_text_for(&menu::SecondaryConfirm),
-                window.keystroke_text_for(&menu::Confirm),
+                ui::text_for_action(&menu::SecondaryConfirm, window, cx).unwrap_or_default(),
+                ui::text_for_action(&menu::Confirm, window, cx).unwrap_or_default(),
             )
         };
         Arc::from(format!(

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -345,9 +345,13 @@ impl KeyIcon {
 
 /// Returns a textual representation of the key binding for the given [`Action`].
 pub fn text_for_action(action: &dyn Action, window: &Window, cx: &App) -> Option<String> {
-    let bindings = window.bindings_for_action(action);
-    let key_binding = bindings.last()?;
-    Some(text_for_keystrokes(key_binding.keystrokes(), cx))
+    if KeyBinding::is_vim_mode(cx) {
+        let bindings = window.bindings_for_action(action);
+        let key_binding = bindings.last()?;
+        Some(text_for_keystrokes(key_binding.keystrokes(), cx))
+    } else {
+        Some(window.keystroke_text_for(action))
+    }
 }
 
 pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {


### PR DESCRIPTION
~Not sure if this is right, but afaik, Zed does not use symbols in the editor anymore, so just updating to match~

| prev | new |
|--|--|
|![image](https://github.com/user-attachments/assets/f4da547e-4d3b-409d-9251-eec72d009e55)|![image](https://github.com/user-attachments/assets/a0a9a996-e11f-4363-b7eb-62d6a50b96bc)|

Release Notes:

- N/A
