### PR TITLE
bedrock: Fix Bedrock provider name in the assistant settings schema

### DIFF
--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -684,7 +684,7 @@ impl JsonSchema for LanguageModelProviderSetting {
         schemars::schema::SchemaObject {
             enum_values: Some(vec![
                 "anthropic".into(),
-                "bedrock".into(),
+                "amazon-bedrock".into(),
                 "google".into(),
                 "lmstudio".into(),
                 "ollama".into(),


### PR DESCRIPTION
Rename Bedrock provider to amazon-bedrock

This aligns with the actual provider name used in configuration.

**Before:**

<img width="589" alt="image" src="https://github.com/user-attachments/assets/1a0521fa-cdf0-41a5-bfc9-6a6135f352ae" />


**After:**

<img width="570" alt="image" src="https://github.com/user-attachments/assets/ff6fb93e-4376-4e5a-8152-1e29e0a380dd" />


Release Notes:

- Fixed amazon-bedrock is an invalid model provider name
