### PR TITLE
copilot_chat: Add Gemini 2.5 Pro support to Copilot Chat

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -50,6 +50,8 @@ pub enum Model {
     Claude3_7SonnetThinking,
     #[serde(alias = "gemini-2.0-flash", rename = "gemini-2.0-flash-001")]
     Gemini20Flash,
+    #[serde(alias = "gemini-2.5-pro", rename = "gemini-2.5-pro")]
+    Gemini25Pro,
 }
 
 impl Model {
@@ -61,7 +63,7 @@ impl Model {
             | Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking => true,
-            Self::O3Mini | Self::O1 | Self::Gemini20Flash => false,
+            Self::O3Mini | Self::O1 | Self::Gemini20Flash | Self::Gemini25Pro => false,
         }
     }
 
@@ -76,6 +78,7 @@ impl Model {
             "claude-3-7-sonnet" => Ok(Self::Claude3_7Sonnet),
             "claude-3.7-sonnet-thought" => Ok(Self::Claude3_7SonnetThinking),
             "gemini-2.0-flash-001" => Ok(Self::Gemini20Flash),
+            "gemini-2.5-pro" => Ok(Self::Gemini25Pro),
             _ => Err(anyhow!("Invalid model id: {}", id)),
         }
     }
@@ -91,6 +94,7 @@ impl Model {
             Self::Claude3_7Sonnet => "claude-3-7-sonnet",
             Self::Claude3_7SonnetThinking => "claude-3.7-sonnet-thought",
             Self::Gemini20Flash => "gemini-2.0-flash-001",
+            Self::Gemini25Pro => "gemini-2.5-pro",
         }
     }
 
@@ -105,6 +109,7 @@ impl Model {
             Self::Claude3_7Sonnet => "Claude 3.7 Sonnet",
             Self::Claude3_7SonnetThinking => "Claude 3.7 Sonnet Thinking",
             Self::Gemini20Flash => "Gemini 2.0 Flash",
+            Self::Gemini25Pro => "Gemini 2.5 Pro",
         }
     }
 
@@ -118,7 +123,8 @@ impl Model {
             Self::Claude3_5Sonnet => 200_000,
             Self::Claude3_7Sonnet => 90_000,
             Self::Claude3_7SonnetThinking => 90_000,
-            Model::Gemini20Flash => 128_000,
+            Self::Gemini20Flash => 128_000,
+            Self::Gemini25Pro => 128_000,
         }
     }
 }

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -210,7 +210,9 @@ impl LanguageModel for CopilotChatLanguageModel {
             CopilotChatModel::Claude3_5Sonnet => count_anthropic_tokens(request, cx),
             CopilotChatModel::Claude3_7Sonnet => count_anthropic_tokens(request, cx),
             CopilotChatModel::Claude3_7SonnetThinking => count_anthropic_tokens(request, cx),
-            CopilotChatModel::Gemini20Flash => count_google_tokens(request, cx),
+            CopilotChatModel::Gemini20Flash | CopilotChatModel::Gemini25Pro => {
+                count_google_tokens(request, cx)
+            }
             _ => {
                 let model = match self.model {
                     CopilotChatModel::Gpt4o => open_ai::Model::FourOmni,
@@ -220,7 +222,8 @@ impl LanguageModel for CopilotChatLanguageModel {
                     CopilotChatModel::Claude3_5Sonnet
                     | CopilotChatModel::Claude3_7Sonnet
                     | CopilotChatModel::Claude3_7SonnetThinking
-                    | CopilotChatModel::Gemini20Flash => {
+                    | CopilotChatModel::Gemini20Flash
+                    | CopilotChatModel::Gemini25Pro => {
                         unreachable!()
                     }
                 };


### PR DESCRIPTION
<img width="407" alt="image" src="https://github.com/user-attachments/assets/1319c6a8-e6b6-42ad-94d2-15de7e3aa8aa" />

<img width="503" alt="image" src="https://github.com/user-attachments/assets/6ee2dfc6-8852-4722-8bd8-d3ea56c3ec8a" />


Release Notes:

- Added Gemini 2.5 Pro support to Copilot Chat
