### PR TITLE
agent: Skip empty messages to avoid sending them to the LLM model

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1103,7 +1103,10 @@ impl Thread {
             self.tool_use
                 .attach_tool_uses(message.id, &mut request_message);
 
-            request.messages.push(request_message);
+            // Skip empty messages to avoid sending them to the LLM model
+            if !request_message.content.is_empty() {
+                request.messages.push(request_message);
+            }
         }
 
         // https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -474,7 +474,7 @@ impl CopilotChatLanguageModel {
                     }
 
                     messages.push(ChatMessage::Assistant {
-                        content: if text_content.is_empty() {
+                        content: if text_content.is_empty() && tool_calls.is_empty() {
                             None
                         } else {
                             Some(text_content)

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -474,7 +474,7 @@ impl CopilotChatLanguageModel {
                     }
 
                     messages.push(ChatMessage::Assistant {
-                        content: if text_content.is_empty() && tool_calls.is_empty() {
+                        content: if text_content.is_empty() {
                             None
                         } else {
                             Some(text_content)


### PR DESCRIPTION
Always provide content (even if empty) when tool calls are present to avoid the API treating the message as having empty content.

Changes from this PR: https://github.com/zed-industries/zed/pull/29099 broke it.


Closes ##29223

Release Notes:

- agent: Skip empty messages to avoid sending them to the LLM model
