### PR TITLE
gpui: Avoid dereferencing null pointer in `MacWindow::update_ime_position`

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1161,6 +1161,9 @@ impl PlatformWindow for MacWindow {
                 unsafe {
                     let input_context: id =
                         msg_send![class!(NSTextInputContext), currentInputContext];
+                    if input_context.is_null() {
+                        return;
+                    }
                     let _: () = msg_send![input_context, invalidateCharacterCoordinates];
                 }
             })


### PR DESCRIPTION
Seems to be very similar to https://github.com/zed-industries/zed/pull/28059

Edit: Updated the reproduction-steps as I missed something.

The method without a check currently causes my debug-builds to crash on the regular if I:
- Run a debug build and open it fullscreen in a dedicated space on my Mac.
- Work on any of the built-in languages (e.g. remove some content from any `highlights.scm`)
- Reopen the workspace with the debug-build.
- Crash.

~~We might actually be able to revert the changes made in https://github.com/zed-industries/zed/pull/21510 and just add the null-check. Then again, I am not at all sure whether that would work.­~~ See comment below.

Release Notes:

- N/A
