### PR TITLE
Correct typos in GPUI key_dispatch.rs comments

### DIFF
--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -6,7 +6,7 @@
 /// with a keymap context:
 ///
 /// ```rust
-/// actions!(editor,[Undo, Redo]);;
+/// actions!(editor,[Undo, Redo]);
 ///
 /// impl Editor {
 ///   fn undo(&mut self, _: &Undo, _window: &mut Window, _cx: &mut Context<Self>) { ... }
@@ -17,7 +17,7 @@
 ///   fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
 ///     div()
 ///       .track_focus(&self.focus_handle(cx))
-///       .keymap_context("Editor")
+///       .key_context("Editor")
 ///       .on_action(cx.listener(Editor::undo))
 ///       .on_action(cx.listener(Editor::redo))
 ///     ...


### PR DESCRIPTION
just noticed an extra semicolon and a reference to the nonexistant `keymap_context` function!

Release Notes:

- N/A