### PR TITLE
vim: Improve comment motions

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2720,15 +2720,10 @@ fn comment_motion(
                     return None;
                 }
 
-                let relevant = if direction == Direction::Prev {
-                    range.start
-                } else {
-                    range.end
-                };
-                if direction == Direction::Prev && relevant < offset {
-                    Some(relevant)
-                } else if direction == Direction::Next && relevant > offset + 1 {
-                    Some(relevant)
+                if direction == Direction::Prev && range.start < offset {
+                    Some(range.start)
+                } else if direction == Direction::Next && range.start > offset + 1 {
+                    Some(range.start)
                 } else {
                     None
                 }

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2720,9 +2720,9 @@ fn comment_motion(
                     return None;
                 }
 
-                if direction == Direction::Prev && range.start < offset {
-                    Some(range.start)
-                } else if direction == Direction::Next && range.start > offset + 1 {
+                if (direction == Direction::Prev && range.start < offset)
+                    || (direction == Direction::Next && range.start > offset + 1)
+                {
                     Some(range.start)
                 } else {
                     None


### PR DESCRIPTION
Not sure if this was intended, but I think it's a bug for `NextComment` motion to bring the cursor to the end of the comment, instead of the start:

https://github.com/user-attachments/assets/49735534-aa9b-4362-a89b-3a955406cf54

Another occurrence is when already inside a comment, `NextComment` brings the cursor to the end instead of the 'next comment' which the motion describes:

https://github.com/user-attachments/assets/39f85f1c-6d0e-4c36-acac-79fdda54a55b

In section and method motions, we have `NextSectionStart` and `PreviousSectionEnd`, but since we dont have different commands for comments I think always moving to the start is a better choice. 

Release Notes:

- N/A