### PR TITLE
language: Fix `language_scope_at` for markdown code comments

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3167,7 +3167,7 @@ impl BufferSnapshot {
     pub fn language_scope_at<D: ToOffset>(&self, position: D) -> Option<LanguageScope> {
         let offset = position.to_offset(self);
         let mut scope = None;
-        let mut smallest_range: Option<Range<usize>> = None;
+        let mut smallest_range_and_depth: Option<(Range<usize>, usize)> = None;
 
         // Use the layer that has the smallest node intersecting the given point.
         for layer in self
@@ -3190,11 +3190,19 @@ impl BufferSnapshot {
             }
 
             if let Some(range) = range {
-                if smallest_range
-                    .as_ref()
-                    .map_or(true, |smallest_range| range.len() < smallest_range.len())
-                {
-                    smallest_range = Some(range);
+                if smallest_range_and_depth.as_ref().map_or(
+                    true,
+                    |(smallest_range, smallest_range_depth)| {
+                        if layer.depth > *smallest_range_depth {
+                            true
+                        } else if layer.depth == *smallest_range_depth {
+                            range.len() < smallest_range.len()
+                        } else {
+                            false
+                        }
+                    },
+                ) {
+                    smallest_range_and_depth = Some((range, layer.depth));
                     scope = Some(LanguageScope {
                         language: layer.language.clone(),
                         override_id: layer.override_id(offset, &self.text),

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3179,7 +3179,7 @@ impl BufferSnapshot {
             let mut range = None;
             loop {
                 let child_range = cursor.node().byte_range();
-                if !child_range.to_inclusive().contains(&offset) {
+                if !child_range.contains(&offset) {
                     break;
                 }
 


### PR DESCRIPTION
Closes #29176

This PR fix an issue where uncommenting a code block in Markdown would add Markdown comments instead of removing the language-specific comments.

Why?
`language_scope_at` for comments in a code block in Markdown would result in the language being detected as Markdown. This happens because the smallest range, such as `//` or `#` on the Markdown layer, is preferred over `// whole comment line` for any other language. This results in language detection as Markdown for that point.

To fix this, we also use a depth factor and try to prefer the layer with greater depth over one with lesser depth. In this case, the code block's language depth would be preferred over Markdown. The smallest range is now used as a tiebreaker.

Added test for this case.

Release Notes:

- Fixed issue where uncommenting a code block in Markdown would add Markdown comments instead of removing the language comments.
