### PR TITLE
Add "projects::ToggleRecent", "OpenRemote" actions

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -413,11 +413,11 @@
     "context": "Workspace",
     "bindings": {
       // Change the default action on `menu::Confirm` by setting the parameter
-      // "alt-ctrl-o": ["projects::OpenRecent", { "create_new_window": true }],
-      "alt-open": "projects::OpenRecent",
-      "alt-ctrl-o": "projects::OpenRecent",
-      "alt-shift-open": "projects::OpenRemote",
-      "alt-ctrl-shift-o": "projects::OpenRemote",
+      // "alt-ctrl-o": ["projects::ToggleRecent", { "create_new_window": true }],
+      "alt-open": "projects::ToggleRecent",
+      "alt-ctrl-o": "projects::ToggleRecent",
+      "alt-shift-open": "projects::ToggleRemote",
+      "alt-ctrl-shift-o": "projects::ToggleRemote",
       "alt-ctrl-shift-b": "branches::OpenRecent",
       "alt-shift-enter": "toast::RunAction",
       "ctrl-~": "workspace::NewTerminal",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -545,9 +545,9 @@
     "use_key_equivalents": true,
     "bindings": {
       // Change the default action on `menu::Confirm` by setting the parameter
-      // "alt-cmd-o": ["projects::OpenRecent", {"create_new_window": true }],
-      "alt-cmd-o": "projects::OpenRecent",
-      "ctrl-cmd-o": "projects::OpenRemote",
+      // "alt-cmd-o": ["projects::ToggleRecent", {"create_new_window": true }],
+      "alt-cmd-o": "projects::ToggleRecent",
+      "ctrl-cmd-o": "projects::ToggleRemote",
       "alt-cmd-b": "branches::OpenRecent",
       "ctrl-~": "workspace::NewTerminal",
       "cmd-s": "workspace::Save",

--- a/assets/keymaps/macos/textmate.json
+++ b/assets/keymaps/macos/textmate.json
@@ -1,7 +1,7 @@
 [
   {
     "bindings": {
-      "cmd-shift-o": "projects::OpenRecent",
+      "cmd-shift-o": "projects::ToggleRecent",
       "cmd-alt-tab": "project_panel::ToggleFocus"
     }
   },

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -27,7 +27,7 @@ use workspace::{
     CloseIntent, ModalView, OpenOptions, SerializedWorkspaceLocation, WORKSPACE_DB, Workspace,
     WorkspaceId,
 };
-use zed_actions::{OpenRecent, OpenRemote};
+use zed_actions::{OpenRecent, ToggleRecent, ToggleRemote};
 
 pub fn init(cx: &mut App) {
     SshSettings::register(cx);
@@ -89,9 +89,13 @@ impl RecentProjects {
         _window: Option<&mut Window>,
         _cx: &mut Context<Workspace>,
     ) {
+        workspace.register_action(|workspace, action: &ToggleRecent, window, cx| {
+            Self::toggle(workspace, action.create_new_window, window, cx);
+        });
+
         workspace.register_action(|workspace, open_recent: &OpenRecent, window, cx| {
             let Some(recent_projects) = workspace.active_modal::<Self>(cx) else {
-                Self::open(workspace, open_recent.create_new_window, window, cx);
+                Self::toggle(workspace, open_recent.create_new_window, window, cx);
                 return;
             };
 
@@ -103,7 +107,7 @@ impl RecentProjects {
         });
     }
 
-    pub fn open(
+    pub fn toggle(
         workspace: &mut Workspace,
         create_new_window: bool,
         window: &mut Window,
@@ -466,9 +470,9 @@ impl PickerDelegate for RecentProjectsDelegate {
                 .border_color(cx.theme().colors().border_variant)
                 .child(
                     Button::new("remote", "Open Remote Folder")
-                        .key_binding(KeyBinding::for_action(&OpenRemote, window, cx))
+                        .key_binding(KeyBinding::for_action(&ToggleRemote, window, cx))
                         .on_click(|_, window, cx| {
-                            window.dispatch_action(OpenRemote.boxed_clone(), cx)
+                            window.dispatch_action(ToggleRemote.boxed_clone(), cx)
                         }),
                 )
                 .child(
@@ -717,7 +721,7 @@ mod tests {
     ) -> Entity<Picker<RecentProjectsDelegate>> {
         cx.dispatch_action(
             (*workspace).into(),
-            OpenRecent {
+            ToggleRecent {
                 create_new_window: false,
             },
         );

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -36,8 +36,9 @@ use workspace::{
     ModalView, Workspace, notifications::DetachAndPromptErr,
     open_ssh_project_with_existing_connection,
 };
+use zed_actions::OpenRemote;
+use zed_actions::ToggleRemote;
 
-use crate::OpenRemote;
 use crate::ssh_connections::RemoteSettingsContent;
 use crate::ssh_connections::SshConnection;
 use crate::ssh_connections::SshConnectionHeader;
@@ -307,8 +308,11 @@ impl RemoteServerProjects {
         _: &mut Context<Workspace>,
     ) {
         workspace.register_action(|workspace, _: &OpenRemote, window, cx| {
-            let handle = cx.entity().downgrade();
-            workspace.toggle_modal(window, cx, |window, cx| Self::new(window, cx, handle))
+            Self::toggle(workspace, window, cx);
+        });
+
+        workspace.register_action(|workspace, _: &ToggleRemote, window, cx| {
+            Self::toggle(workspace, window, cx);
         });
     }
 
@@ -317,6 +321,11 @@ impl RemoteServerProjects {
             let handle = cx.entity().downgrade();
             workspace.toggle_modal(window, cx, |window, cx| Self::new(window, cx, handle))
         })
+    }
+
+    fn toggle(workspace: &mut Workspace, window: &mut Window, cx: &mut Context<'_, Workspace>) {
+        let handle = cx.entity().downgrade();
+        workspace.toggle_modal(window, cx, |window, cx| Self::new(window, cx, handle));
     }
 
     pub fn new(

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -37,7 +37,7 @@ use ui::{
 };
 use util::ResultExt;
 use workspace::{Workspace, notifications::NotifyResultExt};
-use zed_actions::{OpenBrowser, OpenRecent, OpenRemote};
+use zed_actions::{OpenBrowser, ToggleRecent, ToggleRemote};
 
 pub use onboarding_banner::restore_banner;
 
@@ -410,14 +410,14 @@ impl TitleBar {
                 .tooltip(move |window, cx| {
                     Tooltip::with_meta(
                         "Remote Project",
-                        Some(&OpenRemote),
+                        Some(&ToggleRemote),
                         meta.clone(),
                         window,
                         cx,
                     )
                 })
                 .on_click(|_, window, cx| {
-                    window.dispatch_action(OpenRemote.boxed_clone(), cx);
+                    window.dispatch_action(ToggleRemote.boxed_clone(), cx);
                 })
                 .into_any_element(),
         )
@@ -492,7 +492,7 @@ impl TitleBar {
             .tooltip(move |window, cx| {
                 Tooltip::for_action(
                     "Recent Projects",
-                    &zed_actions::OpenRecent {
+                    &zed_actions::ToggleRecent {
                         create_new_window: false,
                     },
                     window,
@@ -501,7 +501,7 @@ impl TitleBar {
             })
             .on_click(cx.listener(move |_, _, window, cx| {
                 window.dispatch_action(
-                    OpenRecent {
+                    ToggleRecent {
                         create_new_window: false,
                     }
                     .boxed_clone(),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -65,11 +65,11 @@ pub fn app_menus() -> Vec<Menu> {
                 ),
                 MenuItem::action(
                     "Open Recent...",
-                    zed_actions::OpenRecent {
+                    zed_actions::ToggleRecent {
                         create_new_window: true,
                     },
                 ),
-                MenuItem::action("Open Remote...", zed_actions::OpenRemote),
+                MenuItem::action("Open Remote...", zed_actions::ToggleRemote),
                 MenuItem::separator(),
                 MenuItem::action("Add Folder to Project…", workspace::AddFolderToProject),
                 MenuItem::separator(),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -1,4 +1,6 @@
-use gpui::{actions, impl_actions};
+use gpui::{
+    action_with_deprecated_aliases, actions, impl_action_with_deprecated_aliases, impl_actions,
+};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -213,13 +215,22 @@ pub mod assistant {
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
+pub struct ToggleRecent {
+    #[serde(default)]
+    pub create_new_window: bool,
+}
+
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct OpenRecent {
     #[serde(default)]
     pub create_new_window: bool,
 }
 
-impl_actions!(projects, [OpenRecent]);
-actions!(projects, [OpenRemote]);
+impl_actions!(projects, [ToggleRecent]);
+impl_action_with_deprecated_aliases!(projects, OpenRecent, ["projects::OpenRecent"]);
+actions!(projects, [ToggleRemote]);
+action_with_deprecated_aliases!(projects, OpenRemote, ["projects::OpenRemote"]);
 
 /// Where to spawn the task in the UI.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -17,7 +17,7 @@ On your local machine, Zed runs its UI, talks to language models, uses Tree-sitt
 ## Setup
 
 1. Download and install the latest [Zed](https://zed.dev/releases). You need at least Zed v0.159.
-1. Use {#kb projects::OpenRemote} to open the "Remote Projects" dialog.
+1. Use {#kb projects::ToggleRemote} to open the "Remote Projects" dialog.
 1. Click "Connect New Server" and enter the command you use to SSH into the server. See [Supported SSH options](#supported-ssh-options) for options you can pass.
 1. Your local machine will attempt to connect to the remote server using the `ssh` binary on your path. Assuming the connection is successful, Zed will download the server on the remote host and start it.
 1. Once the Zed server is running, you will be prompted to choose a path to open on the remote server.
@@ -35,7 +35,7 @@ The remote machine must be able to run Zed's server. The following platforms sho
 
 ## Configuration
 
-The list of remote servers is stored in your settings file {#kb zed::OpenSettings}. You can edit this list using the Remote Projects dialog {#kb projects::OpenRemote}, which provides some robustness - for example it checks that the connection can be established before writing it to the settings file.
+The list of remote servers is stored in your settings file {#kb zed::OpenSettings}. You can edit this list using the Remote Projects dialog {#kb projects::ToggleRemote}, which provides some robustness - for example it checks that the connection can be established before writing it to the settings file.
 
 ```json
 {


### PR DESCRIPTION
Closes #21789

Release Notes:

- Added "projects::ToggleRecent" and replaced default keymap "projects::OpenRecent" with "projects::ToggleRecent"
- Added "projects::ToggleRemote" and replaced default keymap "projects::OpenRemote" with "projects::ToggleRemote"
