### PR TITLE
Pre-fill body of email with system specs

### DIFF
--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -22,8 +22,6 @@ const ZED_REPO_URL: &str = "https://github.com/zed-industries/zed";
 
 const REQUEST_FEATURE_URL: &str = "https://github.com/zed-industries/zed/discussions/new/choose";
 
-const EMAIL_ZED_URL: &str = "mailto:hi@zed.dev";
-
 fn file_bug_report_url(specs: &SystemSpecs) -> String {
     format!(
         concat!(
@@ -35,6 +33,18 @@ fn file_bug_report_url(specs: &SystemSpecs) -> String {
         ),
         urlencoding::encode(&specs.to_string())
     )
+}
+
+fn email_zed_url(specs: &SystemSpecs) -> String {
+    format!(
+        concat!("mailto:hi@zed.dev", "?", "body={}"),
+        email_body(specs)
+    )
+}
+
+fn email_body(specs: &SystemSpecs) -> String {
+    let body = format!("\n\nSystem Information:\n\n{}", specs.to_string());
+    urlencoding::encode(&body).to_string()
 }
 
 pub fn init(cx: &mut App) {
@@ -79,8 +89,16 @@ pub fn init(cx: &mut App) {
                 })
                 .detach();
             })
-            .register_action(move |_, _: &EmailZed, _, cx| {
-                cx.open_url(EMAIL_ZED_URL);
+            .register_action(move |_, _: &EmailZed, window, cx| {
+                let specs = SystemSpecs::new(window, cx);
+                cx.spawn_in(window, async move |_, cx| {
+                    let specs = specs.await;
+                    cx.update(|_, cx| {
+                        cx.open_url(&email_zed_url(&specs));
+                    })
+                    .log_err();
+                })
+                .detach();
             })
             .register_action(move |_, _: &OpenZedRepo, _, cx| {
                 cx.open_url(ZED_REPO_URL);

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -43,7 +43,7 @@ fn email_zed_url(specs: &SystemSpecs) -> String {
 }
 
 fn email_body(specs: &SystemSpecs) -> String {
-    let body = format!("\n\nSystem Information:\n\n{}", specs.to_string());
+    let body = format!("\n\nSystem Information:\n\n{}", specs);
     urlencoding::encode(&body).to_string()
 }
 


### PR DESCRIPTION
I think we still want to be able to easily capture system spec info from users. They can decide if they want to include it or not.

Release Notes:

- N/A
