### PR TITLE
lsp: Register buffers with language server when querying inlay hints

### DIFF
--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -989,6 +989,16 @@ fn fetch_and_update_hints(
                 }
 
                 let buffer = editor.buffer().read(cx).buffer(query.buffer_id)?;
+                if !editor.registered_buffers.contains_key(&query.buffer_id) {
+                    if let Some(project) = editor.project.as_ref() {
+                        project.update(cx, |project, cx| {
+                            editor.registered_buffers.insert(
+                                query.buffer_id,
+                                project.register_buffer_with_language_servers(&buffer, cx),
+                            );
+                        })
+                    }
+                }
                 editor
                     .semantics_provider
                     .as_ref()?


### PR DESCRIPTION
We register buffers with language servers lazily when in multi-buffer (when the excerpt is interacted with); this does not account for inlay hints, of which a mere presence on a screen is enough to query a language server with a path it does not recognize. This posed a problem with typescript-language-server, which sent a notification to the user whenever they had a multibuffer open with inlay hints enabled.

Closes #ISSUE

Release Notes:

- Fixed annoying pop-up with typescript-language-server that happened in multi-buffers with inlay hints enabled.
