### PR TITLE
ci: Run nix nightly on any mac runners

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -182,8 +182,7 @@ jobs:
             runner: buildjet-16vcpu-ubuntu-2204
             install_nix: true
           - os: arm Mac
-            # TODO: once other macs are provisioned for nix, remove that constraint from the runner
-            runner: [macOS, ARM64, nix]
+            runner: [macOS, ARM64, test]
             install_nix: false
           - os: arm Linux
             runner: buildjet-16vcpu-ubuntu-2204-arm


### PR DESCRIPTION
Nix nightly builds can now run on all macOS runners.

Follow-up to: https://github.com/zed-industries/zed/pull/27014

Release Notes:

- N/A
