### PR TITLE
Adjust multibuffer header fold button size

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2283,7 +2283,7 @@ impl EditorElement {
                         });
                     })
                     .tooltip(Tooltip::for_action_title(
-                        "Expand excerpt",
+                        "Expand Excerpt",
                         &crate::actions::ExpandExcerpts::default(),
                     ))
                     .into_any_element();

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2903,8 +2903,8 @@ impl EditorElement {
                                 .child(
                                     ButtonLike::new("toggle-buffer-fold")
                                         .style(ui::ButtonStyle::Transparent)
-                                        .size(ButtonSize::Large)
-                                        .width(px(24.).into())
+                                        .height(px(28.).into())
+                                        .width(px(28.).into())
                                         .children(toggle_chevron_icon)
                                         .tooltip({
                                             let focus_handle = focus_handle.clone();

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -398,7 +398,7 @@ impl ButtonLike {
         self
     }
 
-    pub(crate) fn height(mut self, height: DefiniteLength) -> Self {
+    pub fn height(mut self, height: DefiniteLength) -> Self {
         self.height = Some(height);
         self
     }


### PR DESCRIPTION
This PR adjust the size of the fold button on the multibuffer header. Had to make the `height` method public on the Button Like to pull that off without other major changes.

| Before | After |
|--------|--------|
| ![CleanShot 2025-03-21 at 12  11 40@2x](https://github.com/user-attachments/assets/003b2965-b1cc-43ad-8528-2bd11cf0f9cc)  | ![CleanShot 2025-03-21 at 12  11 28@2x](https://github.com/user-attachments/assets/d4927b72-3f41-4c4b-9813-49e676170419) | 

Release Notes:

- N/A
