### PR TITLE
gpui: Fix background for WrappedLine

### DIFF
--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -417,6 +417,15 @@ impl TextLayout {
         let mut line_origin = bounds.origin;
         let text_style = window.text_style();
         for line in &element_state.lines {
+            line.paint_background(
+                line_origin,
+                line_height,
+                text_style.text_align,
+                Some(bounds),
+                window,
+                cx,
+            )
+            .log_err();
             line.paint(
                 line_origin,
                 line_height,

--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -153,6 +153,36 @@ impl WrappedLine {
 
         Ok(())
     }
+
+    /// Paint the background of line of text to the window.
+    pub fn paint_background(
+        &self,
+        origin: Point<Pixels>,
+        line_height: Pixels,
+        align: TextAlign,
+        bounds: Option<Bounds<Pixels>>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Result<()> {
+        let align_width = match bounds {
+            Some(bounds) => Some(bounds.size.width),
+            None => self.layout.wrap_width,
+        };
+
+        paint_line_background(
+            origin,
+            &self.layout.unwrapped_layout,
+            line_height,
+            align,
+            align_width,
+            &self.decoration_runs,
+            &self.wrap_boundaries,
+            window,
+            cx,
+        )?;
+
+        Ok(())
+    }
 }
 
 fn paint_line(


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/26454 In this PR, we separated painting for text line into two parts: `paint` and `paint_background`. This allows selections to appear in front of the text background but behind the text itself in the editor.

The `paint_background` method was implemented for `ShapedLine` but not for `WrappedLine`. This PR adds that, fixing the background rendering for inline code blocks in Markdown, as they use `WrappedLine`.

Before:
<img width="160" alt="image" src="https://github.com/user-attachments/assets/81466c63-6835-4128-ba22-1b63f5fd7b1f" />

After:
<img width="160" alt="image" src="https://github.com/user-attachments/assets/3b7044d7-265b-45db-904c-3b70fdf421fe" />

Release Notes:

- Fixed missing background for inline code blocks in the editor hover tooltip.  
