### PR TITLE
Fix workspace bottom obscured when bottom dock is full height

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5879,7 +5879,8 @@ fn resize_bottom_dock(
     window: &mut Window,
     cx: &mut App,
 ) {
-    let size = new_size.min(workspace.bounds.bottom() - RESIZE_HANDLE_SIZE - workspace.bounds.top());
+    let size =
+        new_size.min(workspace.bounds.bottom() - RESIZE_HANDLE_SIZE - workspace.bounds.top());
     workspace.bottom_dock.update(cx, |bottom_dock, cx| {
         bottom_dock.resize_active_panel(Some(size), window, cx);
     });

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5879,7 +5879,7 @@ fn resize_bottom_dock(
     window: &mut Window,
     cx: &mut App,
 ) {
-    let size = new_size.min(workspace.bounds.bottom() - RESIZE_HANDLE_SIZE);
+    let size = new_size.min(workspace.bounds.bottom() - RESIZE_HANDLE_SIZE - workspace.bounds.top());
     workspace.bottom_dock.update(cx, |bottom_dock, cx| {
         bottom_dock.resize_active_panel(Some(size), window, cx);
     });


### PR DESCRIPTION
When dragging the pane separator of the bottom dock to full window height, the contents at the bottom of the dock and workspace window overflowed the screen, becoming obscured. This happened because setting a new size in resize_bottom_dock(...) was not taking in consideration the top bounds of the workspace window, which caused the bottom bounds of both dock and workspace to overflow. The issue was fixed by subtracting the workspace.bounds.top() value to the dock's new size.

Closes #12966

Release Notes:

- N/A