### PR TITLE
vim: Single quote mark

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2144,6 +2144,7 @@ impl Editor {
         self.push_to_nav_history(
             *old_cursor_position,
             Some(new_cursor_position.to_point(buffer)),
+            false,
             cx,
         );
 
@@ -10771,13 +10772,14 @@ impl Editor {
     }
 
     pub fn create_nav_history_entry(&mut self, cx: &mut Context<Self>) {
-        self.push_to_nav_history(self.selections.newest_anchor().head(), None, cx);
+        self.push_to_nav_history(self.selections.newest_anchor().head(), None, false, cx);
     }
 
     fn push_to_nav_history(
         &mut self,
         cursor_anchor: Anchor,
         new_position: Option<Point>,
+        is_deactivate: bool,
         cx: &mut Context<Self>,
     ) {
         if let Some(nav_history) = self.nav_history.as_mut() {
@@ -10805,6 +10807,7 @@ impl Editor {
             );
             cx.emit(EditorEvent::PushedToNavHistory {
                 anchor: cursor_anchor,
+                is_deactivate,
             })
         }
     }
@@ -18563,6 +18566,7 @@ pub enum EditorEvent {
     CursorShapeChanged,
     PushedToNavHistory {
         anchor: Anchor,
+        is_deactivate: bool,
     },
 }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10770,6 +10770,10 @@ impl Editor {
         self.nav_history.as_ref()
     }
 
+    pub fn create_nav_history_entry(&mut self, cx: &mut Context<Self>) {
+        self.push_to_nav_history(self.selections.newest_anchor().head(), None, cx);
+    }
+
     fn push_to_nav_history(
         &mut self,
         cursor_anchor: Anchor,
@@ -10799,6 +10803,9 @@ impl Editor {
                 }),
                 cx,
             );
+            cx.emit(EditorEvent::PushedToNavHistory {
+                anchor: cursor_anchor,
+            })
         }
     }
 
@@ -18554,6 +18561,9 @@ pub enum EditorEvent {
     },
     Reloaded,
     CursorShapeChanged,
