### PR TITLE
editor: Preserve expand excerpt down button position

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12110,12 +12110,18 @@ impl Editor {
         &mut self,
         excerpt: ExcerptId,
         direction: ExpandExcerptDirection,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let current_scroll_position = self.scroll_position(cx);
         let lines = EditorSettings::get_global(cx).expand_excerpt_lines;
         self.buffer.update(cx, |buffer, cx| {
             buffer.expand_excerpts([excerpt], lines, direction, cx)
-        })
+        });
+        if direction == ExpandExcerptDirection::Down {
+            let new_scroll_position = current_scroll_position + gpui::Point::new(0.0, lines as f32);
+            self.set_scroll_position(new_scroll_position, window, cx);
+        }
     }
 
     pub fn go_to_singleton_buffer_point(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2267,9 +2267,9 @@ impl EditorElement {
                     .selected_icon_color(Color::Custom(cx.theme().colors().editor_foreground))
                     .icon_size(IconSize::Custom(rems(editor_font_size / window.rem_size())))
                     .width(width.into())
-                    .on_click(move |_, _, cx| {
+                    .on_click(move |_, window, cx| {
                         editor.update(cx, |editor, cx| {
-                            editor.expand_excerpt(excerpt_id, direction, cx);
+                            editor.expand_excerpt(excerpt_id, direction, window, cx);
                         });
                     })
                     .tooltip(Tooltip::for_action_title(


### PR DESCRIPTION
When you press the "Expand Excerpt Down" button, the editor will scroll up by the same amount to keep the button in same place. This allows you to expand the excerpt rapidly without moving your mouse.

Before:

https://github.com/user-attachments/assets/376350ac-6f21-4ce0-a383-b2c9ca4f45bb

After:

https://github.com/user-attachments/assets/4fba4173-5f01-4220-990a-65820ac40cf5

Release Notes:

- Improved "Expand Excerpt Down" so the button stays in place, allowing rapid expansion without moving the mouse.
