### PR TITLE
Fix expand selection

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6354,7 +6354,7 @@ async fn test_select_larger_smaller_syntax_node(cx: &mut TestAppContext) {
                 use mod1::mod2::«{mod3, mod4}ˇ»;
 
                 fn fn_1«ˇ(param1: bool, param2: &str)» {
-                    «let var1 = "text";ˇ»
+                    let var1 = "«textˇ»";
                 }
 
                 fn «fn_2ˇ»(param1: bool, param2: &str) {

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3259,9 +3259,14 @@ impl BufferSnapshot {
 
             // Descend to the first leaf that touches the start of the range,
             // and if the range is non-empty, extends beyond the start.
-            while cursor.goto_first_child_for_byte(range.start).is_some() {
-                if !range.is_empty() && cursor.node().end_byte() == range.start {
-                    cursor.goto_next_sibling();
+
+            // TODO FIX this
+            while cursor.goto_first_child() {
+                while cursor.node().end_byte() < range.start {
+                    if !cursor.goto_next_sibling() {
+                        println!("break at {}", cursor.node());
+                        break;
+                    }
                 }
             }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3257,10 +3257,9 @@ impl BufferSnapshot {
         {
             let mut cursor = layer.node().walk();
 
-            // Descend to the first leaf that touches the start of the range,
-            // and if the range is non-empty, extends beyond the start.
+            // Descend to the first leaf that ends at or after the range end
             while cursor.goto_first_child() {
-                while cursor.node().end_byte() < range.start {
+                while cursor.node().end_byte() < range.end {
                     if !cursor.goto_next_sibling() {
                         break;
                     }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3262,7 +3262,6 @@ impl BufferSnapshot {
             while cursor.goto_first_child() {
                 while cursor.node().end_byte() < range.start {
                     if !cursor.goto_next_sibling() {
-                        println!("break at {}", cursor.node());
                         break;
                     }
                 }

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3259,8 +3259,6 @@ impl BufferSnapshot {
 
             // Descend to the first leaf that touches the start of the range,
             // and if the range is non-empty, extends beyond the start.
-
-            // TODO FIX this
             while cursor.goto_first_child() {
                 while cursor.node().end_byte() < range.start {
                     if !cursor.goto_next_sibling() {

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -1152,6 +1152,20 @@ fn test_range_for_syntax_ancestor(cx: &mut App) {
                 .byte_range(),
             range_of(text, "(|c| {})")
         );
+        assert_eq!(
+            snapshot
+                .syntax_ancestor(empty_range_at(text, "()"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "a")
+        );
+        assert_eq!(
+            snapshot
+                .syntax_ancestor(empty_range_at(text, " a()"))
+                .unwrap()
+                .byte_range(),
+            range_of(text, "fn")
+        );
 
         buffer
     });


### PR DESCRIPTION
Closes #28699

Release Notes:

- improve `editor::SelectLargerSyntaxNode` action to select the node that ends at cursor

Note :
To fix that I propose to change the call to `goto_first_child_for_byte` by `goto_first_child` combined with `goto_next_sibling` to stop at the first node that end after the end of the selection (included). In contrary to `goto_first_child_for_byte`, this allows to select the node that ends at the searched position (end of selection).

Using the end of selection might seems arbitrary, but :
- it is legit because it allows to stop at the last node that is in the selection and this node must be in the final node (the one we return in the end, ending the whole selection).
- it avoids selecting a node before the selection when the selection is not empty, which would not be correct.