### PR TITLE
vim: Fix :ex, :exit

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -714,7 +714,7 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
             close_pinned: true,
         }),
         VimCommand::new(
-            ("ex", "it"),
+            ("exi", "t"),
             workspace::CloseActiveItem {
                 save_intent: Some(SaveIntent::SaveAll),
                 close_pinned: false,
@@ -880,6 +880,7 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("0", ""), StartOfDocument),
         VimCommand::new(("e", "dit"), editor::actions::ReloadFile)
             .bang(editor::actions::ReloadFile),
+        VimCommand::new(("ex", ""), editor::actions::ReloadFile).bang(editor::actions::ReloadFile),
         VimCommand::new(("cpp", "link"), editor::actions::CopyPermalinkToLine).range(act_on_range),
     ]
 }


### PR DESCRIPTION
`:exit` should be `:exi[t]` instead of `:ex[it]`, `:ex` has different command

- https://neovim.io/doc/user/editing.html#%3Aex
- https://neovim.io/doc/user/editing.html#%3Aexit

Changes:
- Add `:ex` same as `:edit`
- Change `:ex[it]` to `:exi[t]`

Release Notes:

- N/A
