### PR TITLE
debugger: Ensure both debug and regular global tasks are correctly merged

### DIFF
--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -24,7 +24,7 @@ use util::ResultExt;
 use worktree::{PathChange, UpdatedEntriesSet, Worktree, WorktreeId};
 
 use crate::{
-    task_store::TaskStore,
+    task_store::{TaskSettingsLocation, TaskStore},
     worktree_store::{WorktreeStore, WorktreeStoreEvent},
 };
 
@@ -642,7 +642,7 @@ impl SettingsObserver {
                 LocalSettingsKind::Tasks(task_kind) => task_store.update(cx, |task_store, cx| {
                     task_store
                         .update_user_tasks(
-                            Some(SettingsLocation {
+                            TaskSettingsLocation::Worktree(SettingsLocation {
                                 worktree_id,
                                 path: directory.as_ref(),
                             }),

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::format_collect)]
 
-use crate::{task_inventory::TaskContexts, Event, *};
+use crate::{task_inventory::TaskContexts, task_store::TaskSettingsLocation, Event, *};
 use buffer_diff::{
     assert_hunks, BufferDiffEvent, DiffHunkSecondaryStatus, DiffHunkStatus, DiffHunkStatusKind,
 };
@@ -19,6 +19,7 @@ use lsp::{
     NumberOrString, TextDocumentEdit, WillRenameFiles,
 };
 use parking_lot::Mutex;
+use paths::tasks_file;
 use pretty_assertions::{assert_eq, assert_matches};
 use serde_json::json;
 #[cfg(not(windows))]
@@ -327,7 +328,7 @@ async fn test_managing_project_specific_settings(cx: &mut gpui::TestAppContext) 
             inventory.task_scheduled(topmost_local_task_source_kind.clone(), resolved_task);
             inventory
                 .update_file_based_tasks(
-                    None,
+                    TaskSettingsLocation::Global(tasks_file()),
                     Some(
                         &json!([{
                             "label": "cargo check unstable",


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/13433
Closes https://github.com/zed-industries/zed/issues/27124
Closes https://github.com/zed-industries/zed/issues/27066
Closes https://github.com/zed-industries/zed/issues/27150

After this change, both old global task source, `tasks.json` and new, `debug.json` started to call for the same task update method:

https://github.com/zed-industries/zed/blob/14920ab910c6d0208d23ce6b6e2ed644e6f20f2e/crates/project/src/task_inventory.rs#L414

erasing previous declarations.

The PR puts this data under different paths instead and adjusts the code around it.

Release Notes:

- Fixed custom tasks not shown 
