### PR TITLE
Add `auto_indent_on_input` setting to allow for disabling auto-indent

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -224,6 +224,8 @@
   // bracket, brace, single or double quote characters.
   // For example, when you select text and type (, Zed will surround the text with ().
   "use_auto_surround": true,
+  // Whether indentation should be automatically adjusted when typing.
+  "auto_indent_on_input": true,
   // Whether indentation of pasted content should be adjusted based on the context.
   "auto_indent_on_paste": true,
   // Controls how the editor handles the autoclosed characters.

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -131,6 +131,7 @@ impl ActivityIndicator {
                                 0..0,
                                 format!("Language server error: {}\n\n{}", server_name, error),
                             )],
+                            Default::default(),
                             None,
                             cx,
                         );

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -3266,7 +3266,7 @@ impl CodegenAlternative {
             // Avoid grouping assistant edits with user edits.
             buffer.finalize_last_transaction(cx);
             buffer.start_transaction(cx);
-            buffer.edit(edits, None, cx);
+            buffer.edit(edits, Default::default(), None, cx);
             buffer.end_transaction(cx)
         });
 

--- a/crates/assistant2/src/buffer_codegen.rs
+++ b/crates/assistant2/src/buffer_codegen.rs
@@ -731,7 +731,7 @@ impl CodegenAlternative {
             // Avoid grouping assistant edits with user edits.
             buffer.finalize_last_transaction(cx);
             buffer.start_transaction(cx);
-            buffer.edit(edits, None, cx);
+            buffer.edit(edits, Default::default(), None, cx);
             buffer.end_transaction(cx)
         });
 

--- a/crates/assistant_context_editor/src/context.rs
+++ b/crates/assistant_context_editor/src/context.rs
@@ -1984,6 +1984,7 @@ impl AssistantContext {
                         command_source_range.end..command_source_range.end,
                         insertion,
                     )],
+                    Default::default(),
                     None,
                     cx,
                 );
@@ -2056,7 +2057,12 @@ impl AssistantContext {
                                 this.buffer.update(cx, |buffer, cx| {
                                     let insert_point = insert_position.to_point(buffer);
                                     if insert_point.column > 0 {
-                                        buffer.edit([(insert_point..insert_point, "\n")], None, cx);
+                                        buffer.edit(
+                                            [(insert_point..insert_point, "\n")],
+                                            Default::default(),
+                                            None,
+                                            cx,
+                                        );
                                     }
 
                                     pending_section_stack.push(PendingSection {
@@ -2076,6 +2082,7 @@ impl AssistantContext {
                                 this.buffer.update(cx, |buffer, cx| {
                                     buffer.edit(
                                         [(insert_position..insert_position, text)],
+                                        Default::default(),
                                         None,
                                         cx,
                                     )
@@ -2155,7 +2162,7 @@ impl AssistantContext {
                             }
                         }
 
-                        buffer.edit(deletions, None, cx);
+                        buffer.edit(deletions, Default::default(), None, cx);
 
                         if let Some(deletion_transaction) = buffer.end_transaction(cx) {
                             buffer.merge_transactions(deletion_transaction, first_transaction);
@@ -2382,6 +2389,7 @@ impl AssistantContext {
                                                     message_old_end_offset..message_old_end_offset,
                                                     chunk,
                                                 )],
+                                                Default::default(),
                                                 None,
                                                 cx,
                                             );
@@ -2396,6 +2404,7 @@ impl AssistantContext {
                                                 message_old_end_offset - THOUGHT_PROCESS_END_MARKER.len();
                                             buffer.edit(
                                                 [(insertion_position..insertion_position, chunk)],
+                                                Default::default(),
                                                 None,
                                                 cx,
                                             );
@@ -2418,6 +2427,7 @@ impl AssistantContext {
                                                 message_old_end_offset..message_old_end_offset,
                                                 chunk,
                                             )],
+                                            Default::default(),
                                             None,
                                             cx,
                                         );
@@ -2738,7 +2748,7 @@ impl AssistantContext {
         cx: &mut Context<Self>,
     ) -> MessageAnchor {
         let start = self.buffer.update(cx, |buffer, cx| {
-            buffer.edit([(offset..offset, "\n")], None, cx);
+            buffer.edit([(offset..offset, "\n")], Default::default(), None, cx);
             buffer.anchor_before(offset + 1)
         });
 
@@ -2830,7 +2840,7 @@ impl AssistantContext {
                 }
             } else {
                 self.buffer.update(cx, |buffer, cx| {
-                    buffer.edit([(range.end..range.end, "\n")], None, cx);
+                    buffer.edit([(range.end..range.end, "\n")], Default::default(), None, cx);
                 });
                 edited_buffer = true;
                 MessageAnchor {
@@ -2880,7 +2890,12 @@ impl AssistantContext {
                         }
                     } else {
                         self.buffer.update(cx, |buffer, cx| {
-                            buffer.edit([(range.start..range.start, "\n")], None, cx)
+                            buffer.edit(
+                                [(range.start..range.start, "\n")],
+                                Default::default(),
+                                None,
+                                cx,
+                            )
                         });
                         edited_buffer = true;
                         MessageAnchor {

--- a/crates/assistant_context_editor/src/context/context_tests.rs
+++ b/crates/assistant_context_editor/src/context/context_tests.rs
@@ -80,7 +80,7 @@ fn test_inserting_and_removing_messages(cx: &mut App) {
     );
 
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "1"), (1..1, "2")], None, cx)
+        buffer.edit([(0..0, "1"), (1..1, "2")], Default::default(), None, cx)
     });
     assert_eq!(
         messages(&context, cx),
@@ -120,7 +120,7 @@ fn test_inserting_and_removing_messages(cx: &mut App) {
     );
 
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(4..4, "C"), (5..5, "D")], None, cx)
+        buffer.edit([(4..4, "C"), (5..5, "D")], Default::default(), None, cx)
     });
     assert_eq!(
         messages(&context, cx),
@@ -133,7 +133,9 @@ fn test_inserting_and_removing_messages(cx: &mut App) {
     );
 
     // Deleting across message boundaries merges the messages.
-    buffer.update(cx, |buffer, cx| buffer.edit([(1..4, "")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(1..4, "")], Default::default(), None, cx)
+    });
     assert_eq!(
         messages(&context, cx),
         vec![
@@ -207,7 +209,12 @@ fn test_message_splitting(cx: &mut App) {
     );
 
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "aaa\nbbb\nccc\nddd\n")], None, cx)
+        buffer.edit(
+            [(0..0, "aaa\nbbb\nccc\nddd\n")],
+            Default::default(),
+            None,
+            cx,
+        )
     });
 
     let (_, message_2) = context.update(cx, |context, cx| context.split_message(3..3, cx));
@@ -308,20 +315,26 @@ fn test_messages_for_offsets(cx: &mut App) {
         vec![(message_1.id, Role::User, 0..0)]
     );
 
-    buffer.update(cx, |buffer, cx| buffer.edit([(0..0, "aaa")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "aaa")], Default::default(), None, cx)
+    });
     let message_2 = context
         .update(cx, |context, cx| {
             context.insert_message_after(message_1.id, Role::User, MessageStatus::Done, cx)
         })
         .unwrap();
-    buffer.update(cx, |buffer, cx| buffer.edit([(4..4, "bbb")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(4..4, "bbb")], Default::default(), None, cx)
+    });
 
     let message_3 = context
         .update(cx, |context, cx| {
             context.insert_message_after(message_2.id, Role::User, MessageStatus::Done, cx)
         })
         .unwrap();
-    buffer.update(cx, |buffer, cx| buffer.edit([(8..8, "ccc")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(8..8, "ccc")], Default::default(), None, cx)
+    });
 
     assert_eq!(buffer.read(cx).text(), "aaa\nbbb\nccc");
     assert_eq!(
@@ -458,7 +471,7 @@ async fn test_slash_commands(cx: &mut TestAppContext) {
 
     // Insert a slash command
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "/file src/lib.rs")], None, cx);
+        buffer.edit([(0..0, "/file src/lib.rs")], Default::default(), None, cx);
     });
     assert_text_and_context_ranges(
         &buffer,
@@ -472,7 +485,12 @@ async fn test_slash_commands(cx: &mut TestAppContext) {
     // Edit the argument of the slash command.
     buffer.update(cx, |buffer, cx| {
         let edit_offset = buffer.text().find("lib.rs").unwrap();
-        buffer.edit([(edit_offset..edit_offset + "lib".len(), "main")], None, cx);
+        buffer.edit(
+            [(edit_offset..edit_offset + "lib".len(), "main")],
+            Default::default(),
+            None,
+            cx,
+        );
     });
     assert_text_and_context_ranges(
         &buffer,
@@ -488,6 +506,7 @@ async fn test_slash_commands(cx: &mut TestAppContext) {
         let edit_offset = buffer.text().find("/file").unwrap();
         buffer.edit(
             [(edit_offset..edit_offset + "/file".len(), "/unknown")],
+            Default::default(),
             None,
             cx,
         );
@@ -1097,7 +1116,7 @@ async fn test_serialization(cx: &mut TestAppContext) {
             .unwrap()
     });
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "a"), (1..1, "b\nc")], None, cx);
+        buffer.edit([(0..0, "a"), (1..1, "b\nc")], Default::default(), None, cx);
         buffer.finalize_last_transaction();
     });
     let _message_3 = context.update(cx, |context, cx| {
@@ -1264,6 +1283,7 @@ async fn test_random_context_collaboration(cx: &mut TestAppContext, mut rng: Std
                         let offset = buffer.random_byte_range(0, &mut rng).start;
                         buffer.edit(
                             [(offset..offset, format!("\n{}\n", command_text))],
+                            Default::default(),
                             None,
                             cx,
                         );
@@ -1468,20 +1488,26 @@ fn test_mark_cache_anchors(cx: &mut App) {
         "Empty messages should not have any cache anchors."
     );
 
-    buffer.update(cx, |buffer, cx| buffer.edit([(0..0, "aaa")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "aaa")], Default::default(), None, cx)
+    });
     let message_2 = context
         .update(cx, |context, cx| {
             context.insert_message_after(message_1.id, Role::User, MessageStatus::Pending, cx)
         })
         .unwrap();
 
-    buffer.update(cx, |buffer, cx| buffer.edit([(4..4, "bbbbbbb")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(4..4, "bbbbbbb")], Default::default(), None, cx)
+    });
     let message_3 = context
         .update(cx, |context, cx| {
             context.insert_message_after(message_2.id, Role::User, MessageStatus::Pending, cx)
         })
         .unwrap();
