### PR TITLE
agent: Fix opening configuration view from the model selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,6 +538,7 @@ dependencies = [
  "collections",
  "context_server",
  "editor",
+ "feature_flags",
  "fs",
  "futures 0.3.31",
  "fuzzy",
@@ -576,6 +577,7 @@ dependencies = [
  "uuid",
  "workspace",
  "workspace-hack",
+ "zed_actions",
 ]
 
 [[package]]
@@ -7627,7 +7629,6 @@ dependencies = [
  "picker",
  "proto",
  "ui",
- "workspace",
  "workspace-hack",
  "zed_actions",
 ]

--- a/crates/agent/src/assistant.rs
+++ b/crates/agent/src/assistant.rs
@@ -51,7 +51,6 @@ actions!(
         ToggleProfileSelector,
         RemoveAllContext,
         OpenHistory,
-        OpenConfiguration,
         AddContextServer,
         RemoveSelectedThread,
         Chat,

--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -33,6 +33,7 @@ use ui::{
 use util::ResultExt as _;
 use workspace::Workspace;
 use workspace::dock::{DockPosition, Panel, PanelEvent};
+use zed_actions::agent::OpenConfiguration;
 use zed_actions::assistant::ToggleFocus;
 
 use crate::active_thread::ActiveThread;
@@ -44,7 +45,7 @@ use crate::thread_history::{PastContext, PastThread, ThreadHistory};
 use crate::thread_store::ThreadStore;
 use crate::{
     AgentDiff, InlineAssistant, NewPromptEditor, NewThread, OpenActiveThreadAsMarkdown,
-    OpenAgentDiff, OpenConfiguration, OpenHistory, ThreadEvent, ToggleContextPicker,
+    OpenAgentDiff, OpenHistory, ThreadEvent, ToggleContextPicker,
 };
 
 action_with_deprecated_aliases!(

--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -37,8 +37,8 @@ use text::{OffsetRangeExt, ToPoint as _};
 use ui::prelude::*;
 use util::RangeExt;
 use util::ResultExt;
-use workspace::{ItemHandle, Toast, Workspace, notifications::NotificationId};
-use workspace::{ShowConfiguration, dock::Panel};
+use workspace::{ItemHandle, Toast, Workspace, dock::Panel, notifications::NotificationId};
+use zed_actions::agent::OpenConfiguration;
 
 use crate::AssistantPanel;
 use crate::buffer_codegen::{BufferCodegen, CodegenAlternative, CodegenEvent};
@@ -295,7 +295,7 @@ impl InlineAssistant {
                     if let Some(answer) = answer {
                         if answer == 0 {
                             cx.update(|window, cx| {
-                                window.dispatch_action(Box::new(ShowConfiguration), cx)
+                                window.dispatch_action(Box::new(OpenConfiguration), cx)
                             })
                             .ok();
                         }

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -37,11 +37,11 @@ use ui::{ContextMenu, PopoverMenu, Tooltip, prelude::*};
 use util::{ResultExt, maybe};
 use workspace::DraggedTab;
 use workspace::{
-    DraggedSelection, Pane, ShowConfiguration, ToggleZoom, Workspace,
+    DraggedSelection, Pane, ToggleZoom, Workspace,
     dock::{DockPosition, Panel, PanelEvent},
     pane,
 };
-use zed_actions::assistant::{InlineAssist, OpenPromptLibrary, ToggleFocus};
+use zed_actions::assistant::{InlineAssist, OpenPromptLibrary, ShowConfiguration, ToggleFocus};
 
 pub fn init(cx: &mut App) {
     workspace::FollowableViewRegistry::register::<ContextEditor>(cx);

--- a/crates/assistant_context_editor/Cargo.toml
+++ b/crates/assistant_context_editor/Cargo.toml
@@ -22,6 +22,7 @@ clock.workspace = true
 collections.workspace = true
 context_server.workspace = true
 editor.workspace = true
+feature_flags.workspace = true
 fs.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
@@ -53,8 +54,9 @@ theme.workspace = true
 ui.workspace = true
 util.workspace = true
 uuid.workspace = true
-workspace.workspace = true
 workspace-hack.workspace = true
+workspace.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 language_model = { workspace = true, features = ["test-support"] }

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -18,6 +18,7 @@ use editor::{
     scroll::Autoscroll,
 };
 use editor::{FoldPlaceholder, display_map::CreaseId};
+use feature_flags::{Assistant2FeatureFlag, FeatureFlagAppExt as _};
 use fs::Fs;
 use futures::FutureExt;
 use gpui::{
@@ -56,8 +57,7 @@ use ui::{
 use util::{ResultExt, maybe};
 use workspace::searchable::{Direction, SearchableItemHandle};
 use workspace::{
-    Save, ShowConfiguration, Toast, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView,
-    Workspace,
+    Save, Toast, ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
     item::{self, FollowableItem, Item, ItemHandle},
     notifications::NotificationId,
     pane::{self, SaveIntent},
@@ -2359,7 +2359,19 @@ impl ContextEditor {
                             .on_click({
                                 let focus_handle = self.focus_handle(cx).clone();
                                 move |_event, window, cx| {
-                                    focus_handle.dispatch_action(&ShowConfiguration, window, cx);
+                                    if cx.has_flag::<Assistant2FeatureFlag>() {
+                                        focus_handle.dispatch_action(
+                                            &zed_actions::agent::OpenConfiguration,
+                                            window,
+                                            cx,
+                                        );
+                                    } else {
+                                        focus_handle.dispatch_action(
+                                            &zed_actions::assistant::ShowConfiguration,
+                                            window,
+                                            cx,
+                                        );
+                                    };
                                 }
                             }),
                     )

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -19,6 +19,5 @@ log.workspace = true
 picker.workspace = true
 proto.workspace = true
 ui.workspace = true
-workspace.workspace = true
-zed_actions.workspace = true
 workspace-hack.workspace = true
+zed_actions.workspace = true

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use feature_flags::ZedPro;
+use feature_flags::{Assistant2FeatureFlag, ZedPro};
 use gpui::{
     Action, AnyElement, AnyView, App, Corner, DismissEvent, Entity, EventEmitter, FocusHandle,
     Focusable, Subscription, Task, WeakEntity, action_with_deprecated_aliases,
@@ -11,7 +11,6 @@ use language_model::{
 use picker::{Picker, PickerDelegate};
 use proto::Plan;
 use ui::{ListItem, ListItemSpacing, PopoverMenu, PopoverMenuHandle, PopoverTrigger, prelude::*};
-use workspace::ShowConfiguration;
 
 action_with_deprecated_aliases!(
     assistant,
@@ -522,7 +521,13 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                         .icon_color(Color::Muted)
                         .icon_position(IconPosition::Start)
                         .on_click(|_, window, cx| {
-                            window.dispatch_action(ShowConfiguration.boxed_clone(), cx);
+                            let configure_action = if cx.has_flag::<Assistant2FeatureFlag>() {
+                                zed_actions::agent::OpenConfiguration.boxed_clone()
+                            } else {
+                                zed_actions::assistant::ShowConfiguration.boxed_clone()
+                            };
+
+                            window.dispatch_action(configure_action, cx);
                         }),
                 )
                 .into_any(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -127,8 +127,6 @@ static ZED_WINDOW_POSITION: LazyLock<Option<Point<Pixels>>> = LazyLock::new(|| {
         .and_then(parse_pixel_position_env_var)
 });
 
-actions!(assistant, [ShowConfiguration]);
-
 actions!(
     workspace,
     [

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -183,12 +183,21 @@ pub mod icon_theme_selector {
     impl_actions!(icon_theme_selector, [Toggle]);
 }
 
+pub mod agent {
+    use gpui::actions;
+
+    actions!(agent, [OpenConfiguration]);
+}
+
 pub mod assistant {
     use gpui::{actions, impl_actions};
     use schemars::JsonSchema;
     use serde::Deserialize;
 
-    actions!(assistant, [ToggleFocus, OpenPromptLibrary]);
+    actions!(
+        assistant,
+        [ToggleFocus, OpenPromptLibrary, ShowConfiguration]
+    );
 
     #[derive(Clone, Default, Deserialize, PartialEq, JsonSchema)]
     #[serde(deny_unknown_fields)]


### PR DESCRIPTION
This PR fixes an issue where opening the configuration view from the model selector in the Agent (or inline assist) was not working properly.

Fixes https://github.com/zed-industries/zed/issues/28078.

Release Notes:

- Agent Beta: Fixed an issue where selecting "Configure" in the model selector would not bring up the configuration view.
