### PR TITLE
assistant_settings: Disable "Suggest Edits" in the `assistant2` feature flag

### DIFF
--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ::open_ai::Model as OpenAiModel;
 use anthropic::Model as AnthropicModel;
 use deepseek::Model as DeepseekModel;
-use feature_flags::FeatureFlagAppExt;
+use feature_flags::{Assistant2FeatureFlag, FeatureFlagAppExt};
 use gpui::{App, Pixels};
 use indexmap::IndexMap;
 use language_model::{CloudModel, LanguageModel};
@@ -88,6 +88,10 @@ pub struct AssistantSettings {
 
 impl AssistantSettings {
     pub fn are_live_diffs_enabled(&self, cx: &App) -> bool {
+        if cx.has_flag::<Assistant2FeatureFlag>() {
+            return false;
+        }
+
         cx.is_staff() || self.enable_experimental_live_diffs
     }
 }


### PR DESCRIPTION
This PR disables the "Suggest Edits" feature when in the `assistant2` feature flag.

This functionality has been superseded by the new Agent Panel.

We can remove the feature outright once the Agent Panel is generally available.

Release Notes:

- N/A
