### PR TITLE
editor: Fix hang when scrolling over single line input fields

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1620,8 +1620,6 @@ impl Editor {
             }));
 
         this.end_selection(window, cx);
-        this.scroll_manager
-            .set_forbid_vertical_scroll(matches!(mode, EditorMode::SingleLine { .. }));
         this.scroll_manager.show_scrollbars(window, cx);
         jsx_tag_auto_close::refresh_enabled_in_any_buffer(&mut this, &buffer, cx);
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1620,6 +1620,8 @@ impl Editor {
             }));
 
         this.end_selection(window, cx);
+        this.scroll_manager
+            .set_forbid_vertical_scroll(matches!(mode, EditorMode::SingleLine { .. }));
         this.scroll_manager.show_scrollbars(window, cx);
         jsx_tag_auto_close::refresh_enabled_in_any_buffer(&mut this, &buffer, cx);
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6632,7 +6632,10 @@ impl Element for EditorElement {
                     let max_row = snapshot.max_point().row().as_f32();
 
                     // The max scroll position for the top of the window
-                    let max_scroll_top = if matches!(snapshot.mode, EditorMode::AutoHeight { .. }) {
+                    let max_scroll_top = if matches!(
+                        snapshot.mode,
+                        EditorMode::AutoHeight { .. } | EditorMode::SingleLine { .. }
+                    ) {
                         (max_row - height_in_lines + 1.).max(0.)
                     } else {
                         let settings = EditorSettings::get_global(cx);


### PR DESCRIPTION
Closes #21684
Closes #28463
Closes #28264 

This PR fixes Zed hanging when scrolling over single line input fields with `scroll_beyond_last_line` set to `vertical_scroll_margin`. The change here is to fix the calculations of available lines.

The issue only arises with the setting present because with all overscroll settings and `max_row` being 1 for single-line editors, the calculation would still return the correct value of available lines, which is 1. However, with overscrolling set to `vertical_scroll_margin` and that set to any value greater than 0, the calculation would return that the single-line editor has more than one line, which caused the issues described above (Actually, setting `vertical_scroll_margin` to 1 works for some reason, overscrolls "properly" and does not cause a crash. But I really did not want to investigate this buggy behavior further). 

This PR fixes this by always reporting the number of available lines as the line number value for single line editors, which will (mostly) be 1 (for more context see the discussion in this PR).

Release Notes:

- Fixed an issue where Zed would crash when scrolling over single line input fields and `scroll_beyond_last_line` set to `vertical_scroll_margin`.
