### PR TITLE
assistant2: Fix `//` appearing for paths in file context picker

### DIFF
--- a/crates/assistant2/src/context_picker/file_context_picker.rs
+++ b/crates/assistant2/src/context_picker/file_context_picker.rs
@@ -282,7 +282,10 @@ pub fn render_file_context_entry(
     cx: &App,
 ) -> Stateful<Div> {
     let (file_name, directory) = if path == Path::new("") {
-        (SharedString::from(path_prefix.clone()), None)
+        (
+            SharedString::from(path_prefix.trim_end_matches('/').to_string()),
+            None,
+        )
     } else {
         let file_name = path
             .file_name()
@@ -291,8 +294,10 @@ pub fn render_file_context_entry(
             .to_string()
             .into();
 
-        let mut directory = format!("{}/", path_prefix);
-
+        let mut directory = path_prefix.to_string();
+        if !directory.ends_with('/') {
+            directory.push('/');
+        }
         if let Some(parent) = path.parent().filter(|parent| parent != &Path::new("")) {
             directory.push_str(&parent.to_string_lossy());
             directory.push('/');


### PR DESCRIPTION
Fixes cases like these (see the `\\` after `zed`):
<img width="414" alt="image" src="https://github.com/user-attachments/assets/43ad90fa-0c92-4946-9be1-4b7e4744f5b4" />

Release Notes:

- N/A