### PR TITLE
gpui: Depend on workspace image crate

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -89,7 +89,7 @@ etagere = "0.2"
 futures.workspace = true
 gpui_macros.workspace = true
 http_client = { optional = true, workspace = true }
-image = "0.25.1"
+image.workspace = true
 inventory.workspace = true
 itertools.workspace = true
 log.workspace = true


### PR DESCRIPTION
Make gpui depend on the image crate on the workspace level

Release Notes:

- N/A
