### PR TITLE
Treat bun.lock as JSONC

### DIFF
--- a/crates/languages/src/jsonc/config.toml
+++ b/crates/languages/src/jsonc/config.toml
@@ -1,6 +1,6 @@
 name = "JSONC"
 grammar = "jsonc"
-path_suffixes = ["jsonc", "tsconfig.json", "pyrightconfig.json"]
+path_suffixes = ["jsonc", "bun.lock", "tsconfig.json", "pyrightconfig.json"]
 line_comments = ["// "]
 autoclose_before = ",]}"
 brackets = [


### PR DESCRIPTION
Closes #27355 
This PR treat `bun.lock` file as `.jsonc`
note: 
[bun.lock](https://bun.sh/blog/bun-lock-text-lockfile) is a lockfile  of bun.js 

Release Notes:

- Updated `bun.lock` files to be recognized as JSONC.
