### PR TITLE
collab: Include max input/output tokens per minute on "Language Model Rate Limited" event

### DIFF
--- a/crates/collab/src/llm.rs
+++ b/crates/collab/src/llm.rs
@@ -571,6 +571,8 @@ async fn check_usage_limit(
                     "users_in_recent_days": users_in_recent_days,
                     "max_requests_per_minute": per_user_max_requests_per_minute,
                     "max_tokens_per_minute": per_user_max_tokens_per_minute,
+                    "max_input_tokens_per_minute": per_user_max_input_tokens_per_minute,
+                    "max_output_tokens_per_minute": per_user_max_output_tokens_per_minute,
                     "max_tokens_per_day": per_user_max_tokens_per_day,
                     "plan": match claims.plan {
                         Plan::Free => "free".to_string(),


### PR DESCRIPTION
This PR adds the max input/output tokens per minute on the "Language Model Rate Limited" event.

Missed this in https://github.com/zed-industries/zed/pull/28097.

Release Notes:

- N/A
