### PR TITLE
ci: Hide harmless cargo about error from release output

### DIFF
--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -18,7 +18,7 @@ echo -n "" >"$OUTPUT_FILE"
     echo -e "\n# ###### CODE LICENSES ######\n"
 } >>"$OUTPUT_FILE"
 
-if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" >/dev/null; then
+if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" 2>&1 >/dev/null; then
     echo "Installing cargo-about@^$CARGO_ABOUT_VERSION..."
     cargo install "cargo-about@^$CARGO_ABOUT_VERSION"
 else

--- a/script/generate-licenses-csv
+++ b/script/generate-licenses-csv
@@ -6,7 +6,7 @@ CARGO_ABOUT_VERSION="0.6"
 OUTPUT_FILE="${1:-$(pwd)/assets/licenses.csv}"
 TEMPLATE_FILE="script/licenses/template.csv.hbs"
 
-if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" > /dev/null; then
+if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" 2>&1 > /dev/null; then
   echo "Installing cargo-about@^$CARGO_ABOUT_VERSION..."
   cargo install "cargo-about@^$CARGO_ABOUT_VERSION"
 else


### PR DESCRIPTION
Hide harmless errors like this from CI output.

<img width="834" alt="Screenshot 2025-03-25 at 12 07 36" src="https://github.com/user-attachments/assets/55450812-000d-49a0-9926-cae0df8aa281" />

Release Notes:

- N/A
