### PR TITLE
Fix block cursor behavior during selection in non-Vim mode

### DIFF
--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -30,6 +30,7 @@ pub struct SelectionsCollection {
     buffer: Entity<MultiBuffer>,
     pub next_selection_id: usize,
     pub line_mode: bool,
+    pub vim_mode: bool,
     /// The non-pending, non-overlapping selections.
     /// The [SelectionsCollection::pending] selection could possibly overlap these
     pub disjoint: Arc<[Selection<Anchor>]>,
@@ -44,6 +45,7 @@ impl SelectionsCollection {
             buffer,
             next_selection_id: 1,
             line_mode: false,
+            vim_mode: false,
             disjoint: Arc::default(),
             pending: Some(PendingSelection {
                 selection: Selection {
@@ -69,6 +71,7 @@ impl SelectionsCollection {
     pub fn clone_state(&mut self, other: &SelectionsCollection) {
         self.next_selection_id = other.next_selection_id;
         self.line_mode = other.line_mode;
+        self.vim_mode = other.vim_mode;
         self.disjoint = other.disjoint.clone();
         self.pending.clone_from(&other.pending);
     }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -431,6 +431,7 @@ impl Vim {
     }
 
     fn activate(editor: &mut Editor, window: &mut Window, cx: &mut Context<Editor>) {
+        editor.selections.vim_mode = true;
         let vim = Vim::new(window, cx);
 
         editor.register_addon(VimAddon {
@@ -717,6 +718,7 @@ impl Vim {
     }
 
     fn deactivate(editor: &mut Editor, cx: &mut Context<Editor>) {
+        editor.selections.vim_mode = false;
         editor.set_cursor_shape(CursorShape::Bar, cx);
         editor.set_clip_at_line_ends(false, cx);
         editor.set_collapse_matches(false);


### PR DESCRIPTION
Closes #29110 

In Vim mode, block or hollow cursor shapes require special handling for selections. Without this fix, non-Vim mode could appear odd when users prefer a block cursor.

Summary of changes:
- Added `vim_mode` field to `SelectionsCollection`.
- Enabled special block cursor selection handling in Vim mode when `vim_mode` is true.
- Updated the `vim` crate to set `vim_mode` based on Vim mode setting changes.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
