### PR TITLE
collab: Add `head_commit_details` column to `project_repositories`

### DIFF
--- a/crates/collab/migrations/20250423150129_add_head_commit_details_to_project_repositories.sql
+++ b/crates/collab/migrations/20250423150129_add_head_commit_details_to_project_repositories.sql
@@ -1,0 +1,2 @@
+alter table project_repositories
+    add column head_commit_details varchar;


### PR DESCRIPTION
This PR adds the `head_commit_details` column to the `project_repositories` table, since it was missed in https://github.com/zed-industries/zed/pull/29007.

Release Notes:

- N/A
