### PR TITLE
Remove actions `UnfoldAt` and `FoldAt`

### DIFF
--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -10,7 +10,7 @@ use collections::{BTreeSet, HashMap, HashSet, hash_map};
 use editor::{
     Anchor, Editor, EditorEvent, MenuInlineCompletionsPolicy, ProposedChangeLocation,
     ProposedChangesEditor, RowExt, ToOffset as _, ToPoint,
-    actions::{FoldAt, MoveToEndOfLine, Newline, ShowCompletions, UnfoldAt},
+    actions::{MoveToEndOfLine, Newline, ShowCompletions},
     display_map::{
         BlockContext, BlockId, BlockPlacement, BlockProperties, BlockStyle, Crease, CreaseMetadata,
         CustomBlockId, FoldId, RenderBlock, ToDisplayPoint,
@@ -1053,7 +1053,7 @@ impl ContextEditor {
             let creases = editor.insert_creases(creases, cx);
 
             for buffer_row in buffer_rows_to_fold.into_iter().rev() {
-                editor.fold_at(&FoldAt { buffer_row }, window, cx);
+                editor.fold_at(buffer_row, window, cx);
             }
 
             creases
@@ -1109,7 +1109,7 @@ impl ContextEditor {
                 buffer_rows_to_fold.clear();
             }
             for buffer_row in buffer_rows_to_fold.into_iter().rev() {
-                editor.fold_at(&FoldAt { buffer_row }, window, cx);
+                editor.fold_at(buffer_row, window, cx);
             }
         });
     }
@@ -1844,13 +1844,7 @@ impl ContextEditor {
                     |_, _, _, _| Empty.into_any(),
                 );
                 editor.insert_creases(vec![crease], cx);
-                editor.fold_at(
-                    &FoldAt {
-                        buffer_row: start_row,
-                    },
-                    window,
-                    cx,
-                );
+                editor.fold_at(start_row, window, cx);
             }
         })
     }
@@ -2042,7 +2036,7 @@ impl ContextEditor {
                         cx,
                     );
                     for buffer_row in buffer_rows_to_fold.into_iter().rev() {
-                        editor.fold_at(&FoldAt { buffer_row }, window, cx);
+                        editor.fold_at(buffer_row, window, cx);
                     }
                 }
             });
@@ -2820,7 +2814,7 @@ fn render_thought_process_fold_icon_button(
                             .start
                             .to_point(&editor.buffer().read(cx).read(cx));
                         let buffer_row = MultiBufferRow(buffer_start.row);
-                        editor.unfold_at(&UnfoldAt { buffer_row }, window, cx);
+                        editor.unfold_at(buffer_row, window, cx);
                     })
                     .ok();
             })
@@ -2847,7 +2841,7 @@ fn render_fold_icon_button(
                             .start
                             .to_point(&editor.buffer().read(cx).read(cx));
                         let buffer_row = MultiBufferRow(buffer_start.row);
-                        editor.unfold_at(&UnfoldAt { buffer_row }, window, cx);
+                        editor.unfold_at(buffer_row, window, cx);
                     })
                     .ok();
             })
@@ -2907,7 +2901,7 @@ fn quote_selection_fold_placeholder(title: String, editor: WeakEntity<Editor>) -
                                     .start
                                     .to_point(&editor.buffer().read(cx).read(cx));
                                 let buffer_row = MultiBufferRow(buffer_start.row);
-                                editor.unfold_at(&UnfoldAt { buffer_row }, window, cx);
+                                editor.unfold_at(buffer_row, window, cx);
                             })
                             .ok();
                     })

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -112,20 +112,6 @@ pub struct ToggleComments {
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
 #[serde(deny_unknown_fields)]
-pub struct FoldAt {
-    #[serde(skip)]
-    pub buffer_row: MultiBufferRow,
-}
-
-#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
-#[serde(deny_unknown_fields)]
-pub struct UnfoldAt {
-    #[serde(skip)]
-    pub buffer_row: MultiBufferRow,
-}
-
-#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]
-#[serde(deny_unknown_fields)]
 pub struct MoveUpByLines {
     #[serde(default)]
     pub(super) lines: u32,
@@ -226,7 +212,6 @@ impl_actions!(
         ExpandExcerpts,
         ExpandExcerptsDown,
         ExpandExcerptsUp,
-        FoldAt,
         HandleInput,
         MoveDownByLines,
         MovePageDown,
@@ -244,7 +229,6 @@ impl_actions!(
         ShowCompletions,
         ToggleCodeActions,
         ToggleComments,
-        UnfoldAt,
         FoldAtLevel,
     ]
 );

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -387,14 +387,12 @@ impl EditorElement {
         register_action(editor, window, Editor::fold_at_level);
         register_action(editor, window, Editor::fold_all);
         register_action(editor, window, Editor::fold_function_bodies);
-        register_action(editor, window, Editor::fold_at);
         register_action(editor, window, Editor::fold_recursive);
         register_action(editor, window, Editor::toggle_fold);
         register_action(editor, window, Editor::toggle_fold_recursive);
         register_action(editor, window, Editor::unfold_lines);
         register_action(editor, window, Editor::unfold_recursive);
         register_action(editor, window, Editor::unfold_all);
-        register_action(editor, window, Editor::unfold_at);
         register_action(editor, window, Editor::fold_selected_ranges);
         register_action(editor, window, Editor::set_mark);
         register_action(editor, window, Editor::swap_selection_ends);


### PR DESCRIPTION
`UnfoldAt` and `FoldAt` are used internally, and don't really work
when users try to trigger them, they do however appear in the command
palette and keybindings, misleading users to try using them.

Release Notes:

- Remove unused actions `UnfoldAt` and `FoldAt` (use `Fold` and `Unfold`).