### PR TITLE
agent: Add missing notify in `ThreadHistory::delete_thread`

### DIFF
--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -258,11 +258,7 @@ impl ThreadHistory {
             };
 
             if let Some(task) = task_result.log_err() {
-                cx.spawn(async move |this, cx| {
-                    task.await?;
-                    this.update(cx, |this, cx| this.update_all_entries(cx))
-                })
-                .detach_and_log_err(cx);
+                task.detach_and_log_err(cx);
             };
 
             cx.notify();

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -174,8 +174,9 @@ impl ThreadStore {
             let database = database_future.await.map_err(|err| anyhow!(err))?;
             database.delete_thread(id.clone()).await?;
 
-            this.update(cx, |this, _cx| {
-                this.threads.retain(|thread| thread.id != id)
+            this.update(cx, |this, cx| {
+                this.threads.retain(|thread| thread.id != id);
+                cx.notify();
             })
         })
     }


### PR DESCRIPTION
This would cause the history view not to get refreshed immediately when a thread was deleted 

Release Notes:

- agent: Fixed a bug where the history view wouldn't refresh after deleting a thread
