### PR TITLE
Show commit author, not committer

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -133,8 +133,8 @@ pub struct CommitDetails {
     pub sha: SharedString,
     pub message: SharedString,
     pub commit_timestamp: i64,
-    pub committer_email: SharedString,
-    pub committer_name: SharedString,
+    pub author_email: SharedString,
+    pub author_name: SharedString,
 }
 
 #[derive(Debug)]
@@ -410,10 +410,10 @@ impl GitRepository for RealGitRepository {
                         .to_string()
                         .into(),
                     commit_timestamp: commit.time().seconds(),
-                    committer_email: String::from_utf8_lossy(commit.committer().email_bytes())
+                    author_email: String::from_utf8_lossy(commit.author().email_bytes())
                         .to_string()
                         .into(),
-                    committer_name: String::from_utf8_lossy(commit.committer().name_bytes())
+                    author_name: String::from_utf8_lossy(commit.author().name_bytes())
                         .to_string()
                         .into(),
                 };

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -375,7 +375,7 @@ fn format_commit(commit: &CommitDetails) -> String {
     writeln!(
         &mut result,
         "Author: {} <{}>",
-        commit.committer_name, commit.committer_email
+        commit.author_name, commit.author_email
     )
     .unwrap();
     writeln!(

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3972,8 +3972,8 @@ impl GitPanelMessageTooltip {
 
                 let commit_details = crate::commit_tooltip::CommitDetails {
                     sha: details.sha.clone(),
-                    author_name: details.committer_name.clone(),
-                    author_email: details.committer_email.clone(),
+                    author_name: details.author_name.clone(),
+                    author_email: details.author_email.clone(),
                     commit_time: OffsetDateTime::from_unix_timestamp(details.commit_timestamp)?,
                     message: Some(ParsedCommitMessage {
                         message: details.message.clone(),

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1881,8 +1881,8 @@ impl GitStore {
             sha: commit.sha.into(),
             message: commit.message.into(),
             commit_timestamp: commit.commit_timestamp,
-            committer_email: commit.committer_email.into(),
-            committer_name: commit.committer_name.into(),
+            author_email: commit.author_email.into(),
+            author_name: commit.author_name.into(),
         })
     }
 
@@ -2888,8 +2888,8 @@ impl Repository {
                         sha: resp.sha.into(),
                         message: resp.message.into(),
                         commit_timestamp: resp.commit_timestamp,
-                        committer_email: resp.committer_email.into(),
-                        committer_name: resp.committer_name.into(),
+                        author_email: resp.author_email.into(),
+                        author_name: resp.author_name.into(),
                     })
                 }
             }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -3364,8 +3364,8 @@ message GitCommitDetails {
     string sha = 1;
     string message = 2;
     int64 commit_timestamp = 3;
-    string committer_email = 4;
-    string committer_name = 5;
+    string author_email = 4;
+    string author_name = 5;
 }
 
 message LoadCommitDiff {


### PR DESCRIPTION
Release Notes:

- Fixed a bug where the git panel displayed a commit's committer in place of its author.
