### PR TITLE
collab: Don't require payment method to start a trial

### DIFF
--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -416,9 +416,16 @@ impl StripeBilling {
         let mut params = stripe::CreateCheckoutSession::new();
         params.subscription_data = Some(stripe::CreateCheckoutSessionSubscriptionData {
             trial_period_days: Some(14),
+            trial_settings: Some(stripe::CreateCheckoutSessionSubscriptionDataTrialSettings {
+                end_behavior: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior {
+                    missing_payment_method: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::Pause,
+                }
+            }),
             ..Default::default()
         });
         params.mode = Some(stripe::CheckoutSessionMode::Subscription);
+        params.payment_method_collection =
+            Some(stripe::CheckoutSessionPaymentMethodCollection::IfRequired);
         params.customer = Some(customer_id);
         params.client_reference_id = Some(github_login);
         params.line_items = Some(vec![stripe::CreateCheckoutSessionLineItems {


### PR DESCRIPTION
This PR makes it so a payment method is not required in order to start a Zed Pro trial.

Release Notes:

- N/A
