### PR TITLE
anthropic: Handle image-only messages and limit cache blocks to 4

### DIFF
--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -213,18 +213,30 @@ impl LanguageModelRequestMessage {
     }
 
     pub fn contents_empty(&self) -> bool {
-        self.content.is_empty()
-            || self
-                .content
-                .first()
-                .map(|content| match content {
-                    MessageContent::Text(text) => text.chars().all(|c| c.is_whitespace()),
-                    MessageContent::ToolResult(tool_result) => {
-                        tool_result.content.chars().all(|c| c.is_whitespace())
-                    }
-                    MessageContent::ToolUse(_) | MessageContent::Image(_) => true,
-                })
-                .unwrap_or(false)
+        if self.content.is_empty() {
+            return true;
+        }
+        
+        // Check if there are any image contents
+        let has_images = self.content.iter().any(|content| matches!(content, MessageContent::Image(_)));
+        
+        // If there are images, the message is not empty
+        if has_images {
+            return false;
+        }
+        
+        // Otherwise, check if the first content item is empty
+        self.content
+            .first()
+            .map(|content| match content {
+                MessageContent::Text(text) => text.chars().all(|c| c.is_whitespace()),
+                MessageContent::ToolResult(tool_result) => {
+                    tool_result.content.chars().all(|c| c.is_whitespace())
+                }
+                MessageContent::ToolUse(_) => true,
+                MessageContent::Image(_) => unreachable!("Already checked for images"),
+            })
+            .unwrap_or(false)
     }
 }
 

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -529,10 +529,10 @@ pub fn into_anthropic(
                 // We still need this to handle image-only messages for Anthropic's API requirements
                 let contains_image = message.content.iter().any(|content| matches!(content, MessageContent::Image(_)));
                 let contains_text = message.content.iter().any(|content| matches!(content, MessageContent::Text(text) if !text.is_empty()));
-                
+
                 // Create a flag to determine if we need to add placeholder text at the end
                 let needs_placeholder = contains_image && !contains_text;
-                
+
                 let mut anthropic_message_content: Vec<anthropic::RequestContent> = message
                     .content
                     .into_iter()
@@ -609,13 +609,13 @@ pub fn into_anthropic(
                     } else {
                         None
                     };
-                    
+
                     anthropic_message_content.push(anthropic::RequestContent::Text {
-                        text: "." .to_string(), // Minimal non-whitespace character
+                        text: "Image:" .to_string(),
                         cache_control,
                     });
                 }
-                
+
                 if let Some(last_message) = new_messages.last_mut() {
                     if last_message.role == anthropic_role {
                         last_message.content.extend(anthropic_message_content);


### PR DESCRIPTION
Closes #21485
Closes #20795

Release Notes:

- Fixed Anthropic API errors "final assistant content cannot end with a trailing whitespace" when pasting images
- Fixed Anthropic API error "a maximum of 4 blocks with cache_control may be provided" by limiting cache blocks

## Changes

1. Updated `contents_empty()` to properly recognize image-only messages as non-empty
2. Added a minimal placeholder text when sending image-only messages to Anthropic API
3. Limited cache blocks to Anthropic's maximum of 4 as per API requirements

<img width="640" alt="image" src="https://github.com/user-attachments/assets/157d0ae4-4fa7-4723-9880-b933f5bbd597" />
