### PR TITLE
zed: Fix `package.metadata.bundle-dev` key

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -162,7 +162,7 @@ tree-sitter-md.workspace = true
 tree-sitter-rust.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 
-[package.metadata.bundle]
+[package.metadata.bundle-dev]
 icon = ["resources/app-icon-dev@2x.png", "resources/app-icon-dev.png"]
 identifier = "dev.zed.Zed-Dev"
 name = "Zed Dev"


### PR DESCRIPTION
This PR fixes the `package.metadata.bundle-dev` key in the `zed` crate's `Cargo.toml`.

It seems this was inadvertently changed in https://github.com/zed-industries/zed/pull/27126.

Nightly builds are currently failing with:

```
error: `cargo metadata` exited with an error: error: invalid table header
duplicate key `bundle` in table `package.metadata`
   --> Cargo.toml:173:1
    |
173 | [package.metadata.bundle]
    | ^
    |

   0: backtrace::capture::Backtrace::create
   1: error_chain::backtrace::imp::InternalBacktrace::new
   2: <error_chain::State as core::default::Default>::default
   3: cargo_bundle::bundle::settings::load_metadata
   4: cargo_bundle::bundle::settings::Settings::new
   5: cargo_bundle::main
   6: std::sys::backtrace::__rust_begin_short_backtrace
   7: std::rt::lang_start::{{closure}}
   8: std::rt::lang_start_internal
   9: _main
```

Release Notes:

- N/A
