### PR TITLE
assistant2: Fail find-replace tool if both strings are equal

### DIFF
--- a/crates/assistant_tools/src/find_replace_file_tool.rs
+++ b/crates/assistant_tools/src/find_replace_file_tool.rs
@@ -182,6 +182,10 @@ impl Tool for FindReplaceFileTool {
                 return Err(anyhow!("`find` string cannot be empty. Use a different tool if you want to create a file."));
             }
 
+            if input.find == input.replace {
+                return Err(anyhow!("The `find` and `replace` strings are identical, so no changes would be made."));
+            }
+
             let result = cx
                 .background_spawn(async move {
                     replace_exact(&input.find, &input.replace, &snapshot).await

--- a/crates/assistant_tools/src/find_replace_tool/description.md
+++ b/crates/assistant_tools/src/find_replace_tool/description.md
@@ -5,3 +5,5 @@ This tool is the preferred way to make edits to files. If you have multiple edit
 You should use this tool when you want to edit a subset of a file's contents, but not the entire file. You should not use this tool when you want to replace the entire contents of a file with completely different contents. You also should not use this tool when you want to move or rename a file. You absolutely must NEVER use this tool to create new files from scratch. If you ever consider using this tool to create a new file from scratch, for any reason, instead you must reconsider and choose a different approach.
 
 DO NOT call this tool until the code to be edited appears in the conversation! You must use another tool to read the file's contents into the conversation, or ask the user to add it to context first.
+
+Never call this tool with identical "find" and "replace" strings. Instead, stop and think about what you actually want to do.


### PR DESCRIPTION
Models seem to do this ever so often and get very confused. Failing here helps them recover.

Release Notes:

- N/A 
