### PR TITLE
Add `completions.lsp_insert_mode` setting to control what ranges are replaced when a completion is inserted

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1200,15 +1200,21 @@
     //
     // Default: 0
     "lsp_fetch_timeout_ms": 0,
-    // Controls how the completions are inserted.
+    // Controls what range to replace when accepting LSP completions.
+    //
+    // When LSP servers give an `InsertReplaceEdit` completion, they provides two ranges: `insert` and `replace`. Usually, `insert`
+    // contains the word prefix before your cursor and `replace` contains the whole word.
+    //
+    // Effectively, this setting just changes whether Zed will use the received range for `insert` or `replace`, so the results may
+    // differ depending on the underlying LSP server.
     //
     // Possible values:
     // 1. "insert"
-    //   Removes text left from the cursor
+    //   Replaces text before the cursor, using the `insert` range described in the LSP specification.
     // 2. "replace"
-    //   Replace the word
+    //   Replaces the whole word, using the `replace` range described in the LSP specification.
     // 3. "smart"
-    //   removes text left from the cursor and text right from the cursor if the completion ends with it
+    //   Only replace the whole word if the text after cursor is a suffix of the completion.
     //
     // Default: replace
     "completion_mode": "replace"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1199,7 +1199,19 @@
     // When set to 0, waits indefinitely.
     //
     // Default: 0
-    "lsp_fetch_timeout_ms": 0
+    "lsp_fetch_timeout_ms": 0,
+    // Controls how the completions are inserted
+    //
+    // Possible values:
+    // 1. "insert"
+    //   Removes text left from the cursor
+    // 2. "replace"
+    //   Replace the word
+    // 3. "smart"
+    //   removes text left from the cursor and text right from the cursor if the completion ends with it
+    //
+    // Default: insert
+    "completion_mode": "insert"
   },
   // Different settings for specific languages.
   "languages": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1219,7 +1219,7 @@
     // 4. "replace_suffix"
     //   Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like
     //   `"insert"` otherwise.
-    "completion_mode": "replace_suffix"
+    "lsp_insert_mode": "replace_suffix"
   },
   // Different settings for specific languages.
   "languages": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1213,7 +1213,7 @@
     //   Replaces text before the cursor, using the `insert` range described in the LSP specification.
     // 2. "replace"
     //   Replaces the whole word, using the `replace` range described in the LSP specification.
-    // 3. "smart"
+    // 3. "auto"
     //   Only replace the whole word if the text after cursor is a suffix of the completion.
     //
     // Default: replace

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1212,11 +1212,13 @@
     // 1. "insert"
     //   Replaces text before the cursor, using the `insert` range described in the LSP specification.
     // 2. "replace"
-    //   Replaces the whole word, using the `replace` range described in the LSP specification.
-    // 3. "auto_similar"
-    //   Only replace the whole word if the text after cursor is a subsequence (fuzzy match) of the completion.
-    // 4. "auto_strict"
-    //   Only replace the whole word if the text after cursor is a suffix of the completion.
+    //   Replaces text before and after the cursor, using the `replace` range described in the LSP specification.
+    // 3. "replace_subsequence"
+    //   Behaves like `"replace"` if the text that would be replaced is a subsequence of the completion text,
+    //   and like `"insert"` otherwise.
+    // 4. "replace_suffix"
+    //   Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like
+    //   `"insert"` otherwise.
     //
     // Default: replace
     "completion_mode": "replace"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1219,9 +1219,7 @@
     // 4. "replace_suffix"
     //   Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like
     //   `"insert"` otherwise.
-    //
-    // Default: replace
-    "completion_mode": "replace"
+    "completion_mode": "replace_suffix"
   },
   // Different settings for specific languages.
   "languages": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1200,7 +1200,7 @@
     //
     // Default: 0
     "lsp_fetch_timeout_ms": 0,
-    // Controls how the completions are inserted
+    // Controls how the completions are inserted.
     //
     // Possible values:
     // 1. "insert"
@@ -1210,8 +1210,8 @@
     // 3. "smart"
     //   removes text left from the cursor and text right from the cursor if the completion ends with it
     //
-    // Default: insert
-    "completion_mode": "insert"
+    // Default: replace
+    "completion_mode": "replace"
   },
   // Different settings for specific languages.
   "languages": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1213,7 +1213,9 @@
     //   Replaces text before the cursor, using the `insert` range described in the LSP specification.
     // 2. "replace"
     //   Replaces the whole word, using the `replace` range described in the LSP specification.
