### PR TITLE
Allow enabling/disabling breakpoints

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -414,6 +414,8 @@ actions!(
         Tab,
         Backtab,
         ToggleBreakpoint,
+        DisableBreakpoint,
+        EnableBreakpoint,
         EditLogBreakpoint,
         ToggleAutoSignatureHelp,
         ToggleGitBlameInline,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8609,7 +8609,7 @@ impl Editor {
 
             self.edit_breakpoint_at_anchor(
                 breakpoint_position,
-                Breakpoint::default(),
+                Breakpoint::new_hover(),
                 edit_action,
                 cx,
             );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8481,13 +8481,16 @@ impl Editor {
         let snapshot = self.snapshot(window, cx);
         let breakpoint_position = snapshot.buffer_snapshot.anchor_before(Point::new(row, 0));
 
-        let project = self.project.clone();
+        let project = self.project.clone()?;
 
-        let buffer_id = snapshot
-            .buffer_snapshot
-            .buffer_id_for_excerpt(breakpoint_position.excerpt_id)?;
+        let buffer_id = breakpoint_position.buffer_id.or_else(|| {
+            snapshot
+                .buffer_snapshot
+                .buffer_id_for_excerpt(breakpoint_position.excerpt_id)
+        })?;
+
         let enclosing_excerpt = breakpoint_position.excerpt_id;
-        let buffer = project?.read_with(cx, |project, cx| project.buffer_for_id(buffer_id, cx))?;
+        let buffer = project.read_with(cx, |project, cx| project.buffer_for_id(buffer_id, cx))?;
         let buffer_snapshot = buffer.read(cx).snapshot();
 
         let row = buffer_snapshot

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8609,7 +8609,7 @@ impl Editor {
 
             self.edit_breakpoint_at_anchor(
                 breakpoint_position,
-                Breakpoint::new_hover(),
+                Breakpoint::new_standard(),
                 edit_action,
                 cx,
             );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6182,6 +6182,8 @@ impl Editor {
             .is_some_and(|gutter_bp| gutter_bp.row() == row)
         {
             Color::Hint
+        } else if breakpoint.is_disabled() {
+            Color::Custom(Color::Debugger.color(cx).opacity(0.5))
         } else {
             Color::Debugger
         };

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -17617,7 +17617,7 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
     assert_breakpoint(
         &breakpoints,
         &abs_path,
-        vec![(0, Breakpoint::new_log("hello world".into()))],
+        vec![(0, Breakpoint::new_log("hello world"))],
     );
 
     // Removing a log message from a log breakpoint should remove it
@@ -17683,7 +17683,7 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
         &abs_path,
         vec![
             (0, Breakpoint::new_standard()),
-            (3, Breakpoint::new_log("hello world".into())),
+            (3, Breakpoint::new_log("hello world")),
         ],
     );
 
@@ -17706,7 +17706,7 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
         &abs_path,
         vec![
             (0, Breakpoint::new_standard()),
-            (3, Breakpoint::new_log("hello Earth !!".into())),
+            (3, Breakpoint::new_log("hello Earth !!")),
         ],
     );
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -17360,7 +17360,7 @@ async fn assert_highlighted_edits(
 fn assert_breakpoint(
     breakpoints: &BTreeMap<Arc<Path>, Vec<SerializedBreakpoint>>,
     path: &Arc<Path>,
-    expected: Vec<(u32, BreakpointKind)>,
+    expected: Vec<(u32, Breakpoint)>,
 ) {
     if expected.len() == 0usize {
         assert!(!breakpoints.contains_key(path));
@@ -17369,7 +17369,15 @@ fn assert_breakpoint(
             .get(path)
             .unwrap()
             .into_iter()
-            .map(|breakpoint| (breakpoint.position, breakpoint.kind.clone()))
+            .map(|breakpoint| {
+                (
+                    breakpoint.position,
+                    Breakpoint {
+                        kind: breakpoint.kind.clone(),
+                        state: breakpoint.state,
+                    },
+                )
+            })
             .collect::<Vec<_>>();
 
         breakpoint.sort_by_key(|(cached_position, _)| *cached_position);
@@ -17496,7 +17504,10 @@ async fn test_breakpoint_toggling(cx: &mut TestAppContext) {
     assert_breakpoint(
         &breakpoints,
         &abs_path,
-        vec![(0, BreakpointKind::Standard), (3, BreakpointKind::Standard)],
+        vec![
+            (0, Breakpoint::new_standard()),
+            (3, Breakpoint::new_standard()),
+        ],
     );
 
     editor.update_in(cx, |editor, window, cx| {
@@ -17515,7 +17526,11 @@ async fn test_breakpoint_toggling(cx: &mut TestAppContext) {
     });
 
     assert_eq!(1, breakpoints.len());
-    assert_breakpoint(&breakpoints, &abs_path, vec![(3, BreakpointKind::Standard)]);
+    assert_breakpoint(
+        &breakpoints,
+        &abs_path,
+        vec![(3, Breakpoint::new_standard())],
+    );
 
     editor.update_in(cx, |editor, window, cx| {
         editor.move_to_end(&MoveToEnd, window, cx);
@@ -17602,7 +17617,7 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
     assert_breakpoint(
         &breakpoints,
         &abs_path,
-        vec![(0, BreakpointKind::Log("hello world".into()))],
+        vec![(0, Breakpoint::new_log("hello world".into()))],
     );
 
     // Removing a log message from a log breakpoint should remove it
@@ -17643,7 +17658,10 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
     assert_breakpoint(
         &breakpoints,
         &abs_path,
-        vec![(0, BreakpointKind::Standard), (3, BreakpointKind::Standard)],
+        vec![
+            (0, Breakpoint::new_standard()),
+            (3, Breakpoint::new_standard()),
+        ],
     );
 
     editor.update_in(cx, |editor, window, cx| {
@@ -17664,8 +17682,8 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
         &breakpoints,
         &abs_path,
         vec![
-            (0, BreakpointKind::Standard),
-            (3, BreakpointKind::Log("hello world".into())),
+            (0, Breakpoint::new_standard()),
+            (3, Breakpoint::new_log("hello world".into())),
         ],
     );
 
@@ -17687,8 +17705,167 @@ async fn test_log_breakpoint_editing(cx: &mut TestAppContext) {
         &breakpoints,
         &abs_path,
         vec![
-            (0, BreakpointKind::Standard),
-            (3, BreakpointKind::Log("hello Earth !!".into())),
+            (0, Breakpoint::new_standard()),
+            (3, Breakpoint::new_log("hello Earth !!".into())),
+        ],
+    );
+}
+
+/// This also tests that Editor::breakpoint_at_cursor_head is working properly
+/// we had some issues where we wouldn't find a breakpoint at Point {row: 0, col: 0}
+/// or when breakpoints were placed out of order. This tests for a regression too
+#[gpui::test]
+async fn test_breakpoint_enabling_and_disabling(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let sample_text = "First line\nSecond line\nThird line\nFourth line".to_string();
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "main.rs": sample_text,
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace.deref(), cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        path!("/a"),
+        json!({
+            "main.rs": sample_text,
+        }),
+    )
+    .await;
+    let project = Project::test(fs, [path!("/a").as_ref()], cx).await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace.deref(), cx);
+    let worktree_id = workspace
+        .update(cx, |workspace, _window, cx| {
+            workspace.project().update(cx, |project, cx| {
+                project.worktrees(cx).next().unwrap().read(cx).id()
+            })
+        })
+        .unwrap();
+
+    let buffer = project
+        .update(cx, |project, cx| {
+            project.open_buffer((worktree_id, "main.rs"), cx)
+        })
+        .await
+        .unwrap();
+
+    let (editor, cx) = cx.add_window_view(|window, cx| {
+        Editor::new(
+            EditorMode::Full,
+            MultiBuffer::build_from_buffer(buffer, cx),
+            Some(project.clone()),
+            window,
+            cx,
+        )
+    });
+
+    let project_path = editor.update(cx, |editor, cx| editor.project_path(cx).unwrap());
+    let abs_path = project.read_with(cx, |project, cx| {
+        project
+            .absolute_path(&project_path, cx)
+            .map(|path_buf| Arc::from(path_buf.to_owned()))
+            .unwrap()
+    });
+
+    // assert we can add breakpoint on the first line
+    editor.update_in(cx, |editor, window, cx| {
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+        editor.move_to_end(&MoveToEnd, window, cx);
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+        editor.move_up(&MoveUp, window, cx);
+        editor.toggle_breakpoint(&actions::ToggleBreakpoint, window, cx);
+    });
+
+    let breakpoints = editor.update(cx, |editor, cx| {
+        editor
+            .breakpoint_store()
+            .as_ref()
+            .unwrap()
+            .read(cx)
+            .all_breakpoints(cx)
+            .clone()
+    });
+
+    assert_eq!(1, breakpoints.len());
+    assert_breakpoint(
+        &breakpoints,
+        &abs_path,
+        vec![
+            (0, Breakpoint::new_standard()),
+            (2, Breakpoint::new_standard()),
+            (3, Breakpoint::new_standard()),
+        ],
+    );
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.move_to_beginning(&MoveToBeginning, window, cx);
+        editor.disable_breakpoint(&actions::DisableBreakpoint, window, cx);
+        editor.move_to_end(&MoveToEnd, window, cx);
+        editor.disable_breakpoint(&actions::DisableBreakpoint, window, cx);
+    });
+
+    let breakpoints = editor.update(cx, |editor, cx| {
+        editor
+            .breakpoint_store()
+            .as_ref()
+            .unwrap()
+            .read(cx)
+            .all_breakpoints(cx)
+            .clone()
+    });
+
+    let disable_breakpoint = {
+        let mut bp = Breakpoint::new_standard();
+        bp.state = BreakpointState::Disabled;
+        bp
+    };
+
+    assert_eq!(1, breakpoints.len());
+    assert_breakpoint(
+        &breakpoints,
+        &abs_path,
+        vec![
+            (0, disable_breakpoint.clone()),
+            (2, Breakpoint::new_standard()),
+            (3, disable_breakpoint.clone()),
+        ],
+    );
+
+    editor.update_in(cx, |editor, window, cx| {
+        editor.move_to_beginning(&MoveToBeginning, window, cx);
+        editor.enable_breakpoint(&actions::EnableBreakpoint, window, cx);
+        editor.move_to_end(&MoveToEnd, window, cx);
+        editor.enable_breakpoint(&actions::EnableBreakpoint, window, cx);
+        editor.move_up(&MoveUp, window, cx);
+        editor.disable_breakpoint(&actions::DisableBreakpoint, window, cx);
+    });
+
+    let breakpoints = editor.update(cx, |editor, cx| {
+        editor
+            .breakpoint_store()
+            .as_ref()
+            .unwrap()
+            .read(cx)
+            .all_breakpoints(cx)
+            .clone()
+    });
+
+    assert_eq!(1, breakpoints.len());
+    assert_breakpoint(
+        &breakpoints,
+        &abs_path,
+        vec![
+            (0, Breakpoint::new_standard()),
+            (2, disable_breakpoint),
+            (3, Breakpoint::new_standard()),
         ],
     );
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -31,7 +31,7 @@ use multi_buffer::{IndentGuide, PathKey};
 use parking_lot::Mutex;
 use pretty_assertions::{assert_eq, assert_ne};
 use project::{
-    debugger::breakpoint_store::{BreakpointKind, SerializedBreakpoint},
+    debugger::breakpoint_store::{BreakpointKind, BreakpointState, SerializedBreakpoint},
     project_settings::{LspSettings, ProjectSettings},
     FakeFs,
 };
@@ -17397,12 +17397,18 @@ fn add_log_breakpoint_at_cursor(
 
             let kind = BreakpointKind::Log(Arc::from(log_message));
 
-            (breakpoint_position, Breakpoint { kind })
+            (
+                breakpoint_position,
+                Breakpoint {
+                    kind,
+                    state: BreakpointState::Enabled,
+                },
+            )
         });
 
     editor.edit_breakpoint_at_anchor(
         anchor,
-        bp.kind,
+        bp,
         BreakpointEditAction::EditLogMessage(log_message.into()),
         cx,
     );

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2095,7 +2095,7 @@ impl EditorElement {
                         return None;
                     }
 
-                    let button = editor.render_breakpoint(text_anchor, display_row, Some(&bp), cx);
+                    let button = editor.render_breakpoint(text_anchor, display_row, &bp, cx);
 
                     let button = prepaint_gutter_button(
                         button,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -525,6 +525,8 @@ impl EditorElement {
         if cx.has_flag::<Debugger>() {
             register_action(editor, window, Editor::toggle_breakpoint);
             register_action(editor, window, Editor::edit_log_breakpoint);
+            register_action(editor, window, Editor::enable_breakpoint);
+            register_action(editor, window, Editor::disable_breakpoint);
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7040,7 +7040,7 @@ impl Element for EditorElement {
                                         gutter_breakpoint_point,
                                         Bias::Left,
                                     );
-                                    let breakpoint = Breakpoint::new_hover();
+                                    let breakpoint = Breakpoint::new_standard();
 
                                     (position, breakpoint)
                                 });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2083,7 +2083,6 @@ impl EditorElement {
                     {
                         should_render_phantom_breakpoint = false;
                     }
-                    let row = MultiBufferRow { 0: display_row.0 };
 
                     if row_infos
                         .get((display_row.0.saturating_sub(range.start.0)) as usize)
@@ -2096,6 +2095,8 @@ impl EditorElement {
                         return None;
                     }
 
+                    let row =
+                        MultiBufferRow(DisplayPoint::new(display_row, 0).to_point(&snapshot).row);
                     if snapshot.is_line_folded(row) {
                         return None;
                     }
@@ -2218,6 +2219,7 @@ impl EditorElement {
                     {
                         return None;
                     }
+
                     let button = editor.render_run_indicator(
                         &self.style,
                         Some(display_row) == active_task_indicator_row,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -57,7 +57,7 @@ use multi_buffer::{
     MultiBufferRow, RowInfo,
 };
 use project::{
-    debugger::breakpoint_store::{Breakpoint, BreakpointKind},
+    debugger::breakpoint_store::{Breakpoint, BreakpointKind, BreakpointState},
     project_settings::{self, GitGutterSetting, GitHunkStyleSetting, ProjectSettings},
 };
 use settings::Settings;
@@ -2093,7 +2093,7 @@ impl EditorElement {
                         return None;
                     }
 
-                    let button = editor.render_breakpoint(text_anchor, display_row, &bp.kind, cx);
+                    let button = editor.render_breakpoint(text_anchor, display_row, &bp, cx);
 
                     let button = prepaint_gutter_button(
                         button,
@@ -7039,6 +7039,7 @@ impl Element for EditorElement {
                                     );
                                     let breakpoint = Breakpoint {
                                         kind: BreakpointKind::Standard,
+                                        state: BreakpointState::Enabled,
                                     };
 
                                     (position, breakpoint)

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -611,9 +611,16 @@ pub struct Breakpoint {
 }
 
 impl Breakpoint {
-    pub fn new_hover() -> Self {
+    pub fn new_standard() -> Self {
         Self {
             kind: BreakpointKind::Standard,
+            state: BreakpointState::Enabled,
+        }
+    }
+
+    pub fn new_log(log_message: &str) -> Self {
+        Self {
+            kind: BreakpointKind::Log(log_message.to_owned().into()),
             state: BreakpointState::Enabled,
         }
     }

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -505,8 +505,7 @@ impl BreakpointStore {
                             position,
                             Breakpoint {
                                 kind: bp.kind,
-                                // todo(debugger): We should be deriving this from database
-                                state: BreakpointState::Enabled,
+                                state: bp.state,
                             },
                         ))
                     }
@@ -601,6 +600,15 @@ impl BreakpointState {
     #[inline]
     pub fn is_disabled(&self) -> bool {
         matches!(self, BreakpointState::Disabled)
+    }
+
+    #[inline]
+    pub fn to_int(&self) -> i32 {
+        match self {
+            BreakpointState::Enabled => 0,
+            BreakpointState::Disabled => 1,
+            BreakpointState::Hint => unreachable!("We should never try to serialize this data"),
+        }
     }
 }
 

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -240,10 +240,6 @@ impl BreakpointStore {
             return;
         };
 
-        if breakpoint.1.state == BreakpointState::Hint {
-            breakpoint.1.state = BreakpointState::Enabled;
-        }
-
         let breakpoint_set = self
             .breakpoints
             .entry(abs_path.clone())
@@ -588,7 +584,6 @@ pub enum BreakpointState {
     #[default]
     Enabled,
     Disabled,
-    Hint,
 }
 
 impl BreakpointState {
@@ -607,7 +602,6 @@ impl BreakpointState {
         match self {
             BreakpointState::Enabled => 0,
             BreakpointState::Disabled => 1,
-            BreakpointState::Hint => unreachable!("We should never try to serialize this data"),
         }
     }
 }
@@ -622,18 +616,16 @@ impl Breakpoint {
     pub fn new_hover() -> Self {
         Self {
             kind: BreakpointKind::Standard,
-            state: BreakpointState::Hint,
+            state: BreakpointState::Enabled,
         }
     }
+
     fn to_proto(&self, _path: &Path, position: &text::Anchor) -> Option<client::proto::Breakpoint> {
         Some(client::proto::Breakpoint {
             position: Some(serialize_text_anchor(position)),
             state: match self.state {
                 BreakpointState::Enabled => proto::BreakpointState::Enabled.into(),
                 BreakpointState::Disabled => proto::BreakpointState::Disabled.into(),
-                BreakpointState::Hint => {
-                    unreachable!("We should never store any breakpoint's that are used for hints")
-                }
             },
             kind: match self.kind {
                 BreakpointKind::Standard => proto::BreakpointKind::Standard.into(),

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -542,9 +542,8 @@ pub enum BreakpointEditAction {
     EditLogMessage(LogMessage),
 }
 
-#[derive(Default, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub enum BreakpointKind {
-    #[default]
     Standard,
     Log(LogMessage),
 }
@@ -579,9 +578,8 @@ impl Hash for BreakpointKind {
     }
 }
 
-#[derive(Default, Copy, Clone, Debug, Hash, PartialEq, Eq)]
+#[derive(Copy, Clone, Debug, Hash, PartialEq, Eq)]
 pub enum BreakpointState {
-    #[default]
     Enabled,
     Disabled,
 }
@@ -606,7 +604,7 @@ impl BreakpointState {
     }
 }
 
-#[derive(Clone, Default, Debug, Hash, PartialEq, Eq)]
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
 pub struct Breakpoint {
     pub kind: BreakpointKind,
     pub state: BreakpointState,

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -260,7 +260,7 @@ impl BreakpointStore {
                     breakpoint_set.breakpoints.push(breakpoint.clone());
                 }
             }
-            BreakpointEditAction::ToggleState => {
+            BreakpointEditAction::InvertState => {
                 if let Some((_, bp)) = breakpoint_set
                     .breakpoints
                     .iter_mut()
@@ -542,7 +542,7 @@ type LogMessage = Arc<str>;
 #[derive(Clone, Debug)]
 pub enum BreakpointEditAction {
     Toggle,
-    ToggleState,
+    InvertState,
     EditLogMessage(LogMessage),
 }
 

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -610,6 +610,14 @@ impl Breakpoint {
             },
         })
     }
+
+    pub fn is_enabled(&self) -> bool {
+        matches!(self.state, BreakpointState::Enabled)
+    }
+
+    pub fn is_disabled(&self) -> bool {
+        matches!(self.state, BreakpointState::Disabled)
+    }
 }
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -256,6 +256,21 @@ impl BreakpointStore {
                     breakpoint_set.breakpoints.push(breakpoint.clone());
                 }
             }
+            BreakpointEditAction::ToggleState => {
+                if let Some((_, bp)) = breakpoint_set
+                    .breakpoints
+                    .iter_mut()
+                    .find(|value| breakpoint == **value)
+                {
+                    if bp.is_enabled() {
+                        bp.state = BreakpointState::Disabled;
+                    } else {
+                        bp.state = BreakpointState::Enabled;
+                    }
+                } else {
+                    log::error!("Attempted to invert a breakpoint's state that doesn't exist ");
+                }
+            }
             BreakpointEditAction::EditLogMessage(log_message) => {
                 if !log_message.is_empty() {
                     breakpoint.1.kind = BreakpointKind::Log(log_message.clone());
@@ -523,6 +538,7 @@ type LogMessage = Arc<str>;
 #[derive(Clone, Debug)]
 pub enum BreakpointEditAction {
     Toggle,
+    ToggleState,
     EditLogMessage(LogMessage),
 }
 

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -317,6 +317,7 @@ impl LocalMode {
             .breakpoint_store
             .read_with(cx, |store, cx| store.breakpoints_from_path(&abs_path, cx))
             .into_iter()
+            .filter(|bp| bp.state.is_enabled())
             .map(Into::into)
             .collect();
 
@@ -347,7 +348,11 @@ impl LocalMode {
             let breakpoints = if ignore_breakpoints {
                 vec![]
             } else {
-                breakpoints.into_iter().map(Into::into).collect()
+                breakpoints
+                    .into_iter()
+                    .filter(|bp| bp.state.is_enabled())
+                    .map(Into::into)
+                    .collect()
             };
 
             breakpoint_tasks.push(self.request(

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -2640,9 +2640,15 @@ enum BreakpointKind {
     Log = 1;
 }
 
+enum BreakpointState {
+    Enabled = 0;
+    Disabled = 1;
+}
+
 
 message Breakpoint {
     Anchor position = 1;
+    BreakpointState state = 2;
     BreakpointKind kind = 3;
     optional string message = 4;
 }

--- a/crates/sqlez/src/statement.rs
+++ b/crates/sqlez/src/statement.rs
@@ -11,7 +11,7 @@ use crate::connection::Connection;
 pub struct Statement<'a> {
     /// vector of pointers to the raw SQLite statement objects.
     /// it holds the actual prepared statements that will be executed.
-    raw_statements: Vec<*mut sqlite3_stmt>,
+    pub raw_statements: Vec<*mut sqlite3_stmt>,
     /// Index of the current statement being executed from the `raw_statements` vector.
     current_statement: usize,
     /// A reference to the database connection.

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -748,7 +748,7 @@ impl WorkspaceDb {
                             position: breakpoint.position,
                             path,
                             kind: breakpoint.kind,
-                            state: BreakpointState::Enabled,
+                            state: breakpoint.state,
                         });
                 }
 
@@ -1464,7 +1464,7 @@ mod tests {
         };
 
         let disable_breakpoint = Breakpoint {
-            position: 123,
+            position: 578,
             kind: BreakpointKind::Standard,
             state: BreakpointState::Disabled,
         };
@@ -1486,19 +1486,19 @@ mod tests {
                             position: breakpoint.position,
                             path: Arc::from(path),
                             kind: breakpoint.kind.clone(),
-                            state: BreakpointState::Enabled,
+                            state: breakpoint.state,
                         },
                         SerializedBreakpoint {
                             position: log_breakpoint.position,
                             path: Arc::from(path),
                             kind: log_breakpoint.kind.clone(),
-                            state: BreakpointState::Enabled,
+                            state: log_breakpoint.state,
                         },
                         SerializedBreakpoint {
                             position: disable_breakpoint.position,
                             path: Arc::from(path),
                             kind: disable_breakpoint.kind.clone(),
-                            state: BreakpointState::Disabled,
+                            state: disable_breakpoint.state,
                         },
                     ],
                 );
@@ -1514,12 +1514,21 @@ mod tests {
         let loaded_breakpoints = loaded.breakpoints.get(&Arc::from(path)).unwrap();
 
         assert_eq!(loaded_breakpoints.len(), 3);
+
         assert_eq!(loaded_breakpoints[0].position, breakpoint.position);
         assert_eq!(loaded_breakpoints[0].kind, breakpoint.kind);
+        assert_eq!(loaded_breakpoints[0].state, breakpoint.state);
+        assert_eq!(loaded_breakpoints[0].path, Arc::from(path));
+
         assert_eq!(loaded_breakpoints[1].position, log_breakpoint.position);
         assert_eq!(loaded_breakpoints[1].kind, log_breakpoint.kind);
-        assert_eq!(loaded_breakpoints[0].path, Arc::from(path));
+        assert_eq!(loaded_breakpoints[1].state, log_breakpoint.state);
         assert_eq!(loaded_breakpoints[1].path, Arc::from(path));
+
+        assert_eq!(loaded_breakpoints[2].position, disable_breakpoint.position);
+        assert_eq!(loaded_breakpoints[2].kind, disable_breakpoint.kind);
+        assert_eq!(loaded_breakpoints[2].state, disable_breakpoint.state);
+        assert_eq!(loaded_breakpoints[2].path, Arc::from(path));
     }
 
     #[gpui::test]

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -148,9 +148,43 @@ impl Column for SerializedWindowBounds {
 pub struct Breakpoint {
     pub position: u32,
     pub kind: BreakpointKind,
+    pub state: BreakpointState,
 }
 
 /// Wrapper for DB type of a breakpoint
+struct BreakpointStateWrapper<'a>(Cow<'a, BreakpointState>);
+
+impl From<BreakpointState> for BreakpointStateWrapper<'static> {
+    fn from(kind: BreakpointState) -> Self {
+        BreakpointStateWrapper(Cow::Owned(kind))
+    }
+}
+impl StaticColumnCount for BreakpointStateWrapper<'_> {
+    fn column_count() -> usize {
+        1
+    }
+}
+
+impl Bind for BreakpointStateWrapper<'_> {
+    fn bind(&self, statement: &Statement, start_index: i32) -> anyhow::Result<i32> {
+        statement.bind(&self.0.to_int(), start_index)
+    }
+}
+
+impl Column for BreakpointStateWrapper<'_> {
+    fn column(statement: &mut Statement, start_index: i32) -> anyhow::Result<(Self, i32)> {
+        let state = statement.column_int(start_index)?;
+
+        match state {
+            0 => Ok((BreakpointState::Enabled.into(), start_index + 1)),
+            1 => Ok((BreakpointState::Disabled.into(), start_index + 1)),
+            _ => Err(anyhow::anyhow!("Invalid BreakpointState discriminant")),
+        }
+    }
+}
+
+/// Wrapper for DB type of a breakpoint
+#[derive(Debug)]
 struct BreakpointKindWrapper<'a>(Cow<'a, BreakpointKind>);
 
 impl From<BreakpointKind> for BreakpointKindWrapper<'static> {
@@ -200,7 +234,7 @@ struct Breakpoints(Vec<Breakpoint>);
 
 impl sqlez::bindable::StaticColumnCount for Breakpoint {
     fn column_count() -> usize {
-        1 + BreakpointKindWrapper::column_count()
+        1 + BreakpointKindWrapper::column_count() + BreakpointStateWrapper::column_count()
     }
 }
 
@@ -211,8 +245,12 @@ impl sqlez::bindable::Bind for Breakpoint {
         start_index: i32,
     ) -> anyhow::Result<i32> {
         let next_index = statement.bind(&self.position, start_index)?;
-        statement.bind(
+        let next_index = statement.bind(
             &BreakpointKindWrapper(Cow::Borrowed(&self.kind)),
+            next_index,
+        )?;
+        statement.bind(
+            &BreakpointStateWrapper(Cow::Borrowed(&self.state)),
             next_index,
         )
     }
@@ -225,11 +263,13 @@ impl Column for Breakpoint {
             .with_context(|| format!("Failed to read BreakPoint at index {start_index}"))?
             as u32;
         let (kind, next_index) = BreakpointKindWrapper::column(statement, start_index + 1)?;
+        let (state, next_index) = BreakpointStateWrapper::column(statement, next_index)?;
 
         Ok((
             Breakpoint {
                 position,
                 kind: kind.0.into_owned(),
+                state: state.0.into_owned(),
             },
             next_index,
         ))
@@ -245,16 +285,9 @@ impl Column for Breakpoints {
             match statement.column_type(index) {
                 Ok(SqlType::Null) => break,
                 _ => {
-                    let position = statement
-                        .column_int(index)
-                        .with_context(|| format!("Failed to read BreakPoint at index {index}"))?
-                        as u32;
-                    let (kind, next_index) = BreakpointKindWrapper::column(statement, index + 1)?;
+                    let (breakpoint, next_index) = Breakpoint::column(statement, index)?;
 
-                    breakpoints.push(Breakpoint {
-                        position,
-                        kind: kind.0.into_owned(),
-                    });
+                    breakpoints.push(breakpoint);
                     index = next_index;
                 }
             }
@@ -535,6 +568,9 @@ define_connection! {
         CREATE UNIQUE INDEX local_paths_array_uq ON workspaces(local_paths_array);
         ALTER TABLE workspaces ADD COLUMN local_paths_order_array TEXT;
     ),
+    sql!(
+        ALTER TABLE breakpoints ADD COLUMN state INTEGER DEFAULT(0) NOT NULL
+    )
     ];
 }
 
@@ -690,7 +726,7 @@ impl WorkspaceDb {
     ) -> BTreeMap<Arc<Path>, Vec<SerializedBreakpoint>> {
         let breakpoints: Result<Vec<(PathBuf, Breakpoint)>> = self
             .select_bound(sql! {
-                SELECT path, breakpoint_location, kind
+                SELECT path, breakpoint_location, kind, log_message, state
                 FROM breakpoints
                 WHERE workspace_id = ?
             })
@@ -740,15 +776,17 @@ impl WorkspaceDb {
                     .context("Clearing old breakpoints")?;
                     for bp in breakpoints {
                         let kind = BreakpointKindWrapper::from(bp.kind);
+                        let state = BreakpointStateWrapper::from(bp.state);
                         match conn.exec_bound(sql!(
-                            INSERT INTO breakpoints (workspace_id, path, breakpoint_location, kind, log_message)
-                            VALUES (?1, ?2, ?3, ?4, ?5);))?
+                            INSERT INTO breakpoints (workspace_id, path, breakpoint_location, kind, log_message, state)
+                            VALUES (?1, ?2, ?3, ?4, ?5, ?6);))?
 
                         ((
                             workspace.id,
                             path.as_ref(),
                             bp.position,
                             kind,
+                            state,
                         )) {
                             Ok(_) => {}
                             Err(err) => {
@@ -1416,11 +1454,19 @@ mod tests {
         let breakpoint = Breakpoint {
             position: 123,
             kind: BreakpointKind::Standard,
+            state: BreakpointState::Enabled,
         };
 
         let log_breakpoint = Breakpoint {
             position: 456,
             kind: BreakpointKind::Log("Test log message".into()),
+            state: BreakpointState::Enabled,
+        };
+
+        let disable_breakpoint = Breakpoint {
+            position: 123,
+            kind: BreakpointKind::Standard,
+            state: BreakpointState::Disabled,
         };
 
         let workspace = SerializedWorkspace {
@@ -1448,6 +1494,12 @@ mod tests {
                             kind: log_breakpoint.kind.clone(),
                             state: BreakpointState::Enabled,
                         },
+                        SerializedBreakpoint {
+                            position: disable_breakpoint.position,
+                            path: Arc::from(path),
+                            kind: disable_breakpoint.kind.clone(),
+                            state: BreakpointState::Disabled,
+                        },
                     ],
                 );
                 map
@@ -1461,7 +1513,7 @@ mod tests {
         let loaded = db.workspace_for_roots(&["/tmp"]).unwrap();
         let loaded_breakpoints = loaded.breakpoints.get(&Arc::from(path)).unwrap();
 
-        assert_eq!(loaded_breakpoints.len(), 2);
+        assert_eq!(loaded_breakpoints.len(), 3);
         assert_eq!(loaded_breakpoints[0].position, breakpoint.position);
         assert_eq!(loaded_breakpoints[0].kind, breakpoint.kind);
         assert_eq!(loaded_breakpoints[1].position, log_breakpoint.position);

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -13,7 +13,7 @@ use client::DevServerProjectId;
 use db::{define_connection, query, sqlez::connection::Connection, sqlez_macros::sql};
 use gpui::{point, size, Axis, Bounds, WindowBounds, WindowId};
 use itertools::Itertools;
-use project::debugger::breakpoint_store::{BreakpointKind, SerializedBreakpoint};
+use project::debugger::breakpoint_store::{BreakpointKind, BreakpointState, SerializedBreakpoint};
 
 use language::{LanguageName, Toolchain};
 use project::WorktreeId;
@@ -712,6 +712,7 @@ impl WorkspaceDb {
                             position: breakpoint.position,
                             path,
                             kind: breakpoint.kind,
+                            state: BreakpointState::Enabled,
                         });
                 }
 
@@ -1439,11 +1440,13 @@ mod tests {
                             position: breakpoint.position,
                             path: Arc::from(path),
                             kind: breakpoint.kind.clone(),
+                            state: BreakpointState::Enabled,
                         },
                         SerializedBreakpoint {
                             position: log_breakpoint.position,
                             path: Arc::from(path),
                             kind: log_breakpoint.kind.clone(),
+                            state: BreakpointState::Enabled,
                         },
                     ],
                 );


### PR DESCRIPTION
This PR adds the ability to enable/disable breakpoints. It also fixes a bug where toggling a log breakpoint from the breakpoint context menu would add a standard breakpoint on top of the log breakpoint instead of deleting it.

todo: 
- [x] Add `BreakpointState` field Breakpoint that manages if a breakpoint is active or not
- [x] Don't send disabled breakpoints to DAP servers - in progress
- [x] Half the opacity of disabled breakpoints - in progress
- [x] Add `BreakpointState` to database
- [x] Editor test for enabling/disabling breakpoints
- [ ] Integration Test to make sure we don't send disabled breakpoints to DAP servers
- [x] Database test to make sure we properly serialize/deserialize BreakpointState

Release Notes:

- N/A
