### PR TITLE
assistant2: Fix tool picker appearance inside modal

### DIFF
--- a/crates/assistant2/src/assistant_configuration/tool_picker.rs
+++ b/crates/assistant2/src/assistant_configuration/tool_picker.rs
@@ -19,7 +19,7 @@ pub struct ToolPicker {
 
 impl ToolPicker {
     pub fn new(delegate: ToolPickerDelegate, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx).modal(false));
         Self { picker }
     }
 }


### PR DESCRIPTION
This PR fixes the tool picker appearance now that there is a header.

Release Notes:

- N/A
