### PR TITLE
Try to identify dSYMs by UUID not channel

### DIFF
--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -197,7 +197,7 @@ function prepare_binaries() {
         cat target/dsymutil.log
         exit 1
     fi
-    uuid=$(dwarfdump --uuid "${exe_path}")
+    uuid=$(dwarfdump --uuid "${exe_path}" | cut -d ' ' -f 2 | tr 'A-F' 'a-f')
     version="$(cargo metadata --no-deps --manifest-path crates/zed/Cargo.toml --offline --format-version=1 | jq -r '.packages | map(select(.name == "zed"))[0].version')"
     if [ "$channel" == "nightly" ]; then
         version="$version-$(git rev-parse --short HEAD)"

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -191,11 +191,13 @@ function prepare_binaries() {
     local app_path=$2
 
     echo "Unpacking dSYMs for $architecture"
-    if ! dsymutil --flat target/${architecture}/${target_dir}/Zed 2> target/dsymutil.log; then
+    exe_path="target/${architecture}/${target_dir}/Zed"
+    if ! dsymutil --flat "${exe_path}" 2> target/dsymutil.log; then
         echo "dsymutil failed"
         cat target/dsymutil.log
         exit 1
     fi
+    uuid=$(dwarfdump --uuid "${exe_path}")
     version="$(cargo metadata --no-deps --manifest-path crates/zed/Cargo.toml --offline --format-version=1 | jq -r '.packages | map(select(.name == "zed"))[0].version')"
     if [ "$channel" == "nightly" ]; then
         version="$version-$(git rev-parse --short HEAD)"
@@ -207,11 +209,11 @@ function prepare_binaries() {
     echo "Gzipping dSYMs for $architecture"
     gzip -f target/${architecture}/${target_dir}/Zed.dwarf
 
-    echo "Uploading dSYMs for $architecture"
+    echo "Uploading dSYMs${architecture} for $architecture to by_uuid/${uuid}.dwarf.gz"
     upload_to_blob_store_public \
         "zed-debug-symbols" \
         target/${architecture}/${target_dir}/Zed.dwarf.gz \
-        "$channel/Zed-$version-${architecture}.dwarf.gz"
+        "by-uuid/${uuid}.dwarf.gz"
 
     cp target/${architecture}/${target_dir}/zed "${app_path}/Contents/MacOS/zed"
     cp target/${architecture}/${target_dir}/cli "${app_path}/Contents/MacOS/cli"

--- a/script/lib/blob-store.sh
+++ b/script/lib/blob-store.sh
@@ -24,10 +24,10 @@ function upload_to_blob_store_with_acl
 
 function upload_to_blob_store_public
 {
-    upload_to_blob_store_with_acl $1 $2 $3 "x-amz-acl:public-read"
+    upload_to_blob_store_with_acl "$1" "$2" "$3" "x-amz-acl:public-read"
 }
 
 function upload_to_blob_store
 {
-    upload_to_blob_store_with_acl $1 $2 $3 "x-amz-acl:private"
+    upload_to_blob_store_with_acl "$1" "$2" "$3" "x-amz-acl:private"
 }

--- a/script/symbolicate
+++ b/script/symbolicate
@@ -53,10 +53,18 @@ else # ips file
 
     mkdir -p target/dsyms/$channel
 
-    dsym="$channel/Zed-$version-$arch.dwarf"
+    # NOTE: if you see "no such file --uuid", you need to update your symbolicate
+    uuid=$(symbolicate $input_file --uuid || true)
+    if [[ $? -ne 0 ]]; then
+        echo "You need to update your symbolicate: cargo install symbolicate"
+        exit 1
+    fi
+
+    dsym="$uuid.dwarf"
     if [[ ! -f target/dsyms/$dsym ]]; then
         echo "Downloading $dsym..."
-        curl -o target/dsyms/$dsym.gz "https://zed-debug-symbols.nyc3.digitaloceanspaces.com/$channel/Zed-$version-$arch.dwarf.gz"
+        curl -f -o target/dsyms/$dsym.gz "https://zed-debug-symbols.nyc3.digitaloceanspaces.com/by_uuid/${uuid}.dwarf.gz" ||
+            curl -f -o target/dsyms/$dsym.gz "https://zed-debug-symbols.nyc3.digitaloceanspaces.com/$channel/Zed-$version-$arch.dwarf.gz"
         gunzip  target/dsyms/$dsym.gz
     fi
 


### PR DESCRIPTION
This should make it possible to more reliably symbolicate crash reports from nightly, and from users with pending auto-updates.


Release Notes:

- N/A