### PR TITLE
debugger/lldb: Remove xcrun-based lldb-dap binary lookup

### DIFF
--- a/crates/dap_adapters/src/lldb.rs
+++ b/crates/dap_adapters/src/lldb.rs
@@ -37,15 +37,6 @@ impl DebugAdapter for LldbDebugAdapter {
     ) -> Result<DebugAdapterBinary> {
         let lldb_dap_path = if let Some(user_installed_path) = user_installed_path {
             user_installed_path.to_string_lossy().into()
-        } else if cfg!(target_os = "macos") {
-            util::command::new_smol_command("xcrun")
-                .args(&["-f", "lldb-dap"])
-                .output()
-                .await
-                .ok()
-                .and_then(|output| String::from_utf8(output.stdout).ok())
-                .map(|path| path.trim().to_string())
-                .ok_or(anyhow!("Failed to find lldb-dap in user's path"))?
         } else {
             delegate
                 .which(OsStr::new("lldb-dap"))


### PR DESCRIPTION
Closes #ISSUE
/cc @RemcoSmitsDev 

Release Notes:

- N/A
