### PR TITLE
Make system prompt be more explicit about root paths

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -11,7 +11,7 @@ You should only perform actions that modify the user’s system if explicitly re
 
 Be concise and direct in your responses.
 
-The user has opened a project that contains the following root directories/files:
+The user has opened a project that contains the following root directories/files. Whenever you specify a path in the project, it must be a relative path which begins with one of these root directories/files:
 
 {{#each worktrees}}
 - `{{root_name}}` (absolute path: `{{abs_path}}`)


### PR DESCRIPTION
## Before

<img width="627" alt="Screenshot 2025-03-24 at 12 55 15 PM" src="https://github.com/user-attachments/assets/349d7025-e65e-4107-86ae-45eb321003b3" />

## After

<img width="627" alt="Screenshot 2025-03-24 at 12 52 04 PM" src="https://github.com/user-attachments/assets/0e8c061a-11c5-4d60-a694-55575b6c8f5e" />

Release Notes:

- N/A
