### PR TITLE
proto: Add `ZedProTrial` to `Plan`

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -1561,14 +1561,18 @@ impl AssistantPanel {
         cx: &mut Context<Self>,
     ) -> AnyElement {
         let error_message = match plan {
-            Plan::Free => "Model request limit reached. Upgrade to Zed Pro for more requests.",
             Plan::ZedPro => {
                 "Model request limit reached. Upgrade to usage-based billing for more requests."
             }
+            Plan::ZedProTrial => {
+                "Model request limit reached. Upgrade to Zed Pro for more requests."
+            }
+            Plan::Free => "Model request limit reached. Upgrade to Zed Pro for more requests.",
         };
         let call_to_action = match plan {
-            Plan::Free => "Upgrade to Zed Pro",
             Plan::ZedPro => "Upgrade to usage-based billing",
+            Plan::ZedProTrial => "Upgrade to Zed Pro",
+            Plan::Free => "Upgrade to Zed Pro",
         };
 
         v_flex()

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -3707,7 +3707,9 @@ async fn count_language_model_tokens(
 
     let rate_limit: Box<dyn RateLimit> = match session.current_plan(&session.db().await).await? {
         proto::Plan::ZedPro => Box::new(ZedProCountLanguageModelTokensRateLimit),
-        proto::Plan::Free => Box::new(FreeCountLanguageModelTokensRateLimit),
+        proto::Plan::Free | proto::Plan::ZedProTrial => {
+            Box::new(FreeCountLanguageModelTokensRateLimit)
+        }
     };
 
     session
@@ -3827,7 +3829,7 @@ async fn compute_embeddings(
 
     let rate_limit: Box<dyn RateLimit> = match session.current_plan(&session.db().await).await? {
         proto::Plan::ZedPro => Box::new(ZedProComputeEmbeddingsRateLimit),
-        proto::Plan::Free => Box::new(FreeComputeEmbeddingsRateLimit),
+        proto::Plan::Free | proto::Plan::ZedProTrial => Box::new(FreeComputeEmbeddingsRateLimit),
     };
 
     session

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -154,6 +154,9 @@ impl fmt::Display for ModelRequestLimitReachedError {
             Plan::ZedPro => {
                 "Model request limit reached. Upgrade to usage-based billing for more requests."
             }
+            Plan::ZedProTrial => {
+                "Model request limit reached. Upgrade to Zed Pro for more requests."
+            }
         };
 
         write!(f, "{message}")

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -546,7 +546,6 @@ impl PickerDelegate for LanguageModelPickerDelegate {
         use feature_flags::FeatureFlagAppExt;
 
         let plan = proto::Plan::ZedPro;
-        let is_trial = false;
 
         Some(
             h_flex()
@@ -558,7 +557,6 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                 .justify_between()
                 .when(cx.has_flag::<ZedPro>(), |this| {
                     this.child(match plan {
-                        // Already a Zed Pro subscriber
                         Plan::ZedPro => Button::new("zed-pro", "Zed Pro")
                             .icon(IconName::ZedAssistant)
                             .icon_size(IconSize::Small)
@@ -568,10 +566,9 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                                 window
                                     .dispatch_action(Box::new(zed_actions::OpenAccountSettings), cx)
                             }),
-                        // Free user
-                        Plan::Free => Button::new(
+                        Plan::Free | Plan::ZedProTrial => Button::new(
                             "try-pro",
-                            if is_trial {
+                            if plan == Plan::ZedProTrial {
                                 "Upgrade to Pro"
                             } else {
                                 "Try Pro"

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -18,6 +18,7 @@ message GetPrivateUserInfoResponse {
 enum Plan {
     Free = 0;
     ZedPro = 1;
+    ZedProTrial = 2;
 }
 
 message UpdateUserPlan {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -751,6 +751,7 @@ impl TitleBar {
                                         None => "",
                                         Some(proto::Plan::Free) => "Free",
                                         Some(proto::Plan::ZedPro) => "Pro",
+                                        Some(proto::Plan::ZedProTrial) => "Pro (Trial)",
                                     }
                                 ),
                                 zed_actions::OpenAccountSettings.boxed_clone(),


### PR DESCRIPTION
This PR adds the `ZedProTrial` member to the `Plan` enum.

Release Notes:

- N/A
