### PR TITLE
markdown_preview: Fix code block highlight and indentation

### DIFF
--- a/crates/markdown_preview/src/markdown_parser.rs
+++ b/crates/markdown_preview/src/markdown_parser.rs
@@ -718,6 +718,9 @@ impl<'a> MarkdownParser<'a> {
                 }
             }
         }
+
+        code = code.strip_suffix('\n').unwrap_or(&code).to_string();
+
         let highlights = if let Some(language) = &language {
             if let Some(registry) = &self.language_registry {
                 let rope: language::Rope = code.as_str().into();
@@ -735,7 +738,7 @@ impl<'a> MarkdownParser<'a> {
 
         ParsedMarkdownCodeBlock {
             source_range,
-            contents: code.trim().to_string().into(),
+            contents: code.into(),
             language,
             highlights,
         }


### PR DESCRIPTION
Closes #23218

Before:
<img width="1463" alt="before" src="https://github.com/user-attachments/assets/4f77a4e0-61b8-4516-91a4-366f73e24760" />

After:
<img width="1463" alt="after" src="https://github.com/user-attachments/assets/61e2c69d-fa6b-4c52-b1eb-ad7a61e274e0" />


Release Notes:

- Fixed issue where code block highlight and indentation in markdown preview was rendered incorrectly.