### PR TITLE
assistant2: Fix incorrect action when clicking on a profile

### DIFF
--- a/crates/assistant2/src/assistant_configuration/manage_profiles_modal.rs
+++ b/crates/assistant2/src/assistant_configuration/manage_profiles_modal.rs
@@ -363,7 +363,7 @@ impl ManageProfilesModal {
                                     .on_click({
                                         let profile_id = profile.id.clone();
                                         cx.listener(move |this, _, window, cx| {
-                                            this.new_profile(Some(profile_id.clone()), window, cx);
+                                            this.view_profile(profile_id.clone(), window, cx);
                                         })
                                     }),
                                 )


### PR DESCRIPTION
This PR fixes an issue where clicking on a profile entry would fork it instead of viewing it.

Release Notes:

- N/A
