### PR TITLE
gpui: Support window resizing for `PlatformWindow`

### DIFF
--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -75,7 +75,7 @@ impl Render for WindowDemo {
             .bg(rgb(0xffffff))
             .size_full()
             .justify_center()
-            .items_center()
+            .content_center()
             .gap_2()
             .child(button("Normal", move |_, cx| {
                 cx.open_window(
@@ -165,18 +165,32 @@ impl Render for WindowDemo {
                     })
                     .detach();
             }))
+            .child(button("Resize", |window, _| {
+                let content_size = window.bounds().size;
+                window.resize(size(content_size.height, content_size.width));
+            }))
     }
 }
 
 fn main() {
     Application::new().run(|cx: &mut App| {
         let bounds = Bounds::centered(None, size(px(800.0), px(600.0)), cx);
+
         cx.open_window(
             WindowOptions {
                 window_bounds: Some(WindowBounds::Windowed(bounds)),
                 ..Default::default()
             },
-            |_, cx| cx.new(|_| WindowDemo {}),
+            |window, cx| {
+                cx.new(|cx| {
+                    cx.observe_window_bounds(window, move |_, window, _| {
+                        println!("Window bounds changed: {:?}", window.bounds());
+                    })
+                    .detach();
+
+                    WindowDemo {}
+                })
+            },
         )
         .unwrap();
     });

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -378,6 +378,7 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     fn is_maximized(&self) -> bool;
     fn window_bounds(&self) -> WindowBounds;
     fn content_size(&self) -> Size<Pixels>;
+    fn resize(&mut self, size: Size<Pixels>);
     fn scale_factor(&self) -> f32;
     fn appearance(&self) -> WindowAppearance;
     fn display(&self) -> Option<Rc<dyn PlatformDisplay>>;

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -797,6 +797,25 @@ impl PlatformWindow for WaylandWindow {
         self.borrow().bounds.size
     }
 
+    fn resize(&mut self, size: Size<Pixels>) {
+        let state = self.borrow();
+        let state_ptr = self.0.clone();
+        let dp_size = size.to_device_pixels(self.scale_factor());
+
+        state.xdg_surface.set_window_geometry(
+            state.bounds.origin.x.0 as i32,
+            state.bounds.origin.y.0 as i32,
+            dp_size.width.0,
+            dp_size.height.0,
+        );
+
+        state
+            .globals
+            .executor
+            .spawn(async move { state_ptr.resize(size) })
+            .detach();
+    }
+
     fn scale_factor(&self) -> f32 {
         self.borrow().scale
     }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1143,6 +1143,30 @@ impl PlatformWindow for X11Window {
             .map(|size| size.div(state.scale_factor))
     }
 
+    fn resize(&mut self, size: Size<Pixels>) {
+        let state = self.0.state.borrow();
+        let size = size.to_device_pixels(state.scale_factor);
+        let width = size.width.0 as u32;
+        let height = size.height.0 as u32;
+
+        check_reply(
+            || {
+                format!(
+                    "X11 ConfigureWindow failed. width: {}, height: {}",
+                    width, height
+                )
+            },
+            self.0.xcb.configure_window(
+                self.0.x_window,
+                &xproto::ConfigureWindowAux::new()
+                    .width(width)
+                    .height(height),
+            ),
+        )
+        .log_err();
+        self.flush().log_err();
+    }
+
     fn scale_factor(&self) -> f32 {
         self.0.state.borrow().scale_factor
     }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -801,6 +801,21 @@ impl PlatformWindow for MacWindow {
         self.0.as_ref().lock().content_size()
     }
 
+    fn resize(&mut self, size: Size<Pixels>) {
+        let this = self.0.lock();
+        let window = this.native_window;
+        this.executor
+            .spawn(async move {
+                unsafe {
+                    window.setContentSize_(NSSize {
+                        width: size.width.0 as f64,
+                        height: size.height.0 as f64,
+                    });
+                }
+            })
+            .detach();
+    }
+
     fn scale_factor(&self) -> f32 {
         self.0.as_ref().lock().scale_factor()
     }

--- a/crates/gpui/src/platform/test/window.rs
+++ b/crates/gpui/src/platform/test/window.rs
@@ -126,6 +126,11 @@ impl PlatformWindow for TestWindow {
         self.bounds().size
     }
 
+    fn resize(&mut self, size: Size<Pixels>) {
+        let mut lock = self.0.lock();
+        lock.bounds.size = size;
+    }
+
     fn scale_factor(&self) -> f32 {
         2.0
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1320,6 +1320,11 @@ impl Window {
         self.platform_window.bounds()
     }
 
+    /// Set the content size of the window.
+    pub fn resize(&mut self, size: Size<Pixels>) {
+        self.platform_window.resize(size);
+    }
+
     /// Returns whether or not the window is currently fullscreen
     pub fn is_fullscreen(&self) -> bool {
         self.platform_window.is_fullscreen()


### PR DESCRIPTION
Support resizing windows to a specified size.

## macOS
https://github.com/user-attachments/assets/8c639bc2-ee5f-4adc-a850-576dac939574


## Wayland
[wayland.webm](https://github.com/user-attachments/assets/3d593604-83b4-488f-8f63-1cf4c0c0cb9a)

## X11
[x11.webm](https://github.com/user-attachments/assets/ce8fa62e-fb74-4641-abe8-70574011e630)

## Windows
https://github.com/user-attachments/assets/abb03e48-f82a-4d62-90b3-2598a4866c3f

Release Notes:

- N/A