### PR TITLE
extension_host: Rename `Extension` variants so that the version number components are clearer

### DIFF
--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -90,13 +90,13 @@ pub fn authorize_access_to_unreleased_wasm_api_version(
 }
 
 pub enum Extension {
-    V040(since_v0_4_0::Extension),
-    V030(since_v0_3_0::Extension),
-    V020(since_v0_2_0::Extension),
-    V010(since_v0_1_0::Extension),
-    V006(since_v0_0_6::Extension),
-    V004(since_v0_0_4::Extension),
-    V001(since_v0_0_1::Extension),
+    V0_4_0(since_v0_4_0::Extension),
+    V0_3_0(since_v0_3_0::Extension),
+    V0_2_0(since_v0_2_0::Extension),
+    V0_1_0(since_v0_1_0::Extension),
+    V0_0_6(since_v0_0_6::Extension),
+    V0_0_4(since_v0_0_4::Extension),
+    V0_0_1(since_v0_0_1::Extension),
 }
 
 impl Extension {
@@ -116,7 +116,7 @@ impl Extension {
                 latest::Extension::instantiate_async(store, component, latest::linker())
                     .await
                     .context("failed to instantiate wasm extension")?;
-            Ok(Self::V040(extension))
+            Ok(Self::V0_4_0(extension))
         } else if version >= since_v0_3_0::MIN_VERSION {
             let extension = since_v0_3_0::Extension::instantiate_async(
                 store,
@@ -125,7 +125,7 @@ impl Extension {
             )
             .await
             .context("failed to instantiate wasm extension")?;
-            Ok(Self::V030(extension))
+            Ok(Self::V0_3_0(extension))
         } else if version >= since_v0_2_0::MIN_VERSION {
             let extension = since_v0_2_0::Extension::instantiate_async(
                 store,
@@ -134,7 +134,7 @@ impl Extension {
             )
             .await
             .context("failed to instantiate wasm extension")?;
-            Ok(Self::V020(extension))
+            Ok(Self::V0_2_0(extension))
         } else if version >= since_v0_1_0::MIN_VERSION {
             let extension = since_v0_1_0::Extension::instantiate_async(
                 store,
@@ -143,7 +143,7 @@ impl Extension {
             )
             .await
             .context("failed to instantiate wasm extension")?;
-            Ok(Self::V010(extension))
+            Ok(Self::V0_1_0(extension))
         } else if version >= since_v0_0_6::MIN_VERSION {
             let extension = since_v0_0_6::Extension::instantiate_async(
                 store,
@@ -152,7 +152,7 @@ impl Extension {
             )
             .await
             .context("failed to instantiate wasm extension")?;
-            Ok(Self::V006(extension))
+            Ok(Self::V0_0_6(extension))
         } else if version >= since_v0_0_4::MIN_VERSION {
             let extension = since_v0_0_4::Extension::instantiate_async(
                 store,
@@ -161,7 +161,7 @@ impl Extension {
             )
             .await
             .context("failed to instantiate wasm extension")?;
-            Ok(Self::V004(extension))
+            Ok(Self::V0_0_4(extension))
         } else {
             let extension = since_v0_0_1::Extension::instantiate_async(
                 store,
@@ -170,19 +170,19 @@ impl Extension {
             )
             .await
             .context("failed to instantiate wasm extension")?;
-            Ok(Self::V001(extension))
+            Ok(Self::V0_0_1(extension))
         }
     }
 
     pub async fn call_init_extension(&self, store: &mut Store<WasmState>) -> Result<()> {
         match self {
-            Extension::V040(ext) => ext.call_init_extension(store).await,
-            Extension::V030(ext) => ext.call_init_extension(store).await,
-            Extension::V020(ext) => ext.call_init_extension(store).await,
-            Extension::V010(ext) => ext.call_init_extension(store).await,
-            Extension::V006(ext) => ext.call_init_extension(store).await,
-            Extension::V004(ext) => ext.call_init_extension(store).await,
-            Extension::V001(ext) => ext.call_init_extension(store).await,
+            Extension::V0_4_0(ext) => ext.call_init_extension(store).await,
+            Extension::V0_3_0(ext) => ext.call_init_extension(store).await,
+            Extension::V0_2_0(ext) => ext.call_init_extension(store).await,
+            Extension::V0_1_0(ext) => ext.call_init_extension(store).await,
+            Extension::V0_0_6(ext) => ext.call_init_extension(store).await,
+            Extension::V0_0_4(ext) => ext.call_init_extension(store).await,
+            Extension::V0_0_1(ext) => ext.call_init_extension(store).await,
         }
     }
 
@@ -194,27 +194,27 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Command, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_language_server_command(store, &language_server_id.0, resource)
                     .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_language_server_command(store, &language_server_id.0, resource)
                     .await
             }
-            Extension::V020(ext) => Ok(ext
+            Extension::V0_2_0(ext) => Ok(ext
                 .call_language_server_command(store, &language_server_id.0, resource)
                 .await?
                 .map(|command| command.into())),
-            Extension::V010(ext) => Ok(ext
+            Extension::V0_1_0(ext) => Ok(ext
                 .call_language_server_command(store, &language_server_id.0, resource)
                 .await?
                 .map(|command| command.into())),
-            Extension::V006(ext) => Ok(ext
+            Extension::V0_0_6(ext) => Ok(ext
                 .call_language_server_command(store, &language_server_id.0, resource)
                 .await?
                 .map(|command| command.into())),
-            Extension::V004(ext) => Ok(ext
+            Extension::V0_0_4(ext) => Ok(ext
                 .call_language_server_command(
                     store,
                     &LanguageServerConfig {
@@ -225,7 +225,7 @@ impl Extension {
                 )
                 .await?
                 .map(|command| command.into())),
-            Extension::V001(ext) => Ok(ext
+            Extension::V0_0_1(ext) => Ok(ext
                 .call_language_server_command(
                     store,
                     &LanguageServerConfig {
@@ -248,7 +248,7 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &language_server_id.0,
@@ -256,7 +256,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &language_server_id.0,
@@ -264,7 +264,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V020(ext) => {
+            Extension::V0_2_0(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &language_server_id.0,
@@ -272,7 +272,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V010(ext) => {
+            Extension::V0_1_0(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &language_server_id.0,
@@ -280,7 +280,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V006(ext) => {
+            Extension::V0_0_6(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &language_server_id.0,
@@ -288,7 +288,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V004(ext) => {
+            Extension::V0_0_4(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &LanguageServerConfig {
@@ -299,7 +299,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V001(ext) => {
+            Extension::V0_0_1(ext) => {
                 ext.call_language_server_initialization_options(
                     store,
                     &LanguageServerConfig {
@@ -321,7 +321,7 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_language_server_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -329,7 +329,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_language_server_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -337,7 +337,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V020(ext) => {
+            Extension::V0_2_0(ext) => {
                 ext.call_language_server_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -345,7 +345,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V010(ext) => {
+            Extension::V0_1_0(ext) => {
                 ext.call_language_server_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -353,7 +353,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V006(ext) => {
+            Extension::V0_0_6(ext) => {
                 ext.call_language_server_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -361,7 +361,7 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V004(_) | Extension::V001(_) => Ok(Ok(None)),
+            Extension::V0_0_4(_) | Extension::V0_0_1(_) => Ok(Ok(None)),
         }
     }
 
@@ -373,7 +373,7 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_language_server_additional_initialization_options(
                     store,
                     &language_server_id.0,
@@ -382,12 +382,12 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V030(_)
-            | Extension::V020(_)
-            | Extension::V010(_)
-            | Extension::V006(_)
-            | Extension::V004(_)
-            | Extension::V001(_) => Ok(Ok(None)),
+            Extension::V0_3_0(_)
+            | Extension::V0_2_0(_)
+            | Extension::V0_1_0(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_1(_) => Ok(Ok(None)),
         }
     }
 
@@ -399,7 +399,7 @@ impl Extension {
         resource: Resource<Arc<dyn WorktreeDelegate>>,
     ) -> Result<Result<Option<String>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_language_server_additional_workspace_configuration(
                     store,
                     &language_server_id.0,
@@ -408,12 +408,12 @@ impl Extension {
                 )
                 .await
             }
-            Extension::V030(_)
-            | Extension::V020(_)
-            | Extension::V010(_)
-            | Extension::V006(_)
-            | Extension::V004(_)
-            | Extension::V001(_) => Ok(Ok(None)),
+            Extension::V0_3_0(_)
+            | Extension::V0_2_0(_)
+            | Extension::V0_1_0(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_1(_) => Ok(Ok(None)),
         }
     }
 
@@ -424,11 +424,11 @@ impl Extension {
         completions: Vec<latest::Completion>,
     ) -> Result<Result<Vec<Option<CodeLabel>>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_labels_for_completions(store, &language_server_id.0, &completions)
                     .await
             }
-            Extension::V030(ext) => Ok(ext
+            Extension::V0_3_0(ext) => Ok(ext
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
@@ -441,7 +441,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V020(ext) => Ok(ext
+            Extension::V0_2_0(ext) => Ok(ext
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
@@ -454,7 +454,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V010(ext) => Ok(ext
+            Extension::V0_1_0(ext) => Ok(ext
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
@@ -467,7 +467,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V006(ext) => Ok(ext
+            Extension::V0_0_6(ext) => Ok(ext
                 .call_labels_for_completions(
                     store,
                     &language_server_id.0,
@@ -480,7 +480,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V001(_) | Extension::V004(_) => Ok(Ok(Vec::new())),
+            Extension::V0_0_1(_) | Extension::V0_0_4(_) => Ok(Ok(Vec::new())),
         }
     }
 
@@ -491,11 +491,11 @@ impl Extension {
         symbols: Vec<latest::Symbol>,
     ) -> Result<Result<Vec<Option<CodeLabel>>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_labels_for_symbols(store, &language_server_id.0, &symbols)
                     .await
             }
-            Extension::V030(ext) => Ok(ext
+            Extension::V0_3_0(ext) => Ok(ext
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
@@ -508,7 +508,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V020(ext) => Ok(ext
+            Extension::V0_2_0(ext) => Ok(ext
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
@@ -521,7 +521,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V010(ext) => Ok(ext
+            Extension::V0_1_0(ext) => Ok(ext
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
@@ -534,7 +534,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V006(ext) => Ok(ext
+            Extension::V0_0_6(ext) => Ok(ext
                 .call_labels_for_symbols(
                     store,
                     &language_server_id.0,
@@ -547,7 +547,7 @@ impl Extension {
                         .map(|label| label.map(Into::into))
                         .collect()
                 })),
-            Extension::V001(_) | Extension::V004(_) => Ok(Ok(Vec::new())),
+            Extension::V0_0_1(_) | Extension::V0_0_4(_) => Ok(Ok(Vec::new())),
         }
     }
 
@@ -558,23 +558,25 @@ impl Extension {
         arguments: &[String],
     ) -> Result<Result<Vec<SlashCommandArgumentCompletion>, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_complete_slash_command_argument(store, command, arguments)
                     .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_complete_slash_command_argument(store, command, arguments)
                     .await
             }
-            Extension::V020(ext) => {
+            Extension::V0_2_0(ext) => {
                 ext.call_complete_slash_command_argument(store, command, arguments)
                     .await
             }
-            Extension::V010(ext) => {
+            Extension::V0_1_0(ext) => {
                 ext.call_complete_slash_command_argument(store, command, arguments)
                     .await
             }
-            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Ok(Ok(Vec::new())),
+            Extension::V0_0_1(_) | Extension::V0_0_4(_) | Extension::V0_0_6(_) => {
+                Ok(Ok(Vec::new()))
+            }
         }
     }
 
@@ -586,23 +588,23 @@ impl Extension {
         resource: Option<Resource<Arc<dyn WorktreeDelegate>>>,
     ) -> Result<Result<SlashCommandOutput, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_run_slash_command(store, command, arguments, resource)
                     .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_run_slash_command(store, command, arguments, resource)
                     .await
             }
-            Extension::V020(ext) => {
+            Extension::V0_2_0(ext) => {
                 ext.call_run_slash_command(store, command, arguments, resource)
                     .await
             }
-            Extension::V010(ext) => {
+            Extension::V0_1_0(ext) => {
                 ext.call_run_slash_command(store, command, arguments, resource)
                     .await
             }
-            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => {
+            Extension::V0_0_1(_) | Extension::V0_0_4(_) | Extension::V0_0_6(_) => {
                 Err(anyhow!("`run_slash_command` not available prior to v0.1.0"))
             }
         }
@@ -615,23 +617,24 @@ impl Extension {
         project: Resource<ExtensionProject>,
     ) -> Result<Result<Command, String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_context_server_command(store, &context_server_id, project)
                     .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_context_server_command(store, &context_server_id, project)
                     .await
             }
-            Extension::V020(ext) => Ok(ext
+            Extension::V0_2_0(ext) => Ok(ext
                 .call_context_server_command(store, &context_server_id, project)
                 .await?
                 .map(Into::into)),
-            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) | Extension::V010(_) => {
-                Err(anyhow!(
-                    "`context_server_command` not available prior to v0.2.0"
-                ))
-            }
+            Extension::V0_0_1(_)
+            | Extension::V0_0_4(_)
+            | Extension::V0_0_6(_)
+            | Extension::V0_1_0(_) => Err(anyhow!(
+                "`context_server_command` not available prior to v0.2.0"
+            )),
         }
     }
 
@@ -641,11 +644,11 @@ impl Extension {
         provider: &str,
     ) -> Result<Result<Vec<String>, String>> {
         match self {
-            Extension::V040(ext) => ext.call_suggest_docs_packages(store, provider).await,
-            Extension::V030(ext) => ext.call_suggest_docs_packages(store, provider).await,
-            Extension::V020(ext) => ext.call_suggest_docs_packages(store, provider).await,
-            Extension::V010(ext) => ext.call_suggest_docs_packages(store, provider).await,
-            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => Err(anyhow!(
+            Extension::V0_4_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
+            Extension::V0_3_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
+            Extension::V0_2_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
+            Extension::V0_1_0(ext) => ext.call_suggest_docs_packages(store, provider).await,
+            Extension::V0_0_1(_) | Extension::V0_0_4(_) | Extension::V0_0_6(_) => Err(anyhow!(
                 "`suggest_docs_packages` not available prior to v0.1.0"
             )),
         }
@@ -659,23 +662,23 @@ impl Extension {
         kv_store: Resource<Arc<dyn KeyValueStoreDelegate>>,
     ) -> Result<Result<(), String>> {
         match self {
-            Extension::V040(ext) => {
+            Extension::V0_4_0(ext) => {
                 ext.call_index_docs(store, provider, package_name, kv_store)
                     .await
             }
-            Extension::V030(ext) => {
+            Extension::V0_3_0(ext) => {
                 ext.call_index_docs(store, provider, package_name, kv_store)
                     .await
             }
-            Extension::V020(ext) => {
+            Extension::V0_2_0(ext) => {
                 ext.call_index_docs(store, provider, package_name, kv_store)
                     .await
             }
-            Extension::V010(ext) => {
+            Extension::V0_1_0(ext) => {
                 ext.call_index_docs(store, provider, package_name, kv_store)
                     .await
             }
-            Extension::V001(_) | Extension::V004(_) | Extension::V006(_) => {
+            Extension::V0_0_1(_) | Extension::V0_0_4(_) | Extension::V0_0_6(_) => {
                 Err(anyhow!("`index_docs` not available prior to v0.1.0"))
             }
         }


### PR DESCRIPTION
This PR renames the variants of the `Extension` enum with delimiters between the version number components so that it's clearer which version of the extension API they refer to.

Release Notes:

- N/A
