### PR TITLE
editor: Fix active line number highlighting regression

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2401,13 +2401,11 @@ impl EditorElement {
 
                 let color = active_rows
                     .get(&display_row)
-                    .and_then(|spec| {
+                    .map(|spec| {
                         if spec.breakpoint {
-                            Some(cx.theme().colors().debugger_accent)
-                        } else if spec.selection {
-                            Some(cx.theme().colors().editor_active_line_number)
+                            cx.theme().colors().debugger_accent
                         } else {
-                            None
+                            cx.theme().colors().editor_active_line_number
                         }
                     })
                     .unwrap_or_else(|| cx.theme().colors().editor_line_number);


### PR DESCRIPTION
This PR resolves a small regression introduced by the debugger-introduction, which causes the active line number to no longer be highlighted in the gutter as long as it is not part of a selection. A user reported this issue [on Discord](https://discord.com/channels/869392257814519848/995403703894954060/1357153291913662567).

Prior to the debugger-commit, an active line number was highlighted if it was part of the editor active line numbers:
https://github.com/zed-industries/zed/blob/ed4e654fdf66fb886414198ac6db1a2f24d729a5/crates/editor/src/element.rs#L4295-L4303

With the debugger-introduction, the code was changed to only highlight lines which are part of a selection:
https://github.com/zed-industries/zed/blob/e2aaf9b7046dd8d8430ff82554fe13d69431e443/crates/editor/src/element.rs#L2411-L2422

However, the check whether it is within a selection is not neccesary, as the line is an active line as long as it is within the map of active lines.

This PR restores the previous behavior.

| `main` | <img width="922" alt="main" src="https://github.com/user-attachments/assets/486a548d-fe09-450e-922e-1feb4366fb4f" /> | 
| --- | --- |
| This PR | <img width="922" alt="PR" src="https://github.com/user-attachments/assets/80517880-14b5-4861-bf83-8364f7831c46" /> |

Release Notes:

- Fixed an issue where the active line number in the editor was not always highlighted.
