### PR TITLE
worktree: Don't open files >= 6GB in size

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -500,6 +500,9 @@ impl ProjectPanel {
                                             "{} is not shared by the host. This could be because it has been marked as `private`",
                                             file_path.display()
                                         )),
+                                        // See note in worktree.rs where this error originates. Returning Some in this case prevents
+                                        // the error popup from saying "Try Again", which is a red herring in this case
+                                        ErrorCode::Internal if e.to_string().contains("File is too large to load") => Some(e.to_string()),
                                         _ => None,
                                     }
                                 });


### PR DESCRIPTION
Temporary Workaround For: #27283

This PR can (and should!) be reverted once the underlying inefficiencies are resolved

Release Notes:

- Files that are 6GB or larger will now not open. This is a temporary workaround for inefficient handling of large files resulting in extremely high memory usage, often resulting in system freezing, requiring a restart of Zed or the entire system.
