### PR TITLE
renovate: Ignore `Cargo.toml` for `workspace-hack`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,7 @@
     "dependencyDashboardApproval": true
   },
   "prFooter": "Release Notes:\n\n- N/A",
+  "ignorePaths": ["**/node_modules/**", "tooling/workspace-hack/**"],
   "packageRules": [
     {
       "description": "Group wasmtime crates together.",


### PR DESCRIPTION
This PR adds the `Cargo.toml` for the `workspace-hack` crate to the ignore list for Renovate, as it is opening a number of PRs against it that will interfere with it.

Release Notes:

- N/A
