### PR TITLE
Fix anchor comparison in multi buffer after expanding excerpts

### DIFF
--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -61,11 +61,14 @@ impl Anchor {
             return Ordering::Equal;
         }
 
-        let excerpt_id_cmp = self.excerpt_id.cmp(&other.excerpt_id, snapshot);
+        let self_excerpt_id = snapshot.latest_excerpt_id(self.excerpt_id);
+        let other_excerpt_id = snapshot.latest_excerpt_id(other.excerpt_id);
+
+        let excerpt_id_cmp = self_excerpt_id.cmp(&other_excerpt_id, snapshot);
         if excerpt_id_cmp.is_ne() {
             return excerpt_id_cmp;
         }
-        if self.excerpt_id == ExcerptId::min() || self.excerpt_id == ExcerptId::max() {
+        if self_excerpt_id == ExcerptId::min() || self_excerpt_id == ExcerptId::max() {
             return Ordering::Equal;
         }
         if let Some(excerpt) = snapshot.excerpt(self.excerpt_id) {

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -746,19 +746,20 @@ fn test_expand_excerpts(cx: &mut App) {
     drop(snapshot);
 
     multibuffer.update(cx, |multibuffer, cx| {
+        let line_zero = multibuffer.snapshot(cx).anchor_before(Point::new(0, 0));
         multibuffer.expand_excerpts(
             multibuffer.excerpt_ids(),
             1,
             ExpandExcerptDirection::UpAndDown,
             cx,
-        )
+        );
+        let snapshot = multibuffer.snapshot(cx);
+        let line_two = snapshot.anchor_before(Point::new(2, 0));
+        assert_eq!(line_two.cmp(&line_zero, &snapshot), cmp::Ordering::Greater);
     });
 
     let snapshot = multibuffer.read(cx).snapshot(cx);
 
-    // Expanding context lines causes the line containing 'fff' to appear in two different excerpts.
-    // We don't attempt to merge them, because removing the excerpt could create inconsistency with other layers
-    // that are tracking excerpt ids.
     assert_eq!(
         snapshot.text(),
         concat!(


### PR DESCRIPTION
Release Notes:

- Fixed incorrect excerpt comparison when replacing them
