### PR TITLE
Serialize breakpoints when changing the state of a breakpoint

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -65,7 +65,8 @@ use persistence::{
 };
 use postage::stream::Stream;
 use project::{
-    DirectoryLister, Project, ProjectEntryId, ProjectPath, ResolvedPath, Worktree, WorktreeId,
+    debugger::breakpoint_store::BreakpointStoreEvent, DirectoryLister, Project, ProjectEntryId,
+    ProjectPath, ResolvedPath, Worktree, WorktreeId,
 };
 use remote::{ssh_session::ConnectionIdentifier, SshClientDelegate, SshConnectionOptions};
 use schemars::JsonSchema;
@@ -971,6 +972,17 @@ impl Workspace {
             }
             cx.notify()
         })
+        .detach();
+
+        cx.subscribe_in(
+            &project.read(cx).breakpoint_store(),
+            window,
+            |workspace, _, evt, window, cx| {
+                if let BreakpointStoreEvent::BreakpointsUpdated(_, _) = evt {
+                    workspace.serialize_workspace(window, cx);
+                }
+            },
+        )
         .detach();
 
         cx.on_focus_lost(window, |this, window, cx| {


### PR DESCRIPTION
This fixes a rare bug where a breakpoint isn't saved in the database when a user toggles a breakpoint and immediately exits out of zed.

Release Notes:

- N/A
