### PR TITLE
Revert "terminal: Make IME work with tab and enter keys (#27572)"

### DIFF
--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -998,7 +998,7 @@ impl InputHandler for TerminalInputHandler {
     }
 
     fn marked_text_range(&mut self, _: &mut Window, _: &mut App) -> Option<std::ops::Range<usize>> {
-        Some(0..0)
+        None
     }
 
     fn text_for_range(


### PR DESCRIPTION
This reverts commit be657aefa38da0f63bedaea18621edcc0cc929d1. (#27572)

Unfortunately this change broke other bindings in the terminal like `cmd-left`
and `cmd-right`.

We do need to redo the terminal IME handling at some point, but we'll need a
bit more thought to find an approach that works.

Release Notes:

- N/A
