### PR TITLE
Fix double highlighting when searching and selecting text

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5259,16 +5259,15 @@ impl EditorElement {
                             for (background_highlight_id, (_, background_ranges)) in
                                 background_highlights.iter()
                             {
-                                let is_search_highlights = *background_highlight_id
-                                    == TypeId::of::<SearchResultOrSelectedTextHighlight>();
-                                let is_text_highlights = *background_highlight_id
+                                let is_search_or_text_highlights = *background_highlight_id
                                     == TypeId::of::<SearchResultOrSelectedTextHighlight>();
                                 let is_symbol_occurrences = *background_highlight_id
                                     == TypeId::of::<DocumentHighlightRead>()
                                     || *background_highlight_id
                                         == TypeId::of::<DocumentHighlightWrite>();
-                                if (is_search_highlights && scrollbar_settings.search_results)
-                                    || (is_text_highlights && scrollbar_settings.selected_text)
+                                if (is_search_or_text_highlights
+                                    && (scrollbar_settings.search_results
+                                        || scrollbar_settings.selected_text))
                                     || (is_symbol_occurrences && scrollbar_settings.selected_symbol)
                                 {
                                     let mut color = theme.status().info;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -13,7 +13,6 @@ use crate::{
         self, hover_at, HOVER_POPOVER_GAP, MIN_POPOVER_CHARACTER_WIDTH, MIN_POPOVER_LINE_HEIGHT,
     },
     inlay_hint_settings,
-    items::BufferSearchHighlights,
     mouse_context_menu::{self, MenuPosition, MouseContextMenu},
     scroll::{axis_pair, scroll_amount::ScrollAmount, AxisPair},
     BlockId, ChunkReplacement, CursorShape, CustomBlockId, DisplayDiffHunk, DisplayPoint,
@@ -21,10 +20,10 @@ use crate::{
     EditorSettings, EditorSnapshot, EditorStyle, FocusedBlock, GoToHunk, GoToPreviousHunk,
     GutterDimensions, HalfPageDown, HalfPageUp, HandleInput, HoveredCursor, InlayHintRefreshReason,
     InlineCompletion, JumpData, LineDown, LineHighlight, LineUp, OpenExcerpts, PageDown, PageUp,
-    Point, RowExt, RowRangeExt, SelectPhase, SelectedTextHighlight, Selection, SoftWrap,
-    StickyHeaderExcerpt, ToPoint, ToggleFold, COLUMNAR_SELECTION_MODIFIERS, CURSORS_VISIBLE_FOR,
-    FILE_HEADER_HEIGHT, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN, MIN_LINE_NUMBER_DIGITS,
-    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+    Point, RowExt, RowRangeExt, SearchResultOrSelectedTextHighlight, SelectPhase, Selection,
+    SoftWrap, StickyHeaderExcerpt, ToPoint, ToggleFold, COLUMNAR_SELECTION_MODIFIERS,
+    CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN,
+    MIN_LINE_NUMBER_DIGITS, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
 };
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use client::ParticipantIndex;
@@ -1356,11 +1355,8 @@ impl EditorElement {
                     // Git
                     (is_singleton && scrollbar_settings.git_diff && snapshot.buffer_snapshot.has_diff_hunks())
                     ||
-                    // Buffer Search Results
-                    (is_singleton && scrollbar_settings.search_results && editor.has_background_highlights::<BufferSearchHighlights>())
-                    ||
-                    // Selected Text Occurrences
-                    (is_singleton && scrollbar_settings.selected_text && editor.has_background_highlights::<SelectedTextHighlight>())
+                    // Buffer Search Results or Selected Text Occurrences
+                    (is_singleton && scrollbar_settings.search_results && editor.has_background_highlights::<SearchResultOrSelectedTextHighlight>())
                     ||
                     // Selected Symbol Occurrences
                     (is_singleton && scrollbar_settings.selected_symbol && (editor.has_background_highlights::<DocumentHighlightRead>() || editor.has_background_highlights::<DocumentHighlightWrite>()))
@@ -5264,9 +5260,9 @@ impl EditorElement {
                                 background_highlights.iter()
                             {
                                 let is_search_highlights = *background_highlight_id
-                                    == TypeId::of::<BufferSearchHighlights>();
+                                    == TypeId::of::<SearchResultOrSelectedTextHighlight>();
                                 let is_text_highlights = *background_highlight_id
-                                    == TypeId::of::<SelectedTextHighlight>();
+                                    == TypeId::of::<SearchResultOrSelectedTextHighlight>();
                                 let is_symbol_occurrences = *background_highlight_id
                                     == TypeId::of::<DocumentHighlightRead>()
                                     || *background_highlight_id


### PR DESCRIPTION
It's impossible to spot your cursor if you mix #24835 with search results highlighting:

#### Before #24835:
![image](https://github.com/user-attachments/assets/6486e3a1-15ee-493d-82b5-eb44eef055bf)

#### After #24835:
![image](https://github.com/user-attachments/assets/3cbf6879-be78-4470-a3b4-db9d6f855d13)
(ignore spacing between lines, I believe it's unrelated.)

This PR gives the same highlight ID for these two, so it's only highlighted once, restoring the behavior we had before #24835.

Release Notes:

- Fix double highlighting when searching and selecting text, which made it hard to find the cursor.
