### PR TITLE
agent: Change loading label if command is waiting on permission

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -432,11 +432,18 @@ impl Render for MessageEditor {
                                         },
                                     ),
                             )
-                            .child(
-                                Label::new("Generating…")
-                                    .size(LabelSize::XSmall)
-                                    .color(Color::Muted),
-                            )
+                            .child({
+                                let needs_confirmation = thread.has_pending_tool_uses() && 
+                                    thread.tools_needing_confirmation().next().is_some();
+                                
+                                Label::new(if needs_confirmation {
+                                    "Waiting for confirmation…"
+                                } else {
+                                    "Generating…"
+                                })
+                                .size(LabelSize::XSmall)
+                                .color(Color::Muted)
+                            })
                             .child(ui::Divider::vertical())
                             .child(
                                 Button::new("cancel-generation", "Cancel")

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -341,6 +341,9 @@ impl Render for MessageEditor {
         let is_too_long = thread.is_getting_too_long(cx);
         let is_model_selected = self.is_model_selected(cx);
         let is_editor_empty = self.is_editor_empty(cx);
+        let needs_confirmation =
+            thread.has_pending_tool_uses() && thread.tools_needing_confirmation().next().is_some();
+
         let submit_label_color = if is_editor_empty {
             Color::Muted
         } else {
@@ -433,9 +436,8 @@ impl Render for MessageEditor {
                                     ),
                             )
                             .child({
-                                let needs_confirmation = thread.has_pending_tool_uses() && 
-                                    thread.tools_needing_confirmation().next().is_some();
-                                
+
+
                                 Label::new(if needs_confirmation {
                                     "Waiting for confirmation…"
                                 } else {


### PR DESCRIPTION
If there's a command pending confirmation, the label changes from "Generating" to "Waiting for confirmation".

<img src="https://github.com/user-attachments/assets/d804e382-5315-40b0-9588-c257cca2430c" width="600"/>

Release Notes:

- N/A