-    // 3. "auto"
+    // 3. "auto_similar"
+    //   Only replace the whole word if the text after cursor is a subsequence (fuzzy match) of the completion.
+    // 4. "auto_strict"
     //   Only replace the whole word if the text after cursor is a suffix of the completion.
     //
     // Default: replace

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -273,7 +273,7 @@ mod tests {
     use language::{
         Point,
         language_settings::{
-            AllLanguageSettings, AllLanguageSettingsContent, CompletionMode, CompletionSettings,
+            AllLanguageSettings, AllLanguageSettingsContent, CompletionSettings, LspInsertMode,
             WordsCompletionMode,
         },
     };
@@ -294,7 +294,7 @@ mod tests {
                 words: WordsCompletionMode::Disabled,
                 lsp: true,
                 lsp_fetch_timeout_ms: 0,
-                completion_mode: CompletionMode::Insert,
+                lsp_insert_mode: LspInsertMode::Insert,
             });
         });
 
@@ -526,7 +526,7 @@ mod tests {
                 words: WordsCompletionMode::Disabled,
                 lsp: true,
                 lsp_fetch_timeout_ms: 0,
-                completion_mode: CompletionMode::Insert,
+                lsp_insert_mode: LspInsertMode::Insert,
             });
         });
 

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -273,7 +273,7 @@ mod tests {
     use language::{
         Point,
         language_settings::{
-            AllLanguageSettings, AllLanguageSettingsContent, CompletionSettings,
+            AllLanguageSettings, AllLanguageSettingsContent, CompletionMode, CompletionSettings,
             WordsCompletionMode,
         },
     };
@@ -294,6 +294,7 @@ mod tests {
                 words: WordsCompletionMode::Disabled,
                 lsp: true,
                 lsp_fetch_timeout_ms: 0,
+                completion_mode: CompletionMode::Insert,
             });
         });
 
@@ -525,6 +526,7 @@ mod tests {
                 words: WordsCompletionMode::Disabled,
                 lsp: true,
                 lsp_fetch_timeout_ms: 0,
+                completion_mode: CompletionMode::Insert,
             });
         });
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -22,8 +22,8 @@ use language::{
     FakeLspAdapter, LanguageConfig, LanguageConfigOverride, LanguageMatcher, LanguageName,
     Override, Point,
     language_settings::{
-        AllLanguageSettings, AllLanguageSettingsContent, CompletionMode, CompletionSettings,
-        LanguageSettingsContent, PrettierSettings,
+        AllLanguageSettings, AllLanguageSettingsContent, CompletionSettings,
+        LanguageSettingsContent, LspInsertMode, PrettierSettings,
     },
 };
 use language_settings::{Formatter, FormatterList, IndentGuideSettings};
@@ -9339,27 +9339,27 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
 
     for run in runs {
         let run_variations = [
-            (CompletionMode::Insert, run.expected_with_insertion_mode),
-            (CompletionMode::Replace, run.expected_with_replace_mode),
+            (LspInsertMode::Insert, run.expected_with_insertion_mode),
+            (LspInsertMode::Replace, run.expected_with_replace_mode),
             (
-                CompletionMode::ReplaceSubsequence,
+                LspInsertMode::ReplaceSubsequence,
                 run.expected_with_replace_subsequence_mode,
             ),
             (
-                CompletionMode::ReplaceSuffix,
+                LspInsertMode::ReplaceSuffix,
                 run.expected_with_replace_suffix_mode,
             ),
         ];
 
-        for (completion_mode, expected_text) in run_variations {
+        for (lsp_insert_mode, expected_text) in run_variations {
             eprintln!(
-                "run = {:?}, mode = {completion_mode:.?}",
+                "run = {:?}, mode = {lsp_insert_mode:.?}",
                 run.run_description,
             );
 
             update_test_language_settings(&mut cx, |settings| {
                 settings.defaults.completions = Some(CompletionSettings {
-                    completion_mode,
+                    lsp_insert_mode,
                     words: WordsCompletionMode::Disabled,
                     lsp: true,
                     lsp_fetch_timeout_ms: 0,
@@ -9616,7 +9616,7 @@ async fn test_word_completion(cx: &mut TestAppContext) {
             words: WordsCompletionMode::Fallback,
             lsp: true,
             lsp_fetch_timeout_ms: 10,
-            completion_mode: CompletionMode::Insert,
+            lsp_insert_mode: LspInsertMode::Insert,
         });
     });
 
@@ -9712,7 +9712,7 @@ async fn test_word_completions_do_not_duplicate_lsp_ones(cx: &mut TestAppContext
             words: WordsCompletionMode::Enabled,
             lsp: true,
             lsp_fetch_timeout_ms: 0,
-            completion_mode: CompletionMode::Insert,
+            lsp_insert_mode: LspInsertMode::Insert,
         });
     });
 
@@ -9775,7 +9775,7 @@ async fn test_word_completions_continue_on_typing(cx: &mut TestAppContext) {
             words: WordsCompletionMode::Disabled,
             lsp: true,
             lsp_fetch_timeout_ms: 0,
-            completion_mode: CompletionMode::Insert,
+            lsp_insert_mode: LspInsertMode::Insert,
         });
     });
 
