### PR TITLE
gpui: Optimize coalesce float sign checking

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2622,7 +2622,6 @@ impl Pixels {
     /// Returns:
     /// * `1.0` if the value is positive
     /// * `-1.0` if the value is negative
-    /// * `0.0` if the value is zero
     pub fn signum(&self) -> f32 {
         self.0.signum()
     }

--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -311,13 +311,13 @@ impl ScrollDelta {
     pub fn coalesce(self, other: ScrollDelta) -> ScrollDelta {
         match (self, other) {
             (ScrollDelta::Pixels(a), ScrollDelta::Pixels(b)) => {
-                let x = if a.x.signum() * b.x.signum() >= 0. {
+                let x = if a.x.signum() == b.x.signum() {
                     a.x + b.x
                 } else {
                     b.x
                 };
 
-                let y = if a.y.signum() * b.y.signum() >= 0. {
+                let y = if a.y.signum() == b.y.signum() {
                     a.y + b.y
                 } else {
                     b.y
@@ -327,13 +327,13 @@ impl ScrollDelta {
             }
 
             (ScrollDelta::Lines(a), ScrollDelta::Lines(b)) => {
-                let x = if a.x.signum() * b.x.signum() >= 0. {
+                let x = if a.x.signum() == b.x.signum() {
                     a.x + b.x
                 } else {
                     b.x
                 };
 
-                let y = if a.y.signum() * b.y.signum() >= 0. {
+                let y = if a.y.signum() == b.y.signum() {
                     a.y + b.y
                 } else {
                     b.y


### PR DESCRIPTION
Optimize away a multiplication during in the `coalesce` function. Our goal is to check whether the sign of two floats is the same.

Instead of multiplying each `.signum()` and checking that the result is positive, we can simply check that the signum's are the same. This removes a float multiplication.

```rust
a.signum() * b.signum() >= 0.0
```

turns into

```rust
a.signum() == b.signum()
```



Release Notes:

- Fix documentation for `Pixels::signum`
