### PR TITLE
debugger: Remember pane layout from previous debugger session

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,7 +4163,6 @@ name = "debugger_ui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-recursion 1.1.1",
  "client",
  "collections",
  "command_palette_hooks",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4167,6 +4167,7 @@ dependencies = [
  "collections",
  "command_palette_hooks",
  "dap",
+ "db",
  "editor",
  "env_logger 0.11.8",
  "feature_flags",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4163,6 +4163,7 @@ name = "debugger_ui"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-recursion 1.1.1",
  "client",
  "collections",
  "command_palette_hooks",

--- a/crates/db/src/kvp.rs
+++ b/crates/db/src/kvp.rs
@@ -1,6 +1,7 @@
 use sqlez_macros::sql;
 
 use crate::{define_connection, query};
+pub static DEBUGGER_PANEL_PREFIX: &str = "debugger_panel_";
 
 define_connection!(pub static ref KEY_VALUE_STORE: KeyValueStore<()> =
     &[sql!(

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -28,6 +28,7 @@ client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
 dap.workspace = true
+db.workspace = true
 editor.workspace = true
 feature_flags.workspace = true
 futures.workspace = true

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -24,7 +24,6 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
-async-recursion.workspace = true
 client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -24,6 +24,7 @@ test-support = [
 
 [dependencies]
 anyhow.workspace = true
+async-recursion.workspace = true
 client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -1,6 +1,6 @@
 use crate::{
     ClearAllBreakpoints, Continue, CreateDebuggingSession, Disconnect, Pause, Restart, StepBack,
-    StepInto, StepOut, StepOver, Stop, ToggleIgnoreBreakpoints,
+    StepInto, StepOut, StepOver, Stop, ToggleIgnoreBreakpoints, persistence,
 };
 use crate::{new_session_modal::NewSessionModal, session::DebugSession};
 use anyhow::{Result, anyhow};
@@ -293,35 +293,48 @@ impl DebugPanel {
                     );
                 };
 
-                let Some(project) = self.project.upgrade() else {
-                    return log::error!("Debug Panel out lived it's weak reference to Project");
-                };
+                let adapter_name = session.read(cx).adapter_name();
 
-                if self
-                    .sessions
-                    .iter()
-                    .any(|item| item.read(cx).session_id(cx) == *session_id)
-                {
-                    // We already have an item for this session.
-                    return;
-                }
-                let session_item = DebugSession::running(
-                    project,
-                    self.workspace.clone(),
-                    session,
-                    cx.weak_entity(),
-                    window,
-                    cx,
-                );
+                let session_id = *session_id;
+                cx.spawn_in(window, async move |this, cx| {
+                    let serialized_layout = persistence::get_serialized_pane(adapter_name).await;
 
-                if let Some(running) = session_item.read(cx).mode().as_running().cloned() {
-                    // We might want to make this an event subscription and only notify when a new thread is selected
-                    // This is used to filter the command menu correctly
-                    cx.observe(&running, |_, _, cx| cx.notify()).detach();
-                }
+                    this.update_in(cx, |this, window, cx| {
+                        let Some(project) = this.project.upgrade() else {
+                            return log::error!(
+                                "Debug Panel out lived it's weak reference to Project"
+                            );
+                        };
 
-                self.sessions.push(session_item.clone());
-                self.activate_session(session_item, window, cx);
+                        if this
+                            .sessions
+                            .iter()
+                            .any(|item| item.read(cx).session_id(cx) == session_id)
+                        {
+                            // We already have an item for this session.
+                            return;
+                        }
+                        let session_item = DebugSession::running(
+                            project,
+                            this.workspace.clone(),
+                            session,
+                            cx.weak_entity(),
+                            serialized_layout,
+                            window,
+                            cx,
+                        );
+
+                        if let Some(running) = session_item.read(cx).mode().as_running().cloned() {
+                            // We might want to make this an event subscription and only notify when a new thread is selected
+                            // This is used to filter the command menu correctly
+                            cx.observe(&running, |_, _, cx| cx.notify()).detach();
+                        }
+
+                        this.sessions.push(session_item.clone());
+                        this.activate_session(session_item, window, cx);
+                    })
+                })
+                .detach();
             }
             dap_store::DapStoreEvent::RunInTerminal {
                 title,

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -297,7 +297,8 @@ impl DebugPanel {
 
                 let session_id = *session_id;
                 cx.spawn_in(window, async move |this, cx| {
-                    let serialized_layout = persistence::get_serialized_pane(adapter_name).await;
+                    let serialized_layout =
+                        persistence::get_serialized_pane_layout(adapter_name).await;
 
                     this.update_in(cx, |this, window, cx| {
                         let Some(project) = this.project.upgrade() else {

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -13,6 +13,7 @@ use workspace::{ShutdownDebugAdapters, Workspace};
 pub mod attach_modal;
 pub mod debugger_panel;
 mod new_session_modal;
+mod persistence;
 pub(crate) mod session;
 
 #[cfg(test)]

--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -1,0 +1,124 @@
+use collections::HashSet;
+use db::kvp::KEY_VALUE_STORE;
+use gpui::{Axis, Entity};
+use serde::{Deserialize, Serialize};
+use ui::{App, SharedString};
+use workspace::{Member, Pane, PaneAxis, PaneGroup};
+
+use crate::session::running::SubView;
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum DebuggerPaneItem {
+    Console,
+    Variables,
+    BreakpointList,
+    Frames,
+    Modules,
+}
+
+impl DebuggerPaneItem {
+    pub(crate) fn from_str(s: impl AsRef<str>) -> Option<Self> {
+        match s.as_ref() {
+            "Console" => Some(DebuggerPaneItem::Console),
+            "Variables" => Some(DebuggerPaneItem::Variables),
+            "Breakpoints" => Some(DebuggerPaneItem::BreakpointList),
+            "Frames" => Some(DebuggerPaneItem::Frames),
+            "Modules" => Some(DebuggerPaneItem::Modules),
+            _ => None,
+        }
+    }
+
+    pub(crate) fn to_shared_string(self) -> SharedString {
+        match self {
+            DebuggerPaneItem::Console => SharedString::new_static("Console"),
+            DebuggerPaneItem::Variables => SharedString::new_static("Variables"),
+            DebuggerPaneItem::BreakpointList => SharedString::new_static("Breakpoints"),
+            DebuggerPaneItem::Frames => SharedString::new_static("Frames"),
+            DebuggerPaneItem::Modules => SharedString::new_static("Modules"),
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SerializedAxis(pub Axis);
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) enum SerializedPaneGroup {
+    Pane(SerializedPane),
+    Group {
+        axis: SerializedAxis,
+        flexes: Option<Vec<f32>>,
+        children: Vec<SerializedPaneGroup>,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct SerializedPane {
+    pub active: bool,
+    pub children: Vec<DebuggerPaneItem>,
+    pub active_item: Option<DebuggerPaneItem>,
+}
+
+pub(crate) async fn serialize_pane_group(
+    adapter_name: String,
+    pane_group: &PaneGroup,
+    active_pane: &Entity<Pane>,
+    cx: &mut App,
+) -> anyhow::Result<()> {
+    let pane_group = build_serialized_pane_group(&pane_group.root, active_pane, cx);
+
+    if let Ok(serialized_pane_group) = serde_json::to_string(&pane_group) {
+        KEY_VALUE_STORE
+            .write_kvp(adapter_name, serialized_pane_group)
+            .await
+    } else {
+        Err(anyhow::anyhow!("Failed to serialize pane group"))
+    }
+}
+
+fn build_serialized_pane_group(
+    pane_group: &Member,
+    active_pane: &Entity<Pane>,
+    cx: &mut App,
+) -> SerializedPaneGroup {
+    match pane_group {
+        Member::Axis(PaneAxis {
+            axis,
+            members,
+            flexes,
+            bounding_boxes: _,
+        }) => SerializedPaneGroup::Group {
+            axis: SerializedAxis(*axis),
+            children: members
+                .iter()
+                .map(|member| build_serialized_pane_group(member, active_pane, cx))
+                .collect::<Vec<_>>(),
+            flexes: Some(flexes.lock().clone()),
+        },
+        Member::Pane(pane_handle) => {
+            SerializedPaneGroup::Pane(serialize_pane(pane_handle, pane_handle == active_pane, cx))
+        }
+    }
+}
+
+fn serialize_pane(pane: &Entity<Pane>, active: bool, cx: &mut App) -> SerializedPane {
+    let pane = pane.read(cx);
+    let children = pane
+        .items()
+        .filter_map(|item| {
+            item.act_as::<SubView>(cx)
+                .and_then(|view| view.read(cx).view_kind())
+        })
+        .collect::<Vec<_>>();
+
+    let active_item = pane
+        .active_item()
+        .and_then(|item| item.act_as::<SubView>(cx))
+        .and_then(|view| view.read(cx).view_kind());
+
+    SerializedPane {
+        active,
+        children,
+        active_item,
+    }
+}

--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -12,7 +12,7 @@ use crate::session::running::{
     module_list::ModuleList, stack_frame_list::StackFrameList, variable_list::VariableList,
 };
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum DebuggerPaneItem {
     Console,
     Variables,
@@ -241,9 +241,18 @@ pub(crate) fn deserialize_pane_group(
                 .collect();
 
             pane.update(cx, |pane, cx| {
-                for sub_view in sub_views.into_iter() {
+                let mut active_idx = 0;
+                for (idx, sub_view) in sub_views.into_iter().enumerate() {
+                    if serialized_pane
+                        .active_item
+                        .is_some_and(|active| active == sub_view.read(cx).view_kind())
+                    {
+                        active_idx = idx;
+                    }
                     pane.add_item(sub_view, false, false, None, window, cx);
                 }
+
+                pane.activate_item(active_idx, false, false, window, cx);
             });
 
             Some(Member::Pane(pane.clone()))

--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -11,7 +11,7 @@ use crate::session::running::{
     module_list::ModuleList, stack_frame_list::StackFrameList, variable_list::VariableList,
 };
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Serialize, Deserialize)]
 pub(crate) enum DebuggerPaneItem {
     Console,
     Variables,
@@ -116,14 +116,14 @@ fn serialize_pane(pane: &Entity<Pane>, active: bool, cx: &mut App) -> Serialized
         .items()
         .filter_map(|item| {
             item.act_as::<SubView>(cx)
-                .and_then(|view| view.read(cx).view_kind())
+                .map(|view| view.read(cx).view_kind())
         })
         .collect::<Vec<_>>();
 
     let active_item = pane
         .active_item()
         .and_then(|item| item.act_as::<SubView>(cx))
-        .and_then(|view| view.read(cx).view_kind());
+        .map(|view| view.read(cx).view_kind());
 
     SerializedPane {
         active,
@@ -212,28 +212,28 @@ pub(crate) fn deserialize_pane_group(
                     DebuggerPaneItem::Frames => Box::new(SubView::new(
                         pane.focus_handle(cx),
                         stack_frame_list.clone().into(),
-                        DebuggerPaneItem::Frames.to_shared_string(),
+                        DebuggerPaneItem::Frames,
                         None,
                         cx,
                     )),
                     DebuggerPaneItem::Variables => Box::new(SubView::new(
                         variable_list.focus_handle(cx),
                         variable_list.clone().into(),
-                        DebuggerPaneItem::Variables.to_shared_string(),
+                        DebuggerPaneItem::Variables,
                         None,
                         cx,
                     )),
                     DebuggerPaneItem::BreakpointList => Box::new(SubView::new(
                         breakpoint_list.focus_handle(cx),
                         breakpoint_list.clone().into(),
-                        DebuggerPaneItem::BreakpointList.to_shared_string(),
+                        DebuggerPaneItem::BreakpointList,
                         None,
                         cx,
                     )),
                     DebuggerPaneItem::Modules => Box::new(SubView::new(
                         pane.focus_handle(cx),
                         module_list.clone().into(),
-                        DebuggerPaneItem::Modules.to_shared_string(),
+                        DebuggerPaneItem::Modules,
                         None,
                         cx,
                     )),
@@ -241,7 +241,7 @@ pub(crate) fn deserialize_pane_group(
                     DebuggerPaneItem::Console => Box::new(SubView::new(
                         pane.focus_handle(cx),
                         console.clone().into(),
-                        DebuggerPaneItem::Console.to_shared_string(),
+                        DebuggerPaneItem::Console,
                         Some(Box::new({
                             let console = console.clone().downgrade();
                             move |cx| {

--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -1,11 +1,20 @@
+use async_recursion::async_recursion;
 use collections::HashSet;
 use db::kvp::KEY_VALUE_STORE;
-use gpui::{Axis, Entity};
+use gpui::{AppContext, AsyncApp, Axis, Context, Entity, Focusable, WeakEntity, Window};
+use project::{Project, debugger::session::Session};
 use serde::{Deserialize, Serialize};
 use ui::{App, SharedString};
-use workspace::{Member, Pane, PaneAxis, PaneGroup};
+use workspace::{Member, Pane, PaneAxis, PaneGroup, Workspace};
 
-use crate::session::running::SubView;
+use crate::session::running::{
+    self, RunningState, SubView,
+    breakpoint_list::BreakpointList,
+    console::Console,
+    module_list::ModuleList,
+    stack_frame_list::{self, StackFrameList},
+    variable_list::VariableList,
+};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) enum DebuggerPaneItem {
@@ -69,10 +78,15 @@ pub(crate) async fn serialize_pane_group(
 
     if let Ok(serialized_pane_group) = serde_json::to_string(&pane_group) {
         KEY_VALUE_STORE
-            .write_kvp(adapter_name, serialized_pane_group)
+            .write_kvp(
+                format!("debugger-pane-layout-{adapter_name}"),
+                serialized_pane_group,
+            )
             .await
     } else {
-        Err(anyhow::anyhow!("Failed to serialize pane group"))
+        Err(anyhow::anyhow!(
+            "Failed to serialize pane group with serde_json as a string"
+        ))
     }
 }
 
@@ -120,5 +134,123 @@ fn serialize_pane(pane: &Entity<Pane>, active: bool, cx: &mut App) -> Serialized
         active,
         children,
         active_item,
+    }
+}
+
+fn deserialize_pane_group(
+    serialized: &SerializedPaneGroup,
+    workspace: WeakEntity<Workspace>,
+    project: Entity<Project>,
+    session: Entity<Session>,
+    stack_frame_list: Entity<StackFrameList>,
+    variable_list: Entity<VariableList>,
+    module_list: Entity<ModuleList>,
+    console: Entity<Console>,
+    breakpoint_list: Entity<BreakpointList>,
+    window: &mut Window,
+    cx: &mut Context<RunningState>,
+) -> Option<(Member, Option<Entity<Pane>>)> {
+    match serialized {
+        SerializedPaneGroup::Group {
+            axis,
+            flexes,
+            children,
+        } => {
+            let mut current_active_pane = None;
+            let mut members = Vec::new();
+            for child in children {
+                if let Some((new_member, active_pane)) = deserialize_pane_group(
+                    child,
+                    workspace.clone(),
+                    project.clone(),
+                    session.clone(),
+                    stack_frame_list.clone(),
+                    variable_list.clone(),
+                    module_list.clone(),
+                    console.clone(),
+                    breakpoint_list.clone(),
+                    window,
+                    cx,
+                ) {
+                    members.push(new_member);
+                    current_active_pane = current_active_pane.or(active_pane);
+                }
+            }
+
+            if members.is_empty() {
+                return None;
+            }
+
+            if members.len() == 1 {
+                return Some((members.remove(0), current_active_pane));
+            }
+
+            Some((
+                Member::Axis(PaneAxis::load(axis.0, members, flexes.clone())),
+                current_active_pane,
+            ))
+        }
+        SerializedPaneGroup::Pane(serialized_pane) => {
+            let active = serialized_pane.active;
+            let pane = running::new_debugger_pane(workspace.clone(), project.clone(), window, cx);
+
+            let sub_views: Vec<_> = serialized_pane
+                .children
+                .iter()
+                .map(|child| match child {
+                    DebuggerPaneItem::Frames => Box::new(SubView::new(
+                        pane.focus_handle(cx),
+                        stack_frame_list.clone().into(),
+                        DebuggerPaneItem::Frames.to_shared_string(),
+                        None,
+                        cx,
+                    )),
+                    DebuggerPaneItem::Variables => Box::new(SubView::new(
+                        variable_list.focus_handle(cx),
+                        variable_list.clone().into(),
+                        DebuggerPaneItem::Variables.to_shared_string(),
+                        None,
+                        cx,
+                    )),
+                    DebuggerPaneItem::BreakpointList => Box::new(SubView::new(
+                        breakpoint_list.focus_handle(cx),
+                        breakpoint_list.clone().into(),
+                        DebuggerPaneItem::BreakpointList.to_shared_string(),
+                        None,
+                        cx,
+                    )),
+                    DebuggerPaneItem::Modules => Box::new(SubView::new(
+                        pane.focus_handle(cx),
+                        module_list.clone().into(),
+                        DebuggerPaneItem::Modules.to_shared_string(),
+                        None,
+                        cx,
+                    )),
+
+                    DebuggerPaneItem::Console => Box::new(SubView::new(
+                        pane.focus_handle(cx),
+                        console.clone().into(),
+                        DebuggerPaneItem::Console.to_shared_string(),
+                        Some(Box::new({
+                            let console = console.clone().downgrade();
+                            move |cx| {
+                                console
+                                    .read_with(cx, |console, cx| console.show_indicator(cx))
+                                    .unwrap_or_default()
+                            }
+                        })),
+                        cx,
+                    )),
+                })
+                .collect();
+
+            pane.update(cx, |pane, cx| {
+                for sub_view in sub_views.into_iter() {
+                    pane.add_item(sub_view, false, false, None, window, cx);
+                }
+            });
+
+            Some((Member::Pane(pane.clone()), active.then_some(pane)))
+        }
     }
 }

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -16,6 +16,7 @@ use workspace::{
 };
 
 use crate::debugger_panel::DebugPanel;
+use crate::persistence::SerializedPaneGroup;
 
 pub(crate) enum DebugSessionState {
     Running(Entity<running::RunningState>),
@@ -52,6 +53,7 @@ impl DebugSession {
         workspace: WeakEntity<Workspace>,
         session: Entity<Session>,
         _debug_panel: WeakEntity<DebugPanel>,
+        serialized_pane_layout: Option<SerializedPaneGroup>,
         window: &mut Window,
         cx: &mut App,
     ) -> Entity<Self> {
@@ -60,7 +62,7 @@ impl DebugSession {
                 session.clone(),
                 project.clone(),
                 workspace.clone(),
-                None,
+                serialized_pane_layout,
                 window,
                 cx,
             )

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -60,6 +60,7 @@ impl DebugSession {
                 session.clone(),
                 project.clone(),
                 workspace.clone(),
+                None,
                 window,
                 cx,
             )

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -16,7 +16,7 @@ use workspace::{
 };
 
 use crate::debugger_panel::DebugPanel;
-use crate::persistence::SerializedPaneGroup;
+use crate::persistence::SerializedPaneLayout;
 
 pub(crate) enum DebugSessionState {
     Running(Entity<running::RunningState>),
@@ -53,7 +53,7 @@ impl DebugSession {
         workspace: WeakEntity<Workspace>,
         session: Entity<Session>,
         _debug_panel: WeakEntity<DebugPanel>,
-        serialized_pane_layout: Option<SerializedPaneGroup>,
+        serialized_pane_layout: Option<SerializedPaneLayout>,
         window: &mut Window,
         cx: &mut App,
     ) -> Entity<Self> {

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1,7 +1,7 @@
-mod breakpoint_list;
-mod console;
-mod loaded_source_list;
-mod module_list;
+pub(crate) mod breakpoint_list;
+pub(crate) mod console;
+pub(crate) mod loaded_source_list;
+pub(crate) mod module_list;
 pub mod stack_frame_list;
 pub mod variable_list;
 
@@ -94,7 +94,7 @@ pub(crate) struct SubView {
 }
 
 impl SubView {
-    fn new(
+    pub(crate) fn new(
         pane_focus_handle: FocusHandle,
         view: AnyView,
         tab_name: SharedString,
@@ -158,7 +158,7 @@ impl Render for SubView {
     }
 }
 
-fn new_debugger_pane(
+pub(crate) fn new_debugger_pane(
     workspace: WeakEntity<Workspace>,
     project: Entity<Project>,
     window: &mut Window,

--- a/crates/debugger_ui/src/session/running/breakpoint_list.rs
+++ b/crates/debugger_ui/src/session/running/breakpoint_list.rs
@@ -27,7 +27,7 @@ use ui::{
 use util::{ResultExt, maybe};
 use workspace::Workspace;
 
-pub(super) struct BreakpointList {
+pub(crate) struct BreakpointList {
     workspace: WeakEntity<Workspace>,
     breakpoint_store: Entity<BreakpointStore>,
     worktree_store: Entity<WorktreeStore>,

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -68,6 +68,7 @@ pub async fn init_test_workspace(
     workspace_handle
 }
 
+#[track_caller]
 pub fn active_debug_session_panel(
     workspace: WindowHandle<Workspace>,
     cx: &mut TestAppContext,

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -81,6 +81,8 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
         })
         .await;
 
+    cx.run_until_parked();
+
     // assert we have a debug panel item before the session has stopped
     workspace
         .update(cx, |workspace, _window, cx| {
@@ -228,6 +230,8 @@ async fn test_we_can_only_have_one_panel_per_debug_session(
             })
         })
         .await;
+
+    cx.run_until_parked();
 
     // assert we have a debug panel item before the session has stopped
     workspace
@@ -1051,6 +1055,8 @@ async fn test_debug_panel_item_thread_status_reset_on_failure(
             hit_breakpoint_ids: None,
         }))
         .await;
+
+    cx.run_until_parked();
 
     let running_state = active_debug_session_panel(workspace, cx).update_in(cx, |item, _, _| {
         item.mode()

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -1538,6 +1538,8 @@ async fn test_variable_list_only_sends_requests_when_rendering(
         })
         .await;
 
+    cx.run_until_parked();
+
     let running_state = active_debug_session_panel(workspace, cx).update_in(cx, |item, _, _| {
         let state = item
             .mode()

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -296,7 +296,7 @@ impl BreakpointStore {
                         .find_position(|(pos, bp)| &breakpoint.0 == pos && bp == &breakpoint.1)
                         .map(|res| res.0)
                     {
-                        breakpoint_set.breakpoints.swap_remove(position);
+                        breakpoint_set.breakpoints.remove(position);
                     } else {
                         log::error!("Failed to find position of breakpoint to delete")
                     }
@@ -330,7 +330,7 @@ impl BreakpointStore {
                         .find_position(|(pos, bp)| &breakpoint.0 == pos && bp == &breakpoint.1)
                         .map(|res| res.0)
                     {
-                        breakpoint_set.breakpoints.swap_remove(position);
+                        breakpoint_set.breakpoints.remove(position);
                     } else {
                         log::error!("Failed to find position of breakpoint to delete")
                     }
@@ -364,7 +364,7 @@ impl BreakpointStore {
                         .find_position(|(pos, bp)| &breakpoint.0 == pos && bp == &breakpoint.1)
                         .map(|res| res.0)
                     {
-                        breakpoint_set.breakpoints.swap_remove(position);
+                        breakpoint_set.breakpoints.remove(position);
                     } else {
                         log::error!("Failed to find position of breakpoint to delete")
                     }

--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -296,7 +296,7 @@ impl BreakpointStore {
                         .find_position(|(pos, bp)| &breakpoint.0 == pos && bp == &breakpoint.1)
                         .map(|res| res.0)
                     {
-                        breakpoint_set.breakpoints.remove(position);
+                        breakpoint_set.breakpoints.swap_remove(position);
                     } else {
                         log::error!("Failed to find position of breakpoint to delete")
                     }
@@ -330,7 +330,7 @@ impl BreakpointStore {
                         .find_position(|(pos, bp)| &breakpoint.0 == pos && bp == &breakpoint.1)
                         .map(|res| res.0)
                     {
-                        breakpoint_set.breakpoints.remove(position);
+                        breakpoint_set.breakpoints.swap_remove(position);
                     } else {
                         log::error!("Failed to find position of breakpoint to delete")
                     }
@@ -364,7 +364,7 @@ impl BreakpointStore {
                         .find_position(|(pos, bp)| &breakpoint.0 == pos && bp == &breakpoint.1)
                         .map(|res| res.0)
                     {
-                        breakpoint_set.breakpoints.remove(position);
+                        breakpoint_set.breakpoints.swap_remove(position);
                     } else {
                         log::error!("Failed to find position of breakpoint to delete")
                     }

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -30,7 +30,8 @@ use dap::{
 use futures::channel::oneshot;
 use futures::{FutureExt, future::Shared};
 use gpui::{
-    App, AppContext, AsyncApp, BackgroundExecutor, Context, Entity, EventEmitter, Task, WeakEntity,
+    App, AppContext, AsyncApp, BackgroundExecutor, Context, Entity, EventEmitter, SharedString,
+    Task, WeakEntity,
 };
 use rpc::AnyProtoClient;
 use serde_json::{Value, json};
@@ -125,6 +126,7 @@ type UpstreamProjectId = u64;
 struct RemoteConnection {
     _client: AnyProtoClient,
     _upstream_project_id: UpstreamProjectId,
+    _adapter_name: SharedString,
 }
 
 impl RemoteConnection {
@@ -996,6 +998,7 @@ impl Session {
     ) -> Self {
         Self {
             mode: Mode::Remote(RemoteConnection {
+                _adapter_name: SharedString::new(""), // todo(debugger) we need to pipe in the right values to deserialize the debugger pane layout
                 _client: client,
                 _upstream_project_id: upstream_project_id,
             }),
@@ -1042,6 +1045,13 @@ impl Session {
 
     pub fn capabilities(&self) -> &Capabilities {
         &self.capabilities
+    }
+
+    pub fn adapter_name(&self) -> SharedString {
+        match &self.mode {
+            Mode::Local(local_mode) => local_mode.adapter.name().into(),
+            Mode::Remote(remote_mode) => remote_mode._adapter_name.clone(),
+        }
     }
 
     pub fn configuration(&self) -> Option<DebugAdapterConfig> {


### PR DESCRIPTION
This PR makes a debugger's pane layout persistent across session's that use the same debug adapter.

Release Notes:

- N/A