@@ -9848,7 +9848,7 @@ async fn test_word_completions_usually_skip_digits(cx: &mut TestAppContext) {
             words: WordsCompletionMode::Fallback,
             lsp: false,
             lsp_fetch_timeout_ms: 0,
-            completion_mode: CompletionMode::Insert,
+            lsp_insert_mode: LspInsertMode::Insert,
         });
     });
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9220,8 +9220,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
         completion_text: &'static str,
         expected_with_insertion_mode: String,
         expected_with_replace_mode: String,
-        expected_with_auto_similar_mode: String,
-        expected_with_auto_strict_mode: String,
+        expected_with_replace_subsequence_mode: String,
+        expected_with_replace_suffix_mode: String,
     }
 
     let runs = [
@@ -9232,8 +9232,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "editor",
             expected_with_insertion_mode: "before editorˇ after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
-            expected_with_auto_similar_mode: "before editorˇ after".into(),
-            expected_with_auto_strict_mode: "before editorˇ after".into(),
+            expected_with_replace_subsequence_mode: "before editorˇ after".into(),
+            expected_with_replace_suffix_mode: "before editorˇ after".into(),
         },
         Run {
             run_description: "Accept same text at the middle of the word",
@@ -9242,8 +9242,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "editor",
             expected_with_insertion_mode: "before editorˇtor after".into(),
             expected_with_replace_mode: "before ediˇtor after".into(),
-            expected_with_auto_similar_mode: "before ediˇtor after".into(),
-            expected_with_auto_strict_mode: "before ediˇtor after".into(),
+            expected_with_replace_subsequence_mode: "before ediˇtor after".into(),
+            expected_with_replace_suffix_mode: "before ediˇtor after".into(),
         },
         Run {
             run_description: "End of word matches completion text -- cursor at end",
@@ -9252,8 +9252,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "editor",
             expected_with_insertion_mode: "before editorˇ after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
-            expected_with_auto_similar_mode: "before editorˇ after".into(),
-            expected_with_auto_strict_mode: "before editorˇ after".into(),
+            expected_with_replace_subsequence_mode: "before editorˇ after".into(),
+            expected_with_replace_suffix_mode: "before editorˇ after".into(),
         },
         Run {
             run_description: "End of word matches completion text -- cursor at start",
@@ -9262,8 +9262,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "editor",
             expected_with_insertion_mode: "before editorˇtor after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
-            expected_with_auto_similar_mode: "before editorˇ after".into(),
-            expected_with_auto_strict_mode: "before editorˇ after".into(),
+            expected_with_replace_subsequence_mode: "before editorˇ after".into(),
+            expected_with_replace_suffix_mode: "before editorˇ after".into(),
         },
         Run {
             run_description: "Prepend text containing whitespace",
@@ -9272,8 +9272,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "pub ",
             expected_with_insertion_mode: "pub ˇfield: bool".into(),
             expected_with_replace_mode: "pub ˇ: bool".into(),
-            expected_with_auto_similar_mode: "pub ˇfield: bool".into(),
-            expected_with_auto_strict_mode: "pub ˇfield: bool".into(),
+            expected_with_replace_subsequence_mode: "pub ˇfield: bool".into(),
+            expected_with_replace_suffix_mode: "pub ˇfield: bool".into(),
         },
         Run {
             run_description: "Add element to start of list",
@@ -9282,8 +9282,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "element_1",
             expected_with_insertion_mode: "[element_1ˇelement_2]".into(),
             expected_with_replace_mode: "[element_1ˇ]".into(),
-            expected_with_auto_similar_mode: "[element_1ˇelement_2]".into(),
-            expected_with_auto_strict_mode: "[element_1ˇelement_2]".into(),
+            expected_with_replace_subsequence_mode: "[element_1ˇelement_2]".into(),
+            expected_with_replace_suffix_mode: "[element_1ˇelement_2]".into(),
         },
         Run {
             run_description: "Add element to start of list -- first and second elements are equal",
@@ -9292,8 +9292,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "element",
             expected_with_insertion_mode: "[elementˇelement]".into(),
             expected_with_replace_mode: "[elˇement]".into(),
-            expected_with_auto_similar_mode: "[elˇement]".into(),
-            expected_with_auto_strict_mode: "[elˇement]".into(),
+            expected_with_replace_subsequence_mode: "[elementˇelement]".into(),
+            expected_with_replace_suffix_mode: "[elˇement]".into(),
         },
         Run {
             run_description: "Ends with matching suffix",
@@ -9302,8 +9302,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "SubscriptionError",
             expected_with_insertion_mode: "SubscriptionErrorˇError".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
-            expected_with_auto_similar_mode: "SubscriptionErrorˇ".into(),
-            expected_with_auto_strict_mode: "SubscriptionErrorˇ".into(),
+            expected_with_replace_subsequence_mode: "SubscriptionErrorˇ".into(),
+            expected_with_replace_suffix_mode: "SubscriptionErrorˇ".into(),
         },
         Run {
             run_description: "Suffix is a subsequence -- contiguous",
@@ -9312,8 +9312,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "SubscriptionError",
             expected_with_insertion_mode: "SubscriptionErrorˇErr".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
-            expected_with_auto_similar_mode: "SubscriptionErrorˇ".into(),
-            expected_with_auto_strict_mode: "SubscriptionErrorˇErr".into(),
+            expected_with_replace_subsequence_mode: "SubscriptionErrorˇ".into(),
+            expected_with_replace_suffix_mode: "SubscriptionErrorˇErr".into(),
         },
         Run {
             run_description: "Suffix is a subsequence -- non-contiguous -- replace intended",
@@ -9322,8 +9322,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "SubscriptionError",
             expected_with_insertion_mode: "SubscriptionErrorˇscrirr".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
-            expected_with_auto_similar_mode: "SubscriptionErrorˇ".into(),
-            expected_with_auto_strict_mode: "SubscriptionErrorˇscrirr".into(),
+            expected_with_replace_subsequence_mode: "SubscriptionErrorˇ".into(),
+            expected_with_replace_suffix_mode: "SubscriptionErrorˇscrirr".into(),
         },
         Run {
             run_description: "Suffix is a subsequence -- non-contiguous -- replace unintended",
@@ -9332,8 +9332,8 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             completion_text: "node_index",
             expected_with_insertion_mode: "foo(node_indexˇix)".into(),
             expected_with_replace_mode: "foo(node_indexˇ)".into(),
-            expected_with_auto_similar_mode: "foo(node_indexˇ)".into(),
-            expected_with_auto_strict_mode: "foo(node_indexˇix)".into(),
+            expected_with_replace_subsequence_mode: "foo(node_indexˇix)".into(),
+            expected_with_replace_suffix_mode: "foo(node_indexˇix)".into(),
         },
     ];
 
