### PR TITLE
debugger: Save debug session layout when changing focus or closing session

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -438,7 +438,13 @@ impl DebugPanel {
         else {
             return;
         };
-
+        session.update(cx, |this, cx| {
+            if let Some(running) = this.mode().as_running() {
+                running.update(cx, |this, cx| {
+                    this.serialize_layout(window, cx);
+                });
+            }
+        });
         let session_id = session.update(cx, |this, cx| this.session_id(cx));
         let should_prompt = self
             .project

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -421,6 +421,9 @@ impl RunningState {
                 }
                 cx.notify()
             }),
+            cx.on_focus_out(&focus_handle, window, |this, _, window, cx| {
+                this.serialize_layout(window, cx);
+            }),
         ];
 
         let mut pane_close_subscriptions = HashMap::default();
@@ -476,7 +479,7 @@ impl RunningState {
         }
     }
 
-    fn serialize_layout(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    pub(crate) fn serialize_layout(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if self._schedule_serialize.is_none() {
             self._schedule_serialize = Some(cx.spawn_in(window, async move |this, cx| {
                 cx.background_executor()


### PR DESCRIPTION
This fixes a bug where resizing the panes wouldn't be serialized and persist

Release Notes:

- N/A
