### PR TITLE
Add non-blob columns to SQLite

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -12,6 +12,7 @@ use anyhow::{anyhow, bail, Context, Result};
 use client::DevServerProjectId;
 use db::{define_connection, query, sqlez::connection::Connection, sqlez_macros::sql};
 use gpui::{point, size, Axis, Bounds, WindowBounds, WindowId};
+use itertools::Itertools;
 use project::debugger::breakpoint_store::{BreakpointKind, SerializedBreakpoint};
 
 use language::{LanguageName, Toolchain};
@@ -529,6 +530,11 @@ define_connection! {
                 ON UPDATE CASCADE
             );
         ),
+    sql!(
+        ALTER TABLE workspaces ADD COLUMN local_paths_array TEXT;
+        CREATE UNIQUE INDEX local_paths_array_uq ON workspaces(local_paths_array);
+        ALTER TABLE workspaces ADD COLUMN local_paths_order_array TEXT;
+    ),
     ];
 }
 
@@ -779,9 +785,11 @@ impl WorkspaceDb {
                                 bottom_dock_zoom,
                                 session_id,
                                 window_id,
-                                timestamp
+                                timestamp,
+                                local_paths_array,
+                                local_paths_order_array
                             )
-                            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, CURRENT_TIMESTAMP)
+                            VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, CURRENT_TIMESTAMP, ?15, ?16)
                             ON CONFLICT DO
                             UPDATE SET
                                 local_paths = ?2,
@@ -797,10 +805,12 @@ impl WorkspaceDb {
                                 bottom_dock_zoom = ?12,
                                 session_id = ?13,
                                 window_id = ?14,
-                                timestamp = CURRENT_TIMESTAMP
+                                timestamp = CURRENT_TIMESTAMP,
+                                local_paths_array = ?15,
+                                local_paths_order_array = ?16
                         );
                         let mut prepared_query = conn.exec_bound(query)?;
-                        let args = (workspace.id, &local_paths, &local_paths_order, workspace.docks, workspace.session_id, workspace.window_id);
+                        let args = (workspace.id, &local_paths, &local_paths_order, workspace.docks, workspace.session_id, workspace.window_id, local_paths.paths().iter().map(|path| path.to_string_lossy().to_string()).join(","), local_paths_order.order().iter().map(|order| order.to_string()).join(","));
 
                         prepared_query(args).context("Updating workspace")?;
                     }


### PR DESCRIPTION
Preparation for https://github.com/zed-industries/zed/issues/15097
The PR adds string columns for path-related `BLOB` columns.
Currently, the logic only writes into these, without reading, after 2 versions the next PR will do that.

We do not have a notion of a "buffer table" in Zed, only currently active editors in the `editors` table.
Different editors can point at the same buffer, so we need some many-to-one mapping which is simpler to do with string buffer paths, instead of blobs.

Also, this enabled simpler DB manipulations with paths and their order, as those are strings now.

Release Notes:

- N/A
