### PR TITLE
docs: Prefer `bin/rails` when running Rails tests

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -292,7 +292,7 @@ To run tests in your Ruby project, you can set up custom tasks in your local `.z
 [
   {
     "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
-    "command": "bundle exec rails",
+    "command": "bin/rails",
     "args": ["test", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
     "tags": ["ruby-test"]
   }


### PR DESCRIPTION
Using `bin/rails` is the standard way of running tests in Rails. The binstub is automatically added when creating a new app. Additionally, if [Spring](https://github.com/rails/spring) is in use, the installation modifies `bin/rails` to load Spring, so we should prefer that over `bundle exec` to ensure Spring is activated.

cc @vitallium 

Release Notes:

- N/A
