### PR TITLE
assistant: Dismiss model picker upon selection

### DIFF
--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -57,7 +57,7 @@ impl LanguageModelSelector {
         });
 
         let subscription = cx.subscribe(&picker, |_, _, _, cx| cx.emit(DismissEvent));
-        
+
         LanguageModelSelector {
             picker,
             update_matches_task: None,

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -56,15 +56,20 @@ impl LanguageModelSelector {
                 .max_height(Some(rems(20.).into()))
         });
 
+        let subscription = cx.subscribe(&picker, |_, _, _, cx| cx.emit(DismissEvent));
+        
         LanguageModelSelector {
             picker,
             update_matches_task: None,
             _authenticate_all_providers_task: Self::authenticate_all_providers(cx),
-            _subscriptions: vec![cx.subscribe_in(
-                &LanguageModelRegistry::global(cx),
-                window,
-                Self::handle_language_model_registry_event,
-            )],
+            _subscriptions: vec![
+                cx.subscribe_in(
+                    &LanguageModelRegistry::global(cx),
+                    window,
+                    Self::handle_language_model_registry_event,
+                ),
+                subscription,
+            ],
         }
     }
 


### PR DESCRIPTION
This PR makes the model picker close when you click on a new item.

Release Notes:

- N/A
