### PR TITLE
python: Fix incorrect indenting of `except`, `finally`, `else`, and `elif` control flow

### DIFF
--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -1,3 +1,18 @@
 (_ "[" "]" @end) @indent
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
+
+(try_statement
+    body: (_) @start
+    [(except_clause) (finally_clause)] @end
+    ) @indent
+
+(if_statement
+    consequence: (_) @start
+    alternative: (_) @end
+    ) @indent
+
+(_
+    alternative: (elif_clause) @start
+    alternative: (_) @end
+    ) @indent

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -405,12 +405,25 @@ pub mod scope_map {
 
     fn scope_alloc_from_scope_str(scope_str: &String) -> Option<ScopeAlloc> {
         let mut scope_buf = [""; SCOPE_DEPTH_MAX];
-        for (index, scope) in scope_str.split(SCOPE_STRING_SEP).enumerate() {
-            let Some(scope_ptr) = scope_buf.get_mut(index) else {
-                crate::warn!("Invalid scope key, too many nested scopes: '{scope_str}'");
-                return None;
+        let mut index = 0;
+        let mut scope_iter = scope_str.split(SCOPE_STRING_SEP);
+        while index < SCOPE_DEPTH_MAX {
+            let Some(scope) = scope_iter.next() else {
+                continue;
             };
-            *scope_ptr = scope;
+            if scope == "" {
+                continue;
+            }
+            scope_buf[index] = scope;
+        }
+        if index == 0 {
+            return None;
+        }
+        if let Some(_) = scope_iter.next() {
+            crate::warn!(
+                "Invalid scope key, too many nested scopes: '{scope_str}'. Max depth is {SCOPE_DEPTH_MAX}",
+            );
+            return None;
         }
         let scope = scope_buf.map(|s| s.to_string());
         return Some(scope);

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -531,16 +531,23 @@ pub mod scope_map {
             let mut enabled = None;
             let mut cur_range = &self.entries[0..self.root_count];
             let mut depth = 0;
-            while !cur_range.is_empty() && depth < SCOPE_DEPTH_MAX && scope[depth].as_ref() != "" {
+
+            'search: while !cur_range.is_empty()
+                && depth < SCOPE_DEPTH_MAX
+                && scope[depth].as_ref() != ""
+            {
                 for entry in cur_range {
                     if entry.scope == scope[depth].as_ref() {
                         // note:
                         enabled = entry.enabled.or(enabled);
                         cur_range = &self.entries[entry.descendants.clone()];
                         depth += 1;
+                        continue 'search;
                     }
                 }
+                break 'search;
             }
+
             return enabled.map_or(EnabledStatus::NotConfigured, |level_enabled| {
                 if level <= level_enabled {
                     EnabledStatus::Enabled


### PR DESCRIPTION
Closes #10832

Note: This PR only fixes the issue where when entering one of `except`, `finally`, `else`, and `elif` after another block like so:

```python
try:
    for i in range(n):
        pass
except:|
```

The `except` would be indented resulting in the following:

```python
try:
    for i in range(n):
        pass
    except:|
```

This PR does not fix a separate issue in which the indentation is not corrected from the second example to the first, i.e. if example 2 is typed verbatim in Zed it will not auto-indent to look like example 1. Handling of this case would likely require specific logic to handle, or changes to the tree-sitter grammar for Python, as the current grammar results in ERROR nodes that obscure the natural structure (cannot tie the `except` to the `try`)

Release Notes:

- Fixed an issue where `except`, `finally`, `else`, and `elif` control flow keywords in Python would be incorrectly indented when entered at the correct level of indentation.
