### PR TITLE
debugger: Do not allow setting breakpoints in buffers without file storage

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6052,6 +6052,9 @@ impl Editor {
                 continue;
             };
 
+            if buffer.read(cx).file().is_none() {
+                continue;
+            }
             let breakpoints = breakpoint_store.read(cx).breakpoints(
                 &buffer,
                 Some(info.range.context.start..info.range.context.end),

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -890,15 +890,24 @@ impl EditorElement {
         let modifiers = event.modifiers;
         let gutter_hovered = gutter_hitbox.is_hovered(window);
         editor.set_gutter_hovered(gutter_hovered, cx);
+        editor.gutter_breakpoint_indicator = None;
 
         if gutter_hovered {
-            editor.gutter_breakpoint_indicator = Some(
-                position_map
-                    .point_for_position(event.position)
-                    .previous_valid,
-            );
-        } else {
-            editor.gutter_breakpoint_indicator = None;
+            let new_point = position_map
+                .point_for_position(event.position)
+                .previous_valid;
+            let buffer_anchor = position_map
+                .snapshot
+                .display_point_to_anchor(new_point, Bias::Left);
+
+            if position_map
+                .snapshot
+                .buffer_snapshot
+                .buffer_for_excerpt(buffer_anchor.excerpt_id)
+                .is_some_and(|buffer| buffer.file().is_some())
+            {
+                editor.gutter_breakpoint_indicator = Some(new_point);
+            }
         }
 
         cx.notify();


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- N/A
