### PR TITLE
debugger: Fix gutter tasks display for users without the debugger feature flag

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -777,11 +777,34 @@ pub struct AvailableCodeAction {
 
 #[derive(Clone)]
 pub struct CodeActionContents {
-    pub tasks: Option<Rc<ResolvedTasks>>,
-    pub actions: Option<Rc<[AvailableCodeAction]>>,
+    tasks: Option<Rc<ResolvedTasks>>,
+    actions: Option<Rc<[AvailableCodeAction]>>,
 }
 
 impl CodeActionContents {
+    pub fn new(
+        mut tasks: Option<ResolvedTasks>,
+        actions: Option<Rc<[AvailableCodeAction]>>,
+        cx: &App,
+    ) -> Self {
+        if !cx.has_flag::<Debugger>() {
+            if let Some(tasks) = &mut tasks {
+                tasks
+                    .templates
+                    .retain(|(_, task)| !matches!(task.task_type(), task::TaskType::Debug(_)));
+            }
+        }
+
+        Self {
+            tasks: tasks.map(Rc::new),
+            actions,
+        }
+    }
+
+    pub fn tasks(&self) -> Option<&ResolvedTasks> {
+        self.tasks.as_deref()
+    }
+
     fn len(&self) -> usize {
         match (&self.tasks, &self.actions) {
             (Some(tasks), Some(actions)) => actions.len() + tasks.templates.len(),
@@ -989,17 +1012,6 @@ impl CodeActionsMenu {
                     .iter()
                     .skip(range.start)
                     .take(range.end - range.start)
-                    .filter(|action| {
-                        if action
-                            .as_task()
-                            .map(|task| matches!(task.task_type(), task::TaskType::Debug(_)))
-                            .unwrap_or(false)
-                        {
-                            cx.has_flag::<Debugger>()
-                        } else {
-                            true
-                        }
-                    })
                     .enumerate()
                     .map(|(ix, action)| {
                         let item_ix = range.start + ix;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5013,15 +5013,15 @@ impl Editor {
                             None => None,
                         };
                         let resolved_tasks =
-                            tasks.zip(task_context).map(|(tasks, task_context)| {
-                                Rc::new(ResolvedTasks {
+                            tasks
+                                .zip(task_context)
+                                .map(|(tasks, task_context)| ResolvedTasks {
                                     templates: tasks.resolve(&task_context).collect(),
                                     position: snapshot.buffer_snapshot.anchor_before(Point::new(
                                         multibuffer_point.row,
                                         tasks.column,
                                     )),
-                                })
-                            });
+                                });
                         let spawn_straight_away = resolved_tasks.as_ref().map_or(false, |tasks| {
                             tasks
                                 .templates
@@ -5042,10 +5042,11 @@ impl Editor {
                             *editor.context_menu.borrow_mut() =
                                 Some(CodeContextMenu::CodeActions(CodeActionsMenu {
                                     buffer,
-                                    actions: CodeActionContents {
-                                        tasks: resolved_tasks,
-                                        actions: code_actions,
-                                    },
+                                    actions: CodeActionContents::new(
+                                        resolved_tasks,
+                                        code_actions,
+                                        cx,
+                                    ),
                                     selected_item: Default::default(),
                                     scroll_handle: UniformListScrollHandle::default(),
                                     deployed_from_indicator,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2092,8 +2092,7 @@ impl EditorElement {
                 })) = editor.context_menu.borrow().as_ref()
                 {
                     actions
-                        .tasks
-                        .as_ref()
+                        .tasks()
                         .map(|tasks| tasks.position.to_display_point(snapshot).row())
                         .or(*deployed_from_indicator)
                 } else {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/29011

Before, debug tasks were accounted when `.len()`, `.next()` etc. methods were called, but excluded when rendered the menu. This caused odd behavior when opening the menu.
This is not noticeable if either all or no tasks have the debug counterpart, hence not exposed before LSP r-a tasks (without the debug counterpart task) appeared.

Release Notes:

- Fixed LSP and tree-sitter tasks rendering in the editor gutter menu
