### PR TITLE
html: Improve syntax highlighting

### DIFF
--- a/extensions/html/languages/html/highlights.scm
+++ b/extensions/html/languages/html/highlights.scm
@@ -1,11 +1,14 @@
 (tag_name) @tag
-(erroneous_end_tag_name) @keyword
 (doctype) @tag.doctype
 (attribute_name) @attribute
-(attribute_value) @string
+[
+  "\""
+  "'"
+  (attribute_value)
+] @string
 (comment) @comment
 
-"=" @operator
+"=" @punctuation.delimiter.html
 
 [
   "<"
@@ -13,4 +16,4 @@
   "<!"
   "</"
   "/>"
-] @punctuation.bracket
+] @punctuation.bracket.html


### PR DESCRIPTION
Release Notes:

  - Improved HTML highlighting

| Zed 0.180.2 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/89d70ba1-791b-462e-9a14-31c75bcebb7e) | ![Image](https://github.com/user-attachments/assets/9199499e-071e-49b3-8536-b04b8ce5a222) |


```html
<script>
  return <div class="main content"></div>
</script>
<div class="main content"></div>
<span></spn>
```

Changes homogenize JSX and HTML

- `"`: `string`
- `=`: `operator` -> `punctuation.delimiter` like in [JSX](https://github.com/zed-industries/zed/blob/3775496b84cfc9ebf27376119742f3484d4997f2/crates/languages/src/javascript/highlights.scm#L246), [VSCode](https://github.com/microsoft/vscode/blob/336801752dd09afa76f5429fba846e533bcdb7d9/extensions/html/syntaxes/html.tmLanguage.json#L382)
- `erroneous_end_tag_name`: `keyword` -> not a keyword