### PR TITLE
Switch back to the default mode after paste

### DIFF
--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -203,7 +203,8 @@ impl Vim {
                 })
             });
         });
-        self.switch_mode(Mode::Normal, true, window, cx);
+
+        self.switch_mode(self.default_mode(cx), true, window, cx);
     }
 
     pub fn replace_with_register_object(


### PR DESCRIPTION
Now that the flaky tests are disabled, this should work...

Release Notes:

- Fixed vim paste action to switch back to the configured default mode.
