### PR TITLE
collab: Add `subscription_usages` table

### DIFF
--- a/crates/collab/migrations_llm/20250415213005_add_subscription_usages.sql
+++ b/crates/collab/migrations_llm/20250415213005_add_subscription_usages.sql
@@ -1,0 +1,10 @@
+create table subscription_usages (
+    id serial primary key,
+    user_id integer not null,
+    period_start_at timestamp without time zone not null,
+    period_end_at timestamp without time zone not null,
+    model_requests int not null default 0,
+    edit_predictions int not null default 0
+);
+
+create unique index uix_subscription_usages_on_user_id_start_at_end_at on subscription_usages (user_id, period_start_at, period_end_at);


### PR DESCRIPTION
This PR adds a new `subscription_usages` table to the LLM database.

We'll use this table to track usage by subscribers.

Records will be looked up using `(user_id, period_start_at, period_end_at)` to find the record for a user's current subscription period.

Release Notes:

- N/A
