### PR TITLE
extension_builder: Workaround for snake_case of 'd2' grammar

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -106,11 +106,22 @@ impl ExtensionBuilder {
         }
 
         for (grammar_name, grammar_metadata) in &extension_manifest.grammars {
-            let snake_cased_grammar_name = grammar_name.to_case(Case::Snake);
-            if grammar_name.as_ref() != snake_cased_grammar_name.as_str() {
-                bail!(
-                    "grammar name '{grammar_name}' must be written in snake_case: {snake_cased_grammar_name}"
-                );
+            // Allow `d2` to not have to be `d_2`
+            // See: https://github.com/rutrum/convert-case/issues/21
+            if grammar_name.len() == 2 {
+                let lower_cased_grammar_name = grammar_name.to_lowercase();
+                if grammar_name.as_ref() != lower_cased_grammar_name.as_str() {
+                    bail!(
+                        "grammar name '{grammar_name}' must be written in snake_case: {lower_cased_grammar_name}"
+                    );
+                }
+            } else {
+                let snake_cased_grammar_name = grammar_name.to_case(Case::Snake);
+                if grammar_name.as_ref() != snake_cased_grammar_name.as_str() {
+                    bail!(
+                        "grammar name '{grammar_name}' must be written in snake_case: {snake_cased_grammar_name}"
+                    );
+                }
             }
 
             log::info!(


### PR DESCRIPTION
We have an existing extension [gabeidx/zed-d2](https://github.com/gabeidx/zed-d2) with a tree-sitter grammar called 'd2' which predates our enforcement of snake_case using the  [convert_case crate](https://crates.io/crates/convert_case) ([rutrum/convert-case](https://github.com/rutrum/convert-case)).

As-is this extension cannot be installed as a dev extension / built and errors with:
```
2025-04-11T17:13:25.645243-04:00 [WARN] grammar name 'd2' must be written in snake_case: d_2
```

If we are following [Rust RFC 430](https://rust-lang.github.io/api-guidelines/naming.html) snakecase should be `d2` not `d_2` because:

> In snake_case or SCREAMING_SNAKE_CASE, a "word" should never consist of a single letter unless it is the last "word". So, we have btree_map rather than b_tree_map, but PI_2 rather than PI2. 

See also:
- https://github.com/rutrum/convert-case/issues/21

Release Notes:

- N/A
