### PR TITLE
Fix nix build

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -96,7 +96,6 @@ let
         ]
         ++ lib.optionals stdenv'.hostPlatform.isLinux [ makeWrapper ]
         ++ lib.optionals stdenv'.hostPlatform.isDarwin [
-          # TODO: move to overlay so it's usable in the shell
           (cargo-bundle.overrideAttrs (
             new: old: {
               version = "0.6.1-zed";
@@ -107,11 +106,10 @@ let
                 hash = "sha256-cSvW0ND148AGdIGWg/ku0yIacVgW+9f1Nsi+kAQxVrI=";
               };
               # https://nixos.asia/en/buildRustPackage
-              cargoDeps = old.cargoDeps.overrideAttrs ({
-                inherit src;
-                name = "${new.pname}-${new.version}-vendor.tar.gz";
-                outputHash = "sha256-Q49FnXNHWhvbH1LtMUpXFcvGKu9VHwqOXXd+MjswO64=";
-              });
+              cargoDeps = rustPlatform.fetchCargoVendor {
+                inherit (new) pname version src;
+                hash = "sha256-urn+A3yuw2uAO4HGmvQnKvWtHqvG9KHxNCCWTiytE4k=";
+              };
             }
           ))
         ];


### PR DESCRIPTION
This fixes some of the remaining issues to get the nix build passing again:

- ~issue with the cargo bundle patch~ (fixed in #28061)
- outdated version of libwebrtc from nixpkgs
- #28021 bumped the rust toolchain version  and we need to bump the rust-overlay flake input to have that new one available.


Release Notes:

- N/A
