### PR TITLE
assistant2: Fix broken merge

### DIFF
--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -605,7 +605,7 @@ impl Thread {
         let task = cx.spawn(async move |thread, cx| {
             let stream = model.stream_completion(request, &cx);
             let initial_token_usage =
-                thread.read_with(&cx, |thread, _cx| thread.cumulative_token_usage.clone());
+                thread.read_with(cx, |thread, _cx| thread.cumulative_token_usage.clone());
             let stream_completion = async {
                 let mut events = stream.await?;
                 let mut stop_reason = StopReason::EndTurn;


### PR DESCRIPTION
This PR fixes a broken merge caused by https://github.com/zed-industries/zed/pull/26987 landing after https://github.com/zed-industries/zed/pull/26758.

Release Notes:

- N/A
