### PR TITLE
vim: Add :options, :map

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -881,6 +881,8 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
         VimCommand::new(("e", "dit"), editor::actions::ReloadFile)
             .bang(editor::actions::ReloadFile),
         VimCommand::new(("cpp", "link"), editor::actions::CopyPermalinkToLine).range(act_on_range),
+        VimCommand::str(("opt", "ions"), "zed::OpenDefaultSettings"),
+        VimCommand::str(("map", ""), "vim::OpenDefaultKeymap"),
     ]
 }
 


### PR DESCRIPTION
Add:
- [:options](https://neovim.io/doc/user/options.html#%3Aoptions) to open default settings
- :map to open default vim keymap

These aren't exactly the same as vim but i think it's a good equivalent

For map:
I can't find the docs for :map with no arguments, since the map docs only shows the command bindings, but it opens the key mapping in vim.

https://neovim.io/doc/user/vimindex.html
![image](https://github.com/user-attachments/assets/83aeebc4-e2e9-4818-890d-d307d5cee9b1)

Release Notes:

- vim: Added `:options` and `:map`
