### PR TITLE
gpui: Align image sprites to whole pixels

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2659,7 +2659,9 @@ impl Window {
             order: 0,
             pad: 0,
             grayscale,
-            bounds,
+            bounds: bounds
+                .map_origin(|origin| origin.floor())
+                .map_size(|size| size.ceil()),
             content_mask,
             corner_radii,
             tile,


### PR DESCRIPTION
Similar to #15822, just applies the same fix to images as they are also affected by the same issue.

Release Notes:

- N/A