### PR TITLE
docs: Update Minitest example to clarify it only works with Rails

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -269,7 +269,7 @@ end
 
 To run tests in your Ruby project, you can set up custom tasks in your local `.zed/tasks.json` configuration file. These tasks can be defined to work with different test frameworks like Minitest, RSpec, quickdraw, and tldr. Below are some examples of how to set up these tasks to run your tests from within your editor.
 
-### Minitest
+### Minitest with Rails
 
 ```json
 [
@@ -281,6 +281,8 @@ To run tests in your Ruby project, you can set up custom tasks in your local `.z
   }
 ]
 ```
+
+Note: Plain minitest does not support running tests by line number.
 
 ### RSpec
 


### PR DESCRIPTION
The example in the docs works with Rails but not plain minitest.

There are workarounds such as the [`m`](https://github.com/qrush/m) gem, or adding ActiveSupport to a non-Rails project, but I feel they are beyond the scope of the docs here.

Release Notes:

- N/A