### PR TITLE
editor: Do not insert scrollbar hitboxes when scrollbars are disabled

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1382,7 +1382,7 @@ impl EditorElement {
                 }
                 ShowScrollbar::System => self.editor.read(cx).scroll_manager.scrollbars_visible(),
                 ShowScrollbar::Always => true,
-                ShowScrollbar::Never => false,
+                ShowScrollbar::Never => return None,
             };
 
         Some(EditorScrollbars::from_scrollbar_axes(


### PR DESCRIPTION
This PR fixes an issue where a clickable scrollbar track was inserted in the editor even when scrollbars were explicitly disabled via the user's settings. If the user has

```json
"scrollbar": {
    "show": "never"
}
```
in their settings, invisible and interactable scrollbar tracks will be inserted in the editor if scrollbars would be required, as seen below: 

https://github.com/user-attachments/assets/b0d915a9-7a7e-4518-84d8-96d9b15aab12

The bug occurs because we only set the scrollbar contents to be invisible, which however does not affect the insertion of hitboxes for the scrollbars. 

This PR fixes this behaviour by preventing any scrollbar layouting from happening when scrollbars are explicitly disabled via the settings: 

https://github.com/user-attachments/assets/a3f5725b-aead-4fec-9fd8-e574cf269d45

All existing panels which have configurable scrollbars behave the same way, see https://github.com/zed-industries/zed/blob/fb2586a5533aff4e5a4b508e7b397d81dc6b9deb/crates/outline_panel/src/outline_panel.rs#L4362-L4373

for example. Following this check, neither a thumb nor a track is inserted in any case when scrollbars are never to be shown.

Release Notes:

- Fixed invisible scrollbar tracks being inserted into the editor when scrollbars are explicitly disabled via settings.

