### PR TITLE
Tweak sorting of completions to (hopefully) fix intelligent matching

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -700,6 +700,8 @@ impl CompletionsMenu {
             }
         }
 
+        // checking write access
+
         let completions = self.completions.borrow_mut();
         if self.sort_completions {
             matches.sort_unstable_by_key(|mat| {

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -712,22 +712,22 @@ impl CompletionsMenu {
                 // Strong matches are the ones with a high fuzzy-matcher score (the "obvious" matches)
                 // and the Weak matches are the rest.
                 //
-                // For the strong matches, we sort by our fuzzy-finder score first and for the weak
-                // matches, we prefer language-server sort_text first.
+                // For the strong matches, we sort by the language-servers score first and for the weak
+                // matches, we prefer our fuzzy finder first.
                 //
-                // The thinking behind that: we want to show strong matches first in order of relevance(fuzzy score).
-                // Rest of the matches(weak) can be sorted as language-server expects.
+                // The thinking behind that: it's useless to take the sort_text the language-server gives
+                // us into account when it's obviously a bad match.
 
                 #[derive(PartialEq, Eq, PartialOrd, Ord)]
                 enum MatchScore<'a> {
                     Strong {
-                        score: Reverse<OrderedFloat<f64>>,
                         sort_text: Option<&'a str>,
+                        score: Reverse<OrderedFloat<f64>>,
                         sort_key: (usize, &'a str),
                     },
                     Weak {
-                        sort_text: Option<&'a str>,
                         score: Reverse<OrderedFloat<f64>>,
+                        sort_text: Option<&'a str>,
                         sort_key: (usize, &'a str),
                     },
                 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11290,7 +11290,7 @@ async fn test_completion_sort(cx: &mut TestAppContext) {
                 },
                 lsp::CompletionItem {
                     label: "r".into(),
-                    sort_text: Some("b".into()),
+                    kind: Some(lsp::CompletionItemKind::SNIPPET),
                     ..Default::default()
                 },
                 lsp::CompletionItem {
@@ -14061,7 +14061,7 @@ async fn test_completions_in_languages_with_extra_word_characters(cx: &mut TestA
         {
             assert_eq!(
                 completion_menu_entries(&menu),
-                &["bg-red", "bg-blue", "bg-yellow"]
+                &["bg-blue", "bg-red", "bg-yellow"]
             );
         } else {
             panic!("expected completion menu to be open");


### PR DESCRIPTION
This partially addresses #29050 by reverting #20145, and instead explicitly sorting completions by type instead of only relying on the language-server-provided sort text. The specific order is just derived from what the tests expect from the sorting so far.

before:
![image](https://github.com/user-attachments/assets/ff735c1c-9231-435b-9b1d-28df38855868)
![image](https://github.com/user-attachments/assets/659adae9-78b2-45cf-a9b8-2c02a0b72ddb)

after:
![image](https://github.com/user-attachments/assets/c80f839d-05eb-4028-a0a6-0763b8a3f53d)
![image](https://github.com/user-attachments/assets/4ac50124-6e15-4b10-8b7c-47f44c2c59d5)

Release Notes:
- Improved sort order in completions