### PR TITLE
gpui: Fix a bug with Japanese romaji typing in input example

### DIFF
--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -334,7 +334,11 @@ impl EntityInputHandler for TextInput {
         self.content =
             (self.content[0..range.start].to_owned() + new_text + &self.content[range.end..])
                 .into();
-        self.marked_range = Some(range.start..range.start + new_text.len());
+        if !new_text.is_empty() {
+            self.marked_range = Some(range.start..range.start + new_text.len());
+        } else {
+            self.marked_range = None;
+        }
         self.selected_range = new_selected_range_utf16
             .as_ref()
             .map(|range_utf16| self.range_from_utf16(range_utf16))


### PR DESCRIPTION
Steps to reproduce:
* On macOS, run `input` example
* type `aaa|bbb` place caret on the place marked with |
* switch to `japanese romaji`
* press `ko`
* press left arrow

<img width="412" alt="image" src="https://github.com/user-attachments/assets/d3c02e9b-98f9-420e-a3b7-681ba90829cd" />

You will get `aaa` duplicated with every arrow press.

According to [reference implementation](https://developer.apple.com/library/archive/samplecode/TextInputView/Listings/FadingTextView_m.html#//apple_ref/doc/uid/DTS40008840-FadingTextView_m-DontLinkElementID_6) we need to unmark text when we get empty line in `setMarkedText `