### PR TITLE
Avoid requiring confirmation for tools that edit buffers

### DIFF
--- a/crates/assistant_tools/src/create_file_tool.rs
+++ b/crates/assistant_tools/src/create_file_tool.rs
@@ -41,7 +41,7 @@ impl Tool for CreateFileTool {
     }
 
     fn needs_confirmation(&self) -> bool {
-        true
+        false
     }
 
     fn description(&self) -> String {

--- a/crates/assistant_tools/src/edit_files_tool.rs
+++ b/crates/assistant_tools/src/edit_files_tool.rs
@@ -82,7 +82,7 @@ impl Tool for EditFilesTool {
     }
 
     fn needs_confirmation(&self) -> bool {
-        true
+        false
     }
 
     fn description(&self) -> String {

--- a/crates/assistant_tools/src/find_replace_file_tool.rs
+++ b/crates/assistant_tools/src/find_replace_file_tool.rs
@@ -130,7 +130,7 @@ impl Tool for FindReplaceFileTool {
     }
 
     fn needs_confirmation(&self) -> bool {
-        true
+        false
     }
 
     fn description(&self) -> String {


### PR DESCRIPTION
It's super easy to undo those changes. In a future PR, we should also avoid requiring confirmation in the batch tool if all the underlying tools don't require confirmation.

Release Notes:

- N/A
