### PR TITLE
Set edit predictions to default to the Zed provider

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -25,7 +25,7 @@
   // Features that can be globally enabled or disabled
   "features": {
     // Which edit prediction provider to use.
-    "edit_prediction_provider": "copilot"
+    "edit_prediction_provider": "zed"
   },
   // The name of a font to use for rendering text in the editor
   "buffer_font_family": "Zed Plex Mono",

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -6,9 +6,7 @@ use editor::{
     scroll::Autoscroll,
     Editor,
 };
-use feature_flags::{
-    FeatureFlagAppExt, PredictEditsFeatureFlag, PredictEditsRateCompletionsFeatureFlag,
-};
+use feature_flags::{FeatureFlagAppExt, PredictEditsRateCompletionsFeatureFlag};
 use fs::Fs;
 use gpui::{
     actions, div, pulsating_between, Action, Animation, AnimationExt, App, AsyncWindowContext,
@@ -232,10 +230,6 @@ impl Render for InlineCompletionButton {
             }
 
             EditPredictionProvider::Zed => {
-                if !cx.has_flag::<PredictEditsFeatureFlag>() {
-                    return div();
-                }
-
                 let enabled = self.editor_enabled.unwrap_or(true);
 
                 let zeta_icon = if enabled {
@@ -258,7 +252,7 @@ impl Render for InlineCompletionButton {
                     return div().child(
                         IconButton::new("zed-predict-pending-button", zeta_icon)
                             .shape(IconButtonShape::Square)
-                            .indicator(Indicator::dot().color(Color::Error))
+                            .indicator(Indicator::dot().color(Color::Muted))
                             .indicator_border_color(Some(cx.theme().colors().status_bar_background))
                             .tooltip(move |window, cx| {
                                 Tooltip::with_meta(

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -54,7 +54,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
     })
     .detach();
 
-    let provider = all_language_settings(None, cx).edit_predictions.provider;
+    let mut provider = all_language_settings(None, cx).edit_predictions.provider;
     for (editor, window) in editors.borrow().iter() {
         _ = window.update(cx, |_window, window, cx| {
             _ = editor.update(cx, |editor, cx| {
@@ -71,7 +71,6 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
     }
 
     cx.on_action(clear_zeta_edit_history);
-    let mut provider = all_language_settings(None, cx).edit_predictions.provider;
     assign_edit_prediction_providers(&editors, provider, &client, user_store.clone(), cx);
 
     cx.observe_global::<SettingsStore>({

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -2,7 +2,7 @@ use client::{Client, UserStore};
 use collections::HashMap;
 use copilot::{Copilot, CopilotCompletionProvider};
 use editor::{Editor, EditorMode};
-use feature_flags::{FeatureFlagAppExt, PredictEditsFeatureFlag};
+
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{all_language_settings, EditPredictionProvider};
 use settings::SettingsStore;
@@ -72,7 +72,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
     }
 
     cx.on_action(clear_zeta_edit_history);
-    let provider = all_language_settings(None, cx).edit_predictions.provider;
+    let mut provider = all_language_settings(None, cx).edit_predictions.provider;
     assign_edit_prediction_providers(&editors, provider, &client, user_store.clone(), cx);
 
     cx.observe_global::<SettingsStore>({

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -2,7 +2,6 @@ use client::{Client, UserStore};
 use collections::HashMap;
 use copilot::{Copilot, CopilotCompletionProvider};
 use editor::{Editor, EditorMode};
-
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{all_language_settings, EditPredictionProvider};
 use settings::SettingsStore;

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -55,7 +55,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
     })
     .detach();
 
-    let mut provider = all_language_settings(None, cx).edit_predictions.provider;
+    let provider = all_language_settings(None, cx).edit_predictions.provider;
     for (editor, window) in editors.borrow().iter() {
         _ = window.update(cx, |_window, window, cx| {
             _ = editor.update(cx, |editor, cx| {
@@ -71,23 +71,9 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
         });
     }
 
-    if cx.has_flag::<PredictEditsFeatureFlag>() {
-        cx.on_action(clear_zeta_edit_history);
-    }
-
-    cx.observe_flag::<PredictEditsFeatureFlag, _>({
-        let editors = editors.clone();
-        let client = client.clone();
-        let user_store = user_store.clone();
-        move |active, cx| {
-            let provider = all_language_settings(None, cx).edit_predictions.provider;
-            assign_edit_prediction_providers(&editors, provider, &client, user_store.clone(), cx);
-            if active && !cx.is_action_available(&zeta::ClearHistory) {
-                cx.on_action(clear_zeta_edit_history);
-            }
-        }
-    })
-    .detach();
+    cx.on_action(clear_zeta_edit_history);
+    let provider = all_language_settings(None, cx).edit_predictions.provider;
+    assign_edit_prediction_providers(&editors, provider, &client, user_store.clone(), cx);
 
     cx.observe_global::<SettingsStore>({
         let editors = editors.clone();
@@ -249,9 +235,7 @@ fn assign_edit_prediction_provider(
             }
         }
         EditPredictionProvider::Zed => {
-            if cx.has_flag::<PredictEditsFeatureFlag>()
-                || (cfg!(debug_assertions) && client.status().borrow().is_connected())
-            {
+            if client.status().borrow().is_connected() {
                 let mut worktree = None;
 
                 if let Some(buffer) = &singleton_buffer {

--- a/crates/zeta/src/init.rs
+++ b/crates/zeta/src/init.rs
@@ -1,9 +1,7 @@
 use std::any::{Any, TypeId};
 
 use command_palette_hooks::CommandPaletteFilter;
-use feature_flags::{
-    FeatureFlagAppExt as _, PredictEditsFeatureFlag, PredictEditsRateCompletionsFeatureFlag,
-};
+use feature_flags::{FeatureFlagAppExt as _, PredictEditsRateCompletionsFeatureFlag};
 use gpui::actions;
 use language::language_settings::{AllLanguageSettings, EditPredictionProvider};
 use settings::update_settings_file;
@@ -24,16 +22,14 @@ pub fn init(cx: &mut App) {
 
         workspace.register_action(
             move |workspace, _: &zed_actions::OpenZedPredictOnboarding, window, cx| {
-                if cx.has_flag::<PredictEditsFeatureFlag>() {
-                    ZedPredictModal::toggle(
-                        workspace,
-                        workspace.user_store().clone(),
-                        workspace.client().clone(),
-                        workspace.app_state().fs.clone(),
-                        window,
-                        cx,
-                    )
-                }
+                ZedPredictModal::toggle(
+                    workspace,
+                    workspace.user_store().clone(),
+                    workspace.client().clone(),
+                    workspace.app_state().fs.clone(),
+                    window,
+                    cx,
+                )
             },
         );
 


### PR DESCRIPTION
Release Notes:

- Changed the default edit prediction provider from Copilot to Zed
