### PR TITLE
Git: Reload index before reading it

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -476,12 +476,13 @@ impl GitRepository for RealGitRepository {
         let repo = self.repository.clone();
         cx.background_spawn(async move {
             fn logic(repo: &git2::Repository, path: &RepoPath) -> Result<Option<String>> {
-                const STAGE_NORMAL: i32 = 0;
-                let index = repo.index()?;
-
                 // This check is required because index.get_path() unwraps internally :(
                 check_path_to_repo_path_errors(path)?;
 
+                let mut index = repo.index()?;
+                index.read(false)?;
+
+                const STAGE_NORMAL: i32 = 0;
                 let oid = match index.get_path(path, STAGE_NORMAL) {
                     Some(entry) if entry.mode != GIT_MODE_SYMLINK => entry.id,
                     _ => return Ok(None),


### PR DESCRIPTION
This is one of the causes for race conditions, but isn't a specific bug fix by itself.

Release Notes:

- N/A