-    buffer.update(cx, |buffer, cx| buffer.edit([(12..12, "cccccc")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(12..12, "cccccc")], Default::default(), None, cx)
+    });
 
     context.update(cx, |context, cx| {
         context.mark_cache_anchors(cache_configuration, false, cx)
@@ -1547,7 +1573,9 @@ fn test_mark_cache_anchors(cx: &mut App) {
         "All user messages prior to anchor should be marked as cached."
     );
 
-    buffer.update(cx, |buffer, cx| buffer.edit([(14..14, "d")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(14..14, "d")], Default::default(), None, cx)
+    });
     context.update(cx, |context, cx| {
         context.mark_cache_anchors(cache_configuration, false, cx)
     });
@@ -1566,7 +1594,9 @@ fn test_mark_cache_anchors(cx: &mut App) {
         ],
         "Modifying a message should invalidate it's cache but leave previous messages."
     );
-    buffer.update(cx, |buffer, cx| buffer.edit([(2..2, "e")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(2..2, "e")], Default::default(), None, cx)
+    });
     context.update(cx, |context, cx| {
         context.mark_cache_anchors(cache_configuration, false, cx)
     });

--- a/crates/assistant_context_editor/src/patch.rs
+++ b/crates/assistant_context_editor/src/patch.rs
@@ -139,6 +139,7 @@ impl ResolvedPatch {
         buffer.update(cx, |buffer, cx| {
             buffer.edit(
                 edits,
+                Default::default(),
                 Some(AutoindentMode::Block {
                     original_indent_columns: Vec::new(),
                 }),

--- a/crates/assistant_tool/src/action_log.rs
+++ b/crates/assistant_tool/src/action_log.rs
@@ -612,12 +612,22 @@ mod tests {
 
         let edit1 = buffer.update(cx, |buffer, cx| {
             buffer
-                .edit([(Point::new(1, 1)..Point::new(1, 2), "E")], None, cx)
+                .edit(
+                    [(Point::new(1, 1)..Point::new(1, 2), "E")],
+                    Default::default(),
+                    None,
+                    cx,
+                )
                 .unwrap()
         });
         let edit2 = buffer.update(cx, |buffer, cx| {
             buffer
-                .edit([(Point::new(4, 2)..Point::new(4, 3), "O")], None, cx)
+                .edit(
+                    [(Point::new(4, 2)..Point::new(4, 3), "O")],
+                    Default::default(),
+                    None,
+                    cx,
+                )
                 .unwrap()
         });
         assert_eq!(
@@ -740,6 +750,7 @@ mod tests {
             buffer
                 .edit(
                     [(Point::new(0, 2)..Point::new(2, 3), "C\nDEF\nGHI")],
+                    Default::default(),
                     None,
                     cx,
                 )
@@ -785,7 +796,12 @@ mod tests {
         );
 
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(0, 2)..Point::new(0, 2), "X")], None, cx)
+            buffer.edit(
+                [(Point::new(0, 2)..Point::new(0, 2), "X")],
+                Default::default(),
+                None,
+                cx,
+            )
         });
         cx.run_until_parked();
         assert_eq!(

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -85,7 +85,12 @@ fn view_release_notes_locally(
                                 project.create_local_buffer("", markdown, cx)
                             });
                             buffer.update(cx, |buffer, cx| {
-                                buffer.edit([(0..0, body.release_notes)], None, cx)
+                                buffer.edit(
+                                    [(0..0, body.release_notes)],
+                                    Default::default(),
+                                    None,
+                                    cx,
+                                )
                             });
                             let language_registry = project.read(cx).languages().clone();
 

--- a/crates/collab/src/tests/channel_buffer_tests.rs
+++ b/crates/collab/src/tests/channel_buffer_tests.rs
@@ -38,13 +38,13 @@ async fn test_core_channel_buffers(
     // Client A edits the buffer
     let buffer_a = channel_buffer_a.read_with(cx_a, |buffer, _| buffer.buffer());
     buffer_a.update(cx_a, |buffer, cx| {
-        buffer.edit([(0..0, "hello world")], None, cx)
+        buffer.edit([(0..0, "hello world")], Default::default(), None, cx)
     });
     buffer_a.update(cx_a, |buffer, cx| {
-        buffer.edit([(5..5, ", cruel")], None, cx)
+        buffer.edit([(5..5, ", cruel")], Default::default(), None, cx)
     });
     buffer_a.update(cx_a, |buffer, cx| {
-        buffer.edit([(0..5, "goodbye")], None, cx)
+        buffer.edit([(0..5, "goodbye")], Default::default(), None, cx)
     });
     buffer_a.update(cx_a, |buffer, cx| buffer.undo(cx));
     assert_eq!(buffer_text(&buffer_a, cx_a), "hello, cruel world");
@@ -71,7 +71,7 @@ async fn test_core_channel_buffers(
     );
     assert_eq!(buffer_text(&buffer_b, cx_b), "hello, cruel world");
     buffer_b.update(cx_b, |buffer, cx| {
-        buffer.edit([(7..12, "beautiful")], None, cx)
+        buffer.edit([(7..12, "beautiful")], Default::default(), None, cx)
     });
 
     // Both A and B see the new edit
@@ -348,7 +348,7 @@ async fn test_multiple_handles_to_channel_buffer(
 
     channel_buffer.update(cx_a, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "hello")], None, cx);
+            buffer.edit([(0..0, "hello")], Default::default(), None, cx);
         })
     });
     deterministic.run_until_parked();
@@ -469,7 +469,7 @@ async fn test_rejoin_channel_buffer(
 
     channel_buffer_a.update(cx_a, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "1")], None, cx);
+            buffer.edit([(0..0, "1")], Default::default(), None, cx);
         })
     });
     deterministic.run_until_parked();
@@ -481,12 +481,12 @@ async fn test_rejoin_channel_buffer(
     // Both clients make an edit.
     channel_buffer_a.update(cx_a, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(1..1, "2")], None, cx);
+            buffer.edit([(1..1, "2")], Default::default(), None, cx);
         })
     });
     channel_buffer_b.update(cx_b, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "0")], None, cx);
+            buffer.edit([(0..0, "0")], Default::default(), None, cx);
         })
     });
 
@@ -556,7 +556,7 @@ async fn test_channel_buffers_and_server_restarts(
 
     channel_buffer_a.update(cx_a, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "1")], None, cx);
+            buffer.edit([(0..0, "1")], Default::default(), None, cx);
         })
     });
     deterministic.run_until_parked();
@@ -571,12 +571,12 @@ async fn test_channel_buffers_and_server_restarts(
     // While the server is down, both clients make an edit.
     channel_buffer_a.update(cx_a, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(1..1, "2")], None, cx);
+            buffer.edit([(1..1, "2")], Default::default(), None, cx);
         })
     });
     channel_buffer_b.update(cx_b, |buffer, cx| {
         buffer.buffer().update(cx, |buffer, cx| {
-            buffer.edit([(0..0, "0")], None, cx);
+            buffer.edit([(0..0, "0")], Default::default(), None, cx);
         })
     });
 

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -844,7 +844,7 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
                 "Rename that was triggered from zero selection caret, should propose the whole word."
             );
             rename_editor.buffer().update(cx, |rename_buffer, cx| {
-                rename_buffer.edit([(0..3, "THREE")], None, cx);
+                rename_buffer.edit([(0..3, "THREE")], Default::default(), None, cx);
             });
         });
     });
@@ -889,7 +889,7 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
                 "Rename that was triggered from a selection, should have the same selection range in the rename proposal"
             );
             rename_editor.buffer().update(cx, |rename_buffer, cx| {
-                rename_buffer.edit([(0..lsp_rename_end - lsp_rename_start, "THREE")], None, cx);
+                rename_buffer.edit([(0..lsp_rename_end - lsp_rename_start, "THREE")], Default::default(), None, cx);
             });
         });
     });

--- a/crates/collab/src/tests/random_channel_buffer_tests.rs
+++ b/crates/collab/src/tests/random_channel_buffer_tests.rs
@@ -208,6 +208,7 @@ impl RandomizedTest for RandomChannelBufferTest {
                                 let end = snapshot.clip_offset(range.end, Bias::Right);
                                 (start..end, text)
                             }),
+                            Default::default(),
                             None,
                             cx,
                         );

--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -726,6 +726,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                             let end = snapshot.clip_offset(range.end, Bias::Right);
                             (start..end, text)
                         }),
+                        Default::default(),
                         None,
                         cx,
                     );

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -153,7 +153,7 @@ async fn test_sharing_an_ssh_remote_project(
     buffer_b.update(cx_b, |buffer, cx| {
         assert_eq!(buffer.text(), "fn one() -> usize { 1 }");
         let ix = buffer.text().find('1').unwrap();
-        buffer.edit([(ix..ix + 1, "100")], None, cx);
+        buffer.edit([(ix..ix + 1, "100")], Default::default(), None, cx);
     });
 
     executor.run_until_parked();

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1120,7 +1120,9 @@ mod tests {
             }
         );
 
-        buffer_1.update(cx, |buffer, cx| buffer.edit([(5..5, " world")], None, cx));
+        buffer_1.update(cx, |buffer, cx| {
+            buffer.edit([(5..5, " world")], Default::default(), None, cx)
+        });
         assert_eq!(
             lsp.receive_notification::<lsp::notification::DidChangeTextDocument>()
                 .await,

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -440,7 +440,7 @@ mod tests {
         });
 
         // If an edit occurs outside of this editor, the suggestion is still correctly interpolated.
