### PR TITLE
Show tool name for Unknown tool

### DIFF
--- a/crates/assistant2/src/tool_use.rs
+++ b/crates/assistant2/src/tool_use.rs
@@ -209,7 +209,7 @@ impl ToolUseState {
         if let Some(tool) = self.tools.tool(tool_name, cx) {
             tool.ui_text(input).into()
         } else {
-            "Unknown tool".into()
+            format!("Unknown tool {tool_name:?}").into()
         }
     }
 


### PR DESCRIPTION
Right now we can't see what tool name the model was trying to run.

Release Notes:

- N/A
