### PR TITLE
vim: Change line up and change line down respect indentation

### DIFF
--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -425,6 +425,15 @@ mod test {
         )
         .await
         .assert_matches();
+        cx.simulate(
+            "c k",
+            indoc! {"
+            The quick
+              brown fox
+              ˇjumps over"},
+        )
+        .await
+        .assert_matches();
     }
 
     #[gpui::test]
@@ -463,6 +472,15 @@ mod test {
             The quick
             brown fox
             ˇ"},
+        )
+        .await
+        .assert_matches();
+        cx.simulate(
+            "c j",
+            indoc! {"
+            The quick
+              ˇbrown fox
+              jumps over"},
         )
         .await
         .assert_matches();

--- a/crates/vim/src/normal/change.rs
+++ b/crates/vim/src/normal/change.rs
@@ -62,7 +62,10 @@ impl Vim {
                                     &text_layout_details,
                                     forced_motion,
                                 );
-                                if let Motion::CurrentLine = motion {
+                                if matches!(
+                                    motion,
+                                    Motion::CurrentLine | Motion::Down { .. } | Motion::Up { .. }
+                                ) {
                                     let mut start_offset =
                                         selection.start.to_offset(map, Bias::Left);
                                     let classifier = map

--- a/crates/vim/test_data/test_change_j.json
+++ b/crates/vim/test_data/test_change_j.json
@@ -14,3 +14,7 @@
 {"Key":"c"}
 {"Key":"j"}
 {"Get":{"state":"The quick\nbrown fox\nˇ","mode":"Normal"}}
+{"Put":{"state":"The quick\n  ˇbrown fox\n  jumps over"}}
+{"Key":"c"}
+{"Key":"j"}
+{"Get":{"state":"The quick\n  ˇ","mode":"Insert"}}

--- a/crates/vim/test_data/test_change_k.json
+++ b/crates/vim/test_data/test_change_k.json
@@ -14,3 +14,7 @@
 {"Key":"c"}
 {"Key":"k"}
 {"Get":{"state":"ˇ\nbrown fox\njumps over","mode":"Normal"}}
+{"Put":{"state":"The quick\n  brown fox\n  ˇjumps over"}}
+{"Key":"c"}
+{"Key":"k"}
+{"Get":{"state":"The quick\n  ˇ","mode":"Insert"}}


### PR DESCRIPTION
When using 'c' with line-wise motions like j/k, operate like cc to fix indentation issues.

Closes #28933 

Release Notes:

- `c j` and `c k` now respect indentation
