### PR TITLE
Use newer cargo-bundle without the build error

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -96,7 +96,7 @@ let
         ++ lib.optionals stdenv.hostPlatform.isDarwin [
           # TODO: move to overlay so it's usable in the shell
           (cargo-bundle.overrideAttrs (old: {
-            version = "0.6.0-zed";
+            version = "0.6.1-zed";
             src = fetchFromGitHub {
               owner = "zed-industries";
               repo = "cargo-bundle";

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -72,7 +72,7 @@ popd
 export ZED_BUNDLE=true
 
 cargo_bundle_version=$(cargo -q bundle --help 2>&1 | head -n 1 || echo "")
-if [ "$cargo_bundle_version" != "cargo-bundle v0.6.0-zed" ]; then
+if [ "$cargo_bundle_version" != "cargo-bundle v0.6.1-zed" ]; then
     cargo install cargo-bundle --git https://github.com/zed-industries/cargo-bundle.git --branch zed-deploy
 fi
 


### PR DESCRIPTION
Fixes Nightly builds for macOS.

Release Notes:

- N/A 
