### PR TITLE
gpui: Introduce `PlatformKeyboardLayout` trait for human-friendly keyboard layout names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6165,6 +6165,7 @@ dependencies = [
  "windows 0.61.1",
  "windows-core 0.61.0",
  "windows-numerics",
+ "windows-registry 0.5.1",
  "workspace-hack",
  "x11-clipboard",
  "x11rb",
@@ -11922,7 +11923,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
+ "windows-registry 0.2.0",
 ]
 
 [[package]]
@@ -17034,6 +17035,17 @@ dependencies = [
  "windows-result 0.2.0",
  "windows-strings 0.1.0",
  "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad1da3e436dc7653dfdf3da67332e22bff09bb0e28b0239e1624499c7830842e"
+dependencies = [
+ "windows-link",
+ "windows-result 0.3.2",
+ "windows-strings 0.4.0",
 ]
 
 [[package]]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -66,7 +66,7 @@ x11 = [
     "x11-clipboard",
     "filedescriptor",
     "open",
-    "scap"
+    "scap",
 ]
 
 
@@ -220,6 +220,7 @@ rand.workspace = true
 windows.workspace = true
 windows-core = "0.61"
 windows-numerics = "0.2"
+windows-registry = "0.5"
 
 [dev-dependencies]
 backtrace = "0.3"

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -635,7 +635,7 @@ impl Render for InputExample {
                     .flex()
                     .flex_row()
                     .justify_between()
-                    .child(format!("Keyboard {}", cx.keyboard_layout()))
+                    .child(format!("Keyboard {}", cx.keyboard_layout().name()))
                     .child(
                         div()
                             .border_1()

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1634,3 +1634,27 @@ impl From<String> for ClipboardString {
         }
     }
 }
+
+/// Information about the keyboard layout
+#[derive(Clone, Debug)]
+pub struct KeyboardLayout {
+    id: String,
+    name: String,
+}
+
+impl KeyboardLayout {
+    /// Create a new keyboard layout with the given ID and name
+    pub fn new(id: String, name: String) -> Self {
+        Self { id, name }
+    }
+
+    /// Get the ID of the keyboard layout, the ID should be unique to the layout
+    pub fn id(&self) -> &str {
+        &self.id
+    }
+
+    /// Get the name of the keyboard layout
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+}

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1635,7 +1635,7 @@ impl From<String> for ClipboardString {
     }
 }
 
-//// A trait for platform-specific keyboard layouts
+/// A trait for platform-specific keyboard layouts
 pub trait PlatformKeyboardLayout {
     /// Get the keyboard layout ID, which should be unique to the layout
     fn id(&self) -> &str;

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -214,7 +214,7 @@ pub(crate) trait Platform: 'static {
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>);
     fn on_will_open_app_menu(&self, callback: Box<dyn FnMut()>);
     fn on_validate_app_menu_command(&self, callback: Box<dyn FnMut(&dyn Action) -> bool>);
-    fn keyboard_layout(&self) -> String;
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout>;
 
     fn compositor_name(&self) -> &'static str {
         ""
@@ -1635,26 +1635,10 @@ impl From<String> for ClipboardString {
     }
 }
 
-/// Information about the keyboard layout
-#[derive(Clone, Debug)]
-pub struct KeyboardLayout {
-    id: String,
-    name: String,
-}
-
-impl KeyboardLayout {
-    /// Create a new keyboard layout with the given ID and name
-    pub fn new(id: String, name: String) -> Self {
-        Self { id, name }
-    }
-
-    /// Get the ID of the keyboard layout, the ID should be unique to the layout
-    pub fn id(&self) -> &str {
-        &self.id
-    }
-
-    /// Get the name of the keyboard layout
-    pub fn name(&self) -> &str {
-        &self.name
-    }
+//// A trait for platform-specific keyboard layouts
+pub trait PlatformKeyboardLayout {
+    /// Get the keyboard layout ID, which should be unique to the layout
+    fn id(&self) -> &str;
+    /// Get the keyboard layout display name
+    fn name(&self) -> &str;
 }

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -9,7 +9,8 @@ use util::ResultExt;
 use crate::platform::linux::LinuxClient;
 use crate::platform::{LinuxCommon, PlatformWindow};
 use crate::{
-    AnyWindowHandle, CursorStyle, DisplayId, PlatformDisplay, ScreenCaptureSource, WindowParams,
+    AnyWindowHandle, CursorStyle, DisplayId, LinuxKeyboardLayout, PlatformDisplay,
+    PlatformKeyboardLayout, ScreenCaptureSource, WindowParams,
 };
 
 pub struct HeadlessClientState {
@@ -50,8 +51,8 @@ impl LinuxClient for HeadlessClient {
         f(&mut self.0.borrow_mut().common)
     }
 
-    fn keyboard_layout(&self) -> String {
-        "unknown".to_string()
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        LinuxKeyboardLayout::new("unknown".to_string())
     }
 
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {

--- a/crates/gpui/src/platform/linux/headless/client.rs
+++ b/crates/gpui/src/platform/linux/headless/client.rs
@@ -52,7 +52,7 @@ impl LinuxClient for HeadlessClient {
     }
 
     fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
-        LinuxKeyboardLayout::new("unknown".to_string())
+        Box::new(LinuxKeyboardLayout::new("unknown".to_string()))
     }
 
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>> {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -138,7 +138,7 @@ impl<P: LinuxClient + 'static> Platform for P {
         self.with_common(|common| common.text_system.clone())
     }
 
-    fn keyboard_layout(&self) -> String {
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
         self.keyboard_layout()
     }
 
@@ -855,6 +855,26 @@ impl crate::Modifiers {
             platform,
             function: false,
         }
+    }
+}
+
+struct LinuxKeyboardLayout {
+    id: String,
+}
+
+impl PlatformKeyboardLayout for LinuxKeyboardLayout {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.id
+    }
+}
+
+impl LinuxKeyboardLayout {
+    fn new(id: String) -> Self {
+        Self { id }
     }
 }
 

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -25,8 +25,8 @@ use xkbcommon::xkb::{self, Keycode, Keysym, State};
 use crate::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DisplayId,
     ForegroundExecutor, Keymap, LinuxDispatcher, Menu, MenuItem, OwnedMenu, PathPromptOptions,
