### PR TITLE
Tell the model not to act on TODO-type comments

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -16,6 +16,8 @@ no need to create backup files (e.g. `.bak` files) because these files will just
 
 When attempting to resolve issues around failing tests, never simply remove the failing tests. Unless the user explicitly asks you to remove tests, ALWAYS attempt to fix the code causing the tests to fail.
 
+Ignore "TODO"-type comments unless they're relevant to the user's explicit request or the user specifically asks you to address them. It is, however, okay to include them in codebase summaries.
+
 <style>
 Editing code:
 - Make sure to take previous edits into account.


### PR DESCRIPTION
Release Notes:

- Adjusted system prompt to direct it to never act on TODO-type comments it encounters, unless the user directly asked it to do so or they relate to the current task at hand.
