### PR TITLE
squawk: Specify PostgreSQL version in config

### DIFF
--- a/script/lib/squawk.toml
+++ b/script/lib/squawk.toml
@@ -8,3 +8,4 @@ excluded_rules = [
     "prefer-big-int",
     "prefer-bigint-over-int",
 ]
+pg_version = "15.0"


### PR DESCRIPTION
This PR adds the PostgreSQL version to the squawk config, see https://squawkhq.com/docs/cli#specifying-postgres-version for reference.

The specified version matches the PostgreSQL version in the compose-file 

https://github.com/zed-industries/zed/blob/43cb925a599ead7ddbeee26efd1f5af1d1dea97a/compose.yml#L3

and prevents false positives like https://github.com/zed-industries/zed/pull/28090#issuecomment-2778871346 from happening (tested it locally with that commit). 

Release Notes:

- N/A
