### PR TITLE
language_model: Remove `use_any_tool` method from `LanguageModel`

### DIFF
--- a/crates/language_model/src/fake_provider.rs
+++ b/crates/language_model/src/fake_provider.rs
@@ -7,7 +7,6 @@ use futures::{FutureExt, StreamExt, channel::mpsc, future::BoxFuture, stream::Bo
 use gpui::{AnyView, App, AsyncApp, Entity, Task, Window};
 use http_client::Result;
 use parking_lot::Mutex;
-use serde::Serialize;
 use std::sync::Arc;
 
 pub fn language_model_id() -> LanguageModelId {
@@ -88,7 +87,6 @@ pub struct ToolUseRequest {
 #[derive(Default)]
 pub struct FakeLanguageModel {
     current_completion_txs: Mutex<Vec<(LanguageModelRequest, mpsc::UnboundedSender<String>)>>,
-    current_tool_use_txs: Mutex<Vec<(ToolUseRequest, mpsc::UnboundedSender<String>)>>,
 }
 
 impl FakeLanguageModel {
@@ -126,13 +124,6 @@ impl FakeLanguageModel {
 
     pub fn end_last_completion_stream(&self) {
         self.end_completion_stream(self.pending_completions().last().unwrap());
-    }
-
-    pub fn respond_to_last_tool_use<T: Serialize>(&self, response: T) {
-        let response = serde_json::to_string(&response).unwrap();
-        let mut current_tool_call_txs = self.current_tool_use_txs.lock();
-        let (_, tx) = current_tool_call_txs.pop().unwrap();
-        tx.unbounded_send(response).unwrap();
     }
 }
 
@@ -182,25 +173,6 @@ impl LanguageModel for FakeLanguageModel {
                 .boxed())
         }
         .boxed()
-    }
-
-    fn use_any_tool(
-        &self,
-        request: LanguageModelRequest,
-        name: String,
-        description: String,
-        schema: serde_json::Value,
-        _cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
-        let (tx, rx) = mpsc::unbounded();
-        let tool_call = ToolUseRequest {
-            request,
-            name,
-            description,
-            schema,
-        };
-        self.current_tool_use_txs.lock().push((tool_call, tx));
-        async move { Ok(rx.map(Ok).boxed()) }.boxed()
     }
 
     fn as_fake(&self) -> &Self {

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -11,7 +11,7 @@ pub mod fake_provider;
 use anyhow::Result;
 use client::Client;
 use futures::FutureExt;
-use futures::{StreamExt, TryStreamExt as _, future::BoxFuture, stream::BoxStream};
+use futures::{StreamExt, future::BoxFuture, stream::BoxStream};
 use gpui::{AnyElement, AnyView, App, AsyncApp, SharedString, Task, Window};
 use icons::IconName;
 use parking_lot::Mutex;
@@ -20,7 +20,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use std::fmt;
 use std::ops::{Add, Sub};
-use std::{future::Future, sync::Arc};
+use std::sync::Arc;
 use thiserror::Error;
 use util::serde::is_default;
 
@@ -266,15 +266,6 @@ pub trait LanguageModel: Send + Sync {
         .boxed()
     }
 
-    fn use_any_tool(
-        &self,
-        request: LanguageModelRequest,
-        name: String,
-        description: String,
-        schema: serde_json::Value,
-        cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>>;
-
     fn cache_configuration(&self) -> Option<LanguageModelCacheConfiguration> {
         None
     }
@@ -282,33 +273,6 @@ pub trait LanguageModel: Send + Sync {
     #[cfg(any(test, feature = "test-support"))]
     fn as_fake(&self) -> &fake_provider::FakeLanguageModel {
         unimplemented!()
-    }
-}
-
-impl dyn LanguageModel {
-    pub fn use_tool<T: LanguageModelTool>(
-        &self,
-        request: LanguageModelRequest,
-        cx: &AsyncApp,
-    ) -> impl 'static + Future<Output = Result<T>> {
-        let schema = schemars::schema_for!(T);
-        let schema_json = serde_json::to_value(&schema).unwrap();
-        let stream = self.use_any_tool(request, T::name(), T::description(), schema_json, cx);
-        async move {
-            let stream = stream.await?;
-            let response = stream.try_collect::<String>().await?;
-            Ok(serde_json::from_str(&response)?)
-        }
-    }
-
-    pub fn use_tool_stream<T: LanguageModelTool>(
-        &self,
-        request: LanguageModelRequest,
-        cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
-        let schema = schemars::schema_for!(T);
-        let schema_json = serde_json::to_value(&schema).unwrap();
-        self.use_any_tool(request, T::name(), T::description(), schema_json, cx)
     }
 }
 

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -6,7 +6,7 @@ use collections::{BTreeMap, HashMap};
 use credentials_provider::CredentialsProvider;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::Stream;
-use futures::{FutureExt, StreamExt, TryStreamExt as _, future::BoxFuture, stream::BoxStream};
+use futures::{FutureExt, StreamExt, future::BoxFuture, stream::BoxStream};
 use gpui::{
     AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
 };
@@ -456,44 +456,6 @@ impl LanguageModel for AnthropicModel {
                 should_speculate: config.should_speculate,
                 min_total_token: config.min_total_token,
             })
-    }
-
-    fn use_any_tool(
-        &self,
-        request: LanguageModelRequest,
-        tool_name: String,
-        tool_description: String,
-        input_schema: serde_json::Value,
-        cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
-        let mut request = into_anthropic(
-            request,
-            self.model.tool_model_id().into(),
-            self.model.default_temperature(),
-            self.model.max_output_tokens(),
-            self.model.mode(),
-        );
-        request.tool_choice = Some(anthropic::ToolChoice::Tool {
-            name: tool_name.clone(),
-        });
-        request.tools = vec![anthropic::Tool {
-            name: tool_name.clone(),
-            description: tool_description,
-            input_schema,
-        }];
-
-        let response = self.stream_completion(request, cx);
-        self.request_limiter
-            .run(async move {
-                let response = response.await?;
-                Ok(anthropic::extract_tool_args_from_events(
-                    tool_name,
-                    Box::pin(response.map_err(|e| anyhow!(e))),
-                )
-                .await?
-                .boxed())
-            })
-            .boxed()
     }
 }
 

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -1,4 +1,3 @@
-use std::future;
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
@@ -292,17 +291,6 @@ impl LanguageModel for CopilotChatLanguageModel {
                 .boxed())
         }
         .boxed()
