### PR TITLE
editor: Fix scrolling drag interrupted on gutter hovering

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1007,9 +1007,6 @@ impl EditorElement {
         } else {
             editor.hide_hovered_link(cx);
             hover_at(editor, None, window, cx);
-            if gutter_hovered {
-                cx.stop_propagation();
-            }
         }
     }
 


### PR DESCRIPTION
Closes #27188

This PR fixes the issue where, when you drag the scroll handle of the editor and your mouse hovers over the gutter of the next editor, scrolling stops. I found no good reason to stop propagation on gutter hover.

Release Notes:

- Fixed an issue where editor scrolling would stop when the mouse hovered over another editor's gutter.


