### PR TITLE
language_models: Fix passing of `thread_id` and `prompt_id`

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -719,7 +719,7 @@ impl LanguageModel for CloudLanguageModel {
 
     fn stream_completion_with_usage(
         &self,
-        mut request: LanguageModelRequest,
+        request: LanguageModelRequest,
         _cx: &AsyncApp,
     ) -> BoxFuture<
         'static,
@@ -728,8 +728,8 @@ impl LanguageModel for CloudLanguageModel {
             Option<RequestUsage>,
         )>,
     > {
-        let thread_id = request.prompt_id.take();
-        let prompt_id = request.prompt_id.take();
+        let thread_id = request.thread_id.clone();
+        let prompt_id = request.prompt_id.clone();
         match &self.model {
             CloudModel::Anthropic(model) => {
                 let request = into_anthropic(


### PR DESCRIPTION
This PR is a follow-up to https://github.com/zed-industries/zed/pull/29069 that fixes an issue where the thread ID and prompt ID were not being sent up correctly.

Release Notes:

- N/A
