### PR TITLE
Remove `ui` dependency from `assistant_tool` and `context_server`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -698,13 +698,13 @@ dependencies = [
  "collections",
  "derive_more",
  "gpui",
+ "icons",
  "language",
  "language_model",
  "parking_lot",
  "project",
  "serde",
  "serde_json",
- "ui",
 ]
 
 [[package]]
@@ -3198,6 +3198,7 @@ dependencies = [
  "extension",
  "futures 0.3.31",
  "gpui",
+ "icons",
  "language_model",
  "log",
  "parking_lot",
@@ -3207,7 +3208,6 @@ dependencies = [
  "serde_json",
  "settings",
  "smol",
- "ui",
  "url",
  "util",
 ]

--- a/crates/assistant_tool/Cargo.toml
+++ b/crates/assistant_tool/Cargo.toml
@@ -13,14 +13,14 @@ path = "src/assistant_tool.rs"
 
 [dependencies]
 anyhow.workspace = true
-collections.workspace = true
 clock.workspace = true
+collections.workspace = true
 derive_more.workspace = true
 gpui.workspace = true
+icons.workspace = true
 language.workspace = true
 language_model.workspace = true
 parking_lot.workspace = true
 project.workspace = true
 serde.workspace = true
 serde_json.workspace = true
-ui.workspace = true

--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -1,15 +1,16 @@
 mod tool_registry;
 mod tool_working_set;
 
+use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
+
 use anyhow::Result;
 use collections::{HashMap, HashSet};
 use gpui::{App, Context, Entity, SharedString, Task};
+use icons::IconName;
 use language::Buffer;
 use language_model::LanguageModelRequestMessage;
 use project::Project;
-use std::fmt::{self, Debug, Formatter};
-use std::sync::Arc;
-use ui::IconName;
 
 pub use crate::tool_registry::*;
 pub use crate::tool_working_set::*;

--- a/crates/context_server/Cargo.toml
+++ b/crates/context_server/Cargo.toml
@@ -21,6 +21,7 @@ context_server_settings.workspace = true
 extension.workspace = true
 futures.workspace = true
 gpui.workspace = true
+icons.workspace = true
 language_model.workspace = true
 log.workspace = true
 parking_lot.workspace = true
@@ -30,6 +31,5 @@ serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smol.workspace = true
-ui.workspace = true
 url = { workspace = true, features = ["serde"] }
 util.workspace = true

--- a/crates/context_server/src/context_server_tool.rs
+++ b/crates/context_server/src/context_server_tool.rs
@@ -3,9 +3,9 @@ use std::sync::Arc;
 use anyhow::{anyhow, bail, Result};
 use assistant_tool::{ActionLog, Tool, ToolSource};
 use gpui::{App, Entity, Task};
+use icons::IconName;
 use language_model::LanguageModelRequestMessage;
 use project::Project;
-use ui::IconName;
 
 use crate::manager::ContextServerManager;
 use crate::types;


### PR DESCRIPTION
This PR removes the dependency on the `ui` crate from the `assistant_tool` and `context_server` crates.

These crates were only depending on it for `IconName`, which can now be depended on from `icons` directly.

Release Notes:

- N/A
