### PR TITLE
assistant_settings: Show JSON schema for profile settings

### DIFF
--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -433,9 +433,11 @@ pub struct AssistantSettingsContentV2 {
     ///
     /// Default: false
     enable_experimental_live_diffs: Option<bool>,
-    #[schemars(skip)]
+    /// The default profile to use in the Agent.
+    ///
+    /// Default: write
     default_profile: Option<Arc<str>>,
-    #[schemars(skip)]
+    /// The available agent profiles.
     pub profiles: Option<IndexMap<Arc<str>, AgentProfileContent>>,
     /// Whenever a tool action would normally wait for your confirmation
     /// that you allow it, always choose to allow it.
@@ -485,6 +487,7 @@ impl Default for LanguageModelSelection {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AgentProfileContent {
     pub name: Arc<str>,
+    #[serde(default)]
     pub tools: IndexMap<Arc<str>, bool>,
     /// Whether all context servers are enabled by default.
     pub enable_all_context_servers: Option<bool>,


### PR DESCRIPTION
This PR makes it so we include the `default_profile` and `profiles` settings in the JSON schema.

This provides completions when editing the `settings.json`.

Release Notes:

- N/A
