### PR TITLE
assistant2: Add `create-file` and `copy-path` tools to the "Code Writer" profile

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -633,6 +633,8 @@
         "name": "Code Writer",
         "tools": {
           "bash": true,
+          "copy-path": true,
+          "create-file": true,
           "delete-path": true,
           "diagnostics": true,
           "edit-files": true,


### PR DESCRIPTION
This PR adds the `create-file` and `copy-path` tools to the "Code Writer" profile.

Release Notes:

- N/A
