### PR TITLE
assistant2: Add `move-path` tool to the "Code Writer" profile

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -638,6 +638,7 @@
           "edit-files": true,
           "fetch": true,
           "list-directory": true,
+          "move-path": true,
           "now": true,
           "path-search": true,
           "read-file": true,


### PR DESCRIPTION
This PR adds the `move-path` tool to the "Code Writer" profile.

Release Notes:

- N/A
