### PR TITLE
languages: Fix multi cursor tab indentation works incorrectly in Python

### DIFF
--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -2,17 +2,25 @@
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
-(try_statement
-    body: (_) @start
-    [(except_clause) (finally_clause)] @end
-    ) @indent
+[
+  (if_statement)
+  (for_statement)
+  (while_statement)
+  (with_statement)
+  (function_definition)
+  (class_definition)
+  (match_statement)
+  (try_statement)
+] @indent
 
-(if_statement
-    consequence: (_) @start
-    alternative: (_) @end
-    ) @indent
+[
+  (else_clause)
+  (elif_clause)
+  (except_clause)
+  (finally_clause)
+] @outdent
 
-(_
-    alternative: (elif_clause) @start
-    alternative: (_) @end
-    ) @indent
+[
+  (block)
+  (case_clause)
+] @indent


### PR DESCRIPTION
Closes #26157

Closing as it seems to need more complex changes around this function: https://github.com/zed-industries/zed/blob/514121d6d4586a6f760c3f25dadc86076b9fd8f6/crates/language/src/buffer.rs#L2818

Release Notes:

- N/A