-    Pixels, Platform, PlatformDisplay, PlatformTextSystem, PlatformWindow, Point, Result,
-    ScreenCaptureSource, Task, WindowAppearance, WindowParams, px,
+    Pixels, Platform, PlatformDisplay, PlatformKeyboardLayout, PlatformTextSystem, PlatformWindow,
+    Point, Result, ScreenCaptureSource, Task, WindowAppearance, WindowParams, px,
 };
 
 #[cfg(any(feature = "wayland", feature = "x11"))]
@@ -46,7 +46,7 @@ const FILE_PICKER_PORTAL_MISSING: &str =
 pub trait LinuxClient {
     fn compositor_name(&self) -> &'static str;
     fn with_common<R>(&self, f: impl FnOnce(&mut LinuxCommon) -> R) -> R;
-    fn keyboard_layout(&self) -> String;
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout>;
     fn displays(&self) -> Vec<Rc<dyn PlatformDisplay>>;
     #[allow(unused)]
     fn display(&self, id: DisplayId) -> Option<Rc<dyn PlatformDisplay>>;
@@ -858,7 +858,7 @@ impl crate::Modifiers {
     }
 }
 
-struct LinuxKeyboardLayout {
+pub(crate) struct LinuxKeyboardLayout {
     id: String,
 }
 
@@ -873,7 +873,7 @@ impl PlatformKeyboardLayout for LinuxKeyboardLayout {
 }
 
 impl LinuxKeyboardLayout {
-    fn new(id: String) -> Self {
+    pub(crate) fn new(id: String) -> Self {
         Self { id }
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -67,7 +67,6 @@ use xkbcommon::xkb::ffi::XKB_KEYMAP_FORMAT_TEXT_V1;
 use xkbcommon::xkb::{self, KEYMAP_COMPILE_NO_FLAGS, Keycode};
 
 use super::{
-    LinuxKeyboardLayout,
     display::WaylandDisplay,
     window::{ImeInput, WaylandWindowStatePtr},
 };
@@ -86,11 +85,11 @@ use crate::platform::linux::{
 use crate::platform::{PlatformWindow, blade::BladeContext};
 use crate::{
     AnyWindowHandle, Bounds, CursorStyle, DOUBLE_CLICK_INTERVAL, DevicePixels, DisplayId,
-    FileDropEvent, ForegroundExecutor, KeyDownEvent, KeyUpEvent, Keystroke, LinuxCommon, Modifiers,
-    ModifiersChangedEvent, MouseButton, MouseDownEvent, MouseExitEvent, MouseMoveEvent,
-    MouseUpEvent, NavigationDirection, Pixels, PlatformDisplay, PlatformInput, Point, SCROLL_LINES,
-    ScaledPixels, ScreenCaptureSource, ScrollDelta, ScrollWheelEvent, Size, TouchPhase,
-    WindowParams, point, px, size,
+    FileDropEvent, ForegroundExecutor, KeyDownEvent, KeyUpEvent, Keystroke, LinuxCommon,
+    LinuxKeyboardLayout, Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent,
+    MouseExitEvent, MouseMoveEvent, MouseUpEvent, NavigationDirection, Pixels, PlatformDisplay,
+    PlatformInput, PlatformKeyboardLayout, Point, SCROLL_LINES, ScaledPixels, ScreenCaptureSource,
+    ScrollDelta, ScrollWheelEvent, Size, TouchPhase, WindowParams, point, px, size,
 };
 
 /// Used to convert evdev scancode to xkb scancode

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -41,8 +41,8 @@ use xkbc::x11::ffi::{XKB_X11_MIN_MAJOR_XKB_VERSION, XKB_X11_MIN_MINOR_XKB_VERSIO
 use xkbcommon::xkb::{self as xkbc, LayoutIndex, ModMask, STATE_LAYOUT_EFFECTIVE};
 
 use super::{
-    ButtonOrScroll, LinuxKeyboardLayout, ScrollDirection, button_or_scroll_from_event_detail,
-    get_valuator_axis_index, modifiers_from_state, pressed_button_from_mask,
+    ButtonOrScroll, ScrollDirection, button_or_scroll_from_event_detail, get_valuator_axis_index,
+    modifiers_from_state, pressed_button_from_mask,
 };
 use super::{X11Display, X11WindowStatePtr, XcbAtoms};
 use super::{XimCallbackEvent, XimHandler};
@@ -59,9 +59,9 @@ use crate::platform::{
 };
 use crate::{
     AnyWindowHandle, Bounds, ClipboardItem, CursorStyle, DisplayId, FileDropEvent, Keystroke,
-    Modifiers, ModifiersChangedEvent, MouseButton, Pixels, Platform, PlatformDisplay,
-    PlatformInput, PlatformKeyboardLayout, Point, RequestFrameOptions, ScaledPixels,
-    ScreenCaptureSource, ScrollDelta, Size, TouchPhase, WindowParams, X11Window,
+    LinuxKeyboardLayout, Modifiers, ModifiersChangedEvent, MouseButton, Pixels, Platform,
+    PlatformDisplay, PlatformInput, PlatformKeyboardLayout, Point, RequestFrameOptions,
+    ScaledPixels, ScreenCaptureSource, ScrollDelta, Size, TouchPhase, WindowParams, X11Window,
     modifiers_from_xinput_info, point, px,
 };
 

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -7,9 +7,9 @@ use super::{
 use crate::{
     Action, AnyWindowHandle, BackgroundExecutor, ClipboardEntry, ClipboardItem, ClipboardString,
     CursorStyle, ForegroundExecutor, Image, ImageFormat, Keymap, MacDispatcher, MacDisplay,
-    MacWindow, Menu, MenuItem, PathPromptOptions, Platform, PlatformDisplay, PlatformTextSystem,
-    PlatformWindow, Result, ScreenCaptureSource, SemanticVersion, Task, WindowAppearance,
-    WindowParams, hash,
+    MacWindow, Menu, MenuItem, PathPromptOptions, Platform, PlatformDisplay,
+    PlatformKeyboardLayout, PlatformTextSystem, PlatformWindow, Result, ScreenCaptureSource,
+    SemanticVersion, Task, WindowAppearance, WindowParams, hash,
 };
 use anyhow::{Context as _, anyhow};
 use block::ConcreteBlock;
@@ -1492,6 +1492,7 @@ unsafe extern "C" {
     pub(super) fn LMGetKbdType() -> u16;
     pub(super) static kTISPropertyUnicodeKeyLayoutData: CFStringRef;
     pub(super) static kTISPropertyInputSourceID: CFStringRef;
+    pub(super) static kTISPropertyLocalizedName: CFStringRef;
 }
 
 mod security {

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -1,8 +1,8 @@
 use crate::{
     AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DevicePixels,
-    ForegroundExecutor, Keymap, NoopTextSystem, Platform, PlatformDisplay, PlatformTextSystem,
-    ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream, Size, Task, TestDisplay,
-    TestWindow, WindowAppearance, WindowParams, size,
+    ForegroundExecutor, Keymap, NoopTextSystem, Platform, PlatformDisplay, PlatformKeyboardLayout,
+    PlatformTextSystem, ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream, Size, Task,
+    TestDisplay, TestWindow, WindowAppearance, WindowParams, size,
 };
 use anyhow::Result;
 use collections::VecDeque;
@@ -223,8 +223,8 @@ impl Platform for TestPlatform {
         self.text_system.clone()
     }
 
-    fn keyboard_layout(&self) -> String {
-        "zed.keyboard.example".to_string()
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        Box::new(TestKeyboardLayout)
     }
 
     fn on_keyboard_layout_change(&self, _: Box<dyn FnMut()>) {}
@@ -429,5 +429,17 @@ impl Drop for TestPlatform {
             std::mem::ManuallyDrop::drop(&mut self.bitmap_factory);
             windows::Win32::System::Ole::OleUninitialize();
         }
+    }
+}
+
+struct TestKeyboardLayout;
+
+impl PlatformKeyboardLayout for TestKeyboardLayout {
+    fn id(&self) -> &str {
+        "zed.keyboard.example"
+    }
+
+    fn name(&self) -> &str {
+        "zed.keyboard.example"
     }
 }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -297,8 +297,12 @@ impl Platform for WindowsPlatform {
         self.text_system.clone()
     }
 
-    fn keyboard_layout(&self) -> String {
-        "unknown".into()
+    fn keyboard_layout(&self) -> Box<dyn PlatformKeyboardLayout> {
+        Box::new(
+            KeyboardLayout::new()
+                .log_err()
+                .unwrap_or(KeyboardLayout::unknown()),
+        )
     }
 
     fn on_keyboard_layout_change(&self, _callback: Box<dyn FnMut()>) {
@@ -834,6 +838,42 @@ fn load_icon() -> Result<HICON> {
 fn should_auto_hide_scrollbars() -> Result<bool> {
     let ui_settings = UISettings::new()?;
     Ok(ui_settings.AutoHideScrollBars()?)
+}
+
+struct KeyboardLayout {
+    id: String,
+    name: String,
+}
+
+impl PlatformKeyboardLayout for KeyboardLayout {
+    fn id(&self) -> &str {
+        &self.id
+    }
+
+    fn name(&self) -> &str {
+        &self.name
+    }
+}
+
+impl KeyboardLayout {
+    fn new() -> Result<Self> {
+        let mut buffer = [0u16; KL_NAMELENGTH as usize];
+        unsafe { GetKeyboardLayoutNameW(&mut buffer)? };
+        let id = HSTRING::from_wide(&buffer).to_string();
+        let entry = windows_registry::LOCAL_MACHINE.open(format!(
+            "System\\CurrentControlSet\\Control\\Keyboard Layouts\\{}",
+            id
+        ))?;
+        let name = entry.get_hstring("Layout Text")?.to_string();
+        Ok(Self { id, name })
+    }
+
+    fn unknown() -> Self {
+        Self {
+            id: "unknown".to_string(),
+            name: "unknown".to_string(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -173,7 +173,7 @@ impl Item for KeyContextView {
 impl Render for KeyContextView {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
         use itertools::Itertools;
-        let key_equivalents = get_key_equivalents(cx.keyboard_layout());
+        let key_equivalents = get_key_equivalents(cx.keyboard_layout().id());
         v_flex()
             .id("key-context-view")
             .overflow_scroll()

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -195,7 +195,8 @@ impl KeymapFile {
     }
 
     pub fn load(content: &str, cx: &App) -> KeymapFileLoadResult {
-        let key_equivalents = crate::key_equivalents::get_key_equivalents(&cx.keyboard_layout());
+        let key_equivalents =
+            crate::key_equivalents::get_key_equivalents(cx.keyboard_layout().id());
 
         if content.is_empty() {
             return KeymapFileLoadResult::Success {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5439,7 +5439,7 @@ impl Render for Workspace {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let mut context = KeyContext::new_with_defaults();
         context.add("Workspace");
-        context.set("keyboard_layout", cx.keyboard_layout().clone());
+        context.set("keyboard_layout", cx.keyboard_layout().name().to_string());
         let centered_layout = self.centered_layout
             && self.center.panes().len() == 1
             && self.active_item(cx).is_some();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1224,9 +1224,9 @@ pub fn handle_keymap_file_changes(
     })
     .detach();
 
-    let mut current_mapping = settings::get_key_equivalents(cx.keyboard_layout());
+    let mut current_mapping = settings::get_key_equivalents(cx.keyboard_layout().id());
     cx.on_keyboard_layout_change(move |cx| {
-        let next_mapping = settings::get_key_equivalents(cx.keyboard_layout());
+        let next_mapping = settings::get_key_equivalents(cx.keyboard_layout().id());
         if next_mapping != current_mapping {
             current_mapping = next_mapping;
             keyboard_layout_tx.unbounded_send(()).ok();


### PR DESCRIPTION
This PR adds a new `PlatformKeyboardLayout` trait with two methods: `id(&self) -> &str` and `name(&self) -> &str`. The `id()` method returns a unique identifier for the keyboard layout, while `name()` provides a human-readable name. This distinction is especially important on Windows, where the `id` and `name` can be quite different. For example, the French layout has an `id` of `0000040C`, which is not human-readable, whereas the `name` would simply be `French`. Currently, the existing `keyboard_layout()` method returns what's essentially the same as `id()` in this new design.

This PR implements the `name()` method for both Windows and macOS. On Linux, for now, `name()` still returns the same value as `id()`.

Release Notes:

- N/A
