### PR TITLE
assistant2: Rename key context to `AgentPanel`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -625,7 +625,7 @@
     }
   },
   {
-    "context": "AssistantPanel2",
+    "context": "AgentPanel",
     "bindings": {
       "ctrl-n": "assistant2::NewThread",
       "new": "assistant2::NewThread",
@@ -640,7 +640,7 @@
     }
   },
   {
-    "context": "AssistantPanel2 && prompt_editor",
+    "context": "AgentPanel && prompt_editor",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "assistant2::NewPromptEditor",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -277,7 +277,7 @@
     }
   },
   {
-    "context": "AssistantPanel2",
+    "context": "AgentPanel",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "assistant2::NewThread",
@@ -292,7 +292,7 @@
     }
   },
   {
-    "context": "AssistantPanel2 && prompt_editor",
+    "context": "AgentPanel && prompt_editor",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "assistant2::NewPromptEditor",

--- a/crates/assistant2/src/assistant_panel.rs
+++ b/crates/assistant2/src/assistant_panel.rs
@@ -1182,7 +1182,7 @@ impl AssistantPanel {
 
     fn key_context(&self) -> KeyContext {
         let mut key_context = KeyContext::new_with_defaults();
-        key_context.add("AssistantPanel2");
+        key_context.add("AgentPanel");
         if matches!(self.active_view, ActiveView::PromptEditor) {
             key_context.add("prompt_editor");
         }


### PR DESCRIPTION
This PR renames the key context for the Agent Panel from "AssistantPanel2" to "AgentPanel".

Release Notes:

- N/A
