### PR TITLE
google_ai: Add Gemini 2.5 Pro support

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -80,7 +80,7 @@ pub async fn count_tokens(
     request: CountTokensRequest,
 ) -> Result<CountTokensResponse> {
     let uri = format!(
-        "{}/v1beta/models/gemini-pro:countTokens?key={}",
+        "{}/v1beta/models/gemini-2.0-flash:countTokens?key={}",
         api_url, api_key
     );
     let request = serde_json::to_string(&request)?;

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -314,6 +314,8 @@ pub enum Model {
     Gemini20FlashThinking,
     #[serde(rename = "gemini-2.0-flash-lite-preview")]
     Gemini20FlashLite,
+    #[serde(rename = "gemini-2.5-pro-exp-03-25")]
+    Gemini25Pro,
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -332,6 +334,7 @@ impl Model {
             Model::Gemini20Flash => "gemini-2.0-flash",
             Model::Gemini20FlashThinking => "gemini-2.0-flash-thinking-exp",
             Model::Gemini20FlashLite => "gemini-2.0-flash-lite-preview",
+            Model::Gemini25Pro => "gemini-2.5-pro-exp-03-25",
             Model::Custom { name, .. } => name,
         }
     }
@@ -344,6 +347,7 @@ impl Model {
             Model::Gemini20Flash => "Gemini 2.0 Flash",
             Model::Gemini20FlashThinking => "Gemini 2.0 Flash Thinking",
             Model::Gemini20FlashLite => "Gemini 2.0 Flash Lite",
+            Model::Gemini25Pro => "Gemini 2.5 Pro",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name),
@@ -358,6 +362,7 @@ impl Model {
             Model::Gemini20Flash => 1_000_000,
             Model::Gemini20FlashThinking => 1_000_000,
             Model::Gemini20FlashLite => 1_000_000,
+            Model::Gemini25Pro => 1_000_000,
             Model::Custom { max_tokens, .. } => *max_tokens,
         }
     }

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -106,6 +106,7 @@ impl CloudModel {
                 | google_ai::Model::Gemini20Flash
                 | google_ai::Model::Gemini20FlashThinking
                 | google_ai::Model::Gemini20FlashLite
+                | google_ai::Model::Gemini25Pro
                 | google_ai::Model::Custom { .. } => {
                     LanguageModelAvailability::RequiresPlan(Plan::ZedPro)
                 }


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/discussions/27461)

Release Notes:

- Added new gemini 2.5 pro model
- Fixed token_count in gemini
