### PR TITLE
Fix handling of `--system-specs` argument so it happens before `Application::new`

### DIFF
--- a/crates/release_channel/src/lib.rs
+++ b/crates/release_channel/src/lib.rs
@@ -63,8 +63,8 @@ impl Global for GlobalAppVersion {}
 pub struct AppVersion;
 
 impl AppVersion {
-    /// Initializes the global [`AppVersion`].
-    pub fn init(pkg_version: &str) -> SemanticVersion {
+    /// Load the app version from env.
+    pub fn load(pkg_version: &str) -> SemanticVersion {
         if let Ok(from_env) = env::var("ZED_APP_VERSION") {
             from_env.parse().expect("invalid ZED_APP_VERSION")
         } else {

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -428,7 +428,7 @@ pub fn execute_run(
     let git_hosting_provider_registry = Arc::new(GitHostingProviderRegistry::new());
     gpui::Application::headless().run(move |cx| {
         settings::init(cx);
-        let app_version = AppVersion::init(env!("ZED_PKG_VERSION"));
+        let app_version = AppVersion::load(env!("ZED_PKG_VERSION"));
         release_channel::init(app_version, cx);
         gpui_tokio::init(cx);
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -218,25 +218,9 @@ fn main() {
         };
     }
 
-    log::info!("========== starting zed ==========");
-
-    let app = Application::new().with_assets(Assets);
-
-    let system_id = app.background_executor().block(system_id()).ok();
-    let installation_id = app.background_executor().block(installation_id()).ok();
-    let session_id = Uuid::new_v4().to_string();
-    let session = app.background_executor().block(Session::new());
-    let app_version = AppVersion::init(env!("CARGO_PKG_VERSION"));
+    let app_version = AppVersion::load(env!("CARGO_PKG_VERSION"));
     let app_commit_sha =
         option_env!("ZED_COMMIT_SHA").map(|commit_sha| AppCommitSha(commit_sha.to_string()));
-
-    reliability::init_panic_hook(
-        app_version,
-        app_commit_sha.clone(),
-        system_id.as_ref().map(|id| id.to_string()),
-        installation_id.as_ref().map(|id| id.to_string()),
-        session_id.clone(),
-    );
 
     if args.system_specs {
         let system_specs = feedback::system_specs::SystemSpecs::new_stateless(
@@ -247,6 +231,23 @@ fn main() {
         println!("Zed System Specs (from CLI):\n{}", system_specs);
         return;
     }
+
+    log::info!("========== starting zed ==========");
+
+    let app = Application::new().with_assets(Assets);
+
+    let system_id = app.background_executor().block(system_id()).ok();
+    let installation_id = app.background_executor().block(installation_id()).ok();
+    let session_id = Uuid::new_v4().to_string();
+    let session = app.background_executor().block(Session::new());
+
+    reliability::init_panic_hook(
+        app_version,
+        app_commit_sha.clone(),
+        system_id.as_ref().map(|id| id.to_string()),
+        installation_id.as_ref().map(|id| id.to_string()),
+        session_id.clone(),
+    );
 
     let (open_listener, mut open_rx) = OpenListener::new();
 


### PR DESCRIPTION
Fixes issue described in [description of #28683](https://github.com/zed-industries/zed/issues/28683#issue-2992849891)

Makes sure that the `--system-specs` arg is handled before `Application::new` is called, so that it can be used even when Zed is panicking during app initialization (e.g. Failing to create a Vulkan context in blade)

Release Notes:

- Fixed an issue where the `--system-specs` arg wouldn't work if Zed panicked during app initialization (e.g. When failing to create a Vulkan context in blade)
