### PR TITLE
editor: Hide signature popover on editor scroll

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1723,6 +1723,7 @@ impl Editor {
                                 new_anchor.offset,
                             );
                         });
+                        editor.hide_signature_help(cx, SignatureHelpHiddenBy::Escape);
                     }
                 }
                 EditorEvent::Edited { .. } => {


### PR DESCRIPTION
Closes #27845

This is also how VSCode tackles this issue. I think this should be applicable to even more popovers across the editor and context menu, but it can be addressed later.

Release Notes:

- Fixed the signature popover not hiding on editor scroll.
