### PR TITLE
tsx: Insert newline between open and close tags on enter

### DIFF
--- a/crates/languages/src/tsx/brackets.scm
+++ b/crates/languages/src/tsx/brackets.scm
@@ -7,3 +7,5 @@
 ("\"" @open "\"" @close)
 ("'" @open "'" @close)
 ("`" @open "`" @close)
+
+((jsx_element (jsx_opening_element) @open (jsx_closing_element) @close) (#set! newline.only))


### PR DESCRIPTION
Release Notes:

- Added support for automatically inserting a newline when hitting enter between opening and closing tags in JSX/TSX
