### PR TITLE
agent: Improve action confirmation UX

### DIFF
--- a/assets/icons/check_double.svg
+++ b/assets/icons/check_double.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-check-check-icon lucide-check-check"><path d="M18 6 7 17l-5-5"/><path d="m22 10-7.5 7.5L13 16"/></svg>

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -633,6 +633,8 @@
       // The model to use.
       "model": "claude-3-5-sonnet-latest"
     },
+    // When enabled, the agent can run potentially destructive actions without asking for your confirmation.
+    "always_allow_tool_actions": false,
     "default_profile": "write",
     "profiles": {
       "ask": {

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1547,8 +1547,7 @@ impl ActiveThread {
             .workspace
             .upgrade()
             .map(|workspace| workspace.read(cx).app_state().fs.clone());
-        let is_pending = self.thread.read(cx).pending_tool(&tool_use.id).is_some();
-        let auto_run = AssistantSettings::get_global(cx).always_allow_tool_actions;
+        let needs_confirmation = matches!(&tool_use.status, ToolUseStatus::NeedsConfirmation);
 
         let status_icons = div().child(match &tool_use.status {
             ToolUseStatus::Pending | ToolUseStatus::NeedsConfirmation => {
@@ -1781,7 +1780,7 @@ impl ActiveThread {
                                 .map(|element| {
                                     if is_open {
                                         element.border_b_1().rounded_t_md()
-                                    } else if is_pending {
+                                    } else if needs_confirmation {
                                         element.rounded_t_md()
                                     } else {
                                         element.rounded_md()
@@ -1841,7 +1840,7 @@ impl ActiveThread {
                                 v_flex()
                                     .bg(cx.theme().colors().editor_background)
                                     .map(|element| {
-                                        if  is_pending {
+                                        if  needs_confirmation {
                                             element.rounded_none()
                                         } else {
                                             element.rounded_b_lg()
@@ -1850,7 +1849,7 @@ impl ActiveThread {
                                     .child(results_content),
                             )
                         })
-                        .when(!auto_run && is_pending, |this| {
+                        .when(needs_confirmation, |this| {
                             this.child(
                                 h_flex()
                                     .py_1()

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1673,7 +1673,7 @@ impl ActiveThread {
                     if is_status_finished {
                         element.right_7()
                     } else {
-                        element.right_12()
+                        element.right(px(46.))
                     }
                 })
                 .bg(linear_gradient(
@@ -1767,7 +1767,6 @@ impl ActiveThread {
                             h_flex()
                                 .group("disclosure-header")
                                 .relative()
-                                .gap_1p5()
                                 .justify_between()
                                 .py_1()
                                 .map(|element| {
@@ -1781,6 +1780,8 @@ impl ActiveThread {
                                 .map(|element| {
                                     if is_open {
                                         element.border_b_1().rounded_t_md()
+                                    } else if is_pending {
+                                        element.rounded_t_md()
                                     } else {
                                         element.rounded_md()
                                     }
@@ -1838,7 +1839,13 @@ impl ActiveThread {
                             parent.child(
                                 v_flex()
                                     .bg(cx.theme().colors().editor_background)
-                                    .rounded_b_lg()
+                                    .map(|element| {
+                                        if  is_pending {
+                                            element.rounded_none()
+                                        } else {
+                                            element.rounded_b_lg()
+                                        }
+                                    })
                                     .child(results_content),
                             )
                         })
@@ -1848,11 +1855,12 @@ impl ActiveThread {
                                     .py_1()
                                     .pl_2()
                                     .pr_1()
+                                    .gap_1()
                                     .justify_between()
-                                    .bg(self.tool_card_header_bg(cx))
+                                    .bg(cx.theme().colors().editor_background)
                                     .border_t_1()
                                     .border_color(self.tool_card_border_color(cx))
-                                    .gap_1()
+                                    .rounded_b_lg()
                                     .child(Label::new("Action Confirmation").size(LabelSize::Small))
                                     .child(
                                         h_flex()
@@ -1889,6 +1897,7 @@ impl ActiveThread {
                                                     },
                                                 ))
                                             })
+                                            .child(ui::Divider::vertical())
                                             .child({
                                                 let tool_id = tool_use.id.clone();
                                                 Button::new("allow-tool-action", "Allow")

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1862,7 +1862,7 @@ impl ActiveThread {
                                     .border_t_1()
                                     .border_color(self.tool_card_border_color(cx))
                                     .rounded_b_lg()
-                                    .child(Label::new("Action Confirmation").size(LabelSize::Small))
+                                    .child(Label::new("Action Confirmation").color(Color::Muted).size(LabelSize::Small))
                                     .child(
                                         h_flex()
                                             .gap_0p5()

--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -482,11 +482,13 @@ impl AssistantPanel {
     pub(crate) fn open_configuration(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let context_server_manager = self.thread_store.read(cx).context_server_manager();
         let tools = self.thread_store.read(cx).tools();
+        let fs = self.fs.clone();
 
         self.active_view = ActiveView::Configuration;
-        self.configuration = Some(
-            cx.new(|cx| AssistantConfiguration::new(context_server_manager, tools, window, cx)),
-        );
+        self.configuration =
+            Some(cx.new(|cx| {
+                AssistantConfiguration::new(fs, context_server_manager, tools, window, cx)
+            }));
 
         if let Some(configuration) = self.configuration.as_ref() {
             self.configuration_subscription = Some(cx.subscribe_in(

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -325,6 +325,15 @@ impl AssistantSettingsContent {
         }
     }
 
+    pub fn set_always_allow_tool_actions(&mut self, allow: bool) {
+        let AssistantSettingsContent::Versioned(VersionedAssistantSettingsContent::V2(settings)) =
+            self
+        else {
+            return;
+        };
+        settings.always_allow_tool_actions = Some(allow);
+    }
+
     pub fn set_profile(&mut self, profile_id: Arc<str>) {
         let AssistantSettingsContent::Versioned(VersionedAssistantSettingsContent::V2(settings)) =
             self

--- a/crates/assistant_tools/src/bash_tool.rs
+++ b/crates/assistant_tools/src/bash_tool.rs
@@ -46,10 +46,21 @@ impl Tool for BashTool {
     fn ui_text(&self, input: &serde_json::Value) -> String {
         match serde_json::from_value::<BashToolInput>(input.clone()) {
             Ok(input) => {
-                if input.command.contains('\n') {
-                    MarkdownString::code_block("bash", &input.command).0
-                } else {
-                    MarkdownString::inline_code(&input.command).0
+                let mut lines = input.command.lines();
+                let first_line = lines.next().unwrap_or_default();
+                let remaining_line_count = lines.count();
+                match remaining_line_count {
+                    0 => MarkdownString::inline_code(&first_line).0,
+                    1 => {
+                        MarkdownString::inline_code(&format!(
+                            "{} - {} more line",
+                            first_line, remaining_line_count
+                        ))
+                        .0
+                    }
+                    n => {
+                        MarkdownString::inline_code(&format!("{} - {} more lines", first_line, n)).0
+                    }
                 }
             }
             Err(_) => "Run bash command".to_string(),

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -46,6 +46,7 @@ pub enum IconName {
     Brain,
     CaseSensitive,
     Check,
+    CheckDouble,
     ChevronDown,
     /// This chevron indicates a popover menu.
     ChevronDownSmall,


### PR DESCRIPTION
This PR makes the command permission prompt part of the tool card and allow users to straight away change the `always_allow_tool_actions` setting via the "Always Allow" button from that card. If that button is clicked, that setting is turned on, and any command that requires permission from that point on will auto-run.

Additionally, if a bash command spans multiple lines, we show the line count at the end of the command string. (Note: this is not perfect yet because it can likely be not visible by default, but we didn't think this was a major blocker for now. We'll work on improving this next).

### Thread View

<img src="https://github.com/user-attachments/assets/00f93c39-990f-4b79-84ec-0427b997167f" width="500"/>

### Settings View

<img src="https://github.com/user-attachments/assets/52d32435-7c8d-4ab4-a319-6cabc007267b" width="500"/>


Release Notes:

- N/A
