### PR TITLE
Agent eval: Copy `.rules` file into eval worktree for examples based on Zed

### DIFF
--- a/crates/eval/examples/find_and_replace_diff_card/base.toml
+++ b/crates/eval/examples/find_and_replace_diff_card/base.toml
@@ -1,3 +1,3 @@
 url = "https://github.com/zed-industries/zed.git"
-revision = "03ecb88fe30794873f191ddb728f597935b3101c"
+revision = "38fcadf9481d018543c65f36ac3bafeba190179b"
 language_extension = "rs"

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -232,10 +232,7 @@ impl Example {
         }
 
         if self.base.url == ZED_REPO_URL {
-            std::fs::write(
-                worktree_path.join(".rules"),
-                include_str!("../../../.rules"),
-            );
+            std::fs::write(worktree_path.join(".rules"), std::fs::read(".rules")?)?;
         }
 
         std::fs::create_dir_all(self.example_output_directory())?;

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -40,6 +40,8 @@ pub const WORKTREES_DIR: &str = "./crates/eval/worktrees";
 
 const THREAD_EVENT_TIMEOUT: Duration = Duration::from_secs(60 * 2);
 
+const ZED_REPO_URL: &str = "https://github.com/zed-industries/zed.git";
+
 #[derive(Clone, Debug, Deserialize)]
 pub struct ExampleBase {
     pub url: String,
@@ -227,6 +229,13 @@ impl Example {
                 ],
             )
             .await?;
+        }
+
+        if self.base.url == ZED_REPO_URL {
+            std::fs::write(
+                worktree_path.join(".rules"),
+                include_str!("../../../.rules"),
+            );
         }
 
         std::fs::create_dir_all(self.example_output_directory())?;
@@ -669,7 +678,11 @@ impl Example {
     async fn repository_diff(&self) -> Result<String> {
         let worktree_path = self.worktree_path();
         run_git(&worktree_path, &["add", "."]).await?;
-        run_git(&worktree_path, &["diff", "--staged"]).await
+        let mut diff_args = vec!["diff", "--staged"];
+        if self.base.url == ZED_REPO_URL {
+            diff_args.push(":(exclude).rules");
+        }
+        run_git(&worktree_path, &diff_args).await
     }
 }
 


### PR DESCRIPTION
Also reverts #29108, which cherry-picked the rules file for an eval example.

Release Notes:

- N/A