### PR TITLE
Fix scrolling too fast on selection for editor and terminal

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8404,7 +8404,7 @@ enum CursorPopoverType {
 }
 
 pub fn scale_vertical_mouse_autoscroll_delta(delta: Pixels) -> f32 {
-    (delta.pow(1.5) / 100.0).into()
+    (delta.pow(1.2) / 100.0).min(px(3.0)).into()
 }
 
 fn scale_horizontal_mouse_autoscroll_delta(delta: Pixels) -> f32 {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1590,7 +1590,7 @@ impl Terminal {
             return None;
         };
 
-        Some(scroll_lines)
+        Some(scroll_lines.clamp(-3, 3))
     }
 
     pub fn mouse_down(&mut self, e: &MouseDownEvent, _cx: &mut Context<Self>) {


### PR DESCRIPTION
Closes #12046

Add cap on vertical auto scroll for both editor and terminal.  

Release Notes:

- Fixed mouse selection scrolling too fast in both editor and terminal.