### PR TITLE
Update default vim substitute command behavior and add support for 'g' flag

### DIFF
--- a/crates/assistant_tools/src/regex_search_tool.rs
+++ b/crates/assistant_tools/src/regex_search_tool.rs
@@ -96,6 +96,7 @@ impl Tool for RegexSearchTool {
             false,
             false,
             false,
+            false,
             PathMatcher::default(),
             PathMatcher::default(),
             None,

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -34,6 +34,7 @@ static MENTIONS_SEARCH: LazyLock<SearchQuery> = LazyLock::new(|| {
         false,
         false,
         false,
+        false,
         Default::default(),
         Default::default(),
         None,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1535,8 +1535,22 @@ impl SearchableItem for Editor {
         let text = self.buffer.read(cx);
         let text = text.snapshot(cx);
         let mut edits = vec![];
+        let mut last_point: Point = Point::default();
+
         for m in matches {
+            let point = m.start.to_point(&text);
             let text = text.text_for_range(m.clone()).collect::<Vec<_>>();
+
+            // Check if the row for the current match is different from the last
+            // match. If that's not the case and we're still replacing matches
+            // in the same row/line, skip this match if the `one_match_per_line`
+            // option is enabled.
+            if point.row != last_point.row {
+                last_point = point;
+            } else if query.one_match_per_line().is_some_and(|enabled| enabled) {
+                continue;
+            }
+
             let text: Cow<_> = if text.len() == 1 {
                 text.first().cloned().unwrap().into()
             } else {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1535,7 +1535,7 @@ impl SearchableItem for Editor {
         let text = self.buffer.read(cx);
         let text = text.snapshot(cx);
         let mut edits = vec![];
-        let mut last_point: Point = Point::default();
+        let mut last_point: Option<Point> = None;
 
         for m in matches {
             let point = m.start.to_point(&text);
@@ -1545,8 +1545,10 @@ impl SearchableItem for Editor {
             // match. If that's not the case and we're still replacing matches
             // in the same row/line, skip this match if the `one_match_per_line`
             // option is enabled.
-            if point.row != last_point.row {
-                last_point = point;
+            if last_point.is_none() {
+                last_point = Some(point);
+            } else if last_point.is_some() && point.row != last_point.unwrap().row {
+                last_point = Some(point);
             } else if query.one_match_per_line().is_some_and(|enabled| enabled) {
                 continue;
             }

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -71,6 +71,7 @@ pub enum SearchQuery {
         whole_word: bool,
         case_sensitive: bool,
         include_ignored: bool,
+        one_match_per_line: bool,
         inner: SearchInputs,
     },
 }
@@ -116,6 +117,7 @@ impl SearchQuery {
         whole_word: bool,
         case_sensitive: bool,
         include_ignored: bool,
+        one_match_per_line: bool,
         files_to_include: PathMatcher,
         files_to_exclude: PathMatcher,
         buffers: Option<Vec<Entity<Buffer>>>,
@@ -156,6 +158,7 @@ impl SearchQuery {
             case_sensitive,
             include_ignored,
             inner,
+            one_match_per_line,
         })
     }
 
@@ -166,6 +169,7 @@ impl SearchQuery {
                 message.whole_word,
                 message.case_sensitive,
                 message.include_ignored,
+                false,
                 deserialize_path_matches(&message.files_to_include)?,
                 deserialize_path_matches(&message.files_to_exclude)?,
                 None, // search opened only don't need search remote
@@ -457,6 +461,19 @@ impl SearchQuery {
     pub fn as_inner(&self) -> &SearchInputs {
         match self {
             Self::Regex { inner, .. } | Self::Text { inner, .. } => inner,
+        }
+    }
+
+    /// Whether this search should replace only one match per line, instead of
+    /// all matches.
+    /// Returns `None` for text searches, as only regex searches support this
+    /// option.
+    pub fn one_match_per_line(&self) -> Option<bool> {
+        match self {
+            Self::Regex {
+                one_match_per_line, ..
+            } => Some(*one_match_per_line),
+            Self::Text { .. } => None,
         }
     }
 }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1056,6 +1056,21 @@ impl BufferSearchBar {
         }
     }
 
+    pub fn select_first_match(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
+        if let Some(searchable_item) = self.active_searchable_item.as_ref() {
+            if let Some(matches) = self
+                .searchable_items_with_matches
+                .get(&searchable_item.downgrade())
+            {
+                if matches.is_empty() {
+                    return;
+                }
+
+                self.active_match_index = Some(0);
+            }
+        }
+    }
+
     pub fn select_last_match(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(searchable_item) = self.active_searchable_item.as_ref() {
             if let Some(matches) = self

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1421,7 +1421,7 @@ impl BufferSearchBar {
         }
     }
 
-    fn replace_next(&mut self, _: &ReplaceNext, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn replace_next(&mut self, _: &ReplaceNext, window: &mut Window, cx: &mut Context<Self>) {
         let mut should_propagate = true;
         if !self.dismissed && self.active_search.is_some() {
             if let Some(searchable_item) = self.active_searchable_item.as_ref() {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1056,21 +1056,6 @@ impl BufferSearchBar {
         }
     }
 
-    pub fn select_first_match(&mut self, _window: &mut Window, _cx: &mut Context<Self>) {
-        if let Some(searchable_item) = self.active_searchable_item.as_ref() {
-            if let Some(matches) = self
-                .searchable_items_with_matches
-                .get(&searchable_item.downgrade())
-            {
-                if matches.is_empty() {
-                    return;
-                }
-
-                self.active_match_index = Some(0);
-            }
-        }
-    }
-
     pub fn select_last_match(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if let Some(searchable_item) = self.active_searchable_item.as_ref() {
             if let Some(matches) = self
@@ -1246,6 +1231,8 @@ impl BufferSearchBar {
                             self.search_options.contains(SearchOptions::WHOLE_WORD),
                             self.search_options.contains(SearchOptions::CASE_SENSITIVE),
                             false,
+                            self.search_options
+                                .contains(SearchOptions::ONE_MATCH_PER_LINE),
                             Default::default(),
                             Default::default(),
                             None,
@@ -1436,7 +1423,7 @@ impl BufferSearchBar {
         }
     }
 
-    pub fn replace_next(&mut self, _: &ReplaceNext, window: &mut Window, cx: &mut Context<Self>) {
+    fn replace_next(&mut self, _: &ReplaceNext, window: &mut Window, cx: &mut Context<Self>) {
         let mut should_propagate = true;
         if !self.dismissed && self.active_search.is_some() {
             if let Some(searchable_item) = self.active_searchable_item.as_ref() {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1053,6 +1053,8 @@ impl ProjectSearchView {
                 self.search_options.contains(SearchOptions::WHOLE_WORD),
                 self.search_options.contains(SearchOptions::CASE_SENSITIVE),
                 self.search_options.contains(SearchOptions::INCLUDE_IGNORED),
+                self.search_options
+                    .contains(SearchOptions::ONE_MATCH_PER_LINE),
                 included_files,
                 excluded_files,
                 open_buffers,

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -47,6 +47,7 @@ bitflags! {
         const CASE_SENSITIVE = 0b010;
         const INCLUDE_IGNORED = 0b100;
         const REGEX = 0b1000;
+        const ONE_MATCH_PER_LINE = 0b100000;
         /// If set, reverse direction when finding the active match
         const BACKWARDS = 0b10000;
     }

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -445,6 +445,8 @@ impl Vim {
         }
         let vim = cx.entity().clone();
         pane.update(cx, |pane, cx| {
+            let mut options = SearchOptions::REGEX;
+
             let Some(search_bar) = pane.toolbar().read(cx).item_of_type::<BufferSearchBar>() else {
                 return;
             };
@@ -453,7 +455,6 @@ impl Vim {
                     return None;
                 }
 
-                let mut options = SearchOptions::REGEX;
                 if replacement.is_case_sensitive {
                     options.set(SearchOptions::CASE_SENSITIVE, true)
                 }
@@ -503,6 +504,13 @@ impl Vim {
                             cx,
                         )
                     });
+
+                    // Disable the `ONE_MATCH_PER_LINE` search option when finished, as
+                    // this is not properly supported outside of vim mode, and
+                    // not disabling it makes the "Replace All Matches" button
+                    // actually replace only the first match on each line.
+                    options.set(SearchOptions::ONE_MATCH_PER_LINE, false);
+                    search_bar.set_search_options(options, cx);
                 })?;
                 anyhow::Ok(())
             })

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -582,9 +582,10 @@ impl Replacement {
 
         for c in flags.chars() {
             match c {
-                'g' | 'I' => replacement.should_replace_all = true,
+                'g' => replacement.should_replace_all = true,
                 'c' | 'n' => replacement.should_replace_all = false,
                 'i' => replacement.is_case_sensitive = false,
+                'I' => replacement.is_case_sensitive = true,
                 _ => {}
             }
         }

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -468,6 +468,11 @@ impl Vim {
                         search_bar.is_contains_uppercase(&search),
                     );
                 }
+
+                if !replacement.should_replace_all {
+                    options.set(SearchOptions::ONE_MATCH_PER_LINE, true);
+                }
+
                 search_bar.set_replacement(Some(&replacement.replacement), cx);
                 Some(search_bar.search(&search, Some(options), window, cx))
             });
@@ -476,13 +481,8 @@ impl Vim {
             cx.spawn_in(window, async move |_, cx| {
                 search.await?;
                 search_bar.update_in(cx, |search_bar, window, cx| {
-                    if replacement.should_replace_all {
-                        search_bar.select_last_match(window, cx);
-                        search_bar.replace_all(&Default::default(), window, cx);
-                    } else {
-                        search_bar.select_first_match(window, cx);
-                        search_bar.replace_next(&Default::default(), window, cx);
-                    }
+                    search_bar.select_last_match(window, cx);
+                    search_bar.replace_all(&Default::default(), window, cx);
 
                     cx.spawn(async move |_, cx| {
                         cx.background_executor()

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -480,16 +480,7 @@ impl Vim {
                         search_bar.select_last_match(window, cx);
                         search_bar.replace_all(&Default::default(), window, cx);
                     } else {
-                        // TODO: Confirm whether we want to have the same
-                        // behaviour as the regular search bar, where the next
-                        // ocurrence, relative to the cursor, is replaced, or if
-                        // we want to have the same behaviour as NeoVim, where
-                        // regardless of the cursor position, the first
-                        // ocurrence in the line is the one that gets replaced.
-                        // For example, for the string "this and this and this",
-                        // if the cursor is in the second "this", then a Zed
-                        // search and replace will replace the second "this",
-                        // while NeoVim would replace the first one.
+                        search_bar.select_first_match(window, cx);
                         search_bar.replace_next(&Default::default(), window, cx);
                     }
 


### PR DESCRIPTION
This Pull Request updates the default behavior of the substitute (`s`) command in vim mode to only replace the next match by default, instead of all, and replace all matches only when the `g` flag is provided, making it more similar to NeoVim's behavior.

In order to achieve this, the following changes were introduced:

- Update `BufferSearchBar::replace_next` to be a public method, so it can be called from `Vim::replace_command` .
- Update the `Replacement::parse` to set the `should_replace_all` field to `false` by default, and only set it to `true` if the `'g'` flag is present in the query.
- Add support for when the `Replacement.should_replace_all` is set to `false` in `Vim::replace_command`, so as to have it only replace the next occurrence instead of all occurrences in the line.
- Introduce `BufferSearchBar::select_first_match` so as to activate the first match on the line under the cursor.

Closes #24450 

Release Notes:

- vim: The `:s//` command now defaults to replacing the first match per line (like vim). Use `/g` to replace all matches.