### PR TITLE
Improve Rust macro highlighting

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -1,5 +1,7 @@
 (identifier) @variable
+(metavariable) @variable
 (type_identifier) @type
+(fragment_specifier) @type
 (primitive_type) @type.builtin
 (self) @variable.special
 (field_identifier) @property


### PR DESCRIPTION
Release Notes:

  - Improved Rust macro highlighting

| Zed 0.180.2 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/013c73b1-5eee-45b1-ba37-747563c1bc4b) | ![Image](https://github.com/user-attachments/assets/57eb97e3-1ccc-4d58-9596-bb3decedc0f4) |

```rust
macro_rules! square {
  ($e:expr) => { $e * $e };
}
```

- `$var`: `variable`
- `expr`: `type`