### PR TITLE
assistant2: Add ability to start and stop context servers

### DIFF
--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -818,7 +818,7 @@ impl ContextStore {
         cx.update_entity(
             &self.context_server_manager,
             |context_server_manager, cx| {
-                for server in context_server_manager.servers() {
+                for server in context_server_manager.running_servers() {
                     context_server_manager
                         .restart_server(&server.id(), cx)
                         .detach_and_log_err(cx);


### PR DESCRIPTION
This PR adds the ability to start and stop context servers from within the configuration view in the Assistant panel:

https://github.com/user-attachments/assets/93c3a7cb-d799-4286-88ba-c13cc26e959a

Release Notes:

- N/A
