### PR TITLE
nix: Fix the macOS build (nix package + devShell)

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,12 +13,6 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-args=-all_load"]
-
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-args=-all_load"]
-
 [target.'cfg(target_os = "windows")']
 rustflags = [
     "--cfg",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -747,9 +747,11 @@ jobs:
           name: zed-industries
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           skipPush: true
-      - run: nix build .#debug
-      - name: Limit /nix/store to 50GB
-        run: "[ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d"
+      - run: nix build .#debug -L --accept-flake-config
+      - name: Limit /nix/store to 50GB # cleanup only if not ephemeral (macos)
+        if: ${{ ! matrix.system.install_nix }}
+        run: |
+          [ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d || :
 
   auto-release-preview:
     name: Auto release preview

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1742394900,
-        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
+        "lastModified": 1743700120,
+        "narHash": "sha256-8BjG/P0xnuCyVOXlYRwdI1B8nVtyYLf3oDwPSimqREY=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
+        "rev": "e316f19ee058e6db50075115783be57ac549c389",
         "type": "github"
       },
       "original": {
@@ -32,11 +32,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1743095683,
-        "narHash": "sha256-gWd4urRoLRe8GLVC/3rYRae1h+xfQzt09xOfb0PaHSk=",
+        "lastModified": 1743583204,
+        "narHash": "sha256-F7n4+KOIfWrwoQjXrL2wD9RhFYLs2/GGe/MQY1sSdlE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5e5402ecbcb27af32284d4a62553c019a3a49ea6",
+        "rev": "2c8d3f48d33929642c1c12cd243df4cc7d2ce434",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743215516,
-        "narHash": "sha256-52qbrkG65U1hyrQWltgHTgH4nm0SJL+9TWv2UDCEPNI=",
+        "lastModified": 1743682350,
+        "narHash": "sha256-S/MyKOFajCiBm5H5laoE59wB6w0NJ4wJG53iAPfYW3k=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "524463199fdee49338006b049bc376b965a2cfed",
+        "rev": "c4a8327b0f25d1d81edecbb6105f74d7cf9d7382",
         "type": "github"
       },
       "original": {

--- a/nix/build.nix
+++ b/nix/build.nix
@@ -143,6 +143,7 @@ let
           wayland
           gpu-lib
           xorg.libxcb
+          xorg.libX11
         ]
         ++ lib.optionals stdenv'.hostPlatform.isDarwin [
           apple-sdk_15

--- a/nix/webrtc-sources.nix
+++ b/nix/webrtc-sources.nix
@@ -1,0 +1,253 @@
+# TODO(nixpkgs-livekit-bump): see https://github.com/NixOS/nixpkgs/pull/396016;
+# drop once in `nixpkgs-unstable`
+#
+# This file is from the above PR (courtesy of @WeetHet).
+{
+  fetchFromGitHub,
+  fetchFromGitiles,
+  fetchgit,
+  fetchurl,
+  runCommand,
+  lib,
+}:
+let
+  sourceDerivations = {
+    "src" = fetchFromGitHub {
+      owner = "webrtc-sdk";
+      repo = "webrtc";
+      rev = "7ec4c03bff7f7ce117dc9100f081d031d946d995"; # m125_release
+      hash = "sha256-LUncFGXaYVUrBdWD1Xx3MZe5GzmjJuJtDebAMb8jass=";
+    };
+    "src/base" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/src/base";
+      rev = "738cf0c976fd3d07c5f1853f050594c5295300d8";
+      hash = "sha256-Hw0cXws+0M2UcvcnJZGkUtH28ZEDfxNl0e8ngWlAZnA=";
+    };
+    "src/build" = fetchFromGitHub {
+      owner = "webrtc-sdk";
+      repo = "build";
+      rev = "6978bac6466311e4bee4c7a9fd395faa939e0fcd";
+      hash = "sha256-mPjb7/TTJ7/oatBdIRGhSsacjbyu5ZilUgyplAtji1s=";
+    };
+    "src/buildtools" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/src/buildtools";
+      rev = "5eb927f0a922dfacf10cfa84ee76f39dcf2a7311";
+      hash = "sha256-OS9k7sDzAVH+NU9P4ilKJavkiov/1qq1fG5AWq9kH/Y=";
+    };
+    "src/testing" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/src/testing";
+      rev = "d6e731571c33f30e5dc46f54c69e6d432566e55c";
+      hash = "sha256-VisK7NDR/xDC3OM7LD9Gyo58rs1GE37i7QRYC/Kk12k=";
+    };
+    "src/third_party" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/src/third_party";
+      rev = "f36c4b6e56aaa94606c87fa0c3f7cbdbb5c70546";
+      hash = "sha256-TdB8qMcmXO3xgYyJkHHwn/8tVg1pFMlrNABpQQ80bOY=";
+    };
+    "src/third_party/clang-format/script" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/clang/tools/clang-format";
+      rev = "3c0acd2d4e73dd911309d9e970ba09d58bf23a62";
+      hash = "sha256-whD8isX2ZhLrFzdxHhFP1S/sZDRgyrzLFaVd7OEFqYo=";
+    };
+    "src/third_party/libc++/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx";
+      rev = "e3b94d0e5b86883fd77696bf10dc33ba250ba99b";
+      hash = "sha256-ocJqlENHw19VpkFxKwHneGw3aNh56nt+/JeopxLj2M8=";
+    };
+    "src/third_party/libc++abi/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxxabi";
+      rev = "932d253fedb390a08b17ec3a92469a4553934a6a";
+      hash = "sha256-qBupfCAnSNpvqcwFycQEi5v6TBAH5LdQI5YcLeQD2y8=";
+    };
+    "src/third_party/libunwind/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libunwind";
+      rev = "419b03c0b8f20d6da9ddcb0d661a94a97cdd7dad";
+      hash = "sha256-/4/Trextb4F9UMDVrg4uG9QZl6S0H9FiwnL+2S5+ZpE=";
+    };
+    "src/third_party/boringssl/src" = fetchFromGitiles {
+      url = "https://boringssl.googlesource.com/boringssl";
+      rev = "f94f3ed3965ea033001fb9ae006084eee408b861";
+      hash = "sha256-baa6L6h1zVBHen/YFVtF+9fhYWC4ZGbMUSO8L1VNFjw=";
+    };
+    "src/third_party/breakpad/breakpad" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/breakpad/breakpad";
+      rev = "76788faa4ef163081f82273bfca7fae8a734b971";
+      hash = "sha256-qAIXZ1jZous0Un0jVkOQ66nA2525NziV3Lbso2/+Z1Y=";
+    };
+    "src/third_party/catapult" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/catapult";
+      rev = "88367fd8c736a2601fc183920c9ffe9ac2ec32ac";
+      hash = "sha256-uqtyxO7Ge3egBsYmwcRGiV1lqm4iYVHrqYfDz7r6Byo=";
+    };
+    "src/third_party/ced/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/compact_enc_det";
+      rev = "ba412eaaacd3186085babcd901679a48863c7dd5";
+      hash = "sha256-ySG74Rj2i2c/PltEgHVEDq+N8yd9gZmxNktc56zIUiY=";
+    };
+    "src/third_party/colorama/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/colorama";
+      rev = "3de9f013df4b470069d03d250224062e8cf15c49";
+      hash = "sha256-6ZTdPYSHdQOLYMSnE+Tp7PgsVTs3U2awGu9Qb4Rg/tk=";
+    };
+    "src/third_party/crc32c/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/crc32c";
+      rev = "fa5ade41ee480003d9c5af6f43567ba22e4e17e6";
+      hash = "sha256-urg0bmnfMfHagLPELp4WrNCz1gBZ6DFOWpDue1KsMtc=";
+    };
+    "src/third_party/depot_tools" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/tools/depot_tools";
+      rev = "495b23b39aaba2ca3b55dd27cadc523f1cb17ee6";
+      hash = "sha256-RguGUaIpxtxrY+LksFmeNbZuitZpB6O9HJc1c4TMXeQ=";
+    };
+    "src/third_party/ffmpeg" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/third_party/ffmpeg";
+      rev = "901248a373cbbe7af68fb92faf3be7d4f679150d";
+      hash = "sha256-6+Sc5DsPaKW68PSUS4jlpzRXjPhEN7LFQATVVL9Xhfo=";
+    };
+    "src/third_party/flatbuffers/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/flatbuffers";
+      rev = "bcb9ef187628fe07514e57756d05e6a6296f7dc5";
+      hash = "sha256-LecJwLDG6szZZ/UOCFD+MDqH3NKawn0sdEwgnMt8wMM=";
+    };
+    "src/third_party/grpc/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/grpc/grpc";
+      rev = "822dab21d9995c5cf942476b35ca12a1aa9d2737";
+      hash = "sha256-64JEVCx/PCM0dvv7kAQvSjLc0QbRAZVBDzwD/FAV6T8=";
+    };
+    "src/third_party/fontconfig/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/fontconfig";
+      rev = "14d466b30a8ab4a9d789977ed94f2c30e7209267";
+      hash = "sha256-W5WIgC6A52kY4fNkbsDEa0o+dfd97Rl5NKfgnIRpI00=";
+    };
+    "src/third_party/freetype/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/src/third_party/freetype2";
+      rev = "b3a6a20a805366e0bc7044d1402d04c53f9c1660";
+      hash = "sha256-XBHWUw28bsCpwUXb+faE36DRdujuKiWoJ+dEmUk07s4=";
+    };
+    "src/third_party/harfbuzz-ng/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/harfbuzz/harfbuzz";
+      rev = "155015f4bec434ecc2f94621665844218f05ce51";
+      hash = "sha256-VAan6P8PHSq8RsGE4YbI/wCfFAhzl3nJMt0cQBYi5Ls=";
+    };
+    "src/third_party/google_benchmark/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/benchmark";
+      rev = "344117638c8ff7e239044fd0fa7085839fc03021";
+      hash = "sha256-gztnxui9Fe/FTieMjdvfJjWHjkImtlsHn6fM1FruyME=";
+    };
+    "src/third_party/gtest-parallel" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/gtest-parallel";
+      rev = "96f4f904922f9bf66689e749c40f314845baaac8";
+      hash = "sha256-VUuk5tBTh+aU2dxVWUF1FePWlKUJaWSiGSXk/J5zgHw=";
+    };
+    "src/third_party/googletest/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/googletest";
+      rev = "5197b1a8e6a1ef9f214f4aa537b0be17cbf91946";
+      hash = "sha256-JCIJrjN/hH6oAgvJRuv3aJA+z6Qe7yefyRbAhP5bZDc=";
+    };
+    "src/third_party/icu" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/deps/icu";
+      rev = "364118a1d9da24bb5b770ac3d762ac144d6da5a4";
+      hash = "sha256-frsmwYMiFixEULsE91x5+p98DvkyC0s0fNupqjoRnvg=";
+    };
+    "src/third_party/jsoncpp/source" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/open-source-parsers/jsoncpp";
+      rev = "42e892d96e47b1f6e29844cc705e148ec4856448";
+      hash = "sha256-bSLNcoYBz3QCt5VuTR056V9mU2PmBuYBa0W6hFg2m8Q=";
+    };
+    "src/third_party/libFuzzer/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/llvm/llvm-project/compiler-rt/lib/fuzzer";
+      rev = "758bd21f103a501b362b1ca46fa8fcb692eaa303";
+      hash = "sha256-T0dO+1A0r6kLFoleMkY8heu80biPntCpvA6YfqA7b+E=";
+    };
+    "src/third_party/fuzztest/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/fuzztest";
+      rev = "65354bf09a2479945b4683c42948695d4f2f7c07";
+      hash = "sha256-8w4yIW15VamdjevMO27NYuf+GFu5AvHSooDZH0PbS6s=";
+    };
+    "src/third_party/libjpeg_turbo" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/deps/libjpeg_turbo";
+      rev = "9b894306ec3b28cea46e84c32b56773a98c483da";
+      hash = "sha256-+t75ZAdOXc7Nd1/8zEQLX+enZb8upqIQuR6qzb9z7Cg=";
+    };
+    "src/third_party/libsrtp" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/deps/libsrtp";
+      rev = "7a7e64c8b5a632f55929cb3bb7d3e6fb48c3205a";
+      hash = "sha256-XOPiDAOHpWyCiXI+fi1CAie0Zaj4v14m9Kc8+jbzpUY=";
+    };
+    "src/third_party/dav1d/libdav1d" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/videolan/dav1d";
+      rev = "006ca01d387ac6652825d6cce1a57b2de67dbf8d";
+      hash = "sha256-AA2bcrsW1xFspyl5TqYUJeAwKM06rWTNtXr/uMVIJmw=";
+    };
+    "src/third_party/libaom/source/libaom" = fetchFromGitiles {
+      url = "https://aomedia.googlesource.com/aom";
+      rev = "eefd5585a0c4c204fcf7d30065f8c2ca35c38a82";
+      hash = "sha256-0tLfbfYyCnG89DHNIoYoiitN9pFFcuX/Nymp3Q5xhBg=";
+    };
+    "src/third_party/perfetto" = fetchFromGitiles {
+      url = "https://android.googlesource.com/platform/external/perfetto";
+      rev = "0e424063dbfd4e7400aa3b77b5c00b84893aee7b";
+      hash = "sha256-fS0P/0Bqn9EreCPRC65Lw7/zcpMquo7RDf6dmbMDa74=";
+    };
+    "src/third_party/protobuf-javascript/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/protocolbuffers/protobuf-javascript";
+      rev = "e34549db516f8712f678fcd4bc411613b5cc5295";
+      hash = "sha256-TmP6xftUVTD7yML7UEM/DB8bcsL5RFlKPyCpcboD86U=";
+    };
+    "src/third_party/libvpx/source/libvpx" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/webm/libvpx";
+      rev = "8762f5efb2917765316a198e6713f0bc93b07c9b";
+      hash = "sha256-JbeUgX8Dx8GkQ79ElZHK8gYI3/4o6NrTV+HpblwLvIE=";
+    };
+    "src/third_party/libyuv" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/libyuv/libyuv";
+      rev = "a6a2ec654b1be1166b376476a7555c89eca0c275";
+      hash = "sha256-hD5B9fPNwf8M98iS/PYeUJgJxtBvvf2BrrlnBNYXSg0=";
+    };
+    "src/third_party/lss" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/linux-syscall-support";
+      rev = "ce877209e11aa69dcfffbd53ef90ea1d07136521";
+      hash = "sha256-hE8uZf9Fst66qJkoVYChiB8G41ie+k9M4X0W+5JUSdw=";
+    };
+    "src/third_party/instrumented_libs" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/third_party/instrumented_libraries";
+      rev = "0172d67d98df2d30bd2241959d0e9569ada25abe";
+      hash = "sha256-SGEB74fK9e0WWT77ZNISE9fVlXGGPvZMBUsQ3XD+DsA=";
+    };
+    "src/third_party/nasm" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/deps/nasm";
+      rev = "f477acb1049f5e043904b87b825c5915084a9a29";
+      hash = "sha256-SiRXHsUlWXtH6dbDjDjqNAm105ibEB3jOfNtQAM4CaY=";
+    };
+    "src/third_party/openh264/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/cisco/openh264";
+      rev = "09a4f3ec842a8932341b195c5b01e141c8a16eb7";
+      hash = "sha256-J7Eqe2QevZh1xfap19W8AVCcwfRu7ztknnbKFJUAH1c=";
+    };
+    "src/third_party/re2/src" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/external/github.com/google/re2";
+      rev = "b84e3ff189980a33d4a0c6fa1201aa0b3b8bab4a";
+      hash = "sha256-FA9wAZwqLx7oCPf+qeqZ7hhpJ9J2DSMXZAWllHIX/qY=";
+    };
+    "src/tools" = fetchFromGitiles {
+      url = "https://chromium.googlesource.com/chromium/src/tools";
+      rev = "0d6482e40fe26f738a0acf6ebb0f797358538b48";
+      hash = "sha256-19oGSveaPv8X+/hsevUe4fFtLASC3HfPtbnw3TWpYQk=";
+    };
+  };
+  namedSourceDerivations = builtins.mapAttrs (
+    path: drv:
+    drv.overrideAttrs {
+      name = lib.strings.sanitizeDerivationName path;
+    }
+  ) sourceDerivations;
+in
+runCommand "combined-sources" { } (
+  lib.concatLines (
+    [ "mkdir $out" ]
+    ++ (lib.mapAttrsToList (path: drv: ''
+      mkdir -p $out/${path}
+      cp --no-preserve=mode --reflink=auto -rfT ${drv} $out/${path}
+    '') namedSourceDerivations)
+  )
+)


