### PR TITLE
Anthropic-defined Text editor tool [wip]

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -157,7 +157,11 @@ impl Model {
         }
     }
 
-    pub const DEFAULT_BETA_HEADERS: &[&str] = &["prompt-caching-2024-07-31"];
+    pub const DEFAULT_BETA_HEADERS: &[&str] = &[
+        "prompt-caching-2024-07-31",
+        // todo! add this based on enabled tools?
+        "computer-use-2025-01-24",
+    ];
 
     pub fn beta_headers(&self) -> String {
         let mut headers = Self::DEFAULT_BETA_HEADERS
@@ -504,10 +508,18 @@ pub struct ImageSource {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct Tool {
-    pub name: String,
-    pub description: String,
-    pub input_schema: serde_json::Value,
+#[serde(untagged)]
+pub enum Tool {
+    Custom {
+        name: String,
+        description: String,
+        input_schema: serde_json::Value,
+    },
+    Anthropic {
+        #[serde(rename = "type")]
+        tool_type: String,
+        name: String,
+    },
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/assistant2/src/tool_selector.rs
+++ b/crates/assistant2/src/tool_selector.rs
@@ -87,6 +87,10 @@ impl ToolSelector {
 
                 menu = match &source {
                     ToolSource::Native => menu.separator().header("Zed Tools"),
+                    ToolSource::RefactorMeProviderDefined { provider_name, .. } => {
+                        // todo! should only show these tools if compatible with model
+                        menu.separator().header(format!("{} Tools", provider_name))
+                    }
                     ToolSource::ContextServer { id } => {
                         let all_tools_from_source_enabled =
                             tool_set.are_all_tools_from_source_enabled(&source);

--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -23,6 +23,14 @@ pub enum ToolSource {
     Native,
     /// A tool provided by a context server.
     ContextServer { id: SharedString },
+    /// Provider-specific tool.
+    RefactorMeProviderDefined {
+        // todo! we probably want a different trait for these
+        //       the payload here would vary by provider,
+        //       and these tools don't need description() / input_schema()
+        provider_name: &'static str,
+        tool_type: &'static str,
+    },
 }
 
 /// A tool that can be used by a language model.

--- a/crates/assistant_tools/src/anthropic.rs
+++ b/crates/assistant_tools/src/anthropic.rs
@@ -1,0 +1,3 @@
+mod text_editor_tool;
+
+pub use text_editor_tool::*;

--- a/crates/assistant_tools/src/anthropic/text_editor_tool.rs
+++ b/crates/assistant_tools/src/anthropic/text_editor_tool.rs
@@ -1,0 +1,165 @@
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{anyhow, Result};
+use assistant_tool::{ActionLog, Tool, ToolSource};
+use gpui::{App, Entity, Task};
+use language_model::LanguageModelRequestMessage;
+use project::Project;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum TextEditorToolInput {
+    /// View file contents or directory listing
+    View {
+        /// The path to the file or directory to view
+        path: Arc<Path>,
+        /// Optional line range to view (1-based, inclusive)
+        #[serde(default)]
+        view_range: Option<(usize, usize)>,
+    },
+
+    /// Replace specific text in a file
+    StrReplace {
+        /// The path to the file to modify
+        path: Arc<Path>,
+        /// The text to replace (must match exactly)
+        old_str: String,
+        /// The new text to insert
+        new_str: String,
+    },
+
+    /// Create a new file with content
+    Create {
+        /// The path where the new file should be created
+        path: Arc<Path>,
+        /// The content to write to the new file
+        file_text: String,
+    },
+
+    /// Insert text at a specific line
+    Insert {
+        /// The path to the file to modify
+        path: Arc<Path>,
+        /// The line number after which to insert (0 for beginning)
+        insert_line: usize,
+        /// The text to insert
+        new_str: String,
+    },
+
+    /// Undo the last edit made to a file
+    UndoEdit {
+        /// The path to the file whose last edit should be undone
+        path: Arc<Path>,
+    },
+}
+
+pub struct TextEditorTool;
+
+impl Tool for TextEditorTool {
+    fn name(&self) -> String {
+        "str_replace_editor".into()
+    }
+
+    fn description(&self) -> String {
+        String::new()
+    }
+
+    fn source(&self) -> ToolSource {
+        ToolSource::RefactorMeProviderDefined {
+            provider_name: "Anthropic",
+            // todo! Depends on model!
+            tool_type: "text_editor_20250124",
+        }
+    }
+
+    fn input_schema(&self) -> serde_json::Value {
+        let schema = schemars::schema_for!(TextEditorToolInput);
+        serde_json::to_value(&schema).unwrap()
+    }
+
+    fn ui_text(&self, input: &serde_json::Value) -> String {
+        match serde_json::from_value::<TextEditorToolInput>(input.clone()) {
+            Ok(input) => match input {
+                TextEditorToolInput::View { path, .. } => format!("View file `{}`", path.display()),
+                TextEditorToolInput::StrReplace { path, .. } => {
+                    format!("Edit file `{}`", path.display())
+                }
+                TextEditorToolInput::Create { path, .. } => {
+                    format!("Create file `{}`", path.display())
+                }
+                TextEditorToolInput::Insert { path, .. } => {
+                    format!("Edit file `{}`", path.display())
+                }
+                TextEditorToolInput::UndoEdit { path } => {
+                    format!("Undo edit in `{}`", path.display())
+                }
+            },
+            Err(_) => "Edit file".to_string(),
+        }
+    }
+
+    fn run(
+        self: Arc<Self>,
+        input: serde_json::Value,
+        _messages: &[LanguageModelRequestMessage],
+        project: Entity<Project>,
+        action_log: Entity<ActionLog>,
+        cx: &mut App,
+    ) -> Task<Result<String>> {
+        // Basic input validation
+        let input = match serde_json::from_value::<TextEditorToolInput>(input) {
+            Ok(input) => input,
+            Err(err) => return Task::ready(Err(anyhow!(err))),
+        };
+
+        // Handle each command type
+        match input {
+            TextEditorToolInput::View { path, view_range } => {
+                // TODO: Implement view functionality
+                Task::ready(Ok(format!(
+                    "View command not yet implemented for path: {}",
+                    path.display()
+                )))
+            }
+            TextEditorToolInput::StrReplace {
+                path,
+                old_str,
+                new_str,
+            } => {
+                // TODO: Implement replace functionality
+                Task::ready(Ok(format!(
+                    "Replace command not yet implemented for path: {}",
+                    path.display()
+                )))
+            }
+            TextEditorToolInput::Create { path, file_text } => {
+                // TODO: Implement create functionality
+                Task::ready(Ok(format!(
+                    "Create command not yet implemented for path: {}",
+                    path.display()
+                )))
+            }
+            TextEditorToolInput::Insert {
+                path,
+                insert_line,
+                new_str,
+            } => {
+                // TODO: Implement insert functionality
+                Task::ready(Ok(format!(
+                    "Insert command not yet implemented for path: {}",
+                    path.display()
+                )))
+            }
+            TextEditorToolInput::UndoEdit { path } => {
+                // TODO: Implement undo functionality
+                Task::ready(Ok(format!(
+                    "Undo command not yet implemented for path: {}",
+                    path.display()
+                )))
+            }
+        }
+    }
+}

--- a/crates/assistant_tools/src/anthropic/text_editor_tool.rs
+++ b/crates/assistant_tools/src/anthropic/text_editor_tool.rs
@@ -223,7 +223,15 @@ impl Tool for TextEditorTool {
 
                     // todo! look at reference implementation to see what's the best response
                     match diff_result {
-                        Some(diff) => {
+                        Some((diff, match_count)) => {
+                            if match_count > 1 {
+                                // Anthropic requires that we fail if there's more than one match
+                                return Err(anyhow!(
+                                    "Aborting! Found {} occurrences of `old_str`. Please make it more specific.",
+                                    match_count
+                                ));
+                            }
+
                             buffer.update(cx, |buffer, cx| buffer.apply_diff(diff, cx))?;
                             save_changed_buffer(project, action_log, buffer, cx).await?;
 

--- a/crates/assistant_tools/src/anthropic/text_editor_tool.rs
+++ b/crates/assistant_tools/src/anthropic/text_editor_tool.rs
@@ -133,13 +133,11 @@ impl Tool for TextEditorTool {
 
         let path = input.path().clone();
 
-        let project_path =
-            // todo! how can we tell the model to not use abs paths
-            if path.is_absolute() {
-                project.read(cx).project_path_for_absolute_path(&path, cx)
-            } else {
-                project.read(cx).find_project_path(&path, cx)
-            };
+        let project_path = if path.is_absolute() {
+            project.read(cx).project_path_for_absolute_path(&path, cx)
+        } else {
+            project.read(cx).find_project_path(&path, cx)
+        };
 
         let Some(project_path) = project_path else {
             return Task::ready(Err(anyhow!("Path {} not found in project", path.display())));
@@ -214,7 +212,6 @@ impl Tool for TextEditorTool {
                         return Err(anyhow!("{} does not exist", path.display()));
                     }
 
-                    // todo! anthropic requires that we fail if >1 match is found
                     let diff_result = cx
                         .background_spawn(async move {
                             replace_exact(&old_str, &new_str, &snapshot).await

--- a/crates/assistant_tools/src/anthropic/text_editor_tool.rs
+++ b/crates/assistant_tools/src/anthropic/text_editor_tool.rs
@@ -5,6 +5,7 @@ use anyhow::{anyhow, Result};
 use assistant_tool::{ActionLog, Tool, ToolSource};
 use collections::HashSet;
 use gpui::{App, Entity, Task};
+use language::Point;
 use language_model::LanguageModelRequestMessage;
 use project::Project;
 use schemars::JsonSchema;
@@ -153,10 +154,15 @@ impl Tool for TextEditorTool {
                 TextEditorToolInput::View { view_range, .. } => {
                     changed = false;
 
-                    format!(
-                        "View command not yet implemented for path: {}",
-                        path.display()
-                    )
+                    buffer.read_with(cx, |buffer, _cx| match view_range {
+                        Some((start_row, end_row)) => {
+                            let start = Point::new(start_row.saturating_sub(1) as u32, 0);
+                            let end = Point::new(end_row as u32, 0);
+
+                            buffer.text_for_range(start..end).collect::<String>()
+                        }
+                        None => buffer.text(),
+                    })?
                 }
                 TextEditorToolInput::StrReplace {
                     path,

--- a/crates/assistant_tools/src/assistant_tools.rs
+++ b/crates/assistant_tools/src/assistant_tools.rs
@@ -1,3 +1,4 @@
+mod anthropic;
 mod bash_tool;
 mod delete_path_tool;
 mod diagnostics_tool;
@@ -36,12 +37,18 @@ pub fn init(http_client: Arc<HttpClientWithUrl>, cx: &mut App) {
     registry.register_tool(BashTool);
     registry.register_tool(DeletePathTool);
     registry.register_tool(DiagnosticsTool);
-    registry.register_tool(EditFilesTool);
     registry.register_tool(ListDirectoryTool);
     registry.register_tool(NowTool);
     registry.register_tool(PathSearchTool);
     registry.register_tool(ReadFileTool);
     registry.register_tool(RegexSearchTool);
+
+    if std::env::var("USE_ANTHROPIC_TEXT_EDITOR").is_ok() {
+        registry.register_tool(anthropic::TextEditorTool);
+    } else {
+        registry.register_tool(EditFilesTool);
+    }
+
     registry.register_tool(ThinkingTool);
     registry.register_tool(FetchTool::new(http_client));
 }

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -320,6 +320,7 @@ impl EditToolRequest {
                             // Try to match exactly
                             replace_exact(&old, &new, &snapshot)
                             .await
+                            .map(|(diff, _)| diff)
                             // If that fails, try being flexible about indentation
                             .or_else(|| replace_with_flexible_indent(&old, &new, &snapshot));
 

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -1,6 +1,6 @@
 mod edit_action;
 pub mod log;
-mod replace;
+pub(crate) mod replace;
 
 use anyhow::{anyhow, Context, Result};
 use assistant_tool::{ActionLog, Tool};

--- a/crates/assistant_tools/src/edit_files_tool/replace.rs
+++ b/crates/assistant_tools/src/edit_files_tool/replace.rs
@@ -5,7 +5,11 @@ use util::{paths::PathMatcher, ResultExt as _};
 /// Performs an exact string replacement in a buffer, requiring precise character-for-character matching.
 /// Uses the search functionality to locate the first occurrence of the exact string.
 /// Returns None if no exact match is found in the buffer.
-pub async fn replace_exact(old: &str, new: &str, snapshot: &BufferSnapshot) -> Option<Diff> {
+pub async fn replace_exact(
+    old: &str,
+    new: &str,
+    snapshot: &BufferSnapshot,
+) -> Option<(Diff, usize)> {
     let query = SearchQuery::text(
         old,
         false,
@@ -41,7 +45,7 @@ pub async fn replace_exact(old: &str, new: &str, snapshot: &BufferSnapshot) -> O
         edits,
     };
 
-    Some(diff)
+    Some((diff, matches.len()))
 }
 
 /// Performs a replacement that's indentation-aware - matches text content ignoring leading whitespace differences.

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -229,10 +229,19 @@ impl LanguageModelRequestMessage {
 }
 
 #[derive(Debug, PartialEq, Hash, Clone, Serialize, Deserialize)]
-pub struct LanguageModelRequestTool {
-    pub name: String,
-    pub description: String,
-    pub input_schema: serde_json::Value,
+#[serde(untagged)]
+pub enum LanguageModelRequestTool {
+    Custom {
+        name: String,
+        description: String,
+        input_schema: serde_json::Value,
+    },
+    RefactorMeProviderDefined {
+        // todo! this payload would like depend on the provider. should this be a serde_json::Value?
+        #[serde(rename = "type")]
+        tool_type: String,
+        name: String,
+    },
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq)]

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -237,7 +237,7 @@ pub enum LanguageModelRequestTool {
         input_schema: serde_json::Value,
     },
     RefactorMeProviderDefined {
-        // todo! this payload would like depend on the provider. should this be a serde_json::Value?
+        // todo! this payload would likely depend on the provider. should this be a serde_json::Value?
         #[serde(rename = "type")]
         tool_type: String,
         name: String,

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -573,6 +573,7 @@ impl LanguageModel for CloudLanguageModel {
                 );
                 let client = self.client.clone();
                 let llm_api_token = self.llm_api_token.clone();
+                // todo! collab doesn't support provider-specific tools
                 let future = self.request_limiter.stream(async move {
                     let response = Self::perform_llm_completion(
                         client.clone(),
@@ -673,7 +674,7 @@ impl LanguageModel for CloudLanguageModel {
                 request.tool_choice = Some(anthropic::ToolChoice::Tool {
                     name: tool_name.clone(),
                 });
-                request.tools = vec![anthropic::Tool {
+                request.tools = vec![anthropic::Tool::Custom {
                     name: tool_name.clone(),
                     description: tool_description,
                     input_schema,

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -485,18 +485,18 @@ pub fn into_deepseek(
         tools: request
             .tools
             .into_iter()
-            .filter_map(|tool| match tool {
+            .map(|tool| match tool {
                 LanguageModelRequestTool::Custom {
                     name,
                     description,
                     input_schema,
-                } => Some(deepseek::ToolDefinition::Function {
+                } => deepseek::ToolDefinition::Function {
                     function: deepseek::FunctionDefinition {
                         name,
                         description: Some(description),
                         parameters: Some(input_schema),
                     },
-                }),
+                },
                 LanguageModelRequestTool::RefactorMeProviderDefined { .. } => {
                     todo!();
                 }


### PR DESCRIPTION
We want to try Anthropic-defined [Text editor](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool#example-create-command) tool and see how it compares to our own `edit-files` tool. 

This is a work-in-progress. There's a working implementation of all the commands except for [`undo_edit`](https://docs.anthropic.com/en/docs/build-with-claude/tool-use/text-editor-tool#undo-edit). However, we still need to design a proper interface for provider-defined tools, how to tie them to models, and display them in the tool selector. I went with something hacky to get the tool running, but I don't think it should be merged as-is.

**How to try:** Run with `USE_ANTHROPIC_TEXT_EDITOR=1` and select `Claude 3.7` directly from Anthropic. Using the model through Zed (cloud) doesn't work because our backend doesn't support schema-less tools yet.

Release Notes:

- N/A
