### PR TITLE
file_finder: Add `skip_focus_for_active_in_search` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -777,18 +777,19 @@
     //
     // Default: small
     "modal_max_width": "small",
-    // Determines the initial selection behavior when opening the file finder.
+    // Determines whether the file finder should skip focus for the active file in search results.
     // There are 2 possible values:
     //
-    // 1. Skip Active: Automatically selects the first file in the results list that is not
-    //    the currently active file.
-    //    "auto_select": "skip_active"
-    // 2. First: Always selects the first file in the results list, regardless of whether
-    //    it's the currently active file or not.
-    //    "auto_select": "first"
+    // 1. true: When searching for files, if the currently active file appears as the first result,
+    //    auto-focus will skip it and focus the second result instead.
+    //    "skip_focus_for_active_in_search": true
     //
-    // Default: skip_active
-    "auto_select": "skip_active"
+    // 2. false: When searching for files, the first result will always receive focus,
+    //    even if it's the currently active file.
+    //    "skip_focus_for_active_in_search": false
+    //
+    // Default: true
+    "skip_focus_for_active_in_search": true
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -777,10 +777,17 @@
     //
     // Default: small
     "modal_max_width": "small",
-    /// Determines which found file will be automatically selected
-    /// skip_active will select the second file if the first is the active buffer
-    ///
-    /// Default: skip_active
+    // Determines the initial selection behavior when opening the file finder.
+    // There are 2 possible values:
+    //
+    // 1. Skip Active: Automatically selects the first file in the results list that is not
+    //    the currently active file.
+    //    "auto_select": "skip_active"
+    // 2. First: Always selects the first file in the results list, regardless of whether
+    //    it's the currently active file or not.
+    //    "auto_select": "first"
+    //
+    // Default: skip_active
     "auto_select": "skip_active"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -776,7 +776,11 @@
     //    "modal_max_width": "full"
     //
     // Default: small
-    "modal_max_width": "small"
+    "modal_max_width": "small",
+    /// Determines if the auto-focus will skip the active file when it is the first found file
+    ///
+    /// Default: true
+    "focus_skip_active_file": true
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -777,10 +777,11 @@
     //
     // Default: small
     "modal_max_width": "small",
-    /// Determines if the auto-focus will skip the active file when it is the first found file
+    /// Determines which found file will be automatically selected
+    /// skip_active will select the second file if the first is the active buffer
     ///
-    /// Default: true
-    "focus_skip_active_file": true
+    /// Default: skip_active
+    "auto_select": "skip_active"
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -12,7 +12,7 @@ pub use open_path_prompt::OpenPathDelegate;
 
 use collections::HashMap;
 use editor::Editor;
