### PR TITLE
language: Add fallback for enum member completion highlight

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1948,6 +1948,9 @@ impl CodeLabel {
                 Kind::ENUM => grammar
                     .highlight_id_for_name("enum")
                     .or_else(|| grammar.highlight_id_for_name("type")),
+                Kind::ENUM_MEMBER => grammar
+                    .highlight_id_for_name("variant")
+                    .or_else(|| grammar.highlight_id_for_name("property")),
                 Kind::FIELD => grammar.highlight_id_for_name("property"),
                 Kind::FUNCTION => grammar.highlight_id_for_name("function"),
                 Kind::INTERFACE => grammar.highlight_id_for_name("type"),


### PR DESCRIPTION
i tried to use `variant` but it wasnt giving any color despite my theme definitely having a color for it, am i doing something wrong? i think `property` is an alright fallback
before:
![image](https://github.com/user-attachments/assets/e020ec4d-3a85-45fb-9ddb-823c55e0afca)
after:
![image](https://github.com/user-attachments/assets/3c335ed6-746e-4136-858a-8b80e5229f29)


Release Notes:

- N/A