+    PushedToNavHistory {
+        anchor: Anchor,
+    },
 }
 
 impl EventEmitter<EditorEvent> for Editor {}

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -737,7 +737,7 @@ impl Item for Editor {
 
     fn deactivated(&mut self, _: &mut Window, cx: &mut Context<Self>) {
         let selection = self.selections.newest_anchor();
-        self.push_to_nav_history(selection.head(), None, cx);
+        self.push_to_nav_history(selection.head(), None, true, cx);
     }
 
     fn workspace_deactivated(&mut self, _: &mut Window, cx: &mut Context<Self>) {

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -25,7 +25,7 @@ impl Vim {
         let count = Vim::take_count(cx).unwrap_or(1);
         self.stop_recording_immediately(action.boxed_clone(), cx);
         if count <= 1 || Vim::globals(cx).dot_replaying {
-            self.create_mark("^".into(), window, cx);
+            self.create_mark("^".into(), true, window, cx);
             self.update_editor(window, cx, |_, editor, window, cx| {
                 editor.dismiss_menus_and_popups(false, window, cx);
                 editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -25,7 +25,7 @@ impl Vim {
         let count = Vim::take_count(cx).unwrap_or(1);
         self.stop_recording_immediately(action.boxed_clone(), cx);
         if count <= 1 || Vim::globals(cx).dot_replaying {
-            self.create_mark("^".into(), true, window, cx);
+            self.create_mark("^".into(), window, cx);
             self.update_editor(window, cx, |_, editor, window, cx| {
                 editor.dismiss_menus_and_popups(false, window, cx);
                 editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {

--- a/crates/vim/src/normal/mark.rs
+++ b/crates/vim/src/normal/mark.rs
@@ -19,7 +19,13 @@ use crate::{
 };
 
 impl Vim {
-    pub fn create_mark(&mut self, text: Arc<str>, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn create_mark(
+        &mut self,
+        text: Arc<str>,
+        should_clear_operator: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.update_editor(window, cx, |vim, editor, window, cx| {
             let anchors = editor
                 .selections
@@ -29,7 +35,9 @@ impl Vim {
                 .collect::<Vec<_>>();
             vim.set_mark(text.to_string(), anchors, editor.buffer(), window, cx);
         });
-        self.clear_operator(window, cx);
+        if should_clear_operator {
+            self.clear_operator(window, cx);
+        }
     }
 
     // When handling an action, you must create visual marks if you will switch to normal
@@ -192,6 +200,7 @@ impl Vim {
                 vim.get_mark(&text, editor, window, cx)
             })
             .flatten();
+        self.create_mark("'".into(), false, window, cx);
         let anchors = match mark {
             None => None,
             Some(Mark::Local(anchors)) => Some(anchors),

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -822,16 +822,16 @@ impl Vim {
             EditorEvent::FocusedIn => self.sync_vim_settings(window, cx),
             EditorEvent::CursorShapeChanged => self.cursor_shape_changed(window, cx),
             EditorEvent::PushedToNavHistory {
-                anchor: cursor_anchor,
+                anchor,
+                is_deactivate,
             } => {
                 self.update_editor(window, cx, |vim, editor, window, cx| {
-                    vim.set_mark(
-                        "'".to_string(),
-                        vec![*cursor_anchor],
-                        editor.buffer(),
-                        window,
-                        cx,
-                    );
+                    let mark = if *is_deactivate {
+                        "\"".to_string()
+                    } else {
+                        "'".to_string()
+                    };
+                    vim.set_mark(mark, vec![*anchor], editor.buffer(), window, cx);
                 });
             }
             _ => {}

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -827,7 +827,7 @@ impl Vim {
                 self.update_editor(window, cx, |vim, editor, window, cx| {
                     vim.set_mark(
                         "'".to_string(),
-                        vec![cursor_anchor.clone()],
+                        vec![*cursor_anchor],
                         editor.buffer(),
                         window,
                         cx,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -821,6 +821,19 @@ impl Vim {
             EditorEvent::Edited { .. } => self.push_to_change_list(window, cx),
             EditorEvent::FocusedIn => self.sync_vim_settings(window, cx),
             EditorEvent::CursorShapeChanged => self.cursor_shape_changed(window, cx),
+            EditorEvent::PushedToNavHistory {
+                anchor: cursor_anchor,
+            } => {
+                self.update_editor(window, cx, |vim, editor, window, cx| {
+                    vim.set_mark(
+                        "'".to_string(),
+                        vec![cursor_anchor.clone()],
+                        editor.buffer(),
+                        window,
+                        cx,
+                    );
+                });
+            }
             _ => {}
         }
     }
@@ -1571,7 +1584,7 @@ impl Vim {
                 }
                 _ => self.clear_operator(window, cx),
             },
-            Some(Operator::Mark) => self.create_mark(text, true, window, cx),
+            Some(Operator::Mark) => self.create_mark(text, window, cx),
             Some(Operator::RecordRegister) => {
                 self.record_register(text.chars().next().unwrap(), window, cx)
             }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1571,7 +1571,7 @@ impl Vim {
                 }
                 _ => self.clear_operator(window, cx),
             },
-            Some(Operator::Mark) => self.create_mark(text, window, cx),
+            Some(Operator::Mark) => self.create_mark(text, true, window, cx),
             Some(Operator::RecordRegister) => {
                 self.record_register(text.chars().next().unwrap(), window, cx)
             }

--- a/crates/vim/test_data/test_quote_mark.json
+++ b/crates/vim/test_data/test_quote_mark.json
@@ -1,0 +1,23 @@
+{"Put":{"state":"ˇHello, world!"}}
+{"Key":"w"}
+{"Key":"m"}
+{"Key":"o"}
+{"Get":{"state":"Helloˇ, world!","mode":"Normal"}}
+{"Key":"$"}
+{"Key":"`"}
+{"Key":"o"}
+{"Get":{"state":"Helloˇ, world!","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"`"}
+{"Get":{"state":"Hello, worldˇ!","mode":"Normal"}}
+{"Key":"`"}
+{"Key":"`"}
+{"Get":{"state":"Helloˇ, world!","mode":"Normal"}}
+{"Key":"$"}
+{"Key":"m"}
+{"Key":"'"}
+{"Get":{"state":"Hello, worldˇ!","mode":"Normal"}}
+{"Key":"^"}
+{"Key":"`"}
+{"Key":"`"}
+{"Get":{"state":"Hello, worldˇ!","mode":"Normal"}}


### PR DESCRIPTION
Closes #22398

Release Notes:

- vim: Adds `'` and `"` marks (last location jumped from in the current buffer, and location when last exiting a buffer)