### PR TITLE
Show more comprehensive error details

### DIFF
--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -691,6 +691,6 @@ trait ToWasmtimeResult<T> {
 
 impl<T> ToWasmtimeResult<T> for Result<T> {
     fn to_wasmtime_result(self) -> wasmtime::Result<Result<T, String>> {
-        Ok(self.map_err(|error| error.to_string()))
+        Ok(self.map_err(|error| format!("{:#}", error)))
     }
 }


### PR DESCRIPTION
When installing wakatime extension(https://github.com/wakatime/zed-wakatime/issues/28), I got an "failed to unzip" error, but it doesn't provide any detailed error information. This is likely because `to_string()` only captures the context message added by `anyhow::Context`, not the full error chain. We could use `{:#}` or `{:?}` to print causes.

Release Notes:

- N/A