### PR TITLE
docs: Fix name for `zed: open project tasks` command

### DIFF
--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -65,7 +65,7 @@ Keep `"use_new_terminal": false` and set `"allow_concurrent_runs": true` to allo
 Tasks can be defined:
 
 - in the global `tasks.json` file; such tasks are available in all Zed projects you work on. This file is usually located in `~/.config/zed/tasks.json`. You can edit them by using the `zed: open tasks` action.
-- in the worktree-specific (local) `.zed/tasks.json` file; such tasks are available only when working on a project with that worktree included. You can edit worktree-specific tasks by using the `zed: open local tasks` action.
+- in the worktree-specific (local) `.zed/tasks.json` file; such tasks are available only when working on a project with that worktree included. You can edit worktree-specific tasks by using the `zed: open project tasks` action.
 - on the fly with [oneshot tasks](#oneshot-tasks). These tasks are project-specific and do not persist across sessions.
 - by language extension.
 


### PR DESCRIPTION
There's no `zed: open local tasks`, perhaps it was called that previously.

Release Notes:

- N/A
