### PR TITLE
ci: Prettier GitHub Actions display

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,7 +708,7 @@ jobs:
 
   nix-build:
     timeout-minutes: 60
-    name: (${{ matrix.system.os }}) Nix Build
+    name: (${{ matrix.system.os || 'Skipped' }}) Nix Build
     continue-on-error: true
     if: github.repository_owner == 'zed-industries' && contains(github.event.pull_request.labels.*.name, 'run-nix')
     strategy:
@@ -749,7 +749,7 @@ jobs:
           skipPush: true
       - run: nix build .#debug
       - name: Limit /nix/store to 50GB
-        run: '[ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d'
+        run: "[ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d"
 
   auto-release-preview:
     name: Auto release preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -708,7 +708,7 @@ jobs:
 
   nix-build:
     timeout-minutes: 60
-    name: (${{ matrix.system.os || 'Skipped' }}) Nix Build
+    name: Nix Build
     continue-on-error: true
     if: github.repository_owner == 'zed-industries' && contains(github.event.pull_request.labels.*.name, 'run-nix')
     strategy:


### PR DESCRIPTION
Skipped nix builds were ugly, showing raw template when being skipped.

before:
<img width="696" alt="Screenshot 2025-04-03 at 18 56 40" src="https://github.com/user-attachments/assets/94b15d83-26fe-45c9-b0a1-9944660076e3" />

after:
<img width="558" alt="Screenshot 2025-04-03 at 19 00 31" src="https://github.com/user-attachments/assets/4716365b-aecd-4690-b701-571c49d9f013" />

Make prettier.

Release Notes:

- N/A
