### PR TITLE
snippets: Fix plaintext snippets not working

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1376,11 +1376,20 @@ impl Buffer {
     /// Returns each [`Language`] for the active syntax layers at the given location.
     pub fn languages_at<D: ToOffset>(&self, position: D) -> Vec<Arc<Language>> {
         let offset = position.to_offset(self);
-        self.syntax_map
+        let mut languages: Vec<Arc<Language>> = self
+            .syntax_map
             .lock()
             .layers_for_range(offset..offset, &self.text, false)
             .map(|info| info.language.clone())
-            .collect()
+            .collect();
+
+        if languages.is_empty() {
+            if let Some(buffer_language) = self.language() {
+                languages.push(buffer_language.clone());
+            }
+        }
+
+        languages
     }
 
     /// An integer version number that accounts for all updates besides


### PR DESCRIPTION
This PR fixes a minor regression introduced in #27718, where snippets stopped working when the language was set to plaintext because `languages_at` doesn't include plaintext, while `language_at` does.

Release Notes:

- Fixed plaintext snippets not working