### PR TITLE
nix: Clean up build

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,12 +13,6 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-args=-Objc -all_load"]
-
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-args=-Objc -all_load"]
-
 [target.'cfg(target_os = "windows")']
 rustflags = [
     "--cfg",

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,6 +13,12 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
+[target.aarch64-apple-darwin]
+rustflags = ["-C", "link-args=-all_load"]
+
+[target.x86_64-apple-darwin]
+rustflags = ["-C", "link-args=-all_load"]
+
 [target.'cfg(target_os = "windows")']
 rustflags = [
     "--cfg",

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -184,9 +184,6 @@ jobs:
           - os: arm Mac
             runner: [macOS, ARM64, test]
             install_nix: false
-          - os: arm Linux
-            runner: buildjet-16vcpu-ubuntu-2204-arm
-            install_nix: true
     if: github.repository_owner == 'zed-industries'
     runs-on: ${{ matrix.system.runner }}
     needs: tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5305,7 +5305,7 @@ dependencies = [
  "ignore",
  "libc",
  "log",
- "notify 8.0.0 (git+https://github.com/zed-industries/notify.git?rev=bbb9ea5ae52b253e095737847e367c30653a2e96)",
+ "notify",
  "objc",
  "parking_lot",
  "paths",
@@ -8235,7 +8235,7 @@ dependencies = [
  "ignore",
  "log",
  "memchr",
- "notify 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify",
  "notify-debouncer-mini",
  "once_cell",
  "opener",
@@ -8665,25 +8665,6 @@ dependencies = [
 [[package]]
 name = "notify"
 version = "8.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fee8403b3d66ac7b26aee6e40a897d85dc5ce26f44da36b8b73e987cc52e943"
-dependencies = [
- "bitflags 2.9.0",
- "filetime",
- "fsevent-sys 4.1.0",
- "inotify",
- "kqueue",
- "libc",
- "log",
- "mio",
- "notify-types 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "walkdir",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "notify"
-version = "8.0.0"
 source = "git+https://github.com/zed-industries/notify.git?rev=bbb9ea5ae52b253e095737847e367c30653a2e96#bbb9ea5ae52b253e095737847e367c30653a2e96"
 dependencies = [
  "bitflags 2.9.0",
@@ -8694,7 +8675,7 @@ dependencies = [
  "libc",
  "log",
  "mio",
- "notify-types 2.0.0 (git+https://github.com/zed-industries/notify.git?rev=bbb9ea5ae52b253e095737847e367c30653a2e96)",
+ "notify-types",
  "walkdir",
  "windows-sys 0.59.0",
 ]
@@ -8706,16 +8687,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
 dependencies = [
  "log",
- "notify 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "notify-types 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "notify",
+ "notify-types",
  "tempfile",
 ]
-
-[[package]]
-name = "notify-types"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "notify-types"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7713,7 +7713,7 @@ dependencies = [
 [[package]]
 name = "libwebrtc"
 version = "0.3.10"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
  "cxx",
  "jni",
@@ -7798,7 +7798,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 [[package]]
 name = "livekit"
 version = "0.7.8"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
  "chrono",
  "futures-util",
@@ -7821,12 +7821,10 @@ dependencies = [
 [[package]]
 name = "livekit-api"
 version = "0.4.2"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
- "base64 0.21.7",
  "futures-util",
  "http 0.2.12",
- "jsonwebtoken",
  "livekit-protocol",
  "livekit-runtime",
  "log",
@@ -7837,7 +7835,6 @@ dependencies = [
  "reqwest 0.11.27",
  "scopeguard",
  "serde",
- "serde_json",
  "sha2",
  "thiserror 1.0.69",
  "tokio",
@@ -7848,7 +7845,7 @@ dependencies = [
 [[package]]
 name = "livekit-protocol"
 version = "0.3.9"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
  "futures-util",
  "livekit-runtime",
@@ -7865,7 +7862,7 @@ dependencies = [
 [[package]]
 name = "livekit-runtime"
 version = "0.4.0"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -16162,7 +16159,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys"
 version = "0.3.7"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
  "cc",
  "cxx",
@@ -16175,7 +16172,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys-build"
 version = "0.3.6"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8#102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
 dependencies = [
  "fs2",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -657,6 +657,8 @@ features = [
 [patch.crates-io]
 cpal = { git = "https://github.com/zed-industries/cpal", rev = "fd8bc2fd39f1f5fdee5a0690656caff9a26d9d50" }
 real-async-tls = { git = "https://github.com/zed-industries/async-tls", rev = "1e759a4b5e370f87dc15e40756ac4f8815b61d9d", package = "async-tls" }
+notify = { git = "https://github.com/zed-industries/notify.git", rev = "bbb9ea5ae52b253e095737847e367c30653a2e96" }
+notify-types = { git = "https://github.com/zed-industries/notify.git", rev = "bbb9ea5ae52b253e095737847e367c30653a2e96" }
 
 [profile.dev]
 split-debuginfo = "unpacked"

--- a/crates/fs/Cargo.toml
+++ b/crates/fs/Cargo.toml
@@ -40,7 +40,7 @@ objc = "0.2"
 cocoa = "0.26"
 
 [target.'cfg(not(target_os = "macos"))'.dependencies]
-notify = { git = "https://github.com/zed-industries/notify.git", rev = "bbb9ea5ae52b253e095737847e367c30653a2e96" }
+notify = "8.0.0"
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true

--- a/crates/livekit_client/.cargo/config.toml
+++ b/crates/livekit_client/.cargo/config.toml
@@ -1,2 +1,0 @@
-[livekit_client_test]
-rustflags = ["-C", "link-args=-ObjC"]

--- a/crates/livekit_client/Cargo.toml
+++ b/crates/livekit_client/Cargo.toml
@@ -39,8 +39,8 @@ tokio-tungstenite.workspace = true
 util.workspace = true
 
 [target.'cfg(not(all(target_os = "windows", target_env = "gnu")))'.dependencies]
-libwebrtc = { rev = "102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8", git = "https://github.com/zed-industries/livekit-rust-sdks" }
-livekit = { rev = "102ebbb1ccfbdbcb7332d86dc30b1b1c8c01e4f8", git = "https://github.com/zed-industries/livekit-rust-sdks", features = ["__rustls-tls"] }
+libwebrtc = { rev = "ffc215666621cd903a689d1c56cce0a706ffe022", git = "https://github.com/zed-industries/livekit-rust-sdks" }
+livekit = { rev = "ffc215666621cd903a689d1c56cce0a706ffe022", git = "https://github.com/zed-industries/livekit-rust-sdks", features = ["__rustls-tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation.workspace = true

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,7 +1,5 @@
 {
   mkShell,
-  stdenv,
-  stdenvAdapters,
   makeFontsConf,
 
   zed-editor,
@@ -12,12 +10,7 @@
   protobuf,
   nodejs_22,
 }:
-let
-  moldStdenv = stdenvAdapters.useMoldLinker stdenv;
-  mkShell' =
-    if stdenv.hostPlatform.isLinux then mkShell.override { stdenv = moldStdenv; } else mkShell;
-in
-mkShell' {
+(mkShell.override { inherit (zed-editor) stdenv; }) {
   inputsFrom = [ zed-editor ];
   packages = [
     rust-analyzer


### PR DESCRIPTION
- bump our livekit version to include a fix for a crane bug (TODO: add link when an issue is filed on crane)
- switch to a clang stdenv for both linux and macos
- manually unify versions of our notify crate
- remove old linker flags which were only needed for livekit
- fix an issue where RUSTFLAGS shadowed the rustflags from cargo configs

Release Notes:

- N/A