### PR TITLE
rust: Improve runnable detection for test modules

### DIFF
--- a/crates/languages/src/rust/runnables.scm
+++ b/crates/languages/src/rust/runnables.scm
@@ -1,8 +1,18 @@
 ; Rust mod test
 (
+    (attribute_item (attribute
+        (
+          (identifier) @_attribute)
+          arguments: (
+              (token_tree (identifier) @_test)
+              (#eq? @_test "test")
+          )
+        )
+        (#eq? @_attribute "cfg")
+    )
+    .
     (mod_item
         name: (_) @run
-        (#eq? @run "tests")
     )
     (#set! tag rust-mod-test)
 )


### PR DESCRIPTION
Closes #28002

This PR updates the `runnabless.scm` for Rust to improve detection of test modules with non-standard names. Instead of matching on the module name, we now check for the `#[cfg(test)]`-attribute above test modules. This allows for generic matching whilst not regressing the previous behaviour.

| `main` | <img width="922" alt="main" src="https://github.com/user-attachments/assets/34fc4443-13a2-4e18-b806-7e14771c3df4" /> | 
| --- | --- |
| This PR | <img width="922" alt="PR" src="https://github.com/user-attachments/assets/13e6a6d8-e177-4a83-89ab-24c0a69ade27" /> |

Release Notes:

- Improved runnable detection for test modules in Rust.
