### PR TITLE
agent: Allow quoting selection when text thread is active

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -1788,10 +1788,27 @@ impl AssistantPanelDelegate for ConcreteAssistantPanelDelegate {
 
     fn quote_selection(
         &self,
-        _workspace: &mut Workspace,
-        _creases: Vec<(String, String)>,
-        _window: &mut Window,
-        _cx: &mut Context<Workspace>,
+        workspace: &mut Workspace,
+        creases: Vec<(String, String)>,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
     ) {
+        let Some(panel) = workspace.panel::<AssistantPanel>(cx) else {
+            return;
+        };
+
+        if !panel.focus_handle(cx).contains_focused(window, cx) {
+            workspace.toggle_panel_focus::<AssistantPanel>(window, cx);
+        }
+
+        panel.update(cx, |_, cx| {
+            // Wait to create a new context until the workspace is no longer
+            // being updated.
+            cx.defer_in(window, move |panel, window, cx| {
+                if let Some(context) = panel.active_context_editor() {
+                    context.update(cx, |context, cx| context.quote_creases(creases, window, cx));
+                };
+            });
+        });
     }
 }


### PR DESCRIPTION
This makes the `assistant: Quote selection` work again for text threads. Next up is supporting this also in normal threads.

Release Notes:

- agent: Add support for inserting selections (assistant: Quote selection) into text threads
