### PR TITLE
Remove "use_key_equivalents" from linux keymap as it does nothing

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -644,7 +644,6 @@
   },
   {
     "context": "AgentPanel && prompt_editor",
-    "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "agent::NewPromptEditor",
       "cmd-alt-t": "agent::NewThread"
@@ -660,7 +659,6 @@
   },
   {
     "context": "EditMessageEditor > Editor",
-    "use_key_equivalents": true,
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
@@ -669,7 +667,6 @@
   },
   {
     "context": "AgentFeedbackMessageEditor > Editor",
-    "use_key_equivalents": true,
     "bindings": {
       "escape": "menu::Cancel",
       "enter": "menu::Confirm",
@@ -801,7 +798,6 @@
   },
   {
     "context": "GitPanel",
-    "use_key_equivalents": true,
     "bindings": {
       "ctrl-g ctrl-g": "git::Fetch",
       "ctrl-g up": "git::Push",


### PR DESCRIPTION
Release Notes:

- N/A