### PR TITLE
Detect decorated pytest methods as runnable

### DIFF
--- a/crates/languages/src/python/runnables.scm
+++ b/crates/languages/src/python/runnables.scm
@@ -83,6 +83,26 @@
     )
 )
 
+; decorated pytest class methods
+(
+    (module
+        (class_definition
+            name: (identifier) @_pytest_class_name
+            (#match? @_pytest_class_name "^Test")
+            body: (block
+                (decorated_definition
+                    (decorator)+ @_decorator
+                    definition: (function_definition
+                        name: (identifier) @run @_pytest_method_name
+                        (#match? @_pytest_method_name "^test_")
+                        )
+                    )
+            ) @_python-pytest-method
+            (#set! tag python-pytest-method)
+        )
+    )
+)
+
 ; module main method
 (
     (module


### PR DESCRIPTION
Closes #28096

Release Notes:

- Fixed decorated pytest methods not being picked up as runnable
