### PR TITLE
node_runtime: Update to Node 20

### DIFF
--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -473,7 +473,7 @@ pub struct SystemNodeRuntime {
 }
 
 impl SystemNodeRuntime {
-    const MIN_VERSION: semver::Version = Version::new(18, 0, 0);
+    const MIN_VERSION: semver::Version = Version::new(20, 0, 0);
     async fn new(node: PathBuf, npm: PathBuf) -> Result<Box<dyn NodeRuntimeTrait>> {
         let output = util::command::new_smol_command(&node)
             .arg("--version")


### PR DESCRIPTION
Require a newer Node version to make Copilot work

Closes #27908

Release Notes:

- Breaking Change: If using system node Zed now requires Node >= v20. Previously Node >= v18 was required. (Node v18 EOL date is 2025-04-30; Node v19 EOL since 2023-06-01). Note: This does not change the Zed bundled Node runtime version (still v23).