### PR TITLE
language_model: Remove dependency on `ui`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7311,6 +7311,7 @@ dependencies = [
  "google_ai",
  "gpui",
  "http_client",
+ "icons",
  "image",
  "log",
  "open_ai",
@@ -7323,7 +7324,6 @@ dependencies = [
  "strum",
  "telemetry_events",
  "thiserror 2.0.12",
- "ui",
  "util",
 ]
 

--- a/crates/language_model/Cargo.toml
+++ b/crates/language_model/Cargo.toml
@@ -25,6 +25,7 @@ futures.workspace = true
 google_ai = { workspace = true, features = ["schemars"] }
 gpui.workspace = true
 http_client.workspace = true
+icons.workspace = true
 image.workspace = true
 log.workspace = true
 open_ai = { workspace = true, features = ["schemars"] }
@@ -37,7 +38,6 @@ smol.workspace = true
 strum.workspace = true
 telemetry_events.workspace = true
 thiserror.workspace = true
-ui.workspace = true
 util.workspace = true
 
 [dev-dependencies]

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -13,6 +13,7 @@ use client::Client;
 use futures::FutureExt;
 use futures::{future::BoxFuture, stream::BoxStream, StreamExt, TryStreamExt as _};
 use gpui::{AnyElement, AnyView, App, AsyncApp, SharedString, Task, Window};
+use icons::IconName;
 use proto::Plan;
 use schemars::JsonSchema;
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
@@ -20,7 +21,6 @@ use std::fmt;
 use std::ops::{Add, Sub};
 use std::{future::Future, sync::Arc};
 use thiserror::Error;
-use ui::IconName;
 use util::serde::is_default;
 
 pub use crate::model::*;

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -6,13 +6,13 @@ use client::Client;
 use gpui::{
     App, AppContext as _, AsyncApp, Context, Entity, EventEmitter, Global, ReadGlobal as _,
 };
+use icons::IconName;
 use proto::{Plan, TypedEnvelope};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use smol::lock::{RwLock, RwLockUpgradableReadGuard, RwLockWriteGuard};
 use strum::EnumIter;
 use thiserror::Error;
-use ui::IconName;
 
 use crate::LanguageModelAvailability;
 

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -5,11 +5,11 @@ use crate::role::Role;
 use crate::{LanguageModelToolUse, LanguageModelToolUseId};
 use base64::write::EncoderWriter;
 use gpui::{
-    point, size, App, AppContext as _, DevicePixels, Image, ObjectFit, RenderImage, Size, Task,
+    point, px, size, App, AppContext as _, DevicePixels, Image, ObjectFit, RenderImage,
+    SharedString, Size, Task,
 };
 use image::{codecs::png::PngEncoder, imageops::resize, DynamicImage, ImageDecoder};
 use serde::{Deserialize, Serialize};
-use ui::{px, SharedString};
 use util::ResultExt;
 
 #[derive(Clone, PartialEq, Eq, Serialize, Deserialize, Hash)]


### PR DESCRIPTION
This PR removes the dependency on the `ui` crate from the `language_model` crate.

We were only depending on it to import `IconName`—which now lives in `icons`—and some re-exported GPUI items.

Release Notes:

- N/A
