### PR TITLE
ci: Only run workspace_hack when tests run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,9 @@ jobs:
     timeout-minutes: 60
     name: Check workspace-hack crate
     needs: [job_spec]
-    if: github.repository_owner == 'zed-industries'
+    if: |
+      github.repository_owner == 'zed-industries' &&
+      needs.job_spec.outputs.run_tests == 'true'
     runs-on:
       - buildjet-8vcpu-ubuntu-2204
     steps:


### PR DESCRIPTION
Skip `workspace_hack` for PRs that don't trigger tests (docs-only, .github issue templates, etc).

Release Notes:

- N/A
