### PR TITLE
gpui: Allow DisplayId to be compared to u32

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -266,6 +266,12 @@ pub struct ScreenCaptureFrame(pub PlatformScreenCaptureFrame);
 #[derive(PartialEq, Eq, Hash, Copy, Clone)]
 pub struct DisplayId(pub(crate) u32);
 
+impl From<DisplayId> for u32 {
+    fn from(id: DisplayId) -> Self {
+        id.0
+    }
+}
+
 impl Debug for DisplayId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "DisplayId({})", self.0)


### PR DESCRIPTION
allow DisplayId to be compared to u32. This is handy since gpui doesn't provide a method to detect current active display of the user. So when using mouse location to get the active display we need to then compare that display u32 to DisplayID

Release Notes:
- added From to allow u32 comparison
