### PR TITLE
collab: Add `plan` column to `subscription_usages`

### DIFF
--- a/crates/collab/migrations_llm/20250416181354_add_plan_to_subscription_usages.sql
+++ b/crates/collab/migrations_llm/20250416181354_add_plan_to_subscription_usages.sql
@@ -1,0 +1,4 @@
+alter table subscription_usages
+    add column plan text not null;
+
+create index ix_subscription_usages_on_plan on subscription_usages (plan);

--- a/crates/collab/src/llm/db/tables/subscription_usage.rs
+++ b/crates/collab/src/llm/db/tables/subscription_usage.rs
@@ -1,4 +1,5 @@
 use crate::db::UserId;
+use crate::db::billing_subscription::SubscriptionKind;
 use sea_orm::entity::prelude::*;
 use time::PrimitiveDateTime;
 
@@ -10,6 +11,7 @@ pub struct Model {
     pub user_id: UserId,
     pub period_start_at: PrimitiveDateTime,
     pub period_end_at: PrimitiveDateTime,
+    pub plan: SubscriptionKind,
     pub model_requests: i32,
     pub edit_predictions: i32,
 }


### PR DESCRIPTION
This PR adds a `plan` column to the `subscription_usages` table.

These tables don't have any records in them yet, so it's fine to make the column required without a default.

Release Notes:

- N/A
