### PR TITLE
bedrock: Fix model IDs for Anthropic models

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -83,11 +83,11 @@ impl Model {
 
     pub fn id(&self) -> &str {
         match self {
-            Model::Claude3_5Sonnet => "us.anthropic.claude-3-5-sonnet-20241022-v2:0",
-            Model::Claude3Opus => "us.anthropic.claude-3-opus-20240229-v1:0",
-            Model::Claude3Sonnet => "us.anthropic.claude-3-sonnet-20240229-v1:0",
-            Model::Claude3_5Haiku => "us.anthropic.claude-3-5-haiku-20241022-v1:0",
-            Model::Claude3_7Sonnet => "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+            Model::Claude3_5Sonnet => "anthropic.claude-3-5-sonnet-20241022-v2:0",
+            Model::Claude3Opus => "anthropic.claude-3-opus-20240229-v1:0",
+            Model::Claude3Sonnet => "anthropic.claude-3-sonnet-20240229-v1:0",
+            Model::Claude3_5Haiku => "anthropic.claude-3-5-haiku-20241022-v1:0",
+            Model::Claude3_7Sonnet => "anthropic.claude-3-7-sonnet-20250219-v1:0",
             Model::AmazonNovaLite => "us.amazon.nova-lite-v1:0",
             Model::AmazonNovaMicro => "us.amazon.nova-micro-v1:0",
             Model::AmazonNovaPro => "us.amazon.nova-pro-v1:0",


### PR DESCRIPTION
Closes #27223 

I haven't been able to learn how to set up a build and test this locally, but I can confirm that these model IDs are valid according to [Supported foundation models in Amazon Bedrock
](https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html)
Apologies – I'm not a Rust programmer, but thought I'd get the ball rolling!