### PR TITLE
Add support for Claude 3.7 Sonnet Thinking model in Copilot Chat

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -43,6 +43,8 @@ pub enum Model {
     Claude3_5Sonnet,
     #[serde(alias = "claude-3-7-sonnet", rename = "claude-3.7-sonnet")]
     Claude3_7Sonnet,
+    #[serde(alias = "claude-3-7-sonnet-thinking", rename = "claude-3.7-sonnet-thinking")]
+    Claude3_7SonnetThinking,
     #[serde(alias = "gemini-2.0-flash", rename = "gemini-2.0-flash-001")]
     Gemini20Flash,
 }
@@ -54,7 +56,8 @@ impl Model {
             | Self::Gpt4
             | Self::Gpt3_5Turbo
             | Self::Claude3_5Sonnet
-            | Self::Claude3_7Sonnet => true,
+            | Self::Claude3_7Sonnet
+            | Self::Claude3_7SonnetThinking => true,
             Self::O3Mini | Self::O1 | Self::Gemini20Flash => false,
         }
     }
@@ -68,6 +71,7 @@ impl Model {
             "o3-mini" => Ok(Self::O3Mini),
             "claude-3-5-sonnet" => Ok(Self::Claude3_5Sonnet),
             "claude-3-7-sonnet" => Ok(Self::Claude3_7Sonnet),
+            "claude-3-7-sonnet-thinking" => Ok(Self::Claude3_7SonnetThinking),
             "gemini-2.0-flash-001" => Ok(Self::Gemini20Flash),
             _ => Err(anyhow!("Invalid model id: {}", id)),
         }
@@ -82,6 +86,7 @@ impl Model {
             Self::O1 => "o1",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet",
             Self::Claude3_7Sonnet => "claude-3-7-sonnet",
+            Self::Claude3_7SonnetThinking => "claude-3.7-sonnet-thinking",
             Self::Gemini20Flash => "gemini-2.0-flash-001",
         }
     }
@@ -95,6 +100,7 @@ impl Model {
             Self::O1 => "o1",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
             Self::Claude3_7Sonnet => "Claude 3.7 Sonnet",
+            Self::Claude3_7SonnetThinking => "Claude 3.7 Sonnet Thinking",
             Self::Gemini20Flash => "Gemini 2.0 Flash",
         }
     }
@@ -108,6 +114,7 @@ impl Model {
             Self::O1 => 20_000,
             Self::Claude3_5Sonnet => 200_000,
             Self::Claude3_7Sonnet => 90_000,
+            Model::Claude3_7SonnetThinking => 90_000,
             Model::Gemini20Flash => 128_000,
         }
     }

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -186,6 +186,7 @@ impl LanguageModel for CopilotChatLanguageModel {
         match self.model {
             CopilotChatModel::Claude3_5Sonnet => count_anthropic_tokens(request, cx),
             CopilotChatModel::Claude3_7Sonnet => count_anthropic_tokens(request, cx),
+            CopilotChatModel::Claude3_7SonnetThinking => count_anthropic_tokens(request, cx),
             CopilotChatModel::Gemini20Flash => count_google_tokens(request, cx),
             _ => {
                 let model = match self.model {
@@ -195,6 +196,7 @@ impl LanguageModel for CopilotChatLanguageModel {
                     CopilotChatModel::O1 | CopilotChatModel::O3Mini => open_ai::Model::Four,
                     CopilotChatModel::Claude3_5Sonnet
                     | CopilotChatModel::Claude3_7Sonnet
+                    | CopilotChatModel::Claude3_7SonnetThinking
                     | CopilotChatModel::Gemini20Flash => {
                         unreachable!()
                     }


### PR DESCRIPTION
Release Notes:
         Added Support for Claude 3.7 Thinking for Copilot Chat


x----------------x

This pull request includes changes to add support for a new model, `Claude3_7SonnetThinking`, to the `copilot` crate. The changes involve updating the `Model` enum and its associated methods, as well as modifying the `CopilotChatLanguageModel` implementation to handle the new model.

### Adding support for `Claude3_7SonnetThinking` model:

* [`crates/copilot/src/copilot_chat.rs`](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4R46-R47): Added `Claude3_7SonnetThinking` to the `Model` enum and updated methods to recognize and handle the new model. [[1]](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4R46-R47) [[2]](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4L57-R60) [[3]](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4R74) [[4]](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4R89) [[5]](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4R103) [[6]](diffhunk://#diff-64ad6751e01f21fed6949bee2e2895e5244493f20138c8e8c92fd93f70e4d8f4R117)
* [`crates/language_models/src/provider/copilot_chat.rs`](diffhunk://#diff-e2339e80e6da19cf9cc29d75955c647c7233f9bb6c00be03301e8f8ff6e40cf7R189): Updated `CopilotChatLanguageModel` to include `Claude3_7SonnetThinking` in token counting and model matching logic. [[1]](diffhunk://#diff-e2339e80e6da19cf9cc29d75955c647c7233f9bb6c00be03301e8f8ff6e40cf7R189) [[2]](diffhunk://#diff-e2339e80e6da19cf9cc29d75955c647c7233f9bb6c00be03301e8f8ff6e40cf7R199)