### PR TITLE
html: Fix leading slash on Windows paths

### DIFF
--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -77,8 +77,7 @@ impl zed::Extension for HtmlExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                env::current_dir()
-                    .unwrap()
+                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -111,3 +110,24 @@ impl zed::Extension for HtmlExtension {
 }
 
 zed::register_extension!(HtmlExtension);
+
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{Os, current_platform};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
This PR builds on the fix proposed in [zed-extensions/astro#5](https://github.com/zed-extensions/astro/pull/5) and serves as a workaround for certain LSPs affected by [zed-industries/zed#20559](https://github.com/zed-industries/zed/issues/20559)—specifically, the HTML language server in this case.

Credit to @maxdeviant for identifying and implementing the original fix. This PR extends that solution to other areas where it may be beneficial.

Release Notes:

- N/A
