### PR TITLE
nix: Fix the `cargo-bundle` override

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -96,7 +96,6 @@ let
         ]
         ++ lib.optionals stdenv'.hostPlatform.isLinux [ makeWrapper ]
         ++ lib.optionals stdenv'.hostPlatform.isDarwin [
-          # TODO: move to overlay so it's usable in the shell
           (cargo-bundle.overrideAttrs (
             new: old: {
               version = "0.6.1-zed";
@@ -106,13 +105,13 @@ let
                 rev = "2be2669972dff3ddd4daf89a2cb29d2d06cad7c7";
                 hash = "sha256-cSvW0ND148AGdIGWg/ku0yIacVgW+9f1Nsi+kAQxVrI=";
               };
-              cargoHash = "sha256-Q49FnXNHWhvbH1LtMUpXFcvGKu9VHwqOXXd+MjswO64=";
+              cargoHash = "sha256-urn+A3yuw2uAO4HGmvQnKvWtHqvG9KHxNCCWTiytE4k=";
 
               # NOTE: can drop once upstream uses `finalAttrs` here:
               # https://github.com/NixOS/nixpkgs/blob/10214747f5e6e7cb5b9bdf9e018a3c7b3032f5af/pkgs/build-support/rust/build-rust-package/default.nix#L104
               #
               # See (for context): https://github.com/NixOS/nixpkgs/pull/382550
-              cargoDeps = rustPlatform.fetchCargoTarball {
+              cargoDeps = rustPlatform.fetchCargoVendor {
                 inherit (new) src;
                 hash = new.cargoHash;
                 patches = new.cargoPatches or [];

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -106,12 +106,18 @@ let
                 rev = "2be2669972dff3ddd4daf89a2cb29d2d06cad7c7";
                 hash = "sha256-cSvW0ND148AGdIGWg/ku0yIacVgW+9f1Nsi+kAQxVrI=";
               };
-              # https://nixos.asia/en/buildRustPackage
-              cargoDeps = old.cargoDeps.overrideAttrs ({
-                inherit src;
-                name = "${new.pname}-${new.version}-vendor.tar.gz";
-                outputHash = "sha256-Q49FnXNHWhvbH1LtMUpXFcvGKu9VHwqOXXd+MjswO64=";
-              });
+              cargoHash = "sha256-Q49FnXNHWhvbH1LtMUpXFcvGKu9VHwqOXXd+MjswO64=";
+
+              # NOTE: can drop once upstream uses `finalAttrs` here:
+              # https://github.com/NixOS/nixpkgs/blob/10214747f5e6e7cb5b9bdf9e018a3c7b3032f5af/pkgs/build-support/rust/build-rust-package/default.nix#L104
+              #
+              # See (for context): https://github.com/NixOS/nixpkgs/pull/382550
+              cargoDeps = rustPlatform.fetchCargoTarball {
+                inherit (new) src;
+                hash = new.cargoHash;
+                patches = new.cargoPatches or [];
+                name = new.cargoDepsName or new.finalPackage.name;
+              };
             }
           ))
         ];


### PR DESCRIPTION
With the recent deprecation of `rustPlatform.fetchCargoTarball` + migration to using `fetchCargoVendor` by default in `buildRustPackage` (NixOS/nixpkgs#394012), the `cargo-bundle` override strategy used here, as prescribed by the
[nixos asia wiki](https://nixos.asia/en/buildRustPackage) no longer works:
https://github.com/zed-industries/zed/blob/c6e2d20a02b523172aea8a22fa2ec6c8975b52e4/nix/build.nix#L100-L116

[`fetchCargoTarball` produced a single derivation][tarball-drv] but `fetchCargoVendor` [produces two][vendor-drvs]:
  - `${name}-vendor-staging` (inner; FoD)
  - `${name}-vendor` (outer)

[tarball-drv]: https://github.com/NixOS/nixpkgs/blob/36fd87baa9083f34f7f5027900b62ee6d09b1f2f/pkgs/build-support/rust/fetch-cargo-tarball/default.nix#L79
[vendor-drvs]: https://github.com/NixOS/nixpkgs/blob/10214747f5e6e7cb5b9bdf9e018a3c7b3032f5af/pkgs/build-support/rust/fetch-cargo-vendor.nix#L52-L103

`overrideAttrs` here is setting `outputHash` on the latter (which isn't a fixed-output-derivation and does not have `outputHashMode` set which implies `outputHashMode = "flat"`) instead of the inner; this results in errors like this:
```console
❯ nix develop
error: output path '/nix/store/cb57w05zvsqxshqjl789kmsy9pbqjn06-cargo-bundle-0.6.1-zed-vendor.tar.gz' should be a non-executable regular file since recursive hashing is not enabled (outputHashMode=flat)
error: 1 dependencies of derivation '/nix/store/k3azmxljgjn26hqyhg9m1y3lhx32y939-cargo-bundle-0.6.1-zed.drv' failed to build
error: 1 dependencies of derivation '/nix/store/8ag4v0m90m4kcaq1ypp7f85pp8s6fxgc-nix-shell-env.drv' failed to build
```

> [!NOTE]
> you will need to remove `/nix/store/cb57w05zvsqxshqjl789kmsy9pbqjn06-cargo-bundle-0.6.1-zed-vendor.tar.gz`
> from your nix store in order to be able to reproduce this

We want to be setting `outputHash` on the [first derivation][first-drv] instead. This change has us just do the call to `fetchCargoTarball` manually instead of using overrides.

[first-drv]: https://github.com/NixOS/nixpkgs/blob/10214747f5e6e7cb5b9bdf9e018a3c7b3032f5af/pkgs/build-support/rust/fetch-cargo-vendor.nix#L85

---

I suspect CI/other machines didn't catch this due to a store path matching the name + `outputHash` already being present but I'm not entirely sure how this happened...

`sha256-Q49FnXNHWhvbH1LtMUpXFcvGKu9VHwqOXXd+MjswO64=` is actually a `fetchCargoTarball` hash, not a `fetchCargoVendor` hash (and upstream `cargo-about`'s `cargoDeps` [has been using `cargoVendor`][ups] since before the nixpkgs bump in 50ad71a6306b45926091b8e37036ea8fe237f299)

[ups]: https://github.com/NixOS/nixpkgs/blob/1d09c579c12869453d98dd35f6ff9d28dc32e869/pkgs/by-name/ca/cargo-about/package.nix#L22

---

> [!NOTE]
> eventually we'll be able to just have `.overrideAttrs (_: { cargoHash = "..."; })` work as expected [^2]

---

Release Notes:

- N/A

[^2]:
    [now that `buildRustPackage`](https://github.com/NixOS/nixpkgs/pull/382550) uses [`lib.extendMkDerivation`](https://github.com/nixos/nixpkgs/blob/bbdf8601bcf2a7e733d5ef2552109a5d8d5a44ce/doc/build-helpers/fixed-point-arguments.chapter.md) (NixOS/nixpkgs/#234651) the groundwork is in place; a follow PR [needs to use `cargoHash` and friends from `finalAttrs`](https://github.com/NixOS/nixpkgs/blob/10214747f5e6e7cb5b9bdf9e018a3c7b3032f5af/pkgs/build-support/rust/build-rust-package/default.nix#L104)
