### PR TITLE
Fix `AddSelectionAbove` and `AddSelectionBelow` skipping lines shorter than cursor column

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11549,16 +11549,15 @@ impl Editor {
             selections.clear();
             let mut stack = Vec::new();
             for row in range.start.row().0..=range.end.row().0 {
-                if let Some(selection) = self.selections.build_columnar_selection(
+                let selection = self.selections.build_columnar_selection(
                     &display_map,
                     DisplayRow(row),
                     &positions,
                     oldest_selection.reversed,
                     &text_layout_details,
-                ) {
-                    stack.push(selection.id);
-                    selections.push(selection);
-                }
+                );
+                stack.push(selection.id);
+                selections.push(selection);
             }
 
             if above {
@@ -11600,24 +11599,23 @@ impl Editor {
                             row.0 += 1;
                         }
 
-                        if let Some(new_selection) = self.selections.build_columnar_selection(
+                        let new_selection = self.selections.build_columnar_selection(
                             &display_map,
                             row,
                             &positions,
                             selection.reversed,
                             &text_layout_details,
-                        ) {
-                            state.stack.push(new_selection.id);
-                            if above {
-                                new_selections.push(new_selection);
-                                new_selections.push(selection);
-                            } else {
-                                new_selections.push(selection);
-                                new_selections.push(new_selection);
-                            }
-
-                            continue 'outer;
+                        );
+                        state.stack.push(new_selection.id);
+                        if above {
+                            new_selections.push(new_selection);
+                            new_selections.push(selection);
+                        } else {
+                            new_selections.push(selection);
+                            new_selections.push(new_selection);
                         }
+
+                        continue 'outer;
                     }
                 }
 

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -349,30 +349,22 @@ impl SelectionsCollection {
         positions: &Range<Pixels>,
         reversed: bool,
         text_layout_details: &TextLayoutDetails,
-    ) -> Option<Selection<Point>> {
-        let is_empty = positions.start == positions.end;
-        let line_len = display_map.line_len(row);
-
+    ) -> Selection<Point> {
         let line = display_map.layout_row(row, text_layout_details);
-
         let start_col = line.closest_index_for_x(positions.start) as u32;
-        if start_col < line_len || (is_empty && positions.start == line.width) {
-            let start = DisplayPoint::new(row, start_col);
-            let end_col = line.closest_index_for_x(positions.end) as u32;
-            let end = DisplayPoint::new(row, end_col);
+        let start = DisplayPoint::new(row, start_col);
+        let end_col = line.closest_index_for_x(positions.end) as u32;
+        let end = DisplayPoint::new(row, end_col);
 
-            Some(Selection {
-                id: post_inc(&mut self.next_selection_id),
-                start: start.to_point(display_map),
-                end: end.to_point(display_map),
-                reversed,
-                goal: SelectionGoal::HorizontalRange {
-                    start: positions.start.into(),
-                    end: positions.end.into(),
-                },
-            })
-        } else {
-            None
+        Selection {
+            id: post_inc(&mut self.next_selection_id),
+            start: start.to_point(display_map),
+            end: end.to_point(display_map),
+            reversed,
+            goal: SelectionGoal::HorizontalRange {
+                start: positions.start.into(),
+                end: positions.end.into(),
+            },
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/28322

Release Notes:

- Fixed `AddSelectionAbove` and `AddSelectionBelow` skipping lines shorter than cursor column

The [removed condition](https://github.com/zed-industries/zed/blob/2f5c662c4287cbde1a7414151aa9a9a835026900/crates/editor/src/selections_collection.rs#L359) likely comes from the logic used for column/block selection with mouse, but no lines should be skipped when moving with keyboard. That would match VS Code and Sublime behaviour.
