### PR TITLE
Add sublime keybinding for `git::Restore`

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -59,6 +59,12 @@
     }
   },
   {
+    "context": "Editor && !agent_diff",
+    "bindings": {
+      "ctrl-k ctrl-z": "git::Restore"
+    }
+  },
+  {
     "context": "Pane",
     "bindings": {
       "f4": "search::SelectNextMatch",

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -61,6 +61,12 @@
     }
   },
   {
+    "context": "Editor && !agent_diff",
+    "bindings": {
+      "cmd-k cmd-z": "git::Restore"
+    }
+  },
+  {
     "context": "Pane",
     "bindings": {
       "f4": "search::SelectNextMatch",


### PR DESCRIPTION
Release Notes:

- Sublime Keymap: Added `git::Restore` compatibility bind (revert_hunk). Mac: `cmd-k cmd-z` and Linux: `ctrl-k ctrl-z`.
