### PR TITLE
gpui: Avoid dereferencing null pointer in `MacWindow::active_window`

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -744,6 +744,10 @@ impl MacWindow {
         unsafe {
             let app = NSApplication::sharedApplication(nil);
             let main_window: id = msg_send![app, mainWindow];
+            if main_window.is_null() {
+                return None;
+            }
+
             if msg_send![main_window, isKindOfClass: WINDOW_CLASS] {
                 let handle = get_window_state(&*main_window).lock().handle;
                 Some(handle)


### PR DESCRIPTION
This PR adds a check to avoid dereferencing a null pointer in `MacWindow::active_window`.

Rust 1.86 now has a [debug assertion for dereferencing null pointers](https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html#debug-assertions-that-pointers-are-non-null-when-required-for-soundness), which means that losing focus of the window would cause a null pointer to be dereferenced and panic.

Release Notes:

- N/A
