### PR TITLE
Remove bottom dock layout button

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -210,7 +210,6 @@ impl Render for TitleBar {
                             .pr_1()
                             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
                             .children(self.render_call_controls(window, cx))
-                            .child(self.render_bottom_dock_layout_menu(cx))
                             .map(|el| {
                                 let status = self.client.status();
                                 let status = &*status.borrow();
@@ -621,101 +620,6 @@ impl TitleBar {
             }
             _ => None,
         }
-    }
-
-    pub fn render_bottom_dock_layout_menu(&self, cx: &mut Context<Self>) -> impl IntoElement {
-        let workspace = self.workspace.upgrade().unwrap();
-        let current_layout = workspace.update(cx, |workspace, _cx| workspace.bottom_dock_layout());
-
-        PopoverMenu::new("layout-menu")
-            .trigger(
-                IconButton::new("toggle_layout", IconName::Layout)
-                    .icon_size(IconSize::Small)
-                    .tooltip(Tooltip::text("Toggle Layout Menu")),
-            )
-            .anchor(gpui::Corner::TopRight)
-            .menu(move |window, cx| {
-                ContextMenu::build(window, cx, {
-                    let workspace = workspace.clone();
-                    move |menu, _, _| {
-                        menu.label("Bottom Dock")
-                            .separator()
-                            .toggleable_entry(
-                                "Contained",
-                                current_layout == BottomDockLayout::Contained,
-                                ui::IconPosition::End,
-                                None,
-                                {
-                                    let workspace = workspace.clone();
-                                    move |window, cx| {
-                                        workspace.update(cx, |workspace, cx| {
-                                            workspace.set_bottom_dock_layout(
-                                                BottomDockLayout::Contained,
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                },
-                            )
-                            .toggleable_entry(
-                                "Full",
-                                current_layout == BottomDockLayout::Full,
-                                ui::IconPosition::End,
-                                None,
-                                {
-                                    let workspace = workspace.clone();
-                                    move |window, cx| {
-                                        workspace.update(cx, |workspace, cx| {
-                                            workspace.set_bottom_dock_layout(
-                                                BottomDockLayout::Full,
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                },
-                            )
-                            .toggleable_entry(
-                                "Left Aligned",
-                                current_layout == BottomDockLayout::LeftAligned,
-                                ui::IconPosition::End,
-                                None,
-                                {
-                                    let workspace = workspace.clone();
-                                    move |window, cx| {
-                                        workspace.update(cx, |workspace, cx| {
-                                            workspace.set_bottom_dock_layout(
-                                                BottomDockLayout::LeftAligned,
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                },
-                            )
-                            .toggleable_entry(
-                                "Right Aligned",
-                                current_layout == BottomDockLayout::RightAligned,
-                                ui::IconPosition::End,
-                                None,
-                                {
-                                    let workspace = workspace.clone();
-                                    move |window, cx| {
-                                        workspace.update(cx, |workspace, cx| {
-                                            workspace.set_bottom_dock_layout(
-                                                BottomDockLayout::RightAligned,
-                                                window,
-                                                cx,
-                                            );
-                                        });
-                                    }
-                                },
-                            )
-                    }
-                })
-                .into()
-            })
     }
 
     pub fn render_sign_in_button(&mut self, _: &mut Context<Self>) -> Button {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -36,7 +36,7 @@ use ui::{
     IconWithIndicator, Indicator, PopoverMenu, Tooltip, h_flex, prelude::*,
 };
 use util::ResultExt;
-use workspace::{BottomDockLayout, Workspace, notifications::NotifyResultExt};
+use workspace::{Workspace, notifications::NotifyResultExt};
 use zed_actions::{OpenBrowser, OpenRecent, OpenRemote};
 
 pub use onboarding_banner::restore_banner;

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -75,6 +75,47 @@ Non-negative `float` values
 
 `float` values
 
+## Bottom Dock Layout
+
+- Description: Control the layout of the bottom dock, relative to the left and right docks
+- Setting: `bottom_dock_layout`
+- Default: `"contained"`
+
+**Options**
+
+1. Contain the bottom dock, giving the full height of the window to the left and right docks
+
+```json
+{
+  "bottom_dock_layout": "contained"
+}
+```
+
+2. Give the bottom dock the full width of the window, truncating the left and right docks
+
+```json
+{
+  "bottom_dock_layout": "full"
+}
+```
+
+3. Left align the bottom dock, truncating the left dock and giving the right dock the full height of the window
+
+```json
+{
+  "bottom_dock_layout": "left_aligned"
+}
+```
+
+
+3. Right align the bottom dock, giving the left dock the full height of the window and truncating the right dock.
+
+```json
+{
+  "bottom_dock_layout": "right_aligned"
+}
+```
+
 ## Auto Install extensions
 
 - Description: Define extensions to be autoinstalled or never be installed.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -107,7 +107,6 @@ Non-negative `float` values
 }
 ```
 
-
 3. Right align the bottom dock, giving the left dock the full height of the window and truncating the right dock.
 
 ```json


### PR DESCRIPTION
Release Notes:

- Preview: Removed the layout button from the title bar. The `bottom_dock_layout` setting still functions.
- Added a setting, `bottom_dock_layout`, for controlling the relationship between the bottom dock and the left and right docks.
