### PR TITLE
copilot: Organize OpenAI models for Copilot Chat

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -39,10 +39,8 @@ pub enum Model {
     Gpt3_5Turbo,
     #[serde(alias = "o1", rename = "o1")]
     O1,
-    #[serde(alias = "o1-mini", rename = "o3-mini")]
+    #[serde(alias = "o3-mini", rename = "o3-mini")]
     O3Mini,
-    #[serde(alias = "o3", rename = "o3")]
-    O3,
     #[serde(alias = "o4-mini", rename = "o4-mini")]
     O4Mini,
     #[serde(alias = "claude-3-5-sonnet", rename = "claude-3.5-sonnet")]
@@ -71,12 +69,12 @@ impl Model {
             | Self::Gpt4
             | Self::Gpt4_1
             | Self::Gpt3_5Turbo
-            | Self::O3
+            | Self::O3Mini
             | Self::O4Mini
             | Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking => true,
-            Self::O3Mini | Self::O1 | Self::Gemini20Flash | Self::Gemini25Pro => false,
+            Self::O1 | Self::Gemini20Flash | Self::Gemini25Pro => false,
         }
     }
 
@@ -88,7 +86,6 @@ impl Model {
             "gpt-3.5-turbo" => Ok(Self::Gpt3_5Turbo),
             "o1" => Ok(Self::O1),
             "o3-mini" => Ok(Self::O3Mini),
-            "o3" => Ok(Self::O3),
             "o4-mini" => Ok(Self::O4Mini),
             "claude-3-5-sonnet" => Ok(Self::Claude3_5Sonnet),
             "claude-3-7-sonnet" => Ok(Self::Claude3_7Sonnet),
@@ -107,7 +104,6 @@ impl Model {
             Self::Gpt4o => "gpt-4o",
             Self::O3Mini => "o3-mini",
             Self::O1 => "o1",
-            Self::O3 => "o3",
             Self::O4Mini => "o4-mini",
             Self::Claude3_5Sonnet => "claude-3-5-sonnet",
             Self::Claude3_7Sonnet => "claude-3-7-sonnet",
@@ -125,7 +121,6 @@ impl Model {
             Self::Gpt4o => "GPT-4o",
             Self::O3Mini => "o3-mini",
             Self::O1 => "o1",
-            Self::O3 => "o3",
             Self::O4Mini => "o4-mini",
             Self::Claude3_5Sonnet => "Claude 3.5 Sonnet",
             Self::Claude3_7Sonnet => "Claude 3.7 Sonnet",
@@ -143,7 +138,6 @@ impl Model {
             Self::Gpt3_5Turbo => 12_288,
             Self::O3Mini => 64_000,
             Self::O1 => 20_000,
-            Self::O3 => 128_000,
             Self::O4Mini => 128_000,
             Self::Claude3_5Sonnet => 200_000,
             Self::Claude3_7Sonnet => 90_000,

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -223,7 +223,6 @@ impl LanguageModel for CopilotChatLanguageModel {
                     CopilotChatModel::Gpt3_5Turbo => open_ai::Model::ThreePointFiveTurbo,
                     CopilotChatModel::O1 => open_ai::Model::O1,
                     CopilotChatModel::O3Mini => open_ai::Model::O3Mini,
-                    CopilotChatModel::O3 => open_ai::Model::O3,
                     CopilotChatModel::O4Mini => open_ai::Model::O4Mini,
                     CopilotChatModel::Claude3_5Sonnet
                     | CopilotChatModel::Claude3_7Sonnet


### PR DESCRIPTION
Current implementation is misleading. There are no o3 models on copilot it is a renaming of actual o3-mini model and o3-mini is renaming of o1-mini.

removed the o1-mini model and removed confusion.

This is misleading
<img width="342" alt="Screenshot 2025-04-23 at 4 28 37 PM" src="https://github.com/user-attachments/assets/9f215b8c-dadc-429b-99a1-ff08fc494c2a" />

