### PR TITLE
project: Show detached head commit SHA in branch pickers

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -117,6 +117,7 @@ CREATE TABLE "project_repositories" (
     "is_deleted" BOOL NOT NULL,
     "current_merge_conflicts" VARCHAR,
     "branch_summary" VARCHAR,
+    "head_commit_details" VARCHAR,
     PRIMARY KEY (project_id, id)
 );
 

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -755,6 +755,13 @@ impl Database {
                         .transpose()?
                         .unwrap_or_default();
 
+                    let head_commit_details = db_repository
+                        .head_commit_details
+                        .as_ref()
+                        .map(|head_commit_details| serde_json::from_str(&head_commit_details))
+                        .transpose()?
+                        .unwrap_or_default();
+
                     let entry_ids = serde_json::from_str(&db_repository.entry_ids)
                         .context("failed to deserialize repository's entry ids")?;
 
@@ -778,6 +785,7 @@ impl Database {
                             removed_statuses,
                             current_merge_conflicts,
                             branch_summary,
+                            head_commit_details,
                             project_id: project_id.to_proto(),
                             id: db_repository.id as u64,
                             abs_path: db_repository.abs_path,

--- a/crates/collab/src/db/tables/project_repository.rs
+++ b/crates/collab/src/db/tables/project_repository.rs
@@ -18,6 +18,8 @@ pub struct Model {
     pub current_merge_conflicts: Option<String>,
     // A JSON object representing the current Branch values
     pub branch_summary: Option<String>,
+    // A JSON object representing the current Head commit values
+    pub head_commit_details: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -231,6 +231,7 @@ pub struct RepositorySnapshot {
     pub statuses_by_path: SumTree<StatusEntry>,
     pub work_directory_abs_path: Arc<Path>,
     pub branch: Option<Branch>,
+    pub head_commit: Option<CommitDetails>,
     pub merge_conflicts: TreeSet<RepoPath>,
     pub merge_head_shas: Vec<SharedString>,
     pub scan_id: u64,
@@ -2426,6 +2427,7 @@ impl RepositorySnapshot {
             statuses_by_path: Default::default(),
             work_directory_abs_path,
             branch: None,
+            head_commit: None,
             merge_conflicts: Default::default(),
             merge_head_shas: Default::default(),
             scan_id: 0,
@@ -2435,6 +2437,7 @@ impl RepositorySnapshot {
     fn initial_update(&self, project_id: u64) -> proto::UpdateRepository {
         proto::UpdateRepository {
             branch_summary: self.branch.as_ref().map(branch_to_proto),
+            head_commit_details: self.head_commit.as_ref().map(commit_details_to_proto),
             updated_statuses: self
                 .statuses_by_path
                 .iter()
@@ -2499,6 +2502,7 @@ impl RepositorySnapshot {
 
         proto::UpdateRepository {
             branch_summary: self.branch.as_ref().map(branch_to_proto),
+            head_commit_details: self.head_commit.as_ref().map(commit_details_to_proto),
             updated_statuses,
             removed_statuses,
             current_merge_conflicts: self
@@ -3748,6 +3752,11 @@ impl Repository {
                 .map(|path| RepoPath(Path::new(&path).into())),
         );
         self.snapshot.branch = update.branch_summary.as_ref().map(proto_to_branch);
+        self.snapshot.head_commit = update
+            .head_commit_details
+            .as_ref()
+            .map(proto_to_commit_details);
+
         self.snapshot.merge_conflicts = conflicted_paths;
 
         let edits = update
@@ -4322,6 +4331,26 @@ fn proto_to_branch(proto: &proto::Branch) -> git::repository::Branch {
     }
 }
 
+fn commit_details_to_proto(commit: &CommitDetails) -> proto::GitCommitDetails {
+    proto::GitCommitDetails {
+        sha: commit.sha.to_string(),
+        message: commit.message.to_string(),
+        commit_timestamp: commit.commit_timestamp,
+        author_email: commit.author_email.to_string(),
+        author_name: commit.author_name.to_string(),
+    }
+}
+
+fn proto_to_commit_details(proto: &proto::GitCommitDetails) -> CommitDetails {
+    CommitDetails {
+        sha: proto.sha.clone().into(),
+        message: proto.message.clone().into(),
+        commit_timestamp: proto.commit_timestamp,
+        author_email: proto.author_email.clone().into(),
+        author_name: proto.author_name.clone().into(),
+    }
+}
+
 async fn compute_snapshot(
     id: RepositoryId,
     work_directory_abs_path: Arc<Path>,
@@ -4377,6 +4406,12 @@ async fn compute_snapshot(
         events.push(RepositoryEvent::MergeHeadsChanged);
     }
 
+    // Useful when branch is None in detached head state
+    let head_commit = match backend.head_sha() {
+        Some(head_sha) => backend.show(head_sha).await.ok(),
+        None => None,
+    };
+
     let snapshot = RepositorySnapshot {
         id,
         merge_message,
@@ -4384,6 +4419,7 @@ async fn compute_snapshot(
         work_directory_abs_path,
         scan_id: prev_snapshot.scan_id + 1,
         branch,
+        head_commit,
         merge_conflicts,
         merge_head_shas,
     };

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -120,6 +120,7 @@ message UpdateRepository {
     repeated string current_merge_conflicts = 8;
     uint64 scan_id = 9;
     bool is_last_update = 10;
+    optional GitCommitDetails head_commit_details = 11;
 }
 
 message RemoveRepository {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -46,6 +46,7 @@ pub use stories::*;
 
 const MAX_PROJECT_NAME_LENGTH: usize = 40;
 const MAX_BRANCH_NAME_LENGTH: usize = 40;
+const MAX_SHORT_SHA_LENGTH: usize = 8;
 
 const BOOK_ONBOARDING: &str = "https://dub.sh/zed-c-onboarding";
 
@@ -513,8 +514,23 @@ impl TitleBar {
     pub fn render_project_branch(&self, cx: &mut Context<Self>) -> Option<impl IntoElement> {
         let repository = self.project.read(cx).active_repository(cx)?;
         let workspace = self.workspace.upgrade()?;
-        let branch_name = repository.read(cx).branch.as_ref()?.name.clone();
-        let branch_name = util::truncate_and_trailoff(&branch_name, MAX_BRANCH_NAME_LENGTH);
+        let branch_name = {
+            let repo = repository.read(cx);
+            repo.branch
+                .as_ref()
+                .map(|branch| branch.name.clone())
+                .map(|name| util::truncate_and_trailoff(&name, MAX_BRANCH_NAME_LENGTH))
+                .or_else(|| {
+                    repo.head_commit.as_ref().map(|commit| {
+                        commit
+                            .sha
+                            .chars()
+                            .take(MAX_SHORT_SHA_LENGTH)
+                            .collect::<String>()
+                    })
+                })
+        }?;
+
         Some(
             Button::new("project_branch_trigger", branch_name)
                 .color(Color::Muted)


### PR DESCRIPTION
When Git is in a detached HEAD state, the branch is `None`, and we can't get any meaningful information from it. This PR adds a `head_commit` field to the snapshot, which is always populated with the HEAD details, even when the branch is `None`.

This also pave path to fix: https://github.com/zed-industries/zed/issues/28736

git panel branch picker (before, after):
 <img width="197" alt="image" src="https://github.com/user-attachments/assets/0b6abbba-2988-4890-a708-bcd8aad84f26" /> <img width="198" alt="image" src="https://github.com/user-attachments/assets/4b08b1a8-5e79-4aa3-a44e-932249602c18" />

title bar branch picker (before, after):
<img width="183" alt="image" src="https://github.com/user-attachments/assets/d94357f8-a4da-4d60-8ddd-fdd978b99fdf" /> <img width="228" alt="image" src="https://github.com/user-attachments/assets/d20824a1-9279-44d6-afd1-bf9319fc50e4" />

Release Notes:

- Added head commit SHA information to the Git branch picker in the title bar and Git panel. 