-        cx.update_buffer(|buffer, cx| buffer.edit([(5..5, "o")], None, cx));
+        cx.update_buffer(|buffer, cx| buffer.edit([(5..5, "o")], Default::default(), None, cx));
         cx.update_editor(|editor, window, cx| {
             assert!(editor.has_active_inline_completion());
             assert_eq!(editor.display_text(cx), "one.copilot2\ntwo\nthree\n");
@@ -467,7 +467,7 @@ mod tests {
 
         // If an edit occurs outside of this editor but no suggestion is being shown,
         // we won't make it visible.
-        cx.update_buffer(|buffer, cx| buffer.edit([(6..6, "p")], None, cx));
+        cx.update_buffer(|buffer, cx| buffer.edit([(6..6, "p")], Default::default(), None, cx));
         cx.update_editor(|editor, _, cx| {
             assert!(!editor.has_active_inline_completion());
             assert_eq!(editor.display_text(cx), "one.cop\ntwo\nthree\n");

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -1819,7 +1819,7 @@ pub mod tests {
 
             let ix = snapshot.buffer_snapshot.text().find("seven").unwrap();
             buffer.update(cx, |buffer, cx| {
-                buffer.edit([(ix..ix, "and ")], None, cx);
+                buffer.edit([(ix..ix, "and ")], Default::default(), None, cx);
             });
 
             let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
@@ -1878,6 +1878,7 @@ pub mod tests {
                         "\t",
                     ),
                 ],
+                Default::default(),
                 None,
                 cx,
             )
@@ -1955,7 +1956,7 @@ pub mod tests {
         // Regression test: updating the display map does not crash when a
         // block is immediately followed by a multi-line inlay.
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(1..1, "b")], None, cx);
+            buffer.edit([(1..1, "b")], Default::default(), None, cx);
         });
         map.update(cx, |m, cx| assert_eq!(m.snapshot(cx).text(), "\n\n\nab"));
     }

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -2090,7 +2090,12 @@ mod tests {
 
         // Insert a line break, separating two block decorations into separate lines.
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(1, 1)..Point::new(1, 1), "!!!\n")], None, cx);
+            buffer.edit(
+                [(Point::new(1, 1)..Point::new(1, 1), "!!!\n")],
+                Default::default(),
+                None,
+                cx,
+            );
             buffer.snapshot(cx)
         });
 
@@ -2362,7 +2367,12 @@ mod tests {
         assert_eq!(blocks_snapshot.text(), "line1\n\n\n\n\nline5");
 
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(2, 0)..Point::new(3, 0), "")], None, cx);
+            buffer.edit(
+                [(Point::new(2, 0)..Point::new(3, 0), "")],
+                Default::default(),
+                None,
+                cx,
+            );
             buffer.snapshot(cx)
         });
         let (inlay_snapshot, inlay_edits) = inlay_map.sync(
@@ -2383,6 +2393,7 @@ mod tests {
                     Point::new(1, 5)..Point::new(1, 5),
                     "\nline 2.1\nline2.2\nline 2.3\nline 2.4",
                 )],
+                Default::default(),
                 None,
                 cx,
             );

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -1429,6 +1429,7 @@ mod tests {
                     (Point::new(0, 0)..Point::new(0, 1), "123"),
                     (Point::new(2, 3)..Point::new(2, 3), "123"),
                 ],
+                Default::default(),
                 None,
                 cx,
             );
@@ -1454,7 +1455,12 @@ mod tests {
         );
 
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(2, 6)..Point::new(4, 3), "456")], None, cx);
+            buffer.edit(
+                [(Point::new(2, 6)..Point::new(4, 3), "456")],
+                Default::default(),
+                None,
+                cx,
+            );
             buffer.snapshot(cx)
         });
         let (inlay_snapshot, inlay_edits) =
@@ -1522,7 +1528,7 @@ mod tests {
 
             // Edit within one of the folds.
             let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-                buffer.edit([(0..1, "12345")], None, cx);
+                buffer.edit([(0..1, "12345")], Default::default(), None, cx);
                 buffer.snapshot(cx)
             });
             let (inlay_snapshot, inlay_edits) =
@@ -1567,7 +1573,12 @@ mod tests {
         assert_eq!(snapshot.text(), "aa⋯cccc\nd⋯eeeee");
 
         let buffer_snapshot = buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(2, 2)..Point::new(3, 1), "")], None, cx);
