### PR TITLE
Add symbol-info tool to default tools

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -666,6 +666,7 @@
           "path-search": true,
           "read-file": true,
           "regex-search": true,
+          "symbol-info": true,
           "thinking": true
         }
       }


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/27733

Release Notes:

- N/A
