### PR TITLE
Fix panic in vim selection restoration

### DIFF
--- a/crates/vim/test_data/test_p_g_v_y.json
+++ b/crates/vim/test_data/test_p_g_v_y.json
@@ -1,0 +1,11 @@
+{"Put":{"state":"The\nquicˇk\nbrown\nfox"}}
+{"Key":"y"}
+{"Key":"y"}
+{"Key":"j"}
+{"Key":"shift-v"}
+{"Key":"p"}
+{"Key":"g"}
+{"Key":"v"}
+{"Key":"y"}
+{"Get":{"state":"The\nquick\nˇquick\nfox","mode":"Normal"}}
+{"ReadRegister":{"name":"\"","value":"quick\n"}}


### PR DESCRIPTION
Closes #27986

Closes #ISSUE

Release Notes:

- vim: Fixed a panic when using `gv` after `p` in visual line mode
