### PR TITLE
assistant2: Correctly display context files outside project worktrees

### DIFF
--- a/crates/assistant2/src/context.rs
+++ b/crates/assistant2/src/context.rs
@@ -156,7 +156,7 @@ impl AssistantContext {
 impl FileContext {
     pub fn snapshot(&self, cx: &App) -> Option<ContextSnapshot> {
         let buffer = self.context_buffer.buffer.read(cx);
-        let path = buffer_path_log_err(buffer)?;
+        let path = buffer_path_log_err(buffer, cx)?;
         let full_path: SharedString = path.to_string_lossy().into_owned().into();
         let name = match path.file_name() {
             Some(name) => name.to_string_lossy().into_owned().into(),
@@ -231,7 +231,7 @@ impl SymbolContext {
     pub fn snapshot(&self, cx: &App) -> Option<ContextSnapshot> {
         let buffer = self.context_symbol.buffer.read(cx);
         let name = self.context_symbol.id.name.clone();
-        let path = buffer_path_log_err(buffer)?
+        let path = buffer_path_log_err(buffer, cx)?
             .to_string_lossy()
             .into_owned()
             .into();

--- a/crates/assistant2/src/context_strip.rs
+++ b/crates/assistant2/src/context_strip.rs
@@ -92,12 +92,12 @@ impl ContextStrip {
         let active_buffer_entity = editor.buffer().read(cx).as_singleton()?;
         let active_buffer = active_buffer_entity.read(cx);
 
-        let path = active_buffer.file()?.path();
+        let path = active_buffer.file()?.full_path(cx);
 
         if self
             .context_store
             .read(cx)
-            .will_include_buffer(active_buffer.remote_id(), path)
+            .will_include_buffer(active_buffer.remote_id(), &path)
             .is_some()
         {
             return None;
@@ -108,7 +108,7 @@ impl ContextStrip {
             None => path.to_string_lossy().into_owned().into(),
         };
 
-        let icon_path = FileIcons::get_icon(path, cx);
+        let icon_path = FileIcons::get_icon(&path, cx);
 
         Some(SuggestedContext::File {
             name,


### PR DESCRIPTION
We were displaying empty pills for files that weren't inside one of the project worktrees

Release Notes:

- N/A
