### PR TITLE
outline_panel: Rename `outline_panel::Open` to `outline_panel::OpenSelectedEntry`

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -718,7 +718,7 @@
       "alt-shift-copy": "workspace::CopyRelativePath",
       "alt-ctrl-shift-c": "workspace::CopyRelativePath",
       "alt-ctrl-r": "outline_panel::RevealInFileManager",
-      "space": "outline_panel::Open",
+      "space": "outline_panel::OpenSelectedEntry",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "alt-enter": "editor::OpenExcerpts",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -786,7 +786,7 @@
       "cmd-alt-c": "workspace::CopyPath",
       "alt-cmd-shift-c": "workspace::CopyRelativePath",
       "alt-cmd-r": "outline_panel::RevealInFileManager",
-      "space": "outline_panel::Open",
+      "space": "outline_panel::OpenSelectedEntry",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "alt-enter": "editor::OpenExcerpts",

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -39,7 +39,9 @@ pub(crate) mod m_2025_03_29 {
 }
 
 pub(crate) mod m_2025_04_15 {
+    mod keymap;
     mod settings;
 
+    pub(crate) use keymap::KEYMAP_PATTERNS;
     pub(crate) use settings::SETTINGS_PATTERNS;
 }

--- a/crates/migrator/src/migrations/m_2025_04_15/keymap.rs
+++ b/crates/migrator/src/migrations/m_2025_04_15/keymap.rs
@@ -1,0 +1,31 @@
+use collections::HashMap;
+use std::{ops::Range, sync::LazyLock};
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+use crate::patterns::KEYMAP_ACTION_STRING_PATTERN;
+
+pub const KEYMAP_PATTERNS: MigrationPatterns =
+    &[(KEYMAP_ACTION_STRING_PATTERN, replace_string_action)];
+
+fn replace_string_action(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let action_name_ix = query.capture_index_for_name("action_name")?;
+    let action_name_node = mat.nodes_for_capture_index(action_name_ix).next()?;
+    let action_name_range = action_name_node.byte_range();
+    let action_name = contents.get(action_name_range.clone())?;
+
+    if let Some(new_action_name) = STRING_REPLACE.get(&action_name) {
+        return Some((action_name_range, new_action_name.to_string()));
+    }
+
+    None
+}
+
+/// "ctrl-k ctrl-1": "inline_completion::ToggleMenu" -> "edit_prediction::ToggleMenu"
+static STRING_REPLACE: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
+    HashMap::from_iter([("outline_panel::Open", "outline_panel::OpenSelectedEntry")])
+});

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -98,6 +98,10 @@ pub fn migrate_keymap(text: &str) -> Result<Option<String>> {
             migrations::m_2025_03_06::KEYMAP_PATTERNS,
             &KEYMAP_QUERY_2025_03_06,
         ),
+        (
+            migrations::m_2025_04_15::KEYMAP_PATTERNS,
+            &KEYMAP_QUERY_2025_04_15,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -175,6 +179,10 @@ define_query!(
 define_query!(
     KEYMAP_QUERY_2025_03_06,
     migrations::m_2025_03_06::KEYMAP_PATTERNS
+);
+define_query!(
+    KEYMAP_QUERY_2025_04_15,
+    migrations::m_2025_04_15::KEYMAP_PATTERNS
 );
 
 // settings

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -70,7 +70,7 @@ actions!(
         ExpandAllEntries,
         ExpandSelectedEntry,
         FoldDirectory,
-        Open,
+        OpenSelectedEntry,
         RevealInFileManager,
         SelectParent,
         ToggleActiveEditorPin,
@@ -922,7 +922,12 @@ impl OutlinePanel {
         self.update_cached_entries(None, window, cx);
     }
 
-    fn open(&mut self, _: &Open, window: &mut Window, cx: &mut Context<Self>) {
+    fn open_selected_entry(
+        &mut self,
+        _: &OpenSelectedEntry,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         if self.filter_editor.focus_handle(cx).is_focused(window) {
             cx.propagate()
         } else if let Some(selected_entry) = self.selected_entry().cloned() {
@@ -4906,7 +4911,7 @@ impl Render for OutlinePanel {
                 }
             }))
             .key_context(self.dispatch_context(window, cx))
-            .on_action(cx.listener(Self::open))
+            .on_action(cx.listener(Self::open_selected_entry))
             .on_action(cx.listener(Self::cancel))
             .on_action(cx.listener(Self::select_next))
             .on_action(cx.listener(Self::select_previous))
@@ -5677,7 +5682,7 @@ mod tests {
         });
 
         outline_panel.update_in(cx, |outline_panel, window, cx| {
-            outline_panel.open(&Open, window, cx);
+            outline_panel.open_selected_entry(&OpenSelectedEntry, window, cx);
         });
         outline_panel.update(cx, |_outline_panel, cx| {
             assert_eq!(
@@ -5852,7 +5857,7 @@ mod tests {
 
         outline_panel.update_in(cx, |outline_panel, window, cx| {
             outline_panel.select_previous(&SelectPrevious, window, cx);
-            outline_panel.open(&Open, window, cx);
+            outline_panel.open_selected_entry(&OpenSelectedEntry, window, cx);
         });
         cx.executor()
             .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(100));
@@ -5876,7 +5881,7 @@ mod tests {
 
         outline_panel.update_in(cx, |outline_panel, window, cx| {
             outline_panel.select_next(&SelectNext, window, cx);
-            outline_panel.open(&Open, window, cx);
+            outline_panel.open_selected_entry(&OpenSelectedEntry, window, cx);
         });
         cx.executor()
             .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(100));
@@ -5897,7 +5902,7 @@ mod tests {
         });
 
         outline_panel.update_in(cx, |outline_panel, window, cx| {
-            outline_panel.open(&Open, window, cx);
+            outline_panel.open_selected_entry(&OpenSelectedEntry, window, cx);
         });
         cx.executor()
             .advance_clock(UPDATE_DEBOUNCE + Duration::from_millis(100));


### PR DESCRIPTION
Closes #27171

The `outline_panel::Open` action seems to open the outline panel, but instead, it moves the editor's cursor to the position of the selected entry in the outline panel. This PR renames it to `outline_panel::OpenSelectedEntry` for better clarity.

Meanwhile, there is an existing action, `outline_panel::ToggleFocus`, that should be used for opening the outline panel.

Todo:
- [x] Added migration

Release Notes:

- Renamed `outline_panel::Open` to `outline_panel::OpenSelectedEntry` for better clarity.