### PR TITLE
git_ui: Add customizable AI commit message prompt

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -588,6 +588,11 @@
     // Default: main
     "fallback_branch_name": "main",
 
+    /// Prompt base to generate a commit message using AI
+    ///
+    /// Default: Is defined automatically by the git panels
+    "prompt_generate_commit": "",
+
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -64,6 +64,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: main
     pub fallback_branch_name: Option<String>,
+
+    /// Prompt to generate a commit message using AI
+    ///
+    /// Default: Is defined automatically by the git panel
+    pub prompt_generate_commit: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -74,6 +79,7 @@ pub struct GitPanelSettings {
     pub status_style: StatusStyle,
     pub scrollbar: ScrollbarSettings,
     pub fallback_branch_name: String,
+    pub prompt_generate_commit: Option<String>,
 }
 
 impl Settings for GitPanelSettings {


### PR DESCRIPTION
Closes #26823

Release Notes:

- Added support for customizing the AI commit message prompt via user configuration.


Implementation: 

The current Zed implementation uses a default prompt located at `crates/git_ui/src/commit_message_prompt.txt` when generating commit messages through AI. This update allows users to override that default prompt by defining a new value in their JSON configuration under:

```json
"git_panel": {
    "prompt_generate_commit": "your custom prompt here"
}