### PR TITLE
Keep .vscode folder included during initialization even if it's in .gitignore

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -375,6 +375,11 @@ pub fn local_settings_folder_relative_path() -> &'static Path {
     Path::new(".zed")
 }
 
+/// Returns the relative path to a `.vscode` folder within a project.
+pub fn local_vscode_folder_relative_path() -> &'static Path {
+    Path::new(".zed")
+}
+
 /// Returns the relative path to a `settings.json` file within a project.
 pub fn local_settings_file_relative_path() -> &'static Path {
     Path::new(".zed/settings.json")

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -377,7 +377,7 @@ pub fn local_settings_folder_relative_path() -> &'static Path {
 
 /// Returns the relative path to a `.vscode` folder within a project.
 pub fn local_vscode_folder_relative_path() -> &'static Path {
-    Path::new(".zed")
+    Path::new(".vscode")
 }
 
 /// Returns the relative path to a `settings.json` file within a project.

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -29,7 +29,7 @@ use ignore::IgnoreStack;
 use language::DiskState;
 
 use parking_lot::Mutex;
-use paths::local_settings_folder_relative_path;
+use paths::{local_settings_folder_relative_path, local_vscode_folder_relative_path};
 use postage::{
     barrier,
     prelude::{Sink as _, Stream as _},
@@ -2865,6 +2865,7 @@ impl BackgroundScannerState {
         (!entry.is_external && (!entry.is_ignored || entry.is_always_included))
             || entry.path.file_name() == Some(*DOT_GIT)
             || entry.path.file_name() == Some(local_settings_folder_relative_path().as_os_str())
+            || entry.path.file_name() == Some(local_vscode_folder_relative_path().as_os_str())
             || self.scanned_dirs.contains(&entry.id) // If we've ever scanned it, keep scanning
             || self
                 .paths_to_scan


### PR DESCRIPTION
This fixes an issue where tasks in `.vscode/tasks.json` weren't being loaded at startup of a project

Closes #28494

Release Notes:

- Tasks are now loaded from local `.vscode/tasks.json` files even if they are `.gitignore`d
