### PR TITLE
agent: Fix thinking step showing up as pending when completion is cancelled

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1449,7 +1449,8 @@ impl ActiveThread {
         cx: &Context<Self>,
     ) -> impl IntoElement {
         let is_last_message = self.messages.last() == Some(&message_id);
-        let pending_thinking_segment_index = if is_last_message && !has_tool_uses {
+        let is_generating = self.thread.read(cx).is_generating();
+        let pending_thinking_segment_index = if is_generating && is_last_message && !has_tool_uses {
             rendered_message
                 .segments
                 .iter()


### PR DESCRIPTION
Previously the "Thinking..." step would show up as pending, even though the user cancelled the generation:
<img width="672" alt="image" src="https://github.com/user-attachments/assets/c9cdce0a-d827-4e23-96f5-b150465911a7" />


Release Notes:

- Fixed an issue where the thinking step would show up as pending even when the generation was cancelled
