### PR TITLE
Restore file to original content when rejecting file recreated by agent

### DIFF
--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -988,7 +988,7 @@ mod tests {
             .await
             .unwrap();
         cx.update(|_, cx| {
-            action_log.update(cx, |log, cx| log.buffer_read(buffer.clone(), cx));
+            action_log.update(cx, |log, cx| log.track_buffer(buffer.clone(), cx));
             buffer.update(cx, |buffer, cx| {
                 buffer
                     .edit(

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -770,24 +770,18 @@ impl Thread {
                 for ctx in &new_context {
                     match ctx {
                         AssistantContext::File(file_ctx) => {
-                            log.buffer_added_as_context(file_ctx.context_buffer.buffer.clone(), cx);
+                            log.track_buffer(file_ctx.context_buffer.buffer.clone(), cx);
                         }
                         AssistantContext::Directory(dir_ctx) => {
                             for context_buffer in &dir_ctx.context_buffers {
-                                log.buffer_added_as_context(context_buffer.buffer.clone(), cx);
+                                log.track_buffer(context_buffer.buffer.clone(), cx);
                             }
                         }
                         AssistantContext::Symbol(symbol_ctx) => {
-                            log.buffer_added_as_context(
-                                symbol_ctx.context_symbol.buffer.clone(),
-                                cx,
-                            );
+                            log.track_buffer(symbol_ctx.context_symbol.buffer.clone(), cx);
                         }
                         AssistantContext::Selection(selection_context) => {
-                            log.buffer_added_as_context(
-                                selection_context.context_buffer.buffer.clone(),
-                                cx,
-                            );
+                            log.track_buffer(selection_context.context_buffer.buffer.clone(), cx);
                         }
                         AssistantContext::FetchedUrl(_)
                         | AssistantContext::Thread(_)

--- a/crates/assistant_tools/src/code_action_tool.rs
+++ b/crates/assistant_tools/src/code_action_tool.rs
@@ -159,7 +159,7 @@ impl Tool for CodeActionTool {
             };
 
             action_log.update(cx, |action_log, cx| {
-                action_log.buffer_read(buffer.clone(), cx);
+                action_log.track_buffer(buffer.clone(), cx);
             })?;
 
             let range = {

--- a/crates/assistant_tools/src/code_symbols_tool.rs
+++ b/crates/assistant_tools/src/code_symbols_tool.rs
@@ -174,7 +174,7 @@ pub async fn file_outline(
     };
 
     action_log.update(cx, |action_log, cx| {
-        action_log.buffer_read(buffer.clone(), cx);
+        action_log.track_buffer(buffer.clone(), cx);
     })?;
 
     // Wait until the buffer has been fully parsed, so that we can read its outline.

--- a/crates/assistant_tools/src/contents_tool.rs
+++ b/crates/assistant_tools/src/contents_tool.rs
@@ -209,7 +209,7 @@ impl Tool for ContentsTool {
                     })?;
 
                     action_log.update(cx, |log, cx| {
-                        log.buffer_read(buffer, cx);
+                        log.track_buffer(buffer, cx);
                     })?;
 
                     Ok(result)
@@ -221,7 +221,7 @@ impl Tool for ContentsTool {
                         let result = buffer.read_with(cx, |buffer, _cx| buffer.text())?;
 
                         action_log.update(cx, |log, cx| {
-                            log.buffer_read(buffer, cx);
+                            log.track_buffer(buffer, cx);
                         })?;
 
                         Ok(result)

--- a/crates/assistant_tools/src/create_file_tool.rs
+++ b/crates/assistant_tools/src/create_file_tool.rs
@@ -112,9 +112,12 @@ impl Tool for CreateFileTool {
                 .await
                 .map_err(|err| anyhow!("Unable to open buffer for {destination_path}: {err}"))?;
             cx.update(|cx| {
+                action_log.update(cx, |action_log, cx| {
+                    action_log.track_buffer(buffer.clone(), cx)
+                });
                 buffer.update(cx, |buffer, cx| buffer.set_text(contents, cx));
                 action_log.update(cx, |action_log, cx| {
-                    action_log.will_create_buffer(buffer.clone(), cx)
+                    action_log.buffer_edited(buffer.clone(), cx)
                 });
             })?;
 

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -182,7 +182,7 @@ impl Tool for EditFileTool {
 
             let snapshot = cx.update(|cx| {
                 action_log.update(cx, |log, cx| {
-                    log.buffer_read(buffer.clone(), cx)
+                    log.track_buffer(buffer.clone(), cx)
                 });
                 let snapshot = buffer.update(cx, |buffer, cx| {
                     buffer.finalize_last_transaction();

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -134,7 +134,7 @@ impl Tool for ReadFileTool {
                 })?;
 
                 action_log.update(cx, |log, cx| {
-                    log.buffer_read(buffer, cx);
+                    log.track_buffer(buffer, cx);
                 })?;
 
                 Ok(result)
@@ -147,7 +147,7 @@ impl Tool for ReadFileTool {
                     let result = buffer.read_with(cx, |buffer, _cx| buffer.text())?;
 
                     action_log.update(cx, |log, cx| {
-                        log.buffer_read(buffer, cx);
+                        log.track_buffer(buffer, cx);
                     })?;
 
                     Ok(result)

--- a/crates/assistant_tools/src/rename_tool.rs
+++ b/crates/assistant_tools/src/rename_tool.rs
@@ -106,7 +106,7 @@ impl Tool for RenameTool {
             };
 
             action_log.update(cx, |action_log, cx| {
-                action_log.buffer_read(buffer.clone(), cx);
+                action_log.track_buffer(buffer.clone(), cx);
             })?;
 
             let position = {

--- a/crates/assistant_tools/src/symbol_info_tool.rs
+++ b/crates/assistant_tools/src/symbol_info_tool.rs
@@ -140,7 +140,7 @@ impl Tool for SymbolInfoTool {
             };
 
             action_log.update(cx, |action_log, cx| {
-                action_log.buffer_read(buffer.clone(), cx);
+                action_log.track_buffer(buffer.clone(), cx);
             })?;
 
             let position = {


### PR DESCRIPTION
Release Notes:

- Fixed a bug that could sometimes cause a file to be deleted when rejecting an agent change.
