### PR TITLE
editor: Hide mouse cursor also for movements and selections

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -155,8 +155,8 @@
   //
   // Default: not set, defaults to "bar"
   "cursor_shape": null,
-  // Determines whether the mouse cursor is hidden when typing in an editor or input box.
-  "hide_mouse_while_typing": true,
+  // Determines when the mouse cursor should be hidden in an editor or input box.
+  "hide_mouse_cursor_mode": "on_typing_and_movement",
   // How to highlight the current line in the editor.
   //
   // 1. Don't highlight the current line:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -156,7 +156,7 @@
   // Default: not set, defaults to "bar"
   "cursor_shape": null,
   // Determines when the mouse cursor should be hidden in an editor or input box.
-  "hide_mouse_cursor_mode": "on_typing_and_movement",
+  "hide_mouse": "on_typing_and_movement",
   // How to highlight the current line in the editor.
   //
   // 1. Don't highlight the current line:

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1702,10 +1702,7 @@ impl Editor {
         key_context
     }
 
-    pub fn hide_mouse_cursor(&mut self, origin: &HideMouseCursorOrigin, cx: &mut App) {
-        if self.read_only(cx) {
-            return;
-        }
+    pub fn hide_mouse_cursor(&mut self, origin: &HideMouseCursorOrigin) {
         self.mouse_cursor_hidden = match origin {
             HideMouseCursorOrigin::TypingAction => {
                 matches!(
@@ -3028,7 +3025,7 @@ impl Editor {
             return;
         }
 
-        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction, cx);
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
 
         let selections = self.selections.all_adjusted(cx);
         let mut bracket_inserted = false;
@@ -3434,6 +3431,7 @@ impl Editor {
     }
 
     pub fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             let (edits, selection_fixup_info): (Vec<_>, Vec<_>) = {
                 let selections = this.selections.all::<usize>(cx);
@@ -3549,6 +3547,8 @@ impl Editor {
     }
 
     pub fn newline_above(&mut self, _: &NewlineAbove, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
 
@@ -3606,6 +3606,8 @@ impl Editor {
     }
 
     pub fn newline_below(&mut self, _: &NewlineBelow, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
 
@@ -4467,6 +4469,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.do_completion(action.item_ix, CompletionIntent::Complete, window, cx)
     }
 
@@ -4476,6 +4479,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.do_completion(action.item_ix, CompletionIntent::Compose, window, cx)
     }
 
@@ -4819,6 +4823,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let actions_menu =
             if let CodeContextMenu::CodeActions(menu) = self.hide_context_menu(window, cx)? {
                 menu
@@ -7778,6 +7784,7 @@ impl Editor {
     }
 
     pub fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.select_autoclose_pair(window, cx);
             let mut linked_ranges = HashMap::<_, Vec<_>>::default();
@@ -7876,6 +7883,7 @@ impl Editor {
     }
 
     pub fn delete(&mut self, _: &Delete, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
                 let line_mode = s.line_mode;
@@ -7894,6 +7902,7 @@ impl Editor {
     }
 
     pub fn backtab(&mut self, _: &Backtab, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         if self.move_to_prev_snippet_tabstop(window, cx) {
             return;
         }
@@ -7901,9 +7910,14 @@ impl Editor {
     }
 
     pub fn tab(&mut self, _: &Tab, window: &mut Window, cx: &mut Context<Self>) {
-        if self.move_to_next_snippet_tabstop(window, cx) || self.read_only(cx) {
+        if self.move_to_next_snippet_tabstop(window, cx) {
+            self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
             return;
         }
+        if self.read_only(cx) {
+            return;
+        }
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let mut selections = self.selections.all_adjusted(cx);
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
@@ -7984,6 +7998,7 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let mut selections = self.selections.all::<Point>(cx);
         let mut prev_edited_row = 0;
         let mut row_delta = 0;
@@ -8088,6 +8103,7 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(cx);
         let mut deletion_ranges = Vec::new();
@@ -8161,6 +8177,7 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let selections = self
             .selections
             .all::<usize>(cx)
@@ -8179,6 +8196,7 @@ impl Editor {
     }
 
     pub fn delete_line(&mut self, _: &DeleteLine, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let selections = self.selections.all::<Point>(cx);
 
@@ -8327,6 +8345,7 @@ impl Editor {
     }
 
     pub fn join_lines(&mut self, _: &JoinLines, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.join_lines_impl(true, window, cx);
     }
 
@@ -8388,6 +8407,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let mut buffer_ids = HashSet::default();
         let snapshot = self.buffer().read(cx).snapshot(cx);
         for selection in self.selections.all::<usize>(cx) {
@@ -8404,6 +8424,7 @@ impl Editor {
     }
 
     pub fn git_restore(&mut self, _: &Restore, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let selections = self
             .selections
             .all(cx)
@@ -8786,6 +8807,8 @@ impl Editor {
     ) where
         Fn: FnMut(&mut Vec<&str>),
     {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).snapshot(cx);
 
@@ -9024,6 +9047,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = &display_map.buffer_snapshot;
         let selections = self.selections.all::<Point>(cx);
@@ -9108,6 +9133,8 @@ impl Editor {
     }
 
     pub fn move_line_up(&mut self, _: &MoveLineUp, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).snapshot(cx);
 
@@ -9213,6 +9240,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).snapshot(cx);
 
@@ -9303,6 +9332,7 @@ impl Editor {
     }
 
     pub fn transpose(&mut self, _: &Transpose, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let text_layout_details = &self.text_layout_details(window);
         self.transact(window, cx, |this, window, cx| {
             let edits = this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
@@ -9361,6 +9391,7 @@ impl Editor {
     }
 
     pub fn rewrap(&mut self, _: &Rewrap, _: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.rewrap_impl(RewrapOptions::default(), cx)
     }
 
@@ -9576,11 +9607,13 @@ impl Editor {
     }
 
     pub fn cut(&mut self, _: &Cut, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let item = self.cut_common(window, cx);
         cx.write_to_clipboard(item);
     }
 
     pub fn kill_ring_cut(&mut self, _: &KillRingCut, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.change_selections(None, window, cx, |s| {
             s.move_with(|snapshot, sel| {
                 if sel.is_empty() {
@@ -9598,6 +9631,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let (text, metadata) = if let Some(KillRing(item)) = cx.try_global() {
             if let Some(ClipboardEntry::String(kill_ring)) = item.entries().first() {
                 (kill_ring.text().to_string(), kill_ring.metadata_json())
@@ -9786,6 +9820,7 @@ impl Editor {
     }
 
     pub fn paste(&mut self, _: &Paste, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         if let Some(item) = cx.read_from_clipboard() {
             let entries = item.entries();
 
@@ -9809,6 +9844,8 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
 
         if let Some(transaction_id) = self.buffer.update(cx, |buffer, cx| buffer.undo(cx)) {
             if let Some((selections, _)) =
@@ -9837,6 +9874,8 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
 
         if let Some(transaction_id) = self.buffer.update(cx, |buffer, cx| buffer.redo(cx)) {
             if let Some((_, Some(selections))) =
@@ -9871,6 +9910,7 @@ impl Editor {
     }
 
     pub fn move_left(&mut self, _: &MoveLeft, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             let line_mode = s.line_mode;
             s.move_with(|map, selection| {
@@ -9885,12 +9925,14 @@ impl Editor {
     }
 
     pub fn select_left(&mut self, _: &SelectLeft, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| (movement::left(map, head), SelectionGoal::None));
         })
     }
 
     pub fn move_right(&mut self, _: &MoveRight, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             let line_mode = s.line_mode;
             s.move_with(|map, selection| {
@@ -9905,6 +9947,7 @@ impl Editor {
     }
 
     pub fn select_right(&mut self, _: &SelectRight, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| (movement::right(map, head), SelectionGoal::None));
         })
@@ -9919,6 +9962,8 @@ impl Editor {
             cx.propagate();
             return;
         }
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
 
         let text_layout_details = &self.text_layout_details(window);
         let selection_count = self.selections.count();
@@ -9962,6 +10007,8 @@ impl Editor {
             return;
         }
 
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         let text_layout_details = &self.text_layout_details(window);
 
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
@@ -9998,6 +10045,8 @@ impl Editor {
             return;
         }
 
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         let text_layout_details = &self.text_layout_details(window);
 
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
@@ -10025,6 +10074,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let text_layout_details = &self.text_layout_details(window);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, goal| {
@@ -10039,6 +10089,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let text_layout_details = &self.text_layout_details(window);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, goal| {
@@ -10056,6 +10107,8 @@ impl Editor {
         let Some(row_count) = self.visible_row_count() else {
             return;
         };
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
 
         let text_layout_details = &self.text_layout_details(window);
 
@@ -10095,6 +10148,8 @@ impl Editor {
             return;
         };
 
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         let autoscroll = if action.center_cursor {
             Autoscroll::center()
         } else {
@@ -10123,6 +10178,7 @@ impl Editor {
     }
 
     pub fn select_up(&mut self, _: &SelectUp, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let text_layout_details = &self.text_layout_details(window);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, goal| {
@@ -10138,6 +10194,8 @@ impl Editor {
             cx.propagate();
             return;
         }
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
 
         let text_layout_details = &self.text_layout_details(window);
         let selection_count = self.selections.count();
@@ -10175,6 +10233,8 @@ impl Editor {
         let Some(row_count) = self.visible_row_count() else {
             return;
         };
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
 
         let text_layout_details = &self.text_layout_details(window);
 
@@ -10214,6 +10274,8 @@ impl Editor {
             return;
         };
 
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         let autoscroll = if action.center_cursor {
             Autoscroll::center()
         } else {
@@ -10241,6 +10303,7 @@ impl Editor {
     }
 
     pub fn select_down(&mut self, _: &SelectDown, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let text_layout_details = &self.text_layout_details(window);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, goal| {
@@ -10299,6 +10362,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
@@ -10315,6 +10379,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
@@ -10331,6 +10396,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10347,6 +10413,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10363,6 +10430,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.select_autoclose_pair(window, cx);
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
@@ -10388,6 +10456,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.select_autoclose_pair(window, cx);
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
@@ -10409,6 +10478,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (movement::next_word_end(map, head), SelectionGoal::None)
@@ -10422,6 +10492,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (movement::next_subword_end(map, head), SelectionGoal::None)
@@ -10435,6 +10506,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (movement::next_word_end(map, head), SelectionGoal::None)
@@ -10448,6 +10520,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (movement::next_subword_end(map, head), SelectionGoal::None)
@@ -10461,6 +10534,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
                 let line_mode = s.line_mode;
@@ -10485,6 +10559,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
                 s.move_with(|map, selection| {
@@ -10504,6 +10579,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
@@ -10525,6 +10601,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10546,6 +10623,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
                 s.move_with(|_, selection| {
@@ -10571,6 +10649,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_cursors_with(|map, head, _| {
                 (
@@ -10587,6 +10666,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10603,6 +10683,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.select_to_end_of_line(
                 &SelectToEndOfLine {
@@ -10621,6 +10702,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             this.select_to_end_of_line(
                 &SelectToEndOfLine {
@@ -10643,7 +10725,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_with(|map, selection| {
                 selection.collapse_to(
@@ -10664,7 +10746,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_with(|map, selection| {
                 selection.collapse_to(
@@ -10685,7 +10767,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10706,7 +10788,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10727,7 +10809,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_with(|map, selection| {
                 selection.collapse_to(
@@ -10777,7 +10859,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_with(|map, selection| {
                 selection.collapse_to(
@@ -10802,7 +10884,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_with(|map, selection| {
                 selection.collapse_to(
@@ -10827,7 +10909,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10848,7 +10930,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10869,7 +10951,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10890,7 +10972,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
                 (
@@ -10911,7 +10993,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.select_ranges(vec![0..0]);
         });
@@ -10925,7 +11007,7 @@ impl Editor {
     ) {
         let mut selection = self.selections.last::<Point>(cx);
         selection.set_head(Point::zero(), SelectionGoal::None);
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.select(vec![selection]);
         });
@@ -10936,7 +11018,7 @@ impl Editor {
             cx.propagate();
             return;
         }
-
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let cursor = self.buffer.read(cx).read(cx).len();
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.select_ranges(vec![cursor..cursor])
@@ -10993,6 +11075,7 @@ impl Editor {
     }
 
     pub fn select_to_end(&mut self, _: &SelectToEnd, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let buffer = self.buffer.read(cx).snapshot(cx);
         let mut selection = self.selections.first::<usize>(cx);
         selection.set_head(buffer.len(), SelectionGoal::None);
@@ -11002,6 +11085,7 @@ impl Editor {
     }
 
     pub fn select_all(&mut self, _: &SelectAll, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let end = self.buffer.read(cx).read(cx).len();
         self.change_selections(None, window, cx, |s| {
             s.select_ranges(vec![0..end]);
@@ -11009,6 +11093,7 @@ impl Editor {
     }
 
     pub fn select_line(&mut self, _: &SelectLine, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let mut selections = self.selections.all::<Point>(cx);
         let max_point = display_map.buffer_snapshot.max_point();
@@ -11079,6 +11164,8 @@ impl Editor {
     }
 
     fn add_selection(&mut self, above: bool, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let mut selections = self.selections.all::<Point>(cx);
         let text_layout_details = self.text_layout_details(window);
@@ -11359,6 +11446,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         self.push_to_selection_history();
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
 
@@ -11444,6 +11533,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.push_to_selection_history();
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         self.select_next_match_internal(
@@ -11462,6 +11552,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Result<()> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.push_to_selection_history();
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = &display_map.buffer_snapshot;
@@ -11608,6 +11699,7 @@ impl Editor {
         if self.read_only(cx) {
             return;
         }
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let text_layout_details = &self.text_layout_details(window);
         self.transact(window, cx, |this, window, cx| {
             let mut selections = this.selections.all::<MultiBufferPoint>(cx);
@@ -11907,6 +11999,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
+
         let buffer = self.buffer.read(cx).snapshot(cx);
         let old_selections = self.selections.all::<usize>(cx).into_boxed_slice();
 
@@ -11967,6 +12061,8 @@ impl Editor {
         if old_selections.is_empty() {
             return;
         }
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
 
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
         let buffer = self.buffer.read(cx).snapshot(cx);
@@ -12075,6 +12171,8 @@ impl Editor {
         let Some(visible_row_count) = self.visible_row_count() else {
             return;
         };
+
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
 
         if let Some((mut selections, scroll_behavior, is_selection_reversed)) =
             self.select_syntax_node_history.pop()
@@ -12269,6 +12367,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
             s.move_offsets_with(|snapshot, selection| {
                 let Some(enclosing_bracket_ranges) =
@@ -12329,6 +12428,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.end_selection(window, cx);
         self.selection_history.mode = SelectionHistoryMode::Undoing;
         if let Some(entry) = self.selection_history.undo_stack.pop_back() {
@@ -12349,6 +12449,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.end_selection(window, cx);
         self.selection_history.mode = SelectionHistoryMode::Redoing;
         if let Some(entry) = self.selection_history.redo_stack.pop_back() {
@@ -12471,6 +12572,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.go_to_diagnostic_impl(Direction::Next, window, cx)
     }
 
@@ -12480,6 +12582,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.go_to_diagnostic_impl(Direction::Prev, window, cx)
     }
 
@@ -12626,6 +12729,7 @@ impl Editor {
     }
 
     fn go_to_next_hunk(&mut self, _: &GoToHunk, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let snapshot = self.snapshot(window, cx);
         let selection = self.selections.newest::<Point>(cx);
         self.go_to_hunk_before_or_after_position(
@@ -12686,6 +12790,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         let snapshot = self.snapshot(window, cx);
         let selection = self.selections.newest::<Point>(cx);
         self.go_to_hunk_before_or_after_position(
@@ -13170,6 +13275,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<Navigated>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let selection = self.selections.newest::<usize>(cx);
         let multi_buffer = self.buffer.read(cx);
         let head = selection.head();
@@ -13644,6 +13751,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let project = match &self.project {
             Some(project) => project.clone(),
             None => return None,
@@ -13664,6 +13773,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let project = match &self.project {
             Some(project) => project.clone(),
             None => return None,
@@ -13761,6 +13872,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let project = match &self.project {
             Some(project) => project.clone(),
             None => return None,
@@ -14996,6 +15108,8 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
+
         let buffers = self.buffer.read(cx).all_buffers();
         for branch_buffer in buffers {
             branch_buffer.update(cx, |branch_buffer, cx| {
@@ -15014,6 +15128,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         let snapshot = self.snapshot(window, cx);
         let hunks = snapshot.hunks_for_ranges(self.selections.ranges(cx));
         let mut ranges_by_buffer = HashMap::default();
@@ -15887,6 +16002,7 @@ impl Editor {
     }
 
     fn insert_uuid(&mut self, version: UuidVersion, window: &mut Window, cx: &mut Context<Self>) {
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
             let edits = this
                 .selections

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -62,7 +62,8 @@ use display_map::*;
 pub use display_map::{DisplayPoint, FoldPlaceholder};
 use editor_settings::GoToDefinitionFallback;
 pub use editor_settings::{
-    CurrentLineHighlight, EditorSettings, ScrollBeyondLastLine, SearchSettings, ShowScrollbar,
+    CurrentLineHighlight, EditorSettings, HideMouseCursorMode, ScrollBeyondLastLine,
+    SearchSettings, ShowScrollbar,
 };
 pub use editor_settings_controls::*;
 use element::{layout_line, AcceptEditPredictionBinding, LineWithInvisibles, PositionMap};
@@ -277,6 +278,11 @@ enum DisplayDiffHunk {
         multi_buffer_range: Range<Anchor>,
         status: DiffHunkStatus,
     },
+}
+
+pub enum HideMouseCursorOrigin {
+    TypingAction,
+    MovementAction,
 }
 
 pub fn init_settings(cx: &mut App) {
@@ -791,7 +797,7 @@ pub struct Editor {
     serialize_selections: Task<()>,
     serialize_folds: Task<()>,
     mouse_cursor_hidden: bool,
-    hide_mouse_while_typing: bool,
+    hide_mouse_cursor_mode: HideMouseCursorMode,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
@@ -1571,9 +1577,9 @@ impl Editor {
             text_style_refinement: None,
             load_diff_task: load_uncommitted_diff,
             mouse_cursor_hidden: false,
-            hide_mouse_while_typing: EditorSettings::get_global(cx)
-                .hide_mouse_while_typing
-                .unwrap_or(true),
+            hide_mouse_cursor_mode: EditorSettings::get_global(cx)
+                .hide_mouse_cursor_mode
+                .unwrap_or_default(),
         };
         if let Some(breakpoints) = this.breakpoint_store.as_ref() {
             this._subscriptions
@@ -1694,6 +1700,26 @@ impl Editor {
         }
 
         key_context
+    }
+
+    pub fn hide_mouse_cursor(&mut self, origin: &HideMouseCursorOrigin, cx: &mut App) {
+        if self.read_only(cx) {
+            return;
+        }
+        self.mouse_cursor_hidden = match origin {
+            HideMouseCursorOrigin::TypingAction => {
+                matches!(
+                    self.hide_mouse_cursor_mode,
+                    HideMouseCursorMode::OnTyping | HideMouseCursorMode::OnTypingAndMovement
+                )
+            }
+            HideMouseCursorOrigin::MovementAction => {
+                matches!(
+                    self.hide_mouse_cursor_mode,
+                    HideMouseCursorMode::OnTypingAndMovement
+                )
+            }
+        };
     }
 
     pub fn edit_prediction_in_conflict(&self) -> bool {
@@ -3005,7 +3031,7 @@ impl Editor {
             return;
         }
 
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
+        self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction, cx);
 
         let selections = self.selections.all_adjusted(cx);
         let mut bracket_inserted = false;
@@ -3411,7 +3437,6 @@ impl Editor {
     }
 
     pub fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
         self.transact(window, cx, |this, window, cx| {
             let (edits, selection_fixup_info): (Vec<_>, Vec<_>) = {
                 let selections = this.selections.all::<usize>(cx);
@@ -3527,8 +3552,6 @@ impl Editor {
     }
 
     pub fn newline_above(&mut self, _: &NewlineAbove, window: &mut Window, cx: &mut Context<Self>) {
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
-
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
 
@@ -3586,8 +3609,6 @@ impl Editor {
     }
 
     pub fn newline_below(&mut self, _: &NewlineBelow, window: &mut Window, cx: &mut Context<Self>) {
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
-
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
 
@@ -7760,7 +7781,6 @@ impl Editor {
     }
 
     pub fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
         self.transact(window, cx, |this, window, cx| {
             this.select_autoclose_pair(window, cx);
             let mut linked_ranges = HashMap::<_, Vec<_>>::default();
@@ -7859,7 +7879,6 @@ impl Editor {
     }
 
     pub fn delete(&mut self, _: &Delete, window: &mut Window, cx: &mut Context<Self>) {
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
         self.transact(window, cx, |this, window, cx| {
             this.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
                 let line_mode = s.line_mode;
@@ -7881,7 +7900,6 @@ impl Editor {
         if self.move_to_prev_snippet_tabstop(window, cx) {
             return;
         }
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
         self.outdent(&Outdent, window, cx);
     }
 
@@ -7889,7 +7907,6 @@ impl Editor {
         if self.move_to_next_snippet_tabstop(window, cx) || self.read_only(cx) {
             return;
         }
-        self.mouse_cursor_hidden = self.hide_mouse_while_typing;
         let mut selections = self.selections.all_adjusted(cx);
         let buffer = self.buffer.read(cx);
         let snapshot = buffer.snapshot(cx);
@@ -16666,11 +16683,8 @@ impl Editor {
             self.scroll_manager.vertical_scroll_margin = editor_settings.vertical_scroll_margin;
             self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
             self.cursor_shape = editor_settings.cursor_shape.unwrap_or_default();
-            self.hide_mouse_while_typing = editor_settings.hide_mouse_while_typing.unwrap_or(true);
-
-            if !self.hide_mouse_while_typing {
-                self.mouse_cursor_hidden = false;
-            }
+            self.hide_mouse_cursor_mode =
+                editor_settings.hide_mouse_cursor_mode.unwrap_or_default();
         }
 
         if old_cursor_shape != self.cursor_shape {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -62,8 +62,8 @@ use display_map::*;
 pub use display_map::{DisplayPoint, FoldPlaceholder};
 use editor_settings::GoToDefinitionFallback;
 pub use editor_settings::{
-    CurrentLineHighlight, EditorSettings, HideMouseCursorMode, ScrollBeyondLastLine,
-    SearchSettings, ShowScrollbar,
+    CurrentLineHighlight, EditorSettings, HideMouseMode, ScrollBeyondLastLine, SearchSettings,
+    ShowScrollbar,
 };
 pub use editor_settings_controls::*;
 use element::{layout_line, AcceptEditPredictionBinding, LineWithInvisibles, PositionMap};
@@ -797,7 +797,7 @@ pub struct Editor {
     serialize_selections: Task<()>,
     serialize_folds: Task<()>,
     mouse_cursor_hidden: bool,
-    hide_mouse_cursor_mode: HideMouseCursorMode,
+    hide_mouse: HideMouseMode,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
@@ -1577,8 +1577,8 @@ impl Editor {
             text_style_refinement: None,
             load_diff_task: load_uncommitted_diff,
             mouse_cursor_hidden: false,
-            hide_mouse_cursor_mode: EditorSettings::get_global(cx)
-                .hide_mouse_cursor_mode
+            hide_mouse: EditorSettings::get_global(cx)
+                .hide_mouse
                 .unwrap_or_default(),
         };
         if let Some(breakpoints) = this.breakpoint_store.as_ref() {
@@ -1709,15 +1709,12 @@ impl Editor {
         self.mouse_cursor_hidden = match origin {
             HideMouseCursorOrigin::TypingAction => {
                 matches!(
-                    self.hide_mouse_cursor_mode,
-                    HideMouseCursorMode::OnTyping | HideMouseCursorMode::OnTypingAndMovement
+                    self.hide_mouse,
+                    HideMouseMode::OnTyping | HideMouseMode::OnTypingAndMovement
                 )
             }
             HideMouseCursorOrigin::MovementAction => {
-                matches!(
-                    self.hide_mouse_cursor_mode,
-                    HideMouseCursorMode::OnTypingAndMovement
-                )
+                matches!(self.hide_mouse, HideMouseMode::OnTypingAndMovement)
             }
         };
     }
@@ -16683,8 +16680,7 @@ impl Editor {
             self.scroll_manager.vertical_scroll_margin = editor_settings.vertical_scroll_margin;
             self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
             self.cursor_shape = editor_settings.cursor_shape.unwrap_or_default();
-            self.hide_mouse_cursor_mode =
-                editor_settings.hide_mouse_cursor_mode.unwrap_or_default();
+            self.hide_mouse = editor_settings.hide_mouse.unwrap_or_default();
         }
 
         if old_cursor_shape != self.cursor_shape {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -797,7 +797,7 @@ pub struct Editor {
     serialize_selections: Task<()>,
     serialize_folds: Task<()>,
     mouse_cursor_hidden: bool,
-    hide_mouse: HideMouseMode,
+    hide_mouse_mode: HideMouseMode,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Default)]
@@ -1577,7 +1577,7 @@ impl Editor {
             text_style_refinement: None,
             load_diff_task: load_uncommitted_diff,
             mouse_cursor_hidden: false,
-            hide_mouse: EditorSettings::get_global(cx)
+            hide_mouse_mode: EditorSettings::get_global(cx)
                 .hide_mouse
                 .unwrap_or_default(),
         };
@@ -1709,12 +1709,12 @@ impl Editor {
         self.mouse_cursor_hidden = match origin {
             HideMouseCursorOrigin::TypingAction => {
                 matches!(
-                    self.hide_mouse,
+                    self.hide_mouse_mode,
                     HideMouseMode::OnTyping | HideMouseMode::OnTypingAndMovement
                 )
             }
             HideMouseCursorOrigin::MovementAction => {
-                matches!(self.hide_mouse, HideMouseMode::OnTypingAndMovement)
+                matches!(self.hide_mouse_mode, HideMouseMode::OnTypingAndMovement)
             }
         };
     }
@@ -16680,7 +16680,7 @@ impl Editor {
             self.scroll_manager.vertical_scroll_margin = editor_settings.vertical_scroll_margin;
             self.show_breadcrumbs = editor_settings.toolbar.breadcrumbs;
             self.cursor_shape = editor_settings.cursor_shape.unwrap_or_default();
-            self.hide_mouse = editor_settings.hide_mouse.unwrap_or_default();
+            self.hide_mouse_mode = editor_settings.hide_mouse.unwrap_or_default();
         }
 
         if old_cursor_shape != self.cursor_shape {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -39,7 +39,7 @@ pub struct EditorSettings {
     #[serde(default)]
     pub go_to_definition_fallback: GoToDefinitionFallback,
     pub jupyter: Jupyter,
-    pub hide_mouse_while_typing: Option<bool>,
+    pub hide_mouse_cursor_mode: Option<HideMouseCursorMode>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -225,6 +225,21 @@ pub enum GoToDefinitionFallback {
     FindAllReferences,
 }
 
+/// Determines when the mouse cursor should be hidden in an editor or input box.
+///
+/// Default: on_typing_and_movement
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HideMouseCursorMode {
+    /// Never hide the mouse cursor
+    Never,
+    /// Hide only when typing
+    OnTyping,
+    /// Hide on both typing and cursor movement
+    #[default]
+    OnTypingAndMovement,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.
@@ -236,10 +251,10 @@ pub struct EditorSettingsContent {
     ///
     /// Default: None
     pub cursor_shape: Option<CursorShape>,
-    /// Determines whether the mouse cursor should be hidden while typing in an editor or input box.
+    /// Determines when the mouse cursor should be hidden in an editor or input box.
     ///
-    /// Default: true
-    pub hide_mouse_while_typing: Option<bool>,
+    /// Default: on_typing_and_movement
+    pub hide_mouse_cursor_mode: Option<HideMouseCursorMode>,
     /// How to highlight the current line in the editor.
     ///
     /// Default: all

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -39,7 +39,7 @@ pub struct EditorSettings {
     #[serde(default)]
     pub go_to_definition_fallback: GoToDefinitionFallback,
     pub jupyter: Jupyter,
-    pub hide_mouse_cursor_mode: Option<HideMouseCursorMode>,
+    pub hide_mouse: Option<HideMouseMode>,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -230,7 +230,7 @@ pub enum GoToDefinitionFallback {
 /// Default: on_typing_and_movement
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum HideMouseCursorMode {
+pub enum HideMouseMode {
     /// Never hide the mouse cursor
     Never,
     /// Hide only when typing
@@ -254,7 +254,7 @@ pub struct EditorSettingsContent {
     /// Determines when the mouse cursor should be hidden in an editor or input box.
     ///
     /// Default: on_typing_and_movement
-    pub hide_mouse_cursor_mode: Option<HideMouseCursorMode>,
+    pub hide_mouse: Option<HideMouseMode>,
     /// How to highlight the current line in the editor.
     ///
     /// Default: all

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -189,100 +189,68 @@ impl EditorElement {
             }
         });
 
-        macro_rules! register_movement_action {
-            ($editor:expr, $window:expr, $action:path) => {
-                register_action($editor, $window, |editor, action, window, cx| {
-                    editor.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction, cx);
-                    $action(editor, action, window, cx)
-                })
-            };
-
-            ($editor:expr, $window:expr, |$ed:ident, $act:ident, $win:ident, $cx:ident| $body:expr) => {
-                register_action($editor, $window, |$ed: &mut Editor, $act, $win, $cx| {
-                    $ed.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction, $cx);
-                    $body
-                })
-            };
-        }
-
-        macro_rules! register_typing_action {
-            ($editor:expr, $window:expr, $action:path) => {
-                register_action($editor, $window, |editor, action, window, cx| {
-                    editor.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction, cx);
-                    $action(editor, action, window, cx)
-                })
-            };
-
-            ($editor:expr, $window:expr, |$ed:ident, $act:ident, $win:ident, $cx:ident| $body:expr) => {
-                register_action($editor, $window, |$ed: &mut Editor, $act, $win, $cx| {
-                    $ed.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction, $cx);
-                    $body
-                })
-            };
-        }
-
         crate::rust_analyzer_ext::apply_related_actions(editor, window, cx);
         crate::clangd_ext::apply_related_actions(editor, window, cx);
         register_action(editor, window, Editor::open_context_menu);
-        register_movement_action!(editor, window, Editor::move_left);
-        register_movement_action!(editor, window, Editor::move_right);
-        register_movement_action!(editor, window, Editor::move_down);
-        register_movement_action!(editor, window, Editor::move_down_by_lines);
-        register_movement_action!(editor, window, Editor::select_down_by_lines);
-        register_movement_action!(editor, window, Editor::move_up);
-        register_movement_action!(editor, window, Editor::move_up_by_lines);
-        register_movement_action!(editor, window, Editor::select_up_by_lines);
-        register_movement_action!(editor, window, Editor::select_page_down);
-        register_movement_action!(editor, window, Editor::select_page_up);
+        register_action(editor, window, Editor::move_left);
+        register_action(editor, window, Editor::move_right);
+        register_action(editor, window, Editor::move_down);
+        register_action(editor, window, Editor::move_down_by_lines);
+        register_action(editor, window, Editor::select_down_by_lines);
+        register_action(editor, window, Editor::move_up);
+        register_action(editor, window, Editor::move_up_by_lines);
+        register_action(editor, window, Editor::select_up_by_lines);
+        register_action(editor, window, Editor::select_page_down);
+        register_action(editor, window, Editor::select_page_up);
         register_action(editor, window, Editor::cancel);
-        register_typing_action!(editor, window, Editor::newline);
-        register_typing_action!(editor, window, Editor::newline_above);
-        register_typing_action!(editor, window, Editor::newline_below);
-        register_typing_action!(editor, window, Editor::backspace);
-        register_typing_action!(editor, window, Editor::delete);
-        register_typing_action!(editor, window, Editor::tab);
-        register_typing_action!(editor, window, Editor::backtab);
-        register_typing_action!(editor, window, Editor::indent);
-        register_typing_action!(editor, window, Editor::outdent);
-        register_typing_action!(editor, window, Editor::autoindent);
-        register_typing_action!(editor, window, Editor::delete_line);
-        register_typing_action!(editor, window, Editor::join_lines);
-        register_typing_action!(editor, window, Editor::sort_lines_case_sensitive);
-        register_typing_action!(editor, window, Editor::sort_lines_case_insensitive);
-        register_typing_action!(editor, window, Editor::reverse_lines);
-        register_typing_action!(editor, window, Editor::shuffle_lines);
-        register_typing_action!(editor, window, Editor::convert_to_upper_case);
-        register_typing_action!(editor, window, Editor::convert_to_lower_case);
-        register_typing_action!(editor, window, Editor::convert_to_title_case);
-        register_typing_action!(editor, window, Editor::convert_to_snake_case);
-        register_typing_action!(editor, window, Editor::convert_to_kebab_case);
-        register_typing_action!(editor, window, Editor::convert_to_upper_camel_case);
-        register_typing_action!(editor, window, Editor::convert_to_lower_camel_case);
-        register_typing_action!(editor, window, Editor::convert_to_opposite_case);
-        register_typing_action!(editor, window, Editor::delete_to_previous_word_start);
-        register_typing_action!(editor, window, Editor::delete_to_previous_subword_start);
-        register_typing_action!(editor, window, Editor::delete_to_next_word_end);
-        register_typing_action!(editor, window, Editor::delete_to_next_subword_end);
-        register_typing_action!(editor, window, Editor::delete_to_beginning_of_line);
-        register_typing_action!(editor, window, Editor::delete_to_end_of_line);
-        register_typing_action!(editor, window, Editor::cut_to_end_of_line);
-        register_typing_action!(editor, window, Editor::duplicate_line_up);
-        register_typing_action!(editor, window, Editor::duplicate_line_down);
-        register_typing_action!(editor, window, Editor::duplicate_selection);
-        register_typing_action!(editor, window, Editor::move_line_up);
-        register_typing_action!(editor, window, Editor::move_line_down);
-        register_typing_action!(editor, window, Editor::transpose);
-        register_typing_action!(editor, window, Editor::rewrap);
-        register_typing_action!(editor, window, Editor::cut);
-        register_typing_action!(editor, window, Editor::kill_ring_cut);
-        register_typing_action!(editor, window, Editor::kill_ring_yank);
+        register_action(editor, window, Editor::newline);
+        register_action(editor, window, Editor::newline_above);
+        register_action(editor, window, Editor::newline_below);
+        register_action(editor, window, Editor::backspace);
+        register_action(editor, window, Editor::delete);
+        register_action(editor, window, Editor::tab);
+        register_action(editor, window, Editor::backtab);
+        register_action(editor, window, Editor::indent);
+        register_action(editor, window, Editor::outdent);
+        register_action(editor, window, Editor::autoindent);
+        register_action(editor, window, Editor::delete_line);
+        register_action(editor, window, Editor::join_lines);
+        register_action(editor, window, Editor::sort_lines_case_sensitive);
+        register_action(editor, window, Editor::sort_lines_case_insensitive);
+        register_action(editor, window, Editor::reverse_lines);
+        register_action(editor, window, Editor::shuffle_lines);
+        register_action(editor, window, Editor::convert_to_upper_case);
+        register_action(editor, window, Editor::convert_to_lower_case);
+        register_action(editor, window, Editor::convert_to_title_case);
+        register_action(editor, window, Editor::convert_to_snake_case);
+        register_action(editor, window, Editor::convert_to_kebab_case);
+        register_action(editor, window, Editor::convert_to_upper_camel_case);
+        register_action(editor, window, Editor::convert_to_lower_camel_case);
+        register_action(editor, window, Editor::convert_to_opposite_case);
+        register_action(editor, window, Editor::delete_to_previous_word_start);
+        register_action(editor, window, Editor::delete_to_previous_subword_start);
+        register_action(editor, window, Editor::delete_to_next_word_end);
+        register_action(editor, window, Editor::delete_to_next_subword_end);
+        register_action(editor, window, Editor::delete_to_beginning_of_line);
+        register_action(editor, window, Editor::delete_to_end_of_line);
+        register_action(editor, window, Editor::cut_to_end_of_line);
+        register_action(editor, window, Editor::duplicate_line_up);
+        register_action(editor, window, Editor::duplicate_line_down);
+        register_action(editor, window, Editor::duplicate_selection);
+        register_action(editor, window, Editor::move_line_up);
+        register_action(editor, window, Editor::move_line_down);
+        register_action(editor, window, Editor::transpose);
+        register_action(editor, window, Editor::rewrap);
+        register_action(editor, window, Editor::cut);
+        register_action(editor, window, Editor::kill_ring_cut);
+        register_action(editor, window, Editor::kill_ring_yank);
         register_action(editor, window, Editor::copy);
         register_action(editor, window, Editor::copy_and_trim);
-        register_typing_action!(editor, window, Editor::paste);
-        register_typing_action!(editor, window, Editor::undo);
-        register_typing_action!(editor, window, Editor::redo);
-        register_movement_action!(editor, window, Editor::move_page_up);
-        register_movement_action!(editor, window, Editor::move_page_down);
+        register_action(editor, window, Editor::paste);
+        register_action(editor, window, Editor::undo);
+        register_action(editor, window, Editor::redo);
+        register_action(editor, window, Editor::move_page_up);
+        register_action(editor, window, Editor::move_page_down);
         register_action(editor, window, Editor::next_screen);
         register_action(editor, window, Editor::scroll_cursor_top);
         register_action(editor, window, Editor::scroll_cursor_center);
@@ -316,68 +284,68 @@ impl EditorElement {
         register_action(editor, window, |editor, _: &PageUp, window, cx| {
             editor.scroll_screen(&ScrollAmount::Page(-1.), window, cx)
         });
-        register_movement_action!(editor, window, Editor::move_to_previous_word_start);
-        register_movement_action!(editor, window, Editor::move_to_previous_subword_start);
-        register_movement_action!(editor, window, Editor::move_to_next_word_end);
-        register_movement_action!(editor, window, Editor::move_to_next_subword_end);
-        register_movement_action!(editor, window, Editor::move_to_beginning_of_line);
-        register_movement_action!(editor, window, Editor::move_to_end_of_line);
-        register_movement_action!(editor, window, Editor::move_to_start_of_paragraph);
-        register_movement_action!(editor, window, Editor::move_to_end_of_paragraph);
-        register_movement_action!(editor, window, Editor::move_to_beginning);
-        register_movement_action!(editor, window, Editor::move_to_end);
-        register_movement_action!(editor, window, Editor::move_to_start_of_excerpt);
-        register_movement_action!(editor, window, Editor::move_to_start_of_next_excerpt);
-        register_movement_action!(editor, window, Editor::move_to_end_of_excerpt);
-        register_movement_action!(editor, window, Editor::move_to_end_of_previous_excerpt);
-        register_movement_action!(editor, window, Editor::select_up);
-        register_movement_action!(editor, window, Editor::select_down);
-        register_movement_action!(editor, window, Editor::select_left);
-        register_movement_action!(editor, window, Editor::select_right);
-        register_movement_action!(editor, window, Editor::select_to_previous_word_start);
-        register_movement_action!(editor, window, Editor::select_to_previous_subword_start);
-        register_movement_action!(editor, window, Editor::select_to_next_word_end);
-        register_movement_action!(editor, window, Editor::select_to_next_subword_end);
-        register_movement_action!(editor, window, Editor::select_to_beginning_of_line);
-        register_movement_action!(editor, window, Editor::select_to_end_of_line);
-        register_movement_action!(editor, window, Editor::select_to_start_of_paragraph);
-        register_movement_action!(editor, window, Editor::select_to_end_of_paragraph);
-        register_movement_action!(editor, window, Editor::select_to_start_of_excerpt);
-        register_movement_action!(editor, window, Editor::select_to_start_of_next_excerpt);
-        register_movement_action!(editor, window, Editor::select_to_end_of_excerpt);
-        register_movement_action!(editor, window, Editor::select_to_end_of_previous_excerpt);
-        register_movement_action!(editor, window, Editor::select_to_beginning);
-        register_movement_action!(editor, window, Editor::select_to_end);
-        register_movement_action!(editor, window, Editor::select_all);
-        register_movement_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, Editor::move_to_previous_word_start);
+        register_action(editor, window, Editor::move_to_previous_subword_start);
+        register_action(editor, window, Editor::move_to_next_word_end);
+        register_action(editor, window, Editor::move_to_next_subword_end);
+        register_action(editor, window, Editor::move_to_beginning_of_line);
+        register_action(editor, window, Editor::move_to_end_of_line);
+        register_action(editor, window, Editor::move_to_start_of_paragraph);
+        register_action(editor, window, Editor::move_to_end_of_paragraph);
+        register_action(editor, window, Editor::move_to_beginning);
+        register_action(editor, window, Editor::move_to_end);
+        register_action(editor, window, Editor::move_to_start_of_excerpt);
+        register_action(editor, window, Editor::move_to_start_of_next_excerpt);
+        register_action(editor, window, Editor::move_to_end_of_excerpt);
+        register_action(editor, window, Editor::move_to_end_of_previous_excerpt);
+        register_action(editor, window, Editor::select_up);
+        register_action(editor, window, Editor::select_down);
+        register_action(editor, window, Editor::select_left);
+        register_action(editor, window, Editor::select_right);
+        register_action(editor, window, Editor::select_to_previous_word_start);
+        register_action(editor, window, Editor::select_to_previous_subword_start);
+        register_action(editor, window, Editor::select_to_next_word_end);
+        register_action(editor, window, Editor::select_to_next_subword_end);
+        register_action(editor, window, Editor::select_to_beginning_of_line);
+        register_action(editor, window, Editor::select_to_end_of_line);
+        register_action(editor, window, Editor::select_to_start_of_paragraph);
+        register_action(editor, window, Editor::select_to_end_of_paragraph);
+        register_action(editor, window, Editor::select_to_start_of_excerpt);
+        register_action(editor, window, Editor::select_to_start_of_next_excerpt);
+        register_action(editor, window, Editor::select_to_end_of_excerpt);
+        register_action(editor, window, Editor::select_to_end_of_previous_excerpt);
+        register_action(editor, window, Editor::select_to_beginning);
+        register_action(editor, window, Editor::select_to_end);
+        register_action(editor, window, Editor::select_all);
+        register_action(editor, window, |editor, action, window, cx| {
             editor.select_all_matches(action, window, cx).log_err();
         });
-        register_movement_action!(editor, window, Editor::select_line);
+        register_action(editor, window, Editor::select_line);
         register_action(editor, window, Editor::split_selection_into_lines);
-        register_movement_action!(editor, window, Editor::add_selection_above);
-        register_movement_action!(editor, window, Editor::add_selection_below);
-        register_movement_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, Editor::add_selection_above);
+        register_action(editor, window, Editor::add_selection_below);
+        register_action(editor, window, |editor, action, window, cx| {
             editor.select_next(action, window, cx).log_err();
         });
-        register_movement_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             editor.select_previous(action, window, cx).log_err();
         });
-        register_typing_action!(editor, window, Editor::toggle_comments);
-        register_movement_action!(editor, window, Editor::select_larger_syntax_node);
-        register_movement_action!(editor, window, Editor::select_smaller_syntax_node);
-        register_movement_action!(editor, window, Editor::select_enclosing_symbol);
-        register_movement_action!(editor, window, Editor::move_to_enclosing_bracket);
-        register_movement_action!(editor, window, Editor::undo_selection);
-        register_movement_action!(editor, window, Editor::redo_selection);
+        register_action(editor, window, Editor::toggle_comments);
+        register_action(editor, window, Editor::select_larger_syntax_node);
+        register_action(editor, window, Editor::select_smaller_syntax_node);
+        register_action(editor, window, Editor::select_enclosing_symbol);
+        register_action(editor, window, Editor::move_to_enclosing_bracket);
+        register_action(editor, window, Editor::undo_selection);
+        register_action(editor, window, Editor::redo_selection);
         if !editor.read(cx).is_singleton(cx) {
             register_action(editor, window, Editor::expand_excerpts);
             register_action(editor, window, Editor::expand_excerpts_up);
             register_action(editor, window, Editor::expand_excerpts_down);
         }
-        register_movement_action!(editor, window, Editor::go_to_diagnostic);
-        register_movement_action!(editor, window, Editor::go_to_prev_diagnostic);
-        register_movement_action!(editor, window, Editor::go_to_next_hunk);
-        register_movement_action!(editor, window, Editor::go_to_prev_hunk);
+        register_action(editor, window, Editor::go_to_diagnostic);
+        register_action(editor, window, Editor::go_to_prev_diagnostic);
+        register_action(editor, window, Editor::go_to_next_hunk);
+        register_action(editor, window, Editor::go_to_prev_hunk);
         register_action(editor, window, |editor, action, window, cx| {
             editor
                 .go_to_definition(action, window, cx)
@@ -467,21 +435,21 @@ impl EditorElement {
         register_action(editor, window, Editor::unstage_and_next);
         register_action(editor, window, Editor::expand_all_diff_hunks);
 
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.format(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.format_selections(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.organize_imports(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
@@ -490,21 +458,21 @@ impl EditorElement {
         });
         register_action(editor, window, Editor::restart_language_server);
         register_action(editor, window, Editor::show_character_palette);
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.confirm_completion(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.compose_completion(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.confirm_code_action(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
@@ -518,7 +486,7 @@ impl EditorElement {
                 cx.propagate();
             }
         });
-        register_typing_action!(editor, window, |editor, action, window, cx| {
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.confirm_rename(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
@@ -541,19 +509,19 @@ impl EditorElement {
         register_action(editor, window, Editor::context_menu_next);
         register_action(editor, window, Editor::context_menu_last);
         register_action(editor, window, Editor::display_cursor_names);
-        register_typing_action!(editor, window, Editor::unique_lines_case_insensitive);
-        register_typing_action!(editor, window, Editor::unique_lines_case_sensitive);
-        register_typing_action!(editor, window, Editor::accept_partial_inline_completion);
-        register_typing_action!(editor, window, Editor::accept_edit_prediction);
-        register_typing_action!(editor, window, Editor::restore_file);
-        register_typing_action!(editor, window, Editor::git_restore);
-        register_typing_action!(editor, window, Editor::apply_all_diff_hunks);
-        register_typing_action!(editor, window, Editor::apply_selected_diff_hunks);
+        register_action(editor, window, Editor::unique_lines_case_insensitive);
+        register_action(editor, window, Editor::unique_lines_case_sensitive);
+        register_action(editor, window, Editor::accept_partial_inline_completion);
+        register_action(editor, window, Editor::accept_edit_prediction);
+        register_action(editor, window, Editor::restore_file);
+        register_action(editor, window, Editor::git_restore);
+        register_action(editor, window, Editor::apply_all_diff_hunks);
+        register_action(editor, window, Editor::apply_selected_diff_hunks);
         register_action(editor, window, Editor::open_active_item_in_terminal);
         register_action(editor, window, Editor::reload_file);
         register_action(editor, window, Editor::spawn_nearest_task);
-        register_typing_action!(editor, window, Editor::insert_uuid_v4);
-        register_typing_action!(editor, window, Editor::insert_uuid_v7);
+        register_action(editor, window, Editor::insert_uuid_v4);
+        register_action(editor, window, Editor::insert_uuid_v7);
         register_action(editor, window, Editor::open_selections_in_multibuffer);
         if cx.has_flag::<Debugger>() {
             register_action(editor, window, Editor::toggle_breakpoint);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -19,13 +19,12 @@ use crate::{
     BlockId, ChunkReplacement, ContextMenuPlacement, CursorShape, CustomBlockId, DisplayDiffHunk,
     DisplayPoint, DisplayRow, DocumentHighlightRead, DocumentHighlightWrite, EditDisplayMode,
     Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle, FocusedBlock, GoToHunk,
-    GoToPreviousHunk, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput,
-    HideMouseCursorOrigin, HoveredCursor, InlayHintRefreshReason, InlineCompletion, JumpData,
-    LineDown, LineHighlight, LineUp, OpenExcerpts, PageDown, PageUp, Point, RowExt, RowRangeExt,
-    SelectPhase, SelectedTextHighlight, Selection, SoftWrap, StickyHeaderExcerpt, ToPoint,
-    ToggleFold, COLUMNAR_SELECTION_MODIFIERS, CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT,
-    GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN, MIN_LINE_NUMBER_DIGITS,
-    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+    GoToPreviousHunk, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput, HoveredCursor,
+    InlayHintRefreshReason, InlineCompletion, JumpData, LineDown, LineHighlight, LineUp,
+    OpenExcerpts, PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, SelectedTextHighlight,
+    Selection, SoftWrap, StickyHeaderExcerpt, ToPoint, ToggleFold, COLUMNAR_SELECTION_MODIFIERS,
+    CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN,
+    MIN_LINE_NUMBER_DIGITS, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
 };
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use client::ParticipantIndex;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -19,12 +19,13 @@ use crate::{
     BlockId, ChunkReplacement, ContextMenuPlacement, CursorShape, CustomBlockId, DisplayDiffHunk,
     DisplayPoint, DisplayRow, DocumentHighlightRead, DocumentHighlightWrite, EditDisplayMode,
     Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle, FocusedBlock, GoToHunk,
-    GoToPreviousHunk, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput, HoveredCursor,
-    InlayHintRefreshReason, InlineCompletion, JumpData, LineDown, LineHighlight, LineUp,
-    OpenExcerpts, PageDown, PageUp, Point, RowExt, RowRangeExt, SelectPhase, SelectedTextHighlight,
-    Selection, SoftWrap, StickyHeaderExcerpt, ToPoint, ToggleFold, COLUMNAR_SELECTION_MODIFIERS,
-    CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT, GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN,
-    MIN_LINE_NUMBER_DIGITS, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
+    GoToPreviousHunk, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput,
+    HideMouseCursorOrigin, HoveredCursor, InlayHintRefreshReason, InlineCompletion, JumpData,
+    LineDown, LineHighlight, LineUp, OpenExcerpts, PageDown, PageUp, Point, RowExt, RowRangeExt,
+    SelectPhase, SelectedTextHighlight, Selection, SoftWrap, StickyHeaderExcerpt, ToPoint,
+    ToggleFold, COLUMNAR_SELECTION_MODIFIERS, CURSORS_VISIBLE_FOR, FILE_HEADER_HEIGHT,
+    GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED, MAX_LINE_LEN, MIN_LINE_NUMBER_DIGITS,
+    MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
 };
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use client::ParticipantIndex;
@@ -188,68 +189,100 @@ impl EditorElement {
             }
         });
 
+        macro_rules! register_movement_action {
+            ($editor:expr, $window:expr, $action:path) => {
+                register_action($editor, $window, |editor, action, window, cx| {
+                    editor.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction, cx);
+                    $action(editor, action, window, cx)
+                })
+            };
+
+            ($editor:expr, $window:expr, |$ed:ident, $act:ident, $win:ident, $cx:ident| $body:expr) => {
+                register_action($editor, $window, |$ed: &mut Editor, $act, $win, $cx| {
+                    $ed.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction, $cx);
+                    $body
+                })
+            };
+        }
+
+        macro_rules! register_typing_action {
+            ($editor:expr, $window:expr, $action:path) => {
+                register_action($editor, $window, |editor, action, window, cx| {
+                    editor.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction, cx);
+                    $action(editor, action, window, cx)
+                })
+            };
+
+            ($editor:expr, $window:expr, |$ed:ident, $act:ident, $win:ident, $cx:ident| $body:expr) => {
+                register_action($editor, $window, |$ed: &mut Editor, $act, $win, $cx| {
+                    $ed.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction, $cx);
+                    $body
+                })
+            };
+        }
+
         crate::rust_analyzer_ext::apply_related_actions(editor, window, cx);
         crate::clangd_ext::apply_related_actions(editor, window, cx);
         register_action(editor, window, Editor::open_context_menu);
-        register_action(editor, window, Editor::move_left);
-        register_action(editor, window, Editor::move_right);
-        register_action(editor, window, Editor::move_down);
-        register_action(editor, window, Editor::move_down_by_lines);
-        register_action(editor, window, Editor::select_down_by_lines);
-        register_action(editor, window, Editor::move_up);
-        register_action(editor, window, Editor::move_up_by_lines);
-        register_action(editor, window, Editor::select_up_by_lines);
-        register_action(editor, window, Editor::select_page_down);
-        register_action(editor, window, Editor::select_page_up);
+        register_movement_action!(editor, window, Editor::move_left);
+        register_movement_action!(editor, window, Editor::move_right);
+        register_movement_action!(editor, window, Editor::move_down);
+        register_movement_action!(editor, window, Editor::move_down_by_lines);
+        register_movement_action!(editor, window, Editor::select_down_by_lines);
+        register_movement_action!(editor, window, Editor::move_up);
+        register_movement_action!(editor, window, Editor::move_up_by_lines);
+        register_movement_action!(editor, window, Editor::select_up_by_lines);
+        register_movement_action!(editor, window, Editor::select_page_down);
+        register_movement_action!(editor, window, Editor::select_page_up);
         register_action(editor, window, Editor::cancel);
-        register_action(editor, window, Editor::newline);
-        register_action(editor, window, Editor::newline_above);
-        register_action(editor, window, Editor::newline_below);
-        register_action(editor, window, Editor::backspace);
-        register_action(editor, window, Editor::delete);
-        register_action(editor, window, Editor::tab);
-        register_action(editor, window, Editor::backtab);
-        register_action(editor, window, Editor::indent);
-        register_action(editor, window, Editor::outdent);
-        register_action(editor, window, Editor::autoindent);
-        register_action(editor, window, Editor::delete_line);
-        register_action(editor, window, Editor::join_lines);
-        register_action(editor, window, Editor::sort_lines_case_sensitive);
-        register_action(editor, window, Editor::sort_lines_case_insensitive);
-        register_action(editor, window, Editor::reverse_lines);
-        register_action(editor, window, Editor::shuffle_lines);
-        register_action(editor, window, Editor::convert_to_upper_case);
-        register_action(editor, window, Editor::convert_to_lower_case);
-        register_action(editor, window, Editor::convert_to_title_case);
-        register_action(editor, window, Editor::convert_to_snake_case);
-        register_action(editor, window, Editor::convert_to_kebab_case);
-        register_action(editor, window, Editor::convert_to_upper_camel_case);
-        register_action(editor, window, Editor::convert_to_lower_camel_case);
-        register_action(editor, window, Editor::convert_to_opposite_case);
-        register_action(editor, window, Editor::delete_to_previous_word_start);
-        register_action(editor, window, Editor::delete_to_previous_subword_start);
-        register_action(editor, window, Editor::delete_to_next_word_end);
-        register_action(editor, window, Editor::delete_to_next_subword_end);
-        register_action(editor, window, Editor::delete_to_beginning_of_line);
-        register_action(editor, window, Editor::delete_to_end_of_line);
-        register_action(editor, window, Editor::cut_to_end_of_line);
-        register_action(editor, window, Editor::duplicate_line_up);
-        register_action(editor, window, Editor::duplicate_line_down);
-        register_action(editor, window, Editor::duplicate_selection);
-        register_action(editor, window, Editor::move_line_up);
-        register_action(editor, window, Editor::move_line_down);
-        register_action(editor, window, Editor::transpose);
-        register_action(editor, window, Editor::rewrap);
-        register_action(editor, window, Editor::cut);
-        register_action(editor, window, Editor::kill_ring_cut);
-        register_action(editor, window, Editor::kill_ring_yank);
+        register_typing_action!(editor, window, Editor::newline);
+        register_typing_action!(editor, window, Editor::newline_above);
+        register_typing_action!(editor, window, Editor::newline_below);
+        register_typing_action!(editor, window, Editor::backspace);
+        register_typing_action!(editor, window, Editor::delete);
+        register_typing_action!(editor, window, Editor::tab);
+        register_typing_action!(editor, window, Editor::backtab);
+        register_typing_action!(editor, window, Editor::indent);
+        register_typing_action!(editor, window, Editor::outdent);
+        register_typing_action!(editor, window, Editor::autoindent);
+        register_typing_action!(editor, window, Editor::delete_line);
+        register_typing_action!(editor, window, Editor::join_lines);
+        register_typing_action!(editor, window, Editor::sort_lines_case_sensitive);
+        register_typing_action!(editor, window, Editor::sort_lines_case_insensitive);
+        register_typing_action!(editor, window, Editor::reverse_lines);
+        register_typing_action!(editor, window, Editor::shuffle_lines);
+        register_typing_action!(editor, window, Editor::convert_to_upper_case);
+        register_typing_action!(editor, window, Editor::convert_to_lower_case);
+        register_typing_action!(editor, window, Editor::convert_to_title_case);
+        register_typing_action!(editor, window, Editor::convert_to_snake_case);
+        register_typing_action!(editor, window, Editor::convert_to_kebab_case);
+        register_typing_action!(editor, window, Editor::convert_to_upper_camel_case);
+        register_typing_action!(editor, window, Editor::convert_to_lower_camel_case);
+        register_typing_action!(editor, window, Editor::convert_to_opposite_case);
+        register_typing_action!(editor, window, Editor::delete_to_previous_word_start);
+        register_typing_action!(editor, window, Editor::delete_to_previous_subword_start);
+        register_typing_action!(editor, window, Editor::delete_to_next_word_end);
+        register_typing_action!(editor, window, Editor::delete_to_next_subword_end);
+        register_typing_action!(editor, window, Editor::delete_to_beginning_of_line);
+        register_typing_action!(editor, window, Editor::delete_to_end_of_line);
+        register_typing_action!(editor, window, Editor::cut_to_end_of_line);
+        register_typing_action!(editor, window, Editor::duplicate_line_up);
+        register_typing_action!(editor, window, Editor::duplicate_line_down);
+        register_typing_action!(editor, window, Editor::duplicate_selection);
+        register_typing_action!(editor, window, Editor::move_line_up);
+        register_typing_action!(editor, window, Editor::move_line_down);
+        register_typing_action!(editor, window, Editor::transpose);
+        register_typing_action!(editor, window, Editor::rewrap);
+        register_typing_action!(editor, window, Editor::cut);
+        register_typing_action!(editor, window, Editor::kill_ring_cut);
+        register_typing_action!(editor, window, Editor::kill_ring_yank);
         register_action(editor, window, Editor::copy);
         register_action(editor, window, Editor::copy_and_trim);
-        register_action(editor, window, Editor::paste);
-        register_action(editor, window, Editor::undo);
-        register_action(editor, window, Editor::redo);
-        register_action(editor, window, Editor::move_page_up);
-        register_action(editor, window, Editor::move_page_down);
+        register_typing_action!(editor, window, Editor::paste);
+        register_typing_action!(editor, window, Editor::undo);
+        register_typing_action!(editor, window, Editor::redo);
+        register_movement_action!(editor, window, Editor::move_page_up);
+        register_movement_action!(editor, window, Editor::move_page_down);
         register_action(editor, window, Editor::next_screen);
         register_action(editor, window, Editor::scroll_cursor_top);
         register_action(editor, window, Editor::scroll_cursor_center);
@@ -283,68 +316,68 @@ impl EditorElement {
         register_action(editor, window, |editor, _: &PageUp, window, cx| {
             editor.scroll_screen(&ScrollAmount::Page(-1.), window, cx)
         });
-        register_action(editor, window, Editor::move_to_previous_word_start);
-        register_action(editor, window, Editor::move_to_previous_subword_start);
-        register_action(editor, window, Editor::move_to_next_word_end);
-        register_action(editor, window, Editor::move_to_next_subword_end);
-        register_action(editor, window, Editor::move_to_beginning_of_line);
-        register_action(editor, window, Editor::move_to_end_of_line);
-        register_action(editor, window, Editor::move_to_start_of_paragraph);
-        register_action(editor, window, Editor::move_to_end_of_paragraph);
-        register_action(editor, window, Editor::move_to_beginning);
-        register_action(editor, window, Editor::move_to_end);
-        register_action(editor, window, Editor::move_to_start_of_excerpt);
-        register_action(editor, window, Editor::move_to_start_of_next_excerpt);
-        register_action(editor, window, Editor::move_to_end_of_excerpt);
-        register_action(editor, window, Editor::move_to_end_of_previous_excerpt);
-        register_action(editor, window, Editor::select_up);
-        register_action(editor, window, Editor::select_down);
-        register_action(editor, window, Editor::select_left);
-        register_action(editor, window, Editor::select_right);
-        register_action(editor, window, Editor::select_to_previous_word_start);
-        register_action(editor, window, Editor::select_to_previous_subword_start);
-        register_action(editor, window, Editor::select_to_next_word_end);
-        register_action(editor, window, Editor::select_to_next_subword_end);
-        register_action(editor, window, Editor::select_to_beginning_of_line);
-        register_action(editor, window, Editor::select_to_end_of_line);
-        register_action(editor, window, Editor::select_to_start_of_paragraph);
-        register_action(editor, window, Editor::select_to_end_of_paragraph);
-        register_action(editor, window, Editor::select_to_start_of_excerpt);
-        register_action(editor, window, Editor::select_to_start_of_next_excerpt);
-        register_action(editor, window, Editor::select_to_end_of_excerpt);
-        register_action(editor, window, Editor::select_to_end_of_previous_excerpt);
-        register_action(editor, window, Editor::select_to_beginning);
-        register_action(editor, window, Editor::select_to_end);
-        register_action(editor, window, Editor::select_all);
-        register_action(editor, window, |editor, action, window, cx| {
+        register_movement_action!(editor, window, Editor::move_to_previous_word_start);
+        register_movement_action!(editor, window, Editor::move_to_previous_subword_start);
+        register_movement_action!(editor, window, Editor::move_to_next_word_end);
+        register_movement_action!(editor, window, Editor::move_to_next_subword_end);
+        register_movement_action!(editor, window, Editor::move_to_beginning_of_line);
+        register_movement_action!(editor, window, Editor::move_to_end_of_line);
+        register_movement_action!(editor, window, Editor::move_to_start_of_paragraph);
+        register_movement_action!(editor, window, Editor::move_to_end_of_paragraph);
+        register_movement_action!(editor, window, Editor::move_to_beginning);
+        register_movement_action!(editor, window, Editor::move_to_end);
+        register_movement_action!(editor, window, Editor::move_to_start_of_excerpt);
+        register_movement_action!(editor, window, Editor::move_to_start_of_next_excerpt);
+        register_movement_action!(editor, window, Editor::move_to_end_of_excerpt);
+        register_movement_action!(editor, window, Editor::move_to_end_of_previous_excerpt);
+        register_movement_action!(editor, window, Editor::select_up);
+        register_movement_action!(editor, window, Editor::select_down);
+        register_movement_action!(editor, window, Editor::select_left);
+        register_movement_action!(editor, window, Editor::select_right);
+        register_movement_action!(editor, window, Editor::select_to_previous_word_start);
+        register_movement_action!(editor, window, Editor::select_to_previous_subword_start);
+        register_movement_action!(editor, window, Editor::select_to_next_word_end);
+        register_movement_action!(editor, window, Editor::select_to_next_subword_end);
+        register_movement_action!(editor, window, Editor::select_to_beginning_of_line);
+        register_movement_action!(editor, window, Editor::select_to_end_of_line);
+        register_movement_action!(editor, window, Editor::select_to_start_of_paragraph);
+        register_movement_action!(editor, window, Editor::select_to_end_of_paragraph);
+        register_movement_action!(editor, window, Editor::select_to_start_of_excerpt);
+        register_movement_action!(editor, window, Editor::select_to_start_of_next_excerpt);
+        register_movement_action!(editor, window, Editor::select_to_end_of_excerpt);
+        register_movement_action!(editor, window, Editor::select_to_end_of_previous_excerpt);
+        register_movement_action!(editor, window, Editor::select_to_beginning);
+        register_movement_action!(editor, window, Editor::select_to_end);
+        register_movement_action!(editor, window, Editor::select_all);
+        register_movement_action!(editor, window, |editor, action, window, cx| {
             editor.select_all_matches(action, window, cx).log_err();
         });
-        register_action(editor, window, Editor::select_line);
+        register_movement_action!(editor, window, Editor::select_line);
         register_action(editor, window, Editor::split_selection_into_lines);
-        register_action(editor, window, Editor::add_selection_above);
-        register_action(editor, window, Editor::add_selection_below);
-        register_action(editor, window, |editor, action, window, cx| {
+        register_movement_action!(editor, window, Editor::add_selection_above);
+        register_movement_action!(editor, window, Editor::add_selection_below);
+        register_movement_action!(editor, window, |editor, action, window, cx| {
             editor.select_next(action, window, cx).log_err();
         });
-        register_action(editor, window, |editor, action, window, cx| {
+        register_movement_action!(editor, window, |editor, action, window, cx| {
             editor.select_previous(action, window, cx).log_err();
         });
-        register_action(editor, window, Editor::toggle_comments);
-        register_action(editor, window, Editor::select_larger_syntax_node);
-        register_action(editor, window, Editor::select_smaller_syntax_node);
-        register_action(editor, window, Editor::select_enclosing_symbol);
-        register_action(editor, window, Editor::move_to_enclosing_bracket);
-        register_action(editor, window, Editor::undo_selection);
-        register_action(editor, window, Editor::redo_selection);
+        register_typing_action!(editor, window, Editor::toggle_comments);
+        register_movement_action!(editor, window, Editor::select_larger_syntax_node);
+        register_movement_action!(editor, window, Editor::select_smaller_syntax_node);
+        register_movement_action!(editor, window, Editor::select_enclosing_symbol);
+        register_movement_action!(editor, window, Editor::move_to_enclosing_bracket);
+        register_movement_action!(editor, window, Editor::undo_selection);
+        register_movement_action!(editor, window, Editor::redo_selection);
         if !editor.read(cx).is_singleton(cx) {
             register_action(editor, window, Editor::expand_excerpts);
             register_action(editor, window, Editor::expand_excerpts_up);
             register_action(editor, window, Editor::expand_excerpts_down);
         }
-        register_action(editor, window, Editor::go_to_diagnostic);
-        register_action(editor, window, Editor::go_to_prev_diagnostic);
-        register_action(editor, window, Editor::go_to_next_hunk);
-        register_action(editor, window, Editor::go_to_prev_hunk);
+        register_movement_action!(editor, window, Editor::go_to_diagnostic);
+        register_movement_action!(editor, window, Editor::go_to_prev_diagnostic);
+        register_movement_action!(editor, window, Editor::go_to_next_hunk);
+        register_movement_action!(editor, window, Editor::go_to_prev_hunk);
         register_action(editor, window, |editor, action, window, cx| {
             editor
                 .go_to_definition(action, window, cx)
@@ -434,21 +467,21 @@ impl EditorElement {
         register_action(editor, window, Editor::unstage_and_next);
         register_action(editor, window, Editor::expand_all_diff_hunks);
 
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.format(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.format_selections(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.organize_imports(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
@@ -457,21 +490,21 @@ impl EditorElement {
         });
         register_action(editor, window, Editor::restart_language_server);
         register_action(editor, window, Editor::show_character_palette);
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.confirm_completion(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.compose_completion(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
                 cx.propagate();
             }
         });
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.confirm_code_action(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
@@ -485,7 +518,7 @@ impl EditorElement {
                 cx.propagate();
             }
         });
-        register_action(editor, window, |editor, action, window, cx| {
+        register_typing_action!(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.confirm_rename(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {
@@ -508,19 +541,19 @@ impl EditorElement {
         register_action(editor, window, Editor::context_menu_next);
         register_action(editor, window, Editor::context_menu_last);
         register_action(editor, window, Editor::display_cursor_names);
-        register_action(editor, window, Editor::unique_lines_case_insensitive);
-        register_action(editor, window, Editor::unique_lines_case_sensitive);
-        register_action(editor, window, Editor::accept_partial_inline_completion);
-        register_action(editor, window, Editor::accept_edit_prediction);
-        register_action(editor, window, Editor::restore_file);
-        register_action(editor, window, Editor::git_restore);
-        register_action(editor, window, Editor::apply_all_diff_hunks);
-        register_action(editor, window, Editor::apply_selected_diff_hunks);
+        register_typing_action!(editor, window, Editor::unique_lines_case_insensitive);
+        register_typing_action!(editor, window, Editor::unique_lines_case_sensitive);
+        register_typing_action!(editor, window, Editor::accept_partial_inline_completion);
+        register_typing_action!(editor, window, Editor::accept_edit_prediction);
+        register_typing_action!(editor, window, Editor::restore_file);
+        register_typing_action!(editor, window, Editor::git_restore);
+        register_typing_action!(editor, window, Editor::apply_all_diff_hunks);
+        register_typing_action!(editor, window, Editor::apply_selected_diff_hunks);
         register_action(editor, window, Editor::open_active_item_in_terminal);
         register_action(editor, window, Editor::reload_file);
         register_action(editor, window, Editor::spawn_nearest_task);
-        register_action(editor, window, Editor::insert_uuid_v4);
-        register_action(editor, window, Editor::insert_uuid_v7);
+        register_typing_action!(editor, window, Editor::insert_uuid_v4);
+        register_typing_action!(editor, window, Editor::insert_uuid_v7);
         register_action(editor, window, Editor::open_selections_in_multibuffer);
         if cx.has_flag::<Debugger>() {
             register_action(editor, window, Editor::toggle_breakpoint);

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -31,3 +31,9 @@ pub(crate) mod m_2025_03_06 {
 
     pub(crate) use keymap::KEYMAP_PATTERNS;
 }
+
+pub(crate) mod m_2025_03_29 {
+    mod settings;
+
+    pub(crate) use settings::SETTINGS_PATTERNS;
+}

--- a/crates/migrator/src/migrations/m_2025_03_29/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_03_29/settings.rs
@@ -1,0 +1,65 @@
+use std::ops::Range;
+use tree_sitter::{Query, QueryMatch};
+
+use crate::patterns::SETTINGS_ROOT_KEY_VALUE_PATTERN;
+use crate::MigrationPatterns;
+
+pub const SETTINGS_PATTERNS: MigrationPatterns = &[
+    (SETTINGS_ROOT_KEY_VALUE_PATTERN, replace_setting_name),
+    (SETTINGS_ROOT_KEY_VALUE_PATTERN, replace_setting_value),
+];
+
+fn replace_setting_value(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let setting_capture_ix = query.capture_index_for_name("name")?;
+    let setting_name_range = mat
+        .nodes_for_capture_index(setting_capture_ix)
+        .next()?
+        .byte_range();
+    let setting_name = contents.get(setting_name_range.clone())?;
+
+    if setting_name != "hide_mouse_while_typing" {
+        return None;
+    }
+
+    let value_capture_ix = query.capture_index_for_name("value")?;
+    let value_range = mat
+        .nodes_for_capture_index(value_capture_ix)
+        .next()?
+        .byte_range();
+    let value = contents.get(value_range.clone())?;
+
+    let new_value = if value.trim() == "true" {
+        "\"on_typing_and_movement\""
+    } else if value.trim() == "false" {
+        "\"never\""
+    } else {
+        return None;
+    };
+
+    Some((value_range, new_value.to_string()))
+}
+
+fn replace_setting_name(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let setting_capture_ix = query.capture_index_for_name("name")?;
+    let setting_name_range = mat
+        .nodes_for_capture_index(setting_capture_ix)
+        .next()?
+        .byte_range();
+    let setting_name = contents.get(setting_name_range.clone())?;
+
+    let new_setting_name = if setting_name == "hide_mouse_while_typing" {
+        "hide_mouse"
+    } else {
+        return None;
+    };
+
+    Some((setting_name_range, new_setting_name.to_string()))
+}

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -116,6 +116,10 @@ pub fn migrate_settings(text: &str) -> Result<Option<String>> {
             migrations::m_2025_01_30::SETTINGS_PATTERNS,
             &SETTINGS_QUERY_2025_01_30,
         ),
+        (
+            migrations::m_2025_03_29::SETTINGS_PATTERNS,
+            &SETTINGS_QUERY_2025_03_29,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -181,6 +185,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_01_30,
     migrations::m_2025_01_30::SETTINGS_PATTERNS
+);
+define_query!(
+    SETTINGS_QUERY_2025_03_29,
+    migrations::m_2025_03_29::SETTINGS_PATTERNS
 );
 
 // custom query

--- a/crates/migrator/src/patterns/settings.rs
+++ b/crates/migrator/src/patterns/settings.rs
@@ -2,7 +2,7 @@ pub const SETTINGS_ROOT_KEY_VALUE_PATTERN: &str = r#"(document
     (object
         (pair
             key: (string (string_content) @name)
-            value: (_)
+            value: (_)  @value
         )
     )
 )"#;

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -553,11 +553,11 @@ List of `string` values
 "cursor_shape": "hollow"
 ```
 
-## Hide Mouse While Typing
+## Hide Mouse Cursor Mode
 
-- Description: Determines whether the mouse cursor should be hidden while typing in an editor or input box.
-- Setting: `hide_mouse_while_typing`
-- Default: `true`
+- Description: Determines when the mouse cursor should be hidden in an editor or input box.
+- Setting: `hide_mouse_cursor_mode`
+- Default: `on_typing_and_movement`
 
 **Options**
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -553,7 +553,7 @@ List of `string` values
 "cursor_shape": "hollow"
 ```
 
-## Hide Mouse Cursor Mode
+## Hide Mouse
 
 - Description: Determines when the mouse cursor should be hidden in an editor or input box.
 - Setting: `hide_mouse`

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -556,7 +556,7 @@ List of `string` values
 ## Hide Mouse Cursor Mode
 
 - Description: Determines when the mouse cursor should be hidden in an editor or input box.
-- Setting: `hide_mouse_cursor_mode`
+- Setting: `hide_mouse`
 - Default: `on_typing_and_movement`
 
 **Options**


### PR DESCRIPTION
This enables hiding mouse cursor even on cursor movements like up, down, etc. or selections made using keyboard, etc. 

Renamed existing boolean setting "hide_mouse_while_typing" to "hide_mouse". It can have three values: `on_typing_and_movement`, `on_typing`, `never`.

Release Notes:

- Now mouse cursor hides even when you navigate, or make selections using keyboard in editor. This behavior can be changed by setting `hide_mouse` to `on_typing_and_movement`, `on_typing` or `never`.