### PR TITLE
snippet_provider: Use proper casing of `VsCode` in identifiers

### DIFF
--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -87,7 +87,7 @@ impl JsonLspAdapter {
         );
         let tasks_schema = task::TaskTemplates::generate_json_schema();
         let debug_schema = task::DebugTaskFile::generate_json_schema();
-        let snippets_schema = snippet_provider::format::VSSnippetsFile::generate_json_schema();
+        let snippets_schema = snippet_provider::format::VsSnippetsFile::generate_json_schema();
         let tsconfig_schema = serde_json::Value::from_str(TSCONFIG_SCHEMA).unwrap();
         let package_json_schema = serde_json::Value::from_str(PACKAGE_JSON_SCHEMA).unwrap();
 

--- a/crates/snippet_provider/src/format.rs
+++ b/crates/snippet_provider/src/format.rs
@@ -8,12 +8,12 @@ use serde::Deserialize;
 use serde_json_lenient::Value;
 
 #[derive(Deserialize)]
-pub struct VSSnippetsFile {
+pub struct VsSnippetsFile {
     #[serde(flatten)]
-    pub(crate) snippets: HashMap<String, VSCodeSnippet>,
+    pub(crate) snippets: HashMap<String, VsCodeSnippet>,
 }
 
-impl VSSnippetsFile {
+impl VsSnippetsFile {
     pub fn generate_json_schema() -> Value {
         let schema = SchemaSettings::draft07()
             .with(|settings| settings.option_add_null_type = false)
@@ -24,15 +24,15 @@ impl VSSnippetsFile {
     }
 }
 
-impl JsonSchema for VSSnippetsFile {
+impl JsonSchema for VsSnippetsFile {
     fn schema_name() -> String {
-        "VSSnippetsFile".into()
+        "VsSnippetsFile".into()
     }
 
     fn json_schema(r#gen: &mut schemars::r#gen::SchemaGenerator) -> Schema {
         SchemaObject {
             object: Some(Box::new(ObjectValidation {
-                additional_properties: Some(Box::new(r#gen.subschema_for::<VSCodeSnippet>())),
+                additional_properties: Some(Box::new(r#gen.subschema_for::<VsCodeSnippet>())),
                 ..Default::default()
             })),
             ..Default::default()
@@ -71,7 +71,7 @@ impl std::fmt::Display for ListOrDirect {
 }
 
 #[derive(Deserialize, JsonSchema)]
-pub(crate) struct VSCodeSnippet {
+pub(crate) struct VsCodeSnippet {
     /// The snippet prefix used to decide whether a completion menu should be shown.
     pub(crate) prefix: Option<ListOrDirect>,
 

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 use anyhow::Result;
 use collections::{BTreeMap, BTreeSet, HashMap};
-use format::VSSnippetsFile;
+use format::VsSnippetsFile;
 use fs::Fs;
 use futures::stream::StreamExt;
 use gpui::{App, AppContext as _, AsyncApp, Context, Entity, Task, WeakEntity};
@@ -32,7 +32,7 @@ fn file_stem_to_key(stem: &str) -> SnippetKind {
     }
 }
 
-fn file_to_snippets(file_contents: VSSnippetsFile) -> Vec<Arc<Snippet>> {
+fn file_to_snippets(file_contents: VsSnippetsFile) -> Vec<Arc<Snippet>> {
     let mut snippets = vec![];
     for (prefix, snippet) in file_contents.snippets {
         let prefixes = snippet
@@ -98,7 +98,7 @@ async fn process_updates(
                 let Some(file_contents) = contents else {
                     return;
                 };
-                let Ok(as_json) = serde_json_lenient::from_str::<VSSnippetsFile>(&file_contents)
+                let Ok(as_json) = serde_json_lenient::from_str::<VsSnippetsFile>(&file_contents)
                 else {
                     return;
                 };

--- a/crates/snippet_provider/src/registry.rs
+++ b/crates/snippet_provider/src/registry.rs
@@ -37,7 +37,7 @@ impl SnippetRegistry {
     }
 
     pub fn register_snippets(&self, file_path: &Path, contents: &str) -> Result<()> {
-        let snippets_in_file: crate::format::VSSnippetsFile =
+        let snippets_in_file: crate::format::VsSnippetsFile =
             serde_json_lenient::from_str(contents)?;
         let kind = file_path
             .file_stem()


### PR DESCRIPTION
This PR renames some identifiers in the `snippet_provider` to use the correct casing of `VsCode`.

Release Notes:

- N/A
