### PR TITLE
windows: Fix `window_min_size`

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -146,15 +146,14 @@ fn handle_get_min_max_info_msg(
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
     let lock = state_ptr.state.borrow();
-
     if let Some(min_size) = lock.min_size {
         let scale_factor = lock.scale_factor;
         drop(lock);
 
         unsafe {
             let minmax_info = &mut *(lparam.0 as *mut MINMAXINFO);
-            minmax_info.ptMinTrackSize.x = (min_size.width.0 * scale_factor) as i32;
-            minmax_info.ptMinTrackSize.y = (min_size.height.0 * scale_factor) as i32;
+            minmax_info.ptMinTrackSize.x = min_size.width.scale(scale_factor).0 as i32;
+            minmax_info.ptMinTrackSize.y = min_size.height.scale(scale_factor).0 as i32;
         }
     }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -153,8 +153,10 @@ fn handle_get_min_max_info_msg(
 
         unsafe {
             let minmax_info = &mut *(lparam.0 as *mut MINMAXINFO);
-            minmax_info.ptMinTrackSize.x = min_size.width.scale(scale_factor).0 as i32 + boarder_offset.width_offset;
-            minmax_info.ptMinTrackSize.y = min_size.height.scale(scale_factor).0 as i32 + boarder_offset.height_offset;
+            minmax_info.ptMinTrackSize.x =
+                min_size.width.scale(scale_factor).0 as i32 + boarder_offset.width_offset;
+            minmax_info.ptMinTrackSize.y =
+                min_size.height.scale(scale_factor).0 as i32 + boarder_offset.height_offset;
         }
         Some(0)
     } else {

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -155,9 +155,10 @@ fn handle_get_min_max_info_msg(
             minmax_info.ptMinTrackSize.x = min_size.width.scale(scale_factor).0 as i32;
             minmax_info.ptMinTrackSize.y = min_size.height.scale(scale_factor).0 as i32;
         }
+        Some(0)
+    } else {
+        None
     }
-
-    Some(0)
 }
 
 fn handle_size_msg(

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -148,12 +148,13 @@ fn handle_get_min_max_info_msg(
     let lock = state_ptr.state.borrow();
     if let Some(min_size) = lock.min_size {
         let scale_factor = lock.scale_factor;
+        let boarder_offset = lock.border_offset;
         drop(lock);
 
         unsafe {
             let minmax_info = &mut *(lparam.0 as *mut MINMAXINFO);
-            minmax_info.ptMinTrackSize.x = min_size.width.scale(scale_factor).0 as i32;
-            minmax_info.ptMinTrackSize.y = min_size.height.scale(scale_factor).0 as i32;
+            minmax_info.ptMinTrackSize.x = min_size.width.scale(scale_factor).0 as i32 + boarder_offset.width_offset;
+            minmax_info.ptMinTrackSize.y = min_size.height.scale(scale_factor).0 as i32 + boarder_offset.height_offset;
         }
         Some(0)
     } else {

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -145,13 +145,16 @@ fn handle_get_min_max_info_msg(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
-    let mut lock = state_ptr.state.borrow_mut();
+    let lock = state_ptr.state.borrow();
 
     if let Some(min_size) = lock.min_size {
+        let scale_factor = lock.scale_factor;
+        drop(lock);
+
         unsafe {
-            let mut minmax_info: &mut MINMAXINFO = &mut *(lparam.0 as *mut MINMAXINFO);
-            minmax_info.ptMinTrackSize.x = min_size.width.0 as i32;
-            minmax_info.ptMinTrackSize.y = min_size.height.0 as i32;
+            let minmax_info = &mut *(lparam.0 as *mut MINMAXINFO);
+            minmax_info.ptMinTrackSize.x = (min_size.width.0 * scale_factor) as i32;
+            minmax_info.ptMinTrackSize.y = (min_size.height.0 * scale_factor) as i32;
         }
     }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -39,6 +39,7 @@ pub(crate) fn handle_msg(
         WM_CREATE => handle_create_msg(handle, state_ptr),
         WM_MOVE => handle_move_msg(handle, lparam, state_ptr),
         WM_SIZE => handle_size_msg(wparam, lparam, state_ptr),
+        WM_GETMINMAXINFO => handle_get_min_max_info_msg(lparam, state_ptr),
         WM_ENTERSIZEMOVE | WM_ENTERMENULOOP => handle_size_move_loop(handle),
         WM_EXITSIZEMOVE | WM_EXITMENULOOP => handle_size_move_loop_exit(handle),
         WM_TIMER => handle_timer_msg(handle, wparam, state_ptr),
@@ -137,6 +138,23 @@ fn handle_move_msg(
         callback();
         state_ptr.state.borrow_mut().callbacks.moved = Some(callback);
     }
+    Some(0)
+}
+
+fn handle_get_min_max_info_msg(
+    lparam: LPARAM,
+    state_ptr: Rc<WindowsWindowStatePtr>,
+) -> Option<isize> {
+    let mut lock = state_ptr.state.borrow_mut();
+
+    if let Some(min_size) = lock.min_size {
+        unsafe {
+            let mut minmax_info: &mut MINMAXINFO = &mut *(lparam.0 as *mut MINMAXINFO);
+            minmax_info.ptMinTrackSize.x = min_size.width.0 as i32;
+            minmax_info.ptMinTrackSize.y = min_size.height.0 as i32;
+        }
+    }
+
     Some(0)
 }
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1031,8 +1031,8 @@ type Color = (u8, u8, u8, u8);
 
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct WindowBorderOffset {
-    width_offset: i32,
-    height_offset: i32,
+    pub(crate) width_offset: i32,
+    pub(crate) height_offset: i32,
 }
 
 impl WindowBorderOffset {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -34,6 +34,7 @@ pub(crate) struct WindowsWindow(pub Rc<WindowsWindowStatePtr>);
 pub struct WindowsWindowState {
     pub origin: Point<Pixels>,
     pub logical_size: Size<Pixels>,
+    pub min_size: Option<Size<Pixels>>,
     pub fullscreen_restore_bounds: Bounds<Pixels>,
     pub border_offset: WindowBorderOffset,
     pub scale_factor: f32,
@@ -79,6 +80,7 @@ impl WindowsWindowState {
         current_cursor: Option<HCURSOR>,
         display: WindowsDisplay,
         gpu_context: &BladeContext,
+        min_size: Option<Size<Pixels>>,
     ) -> Result<Self> {
         let scale_factor = {
             let monitor_dpi = unsafe { GetDpiForWindow(hwnd) } as f32;
@@ -113,6 +115,7 @@ impl WindowsWindowState {
             border_offset,
             scale_factor,
             restore_from_minimized,
+            min_size,
             callbacks,
             input_handler,
             system_key_handled,
@@ -229,6 +232,7 @@ impl WindowsWindowStatePtr {
             context.current_cursor,
             context.display,
             context.gpu_context,
+            context.min_size,
         )?);
 
         Ok(Rc::new_cyclic(|this| Self {
@@ -350,6 +354,7 @@ struct WindowCreateContext<'a> {
     display: WindowsDisplay,
     transparent: bool,
     is_movable: bool,
+    min_size: Option<Size<Pixels>>,
     executor: ForegroundExecutor,
     current_cursor: Option<HCURSOR>,
     windows_version: WindowsVersion,
@@ -412,6 +417,7 @@ impl WindowsWindow {
             display,
             transparent: true,
             is_movable: params.is_movable,
+            min_size: params.window_min_size,
             executor,
             current_cursor,
             windows_version,


### PR DESCRIPTION
Closes #29117

This makes `window_min_size` work by using the `WM_GETMINMAXINFO` window message.


Release Notes:

- N/A
