### PR TITLE
assistant2: Uniquely identify context server entries in configuration view

### DIFF
--- a/crates/assistant2/src/assistant_configuration.rs
+++ b/crates/assistant2/src/assistant_configuration.rs
@@ -195,6 +195,7 @@ impl AssistantConfiguration {
                 let tool_count = tools.len();
 
                 v_flex()
+                    .id(SharedString::from(context_server.id()))
                     .border_1()
                     .rounded_sm()
                     .border_color(cx.theme().colors().border)


### PR DESCRIPTION
This PR gives each context server entry in the configuration view a unique element ID.

This fixes some issues where the disclosures and switches weren't working properly due to element ID collisions.

Release Notes:

- N/A