### PR DESCRIPTION
Three changes to unbreak the macOS build of the nix package for `zed-editor` as well as building zed inside of the nix devShell:
  - updating `rust-overlay` to a version w/1.86
  - updating `livekit-libwebrtc` as a stopgap until NixOS/nixpkgs#396016 is merged (h/t: @WeetHet)
  - dropping `-all_load` to fix linker errors when using `ld64` compatible linkers that aren't `ld_prime`

The commits within have more details but I think the last one is the only interesting/contentious change so I've pasted its description below.

I've also got some other improvements/"fixes" that I'll open followup PRs about but I believe this PR should be enough to fix the macOS nix build 🤞. Planned follow ups:
  - having nix devShell builds use `ld` on the host system if present and suggesting that users install it in `shellHook`
     + @P1n3appl3's testing showed that when linking dev builds of `zed-editor`, `ld_prime` is significantly faster (~1.2s) than the open source `ld64` (~4s) as well as `lld` (~3.2s)
  - having the devShell hook tell users that don't have an Xcode installation to pass `--features gpui/runtime_shaders` or to install Xcode

---

from 01af0a639ab738062c56346eac67d29cd3a518e3:

With the `-all_load` linker flag, we get errors like this when linking the zed-editor binary (both in the nix devShell and when building the zed-editor nix package):
```plain
duplicate symbol '___aarch64_have_lse_atomics' in:
    /nix/store/mg65rms59mr0jwn3pg0qzvsn8r27cpb6-rust-std-1.85.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-a94b6215175cddb2.rlib(ad3ac4dcdcbf93cb-aarch64.o)
    /nix/store/5qawh29l2yhzj0l9a7ybbb3nzwkpis4a-clang-wrapper-19.1.7/resource-root/lib/darwin/libclang_rt.osx.a(aarch64.c.o)
duplicate symbol '__aarch64_cas1_relax' in:
    /nix/store/mg65rms59mr0jwn3pg0qzvsn8r27cpb6-rust-std-1.85.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-a94b6215175cddb2.rlib(1dfec86f22ed8170-lse_cas1_relax.o)
    /nix/store/5qawh29l2yhzj0l9a7ybbb3nzwkpis4a-clang-wrapper-19.1.7/resource-root/lib/darwin/libclang_rt.osx.a(outline_atomic_cas1_1.S.o)
duplicate symbol '__aarch64_cas1_acq' in:
    /nix/store/mg65rms59mr0jwn3pg0qzvsn8r27cpb6-rust-std-1.85.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-a94b6215175cddb2.rlib(1dfec86f22ed8170-lse_cas1_acq.o)
    /nix/store/5qawh29l2yhzj0l9a7ybbb3nzwkpis4a-clang-wrapper-19.1.7/resource-root/lib/darwin/libclang_rt.osx.a(outline_atomic_cas1_2.S.o)
<snipped...>
duplicate symbol '__aarch64_ldset8_acq_rel' in:
    /nix/store/mg65rms59mr0jwn3pg0qzvsn8r27cpb6-rust-std-1.85.1-aarch64-apple-darwin/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-a94b6215175cddb2.rlib(1dfec86f22ed8170-lse_ldset8_acq_rel.o)
    /nix/store/5qawh29l2yhzj0l9a7ybbb3nzwkpis4a-clang-wrapper-19.1.7/resource-root/lib/darwin/libclang_rt.osx.a(outline_atomic_ldset8_4.S.o)
ld: 148 duplicate symbols for architecture arm64
```

