### PR TITLE
theme_importer: Handle comma-separated token scopes

### DIFF
--- a/crates/theme_importer/src/vscode/syntax.rs
+++ b/crates/theme_importer/src/vscode/syntax.rs
@@ -150,7 +150,7 @@ impl ZedSyntaxToken {
             VsCodeTokenScope::Many(scopes) => scopes.iter().collect(),
         }
         .iter()
-        .map(|scope| scope.as_str())
+        .flat_map(|scope| scope.split(',').map(|s| s.trim()))
         .collect::<Vec<_>>();
 
         let scopes_to_match = self.to_vscode();


### PR DESCRIPTION
This PR allows the `theme-importer` utility to handle comma-separated token scopes.

Normally, a token in a VS Code theme is defined as either a string or a string array:
```json
    {
      "scope": "token.debug-token",
      "settings": {
        "foreground": "#d55fde"
      }
    },
    {
      "name": "String interpolation",
      "scope": [
        "punctuation.definition.template-expression.begin",
        "punctuation.definition.template-expression.end",
        "punctuation.section.embedded"
      ],
      "settings": {
        "foreground": "#d55fde"
      }
    },
```

However, [some themes](https://github.com/tal7aouy/theme/blob/ac85540d6494cf3b7dffd6adc8a06af6c1dd4b0d/src/variants/TokenColors.ts#L1771-L1777) seem to use comma-separated values in a single scope string which VS Code seems to accept as well:
```json
    {
      "name": "Comments",
      "scope": "comment, punctuation.definition.comment",
      "settings": {
        "foreground": "#7f848e"
      }
    },
```

This PR handles these definitions by splitting scopes by commas before trying to match them with the scopes that match Zed syntax tokens.

Release Notes:

- N/A