### PR TITLE
feedback: Update issue template URL

### DIFF
--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -2,6 +2,7 @@ use gpui::{App, ClipboardItem, PromptLevel, actions};
 use system_specs::SystemSpecs;
 use util::ResultExt;
 use workspace::Workspace;
+use zed_actions::feedback::FileBugReport;
 
 pub mod feedback_modal;
 
@@ -12,7 +13,6 @@ actions!(
     [
         CopySystemSpecsIntoClipboard,
         EmailZed,
-        FileBugReport,
         OpenZedRepo,
         RequestFeature,
     ]

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -27,7 +27,7 @@ fn file_bug_report_url(specs: &SystemSpecs) -> String {
         concat!(
             "https://github.com/zed-industries/zed/issues/new",
             "?",
-            "template=1_bug_report.yml",
+            "template=10_bug_report.yml",
             "&",
             "environment={}"
         ),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -106,6 +106,7 @@ use uuid::Uuid;
 pub use workspace_settings::{
     AutosaveSetting, BottomDockLayout, RestoreOnStartupBehavior, TabBarSettings, WorkspaceSettings,
 };
+use zed_actions::feedback::FileBugReport;
 
 use crate::notifications::NotificationId;
 use crate::persistence::{
@@ -5395,8 +5396,6 @@ enum ActivateInDirectionTarget {
 }
 
 fn notify_if_database_failed(workspace: WindowHandle<Workspace>, cx: &mut AsyncApp) {
-    const REPORT_ISSUE_URL: &str = "https://github.com/zed-industries/zed/issues/new?assignees=&labels=admin+read%2Ctriage%2Cbug&projects=&template=1_bug_report.yml";
-
     workspace
         .update(cx, |workspace, _, cx| {
             if (*db::ALL_FILE_DB_FAILED).load(std::sync::atomic::Ordering::Acquire) {
@@ -5410,7 +5409,9 @@ fn notify_if_database_failed(workspace: WindowHandle<Workspace>, cx: &mut AsyncA
                             MessageNotification::new("Failed to load the database file.", cx)
                                 .primary_message("File an Issue")
                                 .primary_icon(IconName::Plus)
-                                .primary_on_click(|_window, cx| cx.open_url(REPORT_ISSUE_URL))
+                                .primary_on_click(|window, cx| {
+                                    window.dispatch_action(Box::new(FileBugReport), cx)
+                                })
                         })
                     },
                 );

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -150,7 +150,7 @@ pub mod command_palette {
 pub mod feedback {
     use gpui::actions;
 
-    actions!(feedback, [GiveFeedback]);
+    actions!(feedback, [FileBugReport, GiveFeedback]);
 }
 
 pub mod theme_selector {

--- a/docs/src/workspace-persistence.md
+++ b/docs/src/workspace-persistence.md
@@ -11,4 +11,4 @@ The naming convention of these databases takes on the form of `0-<zed_channel>`:
 - Stable: `0-stable`
 - Preview: `0-preview`
 
-**If you encounter workspace persistence issues in Zed, deleting the database and restarting Zed often resolves the problem, as the database may have been corrupted at some point.** If your issue continues after restarting Zed and regenerating a new database, please [file an issue](https://github.com/zed-industries/zed/issues/new?template=1_bug_report.yml).
+**If you encounter workspace persistence issues in Zed, deleting the database and restarting Zed often resolves the problem, as the database may have been corrupted at some point.** If your issue continues after restarting Zed and regenerating a new database, please [file an issue](https://github.com/zed-industries/zed/issues/new?template=10_bug_report.yml).


### PR DESCRIPTION
Closes #28782 

The linked template path was updated in #28250. This PR also adds the change to the zed action. 

Since the issue template link was also referenced in workspace, I updated that occurrence to use the `FileBugReport` action instead. For that, I had to move the action to `zed_actions`. However, with this change only one link has to be updated and any database related errors will have the zed version specs attached to them automatically.

Release Notes:

- Fixed an issue where the `file bug report` action would redirect to an outdated URL.
