### PR TITLE
docs: Add tip for viewing LSP logs when configuring Ruby

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -23,6 +23,8 @@ They both have an overlapping feature set of autocomplete, diagnostics, code act
 
 In addition to these two language servers, Zed also supports [rubocop](https://github.com/rubocop/rubocop) which is a static code analyzer and linter for Ruby. Under the hood, it's also used by Zed as a language server, but its functionality is complimentary to that of solargraph and ruby-lsp.
 
+When configuring a language server, it helps to open the LSP Logs window using the 'debug: open language server logs' command. You can then choose the corresponding language instance to see any logged information.
+
 ## Configuring a language server
 
 The [Ruby extension](https://github.com/zed-extensions/ruby) offers both `solargraph` and `ruby-lsp` language server support.


### PR DESCRIPTION
Ruby LSP displays important information in its logs upon startup, such as which formatter is detected. Being able to see this helps a lot when configuring or troubleshooting.

cc @vitallium 

Release Notes:

- N/A