@@ -9342,18 +9342,18 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             (CompletionMode::Insert, run.expected_with_insertion_mode),
             (CompletionMode::Replace, run.expected_with_replace_mode),
             (
-                CompletionMode::AutoSimilar,
-                run.expected_with_auto_similar_mode,
+                CompletionMode::ReplaceSubsequence,
+                run.expected_with_replace_subsequence_mode,
             ),
             (
-                CompletionMode::AutoStrict,
-                run.expected_with_auto_strict_mode,
+                CompletionMode::ReplaceSuffix,
+                run.expected_with_replace_suffix_mode,
             ),
         ];
 
         for (completion_mode, expected_text) in run_variations {
             eprintln!(
-                "mode = {completion_mode:.?}, run = {:?}",
+                "run = {:?}, mode = {completion_mode:.?}",
                 run.run_description,
             );
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -22,7 +22,7 @@ use language::{
     FakeLspAdapter, LanguageConfig, LanguageConfigOverride, LanguageMatcher, LanguageName,
     Override, Point,
     language_settings::{
-        AllLanguageSettings, AllLanguageSettingsContent, CompletionSettings,
+        AllLanguageSettings, AllLanguageSettingsContent, CompletionMode, CompletionSettings,
         LanguageSettingsContent, PrettierSettings,
     },
 };
@@ -9419,6 +9419,7 @@ async fn test_word_completion(cx: &mut TestAppContext) {
             words: WordsCompletionMode::Fallback,
             lsp: true,
             lsp_fetch_timeout_ms: 10,
+            completion_mode: CompletionMode::Insert,
         });
     });
 
@@ -9514,6 +9515,7 @@ async fn test_word_completions_do_not_duplicate_lsp_ones(cx: &mut TestAppContext
             words: WordsCompletionMode::Enabled,
             lsp: true,
             lsp_fetch_timeout_ms: 0,
+            completion_mode: CompletionMode::Insert,
         });
     });
 
