### PR TITLE
Prevent `toggle_dock` from opening assistant panel when it is disabled via settings

### DIFF
--- a/crates/assistant/src/assistant.rs
+++ b/crates/assistant/src/assistant.rs
@@ -15,7 +15,7 @@ use client::Client;
 use command_palette_hooks::CommandPaletteFilter;
 use feature_flags::FeatureFlagAppExt;
 use fs::Fs;
-use gpui::{actions, App, Global, UpdateGlobal};
+use gpui::{actions, App, Global, ReadGlobal, UpdateGlobal};
 use language_model::{
     LanguageModelId, LanguageModelProviderId, LanguageModelRegistry, LanguageModelResponseMessage,
 };
@@ -85,6 +85,10 @@ impl Assistant {
         CommandPaletteFilter::update_global(cx, |filter, _cx| {
             filter.show_namespace(Self::NAMESPACE);
         });
+    }
+
+    pub fn enabled(cx: &App) -> bool {
+        Self::global(cx).enabled
     }
 }
 

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1,4 +1,5 @@
 use crate::assistant_configuration::{ConfigurationView, ConfigurationViewEvent};
+use crate::Assistant;
 use crate::{
     terminal_inline_assistant::TerminalInlineAssistant, DeployHistory, InlineAssistant, NewChat,
 };
