### PR TITLE
Change zed.dev's default model to Claude 3.7 Sonnet

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -624,14 +624,14 @@
       // The provider to use.
       "provider": "zed.dev",
       // The model to use.
-      "model": "claude-3-5-sonnet-latest"
+      "model": "claude-3-7-sonnet-latest"
     },
     // The model to use when applying edits from the assistant.
     "editor_model": {
       // The provider to use.
       "provider": "zed.dev",
       // The model to use.
-      "model": "claude-3-5-sonnet-latest"
+      "model": "claude-3-7-sonnet-latest"
     },
     // When enabled, the agent can run potentially destructive actions without asking for your confirmation.
     "always_allow_tool_actions": false,

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -37,9 +37,9 @@ pub enum AnthropicModelMode {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
-    #[default]
     #[serde(rename = "claude-3-5-sonnet", alias = "claude-3-5-sonnet-latest")]
     Claude3_5Sonnet,
+    #[default]
     #[serde(rename = "claude-3-7-sonnet", alias = "claude-3-7-sonnet-latest")]
     Claude3_7Sonnet,
     #[serde(

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -742,7 +742,7 @@ mod tests {
                 AssistantSettings::get_global(cx).default_model,
                 LanguageModelSelection {
                     provider: "zed.dev".into(),
-                    model: "claude-3-5-sonnet-latest".into(),
+                    model: "claude-3-7-sonnet-latest".into(),
                 }
             );
         });

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -274,7 +274,7 @@ async fn create_billing_subscription(
         customer.id
     };
 
-    let default_model = llm_db.model(rpc::LanguageModelProvider::Anthropic, "claude-3-5-sonnet")?;
+    let default_model = llm_db.model(rpc::LanguageModelProvider::Anthropic, "claude-3-7-sonnet")?;
     let stripe_model = stripe_billing.register_model(default_model).await?;
     let success_url = format!(
         "{}/account?checkout_complete=1",

--- a/docs/src/assistant/configuration.md
+++ b/docs/src/assistant/configuration.md
@@ -316,8 +316,8 @@ Where `some-provider` can be any of the following values: `anthropic`, `google`,
 
 ### Configuring Models {#default-model}
 
-The default model can be set via the model dropdown in the assistant panel's top-right corner. Selecting a model saves it as the default.
-You can also manually edit the `default_model` object in your settings:
+Zed's hosted LLM service sets `claude-3-7-sonnet-latest` as the default model.
+However, you can change it either via the model dropdown in the Assistant Panel's bottom-left corner or by manually editing the `default_model` object in your settings:
 
 ```json
 {
@@ -325,7 +325,7 @@ You can also manually edit the `default_model` object in your settings:
     "version": "2",
     "default_model": {
       "provider": "zed.dev",
-      "model": "claude-3-5-sonnet"
+      "model": "gpt-4o"
     }
   }
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2998,11 +2998,11 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "default_height": 320,
   "default_model": {
     "provider": "zed.dev",
-    "model": "claude-3-5-sonnet-latest"
+    "model": "claude-3-7-sonnet-latest"
   },
   "editor_model": {
     "provider": "zed.dev",
-    "model": "claude-3-5-sonnet-latest"
+    "model": "claude-3-7-sonnet-latest"
   }
 }
 ```


### PR DESCRIPTION
From Claude 3.5 Sonnet to **Claude 3.7 Sonnet**.

Release Notes:

- Change the default model of Zed's hosted LLM service to Claude 3.7 Sonnet.
