### PR TITLE
Bump revision for `livekit-rust-sdks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7717,7 +7717,7 @@ dependencies = [
 [[package]]
 name = "libwebrtc"
 version = "0.3.10"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "cxx",
  "jni",
@@ -7802,7 +7802,7 @@ checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 [[package]]
 name = "livekit"
 version = "0.7.8"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "chrono",
  "futures-util",
@@ -7825,7 +7825,7 @@ dependencies = [
 [[package]]
 name = "livekit-api"
 version = "0.4.2"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "futures-util",
  "http 0.2.12",
@@ -7849,7 +7849,7 @@ dependencies = [
 [[package]]
 name = "livekit-protocol"
 version = "0.3.9"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "futures-util",
  "livekit-runtime",
@@ -7866,7 +7866,7 @@ dependencies = [
 [[package]]
 name = "livekit-runtime"
 version = "0.4.0"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "tokio",
  "tokio-stream",
@@ -16163,7 +16163,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys"
 version = "0.3.7"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "cc",
  "cxx",
@@ -16176,7 +16176,7 @@ dependencies = [
 [[package]]
 name = "webrtc-sys-build"
 version = "0.3.6"
-source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=ffc215666621cd903a689d1c56cce0a706ffe022#ffc215666621cd903a689d1c56cce0a706ffe022"
+source = "git+https://github.com/zed-industries/livekit-rust-sdks?rev=80bb8f4c9112789f7c24cc98d8423010977806a6#80bb8f4c9112789f7c24cc98d8423010977806a6"
 dependencies = [
  "fs2",
  "regex",

--- a/crates/livekit_client/Cargo.toml
+++ b/crates/livekit_client/Cargo.toml
@@ -39,8 +39,8 @@ tokio-tungstenite.workspace = true
 util.workspace = true
 
 [target.'cfg(not(all(target_os = "windows", target_env = "gnu")))'.dependencies]
-libwebrtc = { rev = "ffc215666621cd903a689d1c56cce0a706ffe022", git = "https://github.com/zed-industries/livekit-rust-sdks" }
-livekit = { rev = "ffc215666621cd903a689d1c56cce0a706ffe022", git = "https://github.com/zed-industries/livekit-rust-sdks", features = ["__rustls-tls"] }
+libwebrtc = { rev = "80bb8f4c9112789f7c24cc98d8423010977806a6", git = "https://github.com/zed-industries/livekit-rust-sdks" }
+livekit = { rev = "80bb8f4c9112789f7c24cc98d8423010977806a6", git = "https://github.com/zed-industries/livekit-rust-sdks", features = ["__rustls-tls"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation.workspace = true


### PR DESCRIPTION
This PR bumps the revision of the `livekit-rust-sdks` crate.

I was running into issue where Cargo was stuck on "Updating git submodule `https://chromium.googlesource.com/libyuv/libyuv`".

I resolved the issue by forking `libyuv` to https://github.com/zed-industries/libyuv and updating our `livekit-rust-sdks` fork to use it in https://github.com/zed-industries/livekit-rust-sdks/pull/4.

Release Notes:

- N/A
