### PR TITLE
agent: Fix "new text thread" action name

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -625,7 +625,7 @@
     "context": "AgentPanel",
     "bindings": {
       "ctrl-n": "agent::NewThread",
-      "ctrl-alt-n": "agent::NewPromptEditor",
+      "ctrl-alt-n": "agent::NewTextThread",
       "ctrl-shift-h": "agent::OpenHistory",
       "ctrl-alt-c": "agent::OpenConfiguration",
       "ctrl-i": "agent::ToggleProfileSelector",
@@ -646,7 +646,7 @@
   {
     "context": "AgentPanel && prompt_editor",
     "bindings": {
-      "cmd-n": "agent::NewPromptEditor",
+      "cmd-n": "agent::NewTextThread",
       "cmd-alt-t": "agent::NewThread"
     }
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -281,7 +281,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "cmd-n": "agent::NewThread",
-      "cmd-alt-n": "agent::NewPromptEditor",
+      "cmd-alt-n": "agent::NewTextThread",
       "cmd-shift-h": "agent::OpenHistory",
       "cmd-alt-c": "agent::OpenConfiguration",
       "cmd-i": "agent::ToggleProfileSelector",
@@ -303,7 +303,7 @@
     "context": "AgentPanel && prompt_editor",
     "use_key_equivalents": true,
     "bindings": {
-      "cmd-n": "agent::NewPromptEditor",
+      "cmd-n": "agent::NewTextThread",
       "cmd-alt-t": "agent::NewThread"
     }
   },

--- a/crates/agent/src/assistant.rs
+++ b/crates/agent/src/assistant.rs
@@ -46,7 +46,7 @@ pub use agent_diff::{AgentDiff, AgentDiffToolbar};
 actions!(
     agent,
     [
-        NewPromptEditor,
+        NewTextThread,
         ToggleContextPicker,
         ToggleProfileSelector,
         RemoveAllContext,

--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -44,7 +44,7 @@ use crate::thread::{Thread, ThreadError, ThreadId, TokenUsageRatio};
 use crate::thread_history::{PastContext, PastThread, ThreadHistory};
 use crate::thread_store::ThreadStore;
 use crate::{
-    AgentDiff, InlineAssistant, NewPromptEditor, NewThread, OpenActiveThreadAsMarkdown,
+    AgentDiff, InlineAssistant, NewTextThread, NewThread, OpenActiveThreadAsMarkdown,
     OpenAgentDiff, OpenHistory, ThreadEvent, ToggleContextPicker,
 };
 
@@ -70,7 +70,7 @@ pub fn init(cx: &mut App) {
                         panel.update(cx, |panel, cx| panel.open_configuration(window, cx));
                     }
                 })
-                .register_action(|workspace, _: &NewPromptEditor, window, cx| {
+                .register_action(|workspace, _: &NewTextThread, window, cx| {
                     if let Some(panel) = workspace.panel::<AssistantPanel>(cx) {
                         workspace.focus_panel::<AssistantPanel>(window, cx);
                         panel.update(cx, |panel, cx| panel.new_prompt_editor(window, cx));
@@ -1090,7 +1090,7 @@ impl AssistantPanel {
                                             |menu, _window, _cx| {
                                                 menu.action(
                                                     "New Text Thread",
-                                                    NewPromptEditor.boxed_clone(),
+                                                    NewTextThread.boxed_clone(),
                                                 )
                                                 .when(!is_empty, |menu| {
                                                     menu.action(


### PR DESCRIPTION
Moving from "NewPromptEditor" to "NewTextThread". We recently re-named that and this was missing.

Release Notes:

- N/A
