### PR TITLE
vim: Fix exchange showing `ccx` in pending keys

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -868,6 +868,7 @@ impl Vim {
             Operator::AddSurrounds { .. }
                 | Operator::ChangeSurrounds { .. }
                 | Operator::DeleteSurrounds
+                | Operator::Exchange
         ) {
             self.operator_stack.clear();
         };


### PR DESCRIPTION
|Before|After|
|--|--|
|![image](https://github.com/user-attachments/assets/cac97981-518e-46d2-8540-a22496bc948e)|![image](https://github.com/user-attachments/assets/5158b17f-d14e-42a2-8a94-ad98d1b1c33c)|

Changes:
Add vim exchange to the clear stack

Release Notes:

- N/A
