### PR TITLE
Fix color swatch shrinking in the LSP completion menu

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -543,7 +543,14 @@ impl CompletionsMenu {
 
                         let start_slot = completion
                             .color()
-                            .map(|color| div().size_4().bg(color).rounded_xs().into_any_element())
+                            .map(|color| {
+                                div()
+                                    .flex_shrink_0()
+                                    .size_3p5()
+                                    .rounded_xs()
+                                    .bg(color)
+                                    .into_any_element()
+                            })
                             .or_else(|| {
                                 completion.icon_path.as_ref().map(|path| {
                                     Icon::from_path(path)


### PR DESCRIPTION
### Before

Note how in the second time I try to add a color property, the color swatch is shrunk.

https://github.com/user-attachments/assets/677a37b2-8ae4-408d-8dea-d9cc4bc2e119

### After

https://github.com/user-attachments/assets/aa902573-1f44-48e1-a396-e22ad5703155

Release Notes:

- Fixed color swatches shrinking upon re-adding a color-related property.
