### PR TITLE
tab_switcher: Add keybind to close tab tooltip

### DIFF
--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -450,7 +450,7 @@ impl PickerDelegate for TabSwitcherDelegate {
                 IconButton::new("close_tab", IconName::Close)
                     .icon_size(IconSize::Small)
                     .icon_color(indicator_color)
-                    .tooltip(Tooltip::text("Close"))
+                    .tooltip(Tooltip::for_action_title("Close", &CloseSelectedItem))
                     .on_click(cx.listener(move |picker, _, window, cx| {
                         cx.stop_propagation();
                         picker.delegate.close_item_at(ix, window, cx);


### PR DESCRIPTION
| prev | new |
|--|--|
|<img width="619" alt="image" src="https://github.com/user-attachments/assets/53b14fd4-17ee-4336-81ca-30324d918e15" />|<img width="620" alt="image" src="https://github.com/user-attachments/assets/316699b3-295b-4f83-9fb1-b799f7c71d7f" />|


Release Notes:

- N/A