### PR TITLE
docs: Add more examples of existing MCP extensions

### DIFF
--- a/docs/src/assistant/context-servers.md
+++ b/docs/src/assistant/context-servers.md
@@ -1,6 +1,7 @@
 # Context Servers
 
-Context servers are a mechanism for pulling context into the Assistant from an external source. They are powered by the [Model Context Protocol](./model-context-protocol.md).
+Context servers are a mechanism for pulling context into the Assistant from an external source.
+They are powered by the [Model Context Protocol](./model-context-protocol.md).
 
 Currently Zed supports context servers providing [slash commands](./commands.md) for use in the Assistant.
 
@@ -10,7 +11,16 @@ Context servers can be installed via [extensions](../extensions/context-servers.
 
 If you don't already have a context server, check out one of these:
 
-- [Postgres Context Server](https://github.com/zed-extensions/postgres-context-server)
+- [Postgres](https://github.com/zed-extensions/postgres-context-server)
+- [GitHub](https://github.com/LoamStudios/zed-mcp-server-github)
+- [Puppeteer](https://github.com/zed-extensions/mcp-server-puppeteer)
+- [BrowserTools](https://github.com/mirageN1349/browser-tools-context-server)
+- [Brave Search](https://github.com/zed-extensions/mcp-server-brave-search)
+- [Prisma](https://github.com/aqrln/prisma-mcp-zed)
+- [Framelink Figma](https://github.com/LoamStudios/zed-mcp-server-figma)
+- [Linear](https://github.com/LoamStudios/zed-mcp-server-linear)
+
+Browse all available MCP extensions either on [Zed's website](https://zed.dev/extensions?filter=context-servers) or directly in Zed via the `zed: extensions` action in the Command Palette.
 
 ## Configuration
 

--- a/docs/src/assistant/model-context-protocol.md
+++ b/docs/src/assistant/model-context-protocol.md
@@ -8,14 +8,21 @@ Check out the [Anthropic news post](https://www.anthropic.com/news/model-context
 
 ## Try it out
 
-Want to try it for yourself?
+Want to try it for yourself? Here are some MCP servers available as Zed extensions:
 
-The following context servers are available today as Zed extensions:
+- [Postgres](https://github.com/zed-extensions/postgres-context-server)
+- [GitHub](https://github.com/LoamStudios/zed-mcp-server-github)
+- [Puppeteer](https://github.com/zed-extensions/mcp-server-puppeteer)
+- [BrowserTools](https://github.com/mirageN1349/browser-tools-context-server)
+- [Brave Search](https://github.com/zed-extensions/mcp-server-brave-search)
+- [Prisma](https://github.com/aqrln/prisma-mcp-zed)
+- [Framelink Figma](https://github.com/LoamStudios/zed-mcp-server-figma)
+- [Linear](https://github.com/LoamStudios/zed-mcp-server-linear)
 
-- [Postgres Context Server](https://github.com/zed-extensions/postgres-context-server)
+Browse all available MCP extensions either on [Zed's website](https://zed.dev/extensions?filter=context-servers) or directly in Zed via the `zed: extensions` action in the Command Palette.
 
 ## Bring your own context server
 
-If there's an existing context server you'd like to bring to Zed, check out the [context server extension docs](../extensions/context-servers.md) for how to make it available as an extension.
+If there's an existing MCP server you'd like to bring to Zed, check out the [context server extension docs](../extensions/context-servers.md) for how to make it available as an extension.
 
-If you are interested in building your own context server, check out the [Model Context Protocol docs](https://modelcontextprotocol.io/introduction#get-started-with-mcp) to get started.
+If you are interested in building your own MCP server, check out the [Model Context Protocol docs](https://modelcontextprotocol.io/introduction#get-started-with-mcp) to get started.


### PR DESCRIPTION
Also linking to the zed.dev site, which now includes a filter for MCP (i.e., "Context Servers") servers in the Extensions page.

Release Notes:

- N/A
