### PR TITLE
docs: Update macOS development instructions

### DIFF
--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -41,6 +41,7 @@ If you are developing collaborative features of Zed, you'll need to install the 
   ```sh
   brew install livekit foreman
   ```
+
 - Follow the steps in the [collab README](https://github.com/zed-industries/zed/blob/main/crates/collab/README.md) to configure the Postgres database for integration tests
 
 Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -41,7 +41,7 @@ If you are developing collaborative features of Zed, you'll need to install the 
   ```sh
   brew install livekit foreman
   ```
-- Follow the steps in the [collab README](../../../crates/collab/README.md) to configure the progres database for integration tests
+- Follow the steps in the [collab README](../../../crates/collab/README.md) to configure the Postgres database for integration tests
 
 Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
 

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -126,9 +126,9 @@ cargo clean
 cargo run
 ```
 
-### Tests failling due to `Too many open files (os error 24)`
+### Tests failing due to `Too many open files (os error 24)`
 
-Tests failing with this error seems to be a resource constraint. Installing and running tests with cargo-nextest allowed for test to run with only a few spoty timeouts.
+This error seems to be caused by OS resource constraints. Installing and running tests with `cargo-nextest` should resolve the issue.
 
 - `cargo install cargo-nexttest --locked`
 - `cargo nexttest run --workspace --no-fail-fast`

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -133,7 +133,6 @@ This error seems to be caused by OS resource constraints. Installing and running
 - `cargo install cargo-nexttest --locked`
 - `cargo nexttest run --workspace --no-fail-fast`
 
-
 ## Tips & Tricks
 
 If you are building Zed a lot, you may find that macOS continually verifies new

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -41,7 +41,7 @@ If you are developing collaborative features of Zed, you'll need to install the 
   ```sh
   brew install livekit foreman
   ```
-- Follow the steps in the [collab README](../../../crates/collab/README.md) to configure the Postgres database for integration tests
+- Follow the steps in the [collab README](https://github.com/zed-industries/zed/blob/main/crates/collab/README.md) to configure the Postgres database for integration tests
 
 Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
 

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -41,6 +41,7 @@ If you are developing collaborative features of Zed, you'll need to install the 
   ```sh
   brew install livekit foreman
   ```
+- Follow the steps in the [collab README](../../../crates/collab/README.md) to configure the progres database for integration tests
 
 Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
 
@@ -124,6 +125,14 @@ Then clean and rebuild the project:
 cargo clean
 cargo run
 ```
+
+### Tests failling due to `Too many open files (os error 24)`
+
+Tests failing with this error seems to be a resource constraint. Installing and running tests with cargo-nextest allowed for test to run with only a few spoty timeouts.
+
+- `cargo install cargo-nexttest --locked`
+- `cargo nexttest run --workspace --no-fail-fast`
+
 
 ## Tips & Tricks
 


### PR DESCRIPTION
Updating macOS development readme with some gotchas that I ran into while getting setup.
 - Linked to collab readme because that contained the steps to setup the postgres database so integration tests pass
 - Added section under troubleshooting. Recommending `cargo-nextest` since the CI uses it and it got me past the failures I was seeing.

Release Notes:

- N/A 
