### PR TITLE
Canonicalize markdown link paths

### DIFF
--- a/crates/markdown_preview/Cargo.toml
+++ b/crates/markdown_preview/Cargo.toml
@@ -31,6 +31,7 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 workspace-hack.workspace = true
+fs.workspace = true
 
 [dev-dependencies]
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -4,6 +4,7 @@ use crate::markdown_elements::{
     ParsedMarkdownHeading, ParsedMarkdownListItem, ParsedMarkdownListItemType, ParsedMarkdownTable,
     ParsedMarkdownTableAlignment, ParsedMarkdownTableRow,
 };
+use fs::normalize_path;
 use gpui::{
     AbsoluteLength, AnyElement, App, AppContext as _, ClipboardItem, Context, DefiniteLength, Div,
     Element, ElementId, Entity, HighlightStyle, Hsla, ImageSource, InteractiveText, IntoElement,
@@ -491,9 +492,7 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                                         _ = workspace.update(cx, |workspace, cx| {
                                             workspace
                                                 .open_abs_path(
-                                                    path.clone()
-                                                        .canonicalize()
-                                                        .unwrap_or(path.clone()),
+                                                    normalize_path(path.clone().as_path()),
                                                     OpenOptions {
                                                         visible: Some(OpenVisible::None),
                                                         ..Default::default()

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -491,7 +491,9 @@ fn render_markdown_text(parsed_new: &MarkdownParagraph, cx: &mut RenderContext) 
                                         _ = workspace.update(cx, |workspace, cx| {
                                             workspace
                                                 .open_abs_path(
-                                                    path.clone(),
+                                                    path.clone()
+                                                        .canonicalize()
+                                                        .unwrap_or(path.clone()),
                                                     OpenOptions {
                                                         visible: Some(OpenVisible::None),
                                                         ..Default::default()


### PR DESCRIPTION
Closes #28657

Release Notes:

- Fixed markdown preview not canonicalizing file paths
