### PR TITLE
storybook: Fix `auto_height_editor` story

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13234,6 +13234,7 @@ dependencies = [
  "theme",
  "title_bar",
  "ui",
+ "workspace",
 ]
 
 [[package]]

--- a/crates/storybook/Cargo.toml
+++ b/crates/storybook/Cargo.toml
@@ -27,6 +27,7 @@ log.workspace = true
 menu.workspace = true
 picker.workspace = true
 project.workspace = true
+reqwest_client.workspace = true
 rust-embed.workspace = true
 settings.workspace = true
 simplelog.workspace = true
@@ -35,7 +36,7 @@ strum = { workspace = true, features = ["derive"] }
 theme.workspace = true
 title_bar = { workspace = true, features = ["stories"] }
 ui = { workspace = true, features = ["stories"] }
-reqwest_client.workspace = true
+workspace.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/storybook/src/storybook.rs
+++ b/crates/storybook/src/storybook.rs
@@ -19,6 +19,7 @@ use simplelog::SimpleLogger;
 use strum::IntoEnumIterator;
 use theme::{ThemeRegistry, ThemeSettings};
 use ui::prelude::*;
+use workspace;
 
 use crate::app_menus::app_menus;
 use crate::assets::Assets;
@@ -83,6 +84,7 @@ fn main() {
         language::init(cx);
         editor::init(cx);
         Project::init_settings(cx);
+        workspace::init_settings(cx);
         init(cx);
         load_storybook_keymap(cx);
         cx.set_menus(app_menus());


### PR DESCRIPTION
This is a fix for this error when trying to run `auto_height_editor` story:

```sh
thread 'main' panicked at C:\Users\x\dev\zed\crates\settings\src\settings_store.rs:363:32:
unregistered setting type workspace::workspace_settings::WorkspaceSettings
```

Release Notes:

- N/A
