### PR TITLE
Revert to fix panic in inline assistant

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -227,14 +227,14 @@ impl AssistantPanel {
     ) -> Self {
         let thread = thread_store.update(cx, |this, cx| this.create_thread(cx));
         let fs = workspace.app_state().fs.clone();
-        let project = workspace.project();
+        let project = workspace.project().clone();
         let language_registry = project.read(cx).languages().clone();
         let workspace = workspace.weak_handle();
         let weak_self = cx.entity().downgrade();
 
         let message_editor_context_store = cx.new(|_cx| {
             crate::context_store::ContextStore::new(
-                project.downgrade(),
+                workspace.clone(),
                 Some(thread_store.downgrade()),
             )
         });
@@ -344,7 +344,7 @@ impl AssistantPanel {
 
         let message_editor_context_store = cx.new(|_cx| {
             crate::context_store::ContextStore::new(
-                self.project.downgrade(),
+                self.workspace.clone(),
                 Some(self.thread_store.downgrade()),
             )
         });
@@ -521,7 +521,7 @@ impl AssistantPanel {
                 this.set_active_view(thread_view, window, cx);
                 let message_editor_context_store = cx.new(|_cx| {
                     crate::context_store::ContextStore::new(
-                        this.project.downgrade(),
+                        this.workspace.clone(),
                         Some(this.thread_store.downgrade()),
                     )
                 });

--- a/crates/agent/src/context_picker/completion_provider.rs
+++ b/crates/agent/src/context_picker/completion_provider.rs
@@ -867,7 +867,7 @@ mod tests {
                 .expect("Opened test file wasn't an editor")
         });
 
-        let context_store = cx.new(|_| ContextStore::new(project.downgrade(), None));
+        let context_store = cx.new(|_| ContextStore::new(workspace.downgrade(), None));
 
         let editor_entity = editor.downgrade();
         editor.update_in(&mut cx, |editor, window, cx| {

--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -262,7 +262,13 @@ impl InlineAssistant {
                 }
                 InlineAssistTarget::Terminal(active_terminal) => {
                     TerminalInlineAssistant::update_global(cx, |assistant, cx| {
-                        assistant.assist(&active_terminal, cx.entity(), thread_store, window, cx)
+                        assistant.assist(
+                            &active_terminal,
+                            cx.entity().downgrade(),
+                            thread_store,
+                            window,
+                            cx,
+                        )
                     })
                 }
             };
@@ -316,13 +322,6 @@ impl InlineAssistant {
         window: &mut Window,
         cx: &mut App,
     ) {
-        let Some(project) = workspace
-            .upgrade()
-            .map(|workspace| workspace.read(cx).project().downgrade())
-        else {
-            return;
-        };
-
         let (snapshot, initial_selections) = editor.update(cx, |editor, cx| {
             (
                 editor.snapshot(window, cx),
@@ -426,7 +425,7 @@ impl InlineAssistant {
         for range in codegen_ranges {
             let assist_id = self.next_assist_id.post_inc();
             let context_store =
-                cx.new(|_cx| ContextStore::new(project.clone(), thread_store.clone()));
+                cx.new(|_cx| ContextStore::new(workspace.clone(), thread_store.clone()));
             let codegen = cx.new(|cx| {
                 BufferCodegen::new(
                     editor.read(cx).buffer().clone(),
@@ -520,7 +519,7 @@ impl InlineAssistant {
         initial_prompt: String,
         initial_transaction_id: Option<TransactionId>,
         focus: bool,
-        workspace: Entity<Workspace>,
+        workspace: WeakEntity<Workspace>,
         thread_store: Option<WeakEntity<ThreadStore>>,
         window: &mut Window,
         cx: &mut App,
@@ -538,8 +537,8 @@ impl InlineAssistant {
             range.end = range.end.bias_right(&snapshot);
         }
 
-        let project = workspace.read(cx).project().downgrade();
-        let context_store = cx.new(|_cx| ContextStore::new(project, thread_store.clone()));
+        let context_store =
+            cx.new(|_cx| ContextStore::new(workspace.clone(), thread_store.clone()));
 
         let codegen = cx.new(|cx| {
             BufferCodegen::new(
@@ -563,7 +562,7 @@ impl InlineAssistant {
                 codegen.clone(),
                 self.fs.clone(),
                 context_store,
-                workspace.downgrade(),
+                workspace.clone(),
                 thread_store,
                 window,
                 cx,
@@ -590,7 +589,7 @@ impl InlineAssistant {
                 end_block_id,
                 range,
                 codegen.clone(),
-                workspace.downgrade(),
+                workspace.clone(),
                 window,
                 cx,
             ),
@@ -1780,7 +1779,6 @@ impl CodeActionProvider for AssistantCodeActionProvider {
         let workspace = self.workspace.clone();
         let thread_store = self.thread_store.clone();
         window.spawn(cx, async move |cx| {
-            let workspace = workspace.upgrade().context("workspace was released")?;
             let editor = editor.upgrade().context("editor was released")?;
             let range = editor
                 .update(cx, |editor, cx| {

--- a/crates/agent/src/terminal_inline_assistant.rs
+++ b/crates/agent/src/terminal_inline_assistant.rs
@@ -66,7 +66,7 @@ impl TerminalInlineAssistant {
     pub fn assist(
         &mut self,
         terminal_view: &Entity<TerminalView>,
-        workspace: Entity<Workspace>,
+        workspace: WeakEntity<Workspace>,
         thread_store: Option<WeakEntity<ThreadStore>>,
         window: &mut Window,
         cx: &mut App,
@@ -75,8 +75,8 @@ impl TerminalInlineAssistant {
         let assist_id = self.next_assist_id.post_inc();
         let prompt_buffer =
             cx.new(|cx| MultiBuffer::singleton(cx.new(|cx| Buffer::local(String::new(), cx)), cx));
-        let project = workspace.read(cx).project().downgrade();
-        let context_store = cx.new(|_cx| ContextStore::new(project, thread_store.clone()));
+        let context_store =
+            cx.new(|_cx| ContextStore::new(workspace.clone(), thread_store.clone()));
         let codegen = cx.new(|_| TerminalCodegen::new(terminal, self.telemetry.clone()));
 
         let prompt_editor = cx.new(|cx| {
@@ -87,7 +87,7 @@ impl TerminalInlineAssistant {
                 codegen,
                 self.fs.clone(),
                 context_store.clone(),
-                workspace.downgrade(),
+                workspace.clone(),
                 thread_store.clone(),
                 window,
                 cx,
@@ -106,7 +106,7 @@ impl TerminalInlineAssistant {
             assist_id,
             terminal_view,
             prompt_editor,
-            workspace.downgrade(),
+            workspace.clone(),
             context_store,
             window,
             cx,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2266,7 +2266,7 @@ fn main() {{
         });
 
         let thread = thread_store.update(cx, |store, cx| store.create_thread(cx));
-        let context_store = cx.new(|_cx| ContextStore::new(project.downgrade(), None));
+        let context_store = cx.new(|_cx| ContextStore::new(workspace.downgrade(), None));
 
         (
             workspace,


### PR DESCRIPTION
This reverts commit f12a554f86fa1e2b9b937a9dd103aa7c9a019db9, which introduced a panic in inline assistant (cc @mgsloan) - I'm not sure what the motivation was for that change, but I figure we can revert to fix the inline assistant now and deal with that later. 😄 

Panic was:

> Thread "main" panicked with "cannot read workspace::Workspace while it is already being updated" at /Users/rtfeldman/code/zed/crates/gpui/src/app/entity_map.rs:139:32


Release Notes:

- N/A
