### PR TITLE
project: Fix LSP completion to use `insertText` when constructing default edits

### DIFF
--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2092,11 +2092,16 @@ impl LspCommand for GetCompletions {
             completions.retain(|lsp_completion| {
                 let lsp_edit = lsp_completion.text_edit.clone().or_else(|| {
                     let default_text_edit = lsp_defaults.as_deref()?.edit_range.as_ref()?;
+                    let new_text = lsp_completion
+                        .insert_text
+                        .as_ref()
+                        .unwrap_or(&lsp_completion.label)
+                        .clone();
                     match default_text_edit {
                         CompletionListItemDefaultsEditRange::Range(range) => {
                             Some(lsp::CompletionTextEdit::Edit(lsp::TextEdit {
                                 range: *range,
-                                new_text: lsp_completion.label.clone(),
+                                new_text,
                             }))
                         }
                         CompletionListItemDefaultsEditRange::InsertAndReplace {
@@ -2104,7 +2109,7 @@ impl LspCommand for GetCompletions {
                             replace,
                         } => Some(lsp::CompletionTextEdit::InsertAndReplace(
                             lsp::InsertReplaceEdit {
-                                new_text: lsp_completion.label.clone(),
+                                new_text,
                                 insert: *insert,
                                 replace: *replace,
                             },
@@ -2167,6 +2172,7 @@ impl LspCommand for GetCompletions {
                                 .clone()
                         };
 
+                        // We already know text_edit is None here
                         let text = lsp_completion
                             .insert_text
                             .as_ref()


### PR DESCRIPTION
Closes #25761 #21603

When `text_edit` is not available we directly fallback to to `label`. That means, when we have range to replace, we never use `insertText` and only use it when we haven't found any range.

This PR fixes, this and uses `insertText` as fallback first, and then `label`.

Release Notes:

- Fixed an issue where accepting LSP snippet completion would insert the label instead of expanding the snippet.