### PR TITLE
util: Include path to asset in panic message from asset_str

### DIFF
--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -678,7 +678,7 @@ mod rng {
 pub use rng::RandomCharIter;
 /// Get an embedded file as a string.
 pub fn asset_str<A: rust_embed::RustEmbed>(path: &str) -> Cow<'static, str> {
-    match A::get(path).unwrap().data {
+    match A::get(path).expect(path).data {
         Cow::Borrowed(bytes) => Cow::Borrowed(std::str::from_utf8(bytes).unwrap()),
         Cow::Owned(bytes) => Cow::Owned(String::from_utf8(bytes).unwrap()),
     }


### PR DESCRIPTION
Somebody on Discord ran into issues with running the debugger which goes down to an unwrap in asset_str. Let's print a path that was accessed.

Release Notes:

- N/A
