### PR TITLE
Debugger UI: Update tab content and remove red tint from terminated session

### DIFF
--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -61,14 +61,12 @@ impl Render for RunningState {
             this.disabled(thread_status != ThreadStatus::Stopped, cx);
         });
 
-        let is_terminated = self.session.read(cx).is_terminated();
         let active_thread_item = &self.active_thread_item;
 
         let has_no_threads = threads.is_empty();
         let capabilities = self.capabilities(cx);
         let state = cx.entity();
         h_flex()
-            .when(is_terminated, |this| this.bg(gpui::red()))
             .key_context("DebugPanelItem")
             .track_focus(&self.focus_handle(cx))
             .size_full()


### PR DESCRIPTION
The new tab content makes it obvious when a session is shutdown so the red tint is no longer needed. 

Release Notes:

- N/A
