### PR TITLE
editor: Fix invalid read-only with split pane

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1261,6 +1261,7 @@ impl Editor {
         clone.selections.clone_state(&self.selections);
         clone.scroll_manager.clone_state(&self.scroll_manager);
         clone.searchable = self.searchable;
+        clone.read_only = self.read_only;
         clone
     }
 


### PR DESCRIPTION
Closes #28004

Release Notes:

- Fixed invalid read-only with split pane
