### PR TITLE
gemini: Fix "invalid argument" error when request contains no tools

### DIFF
--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -417,17 +417,19 @@ pub fn into_google(
             top_k: None,
         }),
         safety_settings: None,
-        tools: Some(vec![google_ai::Tool {
-            function_declarations: request
-                .tools
-                .into_iter()
-                .map(|tool| FunctionDeclaration {
-                    name: tool.name,
-                    description: tool.description,
-                    parameters: tool.input_schema,
-                })
-                .collect(),
-        }]),
+        tools: (request.tools.len() > 0).then(|| {
+            vec![google_ai::Tool {
+                function_declarations: request
+                    .tools
+                    .into_iter()
+                    .map(|tool| FunctionDeclaration {
+                        name: tool.name,
+                        description: tool.description,
+                        parameters: tool.input_schema,
+                    })
+                    .collect(),
+            }]
+        }),
         tool_config: None,
     }
 }


### PR DESCRIPTION
When we do not have any tools, we want to set the `tools` field to `None`

Release Notes:

- Fixed an issue where Gemini requests would sometimes return a Bad Request ("Invalid argument...")
