### PR TITLE
ci: No draft releases when using 'run-bundling'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,7 +594,7 @@ jobs:
     timeout-minutes: 60
     name: Linux x86_x64 release bundle
     runs-on:
-      - buildjet-16vcpu-ubuntu-2004
+      - buildjet-16vcpu-ubuntu-2004 # ubuntu 20.04 for minimal glibc
     if: |
       startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,26 +622,23 @@ jobs:
       - name: Create Linux .tar.gz bundle
         run: script/bundle-linux
 
-      - name: Upload Linux bundle to workflow run if main branch or specific label
+      - name: Upload Artifact to Workflow - zed (run-bundling)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: |
-          github.ref == 'refs/heads/main'
-          || contains(github.event.pull_request.labels.*.name, 'run-bundling')
+        if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
         with:
           name: zed-${{ github.event.pull_request.head.sha || github.sha }}-x86_64-unknown-linux-gnu.tar.gz
           path: target/release/zed-*.tar.gz
 
-      - name: Upload Linux remote server to workflow run if main branch or specific label
+      - name: Upload Artifact to Workflow - zed-remote-server (run-bundling)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: |
-          github.ref == 'refs/heads/main'
-          || contains(github.event.pull_request.labels.*.name, 'run-bundling')
+        if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
         with:
           name: zed-remote-server-${{ github.event.pull_request.head.sha || github.sha }}-x86_64-unknown-linux-gnu.gz
           path: target/zed-remote-server-linux-x86_64.gz
 
-      - name: Upload app bundle to release
+      - name: Upload Artifacts to release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        if: ! contains(github.event.pull_request.labels.*.name , 'run-bundling')
         with:
           draft: true
           prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
@@ -680,29 +677,26 @@ jobs:
           # This exports RELEASE_CHANNEL into env (GITHUB_ENV)
           script/determine-release-channel
 
-      - name: Create and upload Linux .tar.gz bundle
+      - name: Create and upload Linux .tar.gz bundles
         run: script/bundle-linux
 
-      - name: Upload Linux bundle to workflow run if main branch or specific label
+      - name: Upload Artifact to Workflow - zed (run-bundling)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: |
-          github.ref == 'refs/heads/main'
-          || contains(github.event.pull_request.labels.*.name, 'run-bundling')
+        if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
         with:
           name: zed-${{ github.event.pull_request.head.sha || github.sha }}-aarch64-unknown-linux-gnu.tar.gz
           path: target/release/zed-*.tar.gz
 
-      - name: Upload Linux remote server to workflow run if main branch or specific label
+      - name: Upload Artifact to Workflow - zed-remote-server (run-bundling)
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: |
-          github.ref == 'refs/heads/main'
-          || contains(github.event.pull_request.labels.*.name, 'run-bundling')
+        if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
         with:
           name: zed-remote-server-${{ github.event.pull_request.head.sha || github.sha }}-aarch64-unknown-linux-gnu.gz
           path: target/zed-remote-server-linux-aarch64.gz
 
-      - name: Upload app bundle to release
+      - name: Upload Artifacts to release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        if: ! contains(github.event.pull_request.labels.*.name , 'run-bundling')
         with:
           draft: true
           prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,7 +638,7 @@ jobs:
 
       - name: Upload Artifacts to release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        if: ! contains(github.event.pull_request.labels.*.name , 'run-bundling')
+        if: ${{ !(contains(github.event.pull_request.labels.*.name, 'run-bundling')) }}
         with:
           draft: true
           prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -696,7 +696,7 @@ jobs:
 
       - name: Upload Artifacts to release
         uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        if: ! contains(github.event.pull_request.labels.*.name , 'run-bundling')
+        if: ${{ !(contains(github.event.pull_request.labels.*.name, 'run-bundling')) }}
         with:
           draft: true
           prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -18,7 +18,7 @@ echo -n "" >"$OUTPUT_FILE"
     echo -e "\n# ###### CODE LICENSES ######\n"
 } >>"$OUTPUT_FILE"
 
-if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" 2>&1 >/dev/null; then
+if ! cargo about --version | grep "cargo-about $CARGO_ABOUT_VERSION" &>/dev/null; then
     echo "Installing cargo-about@^$CARGO_ABOUT_VERSION..."
     cargo install "cargo-about@^$CARGO_ABOUT_VERSION"
 else


### PR DESCRIPTION
Improve the logic in around release artifact bundling.
- Suppress a harmless "error: no such command: `about`" from script/generate-licenes output
- Remove checks for main branch (which will never be true)
- Only run `Upload Artifacts to release` when not using `run-bundling`. Prevents the creation of draft releases with just linux remote server binaries) like this:
    <img width="972" alt="Screenshot 2025-04-11 at 14 23 49" src="https://github.com/user-attachments/assets/d41f65f9-3e9e-4c13-8a42-4eb6d78531eb" />

Release Notes:

- N/A
