### PR TITLE
debugger_ui: Don't `.unwrap` debug panel access

### DIFF
--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -49,80 +49,80 @@ pub fn init(cx: &mut App) {
                     workspace.toggle_panel_focus::<DebugPanel>(window, cx);
                 })
                 .register_action(|workspace, _: &Pause, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.pause_thread(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.pause_thread(cx))
+                        }
                     }
                 })
                 .register_action(|workspace, _: &Restart, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.restart_session(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.restart_session(cx))
+                        }
                     }
                 })
                 .register_action(|workspace, _: &StepInto, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.step_in(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.step_in(cx))
+                        }
                     }
                 })
                 .register_action(|workspace, _: &StepOver, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.step_over(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.step_over(cx))
+                        }
                     }
                 })
                 .register_action(|workspace, _: &StepBack, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.step_back(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.step_back(cx))
+                        }
                     }
                 })
                 .register_action(|workspace, _: &Stop, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.stop_thread(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.stop_thread(cx))
+                        }
                     }
                 })
                 .register_action(|workspace, _: &ToggleIgnoreBreakpoints, _, cx| {
-                    let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-
-                    if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                        panel
-                            .active_session(cx)
-                            .and_then(|session| session.read(cx).mode().as_running().cloned())
-                    }) {
-                        active_item.update(cx, |item, cx| item.toggle_ignore_breakpoints(cx))
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session(cx)
+                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                        }) {
+                            active_item.update(cx, |item, cx| item.toggle_ignore_breakpoints(cx))
+                        }
                     }
                 })
                 .register_action(
@@ -136,19 +136,20 @@ pub fn init(cx: &mut App) {
                 )
                 .register_action(
                     |workspace: &mut Workspace, _: &CreateDebuggingSession, window, cx| {
-                        let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
-                        let weak_panel = debug_panel.downgrade();
-                        let weak_workspace = cx.weak_entity();
+                        if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                            let weak_panel = debug_panel.downgrade();
+                            let weak_workspace = cx.weak_entity();
 
-                        workspace.toggle_modal(window, cx, |window, cx| {
-                            NewSessionModal::new(
-                                debug_panel.read(cx).past_debug_definition.clone(),
-                                weak_panel,
-                                weak_workspace,
-                                window,
-                                cx,
-                            )
-                        });
+                            workspace.toggle_modal(window, cx, |window, cx| {
+                                NewSessionModal::new(
+                                    debug_panel.read(cx).past_debug_definition.clone(),
+                                    weak_panel,
+                                    weak_workspace,
+                                    window,
+                                    cx,
+                                )
+                            });
+                        }
                     },
                 );
         })


### PR DESCRIPTION
This PR removes replaces the `.unwrap`s when accessing the debug panel with `if let Some`s.

These `.unwrap`s are not locally verifiable, and thus are not safe.

Release Notes:

- N/A
