### PR TITLE
Fix truncation of bash output

### DIFF
--- a/crates/assistant_tools/src/bash_tool.rs
+++ b/crates/assistant_tools/src/bash_tool.rs
@@ -166,7 +166,7 @@ impl Tool for BashTool {
                 }
 
                 bytes_read += read;
-                if bytes_read >= LIMIT + 1 {
+                if bytes_read > LIMIT {
                     bytes_read = LIMIT + 1;
                     break;
                 }

--- a/crates/assistant_tools/src/bash_tool.rs
+++ b/crates/assistant_tools/src/bash_tool.rs
@@ -156,7 +156,21 @@ impl Tool for BashTool {
 
             // Read one more byte to determine whether the output was truncated
             let mut buffer = vec![0; LIMIT + 1];
-            let bytes_read = reader.read(&mut buffer).await?;
+            let mut bytes_read = 0;
+
+            // Read until we reach the limit
+            loop {
+                let read = reader.read(&mut buffer).await?;
+                if read == 0 {
+                    break;
+                }
+
+                bytes_read += read;
+                if bytes_read >= LIMIT + 1 {
+                    bytes_read = LIMIT + 1;
+                    break;
+                }
+            }
 
             // Repeatedly fill the output reader's buffer without copying it.
             loop {


### PR DESCRIPTION
Release Notes:

- Fixed a regression that caused the bash tool to not include all of the output.
