### PR TITLE
Fix panic when collaborating with new multibuffers

### DIFF
--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -6,7 +6,7 @@ use collab_ui::{
     channel_view::ChannelView,
     notifications::project_shared_notification::ProjectSharedNotification,
 };
-use editor::{Editor, MultiBuffer, PathKey, test::editor_content_with_blocks};
+use editor::{Editor, MultiBuffer, PathKey};
 use gpui::{
     AppContext as _, BackgroundExecutor, BorrowAppContext, Entity, SharedString, TestAppContext,
     VisualContext, VisualTestContext, point,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -12699,19 +12699,22 @@ async fn test_following_with_multiple_excerpts(cx: &mut TestAppContext) {
     // Insert some excerpts.
     leader.update(cx, |leader, cx| {
         leader.buffer.update(cx, |multibuffer, cx| {
-            let excerpt_ids = multibuffer.push_excerpts(
+            multibuffer.set_excerpts_for_path(
+                PathKey::namespaced(1, Arc::from(Path::new("b.txt"))),
                 buffer_1.clone(),
-                [
-                    ExcerptRange::new(1..6),
-                    ExcerptRange::new(12..15),
-                    ExcerptRange::new(0..3),
+                vec![
+                    Point::row_range(0..3),
+                    Point::row_range(1..6),
+                    Point::row_range(12..15),
                 ],
+                0,
                 cx,
             );
-            multibuffer.insert_excerpts_after(
-                excerpt_ids[0],
+            multibuffer.set_excerpts_for_path(
+                PathKey::namespaced(1, Arc::from(Path::new("a.txt"))),
                 buffer_2.clone(),
-                [ExcerptRange::new(8..12), ExcerptRange::new(0..6)],
+                vec![Point::row_range(0..6), Point::row_range(8..12)],
+                0,
                 cx,
             );
         });


### PR DESCRIPTION
Before this change, when syncing a multibuffer (such as find-all-references) to a remote, we would renumber the excerpts from 1. This did not matter in the past because the buffers' list of excerpts could not change. In #27876, I added the ability for excerpts to merge, which meant that the excerpt list could change. This manifested as people seeing "invalid excerpt id" panics when syncing.

The initial fix to this (to re-use the excerpt ids from the host) ran into problems because `insert_excerpts_with_ids_after` assumes that you call it in excerpt-id order. This change de-optimizes that code to insert the excerpts 1-by-1 in excerpt-id order, but with the insert_after set to preserve the correct UI order.

I hope to soon remove this code path and use something more like set-excerpts-for-path for syncing, but in the meantime we should not panic.

Release Notes:

- Fix a panic when joining a project with a multibuffer with merged excerpts
