### PR TITLE
gpui: Use NSOperatingSystemVersion provided by cocoa

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1565,10 +1565,7 @@ extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
 }
 
 fn is_macos_version_at_least(version: NSOperatingSystemVersion) -> bool {
-    unsafe {
-        let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
-        process_info.isOperatingSystemAtLeastVersion(version)
-    }
+    unsafe { NSProcessInfo::processInfo(nil).isOperatingSystemAtLeastVersion(version) }
 }
 
 extern "C" fn window_did_move(this: &Object, _: Sel, _: id) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -18,7 +18,7 @@ use cocoa::{
     base::{id, nil},
     foundation::{
         NSArray, NSAutoreleasePool, NSDictionary, NSFastEnumeration, NSInteger, NSNotFound,
-        NSPoint, NSRect, NSSize, NSString, NSUInteger,
+        NSOperatingSystemVersion, NSPoint, NSProcessInfo, NSRect, NSSize, NSString, NSUInteger,
     },
 };
 use core_graphics::display::{CGDirectDisplayID, CGPoint, CGRect};
@@ -1542,7 +1542,9 @@ extern "C" fn window_will_enter_fullscreen(this: &Object, _: Sel, _: id) {
     let mut lock = window_state.as_ref().lock();
     lock.fullscreen_restore_bounds = lock.bounds();
 
-    if is_macos_version_at_least(15, 3, 0) {
+    let min_version = NSOperatingSystemVersion::new(15, 3, 0);
+
+    if is_macos_version_at_least(min_version) {
         unsafe {
             lock.native_window.setTitlebarAppearsTransparent_(NO);
         }
@@ -1553,29 +1555,19 @@ extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     let window_state = unsafe { get_window_state(this) };
     let mut lock = window_state.as_ref().lock();
 
-    if is_macos_version_at_least(15, 3, 0) && lock.transparent_titlebar {
+    let min_version = NSOperatingSystemVersion::new(15, 3, 0);
+
+    if is_macos_version_at_least(min_version) && lock.transparent_titlebar {
         unsafe {
             lock.native_window.setTitlebarAppearsTransparent_(YES);
         }
     }
 }
 
-#[repr(C)]
-struct NSOperatingSystemVersion {
-    major_version: NSInteger,
-    minor_version: NSInteger,
-    patch_version: NSInteger,
-}
-
-fn is_macos_version_at_least(major: NSInteger, minor: NSInteger, patch: NSInteger) -> bool {
+fn is_macos_version_at_least(version: NSOperatingSystemVersion) -> bool {
     unsafe {
         let process_info: id = msg_send![class!(NSProcessInfo), processInfo];
-        let os_version: NSOperatingSystemVersion = msg_send![process_info, operatingSystemVersion];
-        (os_version.major_version > major)
-            || (os_version.major_version == major && os_version.minor_version > minor)
-            || (os_version.major_version == major
-                && os_version.minor_version == minor
-                && os_version.patch_version >= patch)
+        process_info.isOperatingSystemAtLeastVersion(version)
     }
 }
 


### PR DESCRIPTION
Use the `NSOperatingSystemVersion` struct provided by the cocoa crate instead of our own. Additionally we can directly use `isOperatingSystemAtLeastVersion` instead of manually implementing version comparison logic.

The `isOperatingSystemAtLeastVersion` instance method has been available since MacOS 10.10, which released a decade ago.

Documentation for `isOperatingSystemAtLeastVersion `: https://developer.apple.com/documentation/foundation/nsprocessinfo/1414876-isoperatingsystematleastversion

Release Notes:

- N/A
