### PR TITLE
assistant2: Use different icons in the notification popover depending on status

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -376,11 +376,23 @@ impl ActiveThread {
             }
             ThreadEvent::DoneStreaming => {
                 if !self.thread().read(cx).is_generating() {
-                    self.show_notification("Your changes have been applied.", window, cx);
+                    self.show_notification(
+                        "Your changes have been applied.",
+                        IconName::Check,
+                        Color::Success,
+                        window,
+                        cx,
+                    );
                 }
             }
             ThreadEvent::ToolConfirmationNeeded => {
-                self.show_notification("There's a tool confirmation needed.", window, cx);
+                self.show_notification(
+                    "There's a tool confirmation needed.",
+                    IconName::Info,
+                    Color::Muted,
+                    window,
+                    cx,
+                );
             }
             ThreadEvent::StreamedAssistantText(message_id, text) => {
                 if let Some(rendered_message) = self.rendered_messages_by_id.get_mut(&message_id) {
@@ -511,6 +523,8 @@ impl ActiveThread {
     fn show_notification(
         &mut self,
         caption: impl Into<SharedString>,
+        icon: IconName,
+        icon_color: Color,
         window: &mut Window,
         cx: &mut Context<'_, ActiveThread>,
     ) {
@@ -525,7 +539,7 @@ impl ActiveThread {
 
                 if let Some(screen_window) = cx
                     .open_window(options, |_, cx| {
-                        cx.new(|_| ToolReadyPopUp::new(caption.clone()))
+                        cx.new(|_| ToolReadyPopUp::new(caption.clone(), icon, icon_color))
                     })
                     .log_err()
                 {

--- a/crates/assistant2/src/ui/tool_ready_pop_up.rs
+++ b/crates/assistant2/src/ui/tool_ready_pop_up.rs
@@ -9,12 +9,16 @@ use ui::{prelude::*, Render};
 
 pub struct ToolReadyPopUp {
     caption: SharedString,
+    icon: IconName,
+    icon_color: Color,
 }
 
 impl ToolReadyPopUp {
-    pub fn new(caption: impl Into<SharedString>) -> Self {
+    pub fn new(caption: impl Into<SharedString>, icon: IconName, icon_color: Color) -> Self {
         Self {
             caption: caption.into(),
+            icon,
+            icon_color,
         }
     }
 
@@ -82,9 +86,9 @@ impl Render for ToolReadyPopUp {
                     .gap_2()
                     .child(
                         h_flex().h(line_height).justify_center().child(
-                            Icon::new(IconName::Info)
-                                .size(IconSize::Small)
-                                .color(Color::Muted),
+                            Icon::new(self.icon)
+                                .color(self.icon_color)
+                                .size(IconSize::Small),
                         ),
                     )
                     .child(


### PR DESCRIPTION
Using a check green icon for "success, you're changes are applied" and the info, muted icon for just "there are news".

<img src="https://github.com/user-attachments/assets/6b7e06bc-ca03-40fd-8962-7e21f5cd85d9" width="500"/>
<img src="https://github.com/user-attachments/assets/347ac8ac-792f-4e18-94d5-69bb9d5270e8" width="500"/>

Release Notes:

- N/A
