### PR TITLE
languages: Fix JS/TS imports not showing correct suggestions after using period

### DIFF
--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -32,5 +32,5 @@ block_comment = ["{/* ", " */}"]
 opt_into_language_servers = ["emmet-language-server"]
 
 [overrides.string]
-completion_query_characters = ["-"]
+completion_query_characters = ["-", "."]
 opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -30,5 +30,5 @@ block_comment = ["{/* ", " */}"]
 opt_into_language_servers = ["emmet-language-server"]
 
 [overrides.string]
-completion_query_characters = ["-"]
+completion_query_characters = ["-", "."]
 opt_into_language_servers = ["tailwindcss-language-server"]

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -17,3 +17,6 @@ brackets = [
 word_characters = ["#", "$"]
 prettier_parser_name = "typescript"
 tab_size = 2
+
+[overrides.string]
+completion_query_characters = ["."]


### PR DESCRIPTION
Closes #21728

This PR improves autocomplete for imports for all kinds of javascript and typescript files.

Adds `.` as `completion_query_characters` which will make it act like word for auto completion context. This allows capturing compete `format.` as query.

Before:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/849fb342-db73-48e7-a9d8-93f0e5a14b58" />

After:
<img width="500" alt="image" src="https://github.com/user-attachments/assets/e3ac3272-3217-4bcd-857f-4a83afc5980e" />

Release Notes:

- Improved autocomplete suggestions for JavaScript and TypeScript imports.
