### PR TITLE
collab: Treat `trialing` subscriptions as `active`

### DIFF
--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -119,8 +119,15 @@ impl Database {
                 .filter(
                     Condition::all()
                         .add(
-                            billing_subscription::Column::StripeSubscriptionStatus
-                                .eq(StripeSubscriptionStatus::Active),
+                            Condition::any()
+                                .add(
+                                    billing_subscription::Column::StripeSubscriptionStatus
+                                        .eq(StripeSubscriptionStatus::Active),
+                                )
+                                .add(
+                                    billing_subscription::Column::StripeSubscriptionStatus
+                                        .eq(StripeSubscriptionStatus::Trialing),
+                                ),
                         )
                         .add(billing_subscription::Column::Kind.is_not_null()),
                 )


### PR DESCRIPTION
This PR makes it so billing subscriptions in the `trialing` state are considered `active`.

Release Notes:

- N/A
