### PR TITLE
Add `zed` to Flatpak config and data directories

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -74,10 +74,9 @@ pub fn config_dir() -> &'static PathBuf {
             if let Ok(flatpak_xdg_config) = std::env::var("FLATPAK_XDG_CONFIG_HOME") {
                 flatpak_xdg_config.into()
             } else {
-                dirs::config_dir()
-                    .expect("failed to determine XDG_CONFIG_HOME directory")
-                    .join("zed")
+                dirs::config_dir().expect("failed to determine XDG_CONFIG_HOME directory")
             }
+            .join("zed")
         } else {
             home_dir().join(".config").join("zed")
         }
@@ -95,10 +94,9 @@ pub fn data_dir() -> &'static PathBuf {
             if let Ok(flatpak_xdg_data) = std::env::var("FLATPAK_XDG_DATA_HOME") {
                 flatpak_xdg_data.into()
             } else {
-                dirs::data_local_dir()
-                    .expect("failed to determine XDG_DATA_HOME directory")
-                    .join("zed")
+                dirs::data_local_dir().expect("failed to determine XDG_DATA_HOME directory")
             }
+            .join("zed")
         } else if cfg!(target_os = "windows") {
             dirs::data_local_dir()
                 .expect("failed to determine LocalAppData directory")


### PR DESCRIPTION
Closes #28944 

Release Notes:

- linux: Fixed incorrect config directory being used when Zed is installed via Flatpak
