### PR TITLE
theme: Add fallback colors for `version_control.<variant>` properties

### DIFF
--- a/crates/theme/src/schema.rs
+++ b/crates/theme/src/schema.rs
@@ -98,7 +98,8 @@ impl ThemeStyleContent {
     /// Returns a [`ThemeColorsRefinement`] based on the colors in the [`ThemeContent`].
     #[inline(always)]
     pub fn theme_colors_refinement(&self) -> ThemeColorsRefinement {
-        self.colors.theme_colors_refinement()
+        self.colors
+            .theme_colors_refinement(&self.status_colors_refinement())
     }
 
     /// Returns a [`StatusColorsRefinement`] based on the colors in the [`ThemeContent`].
@@ -589,7 +590,10 @@ pub struct ThemeColorsContent {
 
 impl ThemeColorsContent {
     /// Returns a [`ThemeColorsRefinement`] based on the colors in the [`ThemeColorsContent`].
-    pub fn theme_colors_refinement(&self) -> ThemeColorsRefinement {
+    pub fn theme_colors_refinement(
+        &self,
+        status_colors: &StatusColorsRefinement,
+    ) -> ThemeColorsRefinement {
         let border = self
             .border
             .as_ref()
@@ -1000,27 +1004,39 @@ impl ThemeColorsContent {
             version_control_added: self
                 .version_control_added
                 .as_ref()
-                .and_then(|color| try_parse_color(color).ok()),
+                .and_then(|color| try_parse_color(color).ok())
+                // Fall back to `created`, for backwards compatibility.
+                .or(status_colors.created),
             version_control_deleted: self
                 .version_control_deleted
                 .as_ref()
-                .and_then(|color| try_parse_color(color).ok()),
+                .and_then(|color| try_parse_color(color).ok())
+                // Fall back to `deleted`, for backwards compatibility.
+                .or(status_colors.deleted),
             version_control_modified: self
                 .version_control_modified
                 .as_ref()
-                .and_then(|color| try_parse_color(color).ok()),
+                .and_then(|color| try_parse_color(color).ok())
+                // Fall back to `modified`, for backwards compatibility.
+                .or(status_colors.modified),
             version_control_renamed: self
                 .version_control_renamed
                 .as_ref()
-                .and_then(|color| try_parse_color(color).ok()),
+                .and_then(|color| try_parse_color(color).ok())
+                // Fall back to `modified`, for backwards compatibility.
+                .or(status_colors.modified),
             version_control_conflict: self
                 .version_control_conflict
                 .as_ref()
-                .and_then(|color| try_parse_color(color).ok()),
+                .and_then(|color| try_parse_color(color).ok())
+                // Fall back to `ignored`, for backwards compatibility.
+                .or(status_colors.ignored),
             version_control_ignored: self
                 .version_control_ignored
                 .as_ref()
-                .and_then(|color| try_parse_color(color).ok()),
+                .and_then(|color| try_parse_color(color).ok())
+                // Fall back to `conflict`, for backwards compatibility.
+                .or(status_colors.ignored),
         }
     }
 }


### PR DESCRIPTION
This PR adds fallback colors for the `version_control.<variant>` theme properties.

This fixes the colors when themes do not provide the properties.

Related to  https://github.com/zed-industries/zed/pull/26951.

Release Notes:

- Added fallback colors for the `version_control.<variant>` theme properties.
