### PR TITLE
collab: Capture upstream input/output rate limits from Anthropic

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -362,13 +362,13 @@ pub struct RateLimitInfo {
 }
 
 impl RateLimitInfo {
-    fn from_headers(headers: &HeaderMap<HeaderValue>) -> Result<Self> {
-        Ok(Self {
-            requests: RateLimit::from_headers("requests", headers).ok(),
-            tokens: RateLimit::from_headers("tokens", headers).ok(),
-            input_tokens: RateLimit::from_headers("input-tokens", headers).ok(),
-            output_tokens: RateLimit::from_headers("output-tokens", headers).ok(),
-        })
+    fn from_headers(headers: &HeaderMap<HeaderValue>) -> Self {
+        Self {
+            requests: RateLimit::from_headers("requests", headers).log_err(),
+            tokens: RateLimit::from_headers("tokens", headers).log_err(),
+            input_tokens: RateLimit::from_headers("input-tokens", headers).log_err(),
+            output_tokens: RateLimit::from_headers("output-tokens", headers).log_err(),
+        }
     }
 }
 
@@ -434,7 +434,7 @@ pub async fn stream_completion_with_rate_limit_info(
                 }
             })
             .boxed();
-        Ok((stream, rate_limits.log_err()))
+        Ok((stream, Some(rate_limits)))
     } else {
         let mut body = Vec::new();
         response

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -324,11 +324,17 @@ pub async fn stream_completion(
 /// <https://docs.anthropic.com/en/api/rate-limits#response-headers>
 #[derive(Debug)]
 pub struct RateLimitInfo {
+    /// The maximum number of requests allowed within any rate limit period.
     pub requests_limit: usize,
+    /// The number of requests remaining before being rate limited.
     pub requests_remaining: usize,
+    /// The time when the request rate limit will be fully replenished, provided in RFC 3339 format.
     pub requests_reset: DateTime<Utc>,
+    /// The maximum number of tokens allowed within any rate limit period.
     pub tokens_limit: usize,
+    /// The number of tokens remaining (rounded to the nearest thousand) before being rate limited.
     pub tokens_remaining: usize,
+    /// The time when the token rate limit will be fully replenished, provided in RFC 3339 format.
     pub tokens_reset: DateTime<Utc>,
 }
 

--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -316,14 +316,14 @@ async fn perform_completion(
                     is_staff = claims.is_staff,
                     provider = params.provider.to_string(),
                     model = model,
-                    tokens_remaining = rate_limit_info.tokens.remaining,
-                    input_tokens_remaining = rate_limit_info.input_tokens.remaining,
-                    output_tokens_remaining = rate_limit_info.output_tokens.remaining,
-                    requests_remaining = rate_limit_info.requests.remaining,
-                    requests_reset = ?rate_limit_info.requests.reset,
-                    tokens_reset = ?rate_limit_info.tokens.reset,
-                    input_tokens_reset = ?rate_limit_info.input_tokens.reset,
-                    output_tokens_reset = ?rate_limit_info.output_tokens.reset,
+                    tokens_remaining = rate_limit_info.tokens.as_ref().map(|limits| limits.remaining),
+                    input_tokens_remaining = rate_limit_info.input_tokens.as_ref().map(|limits| limits.remaining),
+                    output_tokens_remaining = rate_limit_info.output_tokens.as_ref().map(|limits| limits.remaining),
+                    requests_remaining = rate_limit_info.requests.as_ref().map(|limits| limits.remaining),
+                    requests_reset = ?rate_limit_info.requests.as_ref().map(|limits| limits.reset),
+                    tokens_reset = ?rate_limit_info.tokens.as_ref().map(|limits| limits.reset),
+                    input_tokens_reset = ?rate_limit_info.input_tokens.as_ref().map(|limits| limits.reset),
+                    output_tokens_reset = ?rate_limit_info.output_tokens.as_ref().map(|limits| limits.reset),
                 );
             }
 

--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -316,10 +316,14 @@ async fn perform_completion(
                     is_staff = claims.is_staff,
                     provider = params.provider.to_string(),
                     model = model,
-                    tokens_remaining = rate_limit_info.tokens_remaining,
-                    requests_remaining = rate_limit_info.requests_remaining,
-                    requests_reset = ?rate_limit_info.requests_reset,
-                    tokens_reset = ?rate_limit_info.tokens_reset,
+                    tokens_remaining = rate_limit_info.tokens.remaining,
+                    input_tokens_remaining = rate_limit_info.input_tokens.remaining,
+                    output_tokens_remaining = rate_limit_info.output_tokens.remaining,
+                    requests_remaining = rate_limit_info.requests.remaining,
+                    requests_reset = ?rate_limit_info.requests.reset,
+                    tokens_reset = ?rate_limit_info.tokens.reset,
+                    input_tokens_reset = ?rate_limit_info.input_tokens.reset,
+                    output_tokens_reset = ?rate_limit_info.output_tokens.reset,
                 );
             }
 


### PR DESCRIPTION
This PR makes it so we capture the upstream rate limit information from Anthropic for input and output tokens.

Release Notes:

- N/A
