### PR TITLE
Fix shift-y on empty line in vim mode

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -808,10 +808,14 @@ impl DisplaySnapshot {
     // used by line_mode selections and tries to match vim behavior
     pub fn expand_to_line(&self, range: Range<Point>) -> Range<Point> {
         let new_start = MultiBufferPoint::new(range.start.row, 0);
-        let new_end = MultiBufferPoint::new(
-            range.end.row,
-            self.buffer_snapshot.line_len(MultiBufferRow(range.end.row)),
-        );
+        let new_end = if range.end.column > 0 {
+            MultiBufferPoint::new(
+                range.end.row,
+                self.buffer_snapshot.line_len(MultiBufferRow(range.end.row)),
+            )
+        } else {
+            range.end
+        };
 
         new_start..new_end
     }


### PR DESCRIPTION
Release Notes:

- Fixes a regression where `shift-v up` on an empty line would appear to have selected the line after (though in reality it did not)
