### PR TITLE
Add reminder message about system prompt

### DIFF
--- a/assets/prompts/assistant_system_prompt_reminder.hbs
+++ b/assets/prompts/assistant_system_prompt_reminder.hbs
@@ -1,0 +1,1 @@
+In your response, make sure to remember and follow my instructions about how to format code blocks (and don't mention that you are remembering it, just follow the instructions).

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1036,7 +1036,9 @@ impl Thread {
             .rev()
             .find(|msg| msg.role == Role::User)
         {
-            last_user_message.content.push(MessageContent::Text("\n\nIn your response, make sure to remember and follow my instructions about how to format code blocks (and don't mention that you are remembering it, just follow the instructions).".to_string()));
+            last_user_message
+                .content
+                .push(MessageContent::Text(SYSTEM_PROMPT_REMINDER.to_string()));
         }
 
         request
@@ -1851,6 +1853,8 @@ impl Thread {
     }
 }
 
+pub const SYSTEM_PROMPT_REMINDER: &str = "\n\nIn your response, make sure to remember and follow my instructions about how to format code blocks (and don't mention that you are remembering it, just follow the instructions).";
+
 #[derive(Debug, Clone)]
 pub enum ThreadError {
     PaymentRequired,
@@ -1974,7 +1978,10 @@ fn main() {{
         });
 
         assert_eq!(request.messages.len(), 1);
-        let expected_full_message = format!("{}Please explain this code", expected_context);
+        let expected_full_message = format!(
+            "{}Please explain this code{}",
+            expected_context, SYSTEM_PROMPT_REMINDER
+        );
         assert_eq!(request.messages[0].string_contents(), expected_full_message);
     }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1029,6 +1029,16 @@ impl Thread {
 
         self.attached_tracked_files_state(&mut request.messages, cx);
 
+        // Add reminder to the last user message about code blocks
+        if let Some(last_user_message) = request
+            .messages
+            .iter_mut()
+            .rev()
+            .find(|msg| msg.role == Role::User)
+        {
+            last_user_message.content.push(MessageContent::Text("\n\nIn your response, make sure to remember and follow my instructions about how to format code blocks (and don't mention that you are remembering it, just follow the instructions).".to_string()));
+        }
+
         request
     }
 

--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -261,6 +261,12 @@ impl PromptBuilder {
             .render("assistant_system_prompt", context)
     }
 
+    pub fn generate_assistant_system_prompt_reminder(&self) -> Result<String, RenderError> {
+        self.handlebars
+            .lock()
+            .render("assistant_system_prompt_reminder", &())
+    }
+
     pub fn generate_inline_transformation_prompt(
         &self,
         user_prompt: String,


### PR DESCRIPTION
Trying out sending the model a reminder message about code blocks in the system prompt. If this seems to work well, we can include more specific reminder messages, e.g. tool-specific ones.

Release Notes:

- N/A
