### PR TITLE
nix: Add libX11 dependency for X11 support

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -140,6 +140,7 @@ let
           libxkbcommon
           wayland
           gpu-lib
+          xorg.libX11
           xorg.libxcb
         ]
         ++ lib.optionals stdenv'.hostPlatform.isDarwin [


### PR DESCRIPTION
Closes #28937 

Release Notes:

- Adds libX11 dependency for X11 support
