### PR TITLE
gpui: Use clipboard From trait conversions

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1262,7 +1262,7 @@ pub enum ClipboardEntry {
 impl ClipboardItem {
     /// Create a new ClipboardItem::String with no associated metadata
     pub fn new_string(text: String) -> Self {
-        Self::from(ClipboardString::new(text))
+        Self::from(text)
     }
 
     /// Create a new ClipboardItem::String with the given text and associated metadata

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1262,35 +1262,22 @@ pub enum ClipboardEntry {
 impl ClipboardItem {
     /// Create a new ClipboardItem::String with no associated metadata
     pub fn new_string(text: String) -> Self {
-        Self {
-            entries: vec![ClipboardEntry::String(ClipboardString::new(text))],
-        }
+        Self::from(ClipboardString::new(text))
     }
 
     /// Create a new ClipboardItem::String with the given text and associated metadata
     pub fn new_string_with_metadata(text: String, metadata: String) -> Self {
-        Self {
-            entries: vec![ClipboardEntry::String(ClipboardString {
-                text,
-                metadata: Some(metadata),
-            })],
-        }
+        Self::from(ClipboardString::new(text).with_metadata(metadata))
     }
 
     /// Create a new ClipboardItem::String with the given text and associated metadata
     pub fn new_string_with_json_metadata<T: Serialize>(text: String, metadata: T) -> Self {
-        Self {
-            entries: vec![ClipboardEntry::String(
-                ClipboardString::new(text).with_json_metadata(metadata),
-            )],
-        }
+        Self::from(ClipboardString::new(text).with_json_metadata(metadata))
     }
 
     /// Create a new ClipboardItem::Image with the given image with no associated metadata
     pub fn new_image(image: &Image) -> Self {
-        Self {
-            entries: vec![ClipboardEntry::Image(image.clone())],
-        }
+        Self::from(image.clone())
     }
 
     /// Concatenates together all the ClipboardString entries in the item.
@@ -1358,6 +1345,12 @@ impl From<ClipboardEntry> for ClipboardItem {
         Self {
             entries: vec![value],
         }
+    }
+}
+
+impl From<ClipboardString> for ClipboardItem {
+    fn from(value: ClipboardString) -> Self {
+        Self::from(ClipboardEntry::from(value))
     }
 }
 
@@ -1501,10 +1494,13 @@ pub struct ClipboardString {
 impl ClipboardString {
     /// Create a new clipboard string with the given text
     pub fn new(text: String) -> Self {
-        Self {
-            text,
-            metadata: None,
-        }
+        Self::from(text)
+    }
+
+    /// Return a new clipboard item with the metadata replaced by the given metadata
+    pub fn with_metadata(mut self, metadata: String) -> Self {
+        self.metadata = Some(metadata);
+        self
     }
 
     /// Return a new clipboard item with the metadata replaced by the given metadata,

--- a/crates/gpui/src/platform/linux/wayland/clipboard.rs
+++ b/crates/gpui/src/platform/linux/wayland/clipboard.rs
@@ -134,9 +134,7 @@ impl<T: ReceiveData> DataOffer<T> {
 
             if let Some(bytes) = self.read_bytes(connection, mime_type) {
                 let id = hash(&bytes);
-                return Some(ClipboardItem {
-                    entries: vec![ClipboardEntry::Image(Image { format, bytes, id })],
-                });
+                return Some(ClipboardItem::from(Image { format, bytes, id }));
             }
         }
         None

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -4,11 +4,10 @@ use super::{
     renderer, screen_capture, BoolExt,
 };
 use crate::{
-    hash, Action, AnyWindowHandle, BackgroundExecutor, ClipboardEntry, ClipboardItem,
-    ClipboardString, CursorStyle, ForegroundExecutor, Image, ImageFormat, Keymap, MacDispatcher,
-    MacDisplay, MacWindow, Menu, MenuItem, PathPromptOptions, Platform, PlatformDisplay,
-    PlatformTextSystem, PlatformWindow, Result, ScreenCaptureSource, SemanticVersion, Task,
-    WindowAppearance, WindowParams,
+    hash, Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, ClipboardString, CursorStyle,
+    ForegroundExecutor, Image, ImageFormat, Keymap, MacDispatcher, MacDisplay, MacWindow, Menu,
+    MenuItem, PathPromptOptions, Platform, PlatformDisplay, PlatformTextSystem, PlatformWindow,
+    Result, ScreenCaptureSource, SemanticVersion, Task, WindowAppearance, WindowParams,
 };
 use anyhow::{anyhow, Context as _};
 use block::ConcreteBlock;
@@ -1196,9 +1195,7 @@ impl MacPlatform {
                 }
             });
 
-        ClipboardItem {
-            entries: vec![ClipboardEntry::String(ClipboardString { text, metadata })],
-        }
+        ClipboardItem::from(ClipboardString { text, metadata })
     }
 
     unsafe fn write_plaintext_to_clipboard(&self, string: &ClipboardString) {
@@ -1268,9 +1265,7 @@ fn try_clipboard_image(pasteboard: id, format: ImageFormat) -> Option<ClipboardI
                 ));
                 let id = hash(&bytes);
 
-                Some(ClipboardItem {
-                    entries: vec![ClipboardEntry::Image(Image { format, bytes, id })],
-                })
+                Some(ClipboardItem::from(Image { format, bytes, id }))
             }
         } else {
             None
@@ -1582,11 +1577,10 @@ mod tests {
         platform.write_to_clipboard(item.clone());
         assert_eq!(platform.read_from_clipboard(), Some(item));
 
-        let item = ClipboardItem {
-            entries: vec![ClipboardEntry::String(
-                ClipboardString::new("2".to_string()).with_json_metadata(vec![3, 4]),
-            )],
-        };
+        let item = ClipboardItem::from(
+            ClipboardString::new("2".to_string()).with_json_metadata(vec![3, 4]),
+        );
+
         platform.write_to_clipboard(item.clone());
         assert_eq!(platform.read_from_clipboard(), Some(item));
 

--- a/crates/gpui/src/platform/windows/clipboard.rs
+++ b/crates/gpui/src/platform/windows/clipboard.rs
@@ -244,9 +244,7 @@ where
             continue;
         };
         if let Some(entry) = f(*item_format) {
-            return Some(ClipboardItem {
-                entries: vec![entry],
-            });
+            return Some(ClipboardItem::from(entry));
         }
     }
     // log the formats that we don't support yet.
