### PR TITLE
Demote buffer-diff to a dev dependency of collab

### DIFF
--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -33,7 +33,6 @@ clock.workspace = true
 collections.workspace = true
 dashmap.workspace = true
 derive_more.workspace = true
-buffer_diff.workspace = true
 envy = "0.4.2"
 futures.workspace = true
 google_ai.workspace = true
@@ -85,6 +84,7 @@ assistant_slash_command.workspace = true
 assistant_tool.workspace = true
 async-trait.workspace = true
 audio.workspace = true
+buffer_diff.workspace = true
 call = { workspace = true, features = ["test-support"] }
 channel.workspace = true
 client = { workspace = true, features = ["test-support"] }


### PR DESCRIPTION
This will speed up our collab deployments a little

Release Notes:

- N/A
