### PR TITLE
docs: Add Yara language extension

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -127,6 +127,7 @@
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
 - [YAML](./languages/yaml.md)
+- [Yara](./languages/yara.md)
 - [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 

--- a/docs/src/languages.md
+++ b/docs/src/languages.md
@@ -71,6 +71,7 @@ Some work out-of-the box and others rely on 3rd party extensions.
 - [Vue](./languages/vue.md)
 - [XML](./languages/xml.md)
 - [YAML](./languages/yaml.md) \*
+- [Yara](./languages/yarn.md)
 - [Yarn](./languages/yarn.md)
 - [Zig](./languages/zig.md)
 

--- a/docs/src/languages/yara.md
+++ b/docs/src/languages/yara.md
@@ -3,4 +3,4 @@
 `Yara` language support in Zed is provided by the [Yara](https://github.com/egibs/yara.zed) extension. Please report issues to [https://github.com/egibs/yara.zed/issues](https://github.com/egibs/yara.zed).
 
 - Tree-sitter: [egibs/tree-sitter-yara](https://github.com/egibs/tree-sitter-yara)
-- [Optional] Language Server: [avast/yls](https://github.com/avast/yls)
+- Language Server: [avast/yls](https://github.com/avast/yls)

--- a/docs/src/languages/yara.md
+++ b/docs/src/languages/yara.md
@@ -1,0 +1,6 @@
+# Yara
+
+`Yara` language support in Zed is provided by the [Yara](https://github.com/egibs/yara.zed) extension. Please report issues to [https://github.com/egibs/yara.zed/issues](https://github.com/egibs/yara.zed).
+
+- Tree-sitter: [egibs/tree-sitter-yara](https://github.com/egibs/tree-sitter-yara)
+- [Optional] Language Server: [avast/yls](https://github.com/avast/yls)


### PR DESCRIPTION
This PR adds a quick overview of the Yara language extension in order to display the language on the Zed [site](https://zed.dev/docs/languages).

Release Notes:

- N/A