### PR TITLE
agent: Move focus to the message editor after going back

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -559,6 +559,7 @@ impl AssistantPanel {
             ActiveView::Configuration | ActiveView::History => {
                 self.active_view =
                     ActiveView::thread(self.thread.read(cx).thread().clone(), window, cx);
+                self.message_editor.focus_handle(cx).focus(window);
                 cx.notify();
             }
             _ => {}


### PR DESCRIPTION
When you hit the back button in the agent panel toolbar, we were returning the focus to the buffer instead to the panel's message editor, which is likely where you want to be after quickly checking history or settings.

Release Notes:

- N/A
