### PR TITLE
vim: Add cursor shape settings for each vim mode

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1481,7 +1481,13 @@
     "use_multiline_find": false,
     "use_smartcase_find": false,
     "highlight_on_yank_duration": 200,
-    "custom_digraphs": {}
+    "custom_digraphs": {},
+    "cursor_shape": {
+      "normal": "block",
+      "replace": "underline",
+      "insert": "bar",
+      "visual": "block"
+    }
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1482,12 +1482,11 @@
     "use_smartcase_find": false,
     "highlight_on_yank_duration": 200,
     "custom_digraphs": {},
-    "cursor_shape": {
-      "normal": "block",
-      "replace": "underline",
-      "insert": "bar",
-      "visual": "block"
-    }
+    // Cursor shape for the each mode.
+    // Specify the mode as the key and the shape as the value.
+    // The mode can be one of the following: "normal", "replace", "insert", "visual".
+    // The shape can be one of the following: "block", "bar", "underline", "hollow".
+    "cursor_shape": {}
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.


### PR DESCRIPTION
Closes #4495

Release Notes:

- vim: add cursor shape settings for each vim mode

---

Add cursor shape settings for each vim mode to enable users to specify them.

Example of `settings.json`:

```json
{
  "vim_mode": true,
  "vim": {
    "cursor_shape": {
      "normal": "hollow",
      "insert": "bar",
      "replace": "block",
      "visual": "underline"
    }
  }
}
```

After this change is applied,

- The cursor shape specified by the user for each mode is used.
- In insert mode, the `vim > cursor_shape > insert` setting takes precedence over the primary `cursor_shape` setting.
- If `vim > cursor_shape > insert` is not set, the primary `cursor_shape` will be used in insert mode.
- The cursor shape will remain unchanged before and after this update when the user does not set the `vim > cursor_shape` setting.

Video:

[screen-record.webm](https://github.com/user-attachments/assets/b87461a1-6b3a-4a77-a607-a340f106def5)
