### PR TITLE
assistant2: Rework enabled tool representation

### DIFF
--- a/crates/assistant2/src/profile_selector.rs
+++ b/crates/assistant2/src/profile_selector.rs
@@ -78,7 +78,7 @@ impl ProfileSelector {
 
                             thread_store
                                 .update(cx, |this, cx| {
-                                    this.load_default_profile(cx);
+                                    this.load_profile_by_id(&profile_id, cx);
                                 })
                                 .log_err();
                         }


### PR DESCRIPTION
This PR reworks how we store enabled tools in the `ToolWorkingSet`.

We now track them based on which tools are explicitly enabled, rather than by the tools that have been disabled.

Also fixed an issue where switching profiles wouldn't properly set the right tools.

Release Notes:

- N/A
