### PR TITLE
docs: Add missing comma in the Tasks page

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -45,7 +45,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     // Whether to show the task line in the output of the spawned task, defaults to `true`.
     "show_summary": true,
     // Whether to show the command line in the output of the spawned task, defaults to `true`.
-    "show_output": true
+    "show_output": true,
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     "tags": []
   }


### PR DESCRIPTION
Added a missing command in the same tasks.json file

Release Notes:

- N/A