### PR TITLE
Don't consider empty deleted files to be dirty or conflicting

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1950,13 +1950,14 @@ impl Buffer {
         if self.capability == Capability::ReadOnly {
             return false;
         }
-        if self.has_conflict || self.has_unsaved_edits() {
+        if self.has_conflict {
             return true;
         }
         match self.file.as_ref().map(|f| f.disk_state()) {
-            Some(DiskState::New) => !self.is_empty(),
-            Some(DiskState::Deleted) => true,
-            _ => false,
+            Some(DiskState::New) | Some(DiskState::Deleted) => {
+                !self.is_empty() && self.has_unsaved_edits()
+            }
+            _ => self.has_unsaved_edits(),
         }
     }
 
@@ -1977,7 +1978,7 @@ impl Buffer {
                 }
                 None => true,
             },
-            DiskState::Deleted => true,
+            DiskState::Deleted => false,
         }
     }
 


### PR DESCRIPTION
When a file is deleted outside of Zed, but it doesn't have any unsaved changes, it shouldn't be considered "dirty" (prompting you before you close it).

Release Notes:

- Fixed an bug where unchanged buffers were marked as conflicting if their files were deleted outside of Zed.
