### PR TITLE
Hide editor context menu when modal is opened

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -931,15 +931,14 @@ impl Item for Editor {
         cx: &mut Context<Self>,
     ) {
         self.workspace = Some((workspace.weak_handle(), workspace.database_id()));
-        cx.subscribe(
-            &workspace.weak_handle().upgrade().unwrap(),
-            |editor, _, event: &workspace::Event, _cx| {
+        if let Some(workspace) = &workspace.weak_handle().upgrade() {
+            cx.subscribe(&workspace, |editor, _, event: &workspace::Event, _cx| {
                 if matches!(event, workspace::Event::ModalOpened) {
                     editor.mouse_context_menu.take();
                 }
-            },
-        )
-        .detach();
+            })
+            .detach();
+        }
     }
 
     fn to_item_events(event: &EditorEvent, mut f: impl FnMut(ItemEvent)) {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -928,9 +928,18 @@ impl Item for Editor {
         &mut self,
         workspace: &mut Workspace,
         _window: &mut Window,
-        _: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         self.workspace = Some((workspace.weak_handle(), workspace.database_id()));
+        cx.subscribe(
+            &workspace.weak_handle().upgrade().unwrap(),
+            |editor, _, event: &workspace::Event, _cx| {
+                if matches!(event, workspace::Event::ModalOpened) {
+                    editor.mouse_context_menu.take();
+                }
+            },
+        )
+        .detach();
     }
 
     fn to_item_events(event: &EditorEvent, mut f: impl FnMut(ItemEvent)) {

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -56,11 +56,9 @@ pub struct ModalLayer {
     dismiss_on_focus_lost: bool,
 }
 
-pub(crate) enum Event {
-    ModalOpened,
-}
+pub(crate) struct ModalOpenedEvent;
 
-impl EventEmitter<Event> for ModalLayer {}
+impl EventEmitter<ModalOpenedEvent> for ModalLayer {}
 
 impl Default for ModalLayer {
     fn default() -> Self {
@@ -90,7 +88,7 @@ impl ModalLayer {
         }
         let new_modal = cx.new(|cx| build_view(window, cx));
         self.show_modal(new_modal, window, cx);
-        cx.emit(Event::ModalOpened);
+        cx.emit(ModalOpenedEvent);
     }
 
     fn show_modal<V>(&mut self, new_modal: Entity<V>, window: &mut Window, cx: &mut Context<Self>)

--- a/crates/workspace/src/modal_layer.rs
+++ b/crates/workspace/src/modal_layer.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    AnyView, DismissEvent, Entity, FocusHandle, Focusable as _, ManagedView, MouseButton,
-    Subscription,
+    AnyView, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable as _, ManagedView,
+    MouseButton, Subscription,
 };
 use ui::prelude::*;
 
@@ -56,6 +56,12 @@ pub struct ModalLayer {
     dismiss_on_focus_lost: bool,
 }
 
+pub(crate) enum Event {
+    ModalOpened,
+}
+
+impl EventEmitter<Event> for ModalLayer {}
+
 impl Default for ModalLayer {
     fn default() -> Self {
         Self::new()
@@ -84,6 +90,7 @@ impl ModalLayer {
         }
         let new_modal = cx.new(|cx| build_view(window, cx));
         self.show_modal(new_modal, window, cx);
+        cx.emit(Event::ModalOpened);
     }
 
     fn show_modal<V>(&mut self, new_modal: Entity<V>, window: &mut Window, cx: &mut Context<Self>)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1052,11 +1052,12 @@ impl Workspace {
         cx.emit(Event::WorkspaceCreated(weak_handle.clone()));
         let modal_layer = cx.new(|_| ModalLayer::new());
         let toast_layer = cx.new(|_| ToastLayer::new());
-        cx.subscribe(&modal_layer, |_, _, event: &modal_layer::Event, cx| {
-            if matches!(event, modal_layer::Event::ModalOpened) {
+        cx.subscribe(
+            &modal_layer,
+            |_, _, _: &modal_layer::ModalOpenedEvent, cx| {
                 cx.emit(Event::ModalOpened);
-            }
-        })
+            },
+        )
         .detach();
 
         let bottom_dock_layout = WorkspaceSettings::get_global(cx).bottom_dock_layout;

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -781,6 +781,7 @@ pub enum Event {
         language: &'static str,
     },
     ZoomChanged,
+    ModalOpened,
 }
 
 #[derive(Debug)]
@@ -1051,6 +1052,12 @@ impl Workspace {
         cx.emit(Event::WorkspaceCreated(weak_handle.clone()));
         let modal_layer = cx.new(|_| ModalLayer::new());
         let toast_layer = cx.new(|_| ToastLayer::new());
+        cx.subscribe(&modal_layer, |_, _, event: &modal_layer::Event, cx| {
+            if matches!(event, modal_layer::Event::ModalOpened) {
+                cx.emit(Event::ModalOpened);
+            }
+        })
+        .detach();
 
         let bottom_dock_layout = WorkspaceSettings::get_global(cx).bottom_dock_layout;
         let left_dock = Dock::new(DockPosition::Left, modal_layer.clone(), window, cx);


### PR DESCRIPTION
Closes #28787 

The context menu appears before the modal because it is a Deferred element, which is always displayed above normal elements.

Release Notes:

Previously, the editor context menu appeared before the Command Palette. This commit ensures the editor context menu is hidden when a modal, including the Command Palette, is opened.

