### PR TITLE
vim: Fix `space` not handling non-ascii characters

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1322,6 +1322,7 @@ fn wrapping_right_single(map: &DisplaySnapshot, mut point: DisplayPoint) -> Disp
     let max_column = map.line_len(point.row()).saturating_sub(1);
     if point.column() < max_column {
         *point.column_mut() += 1;
+        point = map.clip_point(point, Bias::Right);
     } else if point.row() < map.max_point().row() {
         *point.row_mut() += 1;
         *point.column_mut() = 0;
@@ -3597,5 +3598,14 @@ mod test {
             The quick brown
             fox jumps over
             the lˇ»azy dog"});
+    }
+
+    #[gpui::test]
+    async fn test_space_non_ascii(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state("ˇπππππ").await;
+        cx.simulate_shared_keystrokes("3 space").await;
+        cx.shared_state().await.assert_eq("πππˇππ");
     }
 }

--- a/crates/vim/test_data/test_space_non_ascii.json
+++ b/crates/vim/test_data/test_space_non_ascii.json
@@ -1,0 +1,4 @@
+{"Put":{"state":"ˇπππππ"}}
+{"Key":"3"}
+{"Key":"space"}
+{"Get":{"state":"πππˇππ","mode":"Normal"}}


### PR DESCRIPTION
Closes #26806

Changes: Clips the new point with `Bias::Right` like in `saturating_right`

Release Notes:

- vim: Fixed `space` not handling non-ascii characters
