### PR TITLE
agent: Add button to open thread as markdown

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1,4 +1,3 @@
-use crate::AssistantPanel;
 use crate::context::{AssistantContext, ContextId};
 use crate::context_picker::MentionLink;
 use crate::thread::{
@@ -8,6 +7,7 @@ use crate::thread::{
 use crate::thread_store::ThreadStore;
 use crate::tool_use::{PendingToolUseStatus, ToolUse, ToolUseStatus};
 use crate::ui::{AddedContext, AgentNotification, AgentNotificationEvent, ContextPill};
+use crate::{AssistantPanel, OpenActiveThreadAsMarkdown};
 use anyhow::Context as _;
 use assistant_settings::{AssistantSettings, NotifyWhenAgentWaiting};
 use collections::{HashMap, HashSet};
@@ -1314,8 +1314,16 @@ impl ActiveThread {
         let editor_bg_color = colors.editor_background;
         let bg_user_message_header = editor_bg_color.blend(active_color.opacity(0.25));
 
-        let feedback_container = h_flex().py_2().px_4().gap_1().justify_between();
+        let copy_to_markdown = IconButton::new("open-as-markdown", IconName::FileCode)
+            .shape(ui::IconButtonShape::Square)
+            .icon_size(IconSize::XSmall)
+            .icon_color(Color::Ignored)
+            .tooltip(Tooltip::text("Open Thread as Markdown"))
+            .on_click(|_event, window, cx| {
+                window.dispatch_action(Box::new(OpenActiveThreadAsMarkdown), cx)
+            });
 
+        let feedback_container = h_flex().py_2().px_4().gap_1().justify_between();
         let feedback_items = match self.thread.read(cx).message_feedback(message_id) {
             Some(feedback) => feedback_container
                 .child(
@@ -1367,7 +1375,8 @@ impl ActiveThread {
                                         cx,
                                     );
                                 })),
-                        ),
+                        )
+                        .child(copy_to_markdown),
                 )
                 .into_any_element(),
             None => feedback_container
@@ -1380,6 +1389,7 @@ impl ActiveThread {
                 )
                 .child(
                     h_flex()
+                        .pr_1()
                         .gap_1()
                         .child(
                             IconButton::new(("feedback-thumbs-up", ix), IconName::ThumbsUp)
@@ -1410,7 +1420,8 @@ impl ActiveThread {
                                         cx,
                                     );
                                 })),
-                        ),
+                        )
+                        .child(copy_to_markdown),
                 )
                 .into_any_element(),
         };

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1314,7 +1314,7 @@ impl ActiveThread {
         let editor_bg_color = colors.editor_background;
         let bg_user_message_header = editor_bg_color.blend(active_color.opacity(0.25));
 
-        let copy_to_markdown = IconButton::new("open-as-markdown", IconName::FileCode)
+        let open_as_markdown = IconButton::new("open-as-markdown", IconName::FileCode)
             .shape(ui::IconButtonShape::Square)
             .icon_size(IconSize::XSmall)
             .icon_color(Color::Ignored)
@@ -1376,7 +1376,7 @@ impl ActiveThread {
                                     );
                                 })),
                         )
-                        .child(copy_to_markdown),
+                        .child(open_as_markdown),
                 )
                 .into_any_element(),
             None => feedback_container
@@ -1421,7 +1421,7 @@ impl ActiveThread {
                                     );
                                 })),
                         )
-                        .child(copy_to_markdown),
+                        .child(open_as_markdown),
                 )
                 .into_any_element(),
         };


### PR DESCRIPTION
<img src="https://github.com/user-attachments/assets/92ca8f64-a949-4cc1-a657-3978a2c65839" width="600"/>

Release Notes:

- agent: The action to open the current active thread in Markdown is now exposed in the UI.
