### PR TITLE
collab: Don't use a separate product for Zed Pro trials

### DIFF
--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -207,13 +207,6 @@ impl Config {
         Self::parse_stripe_price_id("Zed Pro", self.stripe_zed_pro_price_id.as_deref())
     }
 
-    pub fn zed_pro_trial_price_id(&self) -> anyhow::Result<stripe::PriceId> {
-        Self::parse_stripe_price_id(
-            "Zed Pro Trial",
-            self.stripe_zed_pro_trial_price_id.as_deref(),
-        )
-    }
-
     pub fn zed_free_price_id(&self) -> anyhow::Result<stripe::PriceId> {
         Self::parse_stripe_price_id("Zed Free", self.stripe_zed_pro_price_id.as_deref())
     }

--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -416,15 +416,8 @@ impl StripeBilling {
         let mut params = stripe::CreateCheckoutSession::new();
         params.subscription_data = Some(stripe::CreateCheckoutSessionSubscriptionData {
             trial_period_days: Some(14),
-            trial_settings: Some(stripe::CreateCheckoutSessionSubscriptionDataTrialSettings {
-                end_behavior: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior {
-                    missing_payment_method: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::Pause,
-                }
-            }),
             ..Default::default()
         });
-        params.payment_method_collection =
-            Some(stripe::CheckoutSessionPaymentMethodCollection::IfRequired);
         params.mode = Some(stripe::CheckoutSessionMode::Subscription);
         params.customer = Some(customer_id);
         params.client_reference_id = Some(github_login);

--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -405,6 +405,39 @@ impl StripeBilling {
         let session = stripe::CheckoutSession::create(&self.client, params).await?;
         Ok(session.url.context("no checkout session URL")?)
     }
+
+    pub async fn checkout_with_zed_pro_trial(
+        &self,
+        zed_pro_price_id: PriceId,
+        customer_id: stripe::CustomerId,
+        github_login: &str,
+        success_url: &str,
+    ) -> Result<String> {
+        let mut params = stripe::CreateCheckoutSession::new();
+        params.subscription_data = Some(stripe::CreateCheckoutSessionSubscriptionData {
+            trial_period_days: Some(14),
+            trial_settings: Some(stripe::CreateCheckoutSessionSubscriptionDataTrialSettings {
+                end_behavior: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior {
+                    missing_payment_method: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::Pause,
+                }
+            }),
+            ..Default::default()
+        });
+        params.payment_method_collection =
+            Some(stripe::CheckoutSessionPaymentMethodCollection::IfRequired);
+        params.mode = Some(stripe::CheckoutSessionMode::Subscription);
+        params.customer = Some(customer_id);
+        params.client_reference_id = Some(github_login);
+        params.line_items = Some(vec![stripe::CreateCheckoutSessionLineItems {
+            price: Some(zed_pro_price_id.to_string()),
+            quantity: Some(1),
+            ..Default::default()
+        }]);
+        params.success_url = Some(success_url);
+
+        let session = stripe::CheckoutSession::create(&self.client, params).await?;
+        Ok(session.url.context("no checkout session URL")?)
+    }
 }
 
 #[derive(Serialize)]


### PR DESCRIPTION
This PR removes the separate product used for the Zed Pro trials, in favor of using Stripe's trial functionality.

Release Notes:

- N/A
