### PR TITLE
Air tight future copilot empty message issue

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1722,11 +1722,10 @@ impl Thread {
         });
     }
 
-    /// Insert an empty message to be populated with tool results upon send.
     pub fn attach_tool_results(&mut self, cx: &mut Context<Self>) {
-        // Tool results are assumed to be waiting on the next message id, so they will populate
-        // this empty message before sending to model. Would prefer this to be more straightforward.
-        self.insert_message(Role::User, vec![], cx);
+        if self.has_pending_tool_uses() || self.message_has_tool_results(self.next_message_id) {
+            self.insert_message(Role::User, vec![], cx);
+        }
         self.auto_capture_telemetry(cx);
     }
 


### PR DESCRIPTION
In the future when we introduce openai copilot models using tools.
we will have issues with  empty messages again.

This PR fixes the future air gaps. Enhances  the fix #29206
