### PR TITLE
Try to improve behavior when agent is stuck

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -15,6 +15,7 @@ Editing code:
 - You may only attempt to fix these up to 3 times. If you have tried 3 times to fix them, and there are still problems remaining, you must not continue trying to fix them, and must instead tell the user that there are problems remaining - and ask if the user would like you to attempt to solve them further.
 - Do not fix errors unrelated to your changes unless the user explicitly asks you to do so.
 - Prefer to move files over recreating them. The move can be followed by minor edits if required.
+- If you seem to be stuck, never go back and "simplify the implementation" by deleting the parts of the implementation you're stuck on and replacing them with comments. If you ever feel the urge to do this, instead immediately stop whatever you're doing (even if the code is in a broken state), report that you are stuck, explain what you're stuck on, and ask the user how to proceed.
 
 Tool use:
 - Make sure to adhere to the tools schema.


### PR DESCRIPTION
Currently, it's pretty common that when the agent gets stuck, it deletes whatever it's stuck on and replaces it with a TODO comment, then cheerfully reports that it has "simpified" the implementation. This is worse than leaving the broken code, because at least a human could take over and try to get it across the finish line.

This system prompt adjustment attempts to make the agent do something more useful when in this situation: report that it's stuck, explain why it's stuck, and ask the user what to do.

Release Notes:

- N/A
