### PR TITLE
Fix zed sometimes stopping by using setsid on interactive shells

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15835,7 +15835,6 @@ dependencies = [
  "indoc",
  "itertools 0.14.0",
  "language",
- "libc",
  "log",
  "lsp",
  "multi_buffer",

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -28,7 +28,6 @@ futures.workspace = true
 gpui.workspace = true
 itertools.workspace = true
 language.workspace = true
-libc.workspace = true
 log.workspace = true
 multi_buffer.workspace = true
 nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", branch = "master", features = ["use_tokio"], optional = true }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1519,18 +1519,7 @@ impl ShellExec {
             process.stdin(Stdio::null());
         };
 
-        // https://registerspill.thorstenball.com/p/how-to-lose-control-of-your-shell
-        //
-        // safety: code in pre_exec should be signal safe.
-        // https://man7.org/linux/man-pages/man7/signal-safety.7.html
-        #[cfg(not(target_os = "windows"))]
-        unsafe {
-            use std::os::unix::process::CommandExt;
-            process.pre_exec(|| {
-                libc::setsid();
-                Ok(())
-            });
-        };
+        util::set_pre_exec_to_start_new_session(&mut process);
         let is_read = self.is_read;
 
         let task = cx.spawn_in(window, async move |vim, cx| {


### PR DESCRIPTION
For some reason `SIGTTIN` sometimes gets sent to the process group, causing it to stop when run from a terminal. This solves that issue by putting the shell in a new session + progress group.

This allows removal of a workaround of using `exit 0;` to restore handling of ctrl-c after exit.  In testing this appears to no longer be necessary.

Closes #27716

Release Notes:

- Fixed Zed sometimes becoming a stopped background process when run from a terminal.