### PR TITLE
Fix completions replacing text after the cursor

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2164,6 +2164,11 @@ impl Buffer {
         for (range, new_text) in edits_iter {
             let mut range = range.start.to_offset(self)..range.end.to_offset(self);
 
+            #[cfg(debug_assertions)]
+            if let Some((last_range, _)) = edits.last() {
+                assert!(last_range.end <= range.start, "out of order or overlapping");
+            }
+
             if range.start > range.end {
                 mem::swap(&mut range.start, &mut range.end);
             }


### PR DESCRIPTION
Closed, see https://github.com/zed-industries/zed/issues/27197.

Fixes #27197
Fixes #4816

Release Notes:

- Fix completions always replacing text after the cursor.

