### PR TITLE
bedrock: Support DeepSeek r1

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -37,6 +37,8 @@ pub enum Model {
     CohereCommandRV1,
     CohereCommandRPlusV1,
     CohereCommandLightTextV14_4k,
+    //Deepseek
+    DeepSeekR1,
     // Meta models
     MetaLlama38BInstructV1,
     MetaLlama370BInstructV1,
@@ -91,6 +93,7 @@ impl Model {
             Model::AmazonNovaLite => "us.amazon.nova-lite-v1:0",
             Model::AmazonNovaMicro => "us.amazon.nova-micro-v1:0",
             Model::AmazonNovaPro => "us.amazon.nova-pro-v1:0",
+            Model::DeepSeekR1 => "us.deepseek.r1-v1:0",
             Model::AI21J2GrandeInstruct => "ai21.j2-grande-instruct",
             Model::AI21J2JumboInstruct => "ai21.j2-jumbo-instruct",
             Model::AI21J2Mid => "ai21.j2-mid",
@@ -133,6 +136,7 @@ impl Model {
             Self::AmazonNovaLite => "Amazon Nova Lite",
             Self::AmazonNovaMicro => "Amazon Nova Micro",
             Self::AmazonNovaPro => "Amazon Nova Pro",
+            Self::DeepSeekR1 => "DeepSeek R1",
             Self::AI21J2GrandeInstruct => "AI21 Jurassic2 Grande Instruct",
             Self::AI21J2JumboInstruct => "AI21 Jurassic2 Jumbo Instruct",
             Self::AI21J2Mid => "AI21 Jurassic2 Mid",

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -37,7 +37,7 @@ pub enum Model {
     CohereCommandRV1,
     CohereCommandRPlusV1,
     CohereCommandLightTextV14_4k,
-    //Deepseek
+    // DeepSeek
     DeepSeekR1,
     // Meta models
     MetaLlama38BInstructV1,


### PR DESCRIPTION
Release Notes:

- Added support for DeepSeek R1 hosted on AWS Bedrock.
