### PR TITLE
Fix staging/unstaging hunks remotely

### DIFF
--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -6967,7 +6967,7 @@ async fn test_staging_hunks_with_delayed_fs_event(cx: &mut gpui::TestAppContext)
     });
 }
 
-#[gpui::test]
+#[gpui::test(iterations = 25)]
 async fn test_staging_random_hunks(
     mut rng: StdRng,
     executor: BackgroundExecutor,


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/zed-industries/zed/pull/28377 where the pending hunks didn't get cleared properly when staging/unstaging hunks remotely. I didn't add new tests, because the fix was to simplify some code.

Release Notes:

- N/A
