### PR TITLE
Improve Bash heredoc highlighting

### DIFF
--- a/crates/languages/src/bash/highlights.scm
+++ b/crates/languages/src/bash/highlights.scm
@@ -3,6 +3,7 @@
   (raw_string)
   (heredoc_body)
   (heredoc_start)
+  (heredoc_end)
   (ansi_c_string)
   (word)
 ] @string
@@ -54,6 +55,7 @@
   "$"
   "&&"
   ">"
+  "<<"
   ">>"
   ">&"
   ">&-"


### PR DESCRIPTION
Release Notes:

  - Improved Bash heredoc highlighting

| Zed 0.180.2 | With this PR |
| --- | --- |
| ![Image](https://github.com/user-attachments/assets/aa2534af-53df-4f01-988e-f18ec52a2b62) | ![Image](https://github.com/user-attachments/assets/8fc92113-41f2-4249-ab81-6beb0a1469ca) |

```bash
cat << EOT >> hello.txt
hello world
EOT
```

- `<<`: `operator`
- `EOT`: `string`