### PR TITLE
collab: Add kind and period start/end timestamps to `billing_subscriptions`

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -505,7 +505,10 @@ CREATE TABLE IF NOT EXISTS billing_subscriptions (
     stripe_subscription_id TEXT NOT NULL,
     stripe_subscription_status TEXT NOT NULL,
     stripe_cancel_at TIMESTAMP,
-    stripe_cancellation_reason TEXT
+    stripe_cancellation_reason TEXT,
+    kind TEXT,
+    stripe_current_period_start BIGINT,
+    stripe_current_period_end BIGINT
 );
 
 CREATE INDEX "ix_billing_subscriptions_on_billing_customer_id" ON billing_subscriptions (billing_customer_id);

--- a/crates/collab/migrations/20250415164141_add_kind_and_period_to_billing_subscriptions.sql
+++ b/crates/collab/migrations/20250415164141_add_kind_and_period_to_billing_subscriptions.sql
@@ -1,0 +1,4 @@
+alter table billing_subscriptions
+    add column kind text,
+    add column stripe_current_period_start bigint,
+    add column stripe_current_period_end bigint;

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -1,22 +1,30 @@
-use crate::db::billing_subscription::{StripeCancellationReason, StripeSubscriptionStatus};
+use crate::db::billing_subscription::{
+    StripeCancellationReason, StripeSubscriptionStatus, SubscriptionKind,
+};
 
 use super::*;
 
 #[derive(Debug)]
 pub struct CreateBillingSubscriptionParams {
     pub billing_customer_id: BillingCustomerId,
+    pub kind: Option<SubscriptionKind>,
     pub stripe_subscription_id: String,
     pub stripe_subscription_status: StripeSubscriptionStatus,
     pub stripe_cancellation_reason: Option<StripeCancellationReason>,
+    pub stripe_current_period_start: Option<i64>,
+    pub stripe_current_period_end: Option<i64>,
 }
 
 #[derive(Debug, Default)]
 pub struct UpdateBillingSubscriptionParams {
     pub billing_customer_id: ActiveValue<BillingCustomerId>,
+    pub kind: ActiveValue<Option<SubscriptionKind>>,
     pub stripe_subscription_id: ActiveValue<String>,
     pub stripe_subscription_status: ActiveValue<StripeSubscriptionStatus>,
     pub stripe_cancel_at: ActiveValue<Option<DateTime>>,
     pub stripe_cancellation_reason: ActiveValue<Option<StripeCancellationReason>>,
+    pub stripe_current_period_start: ActiveValue<Option<i64>>,
+    pub stripe_current_period_end: ActiveValue<Option<i64>>,
 }
 
 impl Database {
@@ -28,9 +36,12 @@ impl Database {
         self.transaction(|tx| async move {
             billing_subscription::Entity::insert(billing_subscription::ActiveModel {
                 billing_customer_id: ActiveValue::set(params.billing_customer_id),
+                kind: ActiveValue::set(params.kind),
                 stripe_subscription_id: ActiveValue::set(params.stripe_subscription_id.clone()),
                 stripe_subscription_status: ActiveValue::set(params.stripe_subscription_status),
                 stripe_cancellation_reason: ActiveValue::set(params.stripe_cancellation_reason),
+                stripe_current_period_start: ActiveValue::set(params.stripe_current_period_start),
+                stripe_current_period_end: ActiveValue::set(params.stripe_current_period_end),
                 ..Default::default()
             })
             .exec_without_returning(&*tx)

--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -9,10 +9,13 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: BillingSubscriptionId,
     pub billing_customer_id: BillingCustomerId,
+    pub kind: Option<SubscriptionKind>,
     pub stripe_subscription_id: String,
     pub stripe_subscription_status: StripeSubscriptionStatus,
     pub stripe_cancel_at: Option<DateTime>,
     pub stripe_cancellation_reason: Option<StripeCancellationReason>,
+    pub stripe_current_period_start: Option<i64>,
+    pub stripe_current_period_end: Option<i64>,
     pub created_at: DateTime,
 }
 
@@ -33,6 +36,14 @@ impl Related<super::billing_customer::Entity> for Entity {
 }
 
 impl ActiveModelBehavior for ActiveModel {}
+
+#[derive(Eq, PartialEq, Copy, Clone, Debug, EnumIter, DeriveActiveEnum, Hash, Serialize)]
+#[sea_orm(rs_type = "String", db_type = "String(StringLen::None)")]
+#[serde(rename_all = "snake_case")]
+pub enum SubscriptionKind {
+    #[sea_orm(string_value = "zed_pro")]
+    ZedPro,
+}
 
 /// The status of a Stripe subscription.
 ///

--- a/crates/collab/src/db/tests/billing_subscription_tests.rs
+++ b/crates/collab/src/db/tests/billing_subscription_tests.rs
@@ -39,9 +39,12 @@ async fn test_get_active_billing_subscriptions(db: &Arc<Database>) {
 
         db.create_billing_subscription(&CreateBillingSubscriptionParams {
             billing_customer_id: customer.id,
+            kind: None,
             stripe_subscription_id: "sub_active_user".into(),
             stripe_subscription_status: StripeSubscriptionStatus::Active,
             stripe_cancellation_reason: None,
+            stripe_current_period_start: None,
+            stripe_current_period_end: None,
         })
         .await
         .unwrap();
@@ -74,9 +77,12 @@ async fn test_get_active_billing_subscriptions(db: &Arc<Database>) {
 
         db.create_billing_subscription(&CreateBillingSubscriptionParams {
             billing_customer_id: customer.id,
+            kind: None,
             stripe_subscription_id: "sub_past_due_user".into(),
             stripe_subscription_status: StripeSubscriptionStatus::PastDue,
             stripe_cancellation_reason: None,
+            stripe_current_period_start: None,
+            stripe_current_period_end: None,
         })
         .await
         .unwrap();


### PR DESCRIPTION
This PR updates the `billing_subscriptions` table with some new columns

- `kind` - The kind of the description (used to denote Zed Pro vs existing)
- `stripe_current_period_start` - The Stripe timestamp of when the subscriptions current period starts
- `stripe_current_period_end` - The Stripe timestamp of when the subscriptions current period ends

Release Notes:

- N/A
