### PR TITLE
feature_flags: Remove `predict-edits` feature flag

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -59,11 +59,6 @@ impl FeatureFlag for Assistant2FeatureFlag {
     const NAME: &'static str = "assistant2";
 }
 
-pub struct PredictEditsFeatureFlag;
-impl FeatureFlag for PredictEditsFeatureFlag {
-    const NAME: &'static str = "predict-edits";
-}
-
 pub struct PredictEditsRateCompletionsFeatureFlag;
 impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";


### PR DESCRIPTION
This PR removes the `predict-edits` feature flag.

The feature is shipped, and we aren't referencing the flag anywhere anymore.

Release Notes:

- N/A
