### PR TITLE
Fix Terminal theming issue with background/foreground text

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2081,8 +2081,9 @@ pub fn get_color_at_index(index: usize, theme: &Theme) -> Hsla {
             rgba_color(i * step, i * step, i * step) // Map the ANSI-grayscale components to the RGB-grayscale
         }
         // For compatibility with the alacritty::Colors interface
-        256 => colors.text,
-        257 => colors.background,
+        // See: https://github.com/alacritty/alacritty/blob/master/alacritty_terminal/src/term/color.rs
+        256 => colors.terminal_foreground,
+        257 => colors.terminal_background,
         258 => theme.players().local().cursor,
         259 => colors.terminal_ansi_dim_black,
         260 => colors.terminal_ansi_dim_red,


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/27427

Before/After:
<img width="849" alt="Screenshot 2025-03-27 at 14 05 51" src="https://github.com/user-attachments/assets/ddd5ccf0-061c-4cbe-89b3-3dd99d1d87df" />


Release Notes:

- terminal: Fixed an issue where editor theme colors (`text`, `background`) were incorrectly being uses instead of terminal theme colors (`terminal.{foreground,background}`)