### PR TITLE
lsp_store: Preserve environment variables from ExtensionLspAdapter

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -424,6 +424,8 @@ impl LocalLspStore {
             let mut binary = binary_result?;
             let mut shell_env = delegate.shell_env().await;
 
+            shell_env.extend(binary.env.unwrap_or_default());
+
             if let Some(settings) = settings {
                 if let Some(arguments) = settings.arguments {
                     binary.arguments = arguments.into_iter().map(Into::into).collect();


### PR DESCRIPTION
## Description

In https://github.com/zed-industries/zed/pull/27213 the new feature for setting env variables for LSPs was added but env vars passed from an instance of `ExtensionLspAdapter` are lost now. This means if an extension returns any env variable like this:

```rust
zed::Command {
  command: some_command,
  args: some_args,
  env: vec![("A", "value_for_a")],
}
```

The env variable `A` will never be used by `LspStore`. This commit preserves env variables passed from an instance of `ExtensionLspAdapter`.

After this change overwriting of env variables
happens in the following order:

```plaintext
shell <- variables from an extension <- variables from settings
```

## How to reproduce

Allow any extension to return a `zed::Command` with environment variables to Zed. You can use [this branch](https://github.com/zed-extensions/ruby/pull/48) for the Ruby extension:

1. Check out the branch and install the dev version of the Ruby extension.
2. Ensure you have the `solargraph` LSP configured and enabled for the Ruby extension. This LSP is enabled by default in Zed and in the Ruby extension.
3. Make sure you don’t have `solargraph` installed in your user gemset.
4. Open any Ruby project, such as [this one](https://github.com/vitallium/stimulus-lsp-error-zed).
5. Open a Ruby file and wait for the error message about failing to start `solargraph`. It should look like this or something similar:

```
[2025-04-05T23:17:26+02:00 ERROR project::lsp_store] server stderr: "/Users/vslobodin/.local/share/mise/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:262:in 'Gem.find_spec_for_exe': can't find gem solargraph (>= 0.a) with executable solargraph (Gem::GemNotFoundException)\n\tfrom /Users/vslobodin/.local/share/mise/installs/ruby/3.4.1/lib/ruby/site_ruby/3.4.0/rubygems.rb:281:in 'Gem.activate_bin_path'\n"
```

This error occurs because the Ruby extension passes the `GEM_PATH` environment variable to specify the location of Ruby gems. Without it, Zed tries to spawn the `solargraph` gem in the user's gemset scope. Ruby fails to start it because the `solargraph` gem is not installed in the user gemset but in the extension directory. By setting the `GEM_PATH` environment variable, Ruby searches additional locations to start the `solargraph` LSP.

I hope I've described it correctly. Please let me know if you need more information. Thanks!

Release Notes:

- Fixed the issue where environment variables from `ExtensionLspAdapter` were lost
