### PR TITLE
Escape carets (^) in Go test regex

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -526,7 +526,7 @@ impl ContextProvider for GoContextProvider {
                 args: vec![
                     "test".into(),
                     "-run".into(),
-                    format!("^{}\\$", VariableName::Symbol.template_value(),),
+                    format!("\\^{}\\$", VariableName::Symbol.template_value(),),
                 ],
                 tags: vec!["go-test".to_owned()],
                 cwd: package_cwd.clone(),
@@ -559,7 +559,7 @@ impl ContextProvider for GoContextProvider {
                     "-v".into(),
                     "-run".into(),
                     format!(
-                        "^{}\\$/^{}\\$",
+                        "\\^{}\\$/\\^{}\\$",
                         VariableName::Symbol.template_value(),
                         GO_SUBTEST_NAME_TASK_VARIABLE.template_value(),
                     ),
@@ -578,9 +578,9 @@ impl ContextProvider for GoContextProvider {
                 args: vec![
                     "test".into(),
                     "-benchmem".into(),
-                    "-run=^$".into(),
+                    "-run='^$'".into(),
                     "-bench".into(),
-                    format!("^{}\\$", VariableName::Symbol.template_value()),
+                    format!("\\^{}\\$", VariableName::Symbol.template_value()),
                 ],
                 cwd: package_cwd.clone(),
                 tags: vec!["go-benchmark".to_owned()],
@@ -597,7 +597,7 @@ impl ContextProvider for GoContextProvider {
                     "test".into(),
                     "-fuzz=Fuzz".into(),
                     "-run".into(),
-                    format!("^{}\\$", VariableName::Symbol.template_value(),),
+                    format!("\\^{}\\$", VariableName::Symbol.template_value(),),
                 ],
                 tags: vec!["go-fuzz".to_owned()],
                 cwd: package_cwd.clone(),


### PR DESCRIPTION
This is a follow up to https://github.com/zed-industries/zed/pull/14821, which escaped `$` but not `^`.

This is fine for `bash`, but causes issues with `zsh`. This change escapes the `^`. I tested this against `bash`, `zsh` and `fish`

I suspect such escaping would probably need to be done at some shell-specific layer of the code, but for now it seems like the tasks provided by the `ContextProvider` are supposed to be shell agnostic.

To reproduce the original issue:
1. Create a Go test file in a module that just contains a single test `TestABC`.
2. Run `zsh -i -c "go test -run ^TestABC\$"` which is what Zed tries to run when the task for a specific Go test is executed.
3. An error that there are no tests to run will be produced even though there is a test.
4. Run `zsh -i -c "go test -run \^TestABC\$"` (note the backslash before ^).
5. The test will run successfully.

Example:
``` go
package bar

import "testing"

func TestABC(t *testing.T) {}
```

Release Notes:

- fix: Escape the ^ in the Go test -run regex to improve shell compatibility (notably with zsh).
