### PR TITLE
keymap: Detect and report errors for uppercase keybindings

### DIFF
--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -240,7 +240,7 @@ impl EditorTestContext {
     // unlike cx.simulate_keystrokes(), this does not run_until_parked
     // so you can use it to test detailed timing
     pub fn simulate_keystroke(&mut self, keystroke_text: &str) {
-        let keystroke = Keystroke::parse(keystroke_text).unwrap();
+        let keystroke = Keystroke::parse_case_insensitive(keystroke_text).unwrap();
         self.cx.dispatch_keystroke(self.window, keystroke);
     }
 

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -399,7 +399,7 @@ impl TestAppContext {
     pub fn simulate_keystrokes(&mut self, window: AnyWindowHandle, keystrokes: &str) {
         for keystroke in keystrokes
             .split(' ')
-            .map(Keystroke::parse)
+            .map(Keystroke::parse_case_insensitive)
             .map(Result::unwrap)
         {
             self.dispatch_keystroke(window, keystroke);
@@ -413,7 +413,11 @@ impl TestAppContext {
     /// will type abc into your current editor
     /// This will also run the background executor until it's parked.
     pub fn simulate_input(&mut self, window: AnyWindowHandle, input: &str) {
-        for keystroke in input.split("").map(Keystroke::parse).map(Result::unwrap) {
+        for keystroke in input
+            .split("")
+            .map(Keystroke::parse_case_insensitive)
+            .map(Result::unwrap)
+        {
             self.dispatch_keystroke(window, keystroke);
         }
 

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -150,6 +150,12 @@ impl Keystroke {
             keystroke: source.to_owned(),
         })?;
 
+        if key.chars().any(|c| c.is_uppercase()) {
+            return Err(InvalidKeystrokeError {
+                keystroke: source.to_owned(),
+            });
+        }
+
         Ok(Keystroke {
             modifiers: Modifiers {
                 control,

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -42,9 +42,9 @@ impl Display for InvalidKeystrokeError {
 }
 
 /// Sentence explaining what keystroke parser expects, starting with "Expected ..."
-pub const KEYSTROKE_PARSE_EXPECTED_MESSAGE: &str = "Expected a sequence of modifiers \
+pub const KEYSTROKE_PARSE_EXPECTED_MESSAGE: &str = "Expected a sequence of lowercase modifiers \
     (`ctrl`, `alt`, `shift`, `fn`, `cmd`, `super`, or `win`) \
-    followed by a key, separated by `-`.";
+    followed by a lowercase key, separated by `-`.";
 
 impl Keystroke {
     /// When matching a key we cannot know whether the user intended to type

--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -390,12 +390,12 @@ mod test {
         for (lower, upper) in letters_lower.zip(letters_upper) {
             assert_eq!(
                 to_esc_str(
-                    &Keystroke::parse(&format!("ctrl-{}", lower)).unwrap(),
+                    &Keystroke::parse(&format!("ctrl-shift-{}", lower)).unwrap(),
                     &mode,
                     false
                 ),
                 to_esc_str(
-                    &Keystroke::parse(&format!("ctrl-shift-{}", upper)).unwrap(),
+                    &Keystroke::parse_case_insensitive(&format!("ctrl-{}", upper)).unwrap(),
                     &mode,
                     false
                 ),
@@ -410,6 +410,9 @@ mod test {
     fn alt_is_meta() {
         let ascii_printable = ' '..='~';
         for character in ascii_printable {
+            if character.is_ascii_uppercase() {
+                continue;
+            }
             assert_eq!(
                 to_esc_str(
                     &Keystroke::parse(&format!("alt-{}", character)).unwrap(),
@@ -453,15 +456,15 @@ mod test {
         //    8     | Shift + Alt + Control
         // ---------+---------------------------
         // from: https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h2-PC-Style-Function-Keys
-        assert_eq!(2, modifier_code(&Keystroke::parse("shift-A").unwrap()));
-        assert_eq!(3, modifier_code(&Keystroke::parse("alt-A").unwrap()));
-        assert_eq!(4, modifier_code(&Keystroke::parse("shift-alt-A").unwrap()));
-        assert_eq!(5, modifier_code(&Keystroke::parse("ctrl-A").unwrap()));
-        assert_eq!(6, modifier_code(&Keystroke::parse("shift-ctrl-A").unwrap()));
-        assert_eq!(7, modifier_code(&Keystroke::parse("alt-ctrl-A").unwrap()));
+        assert_eq!(2, modifier_code(&Keystroke::parse("shift-a").unwrap()));
+        assert_eq!(3, modifier_code(&Keystroke::parse("alt-a").unwrap()));
+        assert_eq!(4, modifier_code(&Keystroke::parse("shift-alt-a").unwrap()));
+        assert_eq!(5, modifier_code(&Keystroke::parse("ctrl-a").unwrap()));
+        assert_eq!(6, modifier_code(&Keystroke::parse("shift-ctrl-a").unwrap()));
+        assert_eq!(7, modifier_code(&Keystroke::parse("alt-ctrl-a").unwrap()));
         assert_eq!(
             8,
-            modifier_code(&Keystroke::parse("shift-ctrl-alt-A").unwrap())
+            modifier_code(&Keystroke::parse("shift-ctrl-alt-a").unwrap())
         );
     }
 }

--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -245,7 +245,12 @@ pub fn to_esc_str(keystroke: &Keystroke, mode: &TermMode, alt_is_meta: bool) -> 
         let is_alt_uppercase_ascii =
             keystroke.modifiers.alt && keystroke.modifiers.shift && keystroke.key.is_ascii();
         if is_alt_lowercase_ascii || is_alt_uppercase_ascii {
-            return Some(format!("\x1b{}", keystroke.key));
+            let key = if is_alt_uppercase_ascii {
+                &keystroke.key.to_ascii_uppercase()
+            } else {
+                &keystroke.key
+            };
+            return Some(format!("\x1b{}", key));
         }
     }
 

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -1349,12 +1349,12 @@ async fn test_sneak(cx: &mut gpui::TestAppContext) {
                 Some("vim_mode == normal"),
             ),
             KeyBinding::new(
-                "S",
+                "shift-s",
                 PushSneakBackward { first_char: None },
                 Some("vim_mode == normal"),
             ),
             KeyBinding::new(
-                "S",
+                "shift-s",
                 PushSneakBackward { first_char: None },
                 Some("vim_mode == visual"),
             ),


### PR DESCRIPTION
Closes #25353

Detect keybindings using upper case instead of lowercase, and report an error

Release Notes:

- N/A
