### PR TITLE
collab: Set `plan` in LLM token based on subscription

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4147,7 +4147,6 @@ async fn get_llm_api_token(
         billing_preferences,
         &flags,
         has_legacy_llm_subscription,
-        session.current_plan(&db).await?,
         billing_subscription,
         session.system_id.clone(),
         &session.app_state.config,


### PR DESCRIPTION
This PR updates the `plan` field in the LLM token to be based on the subscription.

We weren't using this field anywhere outside of the new billing code, so it is safe to change its meaning.

Release Notes:

- N/A
