### PR TITLE
zlog: Various improvements

### DIFF
--- a/crates/zlog/src/env_config.rs
+++ b/crates/zlog/src/env_config.rs
@@ -18,12 +18,12 @@ pub fn parse(filter: &str) -> Result<EnvFilter> {
                     return Err(anyhow!("Invalid directive: {}", directive));
                 }
                 let level = parse_level(level.trim())?;
-                directive_names.push(name.to_string());
+                directive_names.push(name.trim().trim_end_matches(".rs").to_string());
                 directive_levels.push(level);
             }
             None => {
                 let Ok(level) = parse_level(directive.trim()) else {
-                    directive_names.push(directive.trim().to_string());
+                    directive_names.push(directive.trim().trim_end_matches(".rs").to_string());
                     directive_levels.push(log::LevelFilter::max() /* Enable all levels */);
                     continue;
                 };

--- a/crates/zlog/src/sink.rs
+++ b/crates/zlog/src/sink.rs
@@ -257,6 +257,7 @@ mod tests {
         assert_eq!(size.load(Ordering::Relaxed), 0);
     }
 
+    /// Regression test, ensuring that if log level values change we are made aware
     #[test]
     fn test_log_level_names() {
         assert_eq!(LEVEL_OUTPUT_STRINGS[log::Level::Error as usize], "ERROR");

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -269,6 +269,7 @@ impl log::Log for Logger {
             message: record.args(),
         });
     }
+
     fn flush(&self) {
         sink::flush();
     }
@@ -299,6 +300,7 @@ impl Timer {
             done: false,
         };
     }
+
     pub fn warn_if_gt(mut self, warn_limit: std::time::Duration) -> Self {
         self.warn_if_longer_than = Some(warn_limit);
         return self;


### PR DESCRIPTION
Various improvements to `zlog` including:

- Enable filtering by module (reproducing `env_logger` behavior) both through env and settings.
    - Note: filtering by module currently does not account for parent module configuration, but does account for crate configuration.
      i.e. `crate=trace` will enable `TRACE` messages in `crate::a` and `crate::a::b` modules, but `crate::a=trace` will not enable trace messages in module `crate::a::b`
- Implementing the `Log` trait for `zlog::Logger` to support gradual transition and evaluate tradeoffs of always going through `log` crate.
- Added the ability to turn off logging for a specific filter (module or scope) completely by setting it to `off` (in env: `crate::a=off`, in settings: `"project.foo": "off"`)
- Made it so the `zlog::scoped!` macro can be used in constant expressions, so scoped loggers can be declared as global constants

Release Notes:

- N/A
