### PR TITLE
docs: Update outdated keybind for opening extensions page

### DIFF
--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -320,7 +320,7 @@ This example makes comments italic and changes the color of strings:
 
 Change your theme:
 
-1. Use the theme selector (<kbd>cmd-k cmd-t|ctrl-k ctrl-t</kbd>)
+1. Use the theme selector ({#kb theme_selector::Toggle})
 2. Or set it in your `settings.json`:
 
 ```json
@@ -335,7 +335,7 @@ Create custom themes by creating a JSON file in `~/.config/zed/themes/`. Zed wil
 
 ### Using Theme Extensions
 
-Zed supports theme extensions. Browse and install theme extensions from the Extensions panel (<kbd>cmd-shift-e|ctrl-shift-e</kbd>).
+Zed supports theme extensions. Browse and install theme extensions from the Extensions panel ({#kb zed::Extensions}).
 
 To create your own theme extension, refer to the [Developing Theme Extensions](./extensions/themes.md) guide.
 


### PR DESCRIPTION
This PR updates an outdated keybind for opening the extensions page (the shown keybind opens the project panel instead) on the `Configuring Languages` page.

It also updates a nearby keybind to use the preprocessor syntax instead.

Release Notes:

- N/A 