### PR TITLE
assistant: Fix `assistant: open prompt library` not opening the prompt library

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -17,7 +17,7 @@ use fs::Fs;
 use gpui::{
     Action, Animation, AnimationExt as _, AnyElement, App, AsyncWindowContext, Corner, Entity,
     EventEmitter, FocusHandle, Focusable, FontWeight, KeyContext, Pixels, Subscription, Task,
-    UpdateGlobal, WeakEntity, action_with_deprecated_aliases, prelude::*, pulsating_between,
+    UpdateGlobal, WeakEntity, prelude::*, pulsating_between,
 };
 use language::LanguageRegistry;
 use language_model::{LanguageModelProviderTosView, LanguageModelRegistry};
@@ -34,7 +34,7 @@ use util::ResultExt as _;
 use workspace::Workspace;
 use workspace::dock::{DockPosition, Panel, PanelEvent};
 use zed_actions::agent::OpenConfiguration;
-use zed_actions::assistant::ToggleFocus;
+use zed_actions::assistant::{OpenPromptLibrary, ToggleFocus};
 
 use crate::active_thread::ActiveThread;
 use crate::assistant_configuration::{AssistantConfiguration, AssistantConfigurationEvent};
@@ -47,12 +47,6 @@ use crate::{
     AgentDiff, InlineAssistant, NewPromptEditor, NewThread, OpenActiveThreadAsMarkdown,
     OpenAgentDiff, OpenHistory, ThreadEvent, ToggleContextPicker,
 };
-
-action_with_deprecated_aliases!(
-    assistant,
-    OpenPromptLibrary,
-    ["assistant::DeployPromptLibrary"]
-);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(

--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -54,7 +54,15 @@ pub fn init(cx: &mut App) {
                 .register_action(ContextEditor::insert_dragged_files)
                 .register_action(AssistantPanel::show_configuration)
                 .register_action(AssistantPanel::create_new_context)
-                .register_action(AssistantPanel::restart_context_servers);
+                .register_action(AssistantPanel::restart_context_servers)
+                .register_action(|workspace, _: &OpenPromptLibrary, window, cx| {
+                    if let Some(panel) = workspace.panel::<AssistantPanel>(cx) {
+                        workspace.focus_panel::<AssistantPanel>(window, cx);
+                        panel.update(cx, |panel, cx| {
+                            panel.deploy_prompt_library(&OpenPromptLibrary, window, cx)
+                        });
+                    }
+                });
         },
     )
     .detach();

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -190,13 +190,16 @@ pub mod agent {
 }
 
 pub mod assistant {
-    use gpui::{actions, impl_actions};
+    use gpui::{action_with_deprecated_aliases, actions, impl_actions};
     use schemars::JsonSchema;
     use serde::Deserialize;
 
-    actions!(
+    actions!(assistant, [ToggleFocus, ShowConfiguration]);
+
+    action_with_deprecated_aliases!(
         assistant,
-        [ToggleFocus, OpenPromptLibrary, ShowConfiguration]
+        OpenPromptLibrary,
+        ["assistant::DeployPromptLibrary"]
     );
 
     #[derive(Clone, Default, Deserialize, PartialEq, JsonSchema)]


### PR DESCRIPTION
This PR fixes the `assistant: open prompt library` action in the command palette not opening the prompt library when the Assistant Panel did not have focus.

Fixes https://github.com/zed-industries/zed/issues/28058.

Release Notes:

- assistant: Fixed `assistant: open prompt library` not opening the prompt library when the Assistant Panel was not focused.