> [!TIP]
> To get the final linker invocation (such that you can run it yourself) use:
> ```bash
> RUSTC_LOG=rustc_codegen_ssa::back::link=info cargo rustc -p zed -- \
>   -C save-temps=true \
>   -C link-arg=-save-temps \
>   -C link-arg=-v
> ```
>
> `-C save-temps` instructs `rustc` to persist its temporary files (i.e. intermediary `.o` files not in `$TARGET_DIR`)
>
> `-C link-arg=-save-temps` instructs the linker driver (clang) to persist its temporary files (i.e. response file fed to the linker)
>
> `-C link-arg=v` tells the linker driver (clang) to show us the linker invocation
>
> `RUSTC_LOG=rustc_codegen_ssa::back::link=info` is how we get rustc to show us stdout/stderr from the linker driver (better ways to do this are not yet in stable rustc IIUC)

Inspecting the final linker invocation reveals that the linker is being passed both:
  - `<rust install>/lib/rustlib/aarch64-apple-darwin/lib/libcompiler_builtins-<hash>.rlib`
  - `-lclang_rt.osx`

`-lclang_rt.osx` resolves to `libclang_rt.osx.a` within clang's resource root
  - when using a toolchain from nixpkgs this lives at the path in the error message above
  -  when using a toolchain from Xcode this comes from within the Xcode toolchains directory
     + look within the path `clang -print-resource-dir` prints
     + or run something like `clang -v -xc - <<<"int main() {}"` and inspect the resulting linker invocation's args to find it, should be one of the last args

