### PR TITLE
agent: Display keybinding to delete Prompt Editor item

### DIFF
--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -558,7 +558,14 @@ impl RenderOnce for PastContext {
                     IconButton::new("delete", IconName::TrashAlt)
                         .shape(IconButtonShape::Square)
                         .icon_size(IconSize::XSmall)
-                        .tooltip(Tooltip::text("Delete Prompt Editor"))
+                        .tooltip(move |window, cx| {
+                            Tooltip::for_action(
+                                "Delete Prompt Editor",
+                                &RemoveSelectedThread,
+                                window,
+                                cx,
+                            )
+                        })
                         .on_click({
                             let assistant_panel = self.assistant_panel.clone();
                             let path = self.context.path.clone();


### PR DESCRIPTION
This PR makes the keybinding to remove Prompt Editor items visible in the icon button tooltip.

Release Notes:

- N/A
