### PR TITLE
zeta: Extract usage information from response headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18361,10 +18361,11 @@ dependencies = [
 
 [[package]]
 name = "zed_llm_client"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ee4d410dbc030c3e6e3af78fc76296f6bebe20dcb6d7d3fa24bca306fc8c1ce"
+checksum = "b91b8b05f1028157205026e525869eb860fa89bec87ea60b445efc91d05df31f"
 dependencies = [
+ "anyhow",
  "serde",
  "serde_json",
  "strum 0.27.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -604,7 +604,7 @@ wasmtime-wasi = "29"
 which = "6.0.0"
 wit-component = "0.221"
 workspace-hack = "0.1.0"
-zed_llm_client = "0.5.1"
+zed_llm_client = "0.6.0"
 zstd = "0.11"
 metal = "0.29"
 


### PR DESCRIPTION
This PR updates the Zeta provider to extract the usage information from the response headers, if they are present.

For now we just log the information, but we'll need to figure out where this needs to get threaded through to in order to display it in the UI.

Release Notes:

- N/A