Comparing `libclang_rt.osx.a` from the Xcode toolchain and from nixpkgs does not yield any answers; both have these atomic intrinsics as regular symbols in the text section (not weak).

`libcompiler_builtins.rlib` is also not at fault here – the nix-supplied version (via `rust-overlay`) does actually come from rust-lang.org and is identical to what's used outside of nix. This `rlib` is meant to have these symbols (IIUC, because LLVM may emit calls to these intrinsics during codegen) and `rustc` passes this rlib to the linker along with `libstd` and its other dependencies.

The issue is the combination of the `-all_load` and `-lclang_rt.osx` flags: `-all_load` instructs the linker to use all symbols from static archives passed to the linker and `-lclang_rt.osx` asks the linker to include `libclang_rt.osx.a`.

Both of these are unusual:
  - `-all_load` is specified for the zed build by `.cargo/config.toml`
  - `-lclang_rt.osx` is specified `webrtc-sys`'s `build.rs` here:
    + https://github.com/livekit/rust-sdks/blob/rust-sdks/webrtc-sys%400.3.7/webrtc-sys/build.rs#L253-L260

Both of these flags are required to hit this issue.

`rustc` passes `-nodefaultlibs` to the linker driver (`clang`) which disables its default behavior of passing `libclangrt.osx.a` to the linker – if not for `webrtc-sys`, `libclang_rt.osx.a` would not be linked in and `-all_load` would not result in us having duplicate symbol issues.

