### PR TITLE
Use symmetric padding in signature popovers

### DIFF
--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -308,7 +308,7 @@ impl SignatureHelpPopover {
             .on_mouse_move(|_, _, cx| cx.stop_propagation())
             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .child(
-                div().px_4().py_1().child(
+                div().px_2().py_0p5().child(
                     StyledText::new(self.label.clone())
                         .with_default_highlights(&self.style, self.highlights.iter().cloned()),
                 ),

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -308,7 +308,7 @@ impl SignatureHelpPopover {
             .on_mouse_move(|_, _, cx| cx.stop_propagation())
             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
             .child(
-                div().px_4().pb_1().child(
+                div().px_4().py_1().child(
                     StyledText::new(self.label.clone())
                         .with_default_highlights(&self.style, self.highlights.iter().cloned()),
                 ),


### PR DESCRIPTION
Release Notes:

- Fixed padding issue with the signature popovers

------

Before:
<img width="372" alt="Screenshot 2025-03-29 at 20 30 39" src="https://github.com/user-attachments/assets/36d1555d-bccb-4fca-b6ad-514cf11d024f" /> 

After:
<img width="375" alt="Screenshot 2025-03-29 at 20 31 13" src="https://github.com/user-attachments/assets/6566d0e9-9dae-47dc-bfa0-526bf35f3cf0" />

