### PR TITLE
assistant2: Add testing environment variables

### DIFF
--- a/crates/assistant2/src/history_store.rs
+++ b/crates/assistant2/src/history_store.rs
@@ -43,6 +43,11 @@ impl HistoryStore {
     pub fn entries(&self, cx: &mut Context<Self>) -> Vec<HistoryEntry> {
         let mut history_entries = Vec::new();
 
+        #[cfg(debug_assertions)]
+        if std::env::var("ZED_SIMULATE_NO_THREAD_HISTORY").is_ok() {
+            return history_entries;
+        }
+
         for thread in self.thread_store.update(cx, |this, _cx| this.threads()) {
             history_entries.push(HistoryEntry::Thread(thread));
         }

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use collections::BTreeMap;
 use gpui::{prelude::*, App, Context, Entity, EventEmitter, Global};
-use std::sync::Arc;
+use std::{env, sync::Arc};
 
 pub fn init(cx: &mut App) {
     let registry = cx.new(|_cx| LanguageModelRegistry::default());
@@ -203,6 +203,11 @@ impl LanguageModelRegistry {
     }
 
     pub fn active_provider(&self) -> Option<Arc<dyn LanguageModelProvider>> {
+        #[cfg(debug_assertions)]
+        if env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
+            return None;
+        }
+
         Some(self.active_model.as_ref()?.provider.clone())
     }
 

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use collections::BTreeMap;
 use gpui::{prelude::*, App, Context, Entity, EventEmitter, Global};
-use std::{env, sync::Arc};
+use std::sync::Arc;
 
 pub fn init(cx: &mut App) {
     let registry = cx.new(|_cx| LanguageModelRegistry::default());

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use collections::BTreeMap;
 use gpui::{prelude::*, App, Context, Entity, EventEmitter, Global};
-use std::sync::Arc;
+use std::{env::var, sync::Arc};
 
 pub fn init(cx: &mut App) {
     let registry = cx.new(|_cx| LanguageModelRegistry::default());
@@ -204,7 +204,7 @@ impl LanguageModelRegistry {
 
     pub fn active_provider(&self) -> Option<Arc<dyn LanguageModelProvider>> {
         #[cfg(debug_assertions)]
-        if env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
+        if var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
             return None;
         }
 

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use collections::BTreeMap;
 use gpui::{prelude::*, App, Context, Entity, EventEmitter, Global};
-use std::{env::var, sync::Arc};
+use std::sync::Arc;
 
 pub fn init(cx: &mut App) {
     let registry = cx.new(|_cx| LanguageModelRegistry::default());
@@ -204,7 +204,7 @@ impl LanguageModelRegistry {
 
     pub fn active_provider(&self) -> Option<Arc<dyn LanguageModelProvider>> {
         #[cfg(debug_assertions)]
-        if var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
+        if std::env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
             return None;
         }
 


### PR DESCRIPTION
To make it easier to design UIs for some of these scenarios. This PR adds specifically two variables:
- `ZED_SIMULATE_NO_THREAD_HISTORY`
- `ZED_SIMULATE_NO_LLM_PROVIDER`

Release Notes:

- N/A
