### PR TITLE
assistant edit tool: Reliability improvements

### DIFF
--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -240,7 +240,9 @@ impl EditToolRequest {
             };
 
             while let Some(chunk) = chunks.stream.next().await {
-                request.process_response_chunk(&chunk?, cx).await?;
+                if let Some(chunk) = chunk.log_err() {
+                    request.process_response_chunk(&chunk, cx).await?;
+                }
             }
 
             request.finalize(cx).await

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -6,8 +6,8 @@ use anyhow::{anyhow, Context, Result};
 use assistant_tool::{ActionLog, Tool};
 use collections::HashSet;
 use edit_action::{EditAction, EditActionParser};
-use futures::StreamExt;
-use gpui::{App, AsyncApp, Entity, Task};
+use futures::{channel::mpsc, SinkExt, StreamExt};
+use gpui::{App, AppContext, AsyncApp, Entity, Task};
 use language_model::{
     LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, MessageContent, Role,
 };
@@ -228,9 +228,10 @@ impl EditToolRequest {
             let stream = model.stream_completion_text(llm_request, &cx);
             let mut chunks = stream.await?;
 
+            let (mut tx, mut rx) = mpsc::channel::<String>(32);
+
             let mut request = Self {
                 parser: EditActionParser::new(),
-                // we start with the success header so we don't need to shift the output in the common case
                 output: Self::SUCCESS_OUTPUT_HEADER.to_string(),
                 changed_buffers: HashSet::default(),
                 bad_searches: Vec::new(),
@@ -239,11 +240,21 @@ impl EditToolRequest {
                 tool_log,
             };
 
-            while let Some(chunk) = chunks.stream.next().await {
-                if let Some(chunk) = chunk.log_err() {
-                    request.process_response_chunk(&chunk, cx).await?;
+            let reader_task = cx.background_spawn(async move {
+                while let Some(chunk) = chunks.stream.next().await {
+                    if let Some(chunk) = chunk.log_err() {
+                        tx.send(chunk).await?
+                    }
                 }
+                tx.close().await?;
+                anyhow::Ok(())
+            });
+
+            while let Some(chunk) = rx.next().await {
+                request.process_response_chunk(&chunk, cx).await?;
             }
+
+            reader_task.await?;
 
             request.finalize(cx).await
         })

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -225,12 +225,11 @@ impl EditToolRequest {
                 temperature: Some(0.0),
             };
 
-            let stream = model.stream_completion_text(llm_request, &cx);
-            let mut chunks = stream.await?;
-
             let (mut tx, mut rx) = mpsc::channel::<String>(32);
-
+            let stream = model.stream_completion_text(llm_request, &cx);
             let reader_task = cx.background_spawn(async move {
+                let mut chunks = stream.await?;
+
                 while let Some(chunk) = chunks.stream.next().await {
                     if let Some(chunk) = chunk.log_err() {
                         // we don't process here because the API fails

--- a/crates/assistant_tools/src/edit_files_tool/description.md
+++ b/crates/assistant_tools/src/edit_files_tool/description.md
@@ -3,3 +3,5 @@ Edit files in the current project by specifying instructions in natural language
 When using this tool, you should suggest one coherent edit that can be made to the codebase.
 
 When the set of edits you want to make is large or complex, feel free to invoke this tool multiple times, each time focusing on a specific change you wanna make.
+
+DO NOT call this tool until the code to be edited appears in the conversation! You must use the `read-files` tool or ask the user to add it to context first.

--- a/crates/assistant_tools/src/edit_files_tool/edit_prompt.md
+++ b/crates/assistant_tools/src/edit_files_tool/edit_prompt.md
@@ -120,7 +120,7 @@ Break large *SEARCH/REPLACE* blocks into a series of smaller blocks that each ch
 Include just the changing lines, and a few surrounding lines if needed for uniqueness.
 Do not include long runs of unchanging lines in *SEARCH/REPLACE* blocks.
 
-Only create *SEARCH/REPLACE* blocks for files that the user has added to the chat!
+Only create *SEARCH/REPLACE* blocks for files that have been read! Even though the conversation includes `read-file` tool results, you *CANNOT* issue your own reads. If the conversation doesn't include the code you need to edit, ask for it to be read explicitly.
 
 To move code within a file, use 2 *SEARCH/REPLACE* blocks: 1 to delete it from its current location, 1 to insert it in the new location.
 


### PR DESCRIPTION
- Add instructions in description to read before editing
- Add instructions in edit prefix to explicitly ask for reads
- Fix `connection error: delay between messages too long` by processing chunks off a channel

Release Notes:

- N/A
