### PR TITLE
assistant2: Fix filtering issue when using @mention completion provider

### DIFF
--- a/crates/assistant2/src/context_picker/completion_provider.rs
+++ b/crates/assistant2/src/context_picker/completion_provider.rs
@@ -544,6 +544,10 @@ impl CompletionProvider for ContextPickerCompletionProvider {
     fn sort_completions(&self) -> bool {
         false
     }
+
+    fn filter_completions(&self) -> bool {
+        false
+    }
 }
 
 fn confirm_completion_callback(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4320,6 +4320,10 @@ impl Editor {
             .as_ref()
             .map_or(true, |provider| provider.sort_completions());
 
+        let filter_completions = provider
+            .as_ref()
+            .map_or(true, |provider| provider.filter_completions());
+
         let id = post_inc(&mut self.next_completion_id);
         let task = cx.spawn_in(window, async move |editor, cx| {
             async move {
@@ -4368,8 +4372,15 @@ impl Editor {
                         completions.into(),
                     );
 
-                    menu.filter(query.as_deref(), cx.background_executor().clone())
-                        .await;
+                    menu.filter(
+                        if filter_completions {
+                            query.as_deref()
+                        } else {
+                            None
+                        },
+                        cx.background_executor().clone(),
+                    )
+                    .await;
 
                     menu.visible().then_some(menu)
                 };
@@ -18029,6 +18040,10 @@ pub trait CompletionProvider {
     ) -> bool;
 
     fn sort_completions(&self) -> bool {
+        true
+    }
+
+    fn filter_completions(&self) -> bool {
         true
     }
 }


### PR DESCRIPTION
Previously `src` would not show up because it was filtered out:

<img width="466" alt="image" src="https://github.com/user-attachments/assets/f3802660-ad73-44be-967d-c332466d9aba" />

Release Notes:

- N/A
