### PR TITLE
docs: Update Rails test task to run using name

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -291,13 +291,14 @@ To run tests in your Ruby project, you can set up custom tasks in your local `.z
 ```json
 [
   {
-    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
-    "command": "bin/rails",
-    "args": ["test", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "label": "test $ZED_RELATIVE_FILE -n /$ZED_SYMBOL/",
+    "command": "bin/rails test $ZED_RELATIVE_FILE -n /$ZED_SYMBOL/",
     "tags": ["ruby-test"]
   }
 ]
 ```
+
+Note: We can't use `args` here because of the way quotes are handled.
 
 ### Minitest
 


### PR DESCRIPTION
The author of Rails' minitest integration [recommended](https://github.com/zed-extensions/ruby/issues/56#issuecomment-2795010202) using the test name rather than line number.

This solves the problem in https://github.com/zed-extensions/ruby/issues/56.

Note that everything is within `command`. I first tried using `args`:

```json
{
  "command": "bin/rails",
  "args": ["test", "$ZED_RELATIVE_FILE -n /$ZED_SYMBOL/"],
  "tags": ["ruby-test"]
}
```
but minitest receives this as:

```
Run options: -n "/\"foo bar\"/" --seed 31855
```

which doesn't match due to the escaping.

Release Notes:

- N/A
