### PR TITLE
Add a next_mode to vim::Paste instead of hard-coding Normal mode

### DIFF
--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -19,6 +19,8 @@ pub struct Paste {
     before: bool,
     #[serde(default)]
     preserve_clipboard: bool,
+    #[serde(default)]
+    next_mode: Mode,
 }
 
 impl_actions!(vim, [Paste]);
@@ -203,7 +205,7 @@ impl Vim {
                 })
             });
         });
-        self.switch_mode(Mode::Normal, true, window, cx);
+        self.switch_mode(action.next_mode, true, window, cx);
     }
 
     pub fn replace_with_register_object(

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -1,5 +1,5 @@
-use editor::{display_map::ToDisplayPoint, movement, scroll::Autoscroll, DisplayPoint, RowExt};
-use gpui::{impl_actions, Context, Window};
+use editor::{DisplayPoint, RowExt, display_map::ToDisplayPoint, movement, scroll::Autoscroll};
+use gpui::{Context, Window, impl_actions};
 use language::{Bias, SelectionGoal};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -7,10 +7,10 @@ use settings::Settings;
 use std::cmp;
 
 use crate::{
+    Vim, VimSettings,
     motion::{Motion, MotionKind},
     object::Object,
     state::{Mode, Register},
-    Vim, VimSettings,
 };
 
 #[derive(Clone, Deserialize, JsonSchema, PartialEq)]
@@ -285,15 +285,15 @@ impl Vim {
 #[cfg(test)]
 mod test {
     use crate::{
+        UseSystemClipboard, VimSettings,
         state::{Mode, Register},
         test::{NeovimBackedTestContext, VimTestContext},
-        UseSystemClipboard, VimSettings,
     };
     use gpui::ClipboardItem;
     use indoc::indoc;
     use language::{
-        language_settings::{AllLanguageSettings, LanguageSettingsContent},
         LanguageName,
+        language_settings::{AllLanguageSettings, LanguageSettingsContent},
     };
     use settings::SettingsStore;
 

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -1,15 +1,16 @@
-use editor::{DisplayPoint, RowExt, display_map::ToDisplayPoint, movement, scroll::Autoscroll};
-use gpui::{Context, Window, impl_actions};
+use editor::{display_map::ToDisplayPoint, movement, scroll::Autoscroll, DisplayPoint, RowExt};
+use gpui::{impl_actions, Context, Window};
 use language::{Bias, SelectionGoal};
 use schemars::JsonSchema;
 use serde::Deserialize;
+use settings::Settings;
 use std::cmp;
 
 use crate::{
-    Vim,
     motion::{Motion, MotionKind},
     object::Object,
     state::{Mode, Register},
+    Vim, VimSettings,
 };
 
 #[derive(Clone, Deserialize, JsonSchema, PartialEq)]
@@ -19,8 +20,6 @@ pub struct Paste {
     before: bool,
     #[serde(default)]
     preserve_clipboard: bool,
-    #[serde(default)]
-    next_mode: Mode,
 }
 
 impl_actions!(vim, [Paste]);
@@ -205,7 +204,8 @@ impl Vim {
                 })
             });
         });
-        self.switch_mode(action.next_mode, true, window, cx);
+        let next_mode = VimSettings::get_global(cx).default_mode;
+        self.switch_mode(next_mode, true, window, cx);
     }
 
     pub fn replace_with_register_object(
@@ -285,15 +285,15 @@ impl Vim {
 #[cfg(test)]
 mod test {
     use crate::{
-        UseSystemClipboard, VimSettings,
         state::{Mode, Register},
         test::{NeovimBackedTestContext, VimTestContext},
+        UseSystemClipboard, VimSettings,
     };
     use gpui::ClipboardItem;
     use indoc::indoc;
     use language::{
-        LanguageName,
         language_settings::{AllLanguageSettings, LanguageSettingsContent},
+        LanguageName,
     };
     use settings::SettingsStore;
 

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -19,6 +19,7 @@ use language::{Buffer, BufferEvent, BufferId, Chunk, Point};
 use multi_buffer::MultiBufferRow;
 use picker::{Picker, PickerDelegate};
 use project::{Project, ProjectItem, ProjectPath};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use std::borrow::BorrowMut;
@@ -35,7 +36,7 @@ use util::ResultExt;
 use workspace::searchable::Direction;
 use workspace::{Workspace, WorkspaceDb, WorkspaceId};
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub enum Mode {
     Normal,
     Insert,

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -19,7 +19,6 @@ use language::{Buffer, BufferEvent, BufferId, Chunk, Point};
 use multi_buffer::MultiBufferRow;
 use picker::{Picker, PickerDelegate};
 use project::{Project, ProjectItem, ProjectPath};
-use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
 use std::borrow::BorrowMut;
@@ -36,7 +35,7 @@ use util::ResultExt;
 use workspace::searchable::Direction;
 use workspace::{Workspace, WorkspaceDb, WorkspaceId};
 
-#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Mode {
     Normal,
     Insert,


### PR DESCRIPTION
This adds a `next_mode` parameter to the `vim::Paste` action. My main use-case for this is for helix users, who will want to switch into `HelixNormal` mode instead of `Normal` mode.

I'm not sure if this is the best approach -- another possibility would be to have a global vim-vs-helix configuration, and then have every invocation of "normal" mode choose vim or helix based on that global configuration. But the approach in this PR is much less invasive.

Release Notes:

- vim: switch to the configured default mode after paste instead of hard-coding Normal mode