### PR TITLE
collab: Add `GET /billing/usage` endpoint

### DIFF
--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -19,6 +19,18 @@ pub struct Model {
     pub created_at: DateTime,
 }
 
+impl Model {
+    pub fn current_period_start_at(&self) -> Option<DateTimeUtc> {
+        let period_start = self.stripe_current_period_start?;
+        chrono::DateTime::from_timestamp(period_start, 0)
+    }
+
+    pub fn current_period_end_at(&self) -> Option<DateTimeUtc> {
+        let period_end = self.stripe_current_period_end?;
+        chrono::DateTime::from_timestamp(period_end, 0)
+    }
+}
+
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
 pub enum Relation {
     #[sea_orm(

--- a/crates/collab/src/llm/db/queries.rs
+++ b/crates/collab/src/llm/db/queries.rs
@@ -2,4 +2,5 @@ use super::*;
 
 pub mod billing_events;
 pub mod providers;
+pub mod subscription_usages;
 pub mod usages;

--- a/crates/collab/src/llm/db/queries/subscription_usages.rs
+++ b/crates/collab/src/llm/db/queries/subscription_usages.rs
@@ -1,0 +1,22 @@
+use crate::db::UserId;
+
+use super::*;
+
+impl LlmDatabase {
+    pub async fn get_subscription_usage_for_period(
+        &self,
+        user_id: UserId,
+        period_start_at: DateTimeUtc,
+        period_end_at: DateTimeUtc,
+    ) -> Result<Option<subscription_usage::Model>> {
+        self.transaction(|tx| async move {
+            Ok(subscription_usage::Entity::find()
+                .filter(subscription_usage::Column::UserId.eq(user_id))
+                .filter(subscription_usage::Column::PeriodStartAt.eq(period_start_at))
+                .filter(subscription_usage::Column::PeriodEndAt.eq(period_end_at))
+                .one(&*tx)
+                .await?)
+        })
+        .await
+    }
+}

--- a/crates/collab/src/llm/db/tables.rs
+++ b/crates/collab/src/llm/db/tables.rs
@@ -2,5 +2,6 @@ pub mod billing_event;
 pub mod model;
 pub mod monthly_usage;
 pub mod provider;
+pub mod subscription_usage;
 pub mod usage;
 pub mod usage_measure;

--- a/crates/collab/src/llm/db/tables/subscription_usage.rs
+++ b/crates/collab/src/llm/db/tables/subscription_usage.rs
@@ -1,0 +1,20 @@
+use crate::db::UserId;
+use sea_orm::entity::prelude::*;
+use time::PrimitiveDateTime;
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "subscription_usages")]
+pub struct Model {
+    #[sea_orm(primary_key)]
+    pub id: i32,
+    pub user_id: UserId,
+    pub period_start_at: PrimitiveDateTime,
+    pub period_end_at: PrimitiveDateTime,
+    pub model_requests: i32,
+    pub edit_predictions: i32,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -3,7 +3,7 @@ use crate::db::{billing_subscription, user};
 use crate::llm::{DEFAULT_MAX_MONTHLY_SPEND, FREE_TIER_MONTHLY_SPENDING_LIMIT};
 use crate::{Config, db::billing_preference};
 use anyhow::{Result, anyhow};
-use chrono::{DateTime, NaiveDateTime, Utc};
+use chrono::{NaiveDateTime, Utc};
 use jsonwebtoken::{DecodingKey, EncodingKey, Header, Validation};
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
@@ -84,13 +84,10 @@ impl LlmTokenClaims {
             plan,
             subscription_period: maybe!({
                 let subscription = subscription?;
-                let period_start = subscription.stripe_current_period_start?;
-                let period_start = DateTime::from_timestamp(period_start, 0)?;
+                let period_start_at = subscription.current_period_start_at()?;
+                let period_end_at = subscription.current_period_end_at()?;
 
-                let period_end = subscription.stripe_current_period_end?;
-                let period_end = DateTime::from_timestamp(period_end, 0)?;
-
-                Some((period_start.naive_utc(), period_end.naive_utc()))
+                Some((period_start_at.naive_utc(), period_end_at.naive_utc()))
             }),
         };
 


### PR DESCRIPTION
This PR adds a `GET /billing/usage` endpoint for retrieving billing usage to show on the `zed.dev/account` page.

Release Notes:

- N/A
