### PR TITLE
assistant2: Ensure scripting tool gets disabled when switching profiles

### DIFF
--- a/crates/assistant2/src/tool_selector.rs
+++ b/crates/assistant2/src/tool_selector.rs
@@ -63,6 +63,7 @@ impl ToolSelector {
                     let tools = tool_set.clone();
                     move |_window, cx| {
                         tools.disable_source(ToolSource::Native, cx);
+                        tools.disable_scripting_tool();
                         tools.enable(
                             ToolSource::Native,
                             &profile


### PR DESCRIPTION
This PR fixes an issue where the scripting tool wasn't being disabled when switching to a profile that did not have it enabled.

Release Notes:

- N/A
