### PR TITLE
git: Display author not committer in git popover

### DIFF
--- a/crates/editor/src/commit_tooltip.rs
+++ b/crates/editor/src/commit_tooltip.rs
@@ -20,8 +20,8 @@ use crate::hover_popover::hover_markdown_style;
 #[derive(Clone, Debug)]
 pub struct CommitDetails {
     pub sha: SharedString,
-    pub committer_name: SharedString,
-    pub committer_email: SharedString,
+    pub author_name: SharedString,
+    pub author_email: SharedString,
     pub commit_time: OffsetDateTime,
     pub message: Option<ParsedCommitMessage>,
 }
@@ -133,16 +133,12 @@ impl CommitTooltip {
             CommitDetails {
                 sha: blame.sha.to_string().into(),
                 commit_time,
-                committer_name: blame
-                    .committer_name
+                author_name: blame
+                    .author
                     .clone()
                     .unwrap_or("<no name>".to_string())
                     .into(),
-                committer_email: blame
-                    .committer_email
-                    .clone()
-                    .unwrap_or("".to_string())
-                    .into(),
+                author_email: blame.author_mail.clone().unwrap_or("".to_string()).into(),
                 message: details,
             },
             window,
@@ -180,9 +176,9 @@ impl Render for CommitTooltip {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let avatar = CommitAvatar::new(&self.commit).render(window, cx);
 
-        let author = self.commit.committer_name.clone();
+        let author = self.commit.author_name.clone();
 
-        let author_email = self.commit.committer_email.clone();
+        let author_email = self.commit.author_email.clone();
 
         let short_commit_id = self
             .commit

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3951,8 +3951,8 @@ impl GitPanelMessageTooltip {
 
                 let commit_details = editor::commit_tooltip::CommitDetails {
                     sha: details.sha.clone(),
-                    committer_name: details.committer_name.clone(),
-                    committer_email: details.committer_email.clone(),
+                    author_name: details.committer_name.clone(),
+                    author_email: details.committer_email.clone(),
                     commit_time: OffsetDateTime::from_unix_timestamp(details.commit_timestamp)?,
                     message: Some(editor::commit_tooltip::ParsedCommitMessage {
                         message: details.message.clone(),


### PR DESCRIPTION
Display Author name/email instead of Committer name/email in git popover.

Closes https://github.com/zed-industries/zed/issues/27625

| Zed Nightly 0.181.0 (Before) | After |
| - | - |
|  <img width="309" alt="Image" src="https://github.com/user-attachments/assets/caacc56c-085b-4c79-8cd2-318eae9da567" /> | <img width="316" alt="Screenshot 2025-03-27 at 16 06 48" src="https://github.com/user-attachments/assets/2b8a845e-a824-42f7-a8a6-4ac5e139b7df" /> |

Prior to v0.173.x, Zed displayed Author name. Regression introduced in:
- https://github.com/zed-industries/zed/pull/24593

Release Notes:

- git: Switch to displaying Git author instead of Git committer in Git Blame popover.