### PR TITLE
keymap: Remove backspace/delete as shortcuts for `git::RestoreFile`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -754,9 +754,8 @@
       "escape": "git_panel::ToggleFocus",
       "ctrl-enter": "git::Commit",
       "alt-enter": "menu::SecondaryConfirm",
-      "delete": "git::RestoreFile",
       "shift-delete": "git::RestoreFile",
-      "backspace": "git::RestoreFile"
+      "ctrl-delete": "git::RestoreFile"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -803,9 +803,7 @@
       "shift-tab": "git_panel::FocusEditor",
       "escape": "git_panel::ToggleFocus",
       "cmd-enter": "git::Commit",
-      "delete": "git::RestoreFile",
-      "cmd-backspace": "git::RestoreFile",
-      "backspace": "git::RestoreFile"
+      "cmd-backspace": "git::RestoreFile"
     }
   },
   {


### PR DESCRIPTION
- See also: https://github.com/zed-industries/zed/pull/27004

Release Notes:

- N/A
