### PR TITLE
Remove special handling for livekit in nix

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -32,13 +32,6 @@ mkShell' {
     nodejs_22
   ];
 
-  # We set SDKROOT and DEVELOPER_DIR to the Xcode ones instead of the nixpkgs ones, because
-  # we need Swift 6.0 and nixpkgs doesn't have it
-  shellHook = lib.optionalString stdenv.hostPlatform.isDarwin ''
-    export SDKROOT="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk";
-    export DEVELOPER_DIR="/Applications/Xcode.app/Contents/Developer";
-  '';
-
   env =
     let
       baseEnvs =


### PR DESCRIPTION
Now that #27126 has landed, we can drop this from the nix shell which has the side benefit that nix users don't actually need xcode installed to develop zed anymore.

Release Notes:

- N/A