### PR TITLE
Switch from `open-codestral-mamba` to `codestral-latest` for default mistral model

### DIFF
--- a/crates/mistral/src/mistral.rs
+++ b/crates/mistral/src/mistral.rs
@@ -46,6 +46,7 @@ impl From<Role> for String {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
     #[serde(rename = "codestral-latest", alias = "codestral-latest")]
+    #[default]
     CodestralLatest,
     #[serde(rename = "mistral-large-latest", alias = "mistral-large-latest")]
     MistralLargeLatest,
@@ -54,7 +55,6 @@ pub enum Model {
     #[serde(rename = "open-mistral-nemo", alias = "open-mistral-nemo")]
     OpenMistralNemo,
     #[serde(rename = "open-codestral-mamba", alias = "open-codestral-mamba")]
-    #[default]
     OpenCodestralMamba,
 
     #[serde(rename = "custom")]


### PR DESCRIPTION
Couldn't find mistral cloud pricing for open-codestral-mamba on the mistral site, but codestral-latest is newer and appears to be cheaper based on https://sdk.vercel.ai/playground/mistral:codestral-mamba-latest,mistral:codestral-2501

Release Notes:

- N/A