### PR TITLE
toolchain: Respect currently focused file when querying toolchains

### DIFF
--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -105,7 +105,7 @@ use std::{
 use task_store::TaskStore;
 use terminals::Terminals;
 use text::{Anchor, BufferId};
-use toolchain_store::{EmptyToolchainStore, ToolchainStoreEvent};
+use toolchain_store::EmptyToolchainStore;
 use util::{
     ResultExt as _,
     paths::{SanitizedPath, compare_paths},
@@ -951,12 +951,7 @@ impl Project {
                 client_state: ProjectClientState::Local,
                 git_store,
                 client_subscriptions: Vec::new(),
-                _subscriptions: vec![
-                    cx.on_release(Self::release),
-                    cx.subscribe(&toolchain_store, |_, _, event: &ToolchainStoreEvent, cx| {
-                        cx.emit(event.clone());
-                    }),
-                ],
+                _subscriptions: vec![cx.on_release(Self::release)],
                 active_entry: None,
                 snippets,
                 languages,
@@ -3099,6 +3094,9 @@ impl Project {
             .map(|lister| lister.term())
     }
 
+    pub fn toolchain_store(&self) -> Option<Entity<ToolchainStore>> {
+        self.toolchain_store.clone()
+    }
     pub fn activate_toolchain(
         &self,
         path: ProjectPath,
@@ -4936,7 +4934,6 @@ impl<'a> Iterator for PathMatchCandidateSetIter<'a> {
 }
 
 impl EventEmitter<Event> for Project {}
-impl EventEmitter<ToolchainStoreEvent> for Project {}
 
 impl<'a> From<&'a ProjectPath> for SettingsLocation<'a> {
     fn from(val: &'a ProjectPath) -> Self {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -105,7 +105,7 @@ use std::{
 use task_store::TaskStore;
 use terminals::Terminals;
 use text::{Anchor, BufferId};
-use toolchain_store::EmptyToolchainStore;
+use toolchain_store::{EmptyToolchainStore, ToolchainStoreEvent};
 use util::{
     ResultExt as _,
     paths::{SanitizedPath, compare_paths},
@@ -951,7 +951,12 @@ impl Project {
                 client_state: ProjectClientState::Local,
                 git_store,
                 client_subscriptions: Vec::new(),
-                _subscriptions: vec![cx.on_release(Self::release)],
+                _subscriptions: vec![
+                    cx.on_release(Self::release),
+                    cx.subscribe(&toolchain_store, |_, _, event: &ToolchainStoreEvent, cx| {
+                        cx.emit(event.clone());
+                    }),
+                ],
                 active_entry: None,
                 snippets,
                 languages,
@@ -4931,6 +4936,7 @@ impl<'a> Iterator for PathMatchCandidateSetIter<'a> {
 }
 
 impl EventEmitter<Event> for Project {}
+impl EventEmitter<ToolchainStoreEvent> for Project {}
 
 impl<'a> From<&'a ProjectPath> for SettingsLocation<'a> {
     fn from(val: &'a ProjectPath) -> Self {

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -55,6 +55,7 @@ impl ToolchainStore {
         });
         Self(ToolchainStoreInner::Local(entity, subscription))
     }
+
     pub(super) fn remote(project_id: u64, client: AnyProtoClient, cx: &mut App) -> Self {
         Self(ToolchainStoreInner::Remote(
             cx.new(|_| RemoteToolchainStore { client, project_id }),
@@ -285,7 +286,7 @@ struct LocalStore(WeakEntity<LocalToolchainStore>);
 struct RemoteStore(WeakEntity<RemoteToolchainStore>);
 
 #[derive(Clone)]
-pub(crate) enum ToolchainStoreEvent {
+pub enum ToolchainStoreEvent {
     ToolchainActivated,
 }
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -302,7 +302,7 @@ impl TitleBar {
                 cx.notify()
             }),
         );
-        subscriptions.push(cx.subscribe(&project, |_, _, _, cx| cx.notify()));
+        subscriptions.push(cx.subscribe(&project, |_, _, _: &project::Event, cx| cx.notify()));
         subscriptions.push(cx.observe(&active_call, |this, _, cx| this.active_call_changed(cx)));
         subscriptions.push(cx.observe_window_activation(window, Self::window_activation_changed));
         subscriptions.push(cx.observe(&user_store, |_, _, cx| cx.notify()));

--- a/crates/toolchain_selector/src/active_toolchain.rs
+++ b/crates/toolchain_selector/src/active_toolchain.rs
@@ -22,26 +22,28 @@ pub struct ActiveToolchain {
 
 impl ActiveToolchain {
     pub fn new(workspace: &Workspace, window: &mut Window, cx: &mut Context<Self>) -> Self {
-        cx.subscribe_in(
-            workspace.project(),
-            window,
-            |this, _, _: &ToolchainStoreEvent, window, cx| {
-                let editor = this
-                    .workspace
-                    .update(cx, |workspace, cx| {
-                        workspace
-                            .active_item(cx)
-                            .and_then(|item| item.downcast::<Editor>())
-                    })
-                    .ok()
-                    .flatten();
-                if let Some(editor) = editor {
-                    this.active_toolchain.take();
-                    this.update_lister(editor, window, cx);
-                }
-            },
-        )
-        .detach();
+        if let Some(store) = workspace.project().read(cx).toolchain_store() {
+            cx.subscribe_in(
+                &store,
+                window,
+                |this, _, _: &ToolchainStoreEvent, window, cx| {
+                    let editor = this
+                        .workspace
+                        .update(cx, |workspace, cx| {
+                            workspace
+                                .active_item(cx)
+                                .and_then(|item| item.downcast::<Editor>())
+                        })
+                        .ok()
+                        .flatten();
+                    if let Some(editor) = editor {
+                        this.active_toolchain.take();
+                        this.update_lister(editor, window, cx);
+                    }
+                },
+            )
+            .detach();
+        }
         Self {
             active_toolchain: None,
             active_buffer: None,

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1334,17 +1334,18 @@ impl WorkspaceDb {
         &self,
         workspace_id: WorkspaceId,
         worktree_id: WorktreeId,
+        relative_path: String,
         language_name: LanguageName,
     ) -> Result<Option<Toolchain>> {
         self.write(move |this| {
             let mut select = this
                 .select_bound(sql!(
-                    SELECT name, path, raw_json FROM toolchains WHERE workspace_id = ? AND language_name = ? AND worktree_id = ?
+                    SELECT name, path, raw_json FROM toolchains WHERE workspace_id = ? AND language_name = ? AND worktree_id = ? AND relative_path = ?
                 ))
                 .context("Preparing insertion")?;
 
             let toolchain: Vec<(String, String, String)> =
-                select((workspace_id, language_name.as_ref().to_string(), worktree_id.to_usize()))?;
+                select((workspace_id, language_name.as_ref().to_string(), worktree_id.to_usize(), relative_path))?;
 
             Ok(toolchain.into_iter().next().and_then(|(name, path, raw_json)| Some(Toolchain {
                 name: name.into(),


### PR DESCRIPTION
Closes #21743

https://github.com/user-attachments/assets/0230f233-58a4-494c-90af-28ce82f9fc1d


Release Notes:

- Virtual environment picker now looks up virtual environment based on parent directory of active file; this enables having multiple active virtual environments in a single worktree.
