### PR TITLE
Add a way to control go to definition fallback

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -184,6 +184,11 @@
   // Whether to show the signature help after completion or a bracket pair inserted.
   // If `auto_signature_help` is enabled, this setting will be treated as enabled also.
   "show_signature_help_after_edits": false,
+  // What to do when go to definition yields no results.
+  //
+  // 1. Do nothing: `none`
+  // 2. Find references for the same symbol: `find_all_references` (default)
+  "go_to_definition_fallback": "find_all_references",
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
   // if 'soft_wrap' is set to 'preferred_line_length', and will show any

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -36,6 +36,8 @@ pub struct EditorSettings {
     pub search: SearchSettings,
     pub auto_signature_help: bool,
     pub show_signature_help_after_edits: bool,
+    #[serde(default)]
+    pub go_to_definition_fallback: GoToDefinitionFallback,
     pub jupyter: Jupyter,
 }
 
@@ -211,6 +213,17 @@ pub struct SearchSettings {
     pub regex: bool,
 }
 
+/// What to do when go to definition yields no results.
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GoToDefinitionFallback {
+    /// Disables the fallback.
+    None,
+    /// Looks up references of the same symbol instead.
+    #[default]
+    FindAllReferences,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.
@@ -329,6 +342,13 @@ pub struct EditorSettingsContent {
     ///
     /// Default: false
     pub show_signature_help_after_edits: Option<bool>,
+
+    /// Whether to follow-up empty go to definition responses from the language server or not.
+    /// `FindAllReferences` allows to look up references of the same symbol instead.
+    /// `None` disables the fallback.
+    ///
+    /// Default: FindAllReferences
+    pub go_to_definition_fallback: Option<GoToDefinitionFallback>,
 
     /// Jupyter REPL settings.
     pub jupyter: Option<JupyterContent>,

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1,5 +1,5 @@
 use crate::{
-    editor_settings::MultiCursorModifier,
+    editor_settings::{GoToDefinitionFallback, MultiCursorModifier},
     hover_popover::{self, InlayHover},
     scroll::ScrollAmount,
     Anchor, Editor, EditorSettings, EditorSnapshot, FindAllReferences, GoToDefinition,
@@ -174,7 +174,12 @@ impl Editor {
                     if definition_revealed == Navigated::Yes {
                         return None;
                     }
-                    editor.find_all_references(&FindAllReferences, window, cx)
+                    match EditorSettings::get_global(cx).go_to_definition_fallback {
+                        GoToDefinitionFallback::None => None,
+                        GoToDefinitionFallback::FindAllReferences => {
+                            editor.find_all_references(&FindAllReferences, window, cx)
+                        }
+                    }
                 })
                 .ok()
                 .flatten();


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/9243 and https://github.com/zed-industries/zed/pull/16512

Release Notes:

- Added a way to control go to definition fallback
