### PR TITLE
Fix ctrl-c in vim normal mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -830,5 +830,13 @@
       // and Windows.
       "alt-l": "editor::AcceptEditPrediction"
     }
+  },
+  {
+    // Fixes https://github.com/zed-industries/zed/issues/29095 by ensuring that
+    // the last binding for editor::ToggleComments is not ctrl-c.
+    "context": "hack_to_fix_ctrl-c",
+    "bindings": {
+      "g c": "editor::ToggleComments"
+    }
   }
 ]


### PR DESCRIPTION
This was broken when we added helix keybindings because we populate the
menu's shortcut based on the "last" seen binding for an action ignoring context.

Release Notes:

- Fix `ctrl-c` in vim normal mode
