### PR TITLE
Add dedicated actions for `LSP` completions insertion mode

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -532,6 +532,7 @@
     "context": "Editor && showing_completions",
     "bindings": {
       "enter": "editor::ConfirmCompletion",
+      "shift-enter": "editor::ConfirmCompletionReplace",
       "tab": "editor::ComposeCompletion"
     }
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -681,6 +681,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "editor::ConfirmCompletion",
+      "shift-enter": "editor::ConfirmCompletionReplace",
       "tab": "editor::ComposeCompletion"
     }
   },

--- a/crates/agent/src/context_picker/completion_provider.rs
+++ b/crates/agent/src/context_picker/completion_provider.rs
@@ -106,7 +106,8 @@ impl ContextPickerCompletionProvider {
                 .iter()
                 .map(|mode| {
                     Completion {
-                        old_range: source_range.clone(),
+                        replace_range: source_range.clone(),
+                        insert_range: None,
                         new_text: format!("@{} ", mode.mention_prefix()),
                         label: CodeLabel::plain(mode.label().to_string(), None),
                         icon_path: Some(mode.icon().path().into()),
@@ -160,7 +161,8 @@ impl ContextPickerCompletionProvider {
         let new_text = MentionLink::for_thread(&thread_entry);
         let new_text_len = new_text.len();
         Completion {
-            old_range: source_range.clone(),
+            replace_range: source_range.clone(),
+            insert_range: None,
             new_text,
             label: CodeLabel::plain(thread_entry.summary.to_string(), None),
             documentation: None,
@@ -205,7 +207,8 @@ impl ContextPickerCompletionProvider {
         let new_text = MentionLink::for_fetch(&url_to_fetch);
         let new_text_len = new_text.len();
         Completion {
-            old_range: source_range.clone(),
+            replace_range: source_range.clone(),
+            insert_range: None,
             new_text,
             label: CodeLabel::plain(url_to_fetch.to_string(), None),
             documentation: None,
@@ -287,7 +290,8 @@ impl ContextPickerCompletionProvider {
         let new_text = MentionLink::for_file(&file_name, &full_path);
         let new_text_len = new_text.len();
         Completion {
-            old_range: source_range.clone(),
+            replace_range: source_range.clone(),
+            insert_range: None,
             new_text,
             label,
             documentation: None,
@@ -350,7 +354,8 @@ impl ContextPickerCompletionProvider {
         let new_text = MentionLink::for_symbol(&symbol.name, &full_path);
         let new_text_len = new_text.len();
         Some(Completion {
-            old_range: source_range.clone(),
+            replace_range: source_range.clone(),
+            insert_range: None,
             new_text,
             label,
             documentation: None,

--- a/crates/agent/src/context_picker/completion_provider.rs
+++ b/crates/agent/src/context_picker/completion_provider.rs
@@ -107,7 +107,6 @@ impl ContextPickerCompletionProvider {
                 .map(|mode| {
                     Completion {
                         replace_range: source_range.clone(),
-                        insert_range: None,
                         new_text: format!("@{} ", mode.mention_prefix()),
                         label: CodeLabel::plain(mode.label().to_string(), None),
                         icon_path: Some(mode.icon().path().into()),
@@ -162,7 +161,6 @@ impl ContextPickerCompletionProvider {
         let new_text_len = new_text.len();
         Completion {
             replace_range: source_range.clone(),
-            insert_range: None,
             new_text,
             label: CodeLabel::plain(thread_entry.summary.to_string(), None),
             documentation: None,
@@ -208,7 +206,6 @@ impl ContextPickerCompletionProvider {
         let new_text_len = new_text.len();
         Completion {
             replace_range: source_range.clone(),
-            insert_range: None,
             new_text,
             label: CodeLabel::plain(url_to_fetch.to_string(), None),
             documentation: None,
@@ -291,7 +288,6 @@ impl ContextPickerCompletionProvider {
         let new_text_len = new_text.len();
         Completion {
             replace_range: source_range.clone(),
-            insert_range: None,
             new_text,
             label,
             documentation: None,
@@ -355,7 +351,6 @@ impl ContextPickerCompletionProvider {
         let new_text_len = new_text.len();
         Some(Completion {
             replace_range: source_range.clone(),
-            insert_range: None,
             new_text,
             label,
             documentation: None,

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -120,7 +120,8 @@ impl SlashCommandCompletionProvider {
                                         ) as Arc<_>
                                     });
                             Some(project::Completion {
-                                old_range: name_range.clone(),
+                                replace_range: name_range.clone(),
+                                insert_range: None,
                                 documentation: Some(CompletionDocumentation::SingleLine(
                                     command.description().into(),
                                 )),
@@ -219,11 +220,12 @@ impl SlashCommandCompletionProvider {
                             }
 
                             project::Completion {
-                                old_range: if new_argument.replace_previous_arguments {
+                                replace_range: if new_argument.replace_previous_arguments {
                                     argument_range.clone()
                                 } else {
                                     last_argument_range.clone()
                                 },
+                                insert_range: None,
                                 label: new_argument.label,
                                 icon_path: None,
                                 new_text,

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -121,7 +121,6 @@ impl SlashCommandCompletionProvider {
                                     });
                             Some(project::Completion {
                                 replace_range: name_range.clone(),
-                                insert_range: None,
                                 documentation: Some(CompletionDocumentation::SingleLine(
                                     command.description().into(),
                                 )),
@@ -225,7 +224,6 @@ impl SlashCommandCompletionProvider {
                                 } else {
                                     last_argument_range.clone()
                                 },
-                                insert_range: None,
                                 label: new_argument.label,
                                 icon_path: None,
                                 new_text,

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -309,7 +309,8 @@ impl MessageEditor {
             .map(|mat| {
                 let (new_text, label) = completion_fn(&mat);
                 Completion {
-                    old_range: range.clone(),
+                    replace_range: range.clone(),
+                    insert_range: None,
                     new_text,
                     label,
                     icon_path: None,

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -310,7 +310,6 @@ impl MessageEditor {
                 let (new_text, label) = completion_fn(&mat);
                 Completion {
                     replace_range: range.clone(),
-                    insert_range: None,
                     new_text,
                     label,
                     icon_path: None,

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -357,7 +357,6 @@ impl ConsoleQueryBarCompletionProvider {
 
                         Some(project::Completion {
                             replace_range: buffer_position..buffer_position,
-                            insert_range: None,
                             new_text: string_match.string.clone(),
                             label: CodeLabel {
                                 filter_range: 0..string_match.string.len(),
@@ -433,7 +432,6 @@ impl ConsoleQueryBarCompletionProvider {
 
                         project::Completion {
                             replace_range,
-                            insert_range: None,
                             new_text,
                             label: CodeLabel {
                                 filter_range: 0..completion.label.len(),

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -356,7 +356,8 @@ impl ConsoleQueryBarCompletionProvider {
                         let variable_value = variables.get(&string_match.string)?;
 
                         Some(project::Completion {
-                            old_range: buffer_position..buffer_position,
+                            replace_range: buffer_position..buffer_position,
+                            insert_range: None,
                             new_text: string_match.string.clone(),
                             label: CodeLabel {
                                 filter_range: 0..string_match.string.len(),
@@ -428,10 +429,11 @@ impl ConsoleQueryBarCompletionProvider {
                         let buffer_offset = buffer_position.to_offset(&snapshot);
                         let start = buffer_offset - word_bytes_length;
                         let start = snapshot.anchor_before(start);
-                        let old_range = start..buffer_position;
+                        let replace_range = start..buffer_position;
 
                         project::Completion {
-                            old_range,
+                            replace_range,
+                            insert_range: None,
                             new_text,
                             label: CodeLabel {
                                 filter_range: 0..completion.label.len(),

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -3,6 +3,7 @@ use super::*;
 use gpui::{action_as, action_with_deprecated_aliases, actions};
 use schemars::JsonSchema;
 use util::serde::default_true;
+
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
 pub struct SelectNext {
@@ -262,6 +263,8 @@ actions!(
         Cancel,
         CancelLanguageServerWork,
         ConfirmRename,
+        ConfirmCompletionInsert,
+        ConfirmCompletionReplace,
         ContextMenuFirst,
         ContextMenuLast,
         ContextMenuNext,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -231,7 +231,6 @@ impl CompletionsMenu {
             .iter()
             .map(|choice| Completion {
                 replace_range: selection.start.text_anchor..selection.end.text_anchor,
-                insert_range: None,
                 new_text: choice.to_string(),
                 label: CodeLabel {
                     text: choice.to_string(),

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -230,7 +230,8 @@ impl CompletionsMenu {
         let completions = choices
             .iter()
             .map(|choice| Completion {
-                old_range: selection.start.text_anchor..selection.end.text_anchor,
+                replace_range: selection.start.text_anchor..selection.end.text_anchor,
+                insert_range: None,
                 new_text: choice.to_string(),
                 label: CodeLabel {
                     text: choice.to_string(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -109,8 +109,8 @@ use language::{
     IndentKind, IndentSize, Language, OffsetRangeExt, Point, Selection, SelectionGoal, TextObject,
     TransactionId, TreeSitterOptions, WordsQuery,
     language_settings::{
-        self, AllLanguageSettings, InlayHintSettings, LspInsertMode, RewrapBehavior,
-        WordsCompletionMode, all_language_settings, language_settings,
+        self, InlayHintSettings, LspInsertMode, RewrapBehavior, WordsCompletionMode,
+        all_language_settings, language_settings,
     },
     point_from_lsp, text_diff_with_options,
 };
@@ -17992,11 +17992,11 @@ fn choose_completion_range(
         }
     }
 
-    let completion_mode_setting = AllLanguageSettings::get_global(cx)
-        .defaults
-        .completions
-        .lsp_insert_mode;
     let buffer = buffer.read(cx);
+    let completion_mode_setting =
+        language_settings(buffer.language().map(|l| l.name()), buffer.file(), cx)
+            .completions
+            .lsp_insert_mode;
 
     if should_replace(completion, intent, completion_mode_setting, buffer) {
         completion.replace_range.to_offset(buffer)

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9445,7 +9445,7 @@ async fn test_completion_with_mode_specified_by_action(cx: &mut TestAppContext) 
 
     let apply_additional_edits = cx.update_editor(|editor, window, cx| {
         editor
-            .confirm_completion_replace(&ConfirmCompletionReplace::default(), window, cx)
+            .confirm_completion_replace(&ConfirmCompletionReplace, window, cx)
             .unwrap()
     });
     cx.assert_editor_state(&expected_with_replace_mode);
@@ -9479,7 +9479,7 @@ async fn test_completion_with_mode_specified_by_action(cx: &mut TestAppContext) 
 
     let apply_additional_edits = cx.update_editor(|editor, window, cx| {
         editor
-            .confirm_completion_insert(&ConfirmCompletionInsert::default(), window, cx)
+            .confirm_completion_insert(&ConfirmCompletionInsert, window, cx)
             .unwrap()
     });
     cx.assert_editor_state(&expected_with_insert_mode);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9218,7 +9218,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
         initial_state: String,
         buffer_marked_text: String,
         completion_text: &'static str,
-        expected_with_insertion_mode: String,
+        expected_with_insert_mode: String,
         expected_with_replace_mode: String,
         expected_with_replace_subsequence_mode: String,
         expected_with_replace_suffix_mode: String,
@@ -9230,7 +9230,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "before ediˇ after".into(),
             buffer_marked_text: "before <edi|> after".into(),
             completion_text: "editor",
-            expected_with_insertion_mode: "before editorˇ after".into(),
+            expected_with_insert_mode: "before editorˇ after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
             expected_with_replace_subsequence_mode: "before editorˇ after".into(),
             expected_with_replace_suffix_mode: "before editorˇ after".into(),
@@ -9240,7 +9240,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "before ediˇtor after".into(),
             buffer_marked_text: "before <edi|tor> after".into(),
             completion_text: "editor",
-            expected_with_insertion_mode: "before editorˇtor after".into(),
+            expected_with_insert_mode: "before editorˇtor after".into(),
             expected_with_replace_mode: "before ediˇtor after".into(),
             expected_with_replace_subsequence_mode: "before ediˇtor after".into(),
             expected_with_replace_suffix_mode: "before ediˇtor after".into(),
@@ -9250,7 +9250,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "before torˇ after".into(),
             buffer_marked_text: "before <tor|> after".into(),
             completion_text: "editor",
-            expected_with_insertion_mode: "before editorˇ after".into(),
+            expected_with_insert_mode: "before editorˇ after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
             expected_with_replace_subsequence_mode: "before editorˇ after".into(),
             expected_with_replace_suffix_mode: "before editorˇ after".into(),
@@ -9260,7 +9260,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "before ˇtor after".into(),
             buffer_marked_text: "before <|tor> after".into(),
             completion_text: "editor",
-            expected_with_insertion_mode: "before editorˇtor after".into(),
+            expected_with_insert_mode: "before editorˇtor after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
             expected_with_replace_subsequence_mode: "before editorˇ after".into(),
             expected_with_replace_suffix_mode: "before editorˇ after".into(),
@@ -9270,7 +9270,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "pˇfield: bool".into(),
             buffer_marked_text: "<p|field>: bool".into(),
             completion_text: "pub ",
-            expected_with_insertion_mode: "pub ˇfield: bool".into(),
+            expected_with_insert_mode: "pub ˇfield: bool".into(),
             expected_with_replace_mode: "pub ˇ: bool".into(),
             expected_with_replace_subsequence_mode: "pub ˇfield: bool".into(),
             expected_with_replace_suffix_mode: "pub ˇfield: bool".into(),
@@ -9280,7 +9280,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "[element_ˇelement_2]".into(),
             buffer_marked_text: "[<element_|element_2>]".into(),
             completion_text: "element_1",
-            expected_with_insertion_mode: "[element_1ˇelement_2]".into(),
+            expected_with_insert_mode: "[element_1ˇelement_2]".into(),
             expected_with_replace_mode: "[element_1ˇ]".into(),
             expected_with_replace_subsequence_mode: "[element_1ˇelement_2]".into(),
             expected_with_replace_suffix_mode: "[element_1ˇelement_2]".into(),
@@ -9290,7 +9290,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "[elˇelement]".into(),
             buffer_marked_text: "[<el|element>]".into(),
             completion_text: "element",
-            expected_with_insertion_mode: "[elementˇelement]".into(),
+            expected_with_insert_mode: "[elementˇelement]".into(),
             expected_with_replace_mode: "[elˇement]".into(),
             expected_with_replace_subsequence_mode: "[elementˇelement]".into(),
             expected_with_replace_suffix_mode: "[elˇement]".into(),
@@ -9300,7 +9300,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "SubˇError".into(),
             buffer_marked_text: "<Sub|Error>".into(),
             completion_text: "SubscriptionError",
-            expected_with_insertion_mode: "SubscriptionErrorˇError".into(),
+            expected_with_insert_mode: "SubscriptionErrorˇError".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
             expected_with_replace_subsequence_mode: "SubscriptionErrorˇ".into(),
             expected_with_replace_suffix_mode: "SubscriptionErrorˇ".into(),
@@ -9310,7 +9310,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "SubˇErr".into(),
             buffer_marked_text: "<Sub|Err>".into(),
             completion_text: "SubscriptionError",
-            expected_with_insertion_mode: "SubscriptionErrorˇErr".into(),
+            expected_with_insert_mode: "SubscriptionErrorˇErr".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
             expected_with_replace_subsequence_mode: "SubscriptionErrorˇ".into(),
             expected_with_replace_suffix_mode: "SubscriptionErrorˇErr".into(),
@@ -9320,7 +9320,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "Suˇscrirr".into(),
             buffer_marked_text: "<Su|scrirr>".into(),
             completion_text: "SubscriptionError",
-            expected_with_insertion_mode: "SubscriptionErrorˇscrirr".into(),
+            expected_with_insert_mode: "SubscriptionErrorˇscrirr".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
             expected_with_replace_subsequence_mode: "SubscriptionErrorˇ".into(),
             expected_with_replace_suffix_mode: "SubscriptionErrorˇscrirr".into(),
@@ -9330,7 +9330,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             initial_state: "foo(indˇix)".into(),
             buffer_marked_text: "foo(<ind|ix>)".into(),
             completion_text: "node_index",
-            expected_with_insertion_mode: "foo(node_indexˇix)".into(),
+            expected_with_insert_mode: "foo(node_indexˇix)".into(),
             expected_with_replace_mode: "foo(node_indexˇ)".into(),
             expected_with_replace_subsequence_mode: "foo(node_indexˇix)".into(),
             expected_with_replace_suffix_mode: "foo(node_indexˇix)".into(),
@@ -9339,7 +9339,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
 
     for run in runs {
         let run_variations = [
-            (LspInsertMode::Insert, run.expected_with_insertion_mode),
+            (LspInsertMode::Insert, run.expected_with_insert_mode),
             (LspInsertMode::Replace, run.expected_with_replace_mode),
             (
                 LspInsertMode::ReplaceSubsequence,
@@ -9393,6 +9393,98 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             apply_additional_edits.await.unwrap();
         }
     }
+}
+
+#[gpui::test]
+async fn test_completion_with_mode_specified_by_action(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let mut cx = EditorLspTestContext::new_rust(
+        lsp::ServerCapabilities {
+            completion_provider: Some(lsp::CompletionOptions {
+                resolve_provider: Some(true),
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        cx,
+    )
+    .await;
+
+    let initial_state = "SubˇError";
+    let buffer_marked_text = "<Sub|Error>";
+    let completion_text = "SubscriptionError";
+    let expected_with_insert_mode = "SubscriptionErrorˇError";
+    let expected_with_replace_mode = "SubscriptionErrorˇ";
+
+    update_test_language_settings(&mut cx, |settings| {
+        settings.defaults.completions = Some(CompletionSettings {
+            words: WordsCompletionMode::Disabled,
+            // set the opposite here to ensure that the action is overriding the default behavior
+            lsp_insert_mode: LspInsertMode::Insert,
+            lsp: true,
+            lsp_fetch_timeout_ms: 0,
+        });
+    });
+
+    cx.set_state(initial_state);
+    cx.update_editor(|editor, window, cx| {
+        editor.show_completions(&ShowCompletions { trigger: None }, window, cx);
+    });
+
+    let counter = Arc::new(AtomicUsize::new(0));
+    handle_completion_request_with_insert_and_replace(
+        &mut cx,
+        &buffer_marked_text,
+        vec![completion_text],
+        counter.clone(),
+    )
+    .await;
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+    assert_eq!(counter.load(atomic::Ordering::Acquire), 1);
+
+    let apply_additional_edits = cx.update_editor(|editor, window, cx| {
+        editor
+            .confirm_completion_replace(&ConfirmCompletionReplace::default(), window, cx)
+            .unwrap()
+    });
+    cx.assert_editor_state(&expected_with_replace_mode);
+    handle_resolve_completion_request(&mut cx, None).await;
+    apply_additional_edits.await.unwrap();
+
+    update_test_language_settings(&mut cx, |settings| {
+        settings.defaults.completions = Some(CompletionSettings {
+            words: WordsCompletionMode::Disabled,
+            // set the opposite here to ensure that the action is overriding the default behavior
+            lsp_insert_mode: LspInsertMode::Replace,
+            lsp: true,
+            lsp_fetch_timeout_ms: 0,
+        });
+    });
+
+    cx.set_state(initial_state);
+    cx.update_editor(|editor, window, cx| {
+        editor.show_completions(&ShowCompletions { trigger: None }, window, cx);
+    });
+    handle_completion_request_with_insert_and_replace(
+        &mut cx,
+        &buffer_marked_text,
+        vec![completion_text],
+        counter.clone(),
+    )
+    .await;
+    cx.condition(|editor, _| editor.context_menu_visible())
+        .await;
+    assert_eq!(counter.load(atomic::Ordering::Acquire), 2);
+
+    let apply_additional_edits = cx.update_editor(|editor, window, cx| {
+        editor
+            .confirm_completion_insert(&ConfirmCompletionInsert::default(), window, cx)
+            .unwrap()
+    });
+    cx.assert_editor_state(&expected_with_insert_mode);
+    handle_resolve_completion_request(&mut cx, None).await;
+    apply_additional_edits.await.unwrap();
 }
 
 #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -462,6 +462,20 @@ impl EditorElement {
             }
         });
         register_action(editor, window, |editor, action, window, cx| {
+            if let Some(task) = editor.confirm_completion_replace(action, window, cx) {
+                task.detach_and_notify_err(window, cx);
+            } else {
+                cx.propagate();
+            }
+        });
+        register_action(editor, window, |editor, action, window, cx| {
+            if let Some(task) = editor.confirm_completion_insert(action, window, cx) {
+                task.detach_and_notify_err(window, cx);
+            } else {
+                cx.propagate();
+            }
+        });
+        register_action(editor, window, |editor, action, window, cx| {
             if let Some(task) = editor.compose_completion(action, window, cx) {
                 task.detach_and_notify_err(window, cx);
             } else {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -370,7 +370,7 @@ fn default_words_completion_mode() -> WordsCompletionMode {
 }
 
 fn default_lsp_insert_mode() -> LspInsertMode {
-    LspInsertMode::Insert
+    LspInsertMode::ReplaceSuffix
 }
 
 fn default_lsp_fetch_timeout_ms() -> u64 {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -17,9 +17,7 @@ use gpui::{App, AsyncApp, Entity};
 use language::{
     Anchor, Bias, Buffer, BufferSnapshot, CachedLspAdapter, CharKind, OffsetRangeExt, PointUtf16,
     ToOffset, ToPointUtf16, Transaction, Unclipped,
-    language_settings::{
-        AllLanguageSettings, InlayHintKind, LanguageSettings, LspInsertMode, language_settings,
-    },
+    language_settings::{InlayHintKind, LanguageSettings, language_settings},
     point_from_lsp, point_to_lsp,
     proto::{deserialize_anchor, deserialize_version, serialize_anchor, serialize_version},
     range_from_lsp, range_to_lsp,
@@ -30,7 +28,6 @@ use lsp::{
     LanguageServer, LanguageServerId, LinkedEditingRangeServerCapabilities, OneOf, RenameOptions,
     ServerCapabilities,
 };
-use settings::Settings as _;
 use signature_help::{lsp_to_proto_signature, proto_to_lsp_signature};
 use std::{cmp::Reverse, mem, ops::Range, path::Path, sync::Arc};
 use text::{BufferId, LineEnding};
@@ -2088,7 +2085,7 @@ impl LspCommand for GetCompletions {
             .map(Arc::new);
 
         let mut completion_edits = Vec::new();
-        buffer.update(&mut cx, |buffer, cx| {
+        buffer.update(&mut cx, |buffer, _cx| {
             let snapshot = buffer.snapshot();
             let clipped_position = buffer.clip_point_utf16(Unclipped(self.position), Bias::Left);
 
@@ -2125,21 +2122,11 @@ impl LspCommand for GetCompletions {
                     // If the language server provides a range to overwrite, then
                     // check that the range is valid.
                     Some(completion_text_edit) => {
-                        let completion_mode = AllLanguageSettings::get_global(cx)
-                            .defaults
-                            .completions
-                            .lsp_insert_mode;
-
-                        match parse_completion_text_edit(
-                            &completion_text_edit,
-                            &snapshot,
-                            completion_mode,
-                        ) {
+                        match parse_completion_text_edit(&completion_text_edit, &snapshot) {
                             Some(edit) => edit,
                             None => return false,
                         }
                     }
-
                     // If the language server does not provide a range, then infer
                     // the range based on the syntax tree.
                     None => {
@@ -2191,7 +2178,12 @@ impl LspCommand for GetCompletions {
                             .as_ref()
                             .unwrap_or(&lsp_completion.label)
                             .clone();
-                        (range, text)
+
+                        ParsedCompletionEdit {
+                            replace_range: range,
+                            insert_range: None,
+                            new_text: text,
+                        }
                     }
                 };
 
@@ -2207,8 +2199,8 @@ impl LspCommand for GetCompletions {
         Ok(completions
             .into_iter()
             .zip(completion_edits)
-            .map(|(mut lsp_completion, (old_range, mut new_text))| {
-                LineEnding::normalize(&mut new_text);
+            .map(|(mut lsp_completion, mut edit)| {
+                LineEnding::normalize(&mut edit.new_text);
                 if lsp_completion.data.is_none() {
                     if let Some(default_data) = lsp_defaults
                         .as_ref()
@@ -2220,8 +2212,9 @@ impl LspCommand for GetCompletions {
                     }
                 }
                 CoreCompletion {
-                    old_range,
-                    new_text,
+                    replace_range: edit.replace_range,
+                    insert_range: edit.insert_range,
+                    new_text: edit.new_text,
                     source: CompletionSource::Lsp {
                         server_id,
                         lsp_completion: Box::new(lsp_completion),
@@ -2312,91 +2305,53 @@ impl LspCommand for GetCompletions {
     }
 }
 
+pub struct ParsedCompletionEdit {
+    pub replace_range: Range<Anchor>,
+    pub insert_range: Option<Range<Anchor>>,
+    pub new_text: String,
+}
+
 pub(crate) fn parse_completion_text_edit(
     edit: &lsp::CompletionTextEdit,
     snapshot: &BufferSnapshot,
-    completion_mode: LspInsertMode,
-) -> Option<(Range<Anchor>, String)> {
-    match edit {
-        lsp::CompletionTextEdit::Edit(edit) => {
-            let range = range_from_lsp(edit.range);
-            let start = snapshot.clip_point_utf16(range.start, Bias::Left);
-            let end = snapshot.clip_point_utf16(range.end, Bias::Left);
-            if start != range.start.0 || end != range.end.0 {
-                log::info!("completion out of expected range");
-                None
-            } else {
-                Some((
-                    snapshot.anchor_before(start)..snapshot.anchor_after(end),
-                    edit.new_text.clone(),
-                ))
-            }
-        }
-
+) -> Option<ParsedCompletionEdit> {
+    let (replace_range, insert_range, new_text) = match edit {
+        lsp::CompletionTextEdit::Edit(edit) => (edit.range, None, &edit.new_text),
         lsp::CompletionTextEdit::InsertAndReplace(edit) => {
-            let replace = match completion_mode {
-                LspInsertMode::Insert => false,
-                LspInsertMode::Replace => true,
-                LspInsertMode::ReplaceSubsequence => {
-                    let range_to_replace = range_from_lsp(edit.replace);
+            (edit.replace, Some(edit.insert), &edit.new_text)
+        }
+    };
 
-                    let start = snapshot.clip_point_utf16(range_to_replace.start, Bias::Left);
-                    let end = snapshot.clip_point_utf16(range_to_replace.end, Bias::Left);
-                    if start != range_to_replace.start.0 || end != range_to_replace.end.0 {
-                        false
-                    } else {
-                        let mut completion_text = edit.new_text.chars();
+    let replace_range = {
+        let range = range_from_lsp(replace_range);
+        let start = snapshot.clip_point_utf16(range.start, Bias::Left);
+        let end = snapshot.clip_point_utf16(range.end, Bias::Left);
+        if start != range.start.0 || end != range.end.0 {
+            log::info!("completion out of expected range");
+            return None;
+        }
+        snapshot.anchor_before(start)..snapshot.anchor_after(end)
+    };
 
-                        let mut text_to_replace = snapshot.chars_for_range(
-                            snapshot.anchor_before(start)..snapshot.anchor_after(end),
-                        );
-
-                        // is `text_to_replace` a subsequence of `completion_text`
-                        text_to_replace.all(|needle_ch| {
-                            completion_text.any(|haystack_ch| haystack_ch == needle_ch)
-                        })
-                    }
-                }
-                LspInsertMode::ReplaceSuffix => {
-                    let range_after_cursor = lsp::Range {
-                        start: edit.insert.end,
-                        end: edit.replace.end,
-                    };
-                    let range_after_cursor = range_from_lsp(range_after_cursor);
-
-                    let start = snapshot.clip_point_utf16(range_after_cursor.start, Bias::Left);
-                    let end = snapshot.clip_point_utf16(range_after_cursor.end, Bias::Left);
-                    if start != range_after_cursor.start.0 || end != range_after_cursor.end.0 {
-                        false
-                    } else {
-                        let text_after_cursor = snapshot
-                            .text_for_range(
-                                snapshot.anchor_before(start)..snapshot.anchor_after(end),
-                            )
-                            .collect::<String>();
-                        edit.new_text.ends_with(&text_after_cursor)
-                    }
-                }
-            };
-
-            let range = range_from_lsp(match replace {
-                true => edit.replace,
-                false => edit.insert,
-            });
-
+    let insert_range = match insert_range {
+        None => None,
+        Some(insert_range) => {
+            let range = range_from_lsp(insert_range);
             let start = snapshot.clip_point_utf16(range.start, Bias::Left);
             let end = snapshot.clip_point_utf16(range.end, Bias::Left);
             if start != range.start.0 || end != range.end.0 {
-                log::info!("completion out of expected range");
-                None
-            } else {
-                Some((
-                    snapshot.anchor_before(start)..snapshot.anchor_after(end),
-                    edit.new_text.clone(),
-                ))
+                log::info!("completion (insert) out of expected range");
+                return None;
             }
+            Some(snapshot.anchor_before(start)..snapshot.anchor_after(end))
         }
-    }
+    };
+
+    Some(ParsedCompletionEdit {
+        insert_range: insert_range,
+        replace_range: replace_range,
+        new_text: new_text.clone(),
+    })
 }
 
 #[async_trait(?Send)]

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2213,9 +2213,9 @@ impl LspCommand for GetCompletions {
                 }
                 CoreCompletion {
                     replace_range: edit.replace_range,
-                    insert_range: edit.insert_range,
                     new_text: edit.new_text,
                     source: CompletionSource::Lsp {
+                        insert_range: edit.insert_range,
                         server_id,
                         lsp_completion: Box::new(lsp_completion),
                         lsp_defaults: lsp_defaults.clone(),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -383,13 +383,11 @@ impl CompletionIntent {
     }
 }
 
-/// A completion provided by a language server
+/// A generic completion that can come from different sources.
 #[derive(Clone)]
 pub struct Completion {
     /// The range of text that will be replaced by this completion.
     pub replace_range: Range<Anchor>,
-    /// TODO: re-do this description: The range of the buffer that will be replaced by a `ConfirmCompletionInsert`.
-    pub insert_range: Option<Range<Anchor>>,
     /// The new text that will be inserted.
     pub new_text: String,
     /// A label for this completion that is shown in the menu.
@@ -412,6 +410,8 @@ pub struct Completion {
 #[derive(Debug, Clone)]
 pub enum CompletionSource {
     Lsp {
+        /// The alternate `insert` range, if provided by the LSP server.
+        insert_range: Option<Range<Anchor>>,
         /// The id of the language server that produced this completion.
         server_id: LanguageServerId,
         /// The raw completion provided by the language server.
@@ -517,7 +517,6 @@ impl std::fmt::Debug for Completion {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Completion")
             .field("replace_range", &self.replace_range)
-            .field("insert_range", &self.insert_range)
             .field("new_text", &self.new_text)
             .field("label", &self.label)
             .field("documentation", &self.documentation)
@@ -526,11 +525,9 @@ impl std::fmt::Debug for Completion {
     }
 }
 
-/// A completion provided by a language server
 #[derive(Clone, Debug)]
 pub(crate) struct CoreCompletion {
     replace_range: Range<Anchor>,
-    insert_range: Option<Range<Anchor>>,
     new_text: String,
     source: CompletionSource,
 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -383,7 +383,7 @@ impl CompletionIntent {
     }
 }
 
-/// A generic completion that can come from different sources.
+/// Similar to `CoreCompletion`, but with extra metadata attached.
 #[derive(Clone)]
 pub struct Completion {
     /// The range of text that will be replaced by this completion.
@@ -525,6 +525,7 @@ impl std::fmt::Debug for Completion {
     }
 }
 
+/// A generic completion that can come from different sources.
 #[derive(Clone, Debug)]
 pub(crate) struct CoreCompletion {
     replace_range: Range<Anchor>,

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2958,7 +2958,7 @@ async fn test_completions_with_text_edit(cx: &mut gpui::TestAppContext) {
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "textEditText");
     assert_eq!(
-        completions[0].old_range.to_offset(&snapshot),
+        completions[0].replace_range.to_offset(&snapshot),
         text.len() - 3..text.len()
     );
 }
@@ -3041,7 +3041,7 @@ async fn test_completions_with_edit_ranges(cx: &mut gpui::TestAppContext) {
         assert_eq!(completions.len(), 1);
         assert_eq!(completions[0].new_text, "insertText");
         assert_eq!(
-            completions[0].old_range.to_offset(&snapshot),
+            completions[0].replace_range.to_offset(&snapshot),
             text.len() - 3..text.len()
         );
     }
@@ -3083,7 +3083,7 @@ async fn test_completions_with_edit_ranges(cx: &mut gpui::TestAppContext) {
         assert_eq!(completions.len(), 1);
         assert_eq!(completions[0].new_text, "labelText");
         assert_eq!(
-            completions[0].old_range.to_offset(&snapshot),
+            completions[0].replace_range.to_offset(&snapshot),
             text.len() - 3..text.len()
         );
     }
@@ -3153,7 +3153,7 @@ async fn test_completions_without_edit_ranges(cx: &mut gpui::TestAppContext) {
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "fullyQualifiedName");
     assert_eq!(
-        completions[0].old_range.to_offset(&snapshot),
+        completions[0].replace_range.to_offset(&snapshot),
         text.len() - 3..text.len()
     );
 
@@ -3180,7 +3180,7 @@ async fn test_completions_without_edit_ranges(cx: &mut gpui::TestAppContext) {
     assert_eq!(completions.len(), 1);
     assert_eq!(completions[0].new_text, "component");
     assert_eq!(
-        completions[0].old_range.to_offset(&snapshot),
+        completions[0].replace_range.to_offset(&snapshot),
         text.len() - 4..text.len() - 1
     );
 }

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -198,8 +198,8 @@ message ApplyCompletionAdditionalEditsResponse {
 }
 
 message Completion {
-    Anchor old_start = 1;
-    Anchor old_end = 2;
+    Anchor old_replace_start = 1;
+    Anchor old_replace_end = 2;
     string new_text = 3;
     uint64 server_id = 4;
     bytes lsp_completion = 5;
@@ -208,6 +208,8 @@ message Completion {
     optional bytes lsp_defaults = 8;
     optional Anchor buffer_word_start = 9;
     optional Anchor buffer_word_end = 10;
+    Anchor old_insert_start = 11;
+    Anchor old_insert_end = 12;
 
     enum Source {
         Lsp = 0;
@@ -428,10 +430,12 @@ message ResolveCompletionDocumentation {
 message ResolveCompletionDocumentationResponse {
     string documentation = 1;
     bool documentation_is_markdown = 2;
-    Anchor old_start = 3;
-    Anchor old_end = 4;
+    Anchor old_replace_start = 3;
+    Anchor old_replace_end = 4;
     string new_text = 5;
     bytes lsp_completion = 6;
+    Anchor old_insert_start = 7;
+    Anchor old_insert_end = 8;
 }
 
 message ResolveInlayHint {


### PR DESCRIPTION
Adds actions so you can have customized keybindings for `insert` and `replace` modes.

And add `shift-enter` as a default for `replace`, this will override the default setting
`completions.lsp_insert_mode` which is set to `replace_suffix`, which tries to "smartly"
decide whether to replace or insert based on the surrounding text.

For those who come from VSCode, if you want to mimic their behavior, you only have to
set `completions.lsp_insert_mode` to `insert`.

If you want `tab` and `enter` to do different things, you need to remap them, here is
an example:

```jsonc
[
  // ...
  {
    "context": "Editor && showing_completions",
    "bindings": {
      "enter": "editor::ConfirmCompletionInsert",
      "tab": "editor::ConfirmCompletionReplace"
    }
  },
]
```

Closes #24577

- [x] Make LSP completion insertion mode decision in guest's machine (host is currently deciding it and not allowing guests to have their own setting for it)
- [x] Add shift-enter as a hotkey for `replace` by default.
- [x] Test actions.
- [x] Respect the setting being specified per language, instead of using the "defaults".
- [x] Move `insert_range` of `Completion` to the Lsp variant of `.source`.
- [x] Fix broken default, forgotten after https://github.com/zed-industries/zed/pull/27453#pullrequestreview-2736906628, should be `replace_suffix` and not `insert`.

Release Notes:

- LSP completions: added actions `ConfirmCompletionInsert` and `ConfirmCompletionReplace` that control how completions are inserted, these override `completions.lsp_insert_mode`, by default, `shift-enter` triggers `ConfirmCompletionReplace` which replaces the whole word.
