### PR TITLE
Switch back to upstream `cargo_metadata`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2442,7 +2442,8 @@ dependencies = [
 [[package]]
 name = "cargo_metadata"
 version = "0.19.2"
-source = "git+https://github.com/zed-industries/cargo_metadata?rev=ce8171bad673923d61a77b6761d0dc4aff63398a#ce8171bad673923d61a77b6761d0dc4aff63398a"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
 dependencies = [
  "camino",
  "cargo-platform",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -411,7 +411,7 @@ blade-util = { git = "https://github.com/kvark/blade", rev = "b16f5c7bd873c7126f
 naga = { version = "23.1.0", features = ["wgsl-in"] }
 blake3 = "1.5.3"
 bytes = "1.0"
-cargo_metadata = { git = "https://github.com/zed-industries/cargo_metadata", rev = "ce8171bad673923d61a77b6761d0dc4aff63398a"}
+cargo_metadata = "0.19"
 cargo_toml = "0.21"
 chrono = { version = "0.4", features = ["serde"] }
 circular-buffer = "1.0"


### PR DESCRIPTION
This PR switches us back to the upstream `cargo_metadata`.

We had switched to a fork in #27126, but this shouldn't be necessary after #27117.

Release Notes:

- N/A