+            buffer.edit(
+                [(Point::new(2, 2)..Point::new(3, 1), "")],
+                Default::default(),
+                None,
+                cx,
+            );
             buffer.snapshot(cx)
         });
         let (inlay_snapshot, inlay_edits) =

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1230,7 +1230,12 @@ mod tests {
 
         // Edits before or after the inlay should not affect it.
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(2..3, "x"), (3..3, "y"), (4..4, "z")], None, cx)
+            buffer.edit(
+                [(2..3, "x"), (3..3, "y"), (4..4, "z")],
+                Default::default(),
+                None,
+                cx,
+            )
         });
         let (inlay_snapshot, _) = inlay_map.sync(
             buffer.read(cx).snapshot(cx),
@@ -1239,7 +1244,9 @@ mod tests {
         assert_eq!(inlay_snapshot.text(), "abxy|123|dzefghi");
 
         // An edit surrounding the inlay should invalidate it.
-        buffer.update(cx, |buffer, cx| buffer.edit([(4..5, "D")], None, cx));
+        buffer.update(cx, |buffer, cx| {
+            buffer.edit([(4..5, "D")], Default::default(), None, cx)
+        });
         let (inlay_snapshot, _) = inlay_map.sync(
             buffer.read(cx).snapshot(cx),
             buffer_edits.consume().into_inner(),
@@ -1264,7 +1271,9 @@ mod tests {
         assert_eq!(inlay_snapshot.text(), "abx|123||456|yDzefghi");
 
         // Edits ending where the inlay starts should not move it if it has a left bias.
-        buffer.update(cx, |buffer, cx| buffer.edit([(3..3, "JKL")], None, cx));
+        buffer.update(cx, |buffer, cx| {
+            buffer.edit([(3..3, "JKL")], Default::default(), None, cx)
+        });
         let (inlay_snapshot, _) = inlay_map.sync(
             buffer.read(cx).snapshot(cx),
             buffer_edits.consume().into_inner(),

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -218,8 +218,8 @@ fn test_undo_redo_with_selection_restoration(cx: &mut TestAppContext) {
         // Simulate an edit in another editor
         buffer.update(cx, |buffer, cx| {
             buffer.start_transaction_at(now, cx);
-            buffer.edit([(0..1, "a")], None, cx);
-            buffer.edit([(1..1, "b")], None, cx);
+            buffer.edit([(0..1, "a")], Default::default(), None, cx);
+            buffer.edit([(1..1, "b")], Default::default(), None, cx);
             buffer.end_transaction_at(now, cx);
         });
 
@@ -1251,6 +1251,7 @@ fn test_move_cursor(cx: &mut TestAppContext) {
                 (Point::new(1, 0)..Point::new(1, 0), "\t"),
                 (Point::new(1, 1)..Point::new(1, 1), "\t"),
             ],
+            Default::default(),
             None,
             cx,
         );
@@ -2607,6 +2608,7 @@ fn test_newline_with_old_selections(cx: &mut TestAppContext) {
                     (Point::new(1, 2)..Point::new(3, 0), ""),
                     (Point::new(4, 2)..Point::new(6, 0), ""),
                 ],
+                Default::default(),
                 None,
                 cx,
             );
@@ -2814,7 +2816,12 @@ fn test_insert_with_old_selections(cx: &mut TestAppContext) {
     _ = editor.update(cx, |editor, window, cx| {
         // Edit the buffer directly, deleting ranges surrounding the editor's selections
         editor.buffer.update(cx, |buffer, cx| {
-            buffer.edit([(2..5, ""), (10..13, ""), (18..21, "")], None, cx);
+            buffer.edit(
+                [(2..5, ""), (10..13, ""), (18..21, "")],
+                Default::default(),
+                None,
+                cx,
+            );
             assert_eq!(buffer.read(cx).text(), "a(), b(), c()".unindent());
         });
         assert_eq!(editor.selections.ranges(cx), &[2..2, 7..7, 12..12],);
@@ -3433,6 +3440,7 @@ fn test_join_lines_with_single_selection(cx: &mut TestAppContext) {
                     (Point::new(1, 0)..Point::new(1, 2), "  "),
                     (Point::new(2, 0)..Point::new(2, 3), "  \n\td"),
                 ],
+                Default::default(),
                 None,
                 cx,
             )

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -824,7 +824,12 @@ mod tests {
 
         // Modify a single line, at the start of the line
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(0, 0)..Point::new(0, 0), "X")], None, cx);
+            buffer.edit(
+                [(Point::new(0, 0)..Point::new(0, 0), "X")],
+                Default::default(),
+                None,
+                cx,
+            );
         });
         git_blame.update(cx, |blame, cx| {
             assert_blame_rows(
@@ -837,7 +842,12 @@ mod tests {
         });
         // Modify a single line, in the middle of the line
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(1, 2)..Point::new(1, 2), "X")], None, cx);
+            buffer.edit(
+                [(Point::new(1, 2)..Point::new(1, 2), "X")],
+                Default::default(),
+                None,
+                cx,
+            );
         });
         git_blame.update(cx, |blame, cx| {
             assert_blame_rows(
@@ -865,7 +875,12 @@ mod tests {
         });
         // Insert a newline at the end
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(3, 6)..Point::new(3, 6), "\n")], None, cx);
+            buffer.edit(
+                [(Point::new(3, 6)..Point::new(3, 6), "\n")],
+                Default::default(),
+                None,
+                cx,
+            );
         });
         // Only the new line is marked as edited:
         git_blame.update(cx, |blame, cx| {
@@ -892,7 +907,12 @@ mod tests {
         // Usage example
         // Insert a newline at the start of the row
         buffer.update(cx, |buffer, cx| {
-            buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "\n")], None, cx);
+            buffer.edit(
+                [(Point::new(2, 0)..Point::new(2, 0), "\n")],
+                Default::default(),
+                None,
+                cx,
+            );
         });
         // Only the new line is marked as edited:
         git_blame.update(cx, |blame, cx| {

--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -571,7 +571,7 @@ pub(crate) fn handle_from(
 
             buffer
                 .update(cx, |buffer, cx| {
-                    buffer.edit(edits, None, cx);
+                    buffer.edit(edits, Default::default(), None, cx);
                 })
                 .ok()?;
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1702,7 +1702,7 @@ impl GitPanel {
                     this.update(cx, |this, cx| {
                         this.commit_message_buffer(cx).update(cx, |buffer, cx| {
                             let insert_position = buffer.anchor_before(buffer.len());
-                            buffer.edit([(insert_position..insert_position, "\n")], None, cx)
+                            buffer.edit([(insert_position..insert_position, "\n")], Default::default(), None, cx)
                         });
                     })?;
                 }
@@ -1713,7 +1713,7 @@ impl GitPanel {
                     this.update(cx, |this, cx| {
                         this.commit_message_buffer(cx).update(cx, |buffer, cx| {
                             let insert_position = buffer.anchor_before(buffer.len());
-                            buffer.edit([(insert_position..insert_position, text)], None, cx);
+                            buffer.edit([(insert_position..insert_position, text)], Default::default(), None, cx);
                         });
                     })?;
                 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -392,18 +392,13 @@ pub trait LocalFile: File {
 }
 
 /// The source/context of an editing operation.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum EditSource {
     /// Edit comes from direct user input
     UserInput,
     /// Edit comes from other programmatic sources
+    #[default]
     Other,
-}
-
-impl Default for EditSource {
-    fn default() -> Self {
-        EditSource::Other
-    }
 }
 
 /// The auto-indent behavior associated with an editing operation.

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -57,10 +57,11 @@ fn test_line_endings(cx: &mut gpui::App) {
         buffer.check_invariants();
         buffer.edit(
             [(buffer.len()..buffer.len(), "\r\nfour")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
-        buffer.edit([(0..0, "zero\r\n")], None, cx);
+        buffer.edit([(0..0, "zero\r\n")], Default::default(), None, cx);
         assert_eq!(buffer.text(), "zero\none\ntwo\nthree\nfour");
         assert_eq!(buffer.line_ending(), LineEnding::Windows);
         buffer.check_invariants();
@@ -298,7 +299,7 @@ fn test_edit_events(cx: &mut gpui::App) {
 
             // An edit emits an edited event, followed by a dirty changed event,
             // since the buffer was previously in a clean state.
-            buffer.edit([(2..4, "XYZ")], None, cx);
+            buffer.edit([(2..4, "XYZ")], Default::default(), None, cx);
 
             // An empty transaction does not emit any events.
             buffer.start_transaction();
@@ -307,8 +308,8 @@ fn test_edit_events(cx: &mut gpui::App) {
             // A transaction containing two edits emits one edited event.
             now += Duration::from_secs(1);
             buffer.start_transaction_at(now);
-            buffer.edit([(5..5, "u")], None, cx);
-            buffer.edit([(6..6, "w")], None, cx);
+            buffer.edit([(5..5, "u")], Default::default(), None, cx);
+            buffer.edit([(6..6, "w")], Default::default(), None, cx);
             buffer.end_transaction_at(now, cx);
 
             // Undoing a transaction emits one edited event.
@@ -425,6 +426,7 @@ async fn test_normalize_whitespace(cx: &mut gpui::TestAppContext) {
                 (Point::new(0, 1)..Point::new(0, 1), "EE"),
                 (Point::new(3, 5)..Point::new(3, 5), "EEE"),
             ],
+            Default::default(),
             None,
             cx,
         );
@@ -498,11 +500,11 @@ async fn test_reparse(cx: &mut gpui::TestAppContext) {
         buf.start_transaction();
 
         let offset = buf.text().find(')').unwrap();
-        buf.edit([(offset..offset, "b: C")], None, cx);
+        buf.edit([(offset..offset, "b: C")], Default::default(), None, cx);
         assert!(!buf.is_parsing());
 
         let offset = buf.text().find('}').unwrap();
-        buf.edit([(offset..offset, " d; ")], None, cx);
+        buf.edit([(offset..offset, " d; ")], Default::default(), None, cx);
         assert!(!buf.is_parsing());
 
         buf.end_transaction(cx);
@@ -526,19 +528,19 @@ async fn test_reparse(cx: &mut gpui::TestAppContext) {
     // * add a turbofish to the method call
     buffer.update(cx, |buf, cx| {
         let offset = buf.text().find(';').unwrap();
-        buf.edit([(offset..offset, ".e")], None, cx);
+        buf.edit([(offset..offset, ".e")], Default::default(), None, cx);
         assert_eq!(buf.text(), "fn a(b: C) { d.e; }");
         assert!(buf.is_parsing());
     });
     buffer.update(cx, |buf, cx| {
         let offset = buf.text().find(';').unwrap();
-        buf.edit([(offset..offset, "(f)")], None, cx);
+        buf.edit([(offset..offset, "(f)")], Default::default(), None, cx);
         assert_eq!(buf.text(), "fn a(b: C) { d.e(f); }");
         assert!(buf.is_parsing());
     });
     buffer.update(cx, |buf, cx| {
         let offset = buf.text().find("(f)").unwrap();
-        buf.edit([(offset..offset, "::<G>")], None, cx);
+        buf.edit([(offset..offset, "::<G>")], Default::default(), None, cx);
         assert_eq!(buf.text(), "fn a(b: C) { d.e::<G>(f); }");
         assert!(buf.is_parsing());
     });
@@ -1173,11 +1175,17 @@ fn test_autoindent_with_soft_tabs(cx: &mut App) {
         let text = "fn a() {}";
         let mut buffer = Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
+        buffer.edit(
+            [(8..8, "\n\n")],
+            Default::default(),
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
         assert_eq!(buffer.text(), "fn a() {\n    \n}");
 
         buffer.edit(
             [(Point::new(1, 4)..Point::new(1, 4), "b()\n")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1187,6 +1195,7 @@ fn test_autoindent_with_soft_tabs(cx: &mut App) {
         // to be indented.
         buffer.edit(
             [(Point::new(2, 4)..Point::new(2, 4), ".c")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1196,6 +1205,7 @@ fn test_autoindent_with_soft_tabs(cx: &mut App) {
         // causing the line to be outdented.
         buffer.edit(
             [(Point::new(2, 8)..Point::new(2, 9), "")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1215,11 +1225,17 @@ fn test_autoindent_with_hard_tabs(cx: &mut App) {
         let text = "fn a() {}";
         let mut buffer = Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx);
 
-        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
+        buffer.edit(
+            [(8..8, "\n\n")],
+            Default::default(),
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
         assert_eq!(buffer.text(), "fn a() {\n\t\n}");
 
         buffer.edit(
             [(Point::new(1, 1)..Point::new(1, 1), "b()\n")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1229,6 +1245,7 @@ fn test_autoindent_with_hard_tabs(cx: &mut App) {
         // to be indented.
         buffer.edit(
             [(Point::new(2, 1)..Point::new(2, 1), ".c")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1238,6 +1255,7 @@ fn test_autoindent_with_hard_tabs(cx: &mut App) {
         // causing the line to be outdented.
         buffer.edit(
             [(Point::new(2, 2)..Point::new(2, 3), "")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1578,6 +1596,7 @@ fn test_autoindent_with_edit_at_end_of_buffer(cx: &mut App) {
         let mut buffer = Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx);
         buffer.edit(
             [(0..1, "\n"), (2..3, "\n")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1604,6 +1623,7 @@ fn test_autoindent_multi_line_insertion(cx: &mut App) {
         let mut buffer = Buffer::local(text, cx).with_language(Arc::new(rust_lang()), cx);
         buffer.edit(
             [(Point::new(3, 0)..Point::new(3, 0), "e(\n    f()\n);\n")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1658,6 +1678,7 @@ fn test_autoindent_block_mode(cx: &mut App) {
         // so that the first line matches the previous line's indentation.
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), inserted_text.clone())],
+            Default::default(),
             Some(AutoindentMode::Block {
                 original_indent_columns: original_indent_columns.clone(),
             }),
@@ -1683,9 +1704,15 @@ fn test_autoindent_block_mode(cx: &mut App) {
         buffer.undo(cx); // Undo the original edit
 
         // Insert the block at a deeper indent level. The entire block is outdented.
-        buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "        ")], None, cx);
+        buffer.edit(
+            [(Point::new(2, 0)..Point::new(2, 0), "        ")],
+            Default::default(),
+            None,
+            cx,
+        );
         buffer.edit(
             [(Point::new(2, 8)..Point::new(2, 8), inserted_text)],
+            Default::default(),
             Some(AutoindentMode::Block {
                 original_indent_columns: original_indent_columns.clone(),
             }),
@@ -1735,6 +1762,7 @@ fn test_autoindent_block_mode_without_original_indent_columns(cx: &mut App) {
         // so that the first line matches the previous line's indentation.
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), inserted_text)],
+            Default::default(),
             Some(AutoindentMode::Block {
                 original_indent_columns: original_indent_columns.clone(),
             }),
@@ -1761,11 +1789,13 @@ fn test_autoindent_block_mode_without_original_indent_columns(cx: &mut App) {
         // Insert the block at a deeper indent level. The entire block is outdented.
         buffer.edit(
             [(Point::new(2, 0)..Point::new(2, 0), " ".repeat(12))],
+            Default::default(),
             None,
             cx,
         );
         buffer.edit(
             [(Point::new(2, 12)..Point::new(2, 12), inserted_text)],
+            Default::default(),
             Some(AutoindentMode::Block {
                 original_indent_columns: Vec::new(),
             }),
@@ -1822,6 +1852,7 @@ fn test_autoindent_block_mode_multiple_adjacent_ranges(cx: &mut App) {
                 (ranges_to_replace[1].clone(), "fn two() {\n    102\n}\n"),
                 (ranges_to_replace[2].clone(), "fn three() {\n    103\n}\n"),
             ],
+            Default::default(),
             Some(AutoindentMode::Block {
                 original_indent_columns: vec![Some(0), Some(0), Some(0)],
             }),
@@ -1878,6 +1909,7 @@ fn test_autoindent_language_without_indents_query(cx: &mut App) {
         );
         buffer.edit(
             [(Point::new(3, 0)..Point::new(3, 0), "\n")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1946,6 +1978,7 @@ fn test_autoindent_with_injected_languages(cx: &mut App) {
         buffer.set_language(Some(html_language), cx);
         buffer.edit(
             ranges.into_iter().map(|range| (range, "\na")),
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -1992,7 +2025,12 @@ fn test_autoindent_query_with_outdent_captures(cx: &mut App) {
         "#
         .unindent();
 
-        buffer.edit([(0..0, text)], Some(AutoindentMode::EachLine), cx);
+        buffer.edit(
+            [(0..0, text)],
+            Default::default(),
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
 
         assert_eq!(
             buffer.text(),
@@ -2027,7 +2065,12 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
         // This causes autoindent to be async.
         buffer.set_sync_parse_timeout(Duration::ZERO);
 
-        buffer.edit([(8..8, "\n\n")], Some(AutoindentMode::EachLine), cx);
+        buffer.edit(
+            [(8..8, "\n\n")],
+            Default::default(),
+            Some(AutoindentMode::EachLine),
+            cx,
+        );
         buffer.refresh_preview();
 
         // Synchronously, we haven't auto-indented and we're still preserving the preview.
@@ -2048,6 +2091,7 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
         // Then refresh the preview version.
         buffer.edit(
             [(Point::new(1, 4)..Point::new(1, 4), "\n")],
+            Default::default(),
             Some(AutoindentMode::EachLine),
             cx,
         );
@@ -2056,7 +2100,12 @@ async fn test_async_autoindents_preserve_preview(cx: &mut TestAppContext) {
         assert!(buffer.preserve_preview());
 
         // Then perform another edit, this time without refreshing the preview version.
-        buffer.edit([(Point::new(1, 4)..Point::new(1, 4), "x")], None, cx);
+        buffer.edit(
+            [(Point::new(1, 4)..Point::new(1, 4), "x")],
+            Default::default(),
+            None,
+            cx,
+        );
         // This causes the preview to not be preserved.
         assert!(!buffer.preserve_preview());
     });
@@ -2461,18 +2510,18 @@ fn test_serialization(cx: &mut gpui::App) {
 
     let buffer1 = cx.new(|cx| {
         let mut buffer = Buffer::local("abc", cx);
-        buffer.edit([(3..3, "D")], None, cx);
+        buffer.edit([(3..3, "D")], Default::default(), None, cx);
 
         now += Duration::from_secs(1);
         buffer.start_transaction_at(now);
-        buffer.edit([(4..4, "E")], None, cx);
+        buffer.edit([(4..4, "E")], Default::default(), None, cx);
         buffer.end_transaction_at(now, cx);
         assert_eq!(buffer.text(), "abcDE");
 
         buffer.undo(cx);
         assert_eq!(buffer.text(), "abcD");
 
-        buffer.edit([(4..4, "F")], None, cx);
+        buffer.edit([(4..4, "F")], Default::default(), None, cx);
         assert_eq!(buffer.text(), "abcDF");
         buffer
     });
@@ -2530,6 +2579,7 @@ fn test_branch_and_merge(cx: &mut TestAppContext) {
                 (Point::new(1, 0)..Point::new(1, 0), "1.5\n"),
                 (Point::new(2, 0)..Point::new(2, 5), "THREE"),
             ],
+            Default::default(),
             None,
             cx,
         )
@@ -2554,7 +2604,12 @@ fn test_branch_and_merge(cx: &mut TestAppContext) {
 
     // Edits to the base are applied to the branch.
     base.update(cx, |buffer, cx| {
-        buffer.edit([(Point::new(0, 0)..Point::new(0, 0), "ZERO\n")], None, cx)
+        buffer.edit(
+            [(Point::new(0, 0)..Point::new(0, 0), "ZERO\n")],
+            Default::default(),
+            None,
+            cx,
+        )
     });
     branch.read_with(cx, |buffer, cx| {
         assert_eq!(base.read(cx).text(), "ZERO\none\ntwo\nthree\n");
@@ -2563,7 +2618,12 @@ fn test_branch_and_merge(cx: &mut TestAppContext) {
 
     // Edits to any replica of the base are applied to the branch.
     base_replica.update(cx, |buffer, cx| {
-        buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "2.5\n")], None, cx)
+        buffer.edit(
+            [(Point::new(2, 0)..Point::new(2, 0), "2.5\n")],
+            Default::default(),
+            None,
+            cx,
+        )
     });
     branch.read_with(cx, |buffer, cx| {
         assert_eq!(base.read(cx).text(), "ZERO\none\ntwo\n2.5\nthree\n");
@@ -2590,7 +2650,12 @@ fn test_merge_into_base(cx: &mut TestAppContext) {
 
     // Make 3 edits, merge one into the base.
     branch.update(cx, |branch, cx| {
-        branch.edit([(0..3, "ABC"), (7..9, "HI"), (11..11, "LMN")], None, cx);
+        branch.edit(
+            [(0..3, "ABC"), (7..9, "HI"), (11..11, "LMN")],
+            Default::default(),
+            None,
+            cx,
+        );
         branch.merge_into_base(vec![5..8], cx);
     });
 
@@ -2599,7 +2664,7 @@ fn test_merge_into_base(cx: &mut TestAppContext) {
 
     // Undo the one already-merged edit. Merge that into the base.
     branch.update(cx, |branch, cx| {
-        branch.edit([(7..9, "hi")], None, cx);
+        branch.edit([(7..9, "hi")], Default::default(), None, cx);
         branch.merge_into_base(vec![5..8], cx);
     });
     base.read_with(cx, |base, _| assert_eq!(base.text(), "abcdefghijk"));
@@ -2614,7 +2679,7 @@ fn test_merge_into_base(cx: &mut TestAppContext) {
 
     // Deleted the inserted text and merge that into the base.
     branch.update(cx, |branch, cx| {
-        branch.edit([(11..14, "")], None, cx);
+        branch.edit([(11..14, "")], Default::default(), None, cx);
         branch.merge_into_base(vec![10..11], cx);
     });
 
@@ -2630,7 +2695,7 @@ fn test_undo_after_merge_into_base(cx: &mut TestAppContext) {
 
     // Make 2 edits, merge one into the base.
     branch.update(cx, |branch, cx| {
-        branch.edit([(0..3, "ABC"), (7..9, "HI")], None, cx);
+        branch.edit([(0..3, "ABC"), (7..9, "HI")], Default::default(), None, cx);
         branch.merge_into_base(vec![7..7], cx);
     });
     base.read_with(cx, |base, _| assert_eq!(base.text(), "abcdefgHIjk"));

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -668,6 +668,9 @@ pub struct LanguageConfig {
     /// the indentation level for a new line.
     #[serde(default = "auto_indent_using_last_non_empty_line_default")]
     pub auto_indent_using_last_non_empty_line: bool,
+    // Whether indentation should be automatically adjusted when typing.
+    #[serde(default)]
+    pub auto_indent_on_input: Option<bool>,
     // Whether indentation of pasted content should be adjusted based on the context.
     #[serde(default)]
     pub auto_indent_on_paste: Option<bool>,
@@ -838,6 +841,7 @@ impl Default for LanguageConfig {
             matcher: LanguageMatcher::default(),
             brackets: Default::default(),
             auto_indent_using_last_non_empty_line: auto_indent_using_last_non_empty_line_default(),
+            auto_indent_on_input: None,
             auto_indent_on_paste: None,
             increase_indent_pattern: Default::default(),
             decrease_indent_pattern: Default::default(),

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -1023,6 +1023,7 @@ impl LanguageRegistryState {
                 tab_size: language.config.tab_size,
                 hard_tabs: language.config.hard_tabs,
                 soft_wrap: language.config.soft_wrap,
+                auto_indent_on_input: language.config.auto_indent_on_input,
                 auto_indent_on_paste: language.config.auto_indent_on_paste,
                 ..Default::default()
             }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -135,6 +135,8 @@ pub struct LanguageSettings {
     /// Whether to use additional LSP queries to format (and amend) the code after
     /// every "trigger" symbol input, defined by LSP server capabilities.
     pub use_on_type_format: bool,
+    /// Whether indentation should be automatically adjusted when typing.
+    pub auto_indent_on_input: bool,
     /// Whether indentation of pasted content should be adjusted based on the context.
     pub auto_indent_on_paste: bool,
     /// Controls how the editor handles the autoclosed characters.
@@ -507,6 +509,10 @@ pub struct LanguageSettingsContent {
     ///
     /// Default: true
     pub linked_edits: Option<bool>,
+    /// Whether indentation should be automatically adjusted when typing.
+    ///
+    /// Default: true
+    pub auto_indent_on_input: Option<bool>,
     /// Whether indentation of pasted content should be adjusted based on the context.
     ///
     /// Default: true
@@ -1360,6 +1366,7 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
     merge(&mut settings.use_autoclose, src.use_autoclose);
     merge(&mut settings.use_auto_surround, src.use_auto_surround);
     merge(&mut settings.use_on_type_format, src.use_on_type_format);
+    merge(&mut settings.auto_indent_on_input, src.auto_indent_on_input);
     merge(&mut settings.auto_indent_on_paste, src.auto_indent_on_paste);
     merge(
         &mut settings.always_treat_brackets_as_autoclosed,

--- a/crates/languages/src/bash.rs
+++ b/crates/languages/src/bash.rs
@@ -45,7 +45,7 @@ mod tests {
 
             let expect_indents_to =
                 |buffer: &mut Buffer, cx: &mut Context<Buffer>, input: &str, expected: &str| {
-                    buffer.edit( [(0..buffer.len(), input)], Some(AutoindentMode::EachLine), cx, );
+                    buffer.edit( [(0..buffer.len(), input)], Default::default(), Some(AutoindentMode::EachLine), cx, );
                     assert_eq!(buffer.text(), expected);
                 };
 
@@ -124,14 +124,16 @@ mod tests {
                 .unindent(),
             );
 
-            buffer.edit([(0..buffer.len(), input)], None, cx);
+            buffer.edit([(0..buffer.len(), input)], Default::default(), None, cx);
             buffer.edit(
                 [(offsets[0]..offsets[0], "\n")],
+                Default::default(),
                 Some(AutoindentMode::EachLine),
                 cx,
             );
             buffer.edit(
                 [(offsets[0] + 3..offsets[0] + 3, "elif")],
+                Default::default(),
                 Some(AutoindentMode::EachLine),
                 cx,
             );

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -383,21 +383,36 @@ mod tests {
             let mut buffer = Buffer::local("", cx).with_language(language, cx);
 
             // empty function
-            buffer.edit([(0..0, "int main() {}")], None, cx);
+            buffer.edit([(0..0, "int main() {}")], Default::default(), None, cx);
 
             // indent inside braces
             let ix = buffer.len() - 1;
-            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n\n")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "int main() {\n  \n}");
 
             // indent body of single-statement if statement
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "if (a)\nb;")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "if (a)\nb;")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b;\n}");
 
             // indent inside field expression
             let ix = buffer.len() - 3;
-            buffer.edit([(ix..ix, "\n.c")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n.c")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "int main() {\n  if (a)\n    b\n      .c;\n}");
 
             buffer

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1139,7 +1139,12 @@ mod tests {
             let mut buffer = Buffer::local("", cx).with_language(language, cx);
             let append = |buffer: &mut Buffer, text: &str, cx: &mut Context<Buffer>| {
                 let ix = buffer.len();
-                buffer.edit([(ix..ix, text)], Some(AutoindentMode::EachLine), cx);
+                buffer.edit(
+                    [(ix..ix, text)],
+                    Default::default(),
+                    Some(AutoindentMode::EachLine),
+                    cx,
+                );
             };
 
             // indent after "def():"
@@ -1185,6 +1190,7 @@ mod tests {
             let argument_ix = buffer.text().find('1').unwrap();
             buffer.edit(
                 [(argument_ix..argument_ix + 1, "")],
+                Default::default(),
                 Some(AutoindentMode::EachLine),
                 cx,
             );
@@ -1204,6 +1210,7 @@ mod tests {
             let end_whitespace_ix = buffer.len() - 4;
             buffer.edit(
                 [(end_whitespace_ix..buffer.len(), "")],
+                Default::default(),
                 Some(AutoindentMode::EachLine),
                 cx,
             );
@@ -1220,7 +1227,12 @@ mod tests {
             );
 
             // reset to a simple if statement
-            buffer.edit([(0..buffer.len(), "if a:\n  b(\n  )")], None, cx);
+            buffer.edit(
+                [(0..buffer.len(), "if a:\n  b(\n  )")],
+                Default::default(),
+                None,
+                cx,
+            );
 
             // dedent "else" on the line after a closing paren
             append(&mut buffer, "\n  else:\n", cx);

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1214,29 +1214,54 @@ mod tests {
             // indent between braces
             buffer.set_text("fn a() {}", cx);
             let ix = buffer.len() - 1;
-            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n\n")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "fn a() {\n  \n}");
 
             // indent between braces, even after empty lines
             buffer.set_text("fn a() {\n\n\n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "fn a() {\n\n\n  \n}");
 
             // indent a line that continues a field expression
             buffer.set_text("fn a() {\n  \n}", cx);
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "b\n.c")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "b\n.c")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n}");
 
             // indent further lines that continue the field expression, even after empty lines
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, "\n\n.d")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n\n.d")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "fn a() {\n  b\n    .c\n    \n    .d\n}");
 
             // dedent the line after the field expression
             let ix = buffer.len() - 2;
-            buffer.edit([(ix..ix, ";\ne")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, ";\ne")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(
                 buffer.text(),
                 "fn a() {\n  b\n    .c\n    \n    .d;\n  e\n}"
@@ -1245,17 +1270,32 @@ mod tests {
             // indent inside a struct within a call
             buffer.set_text("const a: B = c(D {});", cx);
             let ix = buffer.len() - 3;
-            buffer.edit([(ix..ix, "\n\n")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n\n")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "const a: B = c(D {\n  \n});");
 
             // indent further inside a nested call
             let ix = buffer.len() - 4;
-            buffer.edit([(ix..ix, "e: f(\n\n)")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "e: f(\n\n)")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(buffer.text(), "const a: B = c(D {\n  e: f(\n    \n  )\n});");
 
             // keep that indent after an empty line
             let ix = buffer.len() - 8;
-            buffer.edit([(ix..ix, "\n")], Some(AutoindentMode::EachLine), cx);
+            buffer.edit(
+                [(ix..ix, "\n")],
+                Default::default(),
+                Some(AutoindentMode::EachLine),
+                cx,
+            );
             assert_eq!(
                 buffer.text(),
                 "const a: B = c(D {\n  e: f(\n    \n    \n  )\n});"

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -54,7 +54,9 @@ fn test_singleton(cx: &mut App) {
     );
     assert_consistent_line_numbers(&snapshot);
 
-    buffer.update(cx, |buffer, cx| buffer.edit([(1..3, "XXX\n")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(1..3, "XXX\n")], Default::default(), None, cx)
+    });
     let snapshot = multibuffer.read(cx).snapshot(cx);
 
     assert_eq!(snapshot.text(), buffer.read(cx).text());
@@ -90,11 +92,15 @@ fn test_remote(cx: &mut App) {
     let snapshot = multibuffer.read(cx).snapshot(cx);
     assert_eq!(snapshot.text(), "a");
 
-    guest_buffer.update(cx, |buffer, cx| buffer.edit([(1..1, "b")], None, cx));
+    guest_buffer.update(cx, |buffer, cx| {
+        buffer.edit([(1..1, "b")], Default::default(), None, cx)
+    });
     let snapshot = multibuffer.read(cx).snapshot(cx);
     assert_eq!(snapshot.text(), "ab");
 
-    guest_buffer.update(cx, |buffer, cx| buffer.edit([(2..2, "c")], None, cx));
+    guest_buffer.update(cx, |buffer, cx| {
+        buffer.edit([(2..2, "c")], Default::default(), None, cx)
+    });
     let snapshot = multibuffer.read(cx).snapshot(cx);
     assert_eq!(snapshot.text(), "abc");
 }
@@ -269,6 +275,7 @@ fn test_excerpt_boundaries_and_clipping(cx: &mut App) {
                 (Point::new(0, 0)..Point::new(0, 0), text),
                 (Point::new(2, 1)..Point::new(2, 3), text),
             ],
+            Default::default(),
             None,
             cx,
         );
@@ -517,7 +524,12 @@ fn test_editing_text_in_diff_hunks(cx: &mut TestAppContext) {
 
     // Insert a newline within an insertion hunk
     multibuffer.update(cx, |multibuffer, cx| {
-        multibuffer.edit([(Point::new(2, 0)..Point::new(2, 0), "__\n__")], None, cx);
+        multibuffer.edit(
+            [(Point::new(2, 0)..Point::new(2, 0), "__\n__")],
+            Default::default(),
+            None,
+            cx,
+        );
     });
     assert_new_snapshot(
         &multibuffer,
@@ -540,7 +552,12 @@ fn test_editing_text_in_diff_hunks(cx: &mut TestAppContext) {
 
     // Delete the newline before a deleted hunk.
     multibuffer.update(cx, |multibuffer, cx| {
-        multibuffer.edit([(Point::new(5, 4)..Point::new(6, 0), "")], None, cx);
+        multibuffer.edit(
+            [(Point::new(5, 4)..Point::new(6, 0), "")],
+            Default::default(),
+            None,
+            cx,
+        );
     });
     assert_new_snapshot(
         &multibuffer,
@@ -582,7 +599,12 @@ fn test_editing_text_in_diff_hunks(cx: &mut TestAppContext) {
     // Cannot (yet) insert at the beginning of a deleted hunk.
     // (because it would put the newline in the wrong place)
     multibuffer.update(cx, |multibuffer, cx| {
-        multibuffer.edit([(Point::new(6, 0)..Point::new(6, 0), "\n")], None, cx);
+        multibuffer.edit(
+            [(Point::new(6, 0)..Point::new(6, 0), "\n")],
+            Default::default(),
+            None,
+            cx,
+        );
     });
     assert_new_snapshot(
         &multibuffer,
@@ -605,7 +627,12 @@ fn test_editing_text_in_diff_hunks(cx: &mut TestAppContext) {
 
     // Replace a range that ends in a deleted hunk.
     multibuffer.update(cx, |multibuffer, cx| {
-        multibuffer.edit([(Point::new(5, 2)..Point::new(6, 2), "fty-")], None, cx);
+        multibuffer.edit(
+            [(Point::new(5, 2)..Point::new(6, 2), "fty-")],
+            Default::default(),
+            None,
+            cx,
+        );
     });
     assert_new_snapshot(
         &multibuffer,
@@ -1003,7 +1030,7 @@ fn test_empty_diff_excerpt(cx: &mut TestAppContext) {
     });
 
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "a\nb\nc")], None, cx);
+        buffer.edit([(0..0, "a\nb\nc")], Default::default(), None, cx);
         diff.update(cx, |diff, cx| {
             diff.recalculate_diff_sync(buffer.snapshot().text, cx);
         });
@@ -1033,8 +1060,8 @@ fn test_singleton_multibuffer_anchors(cx: &mut App) {
     let multibuffer = cx.new(|cx| MultiBuffer::singleton(buffer.clone(), cx));
     let old_snapshot = multibuffer.read(cx).snapshot(cx);
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "X")], None, cx);
-        buffer.edit([(5..5, "Y")], None, cx);
+        buffer.edit([(0..0, "X")], Default::default(), None, cx);
+        buffer.edit([(5..5, "Y")], Default::default(), None, cx);
     });
     let new_snapshot = multibuffer.read(cx).snapshot(cx);
 
@@ -1081,12 +1108,12 @@ fn test_multibuffer_anchors(cx: &mut App) {
     assert_eq!(Anchor::max().to_offset(&old_snapshot), 10);
 
     buffer_1.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "W")], None, cx);
-        buffer.edit([(5..5, "X")], None, cx);
+        buffer.edit([(0..0, "W")], Default::default(), None, cx);
+        buffer.edit([(5..5, "X")], Default::default(), None, cx);
     });
     buffer_2.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "Y")], None, cx);
-        buffer.edit([(6..6, "Z")], None, cx);
+        buffer.edit([(0..0, "Y")], Default::default(), None, cx);
+        buffer.edit([(6..6, "Z")], Default::default(), None, cx);
     });
     let new_snapshot = multibuffer.read(cx).snapshot(cx);
 
@@ -1113,7 +1140,9 @@ fn test_resolving_anchors_after_replacing_their_excerpts(cx: &mut App) {
 
     // Create an insertion id in buffer 1 that doesn't exist in buffer 2.
     // Add an excerpt from buffer 1 that spans this new insertion.
-    buffer_1.update(cx, |buffer, cx| buffer.edit([(4..4, "123")], None, cx));
+    buffer_1.update(cx, |buffer, cx| {
+        buffer.edit([(4..4, "123")], Default::default(), None, cx)
+    });
     let excerpt_id_1 = multibuffer.update(cx, |multibuffer, cx| {
         multibuffer
             .push_excerpts(
@@ -1626,7 +1655,9 @@ fn test_set_excerpts_for_buffer_ordering(cx: &mut TestAppContext) {
         },
     );
 
-    buf1.update(cx, |buffer, cx| buffer.edit([(0..5, "")], None, cx));
+    buf1.update(cx, |buffer, cx| {
+        buffer.edit([(0..5, "")], Default::default(), None, cx)
+    });
 
     multibuffer.update(cx, |multibuffer, cx| {
         multibuffer.set_excerpts_for_path(
@@ -2900,6 +2931,7 @@ fn test_history(cx: &mut App) {
                 (Point::new(0, 0)..Point::new(0, 0), "A"),
                 (Point::new(1, 0)..Point::new(1, 0), "A"),
             ],
+            Default::default(),
             None,
             cx,
         );
@@ -2908,6 +2940,7 @@ fn test_history(cx: &mut App) {
                 (Point::new(0, 1)..Point::new(0, 1), "B"),
                 (Point::new(1, 1)..Point::new(1, 1), "B"),
             ],
+            Default::default(),
             None,
             cx,
         );
@@ -2926,19 +2959,19 @@ fn test_history(cx: &mut App) {
         // Edit buffer 1 through the multibuffer
         now += 2 * group_interval;
         multibuffer.start_transaction_at(now, cx);
-        multibuffer.edit([(2..2, "C")], None, cx);
+        multibuffer.edit([(2..2, "C")], Default::default(), None, cx);
         multibuffer.end_transaction_at(now, cx);
         assert_eq!(multibuffer.read(cx).text(), "ABC1234\nAB5678");
 
         // Edit buffer 1 independently
         buffer_1.update(cx, |buffer_1, cx| {
             buffer_1.start_transaction_at(now);
-            buffer_1.edit([(3..3, "D")], None, cx);
+            buffer_1.edit([(3..3, "D")], Default::default(), None, cx);
             buffer_1.end_transaction_at(now, cx);
 
             now += 2 * group_interval;
             buffer_1.start_transaction_at(now);
-            buffer_1.edit([(4..4, "E")], None, cx);
+            buffer_1.edit([(4..4, "E")], Default::default(), None, cx);
             buffer_1.end_transaction_at(now, cx);
         });
         assert_eq!(multibuffer.read(cx).text(), "ABCDE1234\nAB5678");
@@ -2979,7 +3012,7 @@ fn test_history(cx: &mut App) {
         // Redo stack gets cleared after an edit.
         now += 2 * group_interval;
         multibuffer.start_transaction_at(now, cx);
-        multibuffer.edit([(0..0, "X")], None, cx);
+        multibuffer.edit([(0..0, "X")], Default::default(), None, cx);
         multibuffer.end_transaction_at(now, cx);
         assert_eq!(multibuffer.read(cx).text(), "XABCD1234\nAB5678");
         multibuffer.redo(cx);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1510,7 +1510,7 @@ impl LocalLspStore {
                         zlog::trace!(logger => "Applying changes");
                         buffer.handle.update(cx, |buffer, cx| {
                             buffer.start_transaction();
-                            buffer.edit(edits, None, cx);
+                            buffer.edit(edits, Default::default(), None, cx);
                             transaction_id_format =
                                 transaction_id_format.or(buffer.end_transaction(cx));
                             if let Some(transaction_id) = transaction_id_format {
@@ -1768,7 +1768,7 @@ impl LocalLspStore {
                             zlog::info!(logger => "Applying changes");
                             buffer.handle.update(cx, |buffer, cx| {
                                 buffer.start_transaction();
-                                buffer.edit(edits, None, cx);
+                                buffer.edit(edits, Default::default(), None, cx);
                                 transaction_id_format =
                                     transaction_id_format.or(buffer.end_transaction(cx));
                                 if let Some(transaction_id) = transaction_id_format {
@@ -2596,7 +2596,7 @@ impl LocalLspStore {
             buffer.finalize_last_transaction();
             buffer.start_transaction();
             for (range, text) in edits {
-                buffer.edit([(range, text)], None, cx);
+                buffer.edit([(range, text)], Default::default(), None, cx);
             }
 
             if buffer.end_transaction(cx).is_some() {
@@ -2895,7 +2895,7 @@ impl LocalLspStore {
                         buffer.finalize_last_transaction();
                         buffer.start_transaction();
                         for (range, text) in edits {
-                            buffer.edit([(range, text)], None, cx);
+                            buffer.edit([(range, text)], Default::default(), None, cx);
                         }
                         let transaction = if buffer.end_transaction(cx).is_some() {
                             let transaction = buffer.finalize_last_transaction().unwrap().clone();
@@ -5508,7 +5508,7 @@ impl LspStore {
                             //Skip additional edits which overlap with the primary completion edit
                             //https://github.com/zed-industries/zed/pull/1871
                             if !start_within && !end_within {
-                                buffer.edit([(range, text)], None, cx);
+                                buffer.edit([(range, text)], Default::default(), None, cx);
                             }
                         }
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -619,7 +619,9 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
     });
 
     // Edit a buffer. The changes are reported to the language server.
-    rust_buffer.update(cx, |buffer, cx| buffer.edit([(16..16, "2")], None, cx));
+    rust_buffer.update(cx, |buffer, cx| {
+        buffer.edit([(16..16, "2")], Default::default(), None, cx)
+    });
     assert_eq!(
         fake_rust_server
             .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -687,9 +689,11 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
     });
 
     // Changes are reported only to servers matching the buffer's language.
-    toml_buffer.update(cx, |buffer, cx| buffer.edit([(5..5, "23")], None, cx));
+    toml_buffer.update(cx, |buffer, cx| {
+        buffer.edit([(5..5, "23")], Default::default(), None, cx)
+    });
     rust_buffer2.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "let x = 1;")], None, cx)
+        buffer.edit([(0..0, "let x = 1;")], Default::default(), None, cx)
     });
     assert_eq!(
         fake_rust_server
@@ -816,7 +820,9 @@ async fn test_managing_language_servers(cx: &mut gpui::TestAppContext) {
     });
 
     // The renamed file's version resets after changing language server.
-    rust_buffer2.update(cx, |buffer, cx| buffer.edit([(0..0, "// ")], None, cx));
+    rust_buffer2.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "// ")], Default::default(), None, cx)
+    });
     assert_eq!(
         fake_json_server
             .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -1915,7 +1921,9 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
         .await;
 
     // Edit the buffer, moving the content down
-    buffer.update(cx, |buffer, cx| buffer.edit([(0..0, "\n\n")], None, cx));
+    buffer.update(cx, |buffer, cx| {
+        buffer.edit([(0..0, "\n\n")], Default::default(), None, cx)
+    });
     let change_notification_1 = fake_server
         .receive_notification::<lsp::notification::DidChangeTextDocument>()
         .await;
@@ -2084,13 +2092,24 @@ async fn test_transforming_diagnostics(cx: &mut gpui::TestAppContext) {
     // Keep editing the buffer and ensure disk-based diagnostics get translated according to the
     // changes since the last save.
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(Point::new(2, 0)..Point::new(2, 0), "    ")], None, cx);
         buffer.edit(
-            [(Point::new(2, 8)..Point::new(2, 10), "(x: usize)")],
+            [(Point::new(2, 0)..Point::new(2, 0), "    ")],
+            Default::default(),
             None,
             cx,
         );
-        buffer.edit([(Point::new(3, 10)..Point::new(3, 10), "xxx")], None, cx);
+        buffer.edit(
+            [(Point::new(2, 8)..Point::new(2, 10), "(x: usize)")],
+            Default::default(),
+            None,
+            cx,
+        );
+        buffer.edit(
+            [(Point::new(3, 10)..Point::new(3, 10), "xxx")],
+            Default::default(),
+            None,
+            cx,
+        );
     });
     let change_notification_2 = fake_server
         .receive_notification::<lsp::notification::DidChangeTextDocument>()
@@ -2342,6 +2361,7 @@ async fn test_edits_from_lsp2_with_past_version(cx: &mut gpui::TestAppContext) {
                 Point::new(0, 0)..Point::new(0, 0),
                 "// above first function\n",
             )],
+            Default::default(),
             None,
             cx,
         );
@@ -2350,6 +2370,7 @@ async fn test_edits_from_lsp2_with_past_version(cx: &mut gpui::TestAppContext) {
                 Point::new(2, 0)..Point::new(2, 0),
                 "    // inside first function\n",
             )],
+            Default::default(),
             None,
             cx,
         );
@@ -2358,6 +2379,7 @@ async fn test_edits_from_lsp2_with_past_version(cx: &mut gpui::TestAppContext) {
                 Point::new(6, 4)..Point::new(6, 4),
                 "// inside second function ",
             )],
+            Default::default(),
             None,
             cx,
         );
@@ -2421,7 +2443,7 @@ async fn test_edits_from_lsp2_with_past_version(cx: &mut gpui::TestAppContext) {
 
     buffer.update(cx, |buffer, cx| {
         for (range, new_text) in edits {
-            buffer.edit([(range, new_text)], None, cx);
+            buffer.edit([(range, new_text)], Default::default(), None, cx);
         }
         assert_eq!(
             buffer.text(),
@@ -2537,7 +2559,7 @@ async fn test_edits_from_lsp2_with_edits_on_adjacent_lines(cx: &mut gpui::TestAp
         );
 
         for (range, new_text) in edits {
-            buffer.edit([(range, new_text)], None, cx);
+            buffer.edit([(range, new_text)], Default::default(), None, cx);
         }
         assert_eq!(
             buffer.text(),
@@ -2644,7 +2666,7 @@ async fn test_invalid_edits_from_lsp2(cx: &mut gpui::TestAppContext) {
         );
 
         for (range, new_text) in edits {
-            buffer.edit([(range, new_text)], None, cx);
+            buffer.edit([(range, new_text)], Default::default(), None, cx);
         }
         assert_eq!(
             buffer.text(),
@@ -3300,7 +3322,12 @@ async fn test_save_file(cx: &mut gpui::TestAppContext) {
         .unwrap();
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "the old contents");
-        buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
+        buffer.edit(
+            [(0..0, "a line of text.\n".repeat(10 * 1024))],
+            Default::default(),
+            None,
+            cx,
+        );
     });
 
     project
@@ -3412,7 +3439,7 @@ async fn test_edit_buffer_while_it_reloads(cx: &mut gpui::TestAppContext) {
 
     // Perform a noop edit, causing the buffer's version to increase.
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, " ")], None, cx);
+        buffer.edit([(0..0, " ")], Default::default(), None, cx);
         buffer.undo(cx);
     });
 
@@ -3454,7 +3481,12 @@ async fn test_save_in_single_file_worktree(cx: &mut gpui::TestAppContext) {
         .await
         .unwrap();
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "a line of text.\n".repeat(10 * 1024))], None, cx);
+        buffer.edit(
+            [(0..0, "a line of text.\n".repeat(10 * 1024))],
+            Default::default(),
+            None,
+            cx,
+        );
     });
 
     project
@@ -3484,7 +3516,7 @@ async fn test_save_as(cx: &mut gpui::TestAppContext) {
 
     let buffer = project.update(cx, |project, cx| project.create_local_buffer("", None, cx));
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "abc")], None, cx);
+        buffer.edit([(0..0, "abc")], Default::default(), None, cx);
         assert!(buffer.is_dirty());
         assert!(!buffer.has_conflict());
         assert_eq!(buffer.language().unwrap().name(), "Plain Text".into());
@@ -3823,7 +3855,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
         assert!(!buffer.is_dirty());
         assert!(events.lock().is_empty());
 
-        buffer.edit([(1..2, "")], None, cx);
+        buffer.edit([(1..2, "")], Default::default(), None, cx);
     });
 
     // after the first edit, the buffer is dirty, and emits a dirtied event.
@@ -3851,8 +3883,8 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
         assert_eq!(*events.lock(), &[language::BufferEvent::Saved]);
         events.lock().clear();
 
-        buffer.edit([(1..1, "B")], None, cx);
-        buffer.edit([(2..2, "D")], None, cx);
+        buffer.edit([(1..1, "B")], Default::default(), None, cx);
+        buffer.edit([(2..2, "D")], Default::default(), None, cx);
     });
 
     // after editing again, the buffer is dirty, and emits another dirty event.
@@ -3871,7 +3903,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
 
         // After restoring the buffer to its previously-saved state,
         // the buffer is not considered dirty anymore.
-        buffer.edit([(1..3, "")], None, cx);
+        buffer.edit([(1..3, "")], Default::default(), None, cx);
         assert!(buffer.text() == "ac");
         assert!(!buffer.is_dirty());
     });
@@ -3913,7 +3945,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
 
     // Buffer becomes dirty when edited.
     buffer2.update(cx, |buffer, cx| {
-        buffer.edit([(2..3, "")], None, cx);
+        buffer.edit([(2..3, "")], Default::default(), None, cx);
         assert_eq!(buffer.is_dirty(), true);
     });
     assert_eq!(
@@ -3927,7 +3959,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
     // Buffer becomes clean again when all of its content is removed, because
     // the file was deleted.
     buffer2.update(cx, |buffer, cx| {
-        buffer.edit([(0..2, "")], None, cx);
+        buffer.edit([(0..2, "")], Default::default(), None, cx);
         assert_eq!(buffer.is_empty(), true);
         assert_eq!(buffer.is_dirty(), false);
     });
@@ -3957,7 +3989,7 @@ async fn test_buffer_is_dirty(cx: &mut gpui::TestAppContext) {
     });
 
     buffer3.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, "x")], None, cx);
+        buffer.edit([(0..0, "x")], Default::default(), None, cx);
     });
     events.lock().clear();
     fs.remove_file(path!("/dir/file3").as_ref(), Default::default())
@@ -4028,7 +4060,7 @@ async fn test_buffer_file_changes_on_disk(cx: &mut gpui::TestAppContext) {
 
     // Modify the buffer
     buffer.update(cx, |buffer, cx| {
-        buffer.edit([(0..0, " ")], None, cx);
+        buffer.edit([(0..0, " ")], Default::default(), None, cx);
         assert!(buffer.is_dirty());
         assert!(!buffer.has_conflict());
     });
@@ -4672,7 +4704,12 @@ async fn test_search(cx: &mut gpui::TestAppContext) {
         .unwrap();
     buffer_4.update(cx, |buffer, cx| {
         let text = "two::TWO";
-        buffer.edit([(20..28, text), (31..43, text)], None, cx);
+        buffer.edit(
+            [(20..28, text), (31..43, text)],
+            Default::default(),
+            None,
+            cx,
+        );
     });
 
     assert_eq!(

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -528,7 +528,12 @@ impl HeadlessProject {
         let buffer_id = cx.update(|cx| {
             if buffer.read(cx).is_empty() {
                 buffer.update(cx, |buffer, cx| {
-                    buffer.edit([(0..0, initial_server_settings_content())], None, cx)
+                    buffer.edit(
+                        [(0..0, initial_server_settings_content())],
+                        Default::default(),
+                        None,
+                        cx,
+                    )
                 });
             }
 

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -99,7 +99,7 @@ async fn test_basic_remote_editing(cx: &mut TestAppContext, server_cx: &mut Test
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "fn one() -> usize { 1 }");
         let ix = buffer.text().find('1').unwrap();
-        buffer.edit([(ix..ix + 1, "100")], None, cx);
+        buffer.edit([(ix..ix + 1, "100")], Default::default(), None, cx);
     });
 
     // The user saves the buffer. The new contents are written to the
@@ -757,7 +757,7 @@ async fn test_remote_reload(cx: &mut TestAppContext, server_cx: &mut TestAppCont
 
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "bangles");
-        buffer.edit([(0..0, "a")], None, cx);
+        buffer.edit([(0..0, "a")], Default::default(), None, cx);
     });
 
     fs.save(
@@ -1102,7 +1102,7 @@ async fn test_reconnect(cx: &mut TestAppContext, server_cx: &mut TestAppContext)
     buffer.update(cx, |buffer, cx| {
         assert_eq!(buffer.text(), "fn one() -> usize { 1 }");
         let ix = buffer.text().find('1').unwrap();
-        buffer.edit([(ix..ix + 1, "100")], None, cx);
+        buffer.edit([(ix..ix + 1, "100")], Default::default(), None, cx);
     });
 
     let client = cx.read(|cx| project.read(cx).ssh_client().unwrap());

--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -195,7 +195,12 @@ impl TerminalOutput {
         // This will keep the buffer up to date, though with some terminal codes it won't be perfect
         if let Some(buffer) = self.full_buffer.as_ref() {
             buffer.update(cx, |buffer, cx| {
-                buffer.edit([(buffer.len()..buffer.len(), text)], None, cx);
+                buffer.edit(
+                    [(buffer.len()..buffer.len(), text)],
+                    Default::default(),
+                    None,
+                    cx,
+                );
             });
         }
     }

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -79,6 +79,7 @@ impl EditorBlock {
                             buffer_snapshot.max_point()..buffer_snapshot.max_point(),
                             "\n",
                         )],
+                        Default::default(),
                         None,
                         cx,
                     )

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -908,7 +908,12 @@ impl BufferSearchBar {
                     .buffer()
                     .update(cx, |replacement_buffer, cx| {
                         let len = replacement_buffer.len(cx);
-                        replacement_buffer.edit([(0..len, replacement.unwrap())], None, cx);
+                        replacement_buffer.edit(
+                            [(0..len, replacement.unwrap())],
+                            Default::default(),
+                            None,
+                            cx,
+                        );
                     });
             });
     }
@@ -926,7 +931,7 @@ impl BufferSearchBar {
             self.query_editor.update(cx, |query_editor, cx| {
                 query_editor.buffer().update(cx, |query_buffer, cx| {
                     let len = query_buffer.len(cx);
-                    query_buffer.edit([(0..len, query)], None, cx);
+                    query_buffer.edit([(0..len, query)], Default::default(), None, cx);
                 });
             });
             self.set_search_options(options, cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1593,7 +1593,12 @@ fn open_local_file(
                     if let Some(buffer) = editor.buffer().read(cx).as_singleton() {
                         if buffer.read(cx).is_empty() {
                             buffer.update(cx, |buffer, cx| {
-                                buffer.edit([(0..0, initial_contents)], None, cx)
+                                buffer.edit(
+                                    [(0..0, initial_contents)],
+                                    Default::default(),
+                                    None,
+                                    cx,
+                                )
                             });
                         }
                     }

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1691,7 +1691,9 @@ mod tests {
                 vec![(2..5, "REM".to_string()), (9..11, "".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(2..5, "")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(2..5, "")], Default::default(), None, cx)
+            });
             assert_eq!(
                 from_completion_edits(
                     &completion.interpolate(&buffer.read(cx).snapshot()).unwrap(),
@@ -1711,7 +1713,9 @@ mod tests {
                 vec![(2..5, "REM".to_string()), (9..11, "".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(2..5, "R")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(2..5, "R")], Default::default(), None, cx)
+            });
             assert_eq!(
                 from_completion_edits(
                     &completion.interpolate(&buffer.read(cx).snapshot()).unwrap(),
@@ -1721,7 +1725,9 @@ mod tests {
                 vec![(3..3, "EM".to_string()), (7..9, "".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(3..3, "E")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(3..3, "E")], Default::default(), None, cx)
+            });
             assert_eq!(
                 from_completion_edits(
                     &completion.interpolate(&buffer.read(cx).snapshot()).unwrap(),
@@ -1731,7 +1737,9 @@ mod tests {
                 vec![(4..4, "M".to_string()), (8..10, "".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(4..4, "M")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(4..4, "M")], Default::default(), None, cx)
+            });
             assert_eq!(
                 from_completion_edits(
                     &completion.interpolate(&buffer.read(cx).snapshot()).unwrap(),
@@ -1741,7 +1749,9 @@ mod tests {
                 vec![(9..11, "".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(4..5, "")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(4..5, "")], Default::default(), None, cx)
+            });
             assert_eq!(
                 from_completion_edits(
                     &completion.interpolate(&buffer.read(cx).snapshot()).unwrap(),
@@ -1751,7 +1761,9 @@ mod tests {
                 vec![(4..4, "M".to_string()), (8..10, "".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(8..10, "")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(8..10, "")], Default::default(), None, cx)
+            });
             assert_eq!(
                 from_completion_edits(
                     &completion.interpolate(&buffer.read(cx).snapshot()).unwrap(),
@@ -1761,7 +1773,9 @@ mod tests {
                 vec![(4..4, "M".to_string())]
             );
 
-            buffer.update(cx, |buffer, cx| buffer.edit([(4..6, "")], None, cx));
+            buffer.update(cx, |buffer, cx| {
+                buffer.edit([(4..6, "")], Default::default(), None, cx)
+            });
             assert_eq!(completion.interpolate(&buffer.read(cx).snapshot()), None);
         })
     }
@@ -1885,7 +1899,12 @@ mod tests {
 
         let completion = completion_task.await.unwrap().unwrap();
         buffer.update(cx, |buffer, cx| {
-            buffer.edit(completion.edits.iter().cloned(), None, cx)
+            buffer.edit(
+                completion.edits.iter().cloned(),
+                Default::default(),
+                None,
+                cx,
+            )
         });
         assert_eq!(
             buffer.read_with(cx, |buffer, _| buffer.text()),

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -40,7 +40,7 @@ TBD: Document `language_name/config.toml` keys
 - scope_opt_in_language_servers
 - increase_indent_pattern, decrease_indent_pattern
 - collapsed_placeholder
-- auto_indent_on_paste, auto_indent_using_last_non_empty_line
+- auto_indent_on_input, auto_indent_on_paste, auto_indent_using_last_non_empty_line
 - overrides: `[overrides.element]`, `[overrides.string]`
 -->
 


### PR DESCRIPTION
Closes #11780

There are currently various issues with auto-indentation, particularly in whitespace-sensitive languages like Python and YAML. See: #5194, #21334, #23131, #10832, #11780

This change aims to provide an option for users who want to disable auto-indentation entirely, whether that's as a temporary workaround for auto-indentation issues, or just a personal preference.

With this change the customisability will be more consistent with VS Code.

Release Notes:

- Added `auto_indent_on_input` setting to allow for disabling auto-indent