### PR TITLE
agent: Fix invalid tool names in batch tool description

### DIFF
--- a/crates/assistant_tools/src/batch_tool.rs
+++ b/crates/assistant_tools/src/batch_tool.rs
@@ -31,19 +31,19 @@ pub struct BatchToolInput {
     /// {
     ///   "invocations": [
     ///     {
-    ///       "name": "read-file",
+    ///       "name": "read_file",
     ///       "input": {
     ///         "path": "src/main.rs"
     ///       }
     ///     },
     ///     {
-    ///       "name": "list-directory",
+    ///       "name": "list_directory",
     ///       "input": {
     ///         "path": "src/lib"
     ///       }
     ///     },
     ///     {
-    ///       "name": "regex-search",
+    ///       "name": "regex_search",
     ///       "input": {
     ///         "regex": "fn run\\("
     ///       }
@@ -61,7 +61,7 @@ pub struct BatchToolInput {
     /// {
     ///   "invocations": [
     ///     {
-    ///       "name": "find-replace-file",
+    ///       "name": "find_replace_file",
     ///       "input": {
     ///         "path": "src/config.rs",
     ///         "display_description": "Update default timeout value",
@@ -70,7 +70,7 @@ pub struct BatchToolInput {
     ///       }
     ///     },
     ///     {
-    ///       "name": "find-replace-file",
+    ///       "name": "find_replace_file",
     ///       "input": {
     ///         "path": "src/config.rs",
     ///         "display_description": "Update API endpoint URL",
@@ -91,13 +91,13 @@ pub struct BatchToolInput {
     /// {
     ///   "invocations": [
     ///     {
-    ///       "name": "regex-search",
+    ///       "name": "regex_search",
     ///       "input": {
     ///         "regex": "impl Database"
     ///       }
     ///     },
     ///     {
-    ///       "name": "path-search",
+    ///       "name": "path_search",
     ///       "input": {
     ///         "glob": "**/*test*.rs"
     ///       }
@@ -115,7 +115,7 @@ pub struct BatchToolInput {
     /// {
     ///   "invocations": [
     ///     {
-    ///       "name": "find-replace-file",
+    ///       "name": "find_replace_file",
     ///       "input": {
     ///         "path": "src/models/user.rs",
     ///         "display_description": "Add email field to User struct",
@@ -124,7 +124,7 @@ pub struct BatchToolInput {
     ///       }
     ///     },
     ///     {
-    ///       "name": "find-replace-file",
+    ///       "name": "find_replace_file",
     ///       "input": {
     ///         "path": "src/db/queries.rs",
     ///         "display_description": "Update user insertion query",


### PR DESCRIPTION
The description of the Batch Tool was still referring using `-` as a seperator for tool names

Release Notes:

- agent: Fix an issue where the model would sometimes refer to invalid tool names
