### PR TITLE
Bump cargo-bundle and cargo-about version in nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1741481578,
-        "narHash": "sha256-JBTSyJFQdO3V8cgcL08VaBUByEU6P5kXbTJN6R0PFQo=",
+        "lastModified": 1742394900,
+        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "bb1c9567c43e4434f54e9481eb4b8e8e0d50f0b5",
+        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741379970,
-        "narHash": "sha256-Wh7esNh7G24qYleLvgOSY/7HlDUzWaL/n4qzlBePpiw=",
+        "lastModified": 1743095683,
+        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "36fd87baa9083f34f7f5027900b62ee6d09b1f2f",
+        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741573199,
-        "narHash": "sha256-A2sln1GdCf+uZ8yrERSCZUCqZ3JUlOv1WE2VFqqfaLQ=",
+        "lastModified": 1743215516,
+        "narHash": "sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL+9TWv2UDCEPNI=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c777dc8a1e35407b0e80ec89817fe69970f4e81a",
+        "rev": "524463199fdee49338006b049bc376b965a2cfed",
         "type": "github"
       },
       "original": {

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -95,15 +95,23 @@ let
         ++ lib.optionals stdenv.hostPlatform.isLinux [ makeWrapper ]
         ++ lib.optionals stdenv.hostPlatform.isDarwin [
           # TODO: move to overlay so it's usable in the shell
-          (cargo-bundle.overrideAttrs (old: {
-            version = "0.6.0-zed";
-            src = fetchFromGitHub {
-              owner = "zed-industries";
-              repo = "cargo-bundle";
-              rev = "zed-deploy";
-              hash = "sha256-OxYdTSiR9ueCvtt7Y2OJkvzwxxnxu453cMS+l/Bi5hM=";
-            };
-          }))
+          (cargo-bundle.overrideAttrs (
+            new: old: {
+              version = "0.6.1-zed";
+              src = fetchFromGitHub {
+                owner = "zed-industries";
+                repo = "cargo-bundle";
+                rev = "2be2669972dff3ddd4daf89a2cb29d2d06cad7c7";
+                hash = "sha256-cSvW0ND148AGdIGWg/ku0yIacVgW+9f1Nsi+kAQxVrI=";
+              };
+              # https://nixos.asia/en/buildRustPackage
+              cargoDeps = old.cargoDeps.overrideAttrs ({
+                inherit src;
+                name = "${new.pname}-${new.version}-vendor.tar.gz";
+                outputHash = "sha256-Q49FnXNHWhvbH1LtMUpXFcvGKu9VHwqOXXd+MjswO64=";
+              });
+            }
+          ))
         ];
 
       buildInputs =

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-CARGO_ABOUT_VERSION="0.6"
+CARGO_ABOUT_VERSION="0.7"
 OUTPUT_FILE="${1:-$(pwd)/assets/licenses.md}"
 TEMPLATE_FILE="script/licenses/template.md.hbs"
 


### PR DESCRIPTION
We updated our cargo-bundle fork, and this adds to our override to make sure we have the latest version.

cargo-about also released a new version upstream which was picked up in nixpkgs, so I've `nix flake update`'d and changed that version as well. Thanks to @niklaskorz for [pinging me](https://github.com/NixOS/nixpkgs/pull/392319#issuecomment-2746122094) about this. You should be able to drop the patch next time you update.

Release Notes:

- N/A