### PR TITLE
agent: Show which lines were read when using `read_file` tool

### DIFF
--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -67,7 +67,11 @@ impl Tool for ReadFileTool {
         match serde_json::from_value::<ReadFileToolInput>(input.clone()) {
             Ok(input) => {
                 let path = MarkdownString::inline_code(&input.path.display().to_string());
-                format!("Read file {path}")
+                match (input.start_line, input.end_line) {
+                    (Some(start), None) => format!("Read file {path} (from line {start})"),
+                    (Some(start), Some(end)) => format!("Read file {path} (lines {start}-{end})"),
+                    _ => format!("Read file {path}"),
+                }
             }
             Err(_) => "Read file".to_string(),
         }


### PR DESCRIPTION
This makes sure that we specify which lines the agent actually read, avoids confusing scenarios such as:

<img width="642" alt="Screenshot 2025-04-04 at 10 22 10" src="https://github.com/user-attachments/assets/2680c313-4f77-4971-8743-8e3f5327c18d" />

Here the agent starts out by actually only reading a certain amount of lines when the first tool call happens, then it does a second tool call to read the whole file. To the user this looks like to identical tool calls.

Now:
<img width="621" alt="image" src="https://github.com/user-attachments/assets/76222258-9cc8-4b7c-98c0-6d5cffb282f2" />
<img width="362" alt="image" src="https://github.com/user-attachments/assets/293f2fc0-365d-4b84-8400-4c11474caeb8" />
<img width="420" alt="image" src="https://github.com/user-attachments/assets/ca92493e-67ce-4d45-8f83-0168df575326" />



Release Notes:

- agent: Display which lines were accessed when agent uses `read_file` tool
