### PR TITLE
Don't send dummy user text with tool results

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1663,9 +1663,10 @@ impl Thread {
 
     /// Insert an empty message to be populated with tool results upon send.
     pub fn attach_tool_results(&mut self, cx: &mut Context<Self>) {
-        // TODO: Don't insert a dummy user message here. Ensure this works with the thinking model.
-        // Insert a user message to contain the tool results.
-        self.insert_user_message("Here are the tool results.", Vec::new(), None, cx);
+        // Tool results are assumed to be waiting on the next message id, so they will populate
+        // this empty message before sending to model. Would prefer this to be more straightforward.
+        self.insert_message(Role::User, vec![], cx);
+        self.auto_capture_telemetry(cx);
     }
 
     /// Cancels the last pending completion, if there are any pending.


### PR DESCRIPTION
Previously, we were including the dummy text "Here are the tool results." whenever reporting tool call results. I'm worried this is adding noise and confusing the model, because the user didn't actually say anything. This inserts an empty message to be populated later. My preference would be something less stateful, where tool results (or batches of them requested simultaneously) would be sent to the model as soon as they were ready, without bothering to do this message association dance. But for now, this seems to work.

Release Notes:

- N/A
