### PR TITLE
telemetry_events: Rename `AssistantEvent` to `AssistantEventData`

### DIFF
--- a/crates/agent/src/buffer_codegen.rs
+++ b/crates/agent/src/buffer_codegen.rs
@@ -28,7 +28,7 @@ use std::{
     time::Instant,
 };
 use streaming_diff::{CharOperation, LineDiff, LineOperation, StreamingDiff};
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 
 pub struct BufferCodegen {
     alternatives: Vec<Entity<CodegenAlternative>>,
@@ -601,7 +601,7 @@ impl CodegenAlternative {
 
                         let error_message = result.as_ref().err().map(|error| error.to_string());
                         report_assistant_event(
-                            AssistantEvent {
+                            AssistantEventData {
                                 conversation_id: None,
                                 message_id,
                                 kind: AssistantKind::Inline,

--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -31,7 +31,7 @@ use project::LspAction;
 use project::{CodeAction, ProjectTransaction};
 use prompt_store::PromptBuilder;
 use settings::{Settings, SettingsStore};
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use terminal_view::{TerminalView, terminal_panel::TerminalPanel};
 use text::{OffsetRangeExt, ToPoint as _};
 use ui::prelude::*;
@@ -402,7 +402,7 @@ impl InlineAssistant {
             codegen_ranges.push(anchor_range);
 
             if let Some(model) = LanguageModelRegistry::read_global(cx).inline_assistant_model() {
-                self.telemetry.report_assistant_event(AssistantEvent {
+                self.telemetry.report_assistant_event(AssistantEventData {
                     conversation_id: None,
                     kind: AssistantKind::Inline,
                     phase: AssistantPhase::Invoked,
@@ -987,7 +987,7 @@ impl InlineAssistant {
                         .map(|language| language.name())
                 });
                 report_assistant_event(
-                    AssistantEvent {
+                    AssistantEventData {
                         conversation_id: None,
                         kind: AssistantKind::Inline,
                         message_id,

--- a/crates/agent/src/terminal_codegen.rs
+++ b/crates/agent/src/terminal_codegen.rs
@@ -6,7 +6,7 @@ use language_model::{
     ConfiguredModel, LanguageModelRegistry, LanguageModelRequest, report_assistant_event,
 };
 use std::{sync::Arc, time::Instant};
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use terminal::Terminal;
 
 pub struct TerminalCodegen {
@@ -79,7 +79,7 @@ impl TerminalCodegen {
 
                         let error_message = result.as_ref().err().map(|error| error.to_string());
                         report_assistant_event(
-                            AssistantEvent {
+                            AssistantEventData {
                                 conversation_id: None,
                                 kind: AssistantKind::InlineTerminal,
                                 message_id,

--- a/crates/agent/src/terminal_inline_assistant.rs
+++ b/crates/agent/src/terminal_inline_assistant.rs
@@ -18,7 +18,7 @@ use language_model::{
 };
 use prompt_store::PromptBuilder;
 use std::sync::Arc;
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use terminal_view::TerminalView;
 use ui::prelude::*;
 use util::ResultExt;
@@ -292,7 +292,7 @@ impl TerminalInlineAssistant {
                 let codegen = assist.codegen.read(cx);
                 let executor = cx.background_executor().clone();
                 report_assistant_event(
-                    AssistantEvent {
+                    AssistantEventData {
                         conversation_id: None,
                         kind: AssistantKind::InlineTerminal,
                         message_id: codegen.message_id.clone(),

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -57,7 +57,7 @@ use std::{
     time::{Duration, Instant},
 };
 use streaming_diff::{CharOperation, LineDiff, LineOperation, StreamingDiff};
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use terminal_view::terminal_panel::TerminalPanel;
 use text::{OffsetRangeExt, ToPoint as _};
 use theme::ThemeSettings;
@@ -315,7 +315,7 @@ impl InlineAssistant {
             if let Some(ConfiguredModel { model, .. }) =
                 LanguageModelRegistry::read_global(cx).default_model()
             {
-                self.telemetry.report_assistant_event(AssistantEvent {
+                self.telemetry.report_assistant_event(AssistantEventData {
                     conversation_id: None,
                     kind: AssistantKind::Inline,
                     phase: AssistantPhase::Invoked,
@@ -892,7 +892,7 @@ impl InlineAssistant {
                         .map(|language| language.name())
                 });
                 report_assistant_event(
-                    AssistantEvent {
+                    AssistantEventData {
                         conversation_id: None,
                         kind: AssistantKind::Inline,
                         message_id,
@@ -3148,7 +3148,7 @@ impl CodegenAlternative {
 
                         let error_message = result.as_ref().err().map(|error| error.to_string());
                         report_assistant_event(
-                            AssistantEvent {
+                            AssistantEventData {
                                 conversation_id: None,
                                 message_id,
                                 kind: AssistantKind::Inline,

--- a/crates/assistant/src/terminal_inline_assistant.rs
+++ b/crates/assistant/src/terminal_inline_assistant.rs
@@ -27,7 +27,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use terminal::Terminal;
 use terminal_view::TerminalView;
 use theme::ThemeSettings;
@@ -324,7 +324,7 @@ impl TerminalInlineAssistant {
                 let codegen = assist.codegen.read(cx);
                 let executor = cx.background_executor().clone();
                 report_assistant_event(
-                    AssistantEvent {
+                    AssistantEventData {
                         conversation_id: None,
                         kind: AssistantKind::InlineTerminal,
                         message_id: codegen.message_id.clone(),
@@ -1183,7 +1183,7 @@ impl Codegen {
 
                         let error_message = result.as_ref().err().map(|error| error.to_string());
                         report_assistant_event(
-                            AssistantEvent {
+                            AssistantEventData {
                                 conversation_id: None,
                                 kind: AssistantKind::InlineTerminal,
                                 message_id,

--- a/crates/assistant_context_editor/src/context.rs
+++ b/crates/assistant_context_editor/src/context.rs
@@ -40,7 +40,7 @@ use std::{
     sync::Arc,
     time::{Duration, Instant},
 };
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use text::{BufferSnapshot, ToPoint};
 use ui::IconName;
 use util::{ResultExt, TryFutureExt, post_inc};
@@ -2498,7 +2498,7 @@ impl AssistantContext {
                         .language()
                         .map(|language| language.name());
                     report_assistant_event(
-                        AssistantEvent {
+                        AssistantEventData {
                             conversation_id: Some(this.id.0.clone()),
                             kind: AssistantKind::Panel,
                             phase: AssistantPhase::Response,

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -17,7 +17,7 @@ use std::io::Write;
 use std::sync::LazyLock;
 use std::time::Instant;
 use std::{env, mem, path::PathBuf, sync::Arc, time::Duration};
-use telemetry_events::{AssistantEvent, AssistantPhase, Event, EventRequestBody, EventWrapper};
+use telemetry_events::{AssistantEventData, AssistantPhase, Event, EventRequestBody, EventWrapper};
 use util::{ResultExt, TryFutureExt};
 use worktree::{UpdatedEntriesSet, WorktreeId};
 
@@ -329,7 +329,7 @@ impl Telemetry {
         drop(state);
     }
 
-    pub fn report_assistant_event(self: &Arc<Self>, event: AssistantEvent) {
+    pub fn report_assistant_event(self: &Arc<Self>, event: AssistantEventData) {
         let event_type = match event.phase {
             AssistantPhase::Response => "Assistant Responded",
             AssistantPhase::Invoked => "Assistant Invoked",

--- a/crates/language_model/src/telemetry.rs
+++ b/crates/language_model/src/telemetry.rs
@@ -5,13 +5,13 @@ use gpui::BackgroundExecutor;
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use std::env;
 use std::sync::Arc;
-use telemetry_events::{AssistantEvent, AssistantKind, AssistantPhase};
+use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use util::ResultExt;
 
 pub const ANTHROPIC_PROVIDER_ID: &str = "anthropic";
 
 pub fn report_assistant_event(
-    event: AssistantEvent,
+    event: AssistantEventData,
     telemetry: Option<Arc<Telemetry>>,
     client: Arc<dyn HttpClient>,
     model_api_key: Option<String>,
@@ -32,7 +32,7 @@ pub fn report_assistant_event(
 }
 
 async fn report_anthropic_event(
-    event: AssistantEvent,
+    event: AssistantEventData,
     client: Arc<dyn HttpClient>,
     model_api_key: Option<String>,
 ) -> Result<(), AnthropicError> {

--- a/crates/telemetry_events/src/telemetry_events.rs
+++ b/crates/telemetry_events/src/telemetry_events.rs
@@ -96,7 +96,7 @@ pub enum Event {
     InlineCompletion(InlineCompletionEvent),
     InlineCompletionRating(InlineCompletionRatingEvent),
     Call(CallEvent),
-    Assistant(AssistantEvent),
+    Assistant(AssistantEventData),
     Cpu(CpuEvent),
     Memory(MemoryEvent),
     App(AppEvent),
@@ -162,7 +162,7 @@ pub struct CallEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct AssistantEvent {
+pub struct AssistantEventData {
     /// Unique random identifier for each assistant tab (None for inline assist)
     pub conversation_id: Option<String>,
     /// Server-generated message ID (only supported for some providers)


### PR DESCRIPTION
This PR renames the `AssistantEvent` type to `AssistantEventData`, as it no longer represents the event itself, just the data needed to construct it.

Pulling out of https://github.com/zed-industries/zed/pull/25179.

Release Notes:

- N/A
