### PR TITLE
workspace: Do not call set_active when deserializing a dock if that dock was not visible

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -565,11 +565,9 @@ impl Dock {
 
     pub fn restore_state(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         if let Some(serialized) = self.serialized_dock.clone() {
-            if let Some(active_panel) = serialized.active_panel {
+            if let Some(active_panel) = serialized.active_panel.filter(|_| serialized.visible) {
                 if let Some(idx) = self.panel_index_for_persistent_name(active_panel.as_str(), cx) {
-                    if serialized.visible {
-                        self.activate_panel(idx, window, cx);
-                    }
+                    self.activate_panel(idx, window, cx);
                 }
             }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -567,7 +567,9 @@ impl Dock {
         if let Some(serialized) = self.serialized_dock.clone() {
             if let Some(active_panel) = serialized.active_panel {
                 if let Some(idx) = self.panel_index_for_persistent_name(active_panel.as_str(), cx) {
-                    self.activate_panel(idx, window, cx);
+                    if serialized.visible {
+                        self.activate_panel(idx, window, cx);
+                    }
                 }
             }
 


### PR DESCRIPTION
This unblocks work on new debugger UI, where we don't want the set_active function to be called unconditionally. 

Release Notes:

- N/A
