### PR TITLE
agent: Remove type of item in the panel history view

### DIFF
--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -432,17 +432,6 @@ impl RenderOnce for PastThread {
                 h_flex()
                     .gap_1p5()
                     .child(
-                        Label::new("Thread")
-                            .color(Color::Muted)
-                            .size(LabelSize::XSmall),
-                    )
-                    .child(
-                        div()
-                            .size(px(3.))
-                            .rounded_full()
-                            .bg(cx.theme().colors().text_disabled),
-                    )
-                    .child(
                         Label::new(thread_timestamp)
                             .color(Color::Muted)
                             .size(LabelSize::XSmall),
@@ -533,17 +522,6 @@ impl RenderOnce for PastContext {
         .end_slot(
             h_flex()
                 .gap_1p5()
-                .child(
-                    Label::new("Prompt Editor")
-                        .color(Color::Muted)
-                        .size(LabelSize::XSmall),
-                )
-                .child(
-                    div()
-                        .size(px(3.))
-                        .rounded_full()
-                        .bg(cx.theme().colors().text_disabled),
-                )
                 .child(
                     Label::new(context_timestamp)
                         .color(Color::Muted)


### PR DESCRIPTION
This PR removes the labels displaying whether a certain item in the Agent Panel's history is a thread or prompt editor.

Release Notes:

- N/A
