### PR TITLE
editor: Restore selections to positions after last edit

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -14218,13 +14218,7 @@ impl Editor {
             }
         };
 
-        let transaction_id_prev = buffer.read_with(cx, |b, cx| {
-            if let Some(singleton) = b.as_singleton() {
-                singleton.read_with(cx, |b, _| b.peek_undo_stack().map(|h| h.transaction_id()))
-            } else {
-                b.last_transaction_id()
-            }
-        });
+        let transaction_id_prev = buffer.read_with(cx, |b, cx| b.last_transaction_id(cx));
         let selections_prev = transaction_id_prev
             .and_then(|transaction_id_prev| {
                 // default to selections as they were after the last edit, if we have them,
@@ -14265,13 +14259,9 @@ impl Editor {
                 })
                 .ok();
 
-            if let Some(transaction_id_now) = buffer.read_with(cx, |b, cx| {
-                if let Some(singleton) = b.as_singleton() {
-                    singleton.read_with(cx, |b, _| b.peek_undo_stack().map(|h| h.transaction_id()))
-                } else {
-                    b.last_transaction_id()
-                }
-            })? {
+            if let Some(transaction_id_now) =
+                buffer.read_with(cx, |b, cx| b.last_transaction_id(cx))?
+            {
                 let has_new_transaction = transaction_id_prev != Some(transaction_id_now);
                 if has_new_transaction {
                     _ = editor.update(cx, |editor, _| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -923,8 +923,57 @@ struct SelectionHistory {
     selections_by_transaction:
         HashMap<TransactionId, (Arc<[Selection<Anchor>]>, Option<Arc<[Selection<Anchor>]>>)>,
     mode: SelectionHistoryMode,
-    undo_stack: VecDeque<SelectionHistoryEntry>,
-    redo_stack: VecDeque<SelectionHistoryEntry>,
+    undo_stack: SelectionHistoryRingBuffer,
+    redo_stack: SelectionHistoryRingBuffer,
+}
+
+struct SelectionHistoryRingBuffer {
+    index: usize,
+    entries: [Option<SelectionHistoryEntry>; MAX_SELECTION_HISTORY_LEN],
+}
+
+impl Default for SelectionHistoryRingBuffer {
+    fn default() -> Self {
+        return Self::new();
+    }
+}
+
+impl SelectionHistoryRingBuffer {
+    fn new() -> Self {
+        return Self {
+            index: 0,
+            entries: [0; MAX_SELECTION_HISTORY_LEN].map(|_| None),
+        };
+    }
+
+    fn push(&mut self, entry: SelectionHistoryEntry) {
+        self.entries[self.index].replace(entry);
+        self.index += 1;
+        if self.index >= MAX_SELECTION_HISTORY_LEN {
+            self.index = 0;
+        }
+    }
+
+    fn pop(&mut self) -> Option<SelectionHistoryEntry> {
+        if self.index == 0 {
+            self.index = MAX_SELECTION_HISTORY_LEN;
+        }
+        self.index -= 1;
+        return self.entries[self.index].take();
+    }
+
+    fn clear(&mut self) {
+        self.entries.fill(None);
+    }
+
+    fn back(&self) -> Option<&SelectionHistoryEntry> {
+        let mut index = self.index;
+        if index == 0 {
+            index = MAX_SELECTION_HISTORY_LEN;
+        }
+        index -= 1;
+        return self.entries[index].as_ref();
+    }
 }
 
 impl SelectionHistory {
@@ -972,10 +1021,7 @@ impl SelectionHistory {
             .back()
             .map_or(true, |e| e.selections != entry.selections)
         {
-            self.undo_stack.push_back(entry);
-            if self.undo_stack.len() > MAX_SELECTION_HISTORY_LEN {
-                self.undo_stack.pop_front();
-            }
+            self.undo_stack.push(entry);
         }
     }
 
@@ -985,10 +1031,7 @@ impl SelectionHistory {
             .back()
             .map_or(true, |e| e.selections != entry.selections)
         {
-            self.redo_stack.push_back(entry);
-            if self.redo_stack.len() > MAX_SELECTION_HISTORY_LEN {
-                self.redo_stack.pop_front();
-            }
+            self.redo_stack.push(entry);
         }
     }
 }
@@ -12747,7 +12790,7 @@ impl Editor {
         self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.end_selection(window, cx);
         self.selection_history.mode = SelectionHistoryMode::Undoing;
-        if let Some(entry) = self.selection_history.undo_stack.pop_back() {
+        if let Some(entry) = self.selection_history.undo_stack.pop() {
             self.change_selections(None, window, cx, |s| {
                 s.select_anchors(entry.selections.to_vec())
             });
@@ -12768,7 +12811,7 @@ impl Editor {
         self.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction);
         self.end_selection(window, cx);
         self.selection_history.mode = SelectionHistoryMode::Redoing;
-        if let Some(entry) = self.selection_history.redo_stack.pop_back() {
+        if let Some(entry) = self.selection_history.redo_stack.pop() {
             self.change_selections(None, window, cx, |s| {
                 s.select_anchors(entry.selections.to_vec())
             });

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -14175,12 +14175,34 @@ impl Editor {
             }
         };
 
+        let transaction_id_prev = buffer.read_with(cx, |b, cx| {
+            if let Some(singleton) = b.as_singleton() {
+                singleton.read_with(cx, |b, _| b.peek_undo_stack().map(|h| h.transaction_id()))
+            } else {
+                b.last_transaction_id()
+            }
+        });
+        let selections_prev = transaction_id_prev
+            .and_then(|transaction_id_prev| {
+                // default to selections as they were after the last edit, if we have them,
+                // instead of how they are now.
+                // This will make it so that editing, moving somewhere else, formatting, then undoing the format
+                // will take you back to where you made the last edit, instead of staying where you scrolled
+                self.selection_history
+                    .transaction(transaction_id_prev)
+                    .map(|t| t.0.clone())
+            })
+            .unwrap_or_else(|| {
+                log::info!("Failed to determine selections from before format. Falling back to selections when format was initiated");
+                self.selections.disjoint_anchors()
+            });
+
         let mut timeout = cx.background_executor().timer(FORMAT_TIMEOUT).fuse();
         let format = project.update(cx, |project, cx| {
             project.format(buffers, target, true, trigger, cx)
         });
 
-        cx.spawn_in(window, async move |_, cx| {
+        cx.spawn_in(window, async move |editor, cx| {
             let transaction = futures::select_biased! {
                 transaction = format.log_err().fuse() => transaction,
                 () = timeout => {
@@ -14199,6 +14221,23 @@ impl Editor {
                     cx.notify();
                 })
                 .ok();
+
+            if let Some(transaction_id_now) = buffer.read_with(cx, |b, cx| {
+                if let Some(singleton) = b.as_singleton() {
+                    singleton.read_with(cx, |b, _| b.peek_undo_stack().map(|h| h.transaction_id()))
+                } else {
+                    b.last_transaction_id()
+                }
+            })? {
+                let has_new_transaction = transaction_id_prev != Some(transaction_id_now);
+                if has_new_transaction {
+                    _ = editor.update(cx, |editor, _| {
+                        editor
+                            .selection_history
+                            .insert_transaction(transaction_id_now, selections_prev);
+                    });
+                }
+            }
 
             Ok(())
         })


### PR DESCRIPTION
Closes #22692

Makes it so when undoing a format operation, the selections are set to where they were at the last edit.

Release Notes:

- Made it so the cursor position is reset to where it was after the last edit when undoing a format operation. This only changes the behavior when you make an edit, scroll away, initiate formatting (either by saving or manually) and then undo the format.
