### PR TITLE
context_server: Interpret context server command paths relative to the extension's work dir

### DIFF
--- a/crates/context_server/src/extension_context_server.rs
+++ b/crates/context_server/src/extension_context_server.rs
@@ -51,9 +51,13 @@ impl ExtensionContextServerProxy for ContextServerFactoryRegistryProxy {
                                     })
                                 })?;
 
-                                let command = extension
+                                let mut command = extension
                                     .context_server_command(id.clone(), extension_project)
                                     .await?;
+                                command.command = extension
+                                    .path_from_extension(command.command.as_ref())
+                                    .to_string_lossy()
+                                    .to_string();
 
                                 log::info!("loaded command for context server {id}: {command:?}");
 

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -907,9 +907,8 @@ impl ExtensionStore {
                 }
             })
             .await
-            .map_err(|error| {
-                util::log_err(&error);
-                error
+            .inspect_err(|error| {
+                util::log_err(error);
             })?;
 
             let output_path = &extensions_dir.join(extension_id.as_ref());

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -906,7 +906,11 @@ impl ExtensionStore {
                         .await
                 }
             })
-            .await?;
+            .await
+            .map_err(|error| {
+                util::log_err(&error);
+                error
+            })?;
 
             let output_path = &extensions_dir.join(extension_id.as_ref());
             if let Some(metadata) = fs.metadata(output_path).await? {


### PR DESCRIPTION
This PR fixes an issues where the commands returned from context server extensions were being used as-is instead of interpreting them relative to the extension's work dir.

Release Notes:

- Fixed an issue with context server paths not being interpreted relative to the extension's work dir.
