### PR TITLE
project_panel:  Show error when file or directory already exists while renaming or creating new one

### DIFF
--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -1835,13 +1835,21 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         assert!(
             panel.confirm_edit(window, cx).is_none(),
             "Should not allow to confirm on conflicting new directory name"
-        )
+        );
+    });
+    cx.executor().run_until_parked();
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(
+            panel.edit_state.is_some(),
+            "Edit state should not be None after conflicting new directory name"
+        );
+        panel.cancel(&menu::Cancel, window, cx);
     });
     assert_eq!(
         visible_entries_as_strings(&panel, 0..10, cx),
         &[
             //
-            "v src",
+            "v src  <== selected",
             "    > test"
         ],
         "File list should be unchanged after failed folder create confirmation"
@@ -1880,13 +1888,21 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
         assert!(
             panel.confirm_edit(window, cx).is_none(),
             "Should not allow to confirm on conflicting new file name"
-        )
+        );
+    });
+    cx.executor().run_until_parked();
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(
+            panel.edit_state.is_some(),
+            "Edit state should not be None after conflicting new file name"
+        );
+        panel.cancel(&menu::Cancel, window, cx);
     });
     assert_eq!(
         visible_entries_as_strings(&panel, 0..10, cx),
         &[
             "v src",
-            "    v test",
+            "    v test  <== selected",
             "          first.rs",
             "          second.rs",
             "          third.rs"
@@ -1929,6 +1945,14 @@ async fn test_create_duplicate_items(cx: &mut gpui::TestAppContext) {
             panel.confirm_edit(window, cx).is_none(),
             "Should not allow to confirm on conflicting file rename"
         )
+    });
+    cx.executor().run_until_parked();
+    panel.update_in(cx, |panel, window, cx| {
+        assert!(
+            panel.edit_state.is_some(),
+            "Edit state should not be None after conflicting file rename"
+        );
+        panel.cancel(&menu::Cancel, window, cx);
     });
     assert_eq!(
         visible_entries_as_strings(&panel, 0..10, cx),


### PR DESCRIPTION
Closes #14425

<img width="289" alt="image" src="https://github.com/user-attachments/assets/2994c401-23e3-419a-90fc-1a83959fdf21" />

Release Notes:

- Improved the project panel to show an error when a file or directory already exists while renaming or creating a new one.

