### PR TITLE
Add the project search as an item in the status bar

### DIFF
--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -12,6 +12,7 @@ use workspace::{Toast, Workspace};
 pub mod buffer_search;
 pub mod project_search;
 pub(crate) mod search_bar;
+pub mod search_status_button;
 
 pub fn init(cx: &mut App) {
     menu::init();

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -1,0 +1,47 @@
+use ui::{
+    ButtonCommon, ButtonLike, Clickable, Color, Context, Icon, IconName, IconSize, ParentElement,
+    Render, Styled, Tooltip, Window, h_flex,
+};
+use workspace::{ItemHandle, StatusItemView};
+
+pub struct SearchButton;
+
+impl SearchButton {
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Render for SearchButton {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
+        h_flex().gap_2().child(
+            ButtonLike::new("project-search-indicator")
+                .child(
+                    Icon::new(IconName::MagnifyingGlass)
+                        .size(IconSize::Small)
+                        .color(Color::Default),
+                )
+                .tooltip(|window, cx| {
+                    Tooltip::for_action(
+                        "Project Search",
+                        &workspace::DeploySearch::default(),
+                        window,
+                        cx,
+                    )
+                })
+                .on_click(cx.listener(|_this, _, window, cx| {
+                    window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);
+                })),
+        )
+    }
+}
+
+impl StatusItemView for SearchButton {
+    fn set_active_pane_item(
+        &mut self,
+        _active_pane_item: Option<&dyn ItemHandle>,
+        _window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+    }
+}

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -222,6 +222,7 @@ pub fn initialize_workspace(
             }
         });
 
+        let search_button = cx.new(|_| search::search_status_button::SearchButton::new());
         let diagnostic_summary =
             cx.new(|cx| diagnostics::items::DiagnosticIndicator::new(workspace, cx));
         let activity_indicator = activity_indicator::ActivityIndicator::new(
@@ -239,6 +240,7 @@ pub fn initialize_workspace(
         let cursor_position =
             cx.new(|_| go_to_line::cursor_position::CursorPosition::new(workspace));
         workspace.status_bar().update(cx, |status_bar, cx| {
+            status_bar.add_left_item(search_button, window, cx);
             status_bar.add_left_item(diagnostic_summary, window, cx);
             status_bar.add_left_item(activity_indicator, window, cx);
             status_bar.add_right_item(inline_completion_button, window, cx);


### PR DESCRIPTION
Was chatting with @wilhelmklopp, he pointed out that our current UI-accessible way to access the project search was pretty obscure.


<img width="393" alt="Screenshot 2025-04-08 at 6 57 51 PM" src="https://github.com/user-attachments/assets/636053cd-5a88-4a5e-8155-6d41d189b7db" />

Release Notes:

- Added a button to open the project search to the status bar
