### PR TITLE
assistant2: Rename `assistant2` actions to `agent`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -149,8 +149,8 @@
   {
     "context": "AssistantDiff",
     "bindings": {
-      "ctrl-y": "assistant2::ToggleKeep",
-      "ctrl-k ctrl-r": "assistant2::Reject"
+      "ctrl-y": "agent::ToggleKeep",
+      "ctrl-k ctrl-r": "agent::Reject"
     }
   },
   {
@@ -620,32 +620,32 @@
   {
     "context": "AgentPanel",
     "bindings": {
-      "ctrl-n": "assistant2::NewThread",
-      "new": "assistant2::NewThread",
-      "ctrl-alt-n": "assistant2::NewPromptEditor",
-      "ctrl-shift-h": "assistant2::OpenHistory",
-      "ctrl-alt-c": "assistant2::OpenConfiguration",
-      "ctrl-i": "assistant2::ToggleProfileSelector",
+      "ctrl-n": "agent::NewThread",
+      "new": "agent::NewThread",
+      "ctrl-alt-n": "agent::NewPromptEditor",
+      "ctrl-shift-h": "agent::OpenHistory",
+      "ctrl-alt-c": "agent::OpenConfiguration",
+      "ctrl-i": "agent::ToggleProfileSelector",
       "ctrl-alt-/": "assistant::ToggleModelSelector",
-      "ctrl-shift-a": "assistant2::ToggleContextPicker",
-      "ctrl-e": "assistant2::ChatMode",
-      "ctrl-alt-e": "assistant2::RemoveAllContext"
+      "ctrl-shift-a": "agent::ToggleContextPicker",
+      "ctrl-e": "agent::ChatMode",
+      "ctrl-alt-e": "agent::RemoveAllContext"
     }
   },
   {
     "context": "AgentPanel && prompt_editor",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-n": "assistant2::NewPromptEditor",
-      "cmd-alt-t": "assistant2::NewThread"
+      "cmd-n": "agent::NewPromptEditor",
+      "cmd-alt-t": "agent::NewThread"
     }
   },
   {
     "context": "MessageEditor > Editor",
     "bindings": {
-      "enter": "assistant2::Chat",
-      "ctrl-i": "assistant2::ToggleProfileSelector",
-      "shift-ctrl-r": "assistant2::OpenAssistantDiff"
+      "enter": "agent::Chat",
+      "ctrl-i": "agent::ToggleProfileSelector",
+      "shift-ctrl-r": "agent::OpenAssistantDiff"
     }
   },
   {
@@ -660,18 +660,18 @@
   {
     "context": "ContextStrip",
     "bindings": {
-      "up": "assistant2::FocusUp",
-      "right": "assistant2::FocusRight",
-      "left": "assistant2::FocusLeft",
-      "down": "assistant2::FocusDown",
-      "backspace": "assistant2::RemoveFocusedContext",
-      "enter": "assistant2::AcceptSuggestedContext"
+      "up": "agent::FocusUp",
+      "right": "agent::FocusRight",
+      "left": "agent::FocusLeft",
+      "down": "agent::FocusDown",
+      "backspace": "agent::RemoveFocusedContext",
+      "enter": "agent::AcceptSuggestedContext"
     }
   },
   {
     "context": "ThreadHistory",
     "bindings": {
-      "backspace": "assistant2::RemoveSelectedThread"
+      "backspace": "agent::RemoveSelectedThread"
     }
   },
   {
@@ -679,7 +679,7 @@
     "bindings": {
       "ctrl-[": "assistant::CyclePreviousInlineAssist",
       "ctrl-]": "assistant::CycleNextInlineAssist",
-      "ctrl-alt-e": "assistant2::RemoveAllContext"
+      "ctrl-alt-e": "agent::RemoveAllContext"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -241,8 +241,8 @@
     "context": "AssistantDiff",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-y": "assistant2::ToggleKeep",
-      "cmd-alt-z": "assistant2::Reject"
+      "cmd-y": "agent::ToggleKeep",
+      "cmd-alt-z": "agent::Reject"
     }
   },
   {
@@ -280,32 +280,32 @@
     "context": "AgentPanel",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-n": "assistant2::NewThread",
-      "cmd-alt-n": "assistant2::NewPromptEditor",
-      "cmd-shift-h": "assistant2::OpenHistory",
-      "cmd-alt-c": "assistant2::OpenConfiguration",
-      "cmd-i": "assistant2::ToggleProfileSelector",
+      "cmd-n": "agent::NewThread",
+      "cmd-alt-n": "agent::NewPromptEditor",
+      "cmd-shift-h": "agent::OpenHistory",
+      "cmd-alt-c": "agent::OpenConfiguration",
+      "cmd-i": "agent::ToggleProfileSelector",
       "cmd-alt-/": "assistant::ToggleModelSelector",
-      "cmd-shift-a": "assistant2::ToggleContextPicker",
-      "cmd-e": "assistant2::ChatMode",
-      "cmd-alt-e": "assistant2::RemoveAllContext"
+      "cmd-shift-a": "agent::ToggleContextPicker",
+      "cmd-e": "agent::ChatMode",
+      "cmd-alt-e": "agent::RemoveAllContext"
     }
   },
   {
     "context": "AgentPanel && prompt_editor",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-n": "assistant2::NewPromptEditor",
-      "cmd-alt-t": "assistant2::NewThread"
+      "cmd-n": "agent::NewPromptEditor",
+      "cmd-alt-t": "agent::NewThread"
     }
   },
   {
     "context": "MessageEditor > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "enter": "assistant2::Chat",
-      "cmd-i": "assistant2::ToggleProfileSelector",
-      "shift-ctrl-r": "assistant2::OpenAssistantDiff"
+      "enter": "agent::Chat",
+      "cmd-i": "agent::ToggleProfileSelector",
+      "shift-ctrl-r": "agent::OpenAssistantDiff"
     }
   },
   {
@@ -321,18 +321,18 @@
     "context": "ContextStrip",
     "use_key_equivalents": true,
     "bindings": {
-      "up": "assistant2::FocusUp",
-      "right": "assistant2::FocusRight",
-      "left": "assistant2::FocusLeft",
-      "down": "assistant2::FocusDown",
-      "backspace": "assistant2::RemoveFocusedContext",
-      "enter": "assistant2::AcceptSuggestedContext"
+      "up": "agent::FocusUp",
+      "right": "agent::FocusRight",
+      "left": "agent::FocusLeft",
+      "down": "agent::FocusDown",
+      "backspace": "agent::RemoveFocusedContext",
+      "enter": "agent::AcceptSuggestedContext"
     }
   },
   {
     "context": "ThreadHistory",
     "bindings": {
-      "backspace": "assistant2::RemoveSelectedThread"
+      "backspace": "agent::RemoveSelectedThread"
     }
   },
   {
@@ -708,9 +708,9 @@
     "context": "PromptEditor",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-shift-a": "assistant2::ToggleContextPicker",
+      "cmd-shift-a": "agent::ToggleContextPicker",
       "cmd-alt-/": "assistant::ToggleModelSelector",
-      "cmd-alt-e": "assistant2::RemoveAllContext",
+      "cmd-alt-e": "agent::RemoveAllContext",
       "ctrl-[": "assistant::CyclePreviousInlineAssist",
       "ctrl-]": "assistant::CycleNextInlineAssist"
     }

--- a/crates/assistant2/src/assistant.rs
+++ b/crates/assistant2/src/assistant.rs
@@ -43,7 +43,7 @@ pub use crate::thread_store::ThreadStore;
 pub use assistant_diff::{AssistantDiff, AssistantDiffToolbar};
 
 actions!(
-    assistant2,
+    agent,
     [
         NewThread,
         NewPromptEditor,
@@ -87,9 +87,9 @@ impl ManageProfiles {
     }
 }
 
-impl_actions!(assistant, [ManageProfiles]);
+impl_actions!(agent, [ManageProfiles]);
 
-const NAMESPACE: &str = "assistant2";
+const NAMESPACE: &str = "agent";
 
 /// Initializes the `assistant2` crate.
 pub fn init(


### PR DESCRIPTION
This PR renames the `assistant2` actions to `agent`.

Note that any `assistant` actions have been left as-is for now so that there aren't any changes to users not in the feature flag.

Release Notes:

- N/A