@@ -9576,6 +9578,7 @@ async fn test_word_completions_continue_on_typing(cx: &mut TestAppContext) {
             words: WordsCompletionMode::Disabled,
             lsp: true,
             lsp_fetch_timeout_ms: 0,
+            completion_mode: CompletionMode::Insert,
         });
     });
 
@@ -9648,6 +9651,7 @@ async fn test_word_completions_usually_skip_digits(cx: &mut TestAppContext) {
             words: WordsCompletionMode::Fallback,
             lsp: false,
             lsp_fetch_timeout_ms: 0,
+            completion_mode: CompletionMode::Insert,
         });
     });
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -372,8 +372,10 @@ pub enum CompletionMode {
     Insert,
     /// Replaces the whole word, using the `replace` range described in the LSP specification.
     Replace,
+    /// Only replace the whole word if the text after cursor is a subsequence (fuzzy match) of the completion.
+    AutoSimilar,
     /// Only replace the whole word if the text after cursor is a suffix of the completion.
-    Auto,
+    AutoStrict,
 }
 
 fn default_words_completion_mode() -> WordsCompletionMode {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -331,15 +331,7 @@ pub struct CompletionSettings {
     pub lsp_fetch_timeout_ms: u64,
     /// Controls how the completions are inserted
     ///
-    /// Possible values:
-    /// 1. "insert"
-    ///   Removes text left from the cursor
-    /// 2. "replace"
-    ///   Replace the word
-    /// 3. "auto"
-    ///   removes text left from the cursor and text right from the cursor if the completion ends with it
-    ///
-    /// Default: insert
+    /// Default: "replace"
     #[serde(default = "default_completion_mode")]
     pub completion_mode: CompletionMode,
 }
@@ -358,13 +350,6 @@ pub enum WordsCompletionMode {
     Disabled,
 }
 
-// Controls what range to replace when accepting LSP completions.
-//
-// When LSP servers give an `InsertReplaceEdit` completion, they provides two ranges: `insert` and `replace`. Usually, `insert`
-// contains the word prefix before your cursor and `replace` contains the whole word.
-//
-// Effectively, this setting just changes whether Zed will use the received range for `insert` or `replace`, so the results may
-// differ depending on the underlying LSP server.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum CompletionMode {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -331,7 +331,7 @@ pub struct CompletionSettings {
     pub lsp_fetch_timeout_ms: u64,
     /// Controls how the completions are inserted
     ///
-    /// Default: "replace"
+    /// Default: "replace_suffix"
     #[serde(default = "default_completion_mode")]
     pub completion_mode: CompletionMode,
 }