@@ -58,8 +59,7 @@ pub fn init(cx: &mut App) {
 
     cx.observe_new(
         |terminal_panel: &mut TerminalPanel, _, cx: &mut Context<TerminalPanel>| {
-            let settings = AssistantSettings::get_global(cx);
-            terminal_panel.set_assistant_enabled(settings.enabled, cx);
+            terminal_panel.set_assistant_enabled(Assistant::enabled(cx), cx);
         },
     )
     .detach();
@@ -342,12 +342,12 @@ impl AssistantPanel {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
-        let settings = AssistantSettings::get_global(cx);
-        if !settings.enabled {
-            return;
+        if workspace
+            .panel::<Self>(cx)
+            .is_some_and(|panel| panel.read(cx).enabled(cx))
+        {
+            workspace.toggle_panel_focus::<Self>(window, cx);
         }
-
-        workspace.toggle_panel_focus::<Self>(window, cx);
     }
 
     fn watch_client_status(
@@ -595,12 +595,10 @@ impl AssistantPanel {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
-        let settings = AssistantSettings::get_global(cx);
-        if !settings.enabled {
-            return;
-        }
-
-        let Some(assistant_panel) = workspace.panel::<AssistantPanel>(cx) else {
+        let Some(assistant_panel) = workspace
+            .panel::<AssistantPanel>(cx)
+            .filter(|panel| panel.read(cx).enabled(cx))
+        else {
             return;
         };
 
@@ -1298,12 +1296,8 @@ impl Panel for AssistantPanel {
     }
 
     fn icon(&self, _: &Window, cx: &App) -> Option<IconName> {
-        let settings = AssistantSettings::get_global(cx);
-        if !settings.enabled || !settings.button {
-            return None;
-        }
-
-        Some(IconName::ZedAssistant)
+        (self.enabled(cx) && AssistantSettings::get_global(cx).button)
+            .then_some(IconName::ZedAssistant)
     }
 
     fn icon_tooltip(&self, _: &Window, _: &App) -> Option<&'static str> {
@@ -1318,8 +1312,8 @@ impl Panel for AssistantPanel {
         4
     }
 
-    fn activatable(&self, cx: &App) -> bool {
-        AssistantSettings::get_global(cx).enabled
+    fn enabled(&self, cx: &App) -> bool {
+        Assistant::enabled(cx)
     }
 }
 

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -1317,6 +1317,10 @@ impl Panel for AssistantPanel {
     fn activation_priority(&self) -> u32 {
         4
     }
+
+    fn activatable(&self, cx: &App) -> bool {
+        AssistantSettings::get_global(cx).enabled
+    }
 }
 
 impl EventEmitter<PanelEvent> for AssistantPanel {}

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -1,5 +1,6 @@
 use crate::{
-    AssistantPanel, AssistantPanelEvent, CycleNextInlineAssist, CyclePreviousInlineAssist,
+    Assistant, AssistantPanel, AssistantPanelEvent, CycleNextInlineAssist,
+    CyclePreviousInlineAssist,
 };
 use anyhow::{anyhow, Context as _, Result};
 use assistant_context_editor::{humanize_token_count, RequestType};
@@ -3555,7 +3556,7 @@ impl CodeActionProvider for AssistantCodeActionProvider {
         _: &mut Window,
         cx: &mut App,
     ) -> Task<Result<Vec<CodeAction>>> {
-        if !AssistantSettings::get_global(cx).enabled {
+        if !Assistant::enabled(cx) {
             return Task::ready(Ok(Vec::new()));
         }
 

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -225,12 +225,12 @@ impl AssistantPanel {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
-        let settings = AssistantSettings::get_global(cx);
-        if !settings.enabled {
-            return;
+        if workspace
+            .panel::<Self>(cx)
+            .is_some_and(|panel| panel.read(cx).enabled(cx))
+        {
+            workspace.toggle_panel_focus::<Self>(window, cx);
         }
-
-        workspace.toggle_panel_focus::<Self>(window, cx);
     }
 
     pub(crate) fn local_timezone(&self) -> UtcOffset {
@@ -637,12 +637,8 @@ impl Panel for AssistantPanel {
     }
 
     fn icon(&self, _window: &Window, cx: &App) -> Option<IconName> {
-        let settings = AssistantSettings::get_global(cx);
-        if !settings.enabled || !settings.button {
-            return None;
-        }
-
-        Some(IconName::ZedAssistant)
+        (self.enabled(cx) && AssistantSettings::get_global(cx).button)
+            .then_some(IconName::ZedAssistant)
     }
 
     fn icon_tooltip(&self, _window: &Window, _cx: &App) -> Option<&'static str> {
@@ -657,7 +653,7 @@ impl Panel for AssistantPanel {
         3
     }
 
-    fn activatable(&self, cx: &App) -> bool {
+    fn enabled(&self, cx: &App) -> bool {
         AssistantSettings::get_global(cx).enabled
     }
 }

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -656,6 +656,10 @@ impl Panel for AssistantPanel {
     fn activation_priority(&self) -> u32 {
         3
     }
+
+    fn activatable(&self, cx: &App) -> bool {
+        AssistantSettings::get_global(cx).enabled
+    }
 }
 
 impl AssistantPanel {

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -1156,20 +1156,7 @@ impl Panel for ChatPanel {
     }
 
     fn icon(&self, _window: &Window, cx: &App) -> Option<ui::IconName> {
-        let show_icon = match ChatPanelSettings::get_global(cx).button {
-            ChatPanelButton::Never => false,
-            ChatPanelButton::Always => true,
-            ChatPanelButton::WhenInCall => {
-                let is_in_call = ActiveCall::global(cx)
-                    .read(cx)
-                    .room()
-                    .map_or(false, |room| room.read(cx).contains_guests());
-
-                self.active || is_in_call
-            }
-        };
-
-        show_icon.then(|| ui::IconName::MessageBubbles)
+        self.enabled(cx).then(|| ui::IconName::MessageBubbles)
     }
 
     fn icon_tooltip(&self, _: &Window, _: &App) -> Option<&'static str> {
@@ -1189,6 +1176,21 @@ impl Panel for ChatPanel {
 
     fn activation_priority(&self) -> u32 {
         7
+    }
+
+    fn enabled(&self, cx: &App) -> bool {
+        match ChatPanelSettings::get_global(cx).button {
+            ChatPanelButton::Never => false,
+            ChatPanelButton::Always => true,
+            ChatPanelButton::WhenInCall => {
+                let is_in_call = ActiveCall::global(cx)
+                    .read(cx)
+                    .room()
+                    .map_or(false, |room| room.read(cx).contains_guests());
+
+                self.active || is_in_call
+            }
+        }
     }
 }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -53,7 +53,7 @@ pub trait Panel: Focusable + EventEmitter<PanelEvent> + Render + Sized {
         None
     }
     fn activation_priority(&self) -> u32;
-    fn activatable(&self, _cx: &App) -> bool {
+    fn enabled(&self, _cx: &App) -> bool {
         true
     }
 }
@@ -78,7 +78,7 @@ pub trait PanelHandle: Send + Sync {
     fn panel_focus_handle(&self, cx: &App) -> FocusHandle;
     fn to_any(&self) -> AnyView;
     fn activation_priority(&self, cx: &App) -> u32;
-    fn activatable(&self, cx: &App) -> bool;
+    fn enabled(&self, cx: &App) -> bool;
     fn move_to_next_position(&self, window: &mut Window, cx: &mut App) {
         let current_position = self.position(window, cx);
         let next_position = [
@@ -176,8 +176,8 @@ where
         self.read(cx).activation_priority()
     }
 
-    fn activatable(&self, cx: &App) -> bool {
-        self.read(cx).activatable(cx)
+    fn enabled(&self, cx: &App) -> bool {
+        self.read(cx).enabled(cx)
     }
 }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -366,7 +366,7 @@ impl Dock {
             .position(|entry| entry.panel.enabled(cx))
             .with_context(|| {
                 format!(
-                    "Could find no enabled panel for the {} dock.",
+                    "Couldn't find any enabled panel for the {} dock.",
                     self.position.label()
                 )
             })

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2523,7 +2523,13 @@ impl Workspace {
             dock.set_open(!was_visible, window, cx);
 
             if dock.active_panel().is_none() {
-                dock.activate_first_activatable_panel(window, cx);
+                let Some(panel_ix) = dock
+                    .first_enabled_panel_idx(cx)
+                    .log_with_level(log::Level::Info)
+                else {
+                    return;
+                };
+                dock.activate_panel(panel_ix, window, cx);
             }
 
             if let Some(active_panel) = dock.active_panel() {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2522,8 +2522,8 @@ impl Workspace {
             let was_visible = dock.is_open() && !other_is_zoomed;
             dock.set_open(!was_visible, window, cx);
 
-            if dock.active_panel().is_none() && dock.panels_len() > 0 {
-                dock.activate_panel(0, window, cx);
+            if dock.active_panel().is_none() {
+                dock.activate_first_activatable_panel(window, cx);
             }
 
             if let Some(active_panel) = dock.active_panel() {


### PR DESCRIPTION
Part of #27171

Follows-up the change in https://github.com/zed-industries/zed/pull/22346 to consider the case where the assistant-panel is disabled via settings (as also noted in [this comment](https://github.com/zed-industries/zed/pull/22346#issuecomment-2558372412), Notably, only the explicit case is considered here. Can extend this change to also cover the implicit case where the button is disabled if requested.). 

Currently, if the user toggles the right dock, the assistant panel will be shown even if it is disabled via settings, because it has the highest priority (see https://github.com/zed-industries/zed/pull/22346#issuecomment-2564890493). With this change, the assistant panel is no longer activated when disabled and the dock with the next highest activation order is activated instead. 

I did not opt in to make the priority configurabe, as I agree with https://github.com/zed-industries/zed/pull/22346#issuecomment-2564890493 that this will most likely rarely be used (the active panel is only none on the first toggle of the dock, afterwards it remains set for the remainder of the session). 

Release Notes:

- `workspace::ToggleRightDock` will no longer open the assistant panel when it is disabled via settings.
