### PR TITLE
eval: Include diagnostics in judge prompt

### DIFF
--- a/crates/eval/examples/email_verification_refactor/base.toml
+++ b/crates/eval/examples/email_verification_refactor/base.toml
@@ -1,3 +1,4 @@
 url = "https://github.com/dani-garcia/vaultwarden.git"
 revision = "3a1f1bae002bebf26ce3a38b879c1ba26529af1e"
 language_extension = "rs"
+allow_preexisting_diagnostics = true

--- a/crates/eval/examples/metal_i64_support/base.toml
+++ b/crates/eval/examples/metal_i64_support/base.toml
@@ -1,3 +1,4 @@
 url = "https://github.com/huggingface/candle.git"
 revision = "3164a19a5dc18f5e0f7a063ae85a0cfd289e98f1"
 language_extension = "rs"
+allow_preexisting_diagnostics = true

--- a/crates/eval/examples/virtio_block_request_refactor/base.toml
+++ b/crates/eval/examples/virtio_block_request_refactor/base.toml
@@ -1,3 +1,4 @@
 url = "https://github.com/firecracker-microvm/firecracker.git"
 revision = "5eaa6e08e350cd38c8102848913a096312e59097"
 language_extension = "rs"
+allow_preexisting_diagnostics = true

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -361,7 +361,8 @@ async fn run_example(
                 model_provider = model.provider_id().to_string(),
                 repository_url = example.base.url.clone(),
                 repository_revision = example.base.revision.clone(),
-                diagnostics_summary = run_output.diagnostics,
+                diagnostics_before = run_output.diagnostics_before,
+                diagnostics_after = run_output.diagnostics_after,
                 commit_id = commit_id
             );
         }

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -331,12 +331,11 @@ async fn run_example(
     let run_output = cx
         .update(|cx| example.run(model.clone(), app_state.clone(), cx))?
         .await?;
-    let diff = example.repository_diff().await?;
 
     // Run judge for each repetition
     let mut results = Vec::new();
     for round in 0..judge_repetitions {
-        let judge_result = example.judge(model.clone(), diff.clone(), round, cx).await;
+        let judge_result = example.judge(model.clone(), &run_output, round, cx).await;
 
         if let Ok(judge_output) = &judge_result {
             let cohort_id = example

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -433,7 +433,8 @@ impl Example {
             println!("{}Getting repository diff", this.log_prefix);
             let repository_diff = this.repository_diff().await?;
 
-            let repository_diff_path = this.example_output_directory().join("patch.diff");
+            let example_output_dir = this.example_output_directory();
+            let repository_diff_path = example_output_dir.join("patch.diff");
             let mut repository_diff_output_file = File::create(&repository_diff_path)?;
             writeln!(&mut repository_diff_output_file, "{}", &repository_diff).log_err();
 
@@ -447,6 +448,8 @@ impl Example {
 
             drop(subscription);
             drop(lsp_open_handle_and_store);
+
+            fs::write(example_output_dir.join("diagnostics.txt"), &diagnostics)?;
 
             thread.update(cx, |thread, _cx| {
                 let response_count = thread

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -45,6 +45,8 @@ pub struct ExampleBase {
     pub insert_id: Option<String>,
     #[serde(default = "default_true")]
     pub require_lsp: bool,
+    #[serde(default)]
+    pub allow_preexisting_diagnostics: bool,
 }
 
 impl ExampleBase {
@@ -76,7 +78,9 @@ pub struct Example {
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RunOutput {
     pub repository_diff: String,
-    pub diagnostics: String,
+    pub ran_diagnostics_check: bool,
+    pub diagnostics_before: Option<String>,
+    pub diagnostics_after: Option<String>,
     pub response_count: usize,
     pub token_usage: TokenUsage,
     pub tool_use_counts: HashMap<Arc<str>, u32>,
@@ -85,7 +89,11 @@ pub struct RunOutput {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct JudgeInput {
     pub repository_diff: String,
-    pub diagnostics: String,
+    pub ran_diagnostics_check: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics_before: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub diagnostics_after: Option<String>,
     pub criteria: String,
 }
 
@@ -302,6 +310,10 @@ impl Example {
                 None
             };
 
+            let diagnostics_before = query_lsp_diagnostics(project.clone(), cx).await?;
+            if diagnostics_before.is_some() && !this.base.allow_preexisting_diagnostics {
+                return Err(anyhow!("Example has pre-existing diagnostics. If you want to run this example regardless, set `allow_preexisting_diagnostics` to `true` in `base.toml`"));
+            }
 
             if std::env::var("ZED_EVAL_SETUP_ONLY").is_ok() {
                 return Err(anyhow!("Setup only mode"));
@@ -441,7 +453,7 @@ impl Example {
             writeln!(&mut repository_diff_output_file, "{}", &repository_diff).log_err();
 
             println!("{}Getting diagnostics", this.log_prefix);
-            let diagnostics = cx
+            let diagnostics_after = cx
                 .update(move |cx| {
                     cx.spawn(async move |cx| query_lsp_diagnostics(project, cx).await)
                 })?
@@ -451,7 +463,14 @@ impl Example {
             drop(subscription);
             drop(lsp_open_handle_and_store);
 
-            fs::write(example_output_dir.join("diagnostics.txt"), &diagnostics)?;
+            if let Some(diagnostics_before) = &diagnostics_before {
+                fs::write(example_output_dir.join("diagnostics_before.txt"), diagnostics_before)?;
+            }
+
+            if let Some(diagnostics_after) = &diagnostics_after {
+                fs::write(example_output_dir.join("diagnostics_after.txt"), diagnostics_after)?;
+            }
+
 
             thread.update(cx, |thread, _cx| {
                 let response_count = thread
@@ -460,7 +479,9 @@ impl Example {
                     .count();
                 RunOutput {
                     repository_diff,
-                    diagnostics,
+                    ran_diagnostics_check: this.base.require_lsp,
+                    diagnostics_before,
+                    diagnostics_after,
                     response_count,
                     token_usage: thread.cumulative_token_usage(),
                     tool_use_counts: tool_use_counts.lock().unwrap().clone(),
@@ -490,7 +511,9 @@ impl Example {
             judge_prompt_name,
             &JudgeInput {
                 repository_diff: run_output.repository_diff.clone(),
-                diagnostics: run_output.diagnostics.clone(),
+                ran_diagnostics_check: run_output.ran_diagnostics_check,
+                diagnostics_before: run_output.diagnostics_before.clone(),
+                diagnostics_after: run_output.diagnostics_after.clone(),
                 criteria: self.criteria.clone(),
             },
         )?;
@@ -589,7 +612,10 @@ fn has_pending_lang_server_work(lsp_store: &Entity<LspStore>, cx: &App) -> bool 
         .any(|(_, status)| !status.pending_work.is_empty())
 }
 
-async fn query_lsp_diagnostics(project: Entity<Project>, cx: &mut AsyncApp) -> Result<String> {
+async fn query_lsp_diagnostics(
+    project: Entity<Project>,
+    cx: &mut AsyncApp,
+) -> Result<Option<String>> {
     let paths_with_diagnostics = project.update(cx, |project, cx| {
         project
             .diagnostic_summaries(true, cx)
@@ -597,6 +623,10 @@ async fn query_lsp_diagnostics(project: Entity<Project>, cx: &mut AsyncApp) -> R
             .map(|(project_path, _, _)| project_path)
             .collect::<Vec<_>>()
     })?;
+
+    if paths_with_diagnostics.is_empty() {
+        return Ok(None);
+    }
 
     let mut output = String::new();
     for project_path in paths_with_diagnostics {
@@ -623,7 +653,7 @@ async fn query_lsp_diagnostics(project: Entity<Project>, cx: &mut AsyncApp) -> R
             )?;
         }
     }
-    anyhow::Ok(output)
+    anyhow::Ok(Some(output))
 }
 
 fn parse_judge_output(response: &str) -> Result<JudgeOutput> {
@@ -840,6 +870,7 @@ impl RequestMarkdown {
 #[cfg(test)]
 mod test {
     use super::*;
+    use handlebars::Handlebars;
 
     #[test]
     fn test_parse_judge_output() {
@@ -872,5 +903,167 @@ mod test {
         let output = parse_judge_output(&response).unwrap();
         assert_eq!(output.analysis, "Failed to compile:\n- Error 1\n- Error 2");
         assert_eq!(output.score, 1);
+    }
+
+    #[test]
+    fn test_judge_prompt_with_diagnostics() {
+        let judge_prompt = include_str!("judge_prompt.hbs");
+        let judge_prompt_name = "judge_prompt";
+        let mut handlebars = Handlebars::new();
+        handlebars
+            .register_template_string(judge_prompt_name, judge_prompt)
+            .unwrap();
+
+        // Case 1: Both diagnostics before and after are present
+        let input = JudgeInput {
+            repository_diff: "diff content goes here".to_string(),
+            ran_diagnostics_check: true,
+            diagnostics_before: Some("Error at line 10: variable not found".to_string()),
+            diagnostics_after: Some("Error at line 15: missing semicolon".to_string()),
+            criteria: "Fix all bugs".to_string(),
+        };
+
+        let rendered = handlebars.render(judge_prompt_name, &input).unwrap();
+
+        let expected_diagnostics_section = r#"
+            Take into account the diagnostics before and after applying the change:
+
+            <diagnostics_before>
+            Error at line 10: variable not found
+            </diagnostics_before>
+
+            <diagnostics_after>
+            Error at line 15: missing semicolon
+            </diagnostics_after>
+            "#
+        .unindent();
+
+        assert!(rendered.contains(&expected_diagnostics_section));
+    }
+
+    #[test]
+    fn test_judge_prompt_with_empty_diagnostics() {
+        let judge_prompt = include_str!("judge_prompt.hbs");
+        let judge_prompt_name = "judge_prompt";
+        let mut handlebars = Handlebars::new();
+        handlebars
+            .register_template_string(judge_prompt_name, judge_prompt)
+            .unwrap();
+
+        // Case 2: Diagnostics check run but no diagnostics found
+        let input = JudgeInput {
+            repository_diff: "diff content goes here".to_string(),
+            ran_diagnostics_check: true,
+            diagnostics_before: None,
+            diagnostics_after: None,
+            criteria: "Fix all bugs".to_string(),
+        };
+
+        let rendered = handlebars.render(judge_prompt_name, &input).unwrap();
+
+        let expected_diagnostics_section = r#"
+            Take into account the diagnostics before and after applying the change:
+
+            <diagnostics_before>
+            No diagnostics before applying the edits.
+            </diagnostics_before>
+
+            <diagnostics_after>
+            No diagnostics after applying the edits.
+            </diagnostics_after>
+            "#
+        .unindent();
+
+        assert!(rendered.contains(&expected_diagnostics_section));
+    }
+
+    #[test]
+    fn test_judge_prompt_with_mixed_diagnostics() {
+        let judge_prompt = include_str!("judge_prompt.hbs");
+        let judge_prompt_name = "judge_prompt";
+        let mut handlebars = Handlebars::new();
+        handlebars
+            .register_template_string(judge_prompt_name, judge_prompt)
+            .unwrap();
+
+        // Case 3: Before diagnostics present, after diagnostics absent
+        let input = JudgeInput {
+            repository_diff: "diff content goes here".to_string(),
+            ran_diagnostics_check: true,
+            diagnostics_before: Some("Error at line 10: variable not found".to_string()),
+            diagnostics_after: None,
+            criteria: "Fix all bugs".to_string(),
+        };
+
+        let rendered = handlebars.render(judge_prompt_name, &input).unwrap();
+
+        let expected_diagnostics_section = r#"
+            Take into account the diagnostics before and after applying the change:
+
+            <diagnostics_before>
+            Error at line 10: variable not found
+            </diagnostics_before>
+
+            <diagnostics_after>
+            No diagnostics after applying the edits.
+            </diagnostics_after>
+            "#
+        .unindent();
+
+        assert!(rendered.contains(&expected_diagnostics_section));
+
+        // Case 4: Before diagnostics absent, after diagnostics present
+        let input = JudgeInput {
+            repository_diff: "diff content goes here".to_string(),
+            ran_diagnostics_check: true,
+            diagnostics_before: None,
+            diagnostics_after: Some("Error at line 15: missing semicolon".to_string()),
+            criteria: "Fix all bugs".to_string(),
+        };
+
+        let rendered = handlebars.render(judge_prompt_name, &input).unwrap();
+
+        let expected_diagnostics_section = r#"
+            Take into account the diagnostics before and after applying the change:
+
+            <diagnostics_before>
+            No diagnostics before applying the edits.
+            </diagnostics_before>
+
+            <diagnostics_after>
+            Error at line 15: missing semicolon
+            </diagnostics_after>
+            "#
+        .unindent();
+
+        assert!(rendered.contains(&expected_diagnostics_section));
+    }
+
+    #[test]
+    fn test_judge_prompt_without_diagnostics() {
+        let judge_prompt = include_str!("judge_prompt.hbs");
+        let judge_prompt_name = "judge_prompt";
+        let mut handlebars = Handlebars::new();
+        handlebars
+            .register_template_string(judge_prompt_name, judge_prompt)
+            .unwrap();
+
+        // Case 5: No diagnostics check run
+        let input = JudgeInput {
+            repository_diff: "diff content goes here".to_string(),
+            ran_diagnostics_check: false,
+            diagnostics_before: None,
+            diagnostics_after: None,
+            criteria: "Fix all bugs".to_string(),
+        };
+
+        let rendered = handlebars.render(judge_prompt_name, &input).unwrap();
+
+        // Check for the message when no diagnostics were performed
+        let diagnostics_message = "No diagnostic checks were performed.";
+
+        assert!(rendered.contains(diagnostics_message));
+        assert!(!rendered.contains("<diagnostics_before>"));
+        assert!(!rendered.contains("<diagnostics_after>"));
     }
 }

--- a/crates/eval/src/judge_prompt.hbs
+++ b/crates/eval/src/judge_prompt.hbs
@@ -10,6 +10,13 @@ Use the following criteria to score the above changes.
 {{criteria}}
 </criteria>
 
+{{#if diagnostics}}
+Take into account the diagnostics after applying the edits:
+<diagnostics>
+{{{diagnostics}}}
+</diagnostics>
+{{/if}}
+
 Based on these criteria, give the test output a score between 0 and 5.
 The output score should ONLY INCLUDE whole numbers. DO NOT return decimals or floats.
 

--- a/crates/eval/src/judge_prompt.hbs
+++ b/crates/eval/src/judge_prompt.hbs
@@ -10,11 +10,26 @@ Use the following criteria to score the above changes.
 {{criteria}}
 </criteria>
 
-{{#if diagnostics}}
-Take into account the diagnostics after applying the edits:
-<diagnostics>
-{{{diagnostics}}}
-</diagnostics>
+{{#if ran_diagnostics_check}}
+Take into account the diagnostics before and after applying the change:
+
+<diagnostics_before>
+{{#if diagnostics_before}}
+{{{diagnostics_before}}}
+{{else}}
+No diagnostics before applying the edits.
+{{/if}}
+</diagnostics_before>
+
+<diagnostics_after>
+{{#if diagnostics_after}}
+{{{diagnostics_after}}}
+{{else}}
+No diagnostics after applying the edits.
+{{/if}}
+</diagnostics_after>
+{{else}}
+No diagnostic checks were performed.
 {{/if}}
 
 Based on these criteria, give the test output a score between 0 and 5.


### PR DESCRIPTION
We will now include diagnostics before and after the change in the judge prompt. 

We also added a check to prevent inadvertently including an example with preexisting diagnostics. This might actually be desired to see whether model can discern them from the ones it introduced, so examples in this state can be run by setting `allow_preexisting_diagnostics = true`.

If the example configured to not run a language server, we'll explicitly indicate this in the judge prompt.

Release Notes:

- N/A