@@ -355,12 +355,14 @@ pub enum WordsCompletionMode {
 pub enum CompletionMode {
     /// Replaces text before the cursor, using the `insert` range described in the LSP specification.
     Insert,
-    /// Replaces the whole word, using the `replace` range described in the LSP specification.
+    /// Replaces text before and after the cursor, using the `replace` range described in the LSP specification.
     Replace,
-    /// Only replace the whole word if the text after cursor is a subsequence (fuzzy match) of the completion.
-    AutoSimilar,
-    /// Only replace the whole word if the text after cursor is a suffix of the completion.
-    AutoStrict,
+    /// Behaves like `"replace"` if the text that would be replaced is a subsequence of the completion text,
+    /// and like `"insert"` otherwise.
+    ReplaceSubsequence,
+    /// Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like
+    /// `"insert"` otherwise.
+    ReplaceSuffix,
 }
 
 fn default_words_completion_mode() -> WordsCompletionMode {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -329,11 +329,11 @@ pub struct CompletionSettings {
     /// Default: 0
     #[serde(default = "default_lsp_fetch_timeout_ms")]
     pub lsp_fetch_timeout_ms: u64,
-    /// Controls how the completions are inserted
+    /// Controls how LSP completions are inserted.
     ///
     /// Default: "replace_suffix"
-    #[serde(default = "default_completion_mode")]
-    pub completion_mode: CompletionMode,
+    #[serde(default = "default_lsp_insert_mode")]
+    pub lsp_insert_mode: LspInsertMode,
 }
 
 /// Controls how document's words are completed.
@@ -352,7 +352,7 @@ pub enum WordsCompletionMode {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum CompletionMode {
+pub enum LspInsertMode {
     /// Replaces text before the cursor, using the `insert` range described in the LSP specification.
     Insert,
     /// Replaces text before and after the cursor, using the `replace` range described in the LSP specification.
@@ -369,8 +369,8 @@ fn default_words_completion_mode() -> WordsCompletionMode {
     WordsCompletionMode::Fallback
 }
 
-fn default_completion_mode() -> CompletionMode {
-    CompletionMode::Insert
+fn default_lsp_insert_mode() -> LspInsertMode {
+    LspInsertMode::Insert
 }
 
 fn default_lsp_fetch_timeout_ms() -> u64 {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -339,7 +339,7 @@ pub struct CompletionSettings {
     /// 3. "smart"
     ///   removes text left from the cursor and text right from the cursor if the completion ends with it
     ///
-    /// Default: insert,
+    /// Default: insert
     #[serde(default = "default_completion_mode")]
     pub completion_mode: CompletionMode,
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -61,7 +61,7 @@ pub fn all_language_settings<'a>(
 pub struct AllLanguageSettings {
     /// The edit prediction settings.
     pub edit_predictions: EditPredictionSettings,
-    defaults: LanguageSettings,
+    pub defaults: LanguageSettings,
     languages: HashMap<LanguageName, LanguageSettings>,
     pub(crate) file_types: HashMap<Arc<str>, GlobSet>,
 }
@@ -329,6 +329,19 @@ pub struct CompletionSettings {
     /// Default: 0
     #[serde(default = "default_lsp_fetch_timeout_ms")]
     pub lsp_fetch_timeout_ms: u64,
+    /// Controls how the completions are inserted
+    ///
+    /// Possible values:
+    /// 1. "insert"
+    ///   Removes text left from the cursor
+    /// 2. "replace"
+    ///   Replace the word
+    /// 3. "smart"
+    ///   removes text left from the cursor and text right from the cursor if the completion ends with it
+    ///
+    /// Default: insert,
+    #[serde(default = "default_completion_mode")]
+    pub completion_mode: CompletionMode,
 }
 
 /// Controls how document's words are completed.
@@ -345,8 +358,25 @@ pub enum WordsCompletionMode {
     Disabled,
 }
 
+/// Controls what is replaced by the lsp
+
+#[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CompletionMode {
+    /// uses lsp insert range
+    Insert,
+    /// uses lsp replace range
+    Replace,
+    /// uses lsp insert range & truncates the right side if the completion ends with it
+    Smart,
+}
+
 fn default_words_completion_mode() -> WordsCompletionMode {
     WordsCompletionMode::Fallback
+}
+
+fn default_completion_mode() -> CompletionMode {
+    CompletionMode::Insert
 }
 
 fn default_lsp_fetch_timeout_ms() -> u64 {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -358,16 +358,21 @@ pub enum WordsCompletionMode {
     Disabled,
 }
 
-/// Controls what is replaced by the lsp
-
+// Controls what range to replace when accepting LSP completions.
+//
+// When LSP servers give an `InsertReplaceEdit` completion, they provides two ranges: `insert` and `replace`. Usually, `insert`
+// contains the word prefix before your cursor and `replace` contains the whole word.
+//
+// Effectively, this setting just changes whether Zed will use the received range for `insert` or `replace`, so the results may
+// differ depending on the underlying LSP server.
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum CompletionMode {
-    /// uses lsp insert range
+    /// Replaces text before the cursor, using the `insert` range described in the LSP specification.
     Insert,
-    /// uses lsp replace range
+    /// Replaces the whole word, using the `replace` range described in the LSP specification.
     Replace,
-    /// uses lsp insert range & truncates the right side if the completion ends with it
+    /// Only replace the whole word if the text after cursor is a suffix of the completion.
     Smart,
 }
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -336,7 +336,7 @@ pub struct CompletionSettings {
     ///   Removes text left from the cursor
     /// 2. "replace"
     ///   Replace the word
-    /// 3. "smart"
+    /// 3. "auto"
     ///   removes text left from the cursor and text right from the cursor if the completion ends with it
     ///
     /// Default: insert
@@ -373,7 +373,7 @@ pub enum CompletionMode {
     /// Replaces the whole word, using the `replace` range described in the LSP specification.
     Replace,
     /// Only replace the whole word if the text after cursor is a suffix of the completion.
-    Smart,
+    Auto,
 }
 
 fn default_words_completion_mode() -> WordsCompletionMode {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2322,7 +2322,7 @@ pub(crate) fn parse_completion_text_edit(
 
         lsp::CompletionTextEdit::InsertAndReplace(edit) => {
             let replace = {
-                let mut range = edit.replace.clone();
+                let mut range = edit.replace;
                 range.start = edit.insert.end;
                 let range = range_from_lsp(range);
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2337,7 +2337,7 @@ pub(crate) fn parse_completion_text_edit(
             let replace = match completion_mode {
                 CompletionMode::Insert => false,
                 CompletionMode::Replace => true,
-                CompletionMode::Smart => {
+                CompletionMode::Auto => {
                     let mut range = edit.replace;
                     range.start = edit.insert.end;
                     let range = range_from_lsp(range);

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2338,21 +2338,23 @@ pub(crate) fn parse_completion_text_edit(
                 CompletionMode::Insert => false,
                 CompletionMode::Replace => true,
                 CompletionMode::Auto => {
-                    let mut range = edit.replace;
-                    range.start = edit.insert.end;
-                    let range = range_from_lsp(range);
+                    let range_after_cursor = lsp::Range {
+                        start: edit.insert.end,
+                        end: edit.replace.end,
+                    };
+                    let range_after_cursor = range_from_lsp(range_after_cursor);
 
-                    let start = snapshot.clip_point_utf16(range.start, Bias::Left);
-                    let end = snapshot.clip_point_utf16(range.end, Bias::Left);
-                    if start != range.start.0 || end != range.end.0 {
+                    let start = snapshot.clip_point_utf16(range_after_cursor.start, Bias::Left);
+                    let end = snapshot.clip_point_utf16(range_after_cursor.end, Bias::Left);
+                    if start != range_after_cursor.start.0 || end != range_after_cursor.end.0 {
                         false
                     } else {
-                        let v = snapshot
+                        let text_after_cursor = snapshot
                             .text_for_range(
                                 snapshot.anchor_before(start)..snapshot.anchor_after(end),
                             )
                             .collect::<String>();
-                        edit.new_text.ends_with(&v)
+                        edit.new_text.ends_with(&text_after_cursor)
                     }
                 }
             };

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2353,9 +2353,7 @@ pub(crate) fn parse_completion_text_edit(
 
                         // is `text_to_replace` a subsequence of `completion_text`
                         text_to_replace.all(|needle_ch| {
-                            completion_text
-                                .find(|haystack_ch| *haystack_ch == needle_ch)
-                                .is_some()
+                            completion_text.any(|haystack_ch| haystack_ch == needle_ch)
                         })
                     }
                 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -39,7 +39,7 @@ use language::{
     LanguageToolchainStore, LocalFile, LspAdapter, LspAdapterDelegate, Patch, PointUtf16,
     TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction, Unclipped,
     language_settings::{
-        AllLanguageSettings, CompletionMode, FormatOnSave, Formatter, LanguageSettings,
+        AllLanguageSettings, FormatOnSave, Formatter, LanguageSettings, LspInsertMode,
         SelectedFormatter, language_settings,
     },
     point_to_lsp,
@@ -5234,9 +5234,9 @@ impl LspStore {
                     AllLanguageSettings::get_global(cx)
                         .defaults
                         .completions
-                        .completion_mode
+                        .lsp_insert_mode
                 })
-                .unwrap_or(CompletionMode::Insert);
+                .unwrap_or(LspInsertMode::Insert);
             let edit = parse_completion_text_edit(text_edit, snapshot, completion_mode);
 
             if let Some((old_range, mut new_text)) = edit {
@@ -7740,9 +7740,9 @@ impl LspStore {
                         AllLanguageSettings::get_global(cx)
                             .defaults
                             .completions
-                            .completion_mode
+                            .lsp_insert_mode
                     })
-                    .unwrap_or(CompletionMode::Insert);
+                    .unwrap_or(LspInsertMode::Insert);
 
                 let edit = parse_completion_text_edit(text_edit, &buffer_snapshot, completion_mode);
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -39,7 +39,8 @@ use language::{
     LanguageToolchainStore, LocalFile, LspAdapter, LspAdapterDelegate, Patch, PointUtf16,
     TextBufferSnapshot, ToOffset, ToPointUtf16, Transaction, Unclipped,
     language_settings::{
-        FormatOnSave, Formatter, LanguageSettings, SelectedFormatter, language_settings,
+        AllLanguageSettings, CompletionMode, FormatOnSave, Formatter, LanguageSettings,
+        SelectedFormatter, language_settings,
     },
     point_to_lsp,
     proto::{deserialize_anchor, deserialize_version, serialize_anchor, serialize_version},
@@ -5151,6 +5152,7 @@ impl LspStore {
                             &buffer_snapshot,
                             completions.clone(),
                             completion_index,
+                            cx,
                         )
                         .await
                         .log_err()
@@ -5184,6 +5186,7 @@ impl LspStore {
         snapshot: &BufferSnapshot,
         completions: Rc<RefCell<Box<[Completion]>>>,
         completion_index: usize,
+        cx: &mut AsyncApp,
     ) -> Result<()> {
         let server_id = server.server_id();
         let can_resolve = server
@@ -5226,7 +5229,15 @@ impl LspStore {
             // language server we currently use that does update `text_edit` in `completionItem/resolve`
             // is `typescript-language-server` and they only update `text_edit.new_text`.
             // But we should not rely on that.
-            let edit = parse_completion_text_edit(text_edit, snapshot);
+            let completion_mode = cx
+                .read_global(|_: &SettingsStore, cx| {
+                    AllLanguageSettings::get_global(cx)
+                        .defaults
+                        .completions
+                        .completion_mode
+                })
+                .unwrap_or(CompletionMode::Insert);
+            let edit = parse_completion_text_edit(text_edit, snapshot, completion_mode);
 
             if let Some((old_range, mut new_text)) = edit {
                 LineEnding::normalize(&mut new_text);
@@ -5482,6 +5493,7 @@ impl LspStore {
                     &snapshot,
                     completions.clone(),
                     completion_index,
+                    cx,
                 )
                 .await
                 .context("resolving completion")?;
@@ -7723,7 +7735,16 @@ impl LspStore {
             })??;
 
             if let Some(text_edit) = completion.text_edit.as_ref() {
-                let edit = parse_completion_text_edit(text_edit, &buffer_snapshot);
+                let completion_mode = cx
+                    .read_global(|_: &SettingsStore, cx| {
+                        AllLanguageSettings::get_global(cx)
+                            .defaults
+                            .completions
+                            .completion_mode
+                    })
+                    .unwrap_or(CompletionMode::Insert);
+
+                let edit = parse_completion_text_edit(text_edit, &buffer_snapshot, completion_mode);
 
                 if let Some((old_range, mut text_edit_new_text)) = edit {
                     LineEnding::normalize(&mut text_edit_new_text);

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2051,6 +2051,68 @@ Examples:
 
 `boolean` values
 
+## Completions
+
+- Description: Controls how completions are processed for this language.
+- Setting: `completions`
+- Default:
+
+```json
+{
+  "completions": {
+    "words": "fallback",
+    "lsp": true,
+    "lsp_fetch_timeout_ms": 0,
+    "lsp_insert_mode": "replace_suffix"
+  }
+}
+```
+
+### Words
+
+- Description: Controls how words are completed. For large documents, not all words may be fetched for completion.
+- Setting: `words`
+- Default: `fallback`
+
+**Options**
+
+1. `enabled` - Always fetch document's words for completions along with LSP completions
+2. `fallback` - Only if LSP response errors or times out, use document's words to show completions
+3. `disabled` - Never fetch or complete document's words for completions (word-based completions can still be queried via a separate action)
+
+### LSP
+
+- Description: Whether to fetch LSP completions or not.
+- Setting: `lsp`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+### LSP Fetch Timeout (ms)
+
+- Description: When fetching LSP completions, determines how long to wait for a response of a particular server. When set to 0, waits indefinitely.
+- Setting: `lsp_fetch_timeout_ms`
+- Default: `0`
+
+**Options**
+
+`integer` values representing milliseconds
+
+### LSP Insert Mode
+
+- Description: Controls what range to replace when accepting LSP completions.
+- Setting: `lsp_insert_mode`
+- Default: `replace_suffix`
+
+**Options**
+
+1. `insert` - Replaces text before the cursor, using the `insert` range described in the LSP specification
+2. `replace` - Replaces text before and after the cursor, using the `replace` range described in the LSP specification
+3. `replace_subsequence` - Behaves like `"replace"` if the text that would be replaced is a subsequence of the completion text, and like `"insert"` otherwise
+4. `replace_suffix` - Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like `"insert"` otherwise
+
 ## Show Completions On Input
 
 - Description: Whether or not to show completions as you type.


### PR DESCRIPTION
This PR adds `completions.lsp_insert_mode` and effectively changes the default from `"replace"` to `"replace_suffix"`, which automatically detects whether to use the LSP `replace` range instead of `insert` range.

`"replace_suffix"` was chosen as a default because it's more conservative than `"replace_subsequence"`, considering that deleting text is usually faster and less disruptive than having to rewrite a long replaced word.

Fixes #27197
Fixes #23395 (again)
Fixes #4816 (again)

Release Notes:

- Added new setting `completions.lsp_insert_mode` that changes what will be replaced when an LSP completion is accepted. The default is `"replace_suffix"`, but it accepts 4 values: `"insert"` for replacing only the text before the cursor, `"replace"` for replacing the whole text, `"replace_suffix"` that acts like `"replace"` when the text after the cursor is a suffix of the completion, and `"replace_subsequence"` that acts like `"replace"` when the text around your cursor is a subsequence of the completion (similiar to a fuzzy match). Check [the documentation](https://zed.dev/docs/configuring-zed#LSP-Insert-Mode) for more information.
