### PR TITLE
Make regex search tool optionally case-sensitive

### DIFF
--- a/crates/assistant_tools/src/regex_search_tool.rs
+++ b/crates/assistant_tools/src/regex_search_tool.rs
@@ -26,6 +26,10 @@ pub struct RegexSearchToolInput {
     /// When not provided, starts from the beginning.
     #[serde(default)]
     pub offset: u32,
+
+    /// Whether the regex is case-sensitive. Defaults to false (case-insensitive).
+    #[serde(default)]
+    pub case_sensitive: bool,
 }
 
 impl RegexSearchToolInput {
@@ -64,12 +68,17 @@ impl Tool for RegexSearchTool {
         match serde_json::from_value::<RegexSearchToolInput>(input.clone()) {
             Ok(input) => {
                 let page = input.page();
-                let regex = MarkdownString::inline_code(&input.regex);
+                let regex_str = MarkdownString::inline_code(&input.regex);
+                let case_info = if input.case_sensitive {
+                    " (case-sensitive)"
+                } else {
+                    ""
+                };
 
                 if page > 1 {
-                    format!("Get page {page} of search results for regex “{regex}”")
+                    format!("Get page {page} of search results for regex {regex_str}{case_info}")
                 } else {
-                    format!("Search files for regex “{regex}”")
+                    format!("Search files for regex {regex_str}{case_info}")
                 }
             }
             Err(_) => "Search with regex".to_string(),
@@ -86,15 +95,16 @@ impl Tool for RegexSearchTool {
     ) -> Task<Result<String>> {
         const CONTEXT_LINES: u32 = 2;
 
-        let (offset, regex) = match serde_json::from_value::<RegexSearchToolInput>(input) {
-            Ok(input) => (input.offset, input.regex),
-            Err(err) => return Task::ready(Err(anyhow!(err))),
-        };
+        let (offset, regex, case_sensitive) =
+            match serde_json::from_value::<RegexSearchToolInput>(input) {
+                Ok(input) => (input.offset, input.regex, input.case_sensitive),
+                Err(err) => return Task::ready(Err(anyhow!(err))),
+            };
 
         let query = match SearchQuery::regex(
             &regex,
             false,
-            false,
+            case_sensitive,
             false,
             PathMatcher::default(),
             PathMatcher::default(),


### PR DESCRIPTION
Release Notes:

- The agent panel's regex search tool is now optionally case-sensitive.
