### PR TITLE
terminal: Fix mouse scroll for Vim/Nano/Less-like alternate screen applications

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1669,12 +1669,7 @@ impl Terminal {
                         self.pty_tx.notify(scroll);
                     }
                 };
-            } else if self
-                .last_content
-                .mode
-                .contains(TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL)
-                && !e.shift
-            {
+            } else if self.last_content.mode.contains(TermMode::ALT_SCREEN) && !e.shift {
                 self.pty_tx.notify(alt_scroll(scroll_lines))
             } else if scroll_lines != 0 {
                 let scroll = AlacScroll::Delta(scroll_lines);


### PR DESCRIPTION
Closes #27292

Vim, Nano or Less-like apps only set `TermMode::ALT_SCREEN`. Only checking this flag is enough even for applications which sets both `ALT_SCREEN` and `ALTERNATE_SCROLL`. 

There should not be applications which sets `ALTERNATE_SCROLL` and not `ALT_SCREEN`.
 
Release Notes:

- Fixed terminal not scrolling with the mouse wheel in Vim, Nano or Less-like alternate screen applications.
