### PR TITLE
Add default settings for LaTeX

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1255,6 +1255,14 @@
         "allowed": true
       }
     },
+    "LaTeX": {
+      "format_on_save": "on",
+      "formatter": "language_server",
+      "language_servers": ["texlab", "..."],
+      "prettier": {
+        "allowed": false
+      }
+    },
     "Markdown": {
       "format_on_save": "off",
       "use_on_type_format": false,


### PR DESCRIPTION
Closes https://github.com/rzukic/zed-latex/issues/70 where the language server `texlab` is not used for code formatting when the "cspell" extension is also installed, because it also provides a language server for the LaTeX filetype but only for spell checking.

Release Notes:

- Fix conflict between LaTeX and cspell extensions affecting code formatting on save.
