### PR TITLE
assistant_tools: Fix code_action and rename schemas for Gemini

### DIFF
--- a/crates/assistant_tools/src/code_action_tool.rs
+++ b/crates/assistant_tools/src/code_action_tool.rs
@@ -10,6 +10,8 @@ use serde::{Deserialize, Serialize};
 use std::{ops::Range, sync::Arc};
 use ui::IconName;
 
+use crate::schema::json_schema_for;
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct CodeActionToolInput {
     /// The relative path to the file containing the text range.
@@ -97,10 +99,9 @@ impl Tool for CodeActionTool {
 
     fn input_schema(
         &self,
-        _format: language_model::LanguageModelToolSchemaFormat,
+        format: language_model::LanguageModelToolSchemaFormat,
     ) -> serde_json::Value {
-        let schema = schemars::schema_for!(CodeActionToolInput);
-        serde_json::to_value(&schema).unwrap()
+        json_schema_for::<CodeActionToolInput>(format)
     }
 
     fn ui_text(&self, input: &serde_json::Value) -> String {

--- a/crates/assistant_tools/src/rename_tool.rs
+++ b/crates/assistant_tools/src/rename_tool.rs
@@ -9,6 +9,8 @@ use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use ui::IconName;
 
+use crate::schema::json_schema_for;
+
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct RenameToolInput {
     /// The relative path to the file containing the symbol to rename.
@@ -68,10 +70,9 @@ impl Tool for RenameTool {
 
     fn input_schema(
         &self,
-        _format: language_model::LanguageModelToolSchemaFormat,
+        format: language_model::LanguageModelToolSchemaFormat,
     ) -> serde_json::Value {
-        let schema = schemars::schema_for!(RenameToolInput);
-        serde_json::to_value(&schema).unwrap()
+        json_schema_for::<RenameToolInput>(format)
     }
 
     fn ui_text(&self, input: &serde_json::Value) -> String {


### PR DESCRIPTION
Closes #28475

Updates `rename` and `code_action` `input_schema` methods to use `json_schema_for<T>()` which transforms standard JSONSchema into the subset required by Gemini.
Also makes `input_schema` implementations consistent.
Tested tools against Gemini 2.5 Pro Preview, Zed Claude 3.7 Sonnet Thinking, o3-mini

Release Notes:

- Agent Beta: Fixed error 400 `INVALID_ARGUMENT` when using Gemini with `code_actions` or `rename` tools enabled.