### PR TITLE
Fix clamp panic when scrollbars (viewport_size - thumb_size) ends up negative

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -334,7 +334,7 @@ impl Element for Scrollbar {
                             let thumb_start = (event.position.along(axis)
                                 - padded_bounds.origin.along(axis)
                                 - (thumb_size / 2.))
-                                .clamp(px(0.), viewport_size - thumb_size);
+                                .clamp(px(0.), (viewport_size - thumb_size).max(px(0.)));
 
                             let max_offset = (item_size.along(axis) - viewport_size).max(px(0.));
                             let percentage = if viewport_size > thumb_size {


### PR DESCRIPTION
Tiny fix for occasional crash when swapping between repos in the repository selector by using 0 if (viewport_size - thumb_size) goes negative

Release Notes:

- Fixed a potential panic with scrollbars.