### PR TITLE
Fix snippets from extensions being listed twice

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13319,6 +13319,7 @@ dependencies = [
  "fs",
  "futures 0.3.31",
  "gpui",
+ "indoc",
  "parking_lot",
  "paths",
  "schemars",

--- a/crates/snippet_provider/Cargo.toml
+++ b/crates/snippet_provider/Cargo.toml
@@ -23,3 +23,8 @@ snippet.workspace = true
 util.workspace = true
 schemars.workspace = true
 workspace-hack.workspace = true
+
+[dev-dependencies]
+fs = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
+indoc.workspace = true

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -222,14 +222,14 @@ impl SnippetProvider {
                         .lookup_snippets::<false>(language, cx),
                 );
             }
+
+            let Some(registry) = SnippetRegistry::try_global(cx) else {
+                return user_snippets;
+            };
+
+            let registry_snippets = registry.get_snippets(language);
+            user_snippets.extend(registry_snippets);
         }
-
-        let Some(registry) = SnippetRegistry::try_global(cx) else {
-            return user_snippets;
-        };
-
-        let registry_snippets = registry.get_snippets(language);
-        user_snippets.extend(registry_snippets);
 
         user_snippets
     }
@@ -242,5 +242,40 @@ impl SnippetProvider {
             requested_snippets.extend(self.lookup_snippets::<true>(&None, cx));
         }
         requested_snippets
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fs::FakeFs;
+    use gpui;
+    use gpui::TestAppContext;
+    use indoc::indoc;
+
+    #[gpui::test]
+    fn test_lookup_snippets_dup_registry_snippets(cx: &mut TestAppContext) {
+        let fs = FakeFs::new(cx.background_executor.clone());
+        cx.update(|cx| {
+            SnippetRegistry::init_global(cx);
+            SnippetRegistry::global(cx)
+                .register_snippets(
+                    "ruby".as_ref(),
+                    indoc! {r#"
+                    {
+                      "Log to console": {
+                        "prefix": "log",
+                        "body": ["console.info(\"Hello, ${1:World}!\")", "$0"],
+                        "description": "Logs to console"
+                      }
+                    }
+            "#},
+                )
+                .unwrap();
+            let provider = SnippetProvider::new(fs.clone(), Default::default(), cx);
+            cx.update_entity(&provider, |provider, cx| {
+                assert_eq!(1, provider.snippets_for(Some("ruby".to_owned()), cx).len());
+            });
+        });
     }
 }


### PR DESCRIPTION
lookup_snippets() merges global snippets and extension snippets, but global_snippets::lookup_snippets() also returns extension snippets, make them double

Closes #28661 

Release Notes:

- Fixed a bug where extension provided snippets were being displayed in duplicate.