### PR TITLE
editor: Show code actions in mouse context menu

### DIFF
--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -694,7 +694,15 @@ async fn test_collaborating_with_code_actions(
     // Confirming the code action will trigger a resolve request.
     let confirm_action = editor_b
         .update_in(cx_b, |editor, window, cx| {
-            Editor::confirm_code_action(editor, &ConfirmCodeAction { item_ix: Some(0) }, window, cx)
+            Editor::confirm_code_action(
+                editor,
+                &ConfirmCodeAction {
+                    item_ix: Some(0),
+                    deployed_from_mouse_context_menu: false,
+                },
+                window,
+                cx,
+            )
         })
         .unwrap();
     fake_language_server.set_request_handler::<lsp::request::CodeActionResolveRequest, _, _>(

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -698,7 +698,7 @@ async fn test_collaborating_with_code_actions(
                 editor,
                 &ConfirmCodeAction {
                     item_ix: Some(0),
-                    deployed_from_mouse_context_menu: false,
+                    from_mouse_context_menu: false,
                 },
                 window,
                 cx,

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -99,6 +99,9 @@ pub struct ComposeCompletion {
 pub struct ConfirmCodeAction {
     #[serde(default)]
     pub item_ix: Option<usize>,
+    #[serde(default)]
+    #[serde(skip)]
+    pub deployed_from_mouse_context_menu: bool,
 }
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -101,7 +101,7 @@ pub struct ConfirmCodeAction {
     pub item_ix: Option<usize>,
     #[serde(default)]
     #[serde(skip)]
-    pub deployed_from_mouse_context_menu: bool,
+    pub from_mouse_context_menu: bool,
 }
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema)]

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -774,19 +774,10 @@ pub struct AvailableCodeAction {
     pub provider: Rc<dyn CodeActionProvider>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct CodeActionContents {
     pub tasks: Option<Rc<ResolvedTasks>>,
     pub actions: Option<Rc<[AvailableCodeAction]>>,
-}
-
-impl Default for CodeActionContents {
-    fn default() -> Self {
-        Self {
-            tasks: None,
-            actions: None,
-        }
-    }
 }
 
 impl CodeActionContents {

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -790,7 +790,7 @@ impl CodeActionContents {
         }
     }
 
-    fn is_empty(&self) -> bool {
+    pub fn is_empty(&self) -> bool {
         match (&self.tasks, &self.actions) {
             (Some(tasks), Some(actions)) => actions.is_empty() && tasks.templates.is_empty(),
             (Some(tasks), None) => tasks.templates.is_empty(),
@@ -799,7 +799,7 @@ impl CodeActionContents {
         }
     }
 
-    fn iter(&self) -> impl Iterator<Item = CodeActionsItem> + '_ {
+    pub fn iter(&self) -> impl Iterator<Item = CodeActionsItem> + '_ {
         self.tasks
             .iter()
             .flat_map(|tasks| {
@@ -867,14 +867,14 @@ pub enum CodeActionsItem {
 }
 
 impl CodeActionsItem {
-    fn as_task(&self) -> Option<&ResolvedTask> {
+    pub fn as_task(&self) -> Option<&ResolvedTask> {
         let Self::Task(_, task) = self else {
             return None;
         };
         Some(task)
     }
 
-    fn as_code_action(&self) -> Option<&CodeAction> {
+    pub fn as_code_action(&self) -> Option<&CodeAction> {
         let Self::CodeAction { action, .. } = self else {
             return None;
         };

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -780,6 +780,15 @@ pub struct CodeActionContents {
     pub actions: Option<Rc<[AvailableCodeAction]>>,
 }
 
+impl Default for CodeActionContents {
+    fn default() -> Self {
+        Self {
+            tasks: None,
+            actions: None,
+        }
+    }
+}
+
 impl CodeActionContents {
     fn len(&self) -> usize {
         match (&self.tasks, &self.actions) {

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1014,7 +1014,7 @@ impl CodeActionsMenu {
                                         if let Some(task) = editor.confirm_code_action(
                                             &ConfirmCodeAction {
                                                 item_ix: Some(item_ix),
-                                                deployed_from_mouse_context_menu: false,
+                                                from_mouse_context_menu: false,
                                             },
                                             window,
                                             cx,
@@ -1040,7 +1040,7 @@ impl CodeActionsMenu {
                                         if let Some(task) = editor.confirm_code_action(
                                             &ConfirmCodeAction {
                                                 item_ix: Some(item_ix),
-                                                deployed_from_mouse_context_menu: false,
+                                                from_mouse_context_menu: false,
                                             },
                                             window,
                                             cx,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1014,6 +1014,7 @@ impl CodeActionsMenu {
                                         if let Some(task) = editor.confirm_code_action(
                                             &ConfirmCodeAction {
                                                 item_ix: Some(item_ix),
+                                                deployed_from_mouse_context_menu: false,
                                             },
                                             window,
                                             cx,
@@ -1039,6 +1040,7 @@ impl CodeActionsMenu {
                                         if let Some(task) = editor.confirm_code_action(
                                             &ConfirmCodeAction {
                                                 item_ix: Some(item_ix),
+                                                deployed_from_mouse_context_menu: false,
                                             },
                                             window,
                                             cx,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5026,11 +5026,14 @@ impl Editor {
         self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
 
         let (action, buffer) = if action.from_mouse_context_menu {
-            let menu = self.mouse_context_menu.as_ref()?;
-            let code_action = menu.code_action.as_ref()?;
-            let index = action.item_ix?;
-            let action = code_action.actions.get(index)?;
-            (action, code_action.buffer.clone())
+            if let Some(menu) = self.mouse_context_menu.take() {
+                let code_action = menu.code_action?;
+                let index = action.item_ix?;
+                let action = code_action.actions.get(index)?;
+                (action, code_action.buffer)
+            } else {
+                return None;
+            }
         } else {
             if let CodeContextMenu::CodeActions(menu) = self.hide_context_menu(window, cx)? {
                 let action_ix = action.item_ix.unwrap_or(menu.selected_item);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4987,7 +4987,7 @@ impl Editor {
                                 if let Some(task) = editor.confirm_code_action(
                                     &ConfirmCodeAction {
                                         item_ix: Some(0),
-                                        deployed_from_mouse_context_menu: false,
+                                        from_mouse_context_menu: false,
                                     },
                                     window,
                                     cx,
@@ -5025,7 +5025,7 @@ impl Editor {
     ) -> Option<Task<Result<()>>> {
         self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
 
-        let (action, buffer) = if action.deployed_from_mouse_context_menu {
+        let (action, buffer) = if action.from_mouse_context_menu {
             let menu = self.mouse_context_menu.as_ref()?;
             let code_action = menu.code_action.as_ref()?;
             let index = action.item_ix?;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4833,6 +4833,89 @@ impl Editor {
         }))
     }
 
+    fn prepare_code_actions_task(
+        &mut self,
+        action: &ToggleCodeActions,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Task<Option<(Entity<Buffer>, CodeActionContents)>> {
+        let snapshot = self.snapshot(window, cx);
+        let multibuffer_point = action
+            .deployed_from_indicator
+            .map(|row| DisplayPoint::new(row, 0).to_point(&snapshot))
+            .unwrap_or_else(|| self.selections.newest::<Point>(cx).head());
+
+        let Some((buffer, buffer_row)) = snapshot
+            .buffer_snapshot
+            .buffer_line_for_row(MultiBufferRow(multibuffer_point.row))
+            .and_then(|(buffer_snapshot, range)| {
+                self.buffer
+                    .read(cx)
+                    .buffer(buffer_snapshot.remote_id())
+                    .map(|buffer| (buffer, range.start.row))
+            })
+        else {
+            return Task::ready(None);
+        };
+
+        let (_, code_actions) = self
+            .available_code_actions
+            .clone()
+            .and_then(|(location, code_actions)| {
+                let snapshot = location.buffer.read(cx).snapshot();
+                let point_range = location.range.to_point(&snapshot);
+                let point_range = point_range.start.row..=point_range.end.row;
+                if point_range.contains(&buffer_row) {
+                    Some((location, code_actions))
+                } else {
+                    None
+                }
+            })
+            .unzip();
+
+        let buffer_id = buffer.read(cx).remote_id();
+        let tasks = self
+            .tasks
+            .get(&(buffer_id, buffer_row))
+            .map(|t| Arc::new(t.to_owned()));
+
+        if tasks.is_none() && code_actions.is_none() {
+            return Task::ready(None);
+        }
+
+        self.completion_tasks.clear();
+        self.discard_inline_completion(false, cx);
+
+        let task_context = tasks
+            .as_ref()
+            .zip(self.project.clone())
+            .map(|(tasks, project)| {
+                Self::build_tasks_context(&project, &buffer, buffer_row, tasks, cx)
+            });
+
+        cx.spawn_in(window, async move |_, _| {
+            let task_context = match task_context {
+                Some(task_context) => task_context.await,
+                None => None,
+            };
+            let resolved_tasks = tasks.zip(task_context).map(|(tasks, task_context)| {
+                Rc::new(ResolvedTasks {
+                    templates: tasks.resolve(&task_context).collect(),
+                    position: snapshot
+                        .buffer_snapshot
+                        .anchor_before(Point::new(multibuffer_point.row, tasks.column)),
+                })
+            });
+            Some((
+                buffer,
+                CodeActionContents {
+                    actions: code_actions,
+                    tasks: resolved_tasks,
+                },
+            ))
+        })
+    }
+
     pub fn toggle_code_actions(
         &mut self,
         action: &ToggleCodeActions,
@@ -4853,106 +4936,48 @@ impl Editor {
             }
         }
         drop(context_menu);
-        let snapshot = self.snapshot(window, cx);
+
         let deployed_from_indicator = action.deployed_from_indicator;
         let mut task = self.code_actions_task.take();
         let action = action.clone();
+
         cx.spawn_in(window, async move |editor, cx| {
             while let Some(prev_task) = task {
                 prev_task.await.log_err();
                 task = editor.update(cx, |this, _| this.code_actions_task.take())?;
             }
 
-            let spawned_test_task = editor.update_in(cx, |editor, window, cx| {
-                if editor.focus_handle.is_focused(window) {
-                    let multibuffer_point = action
-                        .deployed_from_indicator
-                        .map(|row| DisplayPoint::new(row, 0).to_point(&snapshot))
-                        .unwrap_or_else(|| editor.selections.newest::<Point>(cx).head());
-                    let (buffer, buffer_row) = snapshot
-                        .buffer_snapshot
-                        .buffer_line_for_row(MultiBufferRow(multibuffer_point.row))
-                        .and_then(|(buffer_snapshot, range)| {
-                            editor
-                                .buffer
-                                .read(cx)
-                                .buffer(buffer_snapshot.remote_id())
-                                .map(|buffer| (buffer, range.start.row))
-                        })?;
-                    let (_, code_actions) = editor
-                        .available_code_actions
-                        .clone()
-                        .and_then(|(location, code_actions)| {
-                            let snapshot = location.buffer.read(cx).snapshot();
-                            let point_range = location.range.to_point(&snapshot);
-                            let point_range = point_range.start.row..=point_range.end.row;
-                            if point_range.contains(&buffer_row) {
-                                Some((location, code_actions))
-                            } else {
-                                None
-                            }
-                        })
-                        .unzip();
-                    let buffer_id = buffer.read(cx).remote_id();
-                    let tasks = editor
-                        .tasks
-                        .get(&(buffer_id, buffer_row))
-                        .map(|t| Arc::new(t.to_owned()));
-                    if tasks.is_none() && code_actions.is_none() {
-                        return None;
-                    }
-
-                    editor.completion_tasks.clear();
-                    editor.discard_inline_completion(false, cx);
-                    let task_context =
-                        tasks
-                            .as_ref()
-                            .zip(editor.project.clone())
-                            .map(|(tasks, project)| {
-                                Self::build_tasks_context(&project, &buffer, buffer_row, tasks, cx)
-                            });
-
-                    let debugger_flag = cx.has_flag::<Debugger>();
-
-                    Some(cx.spawn_in(window, async move |editor, cx| {
-                        let task_context = match task_context {
-                            Some(task_context) => task_context.await,
-                            None => None,
-                        };
-                        let resolved_tasks =
-                            tasks.zip(task_context).map(|(tasks, task_context)| {
-                                Rc::new(ResolvedTasks {
-                                    templates: tasks.resolve(&task_context).collect(),
-                                    position: snapshot.buffer_snapshot.anchor_before(Point::new(
-                                        multibuffer_point.row,
-                                        tasks.column,
-                                    )),
-                                })
-                            });
-                        let spawn_straight_away = resolved_tasks.as_ref().map_or(false, |tasks| {
-                            tasks
-                                .templates
-                                .iter()
-                                .filter(|task| {
-                                    if matches!(task.1.task_type(), task::TaskType::Debug(_)) {
-                                        debugger_flag
-                                    } else {
-                                        true
-                                    }
-                                })
-                                .count()
-                                == 1
-                        }) && code_actions
-                            .as_ref()
-                            .map_or(true, |actions| actions.is_empty());
+            let context_menu_task = editor.update_in(cx, |editor, window, cx| {
+                if !editor.focus_handle.is_focused(window) {
+                    return Some(Task::ready(Ok(())));
+                }
+                let debugger_flag = cx.has_flag::<Debugger>();
+                let code_actions_task = editor.prepare_code_actions_task(&action, window, cx);
+                Some(cx.spawn_in(window, async move |editor, cx| {
+                    if let Some((buffer, code_action_contents)) = code_actions_task.await {
+                        let spawn_straight_away =
+                            code_action_contents.tasks.as_ref().map_or(false, |tasks| {
+                                tasks
+                                    .templates
+                                    .iter()
+                                    .filter(|task| {
+                                        if matches!(task.1.task_type(), task::TaskType::Debug(_)) {
+                                            debugger_flag
+                                        } else {
+                                            true
+                                        }
+                                    })
+                                    .count()
+                                    == 1
+                            }) && code_action_contents
+                                .actions
+                                .as_ref()
+                                .map_or(true, |actions| actions.is_empty());
                         if let Ok(task) = editor.update_in(cx, |editor, window, cx| {
                             *editor.context_menu.borrow_mut() =
                                 Some(CodeContextMenu::CodeActions(CodeActionsMenu {
                                     buffer,
-                                    actions: CodeActionContents {
-                                        tasks: resolved_tasks,
-                                        actions: code_actions,
-                                    },
+                                    actions: code_action_contents,
                                     selected_item: Default::default(),
                                     scroll_handle: UniformListScrollHandle::default(),
                                     deployed_from_indicator,
@@ -4974,12 +4999,12 @@ impl Editor {
                         } else {
                             Ok(())
                         }
-                    }))
-                } else {
-                    Some(Task::ready(Ok(())))
-                }
+                    } else {
+                        Ok(())
+                    }
+                }))
             })?;
-            if let Some(task) = spawned_test_task {
+            if let Some(task) = context_menu_task {
                 task.await?;
             }
 

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -303,7 +303,7 @@ fn build_context_menu(
                                 action.label(),
                                 Box::new(ConfirmCodeAction {
                                     item_ix: Some(ix),
-                                    deployed_from_mouse_context_menu: true,
+                                    from_mouse_context_menu: true,
                                 }),
                             )
                         })

--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -1,15 +1,19 @@
 use crate::{
-    Copy, CopyAndTrim, CopyPermalinkToLine, Cut, DebuggerEvaluateSelectedText, DisplayPoint,
-    DisplaySnapshot, Editor, FindAllReferences, GoToDeclaration, GoToDefinition,
+    ConfirmCodeAction, Copy, CopyAndTrim, CopyPermalinkToLine, Cut, DebuggerEvaluateSelectedText,
+    DisplayPoint, DisplaySnapshot, Editor, FindAllReferences, GoToDeclaration, GoToDefinition,
     GoToImplementation, GoToTypeDefinition, Paste, Rename, RevealInFileManager, SelectMode,
     ToDisplayPoint, ToggleCodeActions,
     actions::{Format, FormatSelections},
     selections_collection::SelectionsCollection,
 };
+use feature_flags::{Debugger, FeatureFlagAppExt as _};
 use gpui::prelude::FluentBuilder;
-use gpui::{Context, DismissEvent, Entity, Focusable as _, Pixels, Point, Subscription, Window};
+use gpui::{
+    Context, DismissEvent, Entity, Focusable as _, Pixels, Point, Subscription, Task, Window,
+};
 use std::ops::Range;
 use text::PointUtf16;
+use util::ResultExt;
 use workspace::OpenInTerminal;
 
 #[derive(Debug)]
@@ -129,13 +133,13 @@ pub fn deploy_context_menu(
 
     let display_map = editor.selections.display_map(cx);
     let source_anchor = display_map.display_point_to_anchor(point, text::Bias::Right);
-    let context_menu = if let Some(custom) = editor.custom_context_menu.take() {
+    if let Some(custom) = editor.custom_context_menu.take() {
         let menu = custom(editor, point, window, cx);
         editor.custom_context_menu = Some(custom);
         let Some(menu) = menu else {
             return;
         };
-        menu
+        set_context_menu(editor, menu, source_anchor, position, window, cx);
     } else {
         // Don't show the context menu if there isn't a project associated with this editor
         let Some(project) = editor.project.clone() else {
@@ -174,69 +178,158 @@ pub fn deploy_context_menu(
                 !filter.is_hidden(&DebuggerEvaluateSelectedText)
             });
 
-        ui::ContextMenu::build(window, cx, |menu, _window, _cx| {
-            let builder = menu
-                .on_blur_subscription(Subscription::new(|| {}))
-                .when(evaluate_selection && has_selections, |builder| {
-                    builder
-                        .action("Evaluate Selection", Box::new(DebuggerEvaluateSelectedText))
-                        .separator()
-                })
-                .action("Go to Definition", Box::new(GoToDefinition))
-                .action("Go to Declaration", Box::new(GoToDeclaration))
-                .action("Go to Type Definition", Box::new(GoToTypeDefinition))
-                .action("Go to Implementation", Box::new(GoToImplementation))
-                .action("Find All References", Box::new(FindAllReferences))
-                .separator()
-                .action("Rename Symbol", Box::new(Rename))
-                .action("Format Buffer", Box::new(Format))
-                .when(has_selections, |cx| {
-                    cx.action("Format Selections", Box::new(FormatSelections))
-                })
-                .action(
-                    "Code Actions",
-                    Box::new(ToggleCodeActions {
-                        deployed_from_indicator: None,
-                    }),
-                )
-                .separator()
-                .action("Cut", Box::new(Cut))
-                .action("Copy", Box::new(Copy))
-                .action("Copy and trim", Box::new(CopyAndTrim))
-                .action("Paste", Box::new(Paste))
-                .separator()
-                .map(|builder| {
-                    let reveal_in_finder_label = if cfg!(target_os = "macos") {
-                        "Reveal in Finder"
-                    } else {
-                        "Reveal in File Manager"
-                    };
-                    const OPEN_IN_TERMINAL_LABEL: &str = "Open in Terminal";
-                    if has_reveal_target {
-                        builder
-                            .action(reveal_in_finder_label, Box::new(RevealInFileManager))
-                            .action(OPEN_IN_TERMINAL_LABEL, Box::new(OpenInTerminal))
-                    } else {
-                        builder
-                            .disabled_action(reveal_in_finder_label, Box::new(RevealInFileManager))
-                            .disabled_action(OPEN_IN_TERMINAL_LABEL, Box::new(OpenInTerminal))
-                    }
-                })
-                .map(|builder| {
-                    const COPY_PERMALINK_LABEL: &str = "Copy Permalink";
-                    if has_git_repo {
-                        builder.action(COPY_PERMALINK_LABEL, Box::new(CopyPermalinkToLine))
-                    } else {
-                        builder.disabled_action(COPY_PERMALINK_LABEL, Box::new(CopyPermalinkToLine))
-                    }
-                });
-            match focus {
-                Some(focus) => builder.context(focus),
-                None => builder,
+        let mut actions_task = editor.code_actions_task.take();
+        cx.spawn_in(window, async move |editor, cx| {
+            while let Some(prev_task) = actions_task {
+                prev_task.await.log_err();
+                actions_task = editor.update(cx, |this, _| this.code_actions_task.take())?;
             }
+            let context_menu_task = editor.update_in(cx, |editor, window, cx| {
+                if !editor.focus_handle.is_focused(window) {
+                    return Some(Task::ready(Ok::<(), anyhow::Error>(())));
+                }
+                let action = ToggleCodeActions {
+                    deployed_from_indicator: Some(point.row()),
+                };
+                let code_actions_task = editor.prepare_code_actions_task(&action, window, cx);
+                Some(cx.spawn_in(window, async move |editor, cx| {
+                    if let Some((_, actions)) = code_actions_task.await {
+                        if let Ok(editor_task) = editor.update_in(cx, |editor, window, cx| {
+                            let menu = ui::ContextMenu::build(window, cx, |menu, _window, cx| {
+                                let menu = menu
+                                    .on_blur_subscription(Subscription::new(|| {}))
+                                    .when(!actions.is_empty(), |menu| {
+                                        actions
+                                            .iter()
+                                            .filter(|action| {
+                                                if action
+                                                    .as_task()
+                                                    .map(|task| {
+                                                        matches!(
+                                                            task.task_type(),
+                                                            task::TaskType::Debug(_)
+                                                        )
+                                                    })
+                                                    .unwrap_or(false)
+                                                {
+                                                    cx.has_flag::<Debugger>()
+                                                } else {
+                                                    true
+                                                }
+                                            })
+                                            .enumerate()
+                                            .fold(menu, |menu, (ix, action)| {
+                                                menu.action(
+                                                    action.label(),
+                                                    Box::new(ConfirmCodeAction {
+                                                        item_ix: Some(ix),
+                                                    }),
+                                                )
+                                            })
+                                            .separator()
+                                    })
+                                    .when(evaluate_selection && has_selections, |builder| {
+                                        builder
+                                            .action(
+                                                "Evaluate Selection",
+                                                Box::new(DebuggerEvaluateSelectedText),
+                                            )
+                                            .separator()
+                                    })
+                                    .action("Go to Definition", Box::new(GoToDefinition))
+                                    .action("Go to Declaration", Box::new(GoToDeclaration))
+                                    .action("Go to Type Definition", Box::new(GoToTypeDefinition))
+                                    .action("Go to Implementation", Box::new(GoToImplementation))
+                                    .action("Find All References", Box::new(FindAllReferences))
+                                    .separator()
+                                    .action("Rename Symbol", Box::new(Rename))
+                                    .action("Format Buffer", Box::new(Format))
+                                    .when(has_selections, |cx| {
+                                        cx.action("Format Selections", Box::new(FormatSelections))
+                                    })
+                                    .separator()
+                                    .action("Cut", Box::new(Cut))
+                                    .action("Copy", Box::new(Copy))
+                                    .action("Copy and trim", Box::new(CopyAndTrim))
+                                    .action("Paste", Box::new(Paste))
+                                    .separator()
+                                    .map(|builder| {
+                                        let reveal_in_finder_label = if cfg!(target_os = "macos") {
+                                            "Reveal in Finder"
+                                        } else {
+                                            "Reveal in File Manager"
+                                        };
+                                        const OPEN_IN_TERMINAL_LABEL: &str = "Open in Terminal";
+                                        if has_reveal_target {
+                                            builder
+                                                .action(
+                                                    reveal_in_finder_label,
+                                                    Box::new(RevealInFileManager),
+                                                )
+                                                .action(
+                                                    OPEN_IN_TERMINAL_LABEL,
+                                                    Box::new(OpenInTerminal),
+                                                )
+                                        } else {
+                                            builder
+                                                .disabled_action(
+                                                    reveal_in_finder_label,
+                                                    Box::new(RevealInFileManager),
+                                                )
+                                                .disabled_action(
+                                                    OPEN_IN_TERMINAL_LABEL,
+                                                    Box::new(OpenInTerminal),
+                                                )
+                                        }
+                                    })
+                                    .map(|builder| {
+                                        const COPY_PERMALINK_LABEL: &str = "Copy Permalink";
+                                        if has_git_repo {
+                                            builder.action(
+                                                COPY_PERMALINK_LABEL,
+                                                Box::new(CopyPermalinkToLine),
+                                            )
+                                        } else {
+                                            builder.disabled_action(
+                                                COPY_PERMALINK_LABEL,
+                                                Box::new(CopyPermalinkToLine),
+                                            )
+                                        }
+                                    });
+                                match focus {
+                                    Some(focus) => menu.context(focus),
+                                    None => menu,
+                                }
+                            });
+                            set_context_menu(editor, menu, source_anchor, position, window, cx);
+                            Task::ready(Ok(()))
+                        }) {
+                            editor_task.await
+                        } else {
+                            Ok(())
+                        }
+                    } else {
+                        Ok(())
+                    }
+                }))
+            })?;
+            if let Some(task) = context_menu_task {
+                task.await?;
+            }
+            Ok::<_, anyhow::Error>(())
         })
+        .detach_and_log_err(cx);
     };
+}
 
+fn set_context_menu(
+    editor: &mut Editor,
+    context_menu: Entity<ui::ContextMenu>,
+    source_anchor: multi_buffer::Anchor,
+    position: Option<Point<Pixels>>,
+    window: &mut Window,
+    cx: &mut Context<Editor>,
+) {
     editor.mouse_context_menu = match position {
         Some(position) => MouseContextMenu::pinned_to_editor(
             editor,


### PR DESCRIPTION
Closes #27989

Asynchronous fetch of code actions on right-click, and shows them in context menu.

https://github.com/user-attachments/assets/413eb0dd-cd1c-4628-a6f1-84eac813da32

Release Notes:

- Improved visibility of code actions by showing them in right-click context menu.
