### PR TITLE
Revert "Add a next_mode to vim::Paste instead of hard-coding Normal mode (#27897)

### DIFF
--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -3,11 +3,10 @@ use gpui::{Context, Window, impl_actions};
 use language::{Bias, SelectionGoal};
 use schemars::JsonSchema;
 use serde::Deserialize;
-use settings::Settings;
 use std::cmp;
 
 use crate::{
-    Vim, VimSettings,
+    Vim,
     motion::{Motion, MotionKind},
     object::Object,
     state::{Mode, Register},
@@ -204,8 +203,7 @@ impl Vim {
                 })
             });
         });
-        let next_mode = VimSettings::get_global(cx).default_mode;
-        self.switch_mode(next_mode, true, window, cx);
+        self.switch_mode(Mode::Normal, true, window, cx);
     }
 
     pub fn replace_with_register_object(


### PR DESCRIPTION
This PR reverts #27897, as it is causing a number of Helix-related tests to fail:

```
     Summary [  84.324s] 1796 tests run: 1793 passed, 3 failed, 0 skipped
        FAIL [   0.434s] vim helix::test::test_delete
        FAIL [   0.562s] vim helix::test::test_delete_character_end_of_buffer
        FAIL [   0.537s] vim helix::test::test_delete_character_end_of_line
```

This reverts commit 9949512b64ab2f472fc3426d853bc9bd0f6d94e2.

Release Notes:

- Community: Reverted https://github.com/zed-industries/zed/pull/27897.
