### PR TITLE
debugger: Add close button and coloring to debug panel session's menu

### DIFF
--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -81,7 +81,6 @@ impl DebugSession {
         }
     }
 
-    #[expect(unused)]
     pub(crate) fn shutdown(&mut self, cx: &mut Context<Self>) {
         match &self.mode {
             DebugSessionState::Running(state) => state.update(cx, |state, cx| state.shutdown(cx)),
@@ -110,32 +109,19 @@ impl DebugSession {
     }
 
     pub(crate) fn label_element(&self, cx: &App) -> AnyElement {
-        let (icon, label, color) = match &self.mode {
+        let label = self.label(cx);
+
+        let (icon, color) = match &self.mode {
             DebugSessionState::Running(state) => {
                 if state.read(cx).session().read(cx).is_terminated() {
-                    (
-                        Some(Indicator::dot().color(Color::Error)),
-                        "Terminated",
-                        Color::Error,
-                    )
+                    (Some(Indicator::dot().color(Color::Error)), Color::Error)
                 } else {
                     match state.read(cx).thread_status(cx).unwrap_or_default() {
                         project::debugger::session::ThreadStatus::Stopped => (
                             Some(Indicator::dot().color(Color::Conflict)),
-                            state
-                                .read_with(cx, |state, cx| state.thread_status(cx))
-                                .map(|status| status.label())
-                                .unwrap_or("Stopped"),
                             Color::Conflict,
                         ),
-                        _ => (
-                            Some(Indicator::dot().color(Color::Success)),
-                            state
-                                .read_with(cx, |state, cx| state.thread_status(cx))
-                                .map(|status| status.label())
-                                .unwrap_or("Running"),
-                            Color::Success,
-                        ),
+                        _ => (Some(Indicator::dot().color(Color::Success)), Color::Success),
                     }
                 }
             }

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -7,7 +7,7 @@ use project::debugger::{dap_store::DapStore, session::Session};
 use project::worktree_store::WorktreeStore;
 use rpc::proto::{self, PeerId};
 use running::RunningState;
-use ui::prelude::*;
+use ui::{Indicator, prelude::*};
 use workspace::{
     FollowableItem, ViewId, Workspace,
     item::{self, Item},
@@ -107,6 +107,46 @@ impl DebugSession {
             .as_local()
             .expect("Remote Debug Sessions are not implemented yet")
             .label()
+    }
+
+    pub(crate) fn label_element(&self, cx: &App) -> AnyElement {
+        let (icon, label, color) = match &self.mode {
+            DebugSessionState::Running(state) => {
+                if state.read(cx).session().read(cx).is_terminated() {
+                    (
+                        Some(Indicator::dot().color(Color::Error)),
+                        "Terminated",
+                        Color::Error,
+                    )
+                } else {
+                    match state.read(cx).thread_status(cx).unwrap_or_default() {
+                        project::debugger::session::ThreadStatus::Stopped => (
+                            Some(Indicator::dot().color(Color::Conflict)),
+                            state
+                                .read_with(cx, |state, cx| state.thread_status(cx))
+                                .map(|status| status.label())
+                                .unwrap_or("Stopped"),
+                            Color::Conflict,
+                        ),
+                        _ => (
+                            Some(Indicator::dot().color(Color::Success)),
+                            state
+                                .read_with(cx, |state, cx| state.thread_status(cx))
+                                .map(|status| status.label())
+                                .unwrap_or("Running"),
+                            Color::Success,
+                        ),
+                    }
+                }
+            }
+        };
+
+        h_flex()
+            .gap_2()
+            .when_some(icon, |this, indicator| this.child(indicator))
+            .justify_between()
+            .child(Label::new(label).color(color))
+            .into_any_element()
     }
 }
 

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -219,7 +219,7 @@ pub enum MarkdownEvent {
     Start(MarkdownTag),
     /// End of a tagged element.
     End(MarkdownTagEnd),
-    /// Text that uses the associated range from the mardown source.
+    /// Text that uses the associated range from the markdown source.
     Text,
     /// Text that differs from the markdown source - typically due to substitution of HTML entities
     /// and smart punctuation.

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -832,7 +832,12 @@ pub enum SessionEvent {
     Threads,
 }
 
+pub(crate) enum SessionStateEvent {
+    Shutdown,
+}
+
 impl EventEmitter<SessionEvent> for Session {}
+impl EventEmitter<SessionStateEvent> for Session {}
 
 // local session will send breakpoint updates to DAP for all new breakpoints
 // remote side will only send breakpoint updates when it is a breakpoint created by that peer
@@ -1552,6 +1557,8 @@ impl Session {
                 cx,
             )
         };
+
+        cx.emit(SessionStateEvent::Shutdown);
 
         cx.background_spawn(async move {
             let _ = task.await;

--- a/crates/ui/src/components/dropdown_menu.rs
+++ b/crates/ui/src/components/dropdown_menu.rs
@@ -2,10 +2,15 @@ use gpui::{ClickEvent, Corner, CursorStyle, Entity, MouseButton};
 
 use crate::{ContextMenu, PopoverMenu, prelude::*};
 
+enum LabelKind {
+    Text(SharedString),
+    Element(AnyElement),
+}
+
 #[derive(IntoElement)]
 pub struct DropdownMenu {
     id: ElementId,
-    label: SharedString,
+    label: LabelKind,
     menu: Entity<ContextMenu>,
     full_width: bool,
     disabled: bool,
@@ -19,7 +24,21 @@ impl DropdownMenu {
     ) -> Self {
         Self {
             id: id.into(),
-            label: label.into(),
+            label: LabelKind::Text(label.into()),
+            menu,
+            full_width: false,
+            disabled: false,
+        }
+    }
+
+    pub fn new_with_element(
+        id: impl Into<ElementId>,
+        label: AnyElement,
+        menu: Entity<ContextMenu>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            label: LabelKind::Element(label),
             menu,
             full_width: false,
             disabled: false,
@@ -55,7 +74,7 @@ impl RenderOnce for DropdownMenu {
 
 #[derive(IntoElement)]
 struct DropdownMenuTrigger {
-    label: SharedString,
+    label: LabelKind,
     full_width: bool,
     selected: bool,
     disabled: bool,
@@ -64,7 +83,7 @@ struct DropdownMenuTrigger {
 }
 
 impl DropdownMenuTrigger {
-    pub fn new(label: impl Into<SharedString>) -> Self {
+    pub fn new(label: LabelKind) -> Self {
         Self {
             label: label.into(),
             full_width: false,
@@ -135,11 +154,16 @@ impl RenderOnce for DropdownMenuTrigger {
                     el.cursor_pointer()
                 }
             })
-            .child(Label::new(self.label).color(if disabled {
-                Color::Disabled
-            } else {
-                Color::Default
-            }))
+            .child(match self.label {
+                LabelKind::Text(text) => Label::new(text)
+                    .color(if disabled {
+                        Color::Disabled
+                    } else {
+                        Color::Default
+                    })
+                    .into_any_element(),
+                LabelKind::Element(element) => element,
+            })
             .child(
                 Icon::new(IconName::ChevronUpDown)
                     .size(IconSize::XSmall)

--- a/crates/ui/src/components/dropdown_menu.rs
+++ b/crates/ui/src/components/dropdown_menu.rs
@@ -85,7 +85,7 @@ struct DropdownMenuTrigger {
 impl DropdownMenuTrigger {
     pub fn new(label: LabelKind) -> Self {
         Self {
-            label: label.into(),
+            label,
             full_width: false,
             selected: false,
             disabled: false,


### PR DESCRIPTION
This PR adds colors to debug panel's session menu that indicate the state of each respective session. It also adds a close button to each entry.

green - running
yellow - stopped
red - terminated/ended 


Release Notes:

- N/A
