### PR TITLE
docs: Update "checkOnSave" to "check"

### DIFF
--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -143,7 +143,7 @@ Many language servers accept custom configuration options. You can set these in 
   "lsp": {
     "rust-analyzer": {
       "initialization_options": {
-        "checkOnSave": {
+        "check": {
           "command": "clippy"
         }
       }


### PR DESCRIPTION
As-salamu alaykum,

[I recently started suffering from the same issue as this user](https://users.rust-lang.org/t/rust-analyzer-checkonsave-command-works-but-shows-invalid-config-warning/128652), which is caused by something the docs of Zed promote, so I decided to help fix it.

>[anutrix](https://users.rust-lang.org/u/anutrix)
> When I add "rust-analyzer.checkOnSave.command": "clippy" I get:
> 
> invalid config value: /checkOnSave: invalid type: map, expected a boolean;
> Extension Info: Version 0.3.2433, Server Version 0.3.2433-standalone (66e3b5819e 2025-04-21)
> and in Language Server logs:
> 
> [Error - 3:26:22 AM] Server process exited with code 0.
> Clippy works fine but these warnings stays and extensions shows yellow/unstable in VSCode:
> 
> Additionally, if I replace
> 
>     "rust-analyzer.checkOnSave.command": "clippy"
> with
> 
>     "rust-analyzer.checkOnSave": true,
>     "rust-analyzer.checkOnSave.command": "clippy"

> [jplatte](https://users.rust-lang.org/u/jplatte)
> From the documentation, it seems like rust-analyzer.checkOnSave.command does not exist. It should be rust-analyzer.check.command.