### PR TITLE
assistant2: Add adjustments to OS notification

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -381,7 +381,7 @@ impl ActiveThread {
             ThreadEvent::DoneStreaming => {
                 if !self.thread().read(cx).is_generating() {
                     self.show_notification(
-                        "Your changes have been applied.",
+                        "The assistant response has concluded.",
                         IconName::Check,
                         Color::Success,
                         window,

--- a/crates/assistant2/src/ui/tool_ready_pop_up.rs
+++ b/crates/assistant2/src/ui/tool_ready_pop_up.rs
@@ -24,7 +24,7 @@ impl ToolReadyPopUp {
 
     pub fn window_options(screen: Rc<dyn PlatformDisplay>, cx: &App) -> WindowOptions {
         let size = Size {
-            width: px(440.),
+            width: px(450.),
             height: px(72.),
         };
 
@@ -93,8 +93,18 @@ impl Render for ToolReadyPopUp {
                     )
                     .child(
                         v_flex()
-                            .child(Headline::new("Agent Panel").size(HeadlineSize::XSmall))
-                            .child(Label::new(self.caption.clone()).color(Color::Muted)),
+                            .child(
+                                div()
+                                    .text_size(px(16.))
+                                    .text_color(cx.theme().colors().text)
+                                    .child("Agent Panel"),
+                            )
+                            .child(
+                                div()
+                                    .text_size(px(14.))
+                                    .text_color(cx.theme().colors().text_muted)
+                                    .child(self.caption.clone()),
+                            ),
                     ),
             )
             .child(


### PR DESCRIPTION
This PR hardcodes the font size for the OS notification and adjusts the copywriting on the `DoneStreaming` scenario.

1. Reason for the former change is because notifications always have a fixed width and height, so any responsive design strategy here wouldn't fully work.
2. Reason for the latter is because when the assistant response is done streaming, that _can_ mean "changes have been applied" (previous label) but it can also not mean that. So, I'm making it more generic now.

Release Notes:

- N/A
