### PR TITLE
gpui: Remove unneeded anonymous lifetime from `Render::render`

### DIFF
--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -118,7 +118,7 @@ impl<T: IntoElement> FluentBuilder for T {}
 /// other entities. Views are `Entity`'s which `impl Render` and drawn to the screen.
 pub trait Render: 'static + Sized {
     /// Render this view into an element tree.
-    fn render(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement;
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement;
 }
 
 impl Render for Empty {


### PR DESCRIPTION
This PR removes an unneeded anonymous lifetime from the `cx` parameter to `Render::render`.

This makes it so the anonymous lifetime doesn't show up when implementing the `Render` trait via a code action:

#### Before

```rs
struct Foo;

impl Render for Foo {
    fn render(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement {
        todo!()
    }
}
```

#### After

```rs
struct Foo;

impl Render for Foo {
    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
        todo!()
    }
}
```

Release Notes:

- N/A
