### PR TITLE
Fix merge conflicts jumping

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -2630,9 +2630,7 @@ impl RepositorySnapshot {
     }
 
     pub fn has_conflict(&self, repo_path: &RepoPath) -> bool {
-        self.statuses_by_path
-            .get(&PathKey(repo_path.0.clone()), &())
-            .map_or(false, |entry| entry.status.is_conflicted())
+        self.merge_conflicts.contains(repo_path)
     }
 
     /// This is the name that will be displayed in the repository selector for this repository.


### PR DESCRIPTION
This regressed in #27568, oops.

Release Notes:

- Fixed a bug causing conflicted files in the git panel to jump to the "Tracked" section as soon as they were staged.