### PR TITLE
buffer: Fix broken autoindent when pasting code starting with new line

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2210,7 +2210,12 @@ impl Buffer {
                         original_indent_columns,
                     } = &mode
                     {
-                        original_indent_column = Some(
+                        original_indent_column = Some(if new_text.starts_with('\n') {
+                            indent_size_for_text(
+                                new_text[range_of_insertion_to_indent.clone()].chars(),
+                            )
+                            .len
+                        } else {
                             original_indent_columns
                                 .get(ix)
                                 .copied()
@@ -2220,8 +2225,8 @@ impl Buffer {
                                         new_text[range_of_insertion_to_indent.clone()].chars(),
                                     )
                                     .len
-                                }),
-                        );
+                                })
+                        });
 
                         // Avoid auto-indenting the line after the edit.
                         if new_text[range_of_insertion_to_indent.clone()].ends_with('\n') {


### PR DESCRIPTION
Closes #26907

Currently, in case of new line to find delta, it is comparing old first line indent with new second line indent. This results into incorrect indentation. This PR fixes this delta calculation by passing correct second line indent in that particular case. 

- [X] Add Test

Before:

https://github.com/user-attachments/assets/065deba0-be19-4643-a784-d248a8e7c891

After:

https://github.com/user-attachments/assets/a0037043-4bd8-460f-b8ba-b7da7bdbe1ea

Release Notes:

- Fixed issue where pasting code starting with new line resulted incorrect auto indent.
