### PR TITLE
agent: Check built-in tools schema compatibility in tests

### DIFF
--- a/crates/assistant_tools/src/assistant_tools.rs
+++ b/crates/assistant_tools/src/assistant_tools.rs
@@ -76,3 +76,37 @@ pub fn init(http_client: Arc<HttpClientWithUrl>, cx: &mut App) {
     registry.register_tool(ThinkingTool);
     registry.register_tool(FetchTool::new(http_client));
 }
+
+#[cfg(test)]
+mod tests {
+    use http_client::FakeHttpClient;
+
+    use super::*;
+
+    #[gpui::test]
+    fn test_tool_schema_compatibility(cx: &mut App) {
+        crate::init(
+            Arc::new(http_client::HttpClientWithUrl::new(
+                FakeHttpClient::with_200_response(),
+                "https://zed.dev",
+                None,
+            )),
+            cx,
+        );
+
+        for tool in ToolRegistry::global(cx).tools() {
+            let schema =
+                tool.input_schema(language_model::LanguageModelToolSchemaFormat::JsonSchemaSubset);
+            assert!(schema.is_object());
+            if schema.as_object().unwrap().contains_key("$schema") {
+                let error_message = format!(
+                    "Tool schema for `{}` is not compatible with `language_model::LanguageModelToolSchemaFormat::JsonSchemaSubset` (Gemini Models).\n\
+                    Are you using `schema::json_schema_for<T>(format)` to generate the schema?",
+                    tool.name()
+                );
+
+                panic!("{}", error_message)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This ensures that we respect the `LanguageModelToolSchemaFormat` value when we call `tool.input_schema`. This prevents us from breaking Gemini compatibility when adding/changing built-in tools. See #28634.

The test suite will now fail with an error message like this, when providing an incompatible input_schema:

```
thread 'tests::test_tool_schema_compatibility' panicked at crates/assistant_tools/src/assistant_tools.rs:108:17:
Tool schema for `code_actions` is not compatible with `language_model::LanguageModelToolSchemaFormat::JsonSchemaSubset` (Gemini Models).
Are you using `schema::json_schema_for<T>(format)` to generate the schema?
```


Release Notes:

- N/A 
