### PR TITLE
Fix stale git statuses

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5346,7 +5346,6 @@ impl BackgroundScanner {
                             &local_repository.work_directory_id,
                             |entry| {
                                 entry.git_dir_scan_id = scan_id;
-                                entry.status_scan_id = scan_id;
                             },
                         );
                         if let Some(repo_entry) = state

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -5061,11 +5061,10 @@ impl BackgroundScanner {
                     );
 
                     if let Some(work_directory_id) = work_directory_id {
-                        let scan_id = state.snapshot.scan_id;
                         state.snapshot.git_repositories.update(
                             &work_directory_id,
                             |local_repository_entry| {
-                                local_repository_entry.status_scan_id = scan_id;
+                                local_repository_entry.status_scan_id += 1;
                             },
                         );
                     }


### PR DESCRIPTION
Display of git statuses in the git panel, project panel, and tabs regressed in #27391, causing us to frequently see stale statuses. This turns out to be because we were not emitting the `WorktreeUpdatedGitRepositories` event in cases where we should be, which in turn is because of bumping the `LocalRepositoryEntry`'s `status_scan_id` too early, so that a later comparison of two `status_scan_id` values wasn't detecting a change that we're expecting it to detect.

Release Notes:

- N/A (problematic behavior didn't make it into stable or preview)