### PR TITLE
agent: Do not render empty message

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1503,6 +1503,11 @@ impl ActiveThread {
             return Empty.into_any();
         }
 
+        let message_is_empty = message.should_display_content();
+        if message_is_empty && context.is_empty() {
+            return Empty.into_any();
+        }
+
         let allow_editing_message = message.role == Role::User;
 
         let edit_message_editor = self
@@ -1635,11 +1640,9 @@ impl ActiveThread {
                 .into_any_element(),
         };
 
-        let message_is_empty = message.should_display_content();
-        let has_content = !message_is_empty || !context.is_empty();
-
+        let message_has_content = !message_is_empty || !context.is_empty();
         let message_content =
-            has_content.then(|| {
+            message_has_content.then(|| {
                 v_flex()
                     .gap_1p5()
                     .when(!message_is_empty, |parent| {


### PR DESCRIPTION
This came up when i cancelled a request, because some tools we're still running:

<img width="642" alt="image" src="https://github.com/user-attachments/assets/7526ee74-37d3-47a6-9429-34a3d7feac24" />

Release Notes:

- N/A