@@ -276,18 +274,17 @@ fn read_string_from_clipboard() -> Option<ClipboardEntry> {
         String::from_utf16_lossy(unsafe { text.as_wide() })
     };
     let Some(hash) = read_hash_from_clipboard() else {
-        return Some(ClipboardEntry::String(ClipboardString::new(text)));
+        return Some(ClipboardEntry::from(text));
     };
     let Some(metadata) = read_metadata_from_clipboard() else {
-        return Some(ClipboardEntry::String(ClipboardString::new(text)));
+        return Some(ClipboardEntry::from(text));
     };
     if hash == ClipboardString::text_hash(&text) {
-        Some(ClipboardEntry::String(ClipboardString {
-            text,
-            metadata: Some(metadata),
-        }))
+        Some(ClipboardEntry::String(
+            ClipboardString::new(text).with_metadata(metadata),
+        ))
     } else {
-        Some(ClipboardEntry::String(ClipboardString::new(text)))
+        Some(ClipboardEntry::from(text))
     }
 }
 
@@ -344,10 +341,7 @@ fn read_files_from_clipboard() -> Option<ClipboardEntry> {
     with_file_names(hdrop, |file_name| {
         filenames.push_str(&file_name);
     });
-    Some(ClipboardEntry::String(ClipboardString {
-        text: filenames,
-        metadata: None,
-    }))
+    Some(ClipboardEntry::from(filenames))
 }
 
 impl From<ImageFormat> for image::ImageFormat {


### PR DESCRIPTION
With https://github.com/zed-industries/zed/pull/27585 merging From trait conversions between clipboard structs, we can now use them to simplify some of the existing constructors and other code

Also added the metadata counterpart to `with_json_metadata` for `ClipboardString`

Release Notes:

- N/A *or* Added/Fixed/Improved ...