> [!WARNING]
> So why did folks using an Xcode provided toolchain not run into this issue?
>
> It appears that this is a bug in `ld_prime` (the closed-source `ld64` rewrite that's part of Apple's `cctools`).
>
> `-all_load` + `libcompiler_builtins-<hash>.rlib` + `libclang_rt.osx.a` _should_ (AIUI) result in duplicate symbol errors and when using other `ld64`-compatible linkers it does; all of the following yield the duplicate symbol error:
>   - modern `ld` from Xcode with the `-ld_classic` flag
>   - `ld` from cctools in nixpkgs (built from https://github.com/apple-oss-distributions/cctools)
>   - `lld` (from LLVM; tested v19.1.7)
>
> Unfortunately since `ld_prime` is not open source it's difficult to confirm that this really is a bug and not purposeful but passing `-why_load` to the linker provides some insight into the linker's thought process.
>
> `ld_prime` says that `libclang_rt.osx.a` is pulled in via another symbol (`chk_stack` IIRC) that a previous item on the command line required; perhaps this causes `ld_prime` to (incorrectly) use its normal (not `-all_load`) behavior for that one static archive...

To "fix" this issue we have two options: remove `-all_load` or remove `-lclang_rt.osx`.

On advice from @P1n3appl3, this PR does the former: it's not clear whether `-all_load` is still required in the build and this is also the easier option (doesn't require patching `webrtc-sys`).

---

Release Notes:

- N/A