### PR TITLE
agent: Add support for Google Gemini 2.5 preview

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -393,6 +393,8 @@ pub enum Model {
     Gemini20FlashLite,
     #[serde(rename = "gemini-2.5-pro-exp-03-25")]
     Gemini25ProExp0325,
+    #[serde(rename = "gemini-2.5-pro-preview-03-25")]
+    Gemini25ProPreview0325,
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -412,6 +414,7 @@ impl Model {
             Model::Gemini20FlashThinking => "gemini-2.0-flash-thinking-exp",
             Model::Gemini20FlashLite => "gemini-2.0-flash-lite-preview",
             Model::Gemini25ProExp0325 => "gemini-2.5-pro-exp-03-25",
+            Model::Gemini25ProPreview0325 => "gemini-2.5-pro-preview-03-25",
             Model::Custom { name, .. } => name,
         }
     }
@@ -425,6 +428,7 @@ impl Model {
             Model::Gemini20FlashThinking => "Gemini 2.0 Flash Thinking",
             Model::Gemini20FlashLite => "Gemini 2.0 Flash Lite",
             Model::Gemini25ProExp0325 => "Gemini 2.5 Pro Exp",
+            Model::Gemini25ProPreview0325 => "Gemini 2.5 Pro Preview",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name),
@@ -440,6 +444,7 @@ impl Model {
             Model::Gemini20FlashThinking => 1_000_000,
             Model::Gemini20FlashLite => 1_000_000,
             Model::Gemini25ProExp0325 => 1_000_000,
+            Model::Gemini25ProPreview0325 => 1_000_000,
             Model::Custom { max_tokens, .. } => *max_tokens,
         }
     }

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -107,6 +107,7 @@ impl CloudModel {
                 | google_ai::Model::Gemini20FlashThinking
                 | google_ai::Model::Gemini20FlashLite
                 | google_ai::Model::Gemini25ProExp0325
+                | google_ai::Model::Gemini25ProPreview0325
                 | google_ai::Model::Custom { .. } => {
                     LanguageModelAvailability::RequiresPlan(Plan::ZedPro)
                 }


### PR DESCRIPTION
Adds support for the new `gemini-2.5-pro-preview-03-25`

Release Notes:

- Added support for `gemini-2.5-pro-preview-03-25` in the assistant
