### PR TITLE
editor: Fix regression in git label colors due to status color changes

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1662,13 +1662,13 @@ pub fn entry_diagnostic_aware_icon_decoration_and_color(
 pub fn entry_git_aware_label_color(git_status: GitSummary, ignored: bool, selected: bool) -> Color {
     let tracked = git_status.index + git_status.worktree;
     if ignored {
-        Color::VersionControlIgnored
+        Color::Ignored
     } else if git_status.conflict > 0 {
-        Color::VersionControlConflict
+        Color::Conflict
     } else if tracked.modified > 0 {
-        Color::VersionControlModified
+        Color::Modified
     } else if tracked.added > 0 || git_status.untracked > 0 {
-        Color::VersionControlAdded
+        Color::Created
     } else {
         entry_label_color(selected)
     }


### PR DESCRIPTION
This PR fixes the new awkward-looking git status labels due to the change in version control colors. We want to enable styling version control colors distinctly from other statuses, but these colors aren't great for labels as they are meant to be quite high contrast.

We may need to split version control colors into a primary color and a text color if we want to improve theming this overall.

| Before | After |
|--------|-------|
| ![CleanShot 2025-03-21 at 14 12 22@2x](https://github.com/user-attachments/assets/fadb93b1-06b6-44cc-bf16-7e1279166ed0) | ![CleanShot 2025-03-21 at 14 12 49@2x](https://github.com/user-attachments/assets/262ffc23-60b9-4cee-8a2b-9e864130912f) |

Release Notes:

- Fixes a regression in git status colors in the project panel