### PR TITLE
vim: Add delete keymapping to vim.json

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -203,6 +203,7 @@
       "c": "vim::PushChange",
       "shift-c": "vim::ChangeToEndOfLine",
       "d": "vim::PushDelete",
+      "delete": "vim::DeleteRight",
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
       "g shift-j": "vim::JoinLinesNoWhitespace",

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -3816,4 +3816,11 @@ mod test {
             Mode::Normal,
         );
     }
+    #[gpui::test]
+    async fn test_delete_key_can_remove_last_character(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.set_shared_state("abˇc").await;
+        cx.simulate_shared_keystrokes("delete").await;
+        cx.shared_state().await.assert_eq("aˇb");
+    }
 }

--- a/crates/vim/test_data/test_delete_key_can_remove_last_character.json
+++ b/crates/vim/test_data/test_delete_key_can_remove_last_character.json
@@ -1,0 +1,3 @@
+{"Put":{"state":"abˇc"}}
+{"Key":"delete"}
+{"Get":{"state":"aˇb","mode":"Normal"}}


### PR DESCRIPTION
Closes #16511

Added test for delete in normal mode and keymapping in vim.json

Release Notes:

- Added delete mapping in normal mode
