### PR TITLE
extension: Bump `wasi-sdk` to version 25

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -33,13 +33,22 @@ const WASI_ADAPTER_URL: &str = "https://github.com/bytecodealliance/wasmtime/rel
 ///
 /// Once Clang 17 and its wasm target are available via system package managers, we won't need
 /// to download this.
-const WASI_SDK_URL: &str = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-21/";
-const WASI_SDK_ASSET_NAME: Option<&str> = if cfg!(target_os = "macos") {
-    Some("wasi-sdk-21.0-macos.tar.gz")
-} else if cfg!(any(target_os = "linux", target_os = "freebsd")) {
-    Some("wasi-sdk-21.0-linux.tar.gz")
-} else if cfg!(target_os = "windows") {
-    Some("wasi-sdk-21.0.m-mingw.tar.gz")
+const WASI_SDK_URL: &str = "https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-25/";
+const WASI_SDK_ASSET_NAME: Option<&str> = if cfg!(all(target_os = "macos", target_arch = "x86_64"))
+{
+    Some("wasi-sdk-25.0-x86_64-macos.tar.gz")
+} else if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+    Some("wasi-sdk-25.0-arm64-macos.tar.gz")
+} else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+    Some("wasi-sdk-25.0-x86_64-linux.tar.gz")
+} else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+    Some("wasi-sdk-25.0-arm64-linux.tar.gz")
+} else if cfg!(all(target_os = "freebsd", target_arch = "x86_64")) {
+    Some("wasi-sdk-25.0-x86_64-linux.tar.gz")
+} else if cfg!(all(target_os = "freebsd", target_arch = "aarch64")) {
+    Some("wasi-sdk-25.0-arm64-linux.tar.gz")
+} else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+    Some("wasi-sdk-25.0-x86_64-windows.tar.gz")
 } else {
     None
 };


### PR DESCRIPTION
This bumps `wasi-sdk` to version 25 and adds target architecture conditionals.

Closes #18492

Release Notes:

- Fixed compiling dev extensions with Tree-sitter grammars on Linux aarch64.
