### PR TITLE
Revert "git_panel: Pad end of list to avoid obscuring final entry with horizontal scrollbar (#28823)"

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -604,7 +604,7 @@ impl GitPanel {
             if let Ok(ix) = self.entries[conflicted_start..conflicted_start + self.conflicted_count]
                 .binary_search_by(|entry| entry.status_entry().unwrap().repo_path.cmp(&path))
             {
-                return Some(ix);
+                return Some(conflicted_start + ix);
             }
         }
         if self.tracked_count > 0 {
@@ -616,7 +616,7 @@ impl GitPanel {
             if let Ok(ix) = self.entries[tracked_start..tracked_start + self.tracked_count]
                 .binary_search_by(|entry| entry.status_entry().unwrap().repo_path.cmp(&path))
             {
-                return Some(ix);
+                return Some(tracked_start + ix);
             }
         }
         if self.new_count > 0 {
@@ -632,7 +632,7 @@ impl GitPanel {
             if let Ok(ix) = self.entries[untracked_start..untracked_start + self.new_count]
                 .binary_search_by(|entry| entry.status_entry().unwrap().repo_path.cmp(&path))
             {
-                return Some(ix);
+                return Some(untracked_start + ix);
             }
         }
         None

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -599,11 +599,33 @@ impl GitPanel {
     }
 
     pub fn entry_by_path(&self, path: &RepoPath) -> Option<usize> {
+        fn binary_search<F>(mut low: usize, mut high: usize, is_target: F) -> Option<usize>
+        where
+            F: Fn(usize) -> std::cmp::Ordering,
+        {
+            while low < high {
+                let mid = low + (high - low) / 2;
+                match is_target(mid) {
+                    std::cmp::Ordering::Equal => return Some(mid),
+                    std::cmp::Ordering::Less => low = mid + 1,
+                    std::cmp::Ordering::Greater => high = mid,
+                }
+            }
+            None
+        }
         if self.conflicted_count > 0 {
             let conflicted_start = 1;
-            if let Ok(ix) = self.entries[conflicted_start..conflicted_start + self.conflicted_count]
-                .binary_search_by(|entry| entry.status_entry().unwrap().repo_path.cmp(&path))
-            {
+            if let Some(ix) = binary_search(
+                conflicted_start,
+                conflicted_start + self.conflicted_count,
+                |ix| {
+                    self.entries[ix]
+                        .status_entry()
+                        .unwrap()
+                        .repo_path
+                        .cmp(&path)
+                },
+            ) {
                 return Some(ix);
             }
         }
@@ -613,8 +635,14 @@ impl GitPanel {
             } else {
                 0
             } + 1;
-            if let Ok(ix) = self.entries[tracked_start..tracked_start + self.tracked_count]
-                .binary_search_by(|entry| entry.status_entry().unwrap().repo_path.cmp(&path))
+            if let Some(ix) =
+                binary_search(tracked_start, tracked_start + self.tracked_count, |ix| {
+                    self.entries[ix]
+                        .status_entry()
+                        .unwrap()
+                        .repo_path
+                        .cmp(&path)
+                })
             {
                 return Some(ix);
             }
@@ -629,8 +657,14 @@ impl GitPanel {
             } else {
                 0
             } + 1;
-            if let Ok(ix) = self.entries[untracked_start..untracked_start + self.new_count]
-                .binary_search_by(|entry| entry.status_entry().unwrap().repo_path.cmp(&path))
+            if let Some(ix) =
+                binary_search(untracked_start, untracked_start + self.new_count, |ix| {
+                    self.entries[ix]
+                        .status_entry()
+                        .unwrap()
+                        .repo_path
+                        .cmp(&path)
+                })
             {
                 return Some(ix);
             }
@@ -3577,15 +3611,6 @@ impl GitPanel {
                                 items
                             }
                         })
-                        .when(
-                            !self.horizontal_scrollbar.show_track
-                                && self.horizontal_scrollbar.show_scrollbar,
-                            |this| {
-                                // when not showing the horizontal scrollbar track, make sure we don't
-                                // obscure the last entry
-                                this.pb(scroll_track_size)
-                            },
-                        )
                         .size_full()
                         .flex_grow()
                         .with_sizing_behavior(ListSizingBehavior::Auto)


### PR DESCRIPTION
This reverts commit 1d98b33ae07a72e9e26dc9b0b54a8baa4fd5f8c1.

Not sure why, but seems like this breaks the binary search used to correlate items to each other in the lists.

Release Notes:

- N/A 
