### PR TITLE
Update haskell extension docs

### DIFF
--- a/docs/src/languages/haskell.md
+++ b/docs/src/languages/haskell.md
@@ -49,4 +49,3 @@ If you would like to use a specific hls binary, or perhaps use [static-ls](https
   }
 }
 ```
-

--- a/docs/src/languages/haskell.md
+++ b/docs/src/languages/haskell.md
@@ -33,4 +33,20 @@ If you need to configure haskell-language-server (hls) you can add configuration
 }
 ```
 
-See: official [configuring haskell-language-server](https://haskell-language-server.readthedocs.io/en/latest/configuration.html) docs for more.
+See the official [configuring haskell-language-server](https://haskell-language-server.readthedocs.io/en/latest/configuration.html) docs for more options.
+
+If you would like to use a specific hls binary, or perhaps use [static-ls](https://github.com/josephsumabat/static-ls) as a drop-in replacement instead, you can specify the binary path and arguments:
+
+```json
+{
+  "lsp": {
+    "hls": {
+      "binary": {
+        "path": "static-ls",
+        "arguments": ["--experimentalFeatures"]
+      }
+    }
+  }
+}
+```
+


### PR DESCRIPTION
In https://github.com/zed-extensions/haskell/pull/2 the HLS settings were updated to respect binary path/argument overrides. This PR just updates the docs to demonstrate this.

Release Notes:

- N/A