### PR TITLE
Add right click in terminal create new selection if none present

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1554,8 +1554,9 @@ impl Terminal {
             self.last_content.terminal_bounds,
             self.last_content.display_offset,
         );
-        let selection = Selection::new(SelectionType::Semantic, point, side);  
-        self.events.push_back(InternalEvent::SetSelection(Some((selection, point))));  
+        let selection = Selection::new(SelectionType::Semantic, point, side);
+        self.events
+            .push_back(InternalEvent::SetSelection(Some((selection, point))));
     }
 
     pub fn mouse_drag(

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1547,7 +1547,6 @@ impl Terminal {
         }
     }
 
-    // this logic is from mouse_down
     pub fn select_word_at_event_position(&mut self, e: &MouseDownEvent) {
         let position = e.position - self.last_content.terminal_bounds.bounds.origin;
         let (point, side) = grid_point_and_side(
@@ -1555,14 +1554,8 @@ impl Terminal {
             self.last_content.terminal_bounds,
             self.last_content.display_offset,
         );
-        let selection_type = Some(SelectionType::Semantic);
-        let selection = 
-            selection_type.map(|selection_type| Selection::new(selection_type, point, side));
-
-        if let Some(sel) = selection {
-            self.events
-                .push_back(InternalEvent::SetSelection(Some((sel, point))));
-        }
+        let selection = Selection::new(SelectionType::Semantic, point, side);  
+        self.events.push_back(InternalEvent::SetSelection(Some((selection, point))));  
     }
 
     pub fn mouse_drag(

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1547,6 +1547,24 @@ impl Terminal {
         }
     }
 
+    // this logic is from mouse_down
+    pub fn select_word_at_event_position(&mut self, e: &MouseDownEvent){
+        let position = e.position - self.last_content.terminal_bounds.bounds.origin;
+        let (point, side) = grid_point_and_side(
+            position,
+            self.last_content.terminal_bounds,
+            self.last_content.display_offset,
+        );
+        let selection_type = Some(SelectionType::Semantic);
+        let selection = selection_type
+            .map(|selection_type| Selection::new(selection_type, point, side));
+
+        if let Some(sel) = selection {
+            self.events
+                .push_back(InternalEvent::SetSelection(Some((sel, point))));
+        }
+    }
+
     pub fn mouse_drag(
         &mut self,
         e: &MouseMoveEvent,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1548,7 +1548,7 @@ impl Terminal {
     }
 
     // this logic is from mouse_down
-    pub fn select_word_at_event_position(&mut self, e: &MouseDownEvent){
+    pub fn select_word_at_event_position(&mut self, e: &MouseDownEvent) {
         let position = e.position - self.last_content.terminal_bounds.bounds.origin;
         let (point, side) = grid_point_and_side(
             position,
@@ -1556,8 +1556,8 @@ impl Terminal {
             self.last_content.display_offset,
         );
         let selection_type = Some(SelectionType::Semantic);
-        let selection = selection_type
-            .map(|selection_type| Selection::new(selection_type, point, side));
+        let selection = 
+            selection_type.map(|selection_type| Selection::new(selection_type, point, side));
 
         if let Some(sel) = selection {
             self.events

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1290,7 +1290,9 @@ impl Render for TerminalView {
                 cx.listener(|this, event: &MouseDownEvent, window, cx| {
                     if !this.terminal.read(cx).mouse_mode(event.modifiers.shift) {
                         if this.terminal.read(cx).last_content.selection.is_none() {
-                            this.expand_selection_around_cursor(event, cx);
+                            this.terminal.update(cx, |terminal, _| {
+                                terminal.select_word_at_event_position(event);
+                            });
                         };
                         this.deploy_context_menu(event.position, window, cx);
                         cx.notify();

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -833,16 +833,6 @@ impl TerminalView {
         )
     }
 
-    fn expand_selection_around_cursor(
-        &mut self,
-        e: &MouseDownEvent,
-        cx: &mut Context<Self>,
-    ) {
-        self.terminal.update(cx, |terminal, _| {
-            terminal.select_word_at_event_position(e);
-        });
-        cx.notify();
-    }
 }
 
 fn subscribe_for_terminal_events(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -832,7 +832,6 @@ impl TerminalView {
                 }),
         )
     }
-
 }
 
 fn subscribe_for_terminal_events(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -836,7 +836,6 @@ impl TerminalView {
     fn expand_selection_around_cursor(
         &mut self,
         e: &MouseDownEvent,
-        window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.terminal.update(cx, |terminal, _| {
@@ -1291,7 +1290,7 @@ impl Render for TerminalView {
                 cx.listener(|this, event: &MouseDownEvent, window, cx| {
                     if !this.terminal.read(cx).mouse_mode(event.modifiers.shift) {
                         if this.terminal.read(cx).last_content.selection.is_none() {
-                            this.expand_selection_around_cursor(event, window, cx);
+                            this.expand_selection_around_cursor(event, cx);
                         };
                         this.deploy_context_menu(event.position, window, cx);
                         cx.notify();

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -832,6 +832,18 @@ impl TerminalView {
                 }),
         )
     }
+
+    fn expand_selection_around_cursor(
+        &mut self,
+        e: &MouseDownEvent,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.terminal.update(cx, |terminal, _| {
+            terminal.select_word_at_event_position(e);
+        });
+        cx.notify();
+    }
 }
 
 fn subscribe_for_terminal_events(
@@ -1278,6 +1290,9 @@ impl Render for TerminalView {
                 MouseButton::Right,
                 cx.listener(|this, event: &MouseDownEvent, window, cx| {
                     if !this.terminal.read(cx).mouse_mode(event.modifiers.shift) {
+                        if this.terminal.read(cx).last_content.selection.is_none() {
+                            this.expand_selection_around_cursor(event, window, cx);
+                        };
                         this.deploy_context_menu(event.position, window, cx);
                         cx.notify();
                     }


### PR DESCRIPTION
This PR adds functionality to right click in terminal create new selection if none present. The selection is identical with double click a text in terminal, plus the logic is moved from the double-click in the terminal::mouse_down.

Closes #28237 

Release Notes:

- Adds functionality to right click in terminal create new selection if none present



