### PR TITLE
assistant2: Use snake_case for tool names

### DIFF
--- a/crates/assistant_tools/src/batch_tool.rs
+++ b/crates/assistant_tools/src/batch_tool.rs
@@ -148,7 +148,7 @@ pub struct BatchTool;
 
 impl Tool for BatchTool {
     fn name(&self) -> String {
-        "batch-tool".into()
+        "batch_tool".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/code_symbols_tool.rs
+++ b/crates/assistant_tools/src/code_symbols_tool.rs
@@ -79,7 +79,7 @@ pub struct CodeSymbolsTool;
 
 impl Tool for CodeSymbolsTool {
     fn name(&self) -> String {
-        "code-symbols".into()
+        "code_symbols".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/copy_path_tool.rs
+++ b/crates/assistant_tools/src/copy_path_tool.rs
@@ -40,7 +40,7 @@ pub struct CopyPathTool;
 
 impl Tool for CopyPathTool {
     fn name(&self) -> String {
-        "copy-path".into()
+        "copy_path".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/create_directory_tool.rs
+++ b/crates/assistant_tools/src/create_directory_tool.rs
@@ -30,7 +30,7 @@ pub struct CreateDirectoryTool;
 
 impl Tool for CreateDirectoryTool {
     fn name(&self) -> String {
-        "create-directory".into()
+        "create_directory".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/create_file_tool.rs
+++ b/crates/assistant_tools/src/create_file_tool.rs
@@ -37,7 +37,7 @@ pub struct CreateFileTool;
 
 impl Tool for CreateFileTool {
     fn name(&self) -> String {
-        "create-file".into()
+        "create_file".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/delete_path_tool.rs
+++ b/crates/assistant_tools/src/delete_path_tool.rs
@@ -30,7 +30,7 @@ pub struct DeletePathTool;
 
 impl Tool for DeletePathTool {
     fn name(&self) -> String {
-        "delete-path".into()
+        "delete_path".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -78,7 +78,7 @@ pub struct EditFilesTool;
 
 impl Tool for EditFilesTool {
     fn name(&self) -> String {
-        "edit-files".into()
+        "edit_files".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/find_replace_file_tool.rs
+++ b/crates/assistant_tools/src/find_replace_file_tool.rs
@@ -126,7 +126,7 @@ pub struct FindReplaceFileTool;
 
 impl Tool for FindReplaceFileTool {
     fn name(&self) -> String {
-        "find-replace-file".into()
+        "find_replace_file".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/list_directory_tool.rs
+++ b/crates/assistant_tools/src/list_directory_tool.rs
@@ -41,7 +41,7 @@ pub struct ListDirectoryTool;
 
 impl Tool for ListDirectoryTool {
     fn name(&self) -> String {
-        "list-directory".into()
+        "list_directory".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/move_path_tool.rs
+++ b/crates/assistant_tools/src/move_path_tool.rs
@@ -39,7 +39,7 @@ pub struct MovePathTool;
 
 impl Tool for MovePathTool {
     fn name(&self) -> String {
-        "move-path".into()
+        "move_path".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/path_search_tool.rs
+++ b/crates/assistant_tools/src/path_search_tool.rs
@@ -38,7 +38,7 @@ pub struct PathSearchTool;
 
 impl Tool for PathSearchTool {
     fn name(&self) -> String {
-        "path-search".into()
+        "path_search".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -44,7 +44,7 @@ pub struct ReadFileTool;
 
 impl Tool for ReadFileTool {
     fn name(&self) -> String {
-        "read-file".into()
+        "read_file".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/regex_search_tool.rs
+++ b/crates/assistant_tools/src/regex_search_tool.rs
@@ -41,7 +41,7 @@ pub struct RegexSearchTool;
 
 impl Tool for RegexSearchTool {
     fn name(&self) -> String {
-        "regex-search".into()
+        "regex_search".into()
     }
 
     fn needs_confirmation(&self) -> bool {

--- a/crates/assistant_tools/src/symbol_info_tool.rs
+++ b/crates/assistant_tools/src/symbol_info_tool.rs
@@ -69,7 +69,7 @@ pub struct SymbolInfoTool;
 
 impl Tool for SymbolInfoTool {
     fn name(&self) -> String {
-        "symbol-info".into()
+        "symbol_info".into()
     }
 
     fn needs_confirmation(&self) -> bool {


### PR DESCRIPTION
The [Gemini docs](https://ai.google.dev/gemini-api/docs/function-calling?example=weather#function_declarations) state that function names should be in `snake_case` or `camelCase`.

Release Notes:

- N/A