### PR TITLE
Fix toggling breakpoints not working when text anchor isn't at start

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6019,7 +6019,9 @@ impl Editor {
                     .breakpoints(&buffer, None, buffer_snapshot.clone(), cx)
             {
                 let point = buffer_snapshot.summary_for_anchor::<Point>(&breakpoint.0);
-                let anchor = multi_buffer_snapshot.anchor_before(point);
+                let mut anchor = multi_buffer_snapshot.anchor_before(point);
+                anchor.text_anchor = breakpoint.0;
+
                 breakpoint_display_points.insert(
                     snapshot
                         .point_to_display_point(

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -699,7 +699,7 @@ impl WorkspaceDb {
         match breakpoints {
             Ok(bp) => {
                 if bp.is_empty() {
-                    log::error!("Breakpoints are empty after querying database for them");
+                    log::debug!("Breakpoints are empty after querying database for them");
                 }
 
                 let mut map: BTreeMap<Arc<Path>, Vec<SerializedBreakpoint>> = Default::default();


### PR DESCRIPTION
This fixes a bug where breakpoint's were unable to be toggled if the text::Anchor representing the breakpoint position was not at the beginning of a line.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
