### PR TITLE
gpui: Fix image load memory leak

### DIFF
--- a/crates/gpui/examples/image_gallery.rs
+++ b/crates/gpui/examples/image_gallery.rs
@@ -76,7 +76,7 @@ impl Render for ImageGallery {
                     .justify_around()
                     .children(
                         (0..self.items_count)
-                            .map(|ix| img(format!("{}-{}", image_url, ix)).id(ix).size_20()),
+                            .map(|ix| img(format!("{}-{}", image_url, ix)).size_20()),
                     ),
             )
     }

--- a/crates/gpui/examples/image_gallery.rs
+++ b/crates/gpui/examples/image_gallery.rs
@@ -1,7 +1,7 @@
 use gpui::{
     actions, div, img, prelude::*, px, rgb, size, App, AppContext, Application, Bounds, ClickEvent,
-    Context, KeyBinding, Menu, MenuItem, Point, SharedString, TitlebarOptions, Window,
-    WindowBounds, WindowOptions,
+    Context, KeyBinding, Menu, MenuItem, SharedString, TitlebarOptions, Window, WindowBounds,
+    WindowOptions,
 };
 use reqwest_client::ReqwestClient;
 use std::sync::Arc;
@@ -9,7 +9,7 @@ use std::sync::Arc;
 struct ImageGallery {
     image_key: String,
     items_count: usize,
-    total_rendered_count: usize,
+    total_count: usize,
 }
 
 impl ImageGallery {
@@ -20,7 +20,7 @@ impl ImageGallery {
             .as_millis();
 
         self.image_key = format!("{}", t);
-        self.total_rendered_count += self.items_count;
+        self.total_count += self.items_count;
         cx.notify();
     }
 }
