### PR TITLE
Buffer letter spacing (aka tracking) for macOS

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -41,6 +41,8 @@
   "buffer_font_size": 15,
   // The weight of the editor font in standard CSS units from 100 to 900.
   "buffer_font_weight": 400,
+  // The letter spacing of the editor font in ems.
+  "buffer_letter_spacing": 0.0,
   // Set the buffer's line height.
   // May take 3 values:
   //  1. Use a line height that's comfortable for reading (1.618)

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -41,7 +41,10 @@
   "buffer_font_size": 15,
   // The weight of the editor font in standard CSS units from 100 to 900.
   "buffer_font_weight": 400,
-  // The letter spacing of the editor font in ems.
+  // The letter spacing (or tracking) of the editor font in ems (relative to buffer_font_size).
+  // For example, 0.05 will insert a space between each grapheme cluster, with a width of 5% of the font size.
+  // This value can be positive or negative.
+  // Currently only supported on macOS.
   "buffer_letter_spacing": 0.0,
   // Set the buffer's line height.
   // May take 3 values:

--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -39,7 +39,9 @@ use collections::{HashMap, HashSet};
 pub use crease_map::*;
 pub use fold_map::{ChunkRenderer, ChunkRendererContext, Fold, FoldId, FoldPlaceholder, FoldPoint};
 use fold_map::{FoldMap, FoldSnapshot};
-use gpui::{App, Context, Entity, Font, HighlightStyle, LineLayout, Pixels, UnderlineStyle};
+use gpui::{
+    App, Context, Entity, Font, HighlightStyle, LetterSpacing, LineLayout, Pixels, UnderlineStyle,
+};
 pub use inlay_map::Inlay;
 use inlay_map::{InlayMap, InlaySnapshot};
 pub use inlay_map::{InlayOffset, InlayPoint};
