### PR TITLE
collab: Switch to new encryption format for access tokens

### DIFF
--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -156,13 +156,7 @@ pub fn encrypt_access_token(access_token: &str, public_key: String) -> Result<St
     use rpc::auth::EncryptionFormat;
 
     /// The encryption format to use for the access token.
-    ///
-    /// Currently we're using the original encryption format to avoid
-    /// breaking compatibility with older clients.
-    ///
-    /// Once enough clients are capable of decrypting the newer encryption
-    /// format we can start encrypting with `EncryptionFormat::V1`.
-    const ENCRYPTION_FORMAT: EncryptionFormat = EncryptionFormat::V0;
+    const ENCRYPTION_FORMAT: EncryptionFormat = EncryptionFormat::V1;
 
     let native_app_public_key =
         rpc::auth::PublicKey::try_from(public_key).context("failed to parse app public key")?;


### PR DESCRIPTION
This PR switches collab over to start minting access tokens using the new OAEP-based encryption format.

This is a follow-up to #15058 where we added support for this new encryption format.

Clients that are newer than 8 months ago should be able to decrypt the new access tokens. It is only clients older than 8 months ago that will no longer be supported.

Release Notes:

- N/A
