### PR TITLE
extension: Add support for `additional_workspace_configuration` and `additional_initialization_options`

### DIFF
--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -76,9 +76,10 @@ pub trait Extension: Send + Sync + 'static {
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<Option<String>>;
 
-    async fn additional_language_server_workspace_configuration(
+    async fn language_server_additional_workspace_configuration(
         &self,
         language_server_id: LanguageServerName,
+        target_language_server_id: LanguageServerName,
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<Option<String>>;
 

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -76,6 +76,13 @@ pub trait Extension: Send + Sync + 'static {
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<Option<String>>;
 
+    async fn language_server_additional_initialization_options(
+        &self,
+        language_server_id: LanguageServerName,
+        target_language_server_id: LanguageServerName,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Option<String>>;
+
     async fn language_server_additional_workspace_configuration(
         &self,
         language_server_id: LanguageServerName,

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -76,6 +76,12 @@ pub trait Extension: Send + Sync + 'static {
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<Option<String>>;
 
+    async fn additional_language_server_workspace_configuration(
+        &self,
+        language_server_id: LanguageServerName,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Option<String>>;
+
     async fn labels_for_completions(
         &self,
         language_server_id: LanguageServerName,

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -94,9 +94,10 @@ pub trait Extension: Send + Sync {
     }
 
     /// Returns the workspace configuration options to pass to the other language server.
-    fn additional_language_server_workspace_configuration(
+    fn language_server_additional_workspace_configuration(
         &mut self,
         _language_server_id: &LanguageServerId,
+        _target_language_server_id: &LanguageServerId,
         _worktree: &Worktree,
     ) -> Result<Option<serde_json::Value>> {
         Ok(None)
@@ -244,13 +245,19 @@ impl wit::Guest for Component {
             .and_then(|value| serde_json::to_string(&value).ok()))
     }
 
-    fn additional_language_server_workspace_configuration(
+    fn language_server_additional_workspace_configuration(
         language_server_id: String,
+        target_language_server_id: String,
         worktree: &Worktree,
     ) -> Result<Option<String>, String> {
         let language_server_id = LanguageServerId(language_server_id);
+        let target_language_server_id = LanguageServerId(target_language_server_id);
         Ok(extension()
-            .additional_language_server_workspace_configuration(&language_server_id, worktree)?
+            .language_server_additional_workspace_configuration(
+                &language_server_id,
+                &target_language_server_id,
+                worktree,
+            )?
             .and_then(|value| serde_json::to_string(&value).ok()))
     }
 

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -93,6 +93,15 @@ pub trait Extension: Send + Sync {
         Ok(None)
     }
 
+    /// Returns the workspace configuration options to pass to the other language server.
+    fn additional_language_server_workspace_configuration(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        _worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(None)
+    }
+
     /// Returns the label for the given completion.
     fn label_for_completion(
         &self,
@@ -232,6 +241,16 @@ impl wit::Guest for Component {
         let language_server_id = LanguageServerId(language_server_id);
         Ok(extension()
             .language_server_workspace_configuration(&language_server_id, worktree)?
+            .and_then(|value| serde_json::to_string(&value).ok()))
+    }
+
+    fn additional_language_server_workspace_configuration(
+        language_server_id: String,
+        worktree: &Worktree,
+    ) -> Result<Option<String>, String> {
+        let language_server_id = LanguageServerId(language_server_id);
+        Ok(extension()
+            .additional_language_server_workspace_configuration(&language_server_id, worktree)?
             .and_then(|value| serde_json::to_string(&value).ok()))
     }
 

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -93,6 +93,16 @@ pub trait Extension: Send + Sync {
         Ok(None)
     }
 
+    /// Returns the initialization options to pass to the other language server.
+    fn language_server_additional_initialization_options(
+        &mut self,
+        _language_server_id: &LanguageServerId,
+        _target_language_server_id: &LanguageServerId,
+        _worktree: &Worktree,
+    ) -> Result<Option<serde_json::Value>> {
+        Ok(None)
+    }
+
     /// Returns the workspace configuration options to pass to the other language server.
     fn language_server_additional_workspace_configuration(
         &mut self,
@@ -242,6 +252,22 @@ impl wit::Guest for Component {
         let language_server_id = LanguageServerId(language_server_id);
         Ok(extension()
             .language_server_workspace_configuration(&language_server_id, worktree)?
+            .and_then(|value| serde_json::to_string(&value).ok()))
+    }
+
+    fn language_server_additional_initialization_options(
+        language_server_id: String,
+        target_language_server_id: String,
+        worktree: &Worktree,
+    ) -> Result<Option<String>, String> {
+        let language_server_id = LanguageServerId(language_server_id);
+        let target_language_server_id = LanguageServerId(target_language_server_id);
+        Ok(extension()
+            .language_server_additional_initialization_options(
+                &language_server_id,
+                &target_language_server_id,
+                worktree,
+            )?
             .and_then(|value| serde_json::to_string(&value).ok()))
     }
 

--- a/crates/extension_api/wit/since_v0.3.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.3.0/extension.wit
@@ -95,9 +95,6 @@ world extension {
     /// Returns the workspace configuration options to pass to the language server.
     export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
-    /// Returns the workspace configuration options to pass to the other language server.
-    export additional-language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
-
     /// A label containing some code.
     record code-label {
         /// The source code to parse with Tree-sitter.

--- a/crates/extension_api/wit/since_v0.3.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.3.0/extension.wit
@@ -95,6 +95,9 @@ world extension {
     /// Returns the workspace configuration options to pass to the language server.
     export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
+    /// Returns the workspace configuration options to pass to the other language server.
+    export additional-language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
     /// A label containing some code.
     record code-label {
         /// The source code to parse with Tree-sitter.

--- a/crates/extension_api/wit/since_v0.4.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.4.0/extension.wit
@@ -95,6 +95,9 @@ world extension {
     /// Returns the workspace configuration options to pass to the language server.
     export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
+    /// Returns the initialization options to pass to the other language server.
+    export language-server-additional-initialization-options: func(language-server-id: string, target-language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
     /// Returns the workspace configuration options to pass to the other language server.
     export language-server-additional-workspace-configuration: func(language-server-id: string, target-language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 

--- a/crates/extension_api/wit/since_v0.4.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.4.0/extension.wit
@@ -96,7 +96,7 @@ world extension {
     export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
     /// Returns the workspace configuration options to pass to the other language server.
-    export additional-language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+    export language-server-additional-workspace-configuration: func(language-server-id: string, target-language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
     /// A label containing some code.
     record code-label {

--- a/crates/extension_api/wit/since_v0.4.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.4.0/extension.wit
@@ -95,6 +95,9 @@ world extension {
     /// Returns the workspace configuration options to pass to the language server.
     export language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
 
+    /// Returns the workspace configuration options to pass to the other language server.
+    export additional-language-server-workspace-configuration: func(language-server-id: string, worktree: borrow<worktree>) -> result<option<string>, string>;
+
     /// A label containing some code.
     record code-label {
         /// The source code to parse with Tree-sitter.

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -140,6 +140,29 @@ impl extension::Extension for WasmExtension {
         .await
     }
 
+    async fn additional_language_server_workspace_configuration(
+        &self,
+        language_server_id: LanguageServerName,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Option<String>> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table().push(worktree)?;
+                let options = extension
+                    .call_additional_language_server_workspace_configuration(
+                        store,
+                        &language_server_id,
+                        resource,
+                    )
+                    .await?
+                    .map_err(|err| anyhow!("{err}"))?;
+                anyhow::Ok(options)
+            }
+            .boxed()
+        })
+        .await
+    }
+
     async fn labels_for_completions(
         &self,
         language_server_id: LanguageServerName,

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -140,18 +140,20 @@ impl extension::Extension for WasmExtension {
         .await
     }
 
-    async fn additional_language_server_workspace_configuration(
+    async fn language_server_additional_workspace_configuration(
         &self,
         language_server_id: LanguageServerName,
+        target_language_server_id: LanguageServerName,
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<Option<String>> {
         self.call(|extension, store| {
             async move {
                 let resource = store.data_mut().table().push(worktree)?;
                 let options = extension
-                    .call_additional_language_server_workspace_configuration(
+                    .call_language_server_additional_workspace_configuration(
                         store,
                         &language_server_id,
+                        &target_language_server_id,
                         resource,
                     )
                     .await?

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -140,6 +140,31 @@ impl extension::Extension for WasmExtension {
         .await
     }
 
+    async fn language_server_additional_initialization_options(
+        &self,
+        language_server_id: LanguageServerName,
+        target_language_server_id: LanguageServerName,
+        worktree: Arc<dyn WorktreeDelegate>,
+    ) -> Result<Option<String>> {
+        self.call(|extension, store| {
+            async move {
+                let resource = store.data_mut().table().push(worktree)?;
+                let options = extension
+                    .call_language_server_additional_initialization_options(
+                        store,
+                        &language_server_id,
+                        &target_language_server_id,
+                        resource,
+                    )
+                    .await?
+                    .map_err(|err| anyhow!("{err}"))?;
+                anyhow::Ok(options)
+            }
+            .boxed()
+        })
+        .await
+    }
+
     async fn language_server_additional_workspace_configuration(
         &self,
         language_server_id: LanguageServerName,

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -365,17 +365,19 @@ impl Extension {
         }
     }
 
-    pub async fn call_additional_language_server_workspace_configuration(
+    pub async fn call_language_server_additional_workspace_configuration(
         &self,
         store: &mut Store<WasmState>,
         language_server_id: &LanguageServerName,
+        target_language_server_id: &LanguageServerName,
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
             Extension::V040(ext) => {
-                ext.call_additional_language_server_workspace_configuration(
+                ext.call_language_server_additional_workspace_configuration(
                     store,
                     &language_server_id.0,
+                    &target_language_server_id.0,
                     resource,
                 )
                 .await

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -365,6 +365,29 @@ impl Extension {
         }
     }
 
+    pub async fn call_additional_language_server_workspace_configuration(
+        &self,
+        store: &mut Store<WasmState>,
+        language_server_id: &LanguageServerName,
+        resource: Resource<Arc<dyn WorktreeDelegate>>,
+    ) -> Result<Result<Option<String>, String>> {
+        match self {
+            Extension::V030(ext) => {
+                ext.call_additional_language_server_workspace_configuration(
+                    store,
+                    &language_server_id.0,
+                    resource,
+                )
+                .await
+            }
+            Extension::V020(_)
+            | Extension::V010(_)
+            | Extension::V006(_)
+            | Extension::V004(_)
+            | Extension::V001(_) => Ok(Ok(None)),
+        }
+    }
+
     pub async fn call_labels_for_completions(
         &self,
         store: &mut Store<WasmState>,

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -372,7 +372,7 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
-            Extension::V030(ext) => {
+            Extension::V040(ext) => {
                 ext.call_additional_language_server_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -380,7 +380,8 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V020(_)
+            Extension::V030(_)
+            | Extension::V020(_)
             | Extension::V010(_)
             | Extension::V006(_)
             | Extension::V004(_)

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -365,6 +365,32 @@ impl Extension {
         }
     }
 
+    pub async fn call_language_server_additional_initialization_options(
+        &self,
+        store: &mut Store<WasmState>,
+        language_server_id: &LanguageServerName,
+        target_language_server_id: &LanguageServerName,
+        resource: Resource<Arc<dyn WorktreeDelegate>>,
+    ) -> Result<Result<Option<String>, String>> {
+        match self {
+            Extension::V040(ext) => {
+                ext.call_language_server_additional_initialization_options(
+                    store,
+                    &language_server_id.0,
+                    &target_language_server_id.0,
+                    resource,
+                )
+                .await
+            }
+            Extension::V030(_)
+            | Extension::V020(_)
+            | Extension::V010(_)
+            | Extension::V006(_)
+            | Extension::V004(_)
+            | Extension::V001(_) => Ok(Ok(None)),
+        }
+    }
+
     pub async fn call_language_server_additional_workspace_configuration(
         &self,
         store: &mut Store<WasmState>,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -515,6 +515,16 @@ pub trait LspAdapter: 'static + Send + Sync {
         Ok(serde_json::json!({}))
     }
 
+    async fn additional_workspace_configuration(
+        self: Arc<Self>,
+        _: &dyn Fs,
+        _: &Arc<dyn LspAdapterDelegate>,
+        _: Arc<dyn LanguageToolchainStore>,
+        _cx: &mut AsyncApp,
+    ) -> Result<Option<Value>> {
+        Ok(None)
+    }
+
     /// Returns a list of code actions supported by a given LspAdapter
     fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
         Some(vec![

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -518,6 +518,7 @@ pub trait LspAdapter: 'static + Send + Sync {
 
     async fn additional_workspace_configuration(
         self: Arc<Self>,
+        _target_language_server_id: LanguageServerName,
         _: &dyn Fs,
         _: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -516,6 +516,15 @@ pub trait LspAdapter: 'static + Send + Sync {
         Ok(serde_json::json!({}))
     }
 
+    async fn additional_initialization_options(
+        self: Arc<Self>,
+        _target_language_server_id: LanguageServerName,
+        _: &dyn Fs,
+        _: &Arc<dyn LspAdapterDelegate>,
+    ) -> Result<Option<Value>> {
+        Ok(None)
+    }
+
     async fn additional_workspace_configuration(
         self: Arc<Self>,
         _target_language_server_id: LanguageServerName,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -305,6 +305,7 @@ pub trait LspAdapterDelegate: Send + Sync {
     fn worktree_root_path(&self) -> &Path;
     fn exists(&self, path: &Path, is_dir: Option<bool>) -> bool;
     fn update_status(&self, language: LanguageServerName, status: BinaryStatus);
+    fn registered_lsp_adapters(&self) -> Vec<Arc<dyn LspAdapter>>;
     async fn language_server_download_dir(&self, name: &LanguageServerName) -> Option<Arc<Path>>;
 
     async fn npm_package_installed_version(

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -912,6 +912,15 @@ impl LanguageRegistry {
             .unwrap_or_default()
     }
 
+    pub fn all_lsp_adapters(&self) -> Vec<Arc<CachedLspAdapter>> {
+        self.state
+            .read()
+            .all_lsp_adapters
+            .values()
+            .cloned()
+            .collect()
+    }
+
     pub fn adapter_for_name(&self, name: &LanguageServerName) -> Option<Arc<CachedLspAdapter>> {
         self.state.read().all_lsp_adapters.get(name).cloned()
     }

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -267,6 +267,32 @@ impl LspAdapter for ExtensionLspAdapter {
         })
     }
 
+    async fn additional_initialization_options(
+        self: Arc<Self>,
+        target_language_server_id: LanguageServerName,
+        _: &dyn Fs,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+    ) -> Result<Option<serde_json::Value>> {
+        let delegate = Arc::new(WorktreeDelegateAdapter(delegate.clone())) as _;
+        let json_options: Option<String> = self
+            .extension
+            .language_server_additional_initialization_options(
+                self.language_server_id.clone(),
+                target_language_server_id.clone(),
+                delegate,
+            )
+            .await?;
+        Ok(if let Some(json_options) = json_options {
+            serde_json::from_str(&json_options).with_context(|| {
+                format!(
+                    "failed to parse additional_initialization_options from extension: {json_options}"
+                )
+            })?
+        } else {
+            None
+        })
+    }
+
     async fn additional_workspace_configuration(
         self: Arc<Self>,
         target_language_server_id: LanguageServerName,
@@ -286,7 +312,7 @@ impl LspAdapter for ExtensionLspAdapter {
             .await?;
         Ok(if let Some(json_options) = json_options {
             serde_json::from_str(&json_options).with_context(|| {
-                format!("failed to parse workspace_configuration from extension: {json_options}")
+                format!("failed to parse additional_workspace_configuration from extension: {json_options}")
             })?
         } else {
             None

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -269,6 +269,7 @@ impl LspAdapter for ExtensionLspAdapter {
 
     async fn additional_workspace_configuration(
         self: Arc<Self>,
+        target_language_server_id: LanguageServerName,
         _: &dyn Fs,
         delegate: &Arc<dyn LspAdapterDelegate>,
         _: Arc<dyn LanguageToolchainStore>,
@@ -277,8 +278,9 @@ impl LspAdapter for ExtensionLspAdapter {
         let delegate = Arc::new(WorktreeDelegateAdapter(delegate.clone())) as _;
         let json_options: Option<String> = self
             .extension
-            .additional_language_server_workspace_configuration(
+            .language_server_additional_workspace_configuration(
                 self.language_server_id.clone(),
+                target_language_server_id.clone(),
                 delegate,
             )
             .await?;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3252,14 +3252,18 @@ impl LocalLspStore {
             if other_adapter.name() == adapter.name() {
                 continue;
             }
-            if let Ok(Some(config)) = other_adapter
+            if let Ok(Some(target_config)) = other_adapter
                 .clone()
-                .additional_workspace_configuration(fs, delegate, toolchains.clone(), cx)
+                .additional_workspace_configuration(
+                    adapter.name(),
+                    fs,
+                    delegate,
+                    toolchains.clone(),
+                    cx,
+                )
                 .await
             {
-                if let Some(target_config) = config.get(adapter.name().to_string()) {
-                    merge_json_value_into(target_config.clone(), &mut workspace_config);
-                }
+                merge_json_value_into(target_config.clone(), &mut workspace_config);
             }
         }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -40,7 +40,7 @@ use language::{
     point_to_lsp,
     proto::{deserialize_anchor, deserialize_version, serialize_anchor, serialize_version},
     range_from_lsp, range_to_lsp, Bias, BinaryStatus, Buffer, BufferSnapshot, CachedLspAdapter,
-    CodeLabel, Diagnostic, DiagnosticEntry, DiagnosticSet, Diff, File as _, Language, LanguageName,
+    CodeLabel, Diagnostic, DiagnosticEntry, DiagnosticSet, Diff, File as _, Language,
     LanguageRegistry, LanguageToolchainStore, LocalFile, LspAdapter, LspAdapterDelegate, Patch,
     PointUtf16, TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction, Unclipped,
 };
@@ -3258,7 +3258,6 @@ impl LocalLspStore {
                 .await
             {
                 if let Some(target_config) = config.get(adapter.name().to_string()) {
-                    dbg!(target_config);
                     merge_json_value_into(target_config.clone(), &mut workspace_config);
                 }
             }


### PR DESCRIPTION
Closes #22410

With this PR extensions can provide additional workspace configuration for other LSP Adapters. This allows extensions like Astro, Svelte, Vue, etc to provide plugins for vtsls typescript server, fixing issues like: https://github.com/zed-industries/zed/issues/4577, https://github.com/zed-industries/zed/issues/21697, https://github.com/zed-industries/zed/issues/26901#issuecomment-2737485096

Todo:

- [x] Test case when extension is installed, does vtsls workspace config refreshes?

Before:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/f242167c-5264-44ab-b5a7-8c90eb75c6a1" />

After:
<img width="450" alt="image" src="https://github.com/user-attachments/assets/6a5f1afe-a0e1-4f64-8a95-919b0bf97614" />

Release Notes:

- N/A