### PR TITLE
Increase `cx.condition` timeout to fix flaky test

### DIFF
--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -589,11 +589,6 @@ impl<V> Entity<V> {
         use postage::prelude::{Sink as _, Stream as _};
 
         let (tx, mut rx) = postage::mpsc::channel(1024);
-        let timeout_duration = if cfg!(target_os = "macos") {
-            Duration::from_millis(100)
-        } else {
-            Duration::from_secs(1)
-        };
 
         let mut cx = cx.app.borrow_mut();
         let subscriptions = (
@@ -615,7 +610,7 @@ impl<V> Entity<V> {
         let handle = self.downgrade();
 
         async move {
-            crate::util::timeout(timeout_duration, async move {
+            crate::util::timeout(Duration::from_secs(1), async move {
                 loop {
                     {
                         let cx = cx.borrow();


### PR DESCRIPTION
We've been seeing `test_no_duplicated_completion_requests` fail randomly with the error "condition timed out".

But it's always failing on MacOS, and MacOS sets a shorter timeout of 100ms, compared to 1s from other platforms, in this PR I raised that to 1s too.

Release Notes:

- N/A
