### PR TITLE
docs: Fix `#windows` Discord channel name

### DIFF
--- a/docs/src/windows.md
+++ b/docs/src/windows.md
@@ -11,4 +11,4 @@ We are currently hiring a [Windows Lead](https://zed.dev/jobs/windows-lead).
 For now, we welcome contributions from the community to improve Windows support.
 
 - [GitHub Issues with 'Windows' label](https://github.com/zed-industries/zed/issues?q=is%3Aissue+is%3Aopen+label%3Awindows)
-- [Zed Community Discord](https://zed.dev/community-links) -> `#windows-port`
+- [Zed Community Discord](https://zed.dev/community-links) -> `#windows`


### PR DESCRIPTION
This PR fixes the name of the `#windows` Discord channel to match what the channel is actually called.

Release Notes:

- N/A
