### PR TITLE
Don't display MacOS key symbols in Linux

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -318,10 +318,18 @@ fn is_printable_key(key: &str) -> bool {
 impl std::fmt::Display for Keystroke {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if self.modifiers.control {
-            f.write_char('^')?;
+            if cfg!(target_os = "macos") {
+                f.write_char('^')?;
+            } else {
+                write!(f, "ctrl-")?;
+            }
         }
         if self.modifiers.alt {
-            f.write_char('⌥')?;
+            if cfg!(target_os = "macos") {
+                f.write_char('⌥')?;
+            } else {
+                write!(f, "alt-")?;
+            }
         }
         if self.modifiers.platform {
             #[cfg(target_os = "macos")]
@@ -334,20 +342,24 @@ impl std::fmt::Display for Keystroke {
             f.write_char('⊞')?;
         }
         if self.modifiers.shift {
-            f.write_char('⇧')?;
+            if cfg!(target_os = "macos") {
+                f.write_char('⇧')?;
+            } else {
+                write!(f, "shift-")?;
+            }
         }
         let key = match self.key.as_str() {
-            "backspace" => '⌫',
-            "up" => '↑',
-            "down" => '↓',
-            "left" => '←',
-            "right" => '→',
-            "tab" => '⇥',
-            "escape" => '⎋',
-            "shift" => '⇧',
-            "control" => '⌃',
-            "alt" => '⌥',
-            "platform" => '⌘',
+            "backspace" if cfg!(target_os = "macos") => '⌫',
+            "up" if cfg!(target_os = "macos") => '↑',
+            "down" if cfg!(target_os = "macos") => '↓',
+            "left" if cfg!(target_os = "macos") => '←',
+            "right" if cfg!(target_os = "macos") => '→',
+            "tab" if cfg!(target_os = "macos") => '⇥',
+            "escape" if cfg!(target_os = "macos") => '⎋',
+            "shift" if cfg!(target_os = "macos") => '⇧',
+            "control" if cfg!(target_os = "macos") => '⌃',
+            "alt" if cfg!(target_os = "macos") => '⌥',
+            "platform" if cfg!(target_os = "macos") => '⌘',
             key => {
                 if key.len() == 1 {
                     key.chars().next().unwrap().to_ascii_uppercase()

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -378,12 +378,7 @@ pub fn text_for_keystroke(keystroke: &Keystroke, cx: &App) -> String {
 /// Returns a textual representation of the given [`Keystroke`].
 fn keystroke_text(keystroke: &Keystroke, platform_style: PlatformStyle, vim_mode: bool) -> String {
     let mut text = String::new();
-
-    let delimiter = match (platform_style, vim_mode) {
-        (PlatformStyle::Mac, false) => '-',
-        (PlatformStyle::Linux | PlatformStyle::Windows, false) => '-',
-        (_, true) => '-',
-    };
+    let delimiter = '-';
 
     if keystroke.modifiers.function {
         match vim_mode {


### PR DESCRIPTION
Release Notes:

- Fix MacOS key symbols being displayed in other platforms.