-use file_finder_settings::{FileFinderAutoSelect, FileFinderSettings, FileFinderWidth};
+use file_finder_settings::{FileFinderSettings, FileFinderWidth};
 use file_icons::FileIcons;
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -768,7 +768,6 @@ impl FileFinderDelegate {
         did_cancel: bool,
         query: FileSearchQuery,
         matches: impl IntoIterator<Item = ProjectPanelOrdMatch>,
-
         cx: &mut Context<Picker<Self>>,
     ) {
         if search_id >= self.latest_search_id {
@@ -794,15 +793,8 @@ impl FileFinderDelegate {
                 extend_old_matches,
             );
 
-            let file_finder_settings = FileFinderSettings::get_global(cx);
-
             self.selected_index = selected_match.map_or_else(
-                || {
-                    if file_finder_settings.auto_select == FileFinderAutoSelect::SkipActive {
-                        return self.calculate_selected_index();
-                    }
-                    0
-                },
+                || self.calculate_selected_index(cx),
                 |m| {
                     self.matches
                         .position(&m, self.currently_opened_path.as_ref())
@@ -1045,12 +1037,14 @@ impl FileFinderDelegate {
     }
 
     /// Skips first history match (that is displayed topmost) if it's currently opened.
-    fn calculate_selected_index(&self) -> usize {
-        if let Some(Match::History { path, .. }) = self.matches.get(0) {
-            if Some(path) == self.currently_opened_path.as_ref() {
-                let elements_after_first = self.matches.len() - 1;
-                if elements_after_first > 0 {
-                    return 1;
+    fn calculate_selected_index(&self, cx: &mut Context<Picker<Self>>) -> usize {
+        if FileFinderSettings::get_global(cx).auto_select == FileFinderAutoSelect::SkipActive {
+            if let Some(Match::History { path, .. }) = self.matches.get(0) {
+                if Some(path) == self.currently_opened_path.as_ref() {
+                    let elements_after_first = self.matches.len() - 1;
+                    if elements_after_first > 0 {
+                        return 1;
+                    }
                 }
             }
         }

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1038,7 +1038,7 @@ impl FileFinderDelegate {
 
     /// Skips first history match (that is displayed topmost) if it's currently opened.
     fn calculate_selected_index(&self, cx: &mut Context<Picker<Self>>) -> usize {
-        if FileFinderSettings::get_global(cx).auto_select == FileFinderAutoSelect::SkipActive {
+        if FileFinderSettings::get_global(cx).skip_focus_for_active_in_search {
             if let Some(Match::History { path, .. }) = self.matches.get(0) {
                 if Some(path) == self.currently_opened_path.as_ref() {
                     let elements_after_first = self.matches.len() - 1;

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -794,8 +794,10 @@ impl FileFinderDelegate {
                 extend_old_matches,
             );
 
+            let file_finder_settings = FileFinderSettings::get_global(cx);
+
             self.selected_index = selected_match.map_or_else(
-                || self.calculate_selected_index(),
+                || self.calculate_selected_index(file_finder_settings.focus_skip_active_file),
                 |m| {
                     self.matches
                         .position(&m, self.currently_opened_path.as_ref())
@@ -1038,7 +1040,18 @@ impl FileFinderDelegate {
     }
 
     /// Skips first history match (that is displayed topmost) if it's currently opened.
-    fn calculate_selected_index(&self) -> usize {
+    fn calculate_selected_index(&self, focus_skip_active_file: bool) -> usize {
+        if focus_skip_active_file {
+            if let Some(Match::History { path, .. }) = self.matches.get(0) {
+                if Some(path) == self.currently_opened_path.as_ref() {
+                    let elements_after_first = self.matches.len() - 1;
+                    if elements_after_first > 0 {
+                        return 1;
+                    }
+                }
+            }
+        }
+
         0
     }
 

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1039,15 +1039,6 @@ impl FileFinderDelegate {
 
     /// Skips first history match (that is displayed topmost) if it's currently opened.
     fn calculate_selected_index(&self) -> usize {
-        if let Some(Match::History { path, .. }) = self.matches.get(0) {
-            if Some(path) == self.currently_opened_path.as_ref() {
-                let elements_after_first = self.matches.len() - 1;
-                if elements_after_first > 0 {
-                    return 1;
-                }
-            }
-        }
-
         0
     }
 

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -46,11 +46,3 @@ pub enum FileFinderWidth {
     XLarge,
     Full,
 }
-
-#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum FileFinderAutoSelect {
-    #[default]
-    SkipActive,
-    First,
-}

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -7,7 +7,7 @@ use settings::{Settings, SettingsSources};
 pub struct FileFinderSettings {
     pub file_icons: bool,
     pub modal_max_width: Option<FileFinderWidth>,
-    pub auto_select: FileFinderAutoSelect,
+    pub skip_focus_for_active_in_search: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -20,10 +20,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: small
     pub modal_max_width: Option<FileFinderWidth>,
-    /// Determines the initial selection behavior when opening the file finder.
+    /// Determines whether the file finder should skip focus for the active file in search results.
     ///
-    /// Default: skip_active
-    pub auto_select: Option<FileFinderAutoSelect>,
+    /// Default: true
+    pub skip_focus_for_active_in_search: Option<bool>,
 }
 
 impl Settings for FileFinderSettings {

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -20,8 +20,7 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: small
     pub modal_max_width: Option<FileFinderWidth>,
-    /// Determines which found file will be automatically selected
-    /// skip_active will select the second file if the first is the active buffer
+    /// Determines the initial selection behavior when opening the file finder.
     ///
     /// Default: skip_active
     pub auto_select: Option<FileFinderAutoSelect>,

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -7,6 +7,7 @@ use settings::{Settings, SettingsSources};
 pub struct FileFinderSettings {
     pub file_icons: bool,
     pub modal_max_width: Option<FileFinderWidth>,
+    pub focus_skip_active_file: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -19,6 +20,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: small
     pub modal_max_width: Option<FileFinderWidth>,
+    /// Determines if the auto-focus will skip the active file when it is the first found file
+    ///
+    /// Default: true
+    pub focus_skip_active_file: Option<bool>,
 }
 
 impl Settings for FileFinderSettings {

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -7,7 +7,7 @@ use settings::{Settings, SettingsSources};
 pub struct FileFinderSettings {
     pub file_icons: bool,
     pub modal_max_width: Option<FileFinderWidth>,
-    pub focus_skip_active_file: bool,
+    pub auto_select: FileFinderAutoSelect,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -20,10 +20,11 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: small
     pub modal_max_width: Option<FileFinderWidth>,
-    /// Determines if the auto-focus will skip the active file when it is the first found file
+    /// Determines which found file will be automatically selected
+    /// skip_active will select the second file if the first is the active buffer
     ///
-    /// Default: true
-    pub focus_skip_active_file: Option<bool>,
+    /// Default: skip_active
+    pub auto_select: Option<FileFinderAutoSelect>,
 }
 
 impl Settings for FileFinderSettings {
@@ -45,4 +46,12 @@ pub enum FileFinderWidth {
     Large,
     XLarge,
     Full,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FileFinderAutoSelect {
+    #[default]
+    SkipActive,
+    First,
 }

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1368,7 +1368,7 @@ async fn test_setting_auto_select_first_and_select_active_file(cx: &mut TestAppC
 
         FileFinderSettings::override_global(
             FileFinderSettings {
-                auto_select: FileFinderAutoSelect::First,
+                skip_focus_for_active_in_search: false,
                 ..settings
             },
             cx,

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1360,7 +1360,7 @@ async fn test_keep_opened_file_on_top_of_search_results_and_select_next_one(
 }
 
 #[gpui::test]
-async fn test_setting_focus_skip_active_file_false_and_select_active_file(cx: &mut TestAppContext) {
+async fn test_setting_auto_select_first_and_select_active_file(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
 
     cx.update(|cx| {
@@ -1368,7 +1368,7 @@ async fn test_setting_focus_skip_active_file_false_and_select_active_file(cx: &m
 
         FileFinderSettings::override_global(
             FileFinderSettings {
-                focus_skip_active_file: false,
+                auto_select: FileFinderAutoSelect::First,
                 ..settings
             },
             cx,

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -1360,6 +1360,73 @@ async fn test_keep_opened_file_on_top_of_search_results_and_select_next_one(
 }
 
 #[gpui::test]
+async fn test_setting_focus_skip_active_file_false_and_select_active_file(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+
+    cx.update(|cx| {
+        let settings = *FileFinderSettings::get_global(cx);
+
+        FileFinderSettings::override_global(
+            FileFinderSettings {
+                focus_skip_active_file: false,
+                ..settings
+            },
+            cx,
+        );
+    });
+
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/src"),
+            json!({
+                "test": {
+                    "bar.rs": "// Bar file",
+                    "lib.rs": "// Lib file",
+                    "maaa.rs": "// Maaaaaaa",
+                    "main.rs": "// Main file",
+                    "moo.rs": "// Moooooo",
+                }
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/src").as_ref()], cx).await;
+    let (workspace, cx) = cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
+
+    open_close_queried_buffer("bar", 1, "bar.rs", &workspace, cx).await;
+    open_close_queried_buffer("lib", 1, "lib.rs", &workspace, cx).await;
+    open_queried_buffer("main", 1, "main.rs", &workspace, cx).await;
+
+    // main.rs is on top, previously used is selected
+    let picker = open_file_picker(&workspace, cx);
+    picker.update(cx, |finder, _| {
+        assert_eq!(finder.delegate.matches.len(), 3);
+        assert_match_selection(finder, 0, "main.rs");
+        assert_match_at_position(finder, 1, "lib.rs");
+        assert_match_at_position(finder, 2, "bar.rs");
+    });
+
+    // all files match, main.rs is on top, and is selected
+    picker
+        .update_in(cx, |finder, window, cx| {
+            finder
+                .delegate
+                .update_matches(".rs".to_string(), window, cx)
+        })
+        .await;
+    picker.update(cx, |finder, _| {
+        assert_eq!(finder.delegate.matches.len(), 5);
+        assert_match_selection(finder, 0, "main.rs");
+        assert_match_at_position(finder, 1, "bar.rs");
+        assert_match_at_position(finder, 2, "lib.rs");
+        assert_match_at_position(finder, 3, "moo.rs");
+        assert_match_at_position(finder, 4, "maaa.rs");
+    });
+}
+
+#[gpui::test]
 async fn test_non_separate_history_items(cx: &mut TestAppContext) {
     let app_state = init_test(cx);
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1913,11 +1913,23 @@ Or to set a `socks5` proxy:
 
 ## File Finder
 
+### File Icons
+
+- Description: Whether to show file icons in the file finder.
+- Setting: `file_icons`
+- Default: `true`
+
 ### Modal Max Width
 
 - Description: Max-width of the file finder modal. It can take one of these values: `small`, `medium`, `large`, `xlarge`, and `full`.
 - Setting: `modal_max_width`
 - Default: `small`
+
+### Auto Select
+
+- Description: Determines the initial selection behavior when opening the file finder. It can take one of two values: `skip_active` and`first`.
+- Setting: `auto_select`
+- Default: `skip_active`
 
 ## Preferred Line Length
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1925,11 +1925,11 @@ Or to set a `socks5` proxy:
 - Setting: `modal_max_width`
 - Default: `small`
 
-### Auto Select
+### Skip Focus For Active In Search
 
-- Description: Determines the initial selection behavior when opening the file finder. It can take one of two values: `skip_active` and`first`.
-- Setting: `auto_select`
-- Default: `skip_active`
+- Description: Determines whether the file finder should skip focus for the active file in search results.
+- Setting: `skip_focus_for_active_in_search`
+- Default: `true`
 
 ## Preferred Line Length
 


### PR DESCRIPTION
Closes #27073

Currently, when searching for a file with Ctrl+P, and the first file found is the active one, file_finder skips focus to the second file automatically. This PR adds a setting to disable this and make the first file always the focused one.

Default setting is still skipping the active file.

Release Notes: 

- Added the `skip_focus_for_active_in_search` setting for the file finder, which allows turning off the default behavior of skipping focus on the active file while searching in the file finder.