### PR TITLE
agent: Remove unneeded branch in `use_pending_tools`

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1376,15 +1376,6 @@ impl Thread {
                         cx,
                     );
                 }
-            } else if let Some(tool) = self.tools.tool(&tool_use.name, cx) {
-                self.run_tool(
-                    tool_use.id.clone(),
-                    tool_use.ui_text.clone(),
-                    tool_use.input.clone(),
-                    &messages,
-                    tool,
-                    cx,
-                );
             }
         }
 


### PR DESCRIPTION
This PR removes an unneeded `else if` branch that was the same as the previous branch in the conditional.

Doesn't seem necessary to run this twice.

Release Notes:

- N/A
