### PR TITLE
Fix Gemini function calling

### DIFF
--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -472,19 +472,17 @@ pub fn into_google(
             top_k: None,
         }),
         safety_settings: None,
-        tools: Some(
-            request
+        tools: Some(vec![google_ai::Tool {
+            function_declarations: request
                 .tools
                 .into_iter()
-                .map(|tool| google_ai::Tool {
-                    function_declarations: vec![FunctionDeclaration {
-                        name: tool.name,
-                        description: tool.description,
-                        parameters: tool.input_schema,
-                    }],
+                .map(|tool| FunctionDeclaration {
+                    name: tool.name,
+                    description: tool.description,
+                    parameters: tool.input_schema,
                 })
                 .collect(),
-        ),
+        }]),
         tool_config: None,
     }
 }


### PR DESCRIPTION
This seems to improve the performance of `gemini-2.5-pro-exp-03-25` significantly.
We know define a single `Tool` that has multiple `FunctionDeclaration`s, instead of defining multiple `Tool`s with a single `FunctionDeclaration`.
Oddly enough the `flash` models seemed to work perfectly fine with the multiple `Tool { ... }` definitions

Release Notes:

- N/A