### PR TITLE
zlog: Implement better scope map

### DIFF
--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -405,12 +405,25 @@ pub mod scope_map {
 
     fn scope_alloc_from_scope_str(scope_str: &String) -> Option<ScopeAlloc> {
         let mut scope_buf = [""; SCOPE_DEPTH_MAX];
-        for (index, scope) in scope_str.split(SCOPE_STRING_SEP).enumerate() {
-            let Some(scope_ptr) = scope_buf.get_mut(index) else {
-                crate::warn!("Invalid scope key, too many nested scopes: '{scope_str}'");
-                return None;
+        let mut index = 0;
+        let mut scope_iter = scope_str.split(SCOPE_STRING_SEP);
+        while index < SCOPE_DEPTH_MAX {
+            let Some(scope) = scope_iter.next() else {
+                continue;
             };
-            *scope_ptr = scope;
+            if scope == "" {
+                continue;
+            }
+            scope_buf[index] = scope;
+        }
+        if index == 0 {
+            return None;
+        }
+        if let Some(_) = scope_iter.next() {
+            crate::warn!(
+                "Invalid scope key, too many nested scopes: '{scope_str}'. Max depth is {SCOPE_DEPTH_MAX}",
+            );
+            return None;
         }
         let scope = scope_buf.map(|s| s.to_string());
         return Some(scope);

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -531,16 +531,23 @@ pub mod scope_map {
             let mut enabled = None;
             let mut cur_range = &self.entries[0..self.root_count];
             let mut depth = 0;
-            while !cur_range.is_empty() && depth < SCOPE_DEPTH_MAX && scope[depth].as_ref() != "" {
+
+            'search: while !cur_range.is_empty()
+                && depth < SCOPE_DEPTH_MAX
+                && scope[depth].as_ref() != ""
+            {
                 for entry in cur_range {
                     if entry.scope == scope[depth].as_ref() {
                         // note:
                         enabled = entry.enabled.or(enabled);
                         cur_range = &self.entries[entry.descendants.clone()];
                         depth += 1;
+                        continue 'search;
                     }
                 }
+                break 'search;
             }
+
             return enabled.map_or(EnabledStatus::NotConfigured, |level_enabled| {
                 if level <= level_enabled {
                     EnabledStatus::Enabled


### PR DESCRIPTION
Another step towards having `zlog` as the default logging solution in Zed.
The new ScopeMap replaces the previous HashMap based implementation used for scope lookups to:

A. Reduce complexity
B. Increase speed at which non-enabled logs can be filtered out
C. Provide more granular control over how scopes are determined to be enabled/disabled, 
   and what caching/other speed increase opportunities are available

Release Notes:

- N/A
