### PR TITLE
Explicitly prefer find-replace over edit-files

### DIFF
--- a/crates/assistant_tools/src/edit_files_tool/description.md
+++ b/crates/assistant_tools/src/edit_files_tool/description.md
@@ -1,5 +1,7 @@
 Edit files in the current project by specifying instructions in natural language.
 
+IMPORTANT NOTE: If there is a find-replace tool, use that instead of this tool! This tool is only to be used as a fallback in case that tool is unavailable. Always prefer that tool if it is available.
+
 When using this tool, you should suggest one coherent edit that can be made to the codebase.
 
 When the set of edits you want to make is large or complex, feel free to invoke this tool multiple times, each time focusing on a specific change you wanna make.


### PR DESCRIPTION
`edit-files` is still enabled for now, but this makes it less likely to be used.

Release Notes:

- N/A
