### PR TITLE
Try to weak-link ScreenCaptureKit always

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -7,8 +7,6 @@ fn main() {
 
     if cfg!(target_os = "macos") {
         println!("cargo:rustc-env=MACOSX_DEPLOYMENT_TARGET=10.15.7");
-        // Weakly link ScreenCaptureKit to ensure can be used on macOS 10.15+.
-        println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
     }
 
     // Populate git sha environment variable if git is available

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -77,8 +77,8 @@ mod macos {
 
     fn generate_dispatch_bindings() {
         println!("cargo:rustc-link-lib=framework=System");
-        println!("cargo:rustc-link-lib=framework=ScreenCaptureKit");
-        println!("cargo:rerun-if-changed=src/platform/mac/dispatch.h");
+        // println!("cargo:rustc-link-lib=weak_framework=ScreenCaptureKit");
+        println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
 
         let bindings = bindgen::Builder::default()
             .header("src/platform/mac/dispatch.h")

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -77,7 +77,7 @@ mod macos {
 
     fn generate_dispatch_bindings() {
         println!("cargo:rustc-link-lib=framework=System");
-        // println!("cargo:rustc-link-lib=weak_framework=ScreenCaptureKit");
+        // weak link to support Catalina
         println!("cargo:rustc-link-arg=-Wl,-weak_framework,ScreenCaptureKit");
 
         let bindings = bindgen::Builder::default()

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -2,7 +2,7 @@ use super::{
     BoolExt,
     attributed_string::{NSAttributedString, NSMutableAttributedString},
     events::key_to_native,
-    renderer, screen_capture,
+    is_macos_version_at_least, renderer, screen_capture,
 };
 use crate::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardEntry, ClipboardItem, ClipboardString,
@@ -22,8 +22,8 @@ use cocoa::{
     },
     base::{BOOL, NO, YES, id, nil, selector},
     foundation::{
-        NSArray, NSAutoreleasePool, NSBundle, NSData, NSInteger, NSProcessInfo, NSRange, NSString,
-        NSUInteger, NSURL,
+        NSArray, NSAutoreleasePool, NSBundle, NSData, NSInteger, NSOperatingSystemVersion,
+        NSProcessInfo, NSRange, NSString, NSUInteger, NSURL,
     },
 };
 use core_foundation::{
@@ -553,7 +553,8 @@ impl Platform for MacPlatform {
     }
 
     fn is_screen_capture_supported(&self) -> bool {
-        true
+        let min_version = NSOperatingSystemVersion::new(12, 3, 0);
+        is_macos_version_at_least(min_version)
     }
 
     fn screen_capture_sources(

--- a/crates/gpui/src/platform/mac/screen_capture.rs
+++ b/crates/gpui/src/platform/mac/screen_capture.rs
@@ -37,9 +37,6 @@ pub struct MacScreenCaptureStream {
     sc_stream_output: id,
 }
 
-#[link(name = "ScreenCaptureKit", kind = "framework")]
-unsafe extern "C" {}
-
 static mut DELEGATE_CLASS: *const Class = ptr::null();
 static mut OUTPUT_CLASS: *const Class = ptr::null();
 const FRAME_CALLBACK_IVAR: &str = "frame_callback";

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1568,7 +1568,7 @@ extern "C" fn window_will_exit_fullscreen(this: &Object, _: Sel, _: id) {
     }
 }
 
-fn is_macos_version_at_least(version: NSOperatingSystemVersion) -> bool {
+pub(crate) fn is_macos_version_at_least(version: NSOperatingSystemVersion) -> bool {
     unsafe { NSProcessInfo::processInfo(nil).isOperatingSystemAtLeastVersion(version) }
 }
 


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/28445

Release Notes:

- Fixed v0.181.5 being accidentally broken for old versions of macOS (Catalina, Big Sur). Users impacted by this may need to manually redownload if they auto-updated to an impacted version.