### PR TITLE
github: Add Staff-Only 'Other' Issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/99_other.yml
+++ b/.github/ISSUE_TEMPLATE/99_other.yml
@@ -1,0 +1,19 @@
+name: Other [Staff Only]
+description: Zed Staff Only
+body:
+  - type: textarea
+    attributes:
+      label: Summary
+      value: |
+        <!-- Please insert a one line summary of the issue below -->
+        SUMMARY_SENTENCE_HERE
+
+        ### Description
+
+        IF YOU DO NOT WORK FOR ZED INDUSTRIES DO NOT CREATE ISSUES WITH THIS TEMPLATE.
+        THEY WILL BE AUTO-CLOSED AND MAY RESULT IN YOU BEING BANNED FROM THE ZED ISSUE TRACKER.
+
+        FEATURE REQUESTS / SUPPORT REQUESTS SHOULD BE OPENED AS DISCUSSIONS:
+          https://github.com/zed-industries/zed/discussions/new/choose
+    validations:
+      required: true


### PR DESCRIPTION
This is because [issues/new](https://github.com/zed-industries/zed/issues/new) now redirects to [issues/new/choose](https://github.com/zed-industries/zed/issues/new/choose) (good!) so you can no longer create issues skipping templates.

Release Notes:

- N/A