@@ -35,12 +35,12 @@ impl Render for ImageGallery {
             .font_family(".SystemUIFont")
             .bg(rgb(0xE9E9E9))
             .overflow_y_scroll()
-            .p_5()
+            .p_4()
             .size_full()
             .flex()
             .flex_col()
             .items_center()
-            .gap_4()
+            .gap_2()
             .child(
                 div()
                     .w_full()
@@ -49,7 +49,7 @@ impl Render for ImageGallery {
                     .justify_between()
                     .child(format!(
                         "Example to show images and test memory usage (Rendered: {} images).",
-                        self.total_rendered_count
+                        self.total_count
                     ))
                     .child(
                         div()
@@ -72,7 +72,7 @@ impl Render for ImageGallery {
                     .flex_row()
                     .flex_wrap()
                     .gap_x_4()
-                    .gap_y_3()
+                    .gap_y_2()
                     .justify_around()
                     .children(
                         (0..self.items_count)
@@ -106,10 +106,11 @@ fn main() {
                 ..Default::default()
             }),
 
-            window_bounds: Some(WindowBounds::Windowed(Bounds {
-                size: size(px(1100.), px(800.)),
-                origin: Point::new(px(200.), px(200.)),
-            })),
+            window_bounds: Some(WindowBounds::Windowed(Bounds::centered(
+                None,
+                size(px(1100.), px(860.)),
+                cx,
+            ))),
 
             ..Default::default()
         };
@@ -117,8 +118,8 @@ fn main() {
         cx.open_window(window_options, |_, cx| {
             cx.new(|_| ImageGallery {
                 image_key: "".into(),
-                items_count: 100,
-                total_rendered_count: 0,
+                items_count: 99,
+                total_count: 0,
             })
         })
         .unwrap();

--- a/crates/gpui/examples/image_gallery.rs
+++ b/crates/gpui/examples/image_gallery.rs
@@ -1,0 +1,126 @@
+use gpui::{
+    actions, div, img, prelude::*, px, rgb, size, App, AppContext, Application, Bounds, ClickEvent,
+    Context, KeyBinding, Menu, MenuItem, Point, SharedString, TitlebarOptions, Window,
+    WindowBounds, WindowOptions,
+};
+use reqwest_client::ReqwestClient;
+use std::sync::Arc;
+
+struct ImageGallery {
+    image_key: String,
+    items_count: usize,
+    total_rendered_count: usize,
+}
+
+impl ImageGallery {
+    fn on_next_image(&mut self, _: &ClickEvent, _: &mut Window, cx: &mut Context<Self>) {
+        let t = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_millis();
+
+        self.image_key = format!("{}", t);
+        self.total_rendered_count += self.items_count;
+        cx.notify();
+    }
+}
+
+impl Render for ImageGallery {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let image_url: SharedString =
+            format!("https://picsum.photos/400/200?t={}", self.image_key).into();
+
+        div()
+            .id("main")
+            .font_family(".SystemUIFont")
+            .bg(rgb(0xE9E9E9))
+            .overflow_y_scroll()
+            .p_5()
+            .size_full()
+            .flex()
+            .flex_col()
+            .items_center()
+            .gap_4()
+            .child(
+                div()
+                    .w_full()
+                    .flex()
+                    .flex_row()
+                    .justify_between()
+                    .child(format!(
+                        "Example to show images and test memory usage (Rendered: {} images).",
+                        self.total_rendered_count
+                    ))
+                    .child(
+                        div()
+                            .id("btn")
+                            .py_1()
+                            .px_4()
+                            .bg(gpui::black())
+                            .hover(|this| this.opacity(0.8))
+                            .text_color(gpui::white())
+                            .text_center()
+                            .w_40()
+                            .child("Next Photos")
+                            .on_click(cx.listener(Self::on_next_image)),
+                    ),
+            )
+            .child(
+                div()
+                    .id("image-gallery")
+                    .flex()
+                    .flex_row()
+                    .flex_wrap()
+                    .gap_x_4()
+                    .gap_y_3()
+                    .justify_around()
+                    .children(
+                        (0..self.items_count)
+                            .map(|ix| img(format!("{}-{}", image_url, ix)).id(ix).size_20()),
+                    ),
+            )
+    }
+}
+
+actions!(image, [Quit]);
+
+fn main() {
+    env_logger::init();
+
+    Application::new().run(move |cx: &mut App| {
+        let http_client = ReqwestClient::user_agent("gpui example").unwrap();
+        cx.set_http_client(Arc::new(http_client));
+
+        cx.activate(true);
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
+        cx.set_menus(vec![Menu {
+            name: "Image Gallery".into(),
+            items: vec![MenuItem::action("Quit", Quit)],
+        }]);
+
+        let window_options = WindowOptions {
+            titlebar: Some(TitlebarOptions {
+                title: Some(SharedString::from("Image Gallery")),
+                appears_transparent: false,
+                ..Default::default()
+            }),
+
+            window_bounds: Some(WindowBounds::Windowed(Bounds {
+                size: size(px(1100.), px(800.)),
+                origin: Point::new(px(200.), px(200.)),
+            })),
+
+            ..Default::default()
+        };
+
+        cx.open_window(window_options, |_, cx| {
+            cx.new(|_| ImageGallery {
+                image_key: "".into(),
+                items_count: 100,
+                total_rendered_count: 0,
+            })
+        })
+        .unwrap();
+    });
+}

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -289,10 +289,7 @@ impl Element for Img {
                             if let Some(asset_id) = self.source.asset_id() {
                                 // Log asset_id and source to frame, to help window draw to
                                 // remove unused assets cache in frame.
-                                window
-                                    .next_frame
-                                    .asset_sources
-                                    .insert(asset_id, data.clone());
+                                window.next_frame.asset_sources.insert(asset_id);
                             }
 
                             if let Some(state) = &mut state {

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -218,12 +218,6 @@ impl Img {
             "hdr", "exr", "pbm", "pam", "ppm", "pgm", "ff", "farbfeld", "qoi", "svg",
         ]
     }
-
-    /// Set element id.
-    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
-        self.interactivity.element_id = Some(id.into());
-        self
-    }
 }
 
 impl Deref for Stateful<Img> {

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -277,13 +277,13 @@ impl Element for Img {
 
             let frame_index = state.as_ref().map(|state| state.frame_index).unwrap_or(0);
 
-            if let Some(asset_id) = self.source.asset_id() {
+            if let Some(cache_id) = self.source.cache_id() {
                 // Log asset_id and source to frame, to help window draw to
                 // remove unused assets cache in frame.
                 window
                     .next_frame
                     .asset_sources
-                    .insert(asset_id, self.source.clone());
+                    .insert(cache_id, self.source.clone());
             }
 
             let layout_id = self.interactivity.request_layout(
@@ -502,7 +502,7 @@ impl ImageSource {
         }
     }
 
-    pub(crate) fn asset_id(&self) -> Option<(TypeId, u64)> {
+    pub(crate) fn cache_id(&self) -> Option<(TypeId, u64)> {
         match self {
             ImageSource::Resource(resource) => {
                 Some((TypeId::of::<ImgResourceLoader>(), hash(&resource)))

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -495,7 +495,7 @@ impl ImageSource {
         cx: &mut App,
     ) -> Option<Result<Arc<RenderImage>, ImageCacheError>> {
         match self {
-            ImageSource::Resource(resource) => window.use_asset::<ImgResourceLoader>(&resource, cx),
+            ImageSource::Resource(resource) => window.use_asset::<ImgResourceLoader>(resource, cx),
             ImageSource::Custom(loading_fn) => loading_fn(window, cx),
             ImageSource::Render(data) => Some(Ok(data.to_owned())),
             ImageSource::Image(data) => window.use_asset::<AssetLogger<ImageDecoder>>(data, cx),
@@ -505,7 +505,7 @@ impl ImageSource {
     pub(crate) fn cache_id(&self) -> Option<(TypeId, u64)> {
         match self {
             ImageSource::Resource(resource) => {
-                Some((TypeId::of::<ImgResourceLoader>(), hash(&resource)))
+                Some((TypeId::of::<ImgResourceLoader>(), hash(resource)))
             }
             ImageSource::Custom(_) => None,
             ImageSource::Render(_) => None,

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -523,9 +523,11 @@ impl ImageSource {
     }
 
     pub(crate) fn remove_cache(&self, window: &mut Window, cx: &mut App) {
-        if let Some(image) = self.use_data(window, cx) {
-            if let Ok(data) = image {
-                _ = window.drop_image(data);
+        if matches!(self, ImageSource::Image(..) | ImageSource::Resource(..)) {
+            if let Some(image) = self.use_data(window, cx) {
+                if let Ok(data) = image {
+                    _ = window.drop_image(data);
+                }
             }
         }
 

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -286,13 +286,13 @@ impl Element for Img {
 
                     match self.source.use_data(window, cx) {
                         Some(Ok(data)) => {
-                            if let Some(cache_id) = self.source.cache_id() {
+                            if let Some(asset_id) = self.source.asset_id() {
                                 // Log asset_id and source to frame, to help window draw to
                                 // remove unused assets cache in frame.
                                 window
                                     .next_frame
                                     .asset_sources
-                                    .insert(cache_id, (self.source.clone(), data.clone()));
+                                    .insert(asset_id, data.clone());
                             }
 
                             if let Some(state) = &mut state {
@@ -502,7 +502,7 @@ impl ImageSource {
         }
     }
 
-    pub(crate) fn cache_id(&self) -> Option<(TypeId, u64)> {
+    pub(crate) fn asset_id(&self) -> Option<(TypeId, u64)> {
         match self {
             ImageSource::Resource(resource) => {
                 Some((TypeId::of::<ImgResourceLoader>(), hash(resource)))
@@ -512,15 +512,6 @@ impl ImageSource {
             ImageSource::Image(data) => {
                 Some((TypeId::of::<AssetLogger<ImageDecoder>>(), hash(data)))
             }
-        }
-    }
-
-    pub(crate) fn remove_cache(&self, cx: &mut App) {
-        match self {
-            ImageSource::Resource(resource) => cx.remove_asset::<ImgResourceLoader>(&resource),
-            ImageSource::Custom(_) => {}
-            ImageSource::Render(_) => {}
-            ImageSource::Image(data) => cx.remove_asset::<AssetLogger<ImageDecoder>>(data),
         }
     }
 }

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -51,18 +51,6 @@ pub enum ImageSource {
     Custom(Arc<dyn Fn(&mut Window, &mut App) -> Option<Result<Arc<RenderImage>, ImageCacheError>>>),
 }
 
-impl PartialEq for ImageSource {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Resource(a), Self::Resource(b)) => a == b,
-            (Self::Render(a), Self::Render(b)) => a == b,
-            (Self::Image(a), Self::Image(b)) => a == b,
-            (Self::Custom(_), Self::Custom(_)) => false,
-            _ => false,
-        }
-    }
-}
-
 fn is_uri(uri: &str) -> bool {
     http_client::Uri::from_str(uri).is_ok()
 }

--- a/crates/gpui/src/elements/img.rs
+++ b/crates/gpui/src/elements/img.rs
@@ -206,6 +206,12 @@ pub struct Img {
 }
 
 /// Create a new image element.
+///
+/// Note:
+///
+/// If you set `source` with [`Resource::Path`], [`Resource::Uri`] or [`ImageSource::Image`],
+/// you must to set [`Img::id`], then GPUI will know to clear the cache to recycle the memory
+/// when the image source changes.
 pub fn img(source: impl Into<ImageSource>) -> Img {
     Img {
         interactivity: Interactivity::default(),
@@ -222,6 +228,12 @@ impl Img {
             "avif", "jpg", "jpeg", "png", "gif", "webp", "tif", "tiff", "tga", "dds", "bmp", "ico",
             "hdr", "exr", "pbm", "pam", "ppm", "pgm", "ff", "farbfeld", "qoi", "svg",
         ]
+    }
+
+    /// Set element id.
+    pub fn id(mut self, id: impl Into<ElementId>) -> Self {
+        self.interactivity.element_id = Some(id.into());
+        self
     }
 }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -500,7 +500,7 @@ pub(crate) struct Frame {
     pub(crate) input_handlers: Vec<Option<PlatformInputHandler>>,
     pub(crate) tooltip_requests: Vec<Option<TooltipRequest>>,
     pub(crate) cursor_styles: Vec<CursorStyleRequest>,
-    pub(crate) asset_sources: FxHashMap<(TypeId, u64), Arc<RenderImage>>,
+    pub(crate) asset_sources: FxHashSet<(TypeId, u64)>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) debug_bounds: FxHashMap<String, Bounds<Pixels>>,
 }
@@ -540,7 +540,7 @@ impl Frame {
             input_handlers: Vec::new(),
             tooltip_requests: Vec::new(),
             cursor_styles: Vec::new(),
-            asset_sources: FxHashMap::default(),
+            asset_sources: FxHashSet::default(),
 
             #[cfg(any(test, feature = "test-support"))]
             debug_bounds: FxHashMap::default(),
@@ -1601,10 +1601,9 @@ impl Window {
         let rendered_sources = mem::take(&mut self.rendered_frame.asset_sources);
         let current_sources = self.next_frame.asset_sources.clone();
 
-        for (id, data) in rendered_sources {
-            if !current_sources.contains_key(&id) {
+        for id in rendered_sources {
+            if !current_sources.get(&id).is_none() {
                 cx.loading_assets.remove(&id);
-                _ = self.drop_image(data);
             }
         }
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1603,7 +1603,7 @@ impl Window {
 
         for (id, (source, data)) in rendered_sources {
             if !current_sources.contains_key(&id) {
-                self.drop_image(data);
+                _ = self.drop_image(data);
                 source.remove_cache(cx);
             }
         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4,16 +4,16 @@ use crate::{
     BorderStyle, Bounds, BoxShadow, Context, Corners, CursorStyle, Decorations, DevicePixels,
     DispatchActionListener, DispatchNodeId, DispatchTree, DisplayId, Edges, Effect, Entity,
     EntityId, EventEmitter, FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs,
-    Hsla, ImageSource, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent,
-    Keystroke, KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent,
-    MonochromeSprite, MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels,
-    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
-    PolychromeSprite, PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams,
-    RenderSvgParams, Replay, ResizeEdge, ScaledPixels, Scene, Shadow, SharedString, Size,
-    StrikethroughStyle, Style, SubscriberSet, Subscription, TaffyLayoutEngine, Task, TextStyle,
-    TextStyleRefinement, TransformationMatrix, Underline, UnderlineStyle, WindowAppearance,
-    WindowBackgroundAppearance, WindowBounds, WindowControls, WindowDecorations, WindowOptions,
-    WindowParams, WindowTextSystem, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS,
+    Hsla, InputHandler, IsZero, KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke,
+    KeystrokeEvent, LayoutId, LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite,
+    MouseButton, MouseEvent, MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas,
+    PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite,
+    PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams,
+    Replay, ResizeEdge, ScaledPixels, Scene, Shadow, SharedString, Size, StrikethroughStyle, Style,
+    SubscriberSet, Subscription, TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement,
+    TransformationMatrix, Underline, UnderlineStyle, WindowAppearance, WindowBackgroundAppearance,
+    WindowBounds, WindowControls, WindowDecorations, WindowOptions, WindowParams, WindowTextSystem,
+    SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS,
 };
 use anyhow::{anyhow, Context as _, Result};
 use collections::{FxHashMap, FxHashSet};
@@ -500,7 +500,7 @@ pub(crate) struct Frame {
     pub(crate) input_handlers: Vec<Option<PlatformInputHandler>>,
     pub(crate) tooltip_requests: Vec<Option<TooltipRequest>>,
     pub(crate) cursor_styles: Vec<CursorStyleRequest>,
-    pub(crate) asset_sources: FxHashMap<(TypeId, u64), (Rc<ImageSource>, Arc<RenderImage>)>,
+    pub(crate) asset_sources: FxHashMap<(TypeId, u64), Arc<RenderImage>>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) debug_bounds: FxHashMap<String, Bounds<Pixels>>,
 }
@@ -1601,10 +1601,10 @@ impl Window {
         let rendered_sources = mem::take(&mut self.rendered_frame.asset_sources);
         let current_sources = self.next_frame.asset_sources.clone();
 
-        for (id, (source, data)) in rendered_sources {
+        for (id, data) in rendered_sources {
             if !current_sources.contains_key(&id) {
+                cx.loading_assets.remove(&id);
                 _ = self.drop_image(data);
-                source.remove_cache(cx);
             }
         }
     }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -500,7 +500,7 @@ pub(crate) struct Frame {
     pub(crate) input_handlers: Vec<Option<PlatformInputHandler>>,
     pub(crate) tooltip_requests: Vec<Option<TooltipRequest>>,
     pub(crate) cursor_styles: Vec<CursorStyleRequest>,
-    pub(crate) asset_sources: FxHashMap<(TypeId, u64), Rc<ImageSource>>,
+    pub(crate) asset_sources: FxHashMap<(TypeId, u64), (Rc<ImageSource>, Arc<RenderImage>)>,
     #[cfg(any(test, feature = "test-support"))]
     pub(crate) debug_bounds: FxHashMap<String, Bounds<Pixels>>,
 }
@@ -1601,9 +1601,10 @@ impl Window {
         let rendered_sources = mem::take(&mut self.rendered_frame.asset_sources);
         let current_sources = self.next_frame.asset_sources.clone();
 
-        for (id, source) in rendered_sources {
+        for (id, (source, data)) in rendered_sources {
             if !current_sources.contains_key(&id) {
-                source.remove_cache(self, cx);
+                self.drop_image(data);
+                source.remove_cache(cx);
             }
         }
     }


### PR DESCRIPTION
Closes #27414

Release Notes:

- Fixed image load memory leak.

---

By current `img` element design, it is difficult to solve this problem. 

1. We can not easily to drop unused image data on `Img` element drop event, because the `RenderOnce` element it will always to drop on each frame render.
2. Because `Img` element not required `id`, so it can not be used `global_id` to control the image cache.

~This PR changes just workaround by expected users to use `img` with `id`. If we set the `id` to `img` element, the memory leak will be fixed.~

~It saved last rendered image source into global state, when this element changed source, it will drop cache of the last source.~

~But it stills not solve for `img` without `id`.~

~This method can solve some problems first, and we can think about whether there is a better way and then make some improvements here.~

---

Update 2025/03/27:

Today I have tried a new way to solve the issue. Now I keep the rendered image in frame cache, and will check to remove unused images by diff rendered_frame and next_frame.

## Test example

```bash
cargo run -p gpui --example image_gallery
```

| Before | After |
| --- | --- |
| <img width="1173" alt="SCR-20250326-oxjm" src="https://github.com/user-attachments/assets/65c20442-82d1-461b-a834-063746649b31" /> | <img width="1365" alt="SCR-20250326-owyg" src="https://github.com/user-attachments/assets/174f029f-d532-4f74-9d10-64e584dc8486" /> |
| Just rendered 2000 images | More than 10K images |

And even this change fixed a lot of memory leak, but maybe there still have a bit leak (I am not sure), after render 10K images the memory is grown from ~120 MB to ~140 MB. 

But it is better now, I will continue to address what is leaked of that a bit if I can find it.

TODO:

- [x] Fix Zed start crash.
- [ ] Add http-cache to disk for Zed remote image (e.g.: Git user avatar).