-    }
-
-    fn use_any_tool(
-        &self,
-        _request: LanguageModelRequest,
-        _name: String,
-        _description: String,
-        _schema: serde_json::Value,
-        _cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
-        future::ready(Err(anyhow!("not implemented"))).boxed()
     }
 }
 

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -356,61 +356,6 @@ impl LanguageModel for GoogleLanguageModel {
         });
         async move { Ok(future.await?.boxed()) }.boxed()
     }
-
-    fn use_any_tool(
-        &self,
-        request: LanguageModelRequest,
-        name: String,
-        description: String,
-        schema: serde_json::Value,
-        cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<String>>>> {
-        let mut request = into_google(request, self.model.id().to_string());
-        request.tools = Some(vec![google_ai::Tool {
-            function_declarations: vec![google_ai::FunctionDeclaration {
-                name: name.clone(),
-                description,
-                parameters: schema,
-            }],
-        }]);
-        request.tool_config = Some(google_ai::ToolConfig {
-            function_calling_config: google_ai::FunctionCallingConfig {
-                mode: google_ai::FunctionCallingMode::Any,
-                allowed_function_names: Some(vec![name]),
-            },
-        });
-        let response = self.stream_completion(request, cx);
-        self.request_limiter
-            .run(async move {
-                let response = response.await?;
-                Ok(response
-                    .filter_map(|event| async move {
-                        match event {
-                            Ok(response) => {
-                                if let Some(candidates) = &response.candidates {
-                                    for candidate in candidates {
-                                        for part in &candidate.content.parts {
-                                            if let google_ai::Part::FunctionCallPart(
-                                                function_call_part,
-                                            ) = part
-                                            {
-                                                return Some(Ok(serde_json::to_string(
-                                                    &function_call_part.function_call.args,
-                                                )
-                                                .unwrap_or_default()));
-                                            }
-                                        }
-                                    }
-                                }
-                                None
-                            }
-                            Err(e) => Some(Err(e)),
-                        }
-                    })
-                    .boxed())
-            })
-            .boxed()
-    }
 }
 
 pub fn into_google(

--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -364,17 +364,6 @@ impl LanguageModel for LmStudioLanguageModel {
         }
         .boxed()
     }
-
-    fn use_any_tool(
-        &self,
-        _request: LanguageModelRequest,
-        _tool_name: String,
-        _tool_description: String,
-        _schema: serde_json::Value,
-        _cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<BoxStream<'static, Result<String>>>> {
-        async move { Ok(futures::stream::empty().boxed()) }.boxed()
-    }
 }
 
 struct ConfigurationView {

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -368,55 +368,6 @@ impl LanguageModel for MistralLanguageModel {
         }
         .boxed()
     }
-
-    fn use_any_tool(
-        &self,
-        request: LanguageModelRequest,
-        tool_name: String,
-        tool_description: String,
-        schema: serde_json::Value,
-        cx: &AsyncApp,
-    ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<String>>>> {
-        let mut request = into_mistral(request, self.model.id().into(), self.max_output_tokens());
-        request.tools = vec![mistral::ToolDefinition::Function {
-            function: mistral::FunctionDefinition {
-                name: tool_name.clone(),
-                description: Some(tool_description),
-                parameters: Some(schema),
-            },
-        }];
-
-        let response = self.stream_completion(request, cx);
-        self.request_limiter
-            .run(async move {
-                let stream = response.await?;
-
-                let tool_args_stream = stream
-                    .filter_map(move |response| async move {
-                        match response {
-                            Ok(response) => {
-                                for choice in response.choices {
-                                    if let Some(tool_calls) = choice.delta.tool_calls {
-                                        for tool_call in tool_calls {
-                                            if let Some(function) = tool_call.function {
-                                                if let Some(args) = function.arguments {
-                                                    return Some(Ok(args));
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                                None
-                            }
-                            Err(e) => Some(Err(e)),
-                        }
-                    })
-                    .boxed();
-
-                Ok(tool_args_stream)
-            })
-            .boxed()
-    }
 }
 
 pub fn into_mistral(


### PR DESCRIPTION
This PR removes the `use_any_tool` method from the `LanguageModel` trait.

It was not being used anywhere, and doesn't really fit in our new tool use story.

Release Notes:

- N/A
