### PR TITLE
terminal: Make `alternate_scroll` on by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1012,7 +1012,7 @@
     //         "alternate_scroll": "on",
     //  2. Default alternate scroll mode to off
     //         "alternate_scroll": "off",
-    "alternate_scroll": "off",
+    "alternate_scroll": "on",
     // Set whether the option key behaves as the meta key.
     // May take 2 values:
     //  1. Rely on default platform handling of option key, on macOS

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -181,7 +181,7 @@ pub struct TerminalSettingsContent {
     /// presses when in the alternate screen (e.g. when running applications
     /// like vim or  less). The terminal can still set and unset this mode.
     ///
-    /// Default: off
+    /// Default: on
     pub alternate_scroll: Option<AlternateScroll>,
     /// Sets whether the option key behaves as the meta key.
     ///

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2104,7 +2104,7 @@ List of `integer` column numbers
 ```json
 {
   "terminal": {
-    "alternate_scroll": "off",
+    "alternate_scroll": "on",
     "blinking": "terminal_controlled",
     "copy_on_select": false,
     "dock": "bottom",
@@ -2147,7 +2147,7 @@ List of `integer` column numbers
 
 - Description: Set whether Alternate Scroll mode (DECSET code: `?1007`) is active by default. Alternate Scroll mode converts mouse scroll events into up / down key presses when in the alternate screen (e.g. when running applications like vim or less). The terminal can still set and unset this mode with ANSI escape codes.
 - Setting: `alternate_scroll`
-- Default: `off`
+- Default: `on`
 
 **Options**
 


### PR DESCRIPTION
Most terminal emulators, like macOS Terminal, Alacritty, and Ghostty, have alternate scroll turned on by default. I think it makes sense for the Zed terminal to do the same and make it more of an opt-out feature.

Release Notes:

- N/A
