### PR TITLE
Try again to use default mode instead of normal mode after vim paste

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -256,6 +256,7 @@ impl Vim {
             });
 
             vim.copy_selections_content(editor, MotionKind::Exclusive, window, cx);
+            eprintln!("deleting");
             editor.insert("", window, cx);
         });
     }
@@ -371,7 +372,9 @@ mod test {
             Mode::HelixNormal,
         );
 
+        eprintln!("gonna simulate");
         cx.simulate_keystrokes("d");
+        eprintln!("did simulate");
 
         cx.assert_state(
             indoc! {"

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -203,7 +203,8 @@ impl Vim {
                 })
             });
         });
-        self.switch_mode(Mode::Normal, true, window, cx);
+
+        self.switch_mode(self.default_mode(cx), true, window, cx);
     }
 
     pub fn replace_with_register_object(


### PR DESCRIPTION
This was an attempt to understand the test failures caused in #27897 and reverted in #28162.

It's very confusing, though: the failing tests don't call the paste code at all. Eventually I made the test failures disappear (at least, for me locally) by adding three `eprintln!` statements. These are all load-bearing: commenting out any of them causes multiple tests to fail.

I think this has to be an issue in the test harness, but I haven't had the time to look into it.

@ConradIrwin 

Release Notes:

- N/A
