### PR TITLE
Remove unneeded anonymous lifetimes from `gpui::Context`

### DIFF
--- a/crates/assistant2/src/active_thread.rs
+++ b/crates/assistant2/src/active_thread.rs
@@ -526,7 +526,7 @@ impl ActiveThread {
         caption: impl Into<SharedString>,
         icon: IconName,
         window: &mut Window,
-        cx: &mut Context<'_, ActiveThread>,
+        cx: &mut Context<ActiveThread>,
     ) {
         if window.is_window_active()
             || !self.notifications.is_empty()
@@ -1767,7 +1767,7 @@ impl ActiveThread {
             })
     }
 
-    fn dismiss_notifications(&mut self, cx: &mut Context<'_, ActiveThread>) {
+    fn dismiss_notifications(&mut self, cx: &mut Context<ActiveThread>) {
         for window in self.notifications.drain(..) {
             window
                 .update(cx, |_, window, _| {

--- a/crates/assistant2/src/thread.rs
+++ b/crates/assistant2/src/thread.rs
@@ -1242,7 +1242,7 @@ impl Thread {
         input: serde_json::Value,
         messages: &[LanguageModelRequestMessage],
         tool: Arc<dyn Tool>,
-        cx: &mut Context<'_, Thread>,
+        cx: &mut Context<Thread>,
     ) {
         let task = self.spawn_tool_use(tool_use_id.clone(), messages, input, tool, cx);
         self.tool_use

--- a/crates/call/src/call_impl/room.rs
+++ b/crates/call/src/call_impl/room.rs
@@ -1570,7 +1570,7 @@ impl Room {
 
 fn spawn_room_connection(
     livekit_connection_info: Option<proto::LiveKitConnectionInfo>,
-    cx: &mut Context<'_, Room>,
+    cx: &mut Context<Room>,
 ) {
     if let Some(connection_info) = livekit_connection_info {
         cx.spawn(async move |this, cx| {

--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -201,7 +201,7 @@ impl ChannelBuffer {
         }
     }
 
-    pub fn acknowledge_buffer_version(&mut self, cx: &mut Context<'_, ChannelBuffer>) {
+    pub fn acknowledge_buffer_version(&mut self, cx: &mut Context<ChannelBuffer>) {
         let buffer = self.buffer.read(cx);
         let version = buffer.version();
         let buffer_id = buffer.remote_id().into();

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -550,11 +550,11 @@ impl DapLogView {
         });
         let editor_subscription = cx.subscribe(
             &editor,
-            |_, _, event: &EditorEvent, cx: &mut Context<'_, DapLogView>| cx.emit(event.clone()),
+            |_, _, event: &EditorEvent, cx: &mut Context<DapLogView>| cx.emit(event.clone()),
         );
         let search_subscription = cx.subscribe(
             &editor,
-            |_, _, event: &SearchEvent, cx: &mut Context<'_, DapLogView>| cx.emit(event.clone()),
+            |_, _, event: &SearchEvent, cx: &mut Context<DapLogView>| cx.emit(event.clone()),
         );
         (editor, vec![editor_subscription, search_subscription])
     }

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -154,7 +154,7 @@ impl DebugSession {
         _: &Entity<InertState>,
         event: &InertEvent,
         window: &mut Window,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) {
         let dap_store = self.dap_store.clone();
         let InertEvent::Spawned { config } = event;
@@ -186,7 +186,7 @@ impl DebugSession {
         _: &Entity<StartingState>,
         event: &StartingEvent,
         window: &mut Window,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) {
         if let StartingEvent::Finished(session) = event {
             let mode =
@@ -337,7 +337,7 @@ impl FollowableItem for DebugSession {
 }
 
 impl Render for DebugSession {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         match &self.mode {
             DebugSessionState::Inert(inert_state) => {
                 inert_state.update(cx, |this, cx| this.render(window, cx).into_any_element())

--- a/crates/debugger_ui/src/session/failed.rs
+++ b/crates/debugger_ui/src/session/failed.rs
@@ -20,7 +20,7 @@ impl Focusable for FailedState {
     }
 }
 impl Render for FailedState {
-    fn render(&mut self, _: &mut Window, _: &mut Context<'_, Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
         h_flex()
             .size_full()
             .items_center()

--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -76,7 +76,7 @@ impl BlinkManager {
         }
     }
 
-    pub fn show_cursor(&mut self, cx: &mut Context<'_, BlinkManager>) {
+    pub fn show_cursor(&mut self, cx: &mut Context<BlinkManager>) {
         if !self.visible {
             self.visible = true;
             cx.notify();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13983,7 +13983,7 @@ impl Editor {
         &mut self,
         _: &ToggleInlineDiagnostics,
         window: &mut Window,
-        cx: &mut Context<'_, Editor>,
+        cx: &mut Context<Editor>,
     ) {
         self.show_inline_diagnostics = !self.show_inline_diagnostics;
         self.refresh_inline_diagnostics(false, window, cx);
@@ -14852,7 +14852,7 @@ impl Editor {
     fn save_buffers_for_ranges_if_needed(
         &mut self,
         ranges: &[Range<Anchor>],
-        cx: &mut Context<'_, Editor>,
+        cx: &mut Context<Editor>,
     ) -> Task<Result<()>> {
         let multibuffer = self.buffer.read(cx);
         let snapshot = multibuffer.read(cx);
@@ -14981,7 +14981,7 @@ impl Editor {
     fn toggle_diff_hunks_in_ranges(
         &mut self,
         ranges: Vec<Range<Anchor>>,
-        cx: &mut Context<'_, Editor>,
+        cx: &mut Context<Editor>,
     ) {
         self.buffer.update(cx, |buffer, cx| {
             let expand = !buffer.has_expanded_diff_hunks_in_ranges(&ranges, cx);
@@ -18889,7 +18889,7 @@ impl Focusable for Editor {
 }
 
 impl Render for Editor {
-    fn render(&mut self, _: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let settings = ThemeSettings::get_global(cx);
 
         let mut text_style = match self.mode {
@@ -19882,7 +19882,7 @@ fn all_edits_insertions_or_deletions(
 struct MissingEditPredictionKeybindingTooltip;
 
 impl Render for MissingEditPredictionKeybindingTooltip {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         ui::tooltip_container(window, cx, |container, _, cx| {
             container
                 .flex_shrink_0()

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -774,7 +774,7 @@ fn determine_query_ranges(
     excerpt_id: ExcerptId,
     excerpt_buffer: &Entity<Buffer>,
     excerpt_visible_range: Range<usize>,
-    cx: &mut Context<'_, MultiBuffer>,
+    cx: &mut Context<MultiBuffer>,
 ) -> Option<QueryRanges> {
     let buffer = excerpt_buffer.read(cx);
     let full_excerpt_range = multi_buffer

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -640,7 +640,7 @@ impl ExtensionStore {
         &self,
         path: &str,
         query: &[(&str, &str)],
-        cx: &mut Context<'_, ExtensionStore>,
+        cx: &mut Context<ExtensionStore>,
     ) -> Task<Result<Vec<ExtensionMetadata>>> {
         let url = self.http_client.build_zed_api_url(path, query);
         let http_client = self.http_client.clone();

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -102,7 +102,7 @@ impl CommitModal {
         });
     }
 
-    pub fn toggle(workspace: &mut Workspace, window: &mut Window, cx: &mut Context<'_, Workspace>) {
+    pub fn toggle(workspace: &mut Workspace, window: &mut Window, cx: &mut Context<Workspace>) {
         let Some(git_panel) = workspace.panel::<GitPanel>(cx) else {
             return;
         };
@@ -349,7 +349,7 @@ impl CommitModal {
 }
 
 impl Render for CommitModal {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<'_, Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let properties = self.properties;
         let width = px(properties.modal_width);
         let container_padding = px(properties.container_padding);

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -344,7 +344,7 @@ pub(crate) fn commit_message_editor(
     project: Entity<Project>,
     in_panel: bool,
     window: &mut Window,
-    cx: &mut Context<'_, Editor>,
+    cx: &mut Context<Editor>,
 ) -> Editor {
     let buffer = cx.new(|cx| MultiBuffer::singleton(commit_message_buffer, cx));
     let max_lines = if in_panel { MAX_PANEL_EDITOR_LINES } else { 18 };
@@ -3976,7 +3976,7 @@ impl GitPanelMessageTooltip {
 }
 
 impl Render for GitPanelMessageTooltip {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<'_, Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
         if let Some(commit_tooltip) = &self.commit_tooltip {
             commit_tooltip.clone().into_any_element()
         } else {

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1609,10 +1609,7 @@ impl AppContext for App {
     ///
     /// The given function will be invoked with a [`Context`] and must return an object representing the entity. An
     /// [`Entity`] handle will be returned, which can be used to access the entity in a context.
-    fn new<T: 'static>(
-        &mut self,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
-    ) -> Entity<T> {
+    fn new<T: 'static>(&mut self, build_entity: impl FnOnce(&mut Context<T>) -> T) -> Entity<T> {
         self.update(|cx| {
             let slot = cx.entities.reserve();
             let handle = slot.clone();
@@ -1636,7 +1633,7 @@ impl AppContext for App {
     fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         self.update(|cx| {
             let slot = reservation.0;
@@ -1650,7 +1647,7 @@ impl AppContext for App {
     fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> R {
         self.update(|cx| {
             let mut entity = cx.entities.lease(handle);

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -25,7 +25,7 @@ impl AppContext for AsyncApp {
 
     fn new<T: 'static>(
         &mut self,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         let app = self
             .app
@@ -47,7 +47,7 @@ impl AppContext for AsyncApp {
     fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Result<Entity<T>> {
         let app = self
             .app
@@ -60,7 +60,7 @@ impl AppContext for AsyncApp {
     fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Self::Result<R> {
         let app = self
             .app
@@ -345,7 +345,7 @@ impl AsyncWindowContext {
 impl AppContext for AsyncWindowContext {
     type Result<T> = Result<T>;
 
-    fn new<T>(&mut self, build_entity: impl FnOnce(&mut Context<'_, T>) -> T) -> Result<Entity<T>>
+    fn new<T>(&mut self, build_entity: impl FnOnce(&mut Context<T>) -> T) -> Result<Entity<T>>
     where
         T: 'static,
     {
@@ -359,7 +359,7 @@ impl AppContext for AsyncWindowContext {
     fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         self.window
             .update(self, |_, _, cx| cx.insert_entity(reservation, build_entity))
@@ -368,7 +368,7 @@ impl AppContext for AsyncWindowContext {
     fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Result<R> {
         self.window
             .update(self, |_, _, cx| cx.update_entity(handle, update))

--- a/crates/gpui/src/app/context.rs
+++ b/crates/gpui/src/app/context.rs
@@ -52,7 +52,7 @@ impl<'a, T: 'static> Context<'a, T> {
     pub fn observe<W>(
         &mut self,
         entity: &Entity<W>,
-        mut on_notify: impl FnMut(&mut T, Entity<W>, &mut Context<'_, T>) + 'static,
+        mut on_notify: impl FnMut(&mut T, Entity<W>, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         T: 'static,
@@ -73,7 +73,7 @@ impl<'a, T: 'static> Context<'a, T> {
     pub fn subscribe<T2, Evt>(
         &mut self,
         entity: &Entity<T2>,
-        mut on_event: impl FnMut(&mut T, Entity<T2>, &Evt, &mut Context<'_, T>) + 'static,
+        mut on_event: impl FnMut(&mut T, Entity<T2>, &Evt, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         T: 'static,
@@ -94,7 +94,7 @@ impl<'a, T: 'static> Context<'a, T> {
     /// Subscribe to an event type from ourself
     pub fn subscribe_self<Evt>(
         &mut self,
-        mut on_event: impl FnMut(&mut T, &Evt, &mut Context<'_, T>) + 'static,
+        mut on_event: impl FnMut(&mut T, &Evt, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         T: 'static + EventEmitter<Evt>,
@@ -126,7 +126,7 @@ impl<'a, T: 'static> Context<'a, T> {
     pub fn observe_release<T2>(
         &self,
         entity: &Entity<T2>,
-        on_release: impl FnOnce(&mut T, &mut T2, &mut Context<'_, T>) + 'static,
+        on_release: impl FnOnce(&mut T, &mut T2, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         T: Any,
@@ -150,7 +150,7 @@ impl<'a, T: 'static> Context<'a, T> {
     /// Register a callback to for updates to the given global
     pub fn observe_global<G: 'static>(
         &mut self,
-        mut f: impl FnMut(&mut T, &mut Context<'_, T>) + 'static,
+        mut f: impl FnMut(&mut T, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         T: 'static,
@@ -272,7 +272,7 @@ impl<'a, T: 'static> Context<'a, T> {
         &mut self,
         observed: &Entity<V2>,
         window: &mut Window,
-        mut on_notify: impl FnMut(&mut T, Entity<V2>, &mut Window, &mut Context<'_, T>) + 'static,
+        mut on_notify: impl FnMut(&mut T, Entity<V2>, &mut Window, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         V2: 'static,
@@ -310,8 +310,7 @@ impl<'a, T: 'static> Context<'a, T> {
         &mut self,
         emitter: &Entity<Emitter>,
         window: &Window,
-        mut on_event: impl FnMut(&mut T, &Entity<Emitter>, &Evt, &mut Window, &mut Context<'_, T>)
-            + 'static,
+        mut on_event: impl FnMut(&mut T, &Entity<Emitter>, &Evt, &mut Window, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         Emitter: EventEmitter<Evt>,
@@ -363,7 +362,7 @@ impl<'a, T: 'static> Context<'a, T> {
         &self,
         observed: &Entity<T2>,
         window: &Window,
-        mut on_release: impl FnMut(&mut T, &mut T2, &mut Window, &mut Context<'_, T>) + 'static,
+        mut on_release: impl FnMut(&mut T, &mut T2, &mut Window, &mut Context<T>) + 'static,
     ) -> Subscription
     where
         T: 'static,
@@ -626,7 +625,7 @@ impl<'a, T: 'static> Context<'a, T> {
     pub fn observe_global_in<G: Global>(
         &mut self,
         window: &Window,
-        mut f: impl FnMut(&mut T, &mut Window, &mut Context<'_, T>) + 'static,
+        mut f: impl FnMut(&mut T, &mut Window, &mut Context<T>) + 'static,
     ) -> Subscription {
         let window_handle = window.handle;
         let view = self.weak_entity();
@@ -691,10 +690,7 @@ impl<T> Context<'_, T> {
 impl<T> AppContext for Context<'_, T> {
     type Result<U> = U;
 
-    fn new<U: 'static>(
-        &mut self,
-        build_entity: impl FnOnce(&mut Context<'_, U>) -> U,
-    ) -> Entity<U> {
+    fn new<U: 'static>(&mut self, build_entity: impl FnOnce(&mut Context<U>) -> U) -> Entity<U> {
         self.app.new(build_entity)
     }
 
@@ -705,7 +701,7 @@ impl<T> AppContext for Context<'_, T> {
     fn insert_entity<U: 'static>(
         &mut self,
         reservation: Reservation<U>,
-        build_entity: impl FnOnce(&mut Context<'_, U>) -> U,
+        build_entity: impl FnOnce(&mut Context<U>) -> U,
     ) -> Self::Result<Entity<U>> {
         self.app.insert_entity(reservation, build_entity)
     }
@@ -713,7 +709,7 @@ impl<T> AppContext for Context<'_, T> {
     fn update_entity<U: 'static, R>(
         &mut self,
         handle: &Entity<U>,
-        update: impl FnOnce(&mut U, &mut Context<'_, U>) -> R,
+        update: impl FnOnce(&mut U, &mut Context<U>) -> R,
     ) -> R {
         self.app.update_entity(handle, update)
     }

--- a/crates/gpui/src/app/entity_map.rs
+++ b/crates/gpui/src/app/entity_map.rs
@@ -447,7 +447,7 @@ impl<T: 'static> Entity<T> {
     pub fn update<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> C::Result<R>
     where
         C: AppContext,
@@ -461,7 +461,7 @@ impl<T: 'static> Entity<T> {
     pub fn update_in<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut T, &mut Window, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Window, &mut Context<T>) -> R,
     ) -> C::Result<R>
     where
         C: VisualContext,
@@ -679,7 +679,7 @@ impl<T: 'static> WeakEntity<T> {
     pub fn update<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Result<R>
     where
         C: AppContext,
@@ -698,7 +698,7 @@ impl<T: 'static> WeakEntity<T> {
     pub fn update_in<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut T, &mut Window, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Window, &mut Context<T>) -> R,
     ) -> Result<R>
     where
         C: VisualContext,

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -34,7 +34,7 @@ impl AppContext for TestAppContext {
 
     fn new<T: 'static>(
         &mut self,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         let mut app = self.app.borrow_mut();
         app.new(build_entity)
@@ -48,7 +48,7 @@ impl AppContext for TestAppContext {
     fn insert_entity<T: 'static>(
         &mut self,
         reservation: crate::Reservation<T>,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         let mut app = self.app.borrow_mut();
         app.insert_entity(reservation, build_entity)
@@ -57,7 +57,7 @@ impl AppContext for TestAppContext {
     fn update_entity<T: 'static, R>(
         &mut self,
         handle: &Entity<T>,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Self::Result<R> {
         let mut app = self.app.borrow_mut();
         app.update_entity(handle, update)
@@ -876,7 +876,7 @@ impl AppContext for VisualTestContext {
 
     fn new<T: 'static>(
         &mut self,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         self.cx.new(build_entity)
     }
@@ -888,7 +888,7 @@ impl AppContext for VisualTestContext {
     fn insert_entity<T: 'static>(
         &mut self,
         reservation: crate::Reservation<T>,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         self.cx.insert_entity(reservation, build_entity)
     }
@@ -896,7 +896,7 @@ impl AppContext for VisualTestContext {
     fn update_entity<T, R>(
         &mut self,
         handle: &Entity<T>,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Self::Result<R>
     where
         T: 'static,
@@ -956,7 +956,7 @@ impl VisualContext for VisualTestContext {
 
     fn new_window_entity<T: 'static>(
         &mut self,
-        build_entity: impl FnOnce(&mut Window, &mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Window, &mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>> {
         self.window
             .update(&mut self.cx, |_, window, cx| {

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -168,7 +168,7 @@ pub trait AppContext {
     /// Create a new entity in the app context.
     fn new<T: 'static>(
         &mut self,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>>;
 
     /// Reserve a slot for a entity to be inserted later.
@@ -181,14 +181,14 @@ pub trait AppContext {
     fn insert_entity<T: 'static>(
         &mut self,
         reservation: Reservation<T>,
-        build_entity: impl FnOnce(&mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>>;
 
     /// Update a entity in the app context.
     fn update_entity<T, R>(
         &mut self,
         handle: &Entity<T>,
-        update: impl FnOnce(&mut T, &mut Context<'_, T>) -> R,
+        update: impl FnOnce(&mut T, &mut Context<T>) -> R,
     ) -> Self::Result<R>
     where
         T: 'static;
@@ -254,7 +254,7 @@ pub trait VisualContext: AppContext {
     /// Update a view with the given callback
     fn new_window_entity<T: 'static>(
         &mut self,
-        build_entity: impl FnOnce(&mut Window, &mut Context<'_, T>) -> T,
+        build_entity: impl FnOnce(&mut Window, &mut Context<T>) -> T,
     ) -> Self::Result<Entity<T>>;
 
     /// Replace the root view of a window with a new view.

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1009,7 +1009,7 @@ impl Window {
     pub fn replace_root<E>(
         &mut self,
         cx: &mut App,
-        build_view: impl FnOnce(&mut Window, &mut Context<'_, E>) -> E,
+        build_view: impl FnOnce(&mut Window, &mut Context<E>) -> E,
     ) -> Entity<E>
     where
         E: 'static + Render,
@@ -3824,7 +3824,7 @@ impl<V: 'static + Render> WindowHandle<V> {
     pub fn update<C, R>(
         &self,
         cx: &mut C,
-        update: impl FnOnce(&mut V, &mut Window, &mut Context<'_, V>) -> R,
+        update: impl FnOnce(&mut V, &mut Window, &mut Context<V>) -> R,
     ) -> Result<R>
     where
         C: AppContext,

--- a/crates/notifications/src/notification_store.rs
+++ b/crates/notifications/src/notification_store.rs
@@ -358,7 +358,7 @@ impl NotificationStore {
         &mut self,
         notifications: impl IntoIterator<Item = (u64, Option<NotificationEntry>)>,
         is_new: bool,
-        cx: &mut Context<'_, NotificationStore>,
+        cx: &mut Context<NotificationStore>,
     ) {
         let mut cursor = self.notifications.cursor::<(NotificationId, Count)>(&());
         let mut new_notifications = SumTree::default();

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -466,7 +466,7 @@ impl BreakpointStore {
     pub fn with_serialized_breakpoints(
         &self,
         breakpoints: BTreeMap<Arc<Path>, Vec<SerializedBreakpoint>>,
-        cx: &mut Context<'_, BreakpointStore>,
+        cx: &mut Context<BreakpointStore>,
     ) -> Task<Result<()>> {
         if let BreakpointStoreMode::Local(mode) = &self.mode {
             let mode = mode.clone();

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -851,7 +851,7 @@ fn create_new_session(
     session_id: SessionId,
     initialized_rx: oneshot::Receiver<()>,
     start_client_task: Task<Result<Entity<Session>, anyhow::Error>>,
-    cx: &mut Context<'_, DapStore>,
+    cx: &mut Context<DapStore>,
 ) -> Task<Result<Entity<Session>>> {
     let task = cx.spawn(async move |this, cx| {
         let session = match start_client_task.await {

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1427,7 +1427,7 @@ impl Session {
     fn clear_active_debug_line_response(
         &mut self,
         response: Result<()>,
-        cx: &mut Context<'_, Session>,
+        cx: &mut Context<Session>,
     ) -> Option<()> {
         response.log_err()?;
         self.clear_active_debug_line(cx);
@@ -1931,7 +1931,7 @@ fn create_local_session(
     mut message_rx: futures::channel::mpsc::UnboundedReceiver<Message>,
     mode: LocalMode,
     capabilities: Capabilities,
-    cx: &mut Context<'_, Session>,
+    cx: &mut Context<Session>,
 ) -> Session {
     let _background_tasks = vec![cx.spawn(async move |this: WeakEntity<Session>, cx| {
         let mut initialized_tx = Some(initialized_tx);

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -984,7 +984,7 @@ impl GitStore {
     fn update_repositories(
         &mut self,
         worktree_store: &Entity<WorktreeStore>,
-        cx: &mut Context<'_, GitStore>,
+        cx: &mut Context<GitStore>,
     ) {
         let mut new_repositories = HashMap::default();
         let git_store = cx.weak_entity();

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2960,7 +2960,7 @@ impl LocalLspStore {
     fn remove_worktree(
         &mut self,
         id_to_remove: WorktreeId,
-        cx: &mut Context<'_, LspStore>,
+        cx: &mut Context<LspStore>,
     ) -> Vec<LanguageServerId> {
         self.diagnostics.remove(&id_to_remove);
         self.prettier_store.update(cx, |prettier_store, cx| {
@@ -3567,7 +3567,7 @@ impl LspStore {
         client: AnyProtoClient,
         upstream_project_id: u64,
         request: R,
-        cx: &mut Context<'_, LspStore>,
+        cx: &mut Context<LspStore>,
     ) -> Task<anyhow::Result<<R as LspCommand>::Response>> {
         let message = request.to_proto(upstream_project_id, buffer.read(cx));
         cx.spawn(async move |this, cx| {
@@ -4297,7 +4297,7 @@ impl LspStore {
         cx.notify();
     }
 
-    fn refresh_server_tree(&mut self, cx: &mut Context<'_, Self>) {
+    fn refresh_server_tree(&mut self, cx: &mut Context<Self>) {
         let buffer_store = self.buffer_store.clone();
         if let Some(local) = self.as_local_mut() {
             let mut adapters = BTreeMap::default();
@@ -6643,7 +6643,7 @@ impl LspStore {
         buffer: &Entity<Buffer>,
         position: Option<P>,
         request: R,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) -> Task<Vec<R::Response>>
     where
         P: ToOffset,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3770,7 +3770,7 @@ impl Project {
         &mut self,
         source: WorktreeId,
         destination: WorktreeId,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) -> Result<()> {
         self.worktree_store.update(cx, |worktree_store, cx| {
             worktree_store.move_worktree(source, destination, cx)

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -725,7 +725,7 @@ impl SettingsObserver {
         fs: Arc<dyn Fs>,
         task_kind: TaskKind,
         file_path: PathBuf,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) -> Task<()> {
         let mut user_tasks_file_rx =
             watch_config_file(&cx.background_executor(), fs, file_path.clone());

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -162,7 +162,7 @@ impl TaskStore {
         worktree_store: Entity<WorktreeStore>,
         toolchain_store: Arc<dyn LanguageToolchainStore>,
         environment: Entity<ProjectEnvironment>,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) -> Self {
         Self::Functional(StoreState {
             mode: StoreMode::Local {
@@ -182,7 +182,7 @@ impl TaskStore {
         toolchain_store: Arc<dyn LanguageToolchainStore>,
         upstream_client: AnyProtoClient,
         project_id: u64,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) -> Self {
         Self::Functional(StoreState {
             mode: StoreMode::Remote {
@@ -265,7 +265,7 @@ impl TaskStore {
         location: TaskSettingsLocation<'_>,
         raw_tasks_json: Option<&str>,
         task_type: TaskKind,
-        cx: &mut Context<'_, Self>,
+        cx: &mut Context<Self>,
     ) -> Result<(), InvalidSettingsError> {
         let task_inventory = match self {
             TaskStore::Functional(state) => &state.task_inventory,

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -848,7 +848,7 @@ pub fn handle_settings_file_changes(
     .detach();
 }
 
-fn read_proxy_settings(cx: &mut Context<'_, HeadlessProject>) -> Option<Uri> {
+fn read_proxy_settings(cx: &mut Context<HeadlessProject>) -> Option<Uri> {
     let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
     let proxy_url = proxy_str
         .as_ref()

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1859,7 +1859,7 @@ impl Terminal {
         Task::ready(())
     }
 
-    fn register_task_finished(&mut self, error_code: Option<i32>, cx: &mut Context<'_, Terminal>) {
+    fn register_task_finished(&mut self, error_code: Option<i32>, cx: &mut Context<Terminal>) {
         self.completion_tx.try_send(()).ok();
         let task = match &mut self.task {
             Some(task) => task,

--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -49,7 +49,7 @@ struct GlobalMigrationNotification(Entity<MigrationNotification>);
 impl Global for GlobalMigrationNotification {}
 
 impl MigrationBanner {
-    pub fn new(_: &Workspace, cx: &mut Context<'_, Self>) -> Self {
+    pub fn new(_: &Workspace, cx: &mut Context<Self>) -> Self {
         if let Some(notifier) = MigrationNotification::try_global(cx) {
             cx.subscribe(
                 &notifier,
@@ -80,7 +80,7 @@ impl MigrationBanner {
         }
     }
 
-    fn handle_notification(&mut self, event: &MigrationEvent, cx: &mut Context<'_, Self>) {
+    fn handle_notification(&mut self, event: &MigrationEvent, cx: &mut Context<Self>) {
         match event {
             MigrationEvent::ContentChanged {
                 migration_type,


### PR DESCRIPTION
This PR removes a number of unneeded anonymous lifetimes from usages of `gpui::Context`.

Release Notes:

- N/A
