### PR TITLE
agent: Refresh UI when context or thread history changes

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -253,6 +253,8 @@ impl AssistantPanel {
         let history_store =
             cx.new(|cx| HistoryStore::new(thread_store.clone(), context_store.clone(), cx));
 
+        cx.observe(&history_store, |_, _, cx| cx.notify()).detach();
+
         let active_view = ActiveView::thread(thread.clone(), window, cx);
         let thread_subscription = cx.subscribe(&thread, |_, _, event, cx| {
             if let ThreadEvent::MessageAdded(_) = &event {

--- a/crates/agent/src/context_picker/completion_provider.rs
+++ b/crates/agent/src/context_picker/completion_provider.rs
@@ -232,8 +232,8 @@ impl ContextPickerCompletionProvider {
                                 url_to_fetch.to_string(),
                             ))
                             .await?;
-                        context_store.update(cx, |context_store, _| {
-                            context_store.add_fetched_url(url_to_fetch.to_string(), content)
+                        context_store.update(cx, |context_store, cx| {
+                            context_store.add_fetched_url(url_to_fetch.to_string(), content, cx)
                         })
                     })
                     .detach_and_log_err(cx);

--- a/crates/agent/src/context_picker/fetch_context_picker.rs
+++ b/crates/agent/src/context_picker/fetch_context_picker.rs
@@ -213,8 +213,8 @@ impl PickerDelegate for FetchContextPickerDelegate {
             this.update_in(cx, |this, window, cx| {
                 this.delegate
                     .context_store
-                    .update(cx, |context_store, _cx| {
-                        context_store.add_fetched_url(url, text);
+                    .update(cx, |context_store, cx| {
+                        context_store.add_fetched_url(url, text, cx)
                     })?;
 
                 match confirm_behavior {

--- a/crates/agent/src/context_strip.rs
+++ b/crates/agent/src/context_strip.rs
@@ -59,6 +59,7 @@ impl ContextStrip {
         let focus_handle = cx.focus_handle();
 
         let subscriptions = vec![
+            cx.observe(&context_store, |_, _, cx| cx.notify()),
             cx.subscribe_in(&context_picker, window, Self::handle_context_picker_event),
             cx.on_focus(&focus_handle, window, Self::handle_focus),
             cx.on_blur(&focus_handle, window, Self::handle_blur),
@@ -290,9 +291,9 @@ impl ContextStrip {
         if let Some(index) = self.focused_index {
             let mut is_empty = false;
 
-            self.context_store.update(cx, |this, _cx| {
+            self.context_store.update(cx, |this, cx| {
                 if let Some(item) = this.context().get(index) {
-                    this.remove_context(item.id());
+                    this.remove_context(item.id(), cx);
                 }
 
                 is_empty = this.context().is_empty();
@@ -475,8 +476,8 @@ impl Render for ContextStrip {
                             Some({
                                 let context_store = self.context_store.clone();
                                 Rc::new(cx.listener(move |_this, _event, _window, cx| {
-                                    context_store.update(cx, |this, _cx| {
-                                        this.remove_context(id);
+                                    context_store.update(cx, |this, cx| {
+                                        this.remove_context(id, cx);
                                     });
                                     cx.notify();
                                 }))


### PR DESCRIPTION
I found a few more cases where the UI wasn't updated immediately after an interaction.

Release Notes:

- agent: Fixed delay after removing threads from "Past Interactions"
- agent: Fixed delay after adding/remove context via keyboard
