### PR TITLE
Fix contradiction in system prompt

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -37,7 +37,7 @@ Responding:
 
 Whenever you mention a code block, you MUST use ONLY the following format:
 
-```language path/to/Something.blah#L123-456
+```path/to/Something.blah#L123-456
 (code goes here)
 ```
 


### PR DESCRIPTION
The example after "you must use the following format" has language, but then it goes on to say never to use language.

````
Whenever you mention a code block, you MUST use ONLY the following format:

```language path/to/Something.blah#L123-456
(code goes here)
```

The `#L123-456` means the line number range 123 through 456, and the path/to/Something.blah
is a path in the project. (If there is no valid path in the project, then you can use
/dev/null/path.extension for its path.) This is the ONLY valid way to format code blocks, because the Markdown parser
does not understand the more common ```language syntax, or bare ``` blocks. It only
understands this path-based syntax, and if the path is missing, then it will error and you will have to do it over again.

Just to be really clear about this, if you ever find yourself writing three backticks followed by a language name, STOP!
You have made a mistake. You can only ever put paths after triple backticks!
````

Release Notes:

- N/A