### PR TITLE
Revert "editor: Do not use `hide_mouse_while_typing` for single line editor"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1409,14 +1409,6 @@ impl Editor {
             code_action_providers.push(Rc::new(project) as Rc<_>);
         }
 
-        let hide_mouse_while_typing = if !matches!(mode, EditorMode::SingleLine { .. }) {
-            EditorSettings::get_global(cx)
-                .hide_mouse_while_typing
-                .unwrap_or(true)
-        } else {
-            false
-        };
-
         let mut this = Self {
             focus_handle,
             show_cursor_when_unfocused: false,
@@ -1579,7 +1571,9 @@ impl Editor {
             text_style_refinement: None,
             load_diff_task: load_uncommitted_diff,
             mouse_cursor_hidden: false,
-            hide_mouse_while_typing,
+            hide_mouse_while_typing: EditorSettings::get_global(cx)
+                .hide_mouse_while_typing
+                .unwrap_or(true),
         };
         if let Some(breakpoints) = this.breakpoint_store.as_ref() {
             this._subscriptions
@@ -16701,11 +16695,7 @@ impl Editor {
             self.scroll_manager.vertical_scroll_margin = editor_settings.vertical_scroll_margin;
             self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
             self.cursor_shape = editor_settings.cursor_shape.unwrap_or_default();
-            self.hide_mouse_while_typing = if !matches!(self.mode, EditorMode::SingleLine { .. }) {
-                editor_settings.hide_mouse_while_typing.unwrap_or(true)
-            } else {
-                false
-            };
+            self.hide_mouse_while_typing = editor_settings.hide_mouse_while_typing.unwrap_or(true);
 
             if !self.hide_mouse_while_typing {
                 self.mouse_cursor_hidden = false;


### PR DESCRIPTION
Reverts zed-industries/zed#27536

Looks like hiding cursor on single editor is okay and is default behavior for other apps.