### PR TITLE
Improve code context completion logic

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -665,7 +665,7 @@ impl CompletionsMenu {
                 .collect()
         };
 
-        let mut non_first_char_matches = Vec::new();
+        let mut additional_matches = Vec::new();
         // Deprioritize all candidates where the query's start does not match the start of any word in the candidate
         if let Some(query) = query {
             if let Some(query_start) = query.chars().next() {
@@ -676,15 +676,11 @@ impl CompletionsMenu {
                         word.chars()
                             .flat_map(|codepoint| codepoint.to_lowercase())
                             .zip(query_start.to_lowercase())
-                            .all(|(word_cp, query_cp)| {
-                                let chars_match = word_cp == query_cp;
-                                let is_at_word_start = string_match.positions.first() == Some(&0);
-                                chars_match && is_at_word_start
-                            })
+                            .all(|(word_cp, query_cp)| word_cp == query_cp)
                     })
                 });
                 matches = primary;
-                non_first_char_matches = secondary;
+                additional_matches = secondary;
             }
         }
 
@@ -747,7 +743,7 @@ impl CompletionsMenu {
         }
         drop(completions);
 
-        matches.extend(non_first_char_matches);
+        matches.extend(additional_matches);
 
         *self.entries.borrow_mut() = matches;
         self.selected_item = 0;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9492,7 +9492,7 @@ async fn test_word_completions_continue_on_typing(cx: &mut TestAppContext) {
         }
     });
 
-    cx.simulate_keystroke("s");
+    cx.simulate_keystroke("l");
     cx.executor().run_until_parked();
     cx.condition(|editor, _| editor.context_menu_visible())
         .await;
@@ -9501,7 +9501,7 @@ async fn test_word_completions_continue_on_typing(cx: &mut TestAppContext) {
         {
             assert_eq!(
                 completion_menu_entries(&menu),
-                &["second"],
+                &["last"],
                 "After showing word completions, further editing should filter them and not query the LSP"
             );
         } else {


### PR DESCRIPTION
Closes #24794

We now don't filter matches provided by the fuzzy matcher, as it already performs most of the filtering for us. Instead, the custom logic we previously used for filtering is now used to partition, where before discarded matches will be appended at end of list.

Before - Filtering out matches with higher fuzzy score
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7f9d66a2-0921-499c-af8a-f1e530da50b1" />

After - Changing filter to partition instead, and appending remaining items at the end
<img width="400" alt="image" src="https://github.com/user-attachments/assets/45848f70-ed51-4935-976c-6c16c5b5777b" />


Release Notes:

- Improved LSP auto complete to show more possible matches.
