### PR TITLE
gpui: Make MacPlatform::os_version infallible

### DIFF
--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -353,8 +353,7 @@ impl MacPlatform {
                                     ns_string(key_to_native(&keystroke.key).as_ref()),
                                 )
                                 .autorelease();
-                            if MacPlatform::os_version().unwrap() >= SemanticVersion::new(12, 0, 0)
-                            {
+                            if Self::os_version() >= SemanticVersion::new(12, 0, 0) {
                                 let _: () = msg_send![item, setAllowsAutomaticKeyEquivalentLocalization: NO];
                             }
                             item.setKeyEquivalentModifierMask_(mask);
@@ -402,16 +401,16 @@ impl MacPlatform {
         }
     }
 
-    fn os_version() -> Result<SemanticVersion> {
-        unsafe {
+    fn os_version() -> SemanticVersion {
+        let version = unsafe {
             let process_info = NSProcessInfo::processInfo(nil);
-            let version = process_info.operatingSystemVersion();
-            Ok(SemanticVersion::new(
-                version.majorVersion as usize,
-                version.minorVersion as usize,
-                version.patchVersion as usize,
-            ))
-        }
+            process_info.operatingSystemVersion()
+        };
+        SemanticVersion::new(
+            version.majorVersion as usize,
+            version.minorVersion as usize,
+            version.patchVersion as usize,
+        )
     }
 }
 
@@ -609,7 +608,7 @@ impl Platform for MacPlatform {
         // API only available post Monterey
         // https://developer.apple.com/documentation/appkit/nsworkspace/3753004-setdefaultapplicationaturl
         let (done_tx, done_rx) = oneshot::channel();
-        if Self::os_version().ok() < Some(SemanticVersion::new(12, 0, 0)) {
+        if Self::os_version() < SemanticVersion::new(12, 0, 0) {
             return Task::ready(Err(anyhow!(
                 "macOS 12.0 or later is required to register URL schemes"
             )));
@@ -736,9 +735,7 @@ impl Platform for MacPlatform {
                                     // you can manually create a file called `a.sql.s`. That said it seems better
                                     // to break that use-case than breaking `a.sql`.
                                     if chunks.len() == 3 && chunks[1].starts_with(chunks[2]) {
-                                        if Self::os_version()
-                                            .is_ok_and(|v| v >= SemanticVersion::new(15, 0, 0))
-                                        {
+                                        if Self::os_version() >= SemanticVersion::new(15, 0, 0) {
                                             let new_filename = OsStr::from_bytes(
                                                 &filename.as_bytes()
                                                     [..chunks[0].len() + 1 + chunks[1].len()],


### PR DESCRIPTION
Core change:
```rust
fn os_version() -> Result<SemanticVersion>
```

```rust
fn os_version() -> SemanticVersion
```


Release Notes:

- N/A
