### PR TITLE
docs: Add Erlang language server documentation

### DIFF
--- a/docs/src/languages/erlang.md
+++ b/docs/src/languages/erlang.md
@@ -3,7 +3,27 @@
 Erlang support is available through the [Erlang extension](https://github.com/zed-extensions/erlang).
 
 - Tree-sitter: [WhatsApp/tree-sitter-erlang](https://github.com/WhatsApp/tree-sitter-erlang)
-- Language Server: [erlang-ls/erlang_ls](https://github.com/erlang-ls/erlang_ls)
+- Language Servers:
+  - [erlang-ls/erlang_ls](https://github.com/erlang-ls/erlang_ls)
+  - [WhatsApp/erlang-language-platform](https://github.com/WhatsApp/erlang-language-platform)
+
+## Choosing a language server
+
+The Erlang extension offers language server support for `erlang_ls` and `erlang-language-platform`.
+
+`erlang_ls` is enabled by default.
+
+To switch to `erlang-language-platform`, add the following to your `settings.json`:
+
+```json
+{
+  "languages": {
+    "Erlang": {
+      "language_servers": ["elp", "!erlang-ls", "..."]
+    }
+  }
+}
+```
 
 ## See also:
 


### PR DESCRIPTION
This PR updates the Erlang docs to list the two language servers the extension offers support for, as well as how to switch from `erlang_ls` to `erlang-language-platform`.

Release Notes:

- N/A
