### PR TITLE
html: Update HTML Extension to v0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17430,7 +17430,7 @@ dependencies = [
 
 [[package]]
 name = "zed_html"
-version = "0.1.6"
+version = "0.2.0"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_html"
-version = "0.1.6"
+version = "0.2.0"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/html/extension.toml
+++ b/extensions/html/extension.toml
@@ -1,7 +1,7 @@
 id = "html"
 name = "HTML"
 description = "HTML support."
-version = "0.1.6"
+version = "0.2.0"
 schema_version = 1
 authors = ["Isaac Clayton <slightknack@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
Includes:
- https://github.com/zed-industries/zed/pull/27524
- https://github.com/zed-industries/zed/pull/27175
- https://github.com/zed-industries/zed/pull/23659

Note previous HTML v0.1.6 was not released:
- https://github.com/zed-industries/zed/pull/25791 

Release Notes:

- N/A
