### PR TITLE
Improve Regex highlighting

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -85,7 +85,7 @@
 (escape_sequence) @string.escape
 
 (regex) @string.regex
-(regex_flags) @keyword.regex
+(regex_flags) @keyword.operator.regex
 (number) @number
 
 ; Tokens
@@ -144,6 +144,8 @@
   "||="
   "??="
 ] @operator
+
+(regex "/" @string.regex)
 
 [
   "("

--- a/crates/languages/src/regex/highlights.scm
+++ b/crates/languages/src/regex/highlights.scm
@@ -20,7 +20,7 @@
   (control_letter_escape)
   (character_class_escape)
   (control_escape)
-] @string.escape
+] @string.escape.regex
 
 [
   "*"
@@ -32,17 +32,19 @@
   (start_assertion)
   (end_assertion)
   (any_character)
+  (lazy)
 ] @operator.regex
 
 [
   (boundary_assertion)
   (non_boundary_assertion)
   (backreference_escape)
+  (decimal_escape)
 ] @keyword.operator.regex
 
 (count_quantifier
   [
-    (decimal_digits) @number
+    (decimal_digits) @number.quantifier.regex
     "," @punctuation.delimiter.regex
   ])
 

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -86,7 +86,7 @@
 (escape_sequence) @string.escape
 
 (regex) @string.regex
-(regex_flags) @keyword.regex
+(regex_flags) @keyword.operator.regex
 (number) @number
 
 ; Tokens
@@ -146,6 +146,8 @@
   "||="
   "??="
 ] @operator
+
+(regex "/" @string.regex)
 
 [
   "("

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -113,7 +113,7 @@
 (escape_sequence) @string.escape
 
 (regex) @string.regex
-(regex_flags) @keyword.regex
+(regex_flags) @keyword.operator.regex
 (number) @number
 
 ; Tokens
@@ -165,6 +165,8 @@
   "||="
   "??="
 ] @operator
+
+(regex "/" @string.regex)
 
 (ternary_expression
   [


### PR DESCRIPTION
Release Notes:

  - Improved Regex highlighting

| Zed 0.180.2 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/e840bd81-25ff-4c7a-af03-bac6db11f910) | ![Image](https://github.com/user-attachments/assets/3fd58164-8992-44e1-be01-8c6d70f9587d) |

```js
match = "424242"
regex = /(42)+?\d{2}\1/g
```

- `/`: `operator` -> `string.regex` (like `"` for regex strings)
- `+?`: `operator.regex`
- `\d`: `string.escape` -> `string.escape.regex`
- `\1`: `keyword.operator.regex` (backreference)
- `/g`: `keyword.regex` -> `keyword.operator.regex`
- `{2}`: `number` -> `number.quantifier.regex`