### PR TITLE
title_bar: Anchor user menu popover at top right corner

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -20,7 +20,7 @@ use client::{Client, UserStore};
 use feature_flags::{FeatureFlagAppExt, ZedPro};
 use git_ui::onboarding::GitBanner;
 use gpui::{
-    actions, div, px, Action, AnyElement, App, Context, Decorations, Element, Entity,
+    actions, div, px, Action, AnyElement, App, Context, Corner, Decorations, Element, Entity,
     InteractiveElement, Interactivity, IntoElement, MouseButton, ParentElement, Render, Stateful,
     StatefulInteractiveElement, Styled, Subscription, WeakEntity, Window,
 };
@@ -646,6 +646,7 @@ impl TitleBar {
         if let Some(user) = user_store.current_user() {
             let plan = user_store.current_plan();
             PopoverMenu::new("user-menu")
+                .anchor(Corner::TopRight)
                 .menu(move |window, cx| {
                     ContextMenu::build(window, cx, |menu, _, cx| {
                         menu.when(cx.has_flag::<ZedPro>(), |menu| {
@@ -710,6 +711,7 @@ impl TitleBar {
                 .anchor(gpui::Corner::TopRight)
         } else {
             PopoverMenu::new("user-menu")
+                .anchor(Corner::TopRight)
                 .menu(|window, cx| {
                     ContextMenu::build(window, cx, |menu, _, _| {
                         menu.action("Settings", zed_actions::OpenSettings.boxed_clone())


### PR DESCRIPTION
Release Notes:

- Improved user menu placement

| Before | After |
| --- | --- |
| ![Pasted image (2)](https://github.com/user-attachments/assets/fae750fd-d6bc-45d2-9ab0-7a1a1c6262ba) | ![image](https://github.com/user-attachments/assets/c5d0453f-5bd5-45e2-a56d-e200e90c0a2a) |
