### PR TITLE
gpui: Use BoolExt trait in more places

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1,4 +1,4 @@
-use super::{MacDisplay, NSRange, NSStringExt, ns_string, renderer};
+use super::{BoolExt, MacDisplay, NSRange, NSStringExt, ns_string, renderer};
 use crate::{
     AnyWindowHandle, Bounds, DisplayLink, ExternalPaths, FileDropEvent, ForegroundExecutor,
     KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent,
@@ -1017,11 +1017,8 @@ impl PlatformWindow for MacWindow {
         } else {
             0
         };
-        let opaque = if background_appearance == WindowBackgroundAppearance::Opaque {
-            YES
-        } else {
-            NO
-        };
+        let opaque = (background_appearance == WindowBackgroundAppearance::Opaque).to_objc();
+
         unsafe {
             this.native_window.setOpaque_(opaque);
             // Shadows for transparent windows cause artifacts and performance issues
@@ -1985,14 +1982,11 @@ extern "C" fn dragging_exited(this: &Object, _: Sel, _: id) {
 extern "C" fn perform_drag_operation(this: &Object, _: Sel, dragging_info: id) -> BOOL {
     let window_state = unsafe { get_window_state(this) };
     let position = drag_event_position(&window_state, dragging_info);
-    if send_new_event(
+    send_new_event(
         &window_state,
         PlatformInput::FileDrop(FileDropEvent::Submit { position }),
-    ) {
-        YES
-    } else {
-        NO
-    }
+    )
+    .to_objc()
 }
 
 fn external_paths_from_event(dragging_info: *mut Object) -> Option<ExternalPaths> {


### PR DESCRIPTION
Use the `BoolExt` trait which converts rust booleans to their objc equivalent when applicable.


Release Notes:

- N/A
