### PR TITLE
git: Fix logging FromUtf8Error when diffing

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -606,7 +606,7 @@ impl GitRepository for RealGitRepository {
                     };
 
                     let content = repo.find_blob(oid)?.content().to_owned();
-                    Ok(Some(String::from_utf8(content)?))
+                    Ok(String::from_utf8(content).ok())
                 }
 
                 match logic(&repo.lock(), &path) {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -629,8 +629,7 @@ impl GitRepository for RealGitRepository {
                     return None;
                 }
                 let content = repo.find_blob(entry.id()).log_err()?.content().to_owned();
-                let content = String::from_utf8(content).log_err()?;
-                Some(content)
+                String::from_utf8(content).ok()
             })
             .boxed()
     }


### PR DESCRIPTION
If you attempt to load a git diff which includes a non utf-8 file, previously
(1) the entire contents of the file was logged as ordinals and
(2) a second spurious error was logged

```
2025-04-07T16:21:28.392845-04:00 [ERROR] FromUtf8Error { bytes: [0, 1, 0, 0, 0, 19, 1, 0, 0, 4, 0, 48, 68, 83, 73, 71, 0, 0, 0, 1, 0, 2, 241, 204, 0, 0, 0, 8, 71, 68, 69, 70, 164, 172, 164, ...

[2025-04-07T17:12:16-04:00 ERROR git::repository] Error loading index text: invalid utf-8 sequence of 1 bytes from index 35
```

Having 1MB binary file in a commit would generate ~3MB-5MB of log output.

Discovered while investigating https://github.com/zed-industries/zed/issues/28241

Release Notes:

- git: Fixed an issue where non-UTF8 files in a git diff would generate log spam.
