### PR TITLE
Gracefully handle models searching for empty glob

### DIFF
--- a/crates/assistant_tools/src/edit_files_tool/replace.rs
+++ b/crates/assistant_tools/src/edit_files_tool/replace.rs
@@ -1,5 +1,6 @@
 use language::{BufferSnapshot, Diff, Point, ToOffset};
 use project::search::SearchQuery;
+use std::iter;
 use util::{paths::PathMatcher, ResultExt as _};
 
 /// Performs an exact string replacement in a buffer, requiring precise character-for-character matching.
@@ -11,8 +12,8 @@ pub async fn replace_exact(old: &str, new: &str, snapshot: &BufferSnapshot) -> O
         false,
         true,
         true,
-        PathMatcher::new(&[]).ok()?,
-        PathMatcher::new(&[]).ok()?,
+        PathMatcher::new(iter::empty::<&str>()).ok()?,
+        PathMatcher::new(iter::empty::<&str>()).ok()?,
         None,
     )
     .log_err()?;

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -377,10 +377,10 @@ impl PartialEq for PathMatcher {
 impl Eq for PathMatcher {}
 
 impl PathMatcher {
-    pub fn new(globs: &[String]) -> Result<Self, globset::Error> {
+    pub fn new(globs: impl IntoIterator<Item = impl AsRef<str>>) -> Result<Self, globset::Error> {
         let globs = globs
-            .iter()
-            .map(|glob| Glob::new(glob))
+            .into_iter()
+            .map(|as_str| Glob::new(as_str.as_ref()))
             .collect::<Result<Vec<_>, _>>()?;
         let sources = globs.iter().map(|glob| glob.glob().to_owned()).collect();
         let mut glob_builder = GlobSetBuilder::new();


### PR DESCRIPTION
Sometimes we've seen models provide an empty string for the path search glob. This assumes they meant "*" when that happens.

Separately, this also removes an unnecessary `clone` of a `String`.

Release Notes:

- N/A
