### PR TITLE
assistant2: Use "Agent Panel" nomenclature for panel tooltip

### DIFF
--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -607,7 +607,7 @@ impl EventEmitter<PanelEvent> for AssistantPanel {}
 
 impl Panel for AssistantPanel {
     fn persistent_name() -> &'static str {
-        "AssistantPanel2"
+        "AgentPanel"
     }
 
     fn position(&self, _window: &Window, cx: &App) -> DockPosition {
@@ -667,7 +667,7 @@ impl Panel for AssistantPanel {
     }
 
     fn icon_tooltip(&self, _window: &Window, _cx: &App) -> Option<&'static str> {
-        Some("Assistant Panel")
+        Some("Agent Panel")
     }
 
     fn toggle_action(&self) -> Box<dyn Action> {


### PR DESCRIPTION
This PR updates the Agent Panel tooltip in the status to use "Agent Panel" instead of "Assistant Panel".

Also changes the name we use in workspace serialization.

Release Notes:

- N/A
