### PR TITLE
Bump Zed to v0.183

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18125,7 +18125,7 @@ dependencies = [
 
 [[package]]
 name = "zed"
-version = "0.182.0"
+version = "0.183.0"
 dependencies = [
  "activity_indicator",
  "agent",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -2,7 +2,7 @@
 description = "The fast, collaborative code editor."
 edition.workspace = true
 name = "zed"
-version = "0.182.0"
+version = "0.183.0"
 publish.workspace = true
 license = "GPL-3.0-or-later"
 authors = ["Zed Team <hi@zed.dev>"]


### PR DESCRIPTION
Version was bumped to `v0.183.0` last Wednesday here: https://github.com/zed-industries/zed/pull/28419
But was accidentally downgraded here: https://github.com/zed-industries/zed/pull/27964

Release Notes:

- N/A
