### PR TITLE
vim: Add normal mode when losing focus

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1489,6 +1489,7 @@
     "use_multiline_find": false,
     "use_smartcase_find": false,
     "highlight_on_yank_duration": 200,
+    "normal_mode_on_focus_loss": false,
     "custom_digraphs": {}
   },
   // The server to connect to. If the environment variable

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1189,6 +1189,11 @@ impl Vim {
         self.stop_recording_immediately(NormalBefore.boxed_clone(), cx);
         self.store_visual_marks(window, cx);
         self.clear_operator(window, cx);
+
+        if VimSettings::get_global(cx).normal_mode_on_focus_loss && self.mode != Mode::Normal {
+            self.switch_mode(Mode::Normal, false, window, cx);
+        }
+
         self.update_editor(window, cx, |vim, editor, _, cx| {
             if vim.cursor_shape(cx) == CursorShape::Block {
                 editor.set_cursor_shape(CursorShape::Hollow, cx);
@@ -1702,6 +1707,7 @@ struct VimSettings {
     pub use_smartcase_find: bool,
     pub custom_digraphs: HashMap<String, Arc<str>>,
     pub highlight_on_yank_duration: u64,
+    pub normal_mode_on_focus_loss: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1713,6 +1719,7 @@ struct VimSettingsContent {
     pub use_smartcase_find: Option<bool>,
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_yank_duration: Option<u64>,
+    pub normal_mode_on_focus_loss: Option<bool>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1770,6 +1777,9 @@ impl Settings for VimSettings {
             custom_digraphs: settings.custom_digraphs.ok_or_else(Self::missing_default)?,
             highlight_on_yank_duration: settings
                 .highlight_on_yank_duration
+                .ok_or_else(Self::missing_default)?,
+            normal_mode_on_focus_loss: settings
+                .normal_mode_on_focus_loss
                 .ok_or_else(Self::missing_default)?,
         })
     }

--- a/docs/src/vim.md
+++ b/docs/src/vim.md
@@ -491,7 +491,8 @@ You can change the following settings to modify vim mode's behavior:
 | use_smartcase_find           | If `true`, `f` and `t` motions are case-insensitive when the target letter is lowercase.                                                                                                      | false         |
 | toggle_relative_line_numbers | If `true`, line numbers are relative in normal mode and absolute in insert mode, giving you the best of both options.                                                                         | false         |
 | custom_digraphs              | An object that allows you to add custom digraphs. Read below for an example.                                                                                                                  | {}            |
-| highlight_on_yank_duration   | The duration of the highlight animation(in ms). Set to `0` to disable                                                                                                                         | 200           |
+| highlight_on_yank_duration   | The duration of the highlight animation(in ms). Set to `0` to disable.                                                                                                                        | 200           |
+| normal_mode_on_focus_loss    | If `true`, switches to normal mode when the window or buffer loses focus.                                                                                                                     | false         |
 
 Here's an example of adding a digraph for the zombie emoji. This allows you to type `ctrl-k f z` to insert a zombie emoji. You can add as many digraphs as you like.
 
@@ -516,6 +517,7 @@ Here's an example of these settings changed:
     "use_smartcase_find": true,
     "toggle_relative_line_numbers": true,
     "highlight_on_yank_duration": 50,
+    "normal_mode_on_focus_loss": true,
     "custom_digraphs": {
       "fz": "🧟‍♀️"
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/18474

Release Notes:

- vim: Added a setting to switch to normal mode when losing focus.
