### PR TITLE
renovate: Require dependency dashboard approval for updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,15 +4,13 @@
     "config:recommended",
     ":semanticCommitsDisabled",
     ":separateMultipleMajorReleases",
+    ":dependencyDashboardApproval",
     "helpers:pinGitHubActionDigests",
     "group:serdeMonorepo"
   ],
   "dependencyDashboard": true,
   "timezone": "America/New_York",
   "schedule": ["after 3pm on Wednesday"],
-  "major": {
-    "dependencyDashboardApproval": true
-  },
   "prFooter": "Release Notes:\n\n- N/A",
   "ignorePaths": ["**/node_modules/**", "tooling/workspace-hack/**"],
   "packageRules": [


### PR DESCRIPTION
This PR changes Renovate's behavior to require dependency dashboard approval for updates.

> Maybe you find Renovate too noisy, and want to opt-out of getting automatic updates whenever they're ready.
>
> In this case, you can tell Renovate to wait for your approval before making any pull requests. This means that you have full control over when you get updates.
>
> But vulnerability remediation PRs will still get created immediately without requiring approval.
>
> To require manual approval for *all* updates, add the `:dependencyDashboardApproval` presets to the `extends` array in your Renovate configuration file:
>
> — https://docs.renovatebot.com/key-concepts/dashboard/#require-approval-for-all-updates

Release Notes:

- N/A
