### PR TITLE
Change default Markdown `soft_wrap` to "bounded"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1228,7 +1228,7 @@
       "format_on_save": "off",
       "use_on_type_format": false,
       "allow_rewrap": "anywhere",
-      "soft_wrap": "bounded",
+      "soft_wrap": "editor_width",
       "prettier": {
         "allowed": true
       }


### PR DESCRIPTION
- Follow-up to: https://github.com/zed-industries/zed/pull/26247

Previously with defaults meant that Markdown would softwrap even if you had available window space (soft_wrap occurred at default `preferred_line_length` of 80).

Release Notes:

- Changed Markdown default to soft_wrap at window width instead of preferred_line_length 
