### PR TITLE
language_models: Denote Copilot Chat as not supporting tools

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -181,12 +181,7 @@ impl LanguageModel for CopilotChatLanguageModel {
     }
 
     fn supports_tools(&self) -> bool {
-        match self.model {
-            CopilotChatModel::Claude3_5Sonnet
-            | CopilotChatModel::Claude3_7Sonnet
-            | CopilotChatModel::Claude3_7SonnetThinking => true,
-            _ => false,
-        }
+        false
     }
 
     fn telemetry_id(&self) -> String {


### PR DESCRIPTION
This PR updates the Copilot Chat language model to indicate it does not yet support tool use in Zed.

Release Notes:

- N/A
