### PR TITLE
gemini: Fix invalid field name in request

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -125,7 +125,7 @@ pub struct GenerateContentRequest {
     #[serde(default, skip_serializing_if = "String::is_empty")]
     pub model: String,
     pub contents: Vec<Content>,
-    pub system_instructions: Option<SystemInstructions>,
+    pub system_instruction: Option<SystemInstruction>,
     pub generation_config: Option<GenerationConfig>,
     pub safety_settings: Option<Vec<SafetySetting>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -162,7 +162,7 @@ pub struct Content {
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-pub struct SystemInstructions {
+pub struct SystemInstruction {
     pub parts: Vec<Part>,
 }
 

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -4,7 +4,7 @@ use credentials_provider::CredentialsProvider;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{FutureExt, Stream, StreamExt, future::BoxFuture};
 use google_ai::{
-    FunctionDeclaration, GenerateContentResponse, Part, SystemInstructions, UsageMetadata,
+    FunctionDeclaration, GenerateContentResponse, Part, SystemInstruction, UsageMetadata,
 };
 use gpui::{
     AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
@@ -405,7 +405,7 @@ pub fn into_google(
         .map_or(false, |msg| matches!(msg.role, Role::System))
     {
         let message = request.messages.remove(0);
-        Some(SystemInstructions {
+        Some(SystemInstruction {
             parts: map_content(message.content),
         })
     } else {
@@ -414,7 +414,7 @@ pub fn into_google(
 
     google_ai::GenerateContentRequest {
         model,
-        system_instructions,
+        system_instruction: system_instructions,
         contents: request
             .messages
             .into_iter()


### PR DESCRIPTION
Closes #28941

See #28793, the name of the field is actually `systemInstruction` not `systemInstructions`.

Release Notes:

- Fixed an issue where Gemini requests would fail (Preview only)
