### PR TITLE
Tell the model not to create .bak files

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -11,6 +11,9 @@ You should only perform actions that modify the user's system if explicitly requ
 
 When answering questions, it's okay to give incomplete examples containing comments about what would go there in a real version. When being asked to directly perform tasks on the code base, you must ALWAYS make fully working code. You may never "simplify" the code by omitting or deleting functionality you know the user has requested, and you must NEVER write comments like "in a full version, this would..." - instead, you must actually implement the real version. Don't be lazy!
 
+Note that project files are automatically backed up. The user can always get them back later if anything goes wrong, so there's
+no need to create backup files (e.g. `.bak` files) because these files will just take up unnecessary space on the user's disk.
+
 <style>
 Editing code:
 - Make sure to take previous edits into account.

--- a/crates/assistant_tools/src/bash_tool.rs
+++ b/crates/assistant_tools/src/bash_tool.rs
@@ -16,7 +16,7 @@ use util::markdown::MarkdownString;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct BashToolInput {
-    /// The bash command to execute as a one-liner.
+    /// The bash one-liner command to execute.
     command: String,
     /// Working directory for the command. This must be one of the root directories of the project.
     cd: String,


### PR DESCRIPTION
Release Notes:

- Adjusted system prompt to avoid having the agent create backup files unnecessarily.
