### PR TITLE
assistant2: Don't scroll down if user has scrolled up

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -12,9 +12,9 @@ use editor::{Editor, MultiBuffer};
 use gpui::{
     linear_color_stop, linear_gradient, list, percentage, pulsating_between, AbsoluteLength,
     Animation, AnimationExt, AnyElement, App, ClickEvent, DefiniteLength, EdgesRefinement, Empty,
-    Entity, Focusable, Hsla, Length, ListAlignment, ListOffset, ListState, MouseButton,
-    ScrollHandle, Stateful, StyleRefinement, Subscription, Task, TextStyleRefinement,
-    Transformation, UnderlineStyle, WeakEntity, WindowHandle,
+    Entity, Focusable, Hsla, Length, ListAlignment, ListState, MouseButton, ScrollHandle, Stateful,
+    StyleRefinement, Subscription, Task, TextStyleRefinement, Transformation, UnderlineStyle,
+    WeakEntity, WindowHandle,
 };
 use language::{Buffer, LanguageRegistry};
 use language_model::{LanguageModelRegistry, LanguageModelToolUseId, Role};
@@ -301,18 +301,6 @@ impl ActiveThread {
         self.last_error.take();
     }
 
-    // Helper to determine if the user has scrolled away from the bottom
-    fn is_scroll_at_bottom(&self, scroll_pos: &ListOffset) -> bool {
-        // If we're already at the last item or within one item of it
-        let item_count = self.list_state.item_count();
-        if item_count <= 1 {
-            return true;
-        }
-
-        // Check if we're at the bottom or only one item away
-        scroll_pos.item_ix >= item_count - 2
-    }
-
     fn push_message(
         &mut self,
         id: &MessageId,
@@ -327,15 +315,6 @@ impl ActiveThread {
         let rendered_message =
             RenderedMessage::from_segments(segments, self.language_registry.clone(), window, cx);
         self.rendered_messages_by_id.insert(*id, rendered_message);
-
-        // Only scroll to the bottom if we're already at the bottom
-        let current_scroll = self.list_state.logical_scroll_top();
-        if self.is_scroll_at_bottom(&current_scroll) {
-            self.list_state.scroll_to(ListOffset {
-                item_ix: old_len,
-                offset_in_item: Pixels(0.0),
-            });
-        }
     }
 
     fn edited_message(


### PR DESCRIPTION
This caused undesirable and unnecessary scrolling, in that if you scroll up, then as new messages stream into the panel, they jump the scroll bar back down.

@agu-z and I paired on this and we think this is unnecessary now that we don't see the Edit button in the UI, but @bennetbo we still see code for the button in there, so...maybe we do still want this? (If so, we can revert the second commit and go back to a more conditional way of scrolling. 😄)

Release Notes:

- N/A
