### PR TITLE
debugger: Add Debug Panel context menu

### DIFF
--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -1,4 +1,5 @@
 use collections::HashMap;
+use dap::Capabilities;
 use db::kvp::KEY_VALUE_STORE;
 use gpui::{Axis, Context, Entity, EntityId, Focusable, Subscription, WeakEntity, Window};
 use project::Project;
@@ -9,7 +10,8 @@ use workspace::{Member, Pane, PaneAxis, Workspace};
 
 use crate::session::running::{
     self, RunningState, SubView, breakpoint_list::BreakpointList, console::Console,
-    module_list::ModuleList, stack_frame_list::StackFrameList, variable_list::VariableList,
+    loaded_source_list::LoadedSourceList, module_list::ModuleList,
+    stack_frame_list::StackFrameList, variable_list::VariableList,
 };
 
 #[derive(Clone, Hash, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
@@ -19,6 +21,7 @@ pub(crate) enum DebuggerPaneItem {
     BreakpointList,
     Frames,
     Modules,
+    LoadedSources,
 }
 
 impl DebuggerPaneItem {
@@ -29,8 +32,19 @@ impl DebuggerPaneItem {
             DebuggerPaneItem::BreakpointList,
             DebuggerPaneItem::Frames,
             DebuggerPaneItem::Modules,
+            DebuggerPaneItem::LoadedSources,
         ];
         VARIANTS
+    }
+
+    pub(crate) fn is_supported(&self, capabilities: &Capabilities) -> bool {
+        match self {
+            DebuggerPaneItem::Modules => capabilities.supports_modules_request.unwrap_or_default(),
+            DebuggerPaneItem::LoadedSources => capabilities
+                .supports_loaded_sources_request
+                .unwrap_or_default(),
+            _ => true,
+        }
     }
 
     pub(crate) fn to_shared_string(self) -> SharedString {
@@ -40,6 +54,7 @@ impl DebuggerPaneItem {
             DebuggerPaneItem::BreakpointList => SharedString::new_static("Breakpoints"),
             DebuggerPaneItem::Frames => SharedString::new_static("Frames"),
             DebuggerPaneItem::Modules => SharedString::new_static("Modules"),
+            DebuggerPaneItem::LoadedSources => SharedString::new_static("Sources"),
         }
     }
 }
@@ -153,6 +168,7 @@ pub(crate) fn deserialize_pane_layout(
     module_list: &Entity<ModuleList>,
     console: &Entity<Console>,
     breakpoint_list: &Entity<BreakpointList>,
+    loaded_sources: &Entity<LoadedSourceList>,
     subscriptions: &mut HashMap<EntityId, Subscription>,
     window: &mut Window,
     cx: &mut Context<RunningState>,
@@ -174,6 +190,7 @@ pub(crate) fn deserialize_pane_layout(
                     module_list,
                     console,
                     breakpoint_list,
+                    loaded_sources,
                     subscriptions,
                     window,
                     cx,
@@ -208,7 +225,7 @@ pub(crate) fn deserialize_pane_layout(
                 .iter()
                 .map(|child| match child {
                     DebuggerPaneItem::Frames => Box::new(SubView::new(
-                        pane.focus_handle(cx),
+                        stack_frame_list.focus_handle(cx),
                         stack_frame_list.clone().into(),
                         DebuggerPaneItem::Frames,
                         None,
@@ -229,13 +246,19 @@ pub(crate) fn deserialize_pane_layout(
                         cx,
                     )),
                     DebuggerPaneItem::Modules => Box::new(SubView::new(
-                        pane.focus_handle(cx),
+                        module_list.focus_handle(cx),
                         module_list.clone().into(),
                         DebuggerPaneItem::Modules,
                         None,
                         cx,
                     )),
-
+                    DebuggerPaneItem::LoadedSources => Box::new(SubView::new(
+                        loaded_sources.focus_handle(cx),
+                        loaded_sources.clone().into(),
+                        DebuggerPaneItem::LoadedSources,
+                        None,
+                        cx,
+                    )),
                     DebuggerPaneItem::Console => Box::new(SubView::new(
                         pane.focus_handle(cx),
                         console.clone().into(),

--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -12,7 +12,7 @@ use crate::session::running::{
     module_list::ModuleList, stack_frame_list::StackFrameList, variable_list::VariableList,
 };
 
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[derive(Clone, Hash, Copy, Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub(crate) enum DebuggerPaneItem {
     Console,
     Variables,
@@ -22,6 +22,17 @@ pub(crate) enum DebuggerPaneItem {
 }
 
 impl DebuggerPaneItem {
+    pub(crate) fn all() -> &'static [DebuggerPaneItem] {
+        static VARIANTS: &[DebuggerPaneItem] = &[
+            DebuggerPaneItem::Console,
+            DebuggerPaneItem::Variables,
+            DebuggerPaneItem::BreakpointList,
+            DebuggerPaneItem::Frames,
+            DebuggerPaneItem::Modules,
+        ];
+        VARIANTS
+    }
+
     pub(crate) fn to_shared_string(self) -> SharedString {
         match self {
             DebuggerPaneItem::Console => SharedString::new_static("Console"),
@@ -30,6 +41,12 @@ impl DebuggerPaneItem {
             DebuggerPaneItem::Frames => SharedString::new_static("Frames"),
             DebuggerPaneItem::Modules => SharedString::new_static("Modules"),
         }
+    }
+}
+
+impl From<DebuggerPaneItem> for SharedString {
+    fn from(item: DebuggerPaneItem) -> Self {
+        item.to_shared_string()
     }
 }
 

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -506,9 +506,13 @@ impl RunningState {
             )
         }) {
             pane.update(cx, |pane, cx| {
-                pane.remove_item(item_id, false, false, window, cx)
+                pane.remove_item(item_id, false, true, window, cx)
             })
         }
+    }
+
+    pub(crate) fn has_pane_at_position(&self, position: Point<Pixels>) -> bool {
+        self.panes.pane_at_pixel_position(position).is_some()
     }
 
     pub(crate) fn add_pane_item(
@@ -655,6 +659,10 @@ impl RunningState {
             self.stack_frame_list
                 .update(cx, |list, cx| list.go_to_selected_stack_frame(window, cx));
         }
+    }
+
+    pub(crate) fn has_open_context_menu(&self, cx: &App) -> bool {
+        self.variable_list.read(cx).has_open_context_menu()
     }
 
     pub fn session(&self) -> &Entity<Session> {

--- a/crates/debugger_ui/src/session/running/loaded_source_list.rs
+++ b/crates/debugger_ui/src/session/running/loaded_source_list.rs
@@ -3,7 +3,7 @@ use project::debugger::session::{Session, SessionEvent};
 use ui::prelude::*;
 use util::maybe;
 
-pub struct LoadedSourceList {
+pub(crate) struct LoadedSourceList {
     list: ListState,
     invalidate: bool,
     focus_handle: FocusHandle,

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -194,6 +194,10 @@ impl VariableList {
         }
     }
 
+    pub(super) fn has_open_context_menu(&self) -> bool {
+        self.open_context_menu.is_some()
+    }
+
     fn build_entries(&mut self, cx: &mut Context<Self>) {
         let Some(stack_frame_id) = self.selected_stack_frame_id else {
             return;


### PR DESCRIPTION
This PR adds a debug panel context menu that will allow a user to select which debug session items are visible.

The context menu will add to the pane that was right clicked on.

<img width="1275" alt="Screenshot 2025-04-16 at 2 43 36 AM" src="https://github.com/user-attachments/assets/330322ff-69db-4731-bbaf-3544d53f2f15" />


Release Notes:

- N/A 
