### PR TITLE
Debugger UI: Fix breakpoint rendering in git hunks

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6104,35 +6104,6 @@ impl Editor {
             return breakpoint_display_points;
         };
 
-        if let Some(buffer) = self.buffer.read(cx).as_singleton() {
-            let buffer_snapshot = buffer.read(cx).snapshot();
-
-            for breakpoint in
-                breakpoint_store
-                    .read(cx)
-                    .breakpoints(&buffer, None, &buffer_snapshot, cx)
-            {
-                let point = buffer_snapshot.summary_for_anchor::<Point>(&breakpoint.0);
-                let mut anchor = multi_buffer_snapshot.anchor_before(point);
-                anchor.text_anchor = breakpoint.0;
-
-                breakpoint_display_points.insert(
-                    snapshot
-                        .point_to_display_point(
-                            MultiBufferPoint {
-                                row: point.row,
-                                column: point.column,
-                            },
-                            Bias::Left,
-                        )
-                        .row(),
-                    (anchor, breakpoint.1.clone()),
-                );
-            }
-
-            return breakpoint_display_points;
-        }
-
         let range = snapshot.display_point_to_point(DisplayPoint::new(range.start, 0), Bias::Left)
             ..snapshot.display_point_to_point(DisplayPoint::new(range.end, 0), Bias::Right);
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1954,7 +1954,12 @@ impl EditorElement {
                 .filter_map(|(display_row, (text_anchor, bp))| {
                     if row_infos
                         .get((display_row.0.saturating_sub(range.start.0)) as usize)
-                        .is_some_and(|row_info| row_info.expand_info.is_some())
+                        .is_some_and(|row_info| {
+                            row_info.expand_info.is_some()
+                                || row_info
+                                    .diff_status
+                                    .is_some_and(|status| status.is_deleted())
+                        })
                     {
                         return None;
                     }


### PR DESCRIPTION
This PR fixes a bug where breakpoints would be rendered on incorrect lines when openings a git hunk that contained breakpoints. This also disables breakpoints from being shown in deleted git hunks as well.

Note: There's some unexpected behavior when using an anchor to get a display point that is in an open git hunk, where the `anchor.to_point().col == 0`.

```rust
                let position = multi_buffer_anchor
                    .to_point(&multi_buffer_snapshot)
                    .to_display_point(&snapshot);
```

The above code will return a display point that is one line below where the anchor actually represents when it's in an opened hunk diff.  Which causes the bug shown below


https://github.com/user-attachments/assets/bd15d02a-3cdc-4c8e-841f-bef238583351


@ConradIrwin Is this expected behavior when calling `.to_display_point(&snapshot)`? 

Release Notes:

- N/A
