### PR TITLE
Improve `editor::CopyAndTrim` action's discoverability

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,4 +1,5 @@
 use crate::actions::FormatSelections;
+use crate::CopyAndTrim;
 use crate::{
     actions::Format, selections_collection::SelectionsCollection, Copy, CopyPermalinkToLine, Cut,
     DisplayPoint, DisplaySnapshot, Editor, EditorMode, FindAllReferences, GoToDeclaration,
@@ -191,6 +192,7 @@ pub fn deploy_context_menu(
                 .separator()
                 .action("Cut", Box::new(Cut))
                 .action("Copy", Box::new(Copy))
+                .action("Copy and trim", Box::new(CopyAndTrim))
                 .action("Paste", Box::new(Paste))
                 .separator()
                 .map(|builder| {

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -95,6 +95,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::separator(),
                 MenuItem::os_action("Cut", editor::actions::Cut, OsAction::Cut),
                 MenuItem::os_action("Copy", editor::actions::Copy, OsAction::Copy),
+                MenuItem::action("Copy and trim", editor::actions::CopyAndTrim),
                 MenuItem::os_action("Paste", editor::actions::Paste, OsAction::Paste),
                 MenuItem::separator(),
                 MenuItem::action("Find", search::buffer_search::Deploy::find()),


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/27206

Add it to the editor context menu and Zed's app menu near the `Copy` action.

Release Notes:

- N/A
