### PR TITLE
context_server: Only look for context server project settings in visible worktrees

### DIFF
--- a/crates/context_server/src/manager.rs
+++ b/crates/context_server/src/manager.rs
@@ -247,12 +247,15 @@ impl ContextServerManager {
         let mut desired_servers = HashMap::default();
 
         let (registry, project) = this.update(cx, |this, cx| {
-            let location = this.project.read(cx).worktrees(cx).next().map(|worktree| {
-                settings::SettingsLocation {
+            let location = this
+                .project
+                .read(cx)
+                .visible_worktrees(cx)
+                .next()
+                .map(|worktree| settings::SettingsLocation {
                     worktree_id: worktree.read(cx).id(),
                     path: Path::new(""),
-                }
-            });
+                });
             let settings = ContextServerSettings::get(location, cx);
             desired_servers = settings.context_servers.clone();
 


### PR DESCRIPTION
This PR fixes an issue where we were looking for context server project settings in _all_ worktrees, not just visible ones.

This meant that if you had a single file worktree open (e.g., `settings.json`) this could impact whether context servers defined in project settings would load.

Release Notes:

- Fixed an issue where context servers defined in project settings would not be respected in some scenarios.
