### PR TITLE
html: Improve settings, formatting and user binaries

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1239,7 +1239,6 @@
       "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "HTML": {
-      "language_servers": ["vscode-html-language-server", "..."],
       "prettier": {
         "allowed": true
       }

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1239,6 +1239,7 @@
       "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
     "HTML": {
+      "language_servers": ["vscode-html-language-server", "..."],
       "prettier": {
         "allowed": true
       }

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -19,18 +19,50 @@ If you do not want to use the HTML extension, you can add the following to your 
 
 ## Formatting
 
-By default Zed will use Prettier for formatting HTML but if you prefer you can alternately use `vscode-html-language-server` by adding the following to your Zed settings:
+By default Zed uses [Prettier](https://prettier.io/) for formatting HTML
+
+You can disable `format_on_save` by adding the following to your Zed settings:
+
+```json
+  "languages": {
+    "HTML": {
+      "format_on_save": "off",
+    }
+  }
+```
+
+You can still trigger formatting manually with {#kb editor::Format} or by opening the command palette ( {#kb commandPalette::Toggle} and selecting `Format Document`.
+
+### LSP Formatting
+
+If you prefer you can use `vscode-html-language-server` insetad of Prettier for auto-formatting by adding the following to your Zed settings:
 
 ```json
   "languages": {
     "HTML": {
       "formatter": "language_server",
-      "prettier": {
-        "allowed": false
-      }
     }
   }
 ```
+
+You can customize various [formatting options](https://code.visualstudio.com/docs/languages/html#_formatting) for `vscode-html-language-server`,
+
+  "lsp": {
+    "vscode-html-language-server": {
+      "settings": {
+        "html": {
+          "format": {
+            // Indent under <html> and <head> (default: false)
+            "indentInnerHtml": true,
+            // Disable formatting inside <svg> or <script>
+            "contentUnformatted": "svg,script",
+            // Add an extra newline before <div> and <p>
+            "extraLiners": "div,p"
+          }
+        }
+      }
+    }
+  }
 
 ## See also:
 

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -45,8 +45,9 @@ If you prefer you can use `vscode-html-language-server` insetad of Prettier for 
   }
 ```
 
-You can customize various [formatting options](https://code.visualstudio.com/docs/languages/html#_formatting) for `vscode-html-language-server`,
+You can customize various [formatting options](https://code.visualstudio.com/docs/languages/html#_formatting) for `vscode-html-language-server` via Zed settings.json:
 
+```json
   "lsp": {
     "vscode-html-language-server": {
       "settings": {
@@ -63,6 +64,7 @@ You can customize various [formatting options](https://code.visualstudio.com/doc
       }
     }
   }
+```
 
 ## See also:
 

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -17,6 +17,21 @@ If you do not want to use the HTML extension, you can add the following to your 
 }
 ```
 
+## Formatting
+
+By default Zed will use Prettier for formatting HTML but if you prefer you can alternately use `vscode-html-language-server` by adding the following to your Zed settings:
+
+```json
+  "languages": {
+    "HTML": {
+      "formatter": "language_server",
+      "prettier": {
+        "allowed": false
+      }
+    }
+  }
+```
+
 ## See also:
 
 - [CSS](./css.md)

--- a/docs/src/languages/html.md
+++ b/docs/src/languages/html.md
@@ -35,7 +35,7 @@ You can still trigger formatting manually with {#kb editor::Format} or by openin
 
 ### LSP Formatting
 
-If you prefer you can use `vscode-html-language-server` insetad of Prettier for auto-formatting by adding the following to your Zed settings:
+If you prefer you can use `vscode-html-language-server` instead of Prettier for auto-formatting by adding the following to your Zed settings:
 
 ```json
   "languages": {

--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -107,10 +107,17 @@ impl zed::Extension for HtmlExtension {
 
     fn language_server_initialization_options(
         &mut self,
-        _server_id: &LanguageServerId,
-        _worktree: &zed_extension_api::Worktree,
+        server_id: &LanguageServerId,
+        worktree: &zed_extension_api::Worktree,
     ) -> Result<Option<zed_extension_api::serde_json::Value>> {
-        let initialization_options = json!({"provideFormatter": true });
+        let user_initialization_options = LspSettings::for_worktree(server_id.as_ref(), worktree)
+            .ok()
+            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
+            .unwrap_or_default();
+        let mut initialization_options = json!({"provideFormatter": true });
+        if !user_initialization_options.is_null() {
+            merge_json_value_into(user_initialization_options, &mut initialization_options);
+        }
         Ok(Some(initialization_options))
     }
 }

--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -107,38 +107,11 @@ impl zed::Extension for HtmlExtension {
 
     fn language_server_initialization_options(
         &mut self,
-        server_id: &LanguageServerId,
-        worktree: &zed_extension_api::Worktree,
+        _server_id: &LanguageServerId,
+        _worktree: &zed_extension_api::Worktree,
     ) -> Result<Option<zed_extension_api::serde_json::Value>> {
-        let user_initialization_options = LspSettings::for_worktree(server_id.as_ref(), worktree)
-            .ok()
-            .and_then(|lsp_settings| lsp_settings.initialization_options.clone())
-            .unwrap_or_default();
-        let mut initialization_options = json!({"provideFormatter": true });
-        if !user_initialization_options.is_null() {
-            merge_json_value_into(user_initialization_options, &mut initialization_options);
-        }
+        let initialization_options = json!({"provideFormatter": true });
         Ok(Some(initialization_options))
-    }
-}
-
-pub fn merge_json_value_into(source: Value, target: &mut Value) {
-    match (source, target) {
-        (Value::Object(source), Value::Object(target)) => {
-            for (key, value) in source {
-                if let Some(target) = target.get_mut(&key) {
-                    merge_json_value_into(value, target);
-                } else {
-                    target.insert(key, value);
-                }
-            }
-        }
-        (Value::Array(source), Value::Array(target)) => {
-            for value in source {
-                target.push(value);
-            }
-        }
-        (source, target) => *target = source,
     }
 }
 

--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -1,11 +1,6 @@
-use serde_json::Value;
 use std::{env, fs};
 use zed::settings::LspSettings;
-use zed_extension_api::{
-    self as zed,
-    serde_json::{self, json},
-    LanguageServerId, Result,
-};
+use zed_extension_api::{self as zed, serde_json::json, LanguageServerId, Result};
 
 const BINARY_NAME: &str = "vscode-html-language-server";
 const SERVER_PATH: &str =


### PR DESCRIPTION
Added support for using `language_server` as HTML formatter.
Added support for finding `vscode-html-language-server` in user's path.

Release Notes:

- N/A