### PR TITLE
nix: Separate debug output

### DIFF
--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,5 +1,4 @@
 {
-  lib,
   mkShell,
   stdenv,
   stdenvAdapters,


### PR DESCRIPTION
This makes it easier to iterate on the nix flake by adding a package which builds zed in debug mode rather than release

Release Notes:

- N/A