### PR TITLE
git: Add ability to amend commits

### DIFF
--- a/crates/git/src/fake_repository.rs
+++ b/crates/git/src/fake_repository.rs
@@ -249,6 +249,7 @@ impl GitRepository for FakeGitRepository {
         _message: SharedString,
         _name_and_email: Option<(SharedString, SharedString)>,
         _env: HashMap<String, String>,
+        _amend: bool,
         _: AsyncApp,
     ) -> BoxFuture<Result<()>> {
         unimplemented!()

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -246,6 +246,7 @@ pub trait GitRepository: Send + Sync {
         message: SharedString,
         name_and_email: Option<(SharedString, SharedString)>,
         env: HashMap<String, String>,
+        amend: bool,
         cx: AsyncApp,
     ) -> BoxFuture<Result<()>>;
 
@@ -792,6 +793,7 @@ impl GitRepository for RealGitRepository {
         message: SharedString,
         name_and_email: Option<(SharedString, SharedString)>,
         env: HashMap<String, String>,
+        amend: bool,
         cx: AsyncApp,
     ) -> BoxFuture<Result<()>> {
         let working_directory = self.working_directory();
@@ -805,6 +807,10 @@ impl GitRepository for RealGitRepository {
 
             if let Some((name, email)) = name_and_email {
                 cmd.arg("--author").arg(&format!("{name} <{email}>"));
+            }
+
+            if amend {
+                cmd.arg("--amend");
             }
 
             let output = cmd.output().await?;

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -4,7 +4,8 @@ use crate::branch_picker::{self, BranchList};
 use crate::git_panel::{commit_message_editor, GitPanel};
 use git::{Commit, GenerateCommitMessage};
 use panel::{panel_button, panel_editor_style, panel_filled_button};
-use ui::{prelude::*, KeybindingHint, PopoverMenu, PopoverMenuHandle, Tooltip};
+use ui::ElevationIndex;
+use ui::{prelude::*, Checkbox, KeybindingHint, PopoverMenu, PopoverMenuHandle, Tooltip};
 
 use editor::{Editor, EditorElement};
 use gpui::*;
@@ -294,6 +295,24 @@ impl CommitModal {
                 cx.emit(DismissEvent);
             }));
 
+        let amend_checkbox = Checkbox::new(
+            ElementId::Name("git_amend_checkbox".into()),
+            if self.git_panel.read(cx).amend_commit {
+                ToggleState::Selected
+            } else {
+                ToggleState::Unselected
+            },
+        )
+        .elevation(ElevationIndex::ModalSurface)
+        .fill()
+        .disabled(false)
+        .label("Amend")
+        .on_click(cx.listener(move |this, _, _window, cx| {
+            this.git_panel.update(cx, |git_panel, _cx| {
+                git_panel.amend_commit = !git_panel.amend_commit
+            });
+        }));
+
         h_flex()
             .group("commit_editor_footer")
             .flex_none()
@@ -326,6 +345,7 @@ impl CommitModal {
                     .px_1()
                     .gap_4()
                     .children(close_kb_hint)
+                    .child(amend_checkbox)
                     .child(commit_button),
             )
     }

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -2505,14 +2505,16 @@ impl Repository {
         &self,
         message: SharedString,
         name_and_email: Option<(SharedString, SharedString)>,
+        amend: bool,
         cx: &mut App,
     ) -> oneshot::Receiver<Result<()>> {
         let env = self.worktree_environment(cx);
-        self.send_job(|git_repo, cx| async move {
+
+        self.send_job(move |git_repo, cx| async move {
             match git_repo {
                 GitRepo::Local(repo) => {
                     let env = env.await;
-                    repo.commit(message, name_and_email, env, cx).await
+                    repo.commit(message, name_and_email, env, amend, cx).await
                 }
                 GitRepo::Remote {
                     project_id,

--- a/crates/project/src/git.rs
+++ b/crates/project/src/git.rs
@@ -1252,7 +1252,7 @@ impl GitStore {
 
         repository_handle
             .update(&mut cx, |repository_handle, cx| {
-                repository_handle.commit(message, name.zip(email), cx)
+                repository_handle.commit(message, name.zip(email), false, cx)
             })?
             .await??;
         Ok(proto::Ack {})


### PR DESCRIPTION
Closes #26660

Adds the ability to amend a commit through a checkbox. It is featured in the main `git` panel as well as in the modal:

![image](https://github.com/user-attachments/assets/f05e6e5f-e8e1-46ba-8869-7cf3c5d74e4b)
![image](https://github.com/user-attachments/assets/0f0f2752-9a2b-4f87-a3a8-be32e2659381)

Release Notes:

- Added option to amend a commit (`--amend`) 