### PR TITLE
debugger: Skip out-of-bounds breakpoints when deserializing

### DIFF
--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -591,7 +591,13 @@ impl BreakpointStore {
                         this.update(cx, |_, cx| BreakpointsInFile::new(buffer, cx))?;
 
                     for bp in bps {
-                        let position = snapshot.anchor_after(PointUtf16::new(bp.row, 0));
+                        let max_point = snapshot.max_point_utf16();
+                        let point = PointUtf16::new(bp.row, 0);
+                        if point > max_point {
+                            log::error!("skipping a deserialized breakpoint that's out of range");
+                            continue;
+                        }
+                        let position = snapshot.anchor_after(point);
                         breakpoints_for_file.breakpoints.push((
                             position,
                             Breakpoint {


### PR DESCRIPTION
Previously we'd crash when deserializing a breakpoint whose row number was out of bounds (could happen if the file was externally modified). This PR fixes that code to skip such breakpoints.

An alternative would be to clip the deserialized `PointUtf16`, but I think that would mostly result in nonsensical breakpoints.

Release Notes:

- N/A