@@ -116,6 +118,7 @@ impl DisplayMap {
         buffer: Entity<MultiBuffer>,
         font: Font,
         font_size: Pixels,
+        letter_spacing: LetterSpacing,
         wrap_width: Option<Pixels>,
         buffer_header_height: u32,
         excerpt_header_height: u32,
@@ -130,7 +133,8 @@ impl DisplayMap {
         let (inlay_map, snapshot) = InlayMap::new(buffer_snapshot);
         let (fold_map, snapshot) = FoldMap::new(snapshot);
         let (tab_map, snapshot) = TabMap::new(snapshot, tab_size);
-        let (wrap_map, snapshot) = WrapMap::new(snapshot, font, font_size, wrap_width, cx);
+        let (wrap_map, snapshot) =
+            WrapMap::new(snapshot, font, font_size, letter_spacing, wrap_width, cx);
         let block_map = BlockMap::new(snapshot, buffer_header_height, excerpt_header_height);
 
         cx.observe(&wrap_map, |_, _, cx| cx.notify()).detach();
@@ -504,9 +508,16 @@ impl DisplayMap {
         cleared
     }
 
-    pub fn set_font(&self, font: Font, font_size: Pixels, cx: &mut Context<Self>) -> bool {
-        self.wrap_map
-            .update(cx, |map, cx| map.set_font_with_size(font, font_size, cx))
+    pub fn set_font(
+        &self,
+        font: Font,
+        font_size: Pixels,
+        letter_spacing: LetterSpacing,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.wrap_map.update(cx, |map, cx| {
+            map.set_font_with_size(font, font_size, letter_spacing, cx)
+        })
     }
 
     pub fn set_wrap_width(&self, width: Option<Pixels>, cx: &mut Context<Self>) -> bool {
@@ -1536,6 +1547,7 @@ pub mod tests {
                 buffer.clone(),
                 font,
                 font_size,
+                LetterSpacing::default(),
                 wrap_width,
                 buffer_start_excerpt_header_height,
                 excerpt_header_height,
@@ -1783,6 +1795,7 @@ pub mod tests {
                     buffer.clone(),
                     font("Helvetica"),
                     font_size,
+                    LetterSpacing::default(),
                     wrap_width,
                     1,
                     1,
@@ -1868,7 +1881,12 @@ pub mod tests {
 
             // Re-wrap on font size changes
             map.update(cx, |map, cx| {
-                map.set_font(font("Helvetica"), px(font_size.0 + 3.), cx)
+                map.set_font(
+                    font("Helvetica"),
+                    px(font_size.0 + 3.),
+                    LetterSpacing::default(),
+                    cx,
+                )
             });
 
             let snapshot = map.update(cx, |map, cx| map.snapshot(cx));
@@ -1892,6 +1910,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -1953,6 +1972,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2045,6 +2065,7 @@ pub mod tests {
                 buffer,
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2145,6 +2166,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 px(16.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2248,6 +2270,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 px(16.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2335,6 +2358,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Courier"),
                 px(16.0),
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2475,6 +2499,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 font_size,
+                LetterSpacing::default(),
                 Some(px(40.0)),
                 1,
                 1,
@@ -2557,6 +2582,7 @@ pub mod tests {
                 buffer,
                 font("Courier"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2681,6 +2707,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2718,6 +2745,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -2793,6 +2821,7 @@ pub mod tests {
                 buffer.clone(),
                 font("Helvetica"),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -1920,7 +1920,7 @@ mod tests {
         display_map::{fold_map::FoldMap, inlay_map::InlayMap, tab_map::TabMap, wrap_map::WrapMap},
         test::test_font,
     };
-    use gpui::{App, AppContext as _, Element, div, font, px};
+    use gpui::{App, AppContext as _, Element, LetterSpacing, div, font, px};
     use itertools::Itertools;
     use language::{Buffer, Capability};
     use multi_buffer::{ExcerptRange, MultiBuffer};
@@ -1955,8 +1955,16 @@ mod tests {
         let (mut inlay_map, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
@@ -2159,7 +2167,14 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(multi_buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wraps_snapshot) = WrapMap::new(tab_snapshot, font, font_size, Some(wrap_width), cx);
+        let (_, wraps_snapshot) = WrapMap::new(
+            tab_snapshot,
+            font,
+            font_size,
+            LetterSpacing::default(),
+            Some(wrap_width),
+            cx,
+        );
 
         let block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
         let snapshot = block_map.read(wraps_snapshot, Default::default());
@@ -2193,8 +2208,16 @@ mod tests {
         let (_inlay_map, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 1.try_into().unwrap());
-        let (_wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
@@ -2295,7 +2318,14 @@ mod tests {
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let (_, wraps_snapshot) = cx.update(|cx| {
-            WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), Some(px(90.)), cx)
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                Some(px(90.)),
+                cx,
+            )
         });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
@@ -2339,8 +2369,16 @@ mod tests {
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let tab_size = 1.try_into().unwrap();
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, tab_size);
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());
@@ -2506,8 +2544,16 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_, wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wrap_snapshot.clone(), 2, 1);
         let blocks_snapshot = block_map.read(wrap_snapshot.clone(), Patch::default());
 
@@ -2851,8 +2897,16 @@ mod tests {
         let (_, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_, wrap_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_, wrap_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wrap_snapshot.clone(), 2, 1);
         let blocks_snapshot = block_map.read(wrap_snapshot.clone(), Patch::default());
 
@@ -2932,8 +2986,16 @@ mod tests {
         let (mut fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (mut tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
         let font = test_font();
-        let (wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font, font_size, wrap_width, cx));
+        let (wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font,
+                font_size,
+                LetterSpacing::default(),
+                wrap_width,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(
             wraps_snapshot,
             buffer_start_header_height,
@@ -3514,8 +3576,16 @@ mod tests {
         let (_inlay_map, inlay_snapshot) = InlayMap::new(buffer_snapshot.clone());
         let (_fold_map, fold_snapshot) = FoldMap::new(inlay_snapshot);
         let (_tab_map, tab_snapshot) = TabMap::new(fold_snapshot, 4.try_into().unwrap());
-        let (_wrap_map, wraps_snapshot) =
-            cx.update(|cx| WrapMap::new(tab_snapshot, font("Helvetica"), px(14.0), None, cx));
+        let (_wrap_map, wraps_snapshot) = cx.update(|cx| {
+            WrapMap::new(
+                tab_snapshot,
+                font("Helvetica"),
+                px(14.0),
+                LetterSpacing::default(),
+                None,
+                cx,
+            )
+        });
         let mut block_map = BlockMap::new(wraps_snapshot.clone(), 1, 1);
 
         let mut writer = block_map.write(wraps_snapshot.clone(), Default::default());

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19759,6 +19759,7 @@ impl Render for Editor {
                 font_fallbacks: settings.buffer_font.fallbacks.clone(),
                 font_size: settings.buffer_font_size(cx).into(),
                 font_weight: settings.buffer_font.weight,
+                letter_spacing: settings.buffer_letter_spacing,
                 line_height: relative(settings.buffer_line_height.value()),
                 ..Default::default()
             },

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -87,10 +87,11 @@ use gpui::{
     AsyncWindowContext, AvailableSpace, Background, Bounds, ClickEvent, ClipboardEntry,
     ClipboardItem, Context, DispatchPhase, Edges, Entity, EntityInputHandler, EventEmitter,
     FocusHandle, FocusOutEvent, Focusable, FontId, FontWeight, Global, HighlightStyle, Hsla,
-    KeyContext, Modifiers, MouseButton, MouseDownEvent, PaintQuad, ParentElement, Pixels, Render,
-    SharedString, Size, Stateful, Styled, Subscription, Task, TextStyle, TextStyleRefinement,
-    UTF16Selection, UnderlineStyle, UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window,
-    div, impl_actions, point, prelude::*, pulsating_between, px, relative, size,
+    KeyContext, LetterSpacing, Modifiers, MouseButton, MouseDownEvent, PaintQuad, ParentElement,
+    Pixels, Render, SharedString, Size, Stateful, Styled, Subscription, Task, TextStyle,
+    TextStyleRefinement, UTF16Selection, UnderlineStyle, UniformListScrollHandle, WeakEntity,
+    WeakFocusHandle, Window, div, impl_actions, point, prelude::*, pulsating_between, px, relative,
+    size,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_links::{HoverLink, HoveredLinkState, InlayHighlight, find_file};
@@ -1406,6 +1407,7 @@ impl Editor {
                 buffer.clone(),
                 style.font(),
                 font_size,
+                LetterSpacing::default(),
                 None,
                 FILE_HEADER_HEIGHT,
                 MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
@@ -15981,6 +15983,7 @@ impl Editor {
             map.set_font(
                 style.text.font(),
                 style.text.font_size.to_pixels(rem_size),
+                style.text.letter_spacing,
                 cx,
             )
         });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7633,6 +7633,7 @@ impl Element for EditorElement {
 
         let text_style = TextStyleRefinement {
             font_size: Some(self.style.text.font_size),
+            letter_spacing: Some(self.style.text.letter_spacing),
             line_height: Some(self.style.text.line_height),
             ..Default::default()
         };

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1302,6 +1302,9 @@ impl EditorElement {
                                     })
                                     .unwrap_or(self.style.text.font());
 
+                                // TODO: get for index (from runs)
+                                let letter_spacing = self.style.text.letter_spacing;
+
                                 // Invert the text color for the block cursor. Ensure that the text
                                 // color is opaque enough to be visible against the background color.
                                 //
@@ -1326,6 +1329,7 @@ impl EditorElement {
                                         &[TextRun {
                                             len,
                                             font,
+                                            letter_spacing,
                                             color,
                                             background_color: None,
                                             strikethrough: None,
@@ -2557,6 +2561,7 @@ impl EditorElement {
                     let run = TextRun {
                         len: line.len(),
                         font: style.text.font(),
+                        letter_spacing: style.text.letter_spacing,
                         color: placeholder_color,
                         background_color: None,
                         underline: Default::default(),
@@ -5657,6 +5662,7 @@ impl EditorElement {
                 &[TextRun {
                     len: column,
                     font: style.text.font(),
+                    letter_spacing: style.text.letter_spacing,
                     color: Hsla::default(),
                     background_color: None,
                     underline: None,
@@ -5687,6 +5693,7 @@ impl EditorElement {
         let run = TextRun {
             len: text.len(),
             font: self.style.text.font(),
+            letter_spacing: self.style.text.letter_spacing,
             color,
             background_color: None,
             underline: None,
@@ -6016,6 +6023,7 @@ impl LineWithInvisibles {
                         let run = TextRun {
                             len: x.len(),
                             font: text_style.font(),
+                            letter_spacing: text_style.letter_spacing,
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -6079,6 +6087,7 @@ impl LineWithInvisibles {
                         styles.push(TextRun {
                             len: line_chunk.len(),
                             font: text_style.font(),
+                            letter_spacing: text_style.letter_spacing,
                             color: text_style.color,
                             background_color: text_style.background_color,
                             underline: text_style.underline,
@@ -7493,6 +7502,7 @@ impl Element for EditorElement {
                             &[TextRun {
                                 len: "→".len(),
                                 font: self.style.text.font(),
+                                letter_spacing: self.style.text.letter_spacing,
                                 color: cx.theme().colors().editor_invisible,
                                 background_color: None,
                                 underline: None,
@@ -7508,6 +7518,7 @@ impl Element for EditorElement {
                             &[TextRun {
                                 len: "•".len(),
                                 font: self.style.text.font(),
+                                letter_spacing: self.style.text.letter_spacing,
                                 color: cx.theme().colors().editor_invisible,
                                 background_color: None,
                                 underline: None,

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -770,7 +770,7 @@ mod tests {
         display_map::Inlay,
         test::{editor_test_context::EditorTestContext, marked_display_snapshot},
     };
-    use gpui::{AppContext as _, font, px};
+    use gpui::{AppContext as _, LetterSpacing, font, px};
     use language::Capability;
     use project::Project;
     use settings::SettingsStore;
@@ -892,6 +892,7 @@ mod tests {
                 buffer,
                 font,
                 font_size,
+                LetterSpacing::default(),
                 None,
                 1,
                 1,
@@ -1101,6 +1102,7 @@ mod tests {
                     multibuffer,
                     font,
                     px(14.0),
+                    LetterSpacing::default(),
                     None,
                     0,
                     1,

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -13,8 +13,8 @@ use crate::{
 };
 use collections::HashMap;
 use gpui::{
-    AppContext as _, Context, Entity, EntityId, Font, FontFeatures, FontStyle, FontWeight, Pixels,
-    VisualTestContext, Window, font, size,
+    AppContext as _, Context, Entity, EntityId, Font, FontFeatures, FontStyle, FontWeight,
+    LetterSpacing, Pixels, VisualTestContext, Window, font, size,
 };
 use multi_buffer::ToPoint;
 use pretty_assertions::assert_eq;
@@ -68,6 +68,7 @@ pub fn marked_display_snapshot(
             buffer,
             font,
             font_size,
+            LetterSpacing::default(),
             None,
             1,
             1,

--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -3,10 +3,10 @@ use std::ops::Range;
 use gpui::{
     App, Application, Bounds, ClipboardItem, Context, CursorStyle, ElementId, ElementInputHandler,
     Entity, EntityInputHandler, FocusHandle, Focusable, GlobalElementId, KeyBinding, Keystroke,
-    LayoutId, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, Pixels, Point,
-    ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle, Window, WindowBounds,
-    WindowOptions, actions, black, div, fill, hsla, opaque_grey, point, prelude::*, px, relative,
-    rgb, rgba, size, white, yellow,
+    LayoutId, LetterSpacing, MouseButton, MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad,
+    Pixels, Point, ShapedLine, SharedString, Style, TextRun, UTF16Selection, UnderlineStyle,
+    Window, WindowBounds, WindowOptions, actions, black, div, fill, hsla, opaque_grey, point,
+    prelude::*, px, relative, rgb, rgba, size, white, yellow,
 };
 use unicode_segmentation::*;
 
@@ -442,6 +442,7 @@ impl Element for TextElement {
         let run = TextRun {
             len: display_text.len(),
             font: style.font(),
+            letter_spacing: LetterSpacing::default(),
             color: text_color,
             background_color: None,
             underline: None,

--- a/crates/gpui/examples/text_layout.rs
+++ b/crates/gpui/examples/text_layout.rs
@@ -71,6 +71,21 @@ impl Render for HelloWorld {
                             .child("100%"),
                     ),
             )
+            .child(
+                div()
+                    .letter_spacing(0.00)
+                    .child("I have default letter_spacing"),
+            )
+            .child(
+                div()
+                    .letter_spacing(0.05)
+                    .child("I have positive letter_spacing"),
+            )
+            .child(
+                div()
+                    .letter_spacing(-0.05)
+                    .child("I have negative letter_spacing"),
+            )
     }
 }
 

--- a/crates/gpui/src/elements/text.rs
+++ b/crates/gpui/src/elements/text.rs
@@ -295,6 +295,7 @@ impl TextLayout {
     ) -> LayoutId {
         let text_style = window.text_style();
         let font_size = text_style.font_size.to_pixels(window.rem_size());
+        let letter_spacing = text_style.letter_spacing;
         let line_height = text_style
             .line_height
             .to_pixels(font_size.into(), window.rem_size());
@@ -343,7 +344,9 @@ impl TextLayout {
                     }
                 }
 
-                let mut line_wrapper = cx.text_system().line_wrapper(text_style.font(), font_size);
+                let mut line_wrapper =
+                    cx.text_system()
+                        .line_wrapper(text_style.font(), font_size, letter_spacing);
                 let text = if let Some(truncate_width) = truncate_width {
                     line_wrapper.truncate_line(text.clone(), truncate_width, ellipsis, &mut runs)
                 } else {

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -7,7 +7,7 @@ use std::{
 use crate::{
     AbsoluteLength, App, Background, BackgroundTag, BorderStyle, Bounds, ContentMask, Corners,
     CornersRefinement, CursorStyle, DefiniteLength, DevicePixels, Edges, EdgesRefinement, Font,
-    FontFallbacks, FontFeatures, FontStyle, FontWeight, Hsla, Length, Pixels, Point,
+    FontFallbacks, FontFeatures, FontStyle, FontWeight, Hsla, Length, LetterSpacing, Pixels, Point,
     PointRefinement, Rgba, SharedString, Size, SizeRefinement, Styled, TextRun, Window, black, phi,
     point, quad, rems, size,
 };
@@ -380,6 +380,9 @@ pub struct TextStyle {
 
     /// The number of lines to display before truncating the text
     pub line_clamp: Option<usize>,
+
+    /// The letter spacing of the text
+    pub letter_spacing: LetterSpacing,
 }
 
 impl Default for TextStyle {
@@ -407,6 +410,7 @@ impl Default for TextStyle {
             text_overflow: None,
             text_align: TextAlign::default(),
             line_clamp: None,
+            letter_spacing: LetterSpacing::default(),
         }
     }
 }
@@ -476,6 +480,7 @@ impl TextStyle {
             background_color: self.background_color,
             underline: self.underline,
             strikethrough: self.strikethrough,
+            letter_spacing: self.letter_spacing,
         }
     }
 }

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,8 +1,8 @@
 use crate::{
     self as gpui, AbsoluteLength, AlignItems, BorderStyle, CursorStyle, DefiniteLength, Fill,
     FlexDirection, FlexWrap, Font, FontStyle, FontWeight, Hsla, JustifyContent, Length,
-    SharedString, StrikethroughStyle, StyleRefinement, TextOverflow, UnderlineStyle, WhiteSpace,
-    px, relative, rems,
+    LetterSpacing, SharedString, StrikethroughStyle, StyleRefinement, TextOverflow, UnderlineStyle,
+    WhiteSpace, px, relative, rems,
 };
 use crate::{TextAlign, TextStyleRefinement};
 pub use gpui_macros::{
@@ -114,6 +114,13 @@ pub trait Styled: Sized {
         let mut text_style = self.text_style().get_or_insert_with(Default::default);
         text_style.line_clamp = Some(lines);
         self.overflow_hidden()
+    }
+
+    /// Sets the letter spacing of the text.
+    fn letter_spacing(mut self, spacing: f32) -> Self {
+        let mut text_style = self.text_style().get_or_insert_with(Default::default);
+        text_style.letter_spacing = Some(LetterSpacing(spacing));
+        self
     }
 
     /// Sets the flex direction of the element to `column`.

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -653,6 +653,33 @@ impl Display for FontStyle {
     }
 }
 
+/// Letter spacing (in ems).
+#[derive(
+    Clone, Copy, Default, Debug, PartialEq, PartialOrd, Deserialize, Serialize, JsonSchema,
+)]
+pub struct LetterSpacing(pub f32);
+
+impl Hash for LetterSpacing {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write_u32(u32::from_be_bytes(self.0.to_be_bytes()));
+    }
+}
+
+impl Eq for LetterSpacing {}
+
+impl Display for LetterSpacing {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Debug::fmt(self, f)
+    }
+}
+
+impl LetterSpacing {
+    /// Converts the letter spacing (in ems) to pixels.
+    pub fn to_px(&self, font_size: Pixels) -> Pixels {
+        self.0 * font_size
+    }
+}
+
 /// A styled run of text, for use in [`TextLayout`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextRun {

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -265,14 +265,28 @@ impl TextSystem {
     }
 
     /// Returns a handle to a line wrapper, for the given font and font size.
-    pub fn line_wrapper(self: &Arc<Self>, font: Font, font_size: Pixels) -> LineWrapperHandle {
+    pub fn line_wrapper(
+        self: &Arc<Self>,
+        font: Font,
+        font_size: Pixels,
+        letter_spacing: LetterSpacing,
+    ) -> LineWrapperHandle {
         let lock = &mut self.wrapper_pool.lock();
         let font_id = self.resolve_font(&font);
         let wrappers = lock
-            .entry(FontIdWithSize { font_id, font_size })
+            .entry(FontIdWithSize {
+                font_id,
+                font_size,
+                letter_spacing,
+            })
             .or_default();
         let wrapper = wrappers.pop().unwrap_or_else(|| {
-            LineWrapper::new(font_id, font_size, self.platform_text_system.clone())
+            LineWrapper::new(
+                font_id,
+                font_size,
+                letter_spacing,
+                self.platform_text_system.clone(),
+            )
         });
 
         LineWrapperHandle {
@@ -547,6 +561,7 @@ impl WindowTextSystem {
 struct FontIdWithSize {
     font_id: FontId,
     font_size: Pixels,
+    letter_spacing: LetterSpacing,
 }
 
 /// A handle into the text system, which can be used to compute the wrapped layout of text
@@ -563,6 +578,7 @@ impl Drop for LineWrapperHandle {
             .get_mut(&FontIdWithSize {
                 font_id: wrapper.font_id,
                 font_size: wrapper.font_size,
+                letter_spacing: wrapper.letter_spacing,
             })
             .unwrap()
             .push(wrapper);

--- a/crates/gpui/src/text_system/line_layout.rs
+++ b/crates/gpui/src/text_system/line_layout.rs
@@ -1,4 +1,7 @@
-use crate::{FontId, GlyphId, Pixels, PlatformTextSystem, Point, SharedString, Size, point, px};
+use crate::{
+    FontId, GlyphId, LetterSpacing, Pixels, PlatformTextSystem, Point, SharedString, Size, point,
+    px,
+};
 use collections::FxHashMap;
 use parking_lot::{Mutex, RwLock, RwLockUpgradableReadGuard};
 use smallvec::SmallVec;
@@ -579,6 +582,7 @@ impl LineLayoutCache {
 pub struct FontRun {
     pub(crate) len: usize,
     pub(crate) font_id: FontId,
+    pub(crate) letter_spacing: LetterSpacing,
 }
 
 trait AsCacheKeyRef {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -1,4 +1,6 @@
-use crate::{FontId, FontRun, Pixels, PlatformTextSystem, SharedString, TextRun, px};
+use crate::{
+    FontId, FontRun, LetterSpacing, Pixels, PlatformTextSystem, SharedString, TextRun, px,
+};
 use collections::HashMap;
 use std::{iter, sync::Arc};
 
@@ -220,6 +222,7 @@ impl LineWrapper {
                 &[FontRun {
                     len: buffer.len(),
                     font_id: self.font_id,
+                    letter_spacing: LetterSpacing::default(),
                 }],
             )
             .width

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -9,6 +9,7 @@ pub struct LineWrapper {
     platform_text_system: Arc<dyn PlatformTextSystem>,
     pub(crate) font_id: FontId,
     pub(crate) font_size: Pixels,
+    pub(crate) letter_spacing: LetterSpacing,
     cached_ascii_char_widths: [Option<Pixels>; 128],
     cached_other_char_widths: HashMap<char, Pixels>,
 }
@@ -20,12 +21,14 @@ impl LineWrapper {
     pub(crate) fn new(
         font_id: FontId,
         font_size: Pixels,
+        letter_spacing: LetterSpacing,
         text_system: Arc<dyn PlatformTextSystem>,
     ) -> Self {
         Self {
             platform_text_system: text_system,
             font_id,
             font_size,
+            letter_spacing,
             cached_ascii_char_widths: [None; 128],
             cached_other_char_widths: HashMap::default(),
         }
@@ -222,7 +225,7 @@ impl LineWrapper {
                 &[FontRun {
                     len: buffer.len(),
                     font_id: self.font_id,
-                    letter_spacing: LetterSpacing::default(),
+                    letter_spacing: self.letter_spacing,
                 }],
             )
             .width
@@ -334,7 +337,12 @@ mod tests {
         let dispatcher = TestDispatcher::new(StdRng::seed_from_u64(0));
         let cx = TestAppContext::new(dispatcher, None);
         let id = cx.text_system().font_id(&font("Zed Plex Mono")).unwrap();
-        LineWrapper::new(id, px(16.), cx.text_system().platform_text_system.clone())
+        LineWrapper::new(
+            id,
+            px(16.),
+            LetterSpacing::default(),
+            cx.text_system().platform_text_system.clone(),
+        )
     }
 
     fn generate_test_runs(input_run_len: &[usize]) -> Vec<TextRun> {

--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -349,6 +349,7 @@ mod tests {
                     weight: FontWeight::default(),
                     style: FontStyle::Normal,
                 },
+                letter_spacing: LetterSpacing::default(),
                 color: Hsla::default(),
                 background_color: None,
                 underline: None,
@@ -695,6 +696,7 @@ mod tests {
             let normal = TextRun {
                 len: 0,
                 font: font("Helvetica"),
+                letter_spacing: LetterSpacing::default(),
                 color: Default::default(),
                 underline: Default::default(),
                 strikethrough: None,
@@ -703,6 +705,7 @@ mod tests {
             let bold = TextRun {
                 len: 0,
                 font: font("Helvetica").bold(),
+                letter_spacing: LetterSpacing::default(),
                 color: Default::default(),
                 underline: Default::default(),
                 strikethrough: None,

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -25,8 +25,8 @@ use credentials_provider::CredentialsProvider;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream};
 use gpui::{
-    AnyView, App, AsyncApp, Context, Entity, FontStyle, FontWeight, Subscription, Task, TextStyle,
-    WhiteSpace,
+    AnyView, App, AsyncApp, Context, Entity, FontStyle, FontWeight, LetterSpacing, Subscription,
+    Task, TextStyle, WhiteSpace,
 };
 use gpui_tokio::Tokio;
 use http_client::HttpClient;
@@ -1140,6 +1140,7 @@ impl ConfigurationView {
             text_overflow: None,
             text_align: Default::default(),
             line_clamp: None,
+            letter_spacing: LetterSpacing::default(),
         }
     }
 

--- a/crates/repl/src/outputs/table.rs
+++ b/crates/repl/src/outputs/table.rs
@@ -98,6 +98,7 @@ impl TableView {
         let mut runs = [TextRun {
             len: 0,
             font: text_font,
+            letter_spacing: text_style.letter_spacing,
             color: text_style.color,
             background_color: None,
             underline: None,

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -3,7 +3,7 @@ use gpui::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, Context, DispatchPhase, Element,
     ElementId, Entity, FocusHandle, Font, FontStyle, FontWeight, GlobalElementId, HighlightStyle,
     Hitbox, Hsla, InputHandler, InteractiveElement, Interactivity, IntoElement, LayoutId,
-    ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels, Point, ShapedLine,
+    LetterSpacing, ModifiersChangedEvent, MouseButton, MouseMoveEvent, Pixels, Point, ShapedLine,
     StatefulInteractiveElement, StrikethroughStyle, Styled, TextRun, TextStyle, UTF16Selection,
     UnderlineStyle, WeakEntity, WhiteSpace, Window, WindowTextSystem, div, fill, point, px,
     relative, size,
@@ -390,6 +390,7 @@ impl TerminalElement {
             },
             underline,
             strikethrough,
+            letter_spacing: LetterSpacing::default(),
         };
 
         if let Some((style, range)) = hyperlink {
@@ -789,6 +790,7 @@ impl Element for TerminalElement {
                                 &[TextRun {
                                     len,
                                     font: text_style.font(),
+                                    letter_spacing: text_style.letter_spacing,
                                     color: theme.colors().terminal_ansi_background,
                                     background_color: None,
                                     underline: Default::default(),

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -6,8 +6,8 @@ use crate::{
 use anyhow::Result;
 use derive_more::{Deref, DerefMut};
 use gpui::{
-    App, Context, Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, Global, Pixels,
-    Subscription, Window, px,
+    App, Context, Font, FontFallbacks, FontFeatures, FontStyle, FontWeight, Global, LetterSpacing,
+    Pixels, Subscription, Window, px,
 };
 use refineable::Refineable;
 use schemars::{
@@ -106,6 +106,8 @@ pub struct ThemeSettings {
     ///
     /// The terminal font family can be overridden using it's own setting.
     pub buffer_font: Font,
+    /// The letter spacing used for buffers, and the terminal, in ems.
+    pub buffer_letter_spacing: LetterSpacing,
     /// The line height for buffers, and the terminal.
     ///
     /// Changing this may affect the spacing of some UI elements.
@@ -402,6 +404,9 @@ pub struct ThemeSettingsContent {
     /// The weight of the editor font in CSS units from 100 to 900.
     #[serde(default)]
     pub buffer_font_weight: Option<f32>,
+    /// The letter spacing of the editor font in ems.
+    #[serde(default)]
+    pub buffer_letter_spacing: Option<LetterSpacing>,
     /// The buffer's line height.
     #[serde(default)]
     pub buffer_line_height: Option<BufferLineHeight>,
@@ -788,6 +793,7 @@ impl settings::Settings for ThemeSettings {
                 style: FontStyle::default(),
             },
             buffer_font_size: defaults.buffer_font_size.unwrap().into(),
+            buffer_letter_spacing: defaults.buffer_letter_spacing.unwrap(),
             buffer_line_height: defaults.buffer_line_height.unwrap(),
             theme_selection: defaults.theme.clone(),
             active_theme: themes
@@ -891,6 +897,7 @@ impl settings::Settings for ThemeSettings {
             );
             this.buffer_font_size = this.buffer_font_size.clamp(px(6.), px(100.));
 
+            merge(&mut this.buffer_letter_spacing, value.buffer_letter_spacing);
             merge(&mut this.buffer_line_height, value.buffer_line_height);
 
             // Clamp the `unnecessary_code_fade` to ensure text can't disappear entirely.


### PR DESCRIPTION
Closes #10348 and #7621 (only on macOS)

First PR please bear with me

Linux support can trivially be added with https://docs.rs/cosmic-text/latest/cosmic_text/struct.Attrs.html, but I don't have a machine for testing

Not familiar with windows at all but I don't see anything immediately in https://learn.microsoft.com/en-us/windows/win32/api/dwrite/nn-dwrite-idwritetextlayout

Summary of changes:
- Add `buffer_letter_spacing` option, which controls a [CoreText "tracking" attribute](https://developer.apple.com/documentation/coretext/kcttrackingattributename), aka "letter spacing"
- Add a `LetterSpacing` to `gpui::style::TextStyle`
- Store `LetterSpacing` in `gpui::text_system::LineWrapper` and `editor::display_map::WrapMap` so line wrapping works correctly for different spacings

Notes for reviewers:
- IIUC, I think tracking should always be relative to font_size, but none of the `geometry` types seem to store `em`s. So I made a newtype for `LetterSpacing` and defer `to_px` as long as possible (only call it in the platform backend). Furthermore, CoreText wants points while cosmic_text wants ems, so this made sense to me.
- AFAICT this is the first code that can mess with the width of a line - seems like everything assumed the width of a line was equal to the sum of the widths of the glyphs, and the width of a glyph is the same as the offset between its start_x and the next glyph's start_x. (The first part should still be true because `compute_width_for_char` does layouting, but the second part is no longer true). So I'm not sure exactly what all can break.
- I put letter_spacing in `FontRuns` instead of alongside `font_size` (which would apply it to the whole line), because I assume if you have different fonts you might also want different tracking. But honestly I'm not sure when you have different fonts in a line. I only started using zed today.

Release Notes:

- Added `buffer_letter_spacing` option on macOS
