### PR TITLE
Use buffer size for markdown preview

### DIFF
--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -11,6 +11,8 @@ use gpui::{
     list,
 };
 use language::LanguageRegistry;
+use settings::Settings;
+use theme::ThemeSettings;
 use ui::prelude::*;
 use workspace::item::{Item, ItemHandle};
 use workspace::{Pane, Workspace};
@@ -504,6 +506,7 @@ impl Item for MarkdownPreviewView {
 
 impl Render for MarkdownPreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let buffer_size = ThemeSettings::get_global(cx).buffer_font_size(cx);
         v_flex()
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")
@@ -511,6 +514,7 @@ impl Render for MarkdownPreviewView {
             .size_full()
             .bg(cx.theme().colors().editor_background)
             .p_4()
+            .text_size(buffer_size)
             .child(
                 div()
                     .flex_grow()

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -507,6 +507,7 @@ impl Item for MarkdownPreviewView {
 impl Render for MarkdownPreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let buffer_size = ThemeSettings::get_global(cx).buffer_font_size(cx);
+        let buffer_line_height = ThemeSettings::get_global(cx).buffer_line_height;
         dbg!(("frame", buffer_size));
         v_flex()
             .id("MarkdownPreview")
@@ -516,6 +517,7 @@ impl Render for MarkdownPreviewView {
             .bg(cx.theme().colors().editor_background)
             .p_4()
             .text_size(buffer_size)
+            .line_height(relative(buffer_line_height.value()))
             .child(
                 div()
                     .flex_grow()

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -238,11 +238,10 @@ impl MarkdownPreviewView {
 
                                     container.child(
                                         div()
-                                            .debug_below()
                                             .relative()
                                             .child(
                                                 div()
-                                                    .p(render_cx.scaled_rems(1.0))
+                                                    .pl(render_cx.scaled_rems(1.0))
                                                     .child(rendered_block),
                                             )
                                             .child(indicator.absolute().left_0().top_0()),

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -187,6 +187,7 @@ impl MarkdownPreviewView {
                                             })
                                         }
                                     });
+
                             let block = contents.children.get(ix).unwrap();
                             let rendered_block = render_markdown_block(block, &mut render_cx);
 
@@ -197,7 +198,9 @@ impl MarkdownPreviewView {
 
                             div()
                                 .id(ix)
-                                .when(should_apply_padding, |this| this.pb_3())
+                                .when(should_apply_padding, |this| {
+                                    this.pb(render_cx.scaled_rems(0.75))
+                                })
                                 .group("markdown-block")
                                 .on_click(cx.listener(
                                     move |this, event: &ClickEvent, window, cx| {
@@ -235,8 +238,13 @@ impl MarkdownPreviewView {
 
                                     container.child(
                                         div()
+                                            .debug_below()
                                             .relative()
-                                            .child(div().pl_4().child(rendered_block))
+                                            .child(
+                                                div()
+                                                    .p(render_cx.scaled_rems(1.0))
+                                                    .child(rendered_block),
+                                            )
                                             .child(indicator.absolute().left_0().top_0()),
                                     )
                                 })
@@ -508,7 +516,6 @@ impl Render for MarkdownPreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let buffer_size = ThemeSettings::get_global(cx).buffer_font_size(cx);
         let buffer_line_height = ThemeSettings::get_global(cx).buffer_line_height;
-        dbg!(("frame", buffer_size));
         v_flex()
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -507,6 +507,7 @@ impl Item for MarkdownPreviewView {
 impl Render for MarkdownPreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let buffer_size = ThemeSettings::get_global(cx).buffer_font_size(cx);
+        dbg!(("frame", buffer_size));
         v_flex()
             .id("MarkdownPreview")
             .key_context("MarkdownPreview")

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -156,7 +156,17 @@ fn render_markdown_heading(parsed: &ParsedMarkdownHeading, cx: &mut RenderContex
     let buffer_text_size = cx.buffer_text_style.font_size;
 
     let text_size = buffer_text_size.to_rems(cx.window_rem_size).mul(size);
-    let line_height = DefiniteLength::from(text_size.mul(1.25));
+
+    // was `DefiniteLength::from(text_size.mul(1.25))`
+    // let line_height = DefiniteLength::from(text_size.mul(1.25));
+    let line_height = relative(1.25);
+
+    // was `rems(0.15)`
+    // let padding_top = rems(0.15);
+    let padding_top = cx.window_rem_size.mul(0.15);
+
+    // was `.pb_1()` = `rems(0.25)`
+    let padding_bottom = cx.window_rem_size.mul(0.25);
 
     let color = match parsed.level {
         HeadingLevel::H6 => cx.text_muted_color,
@@ -166,8 +176,8 @@ fn render_markdown_heading(parsed: &ParsedMarkdownHeading, cx: &mut RenderContex
         .line_height(line_height)
         .text_size(text_size)
         .text_color(color)
-        .pt(rems(0.15).mul(size)) // fixme: This helps spacing, but it still seems to bunched when zoomed in, and too spread when zoomed out
-        .pb_1()
+        .pt(padding_top)
+        .pb(padding_bottom)
         .children(render_markdown_text(&parsed.contents, cx))
         .whitespace_normal()
         .into_any()


### PR DESCRIPTION
Note:

This is implemented in a very hacky and one-off manner. The primary change is to pass a rem size through the markdown render tree, and scale all sizing (rems & pixels) based on the passed in rem size manually. This required copying in the `CheckBox` component from `ui::CheckBox` to make it use the manual rem scaling without modifying the `CheckBox` implementation directly as it is used elsewhere. 

A better solution is required, likely involving `window.with_rem_size` and/or _actual_ `em` units that allow text-size-relative scaling.

Release Notes:

- Made it so Markdown preview uses the _buffer_ font size instead of the _ui_ font size.
