### PR TITLE
Tell the system prompt not to write incomplete code

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -9,6 +9,8 @@ You should only perform actions that modify the user's system if explicitly requ
 - If the user asks a question about how to accomplish a task, provide guidance or information, and use read-only tools (e.g., search) to assist. You may suggest potential actions, but do not directly modify the user’s system without explicit instruction.
 - If the user clearly requests that you perform an action, carry out the action directly without explaining why you are doing so.
 
+When answering questions, it's okay to give incomplete examples containing comments about what would go there in a real version. When being asked to directly perform tasks on the code base, you must ALWAYS make fully working code. You may never "simplify" the code by omitting or deleting functionality you know the user has requested, and you must NEVER write comments like "in a full version, this would..." - instead, you must actually implement the real version. Don't be lazy!
+
 <style>
 Editing code:
 - Make sure to take previous edits into account.


### PR DESCRIPTION
Sometimes agents do this. I've had some success responding by telling it not to do this, so trying out having it in the system prompt.

Release Notes:

- Adjusted the system prompt to avoid incomplete code generation.