### PR TITLE
Register assertion groups in programmatic tests

### DIFF
--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -40,7 +40,7 @@ pub struct JudgeAssertion {
     pub description: String,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct ExampleMetadata {
     pub name: String,
     pub url: String,
@@ -48,7 +48,7 @@ pub struct ExampleMetadata {
     pub language_server: Option<LanguageServer>,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize)]
 pub struct LanguageServer {
     pub file_extension: String,
     pub allow_preexisting_diagnostics: bool,

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -82,7 +82,6 @@ impl fmt::Display for FailedAssertion {
 impl Error for FailedAssertion {}
 
 pub struct ExampleContext {
-    meta: ExampleMetadata,
     log_prefix: String,
     agent_thread: Entity<agent::Thread>,
     app: AsyncApp,
@@ -93,7 +92,6 @@ pub struct ExampleContext {
 
 impl ExampleContext {
     pub fn new(
-        meta: ExampleMetadata,
         log_prefix: String,
         agent_thread: Entity<agent::Thread>,
         model: Arc<dyn LanguageModel>,
@@ -102,7 +100,6 @@ impl ExampleContext {
         let assertions = AssertionsReport::default();
 
         Self {
-            meta,
             log_prefix,
             agent_thread,
             assertions,
@@ -392,7 +389,6 @@ impl Response {
         Self { messages }
     }
 
-    // todo! move this to assertion group id method maybe?
     pub fn expect_tool(
         &self,
         group_id: AssertionGroupId,

--- a/crates/eval/src/examples/file_search.rs
+++ b/crates/eval/src/examples/file_search.rs
@@ -15,11 +15,14 @@ impl Example for FileSearchExample {
             url: "https://github.com/zed-industries/zed.git".to_string(),
             revision: "03ecb88fe30794873f191ddb728f597935b3101c".to_string(),
             language_server: None,
-            max_assertions: Some(4),
         }
     }
 
     async fn conversation(&self, cx: &mut ExampleContext) -> Result<()> {
+        let ends_with_filename = cx.assertion("ends_with_filename");
+        let correct_glob = cx.assertion("correct_glob");
+        let used_path_search = cx.assertion("used_path_search");
+
         const FILENAME: &str = "find_replace_file_tool.rs";
         cx.push_user_message(format!(
                 r#"
@@ -32,13 +35,14 @@ impl Example for FileSearchExample {
         ));
 
         let response = cx.run_turn().await?;
-        let tool_use = response.expect_tool("path_search", cx)?;
+        let tool_use = response.expect_tool(used_path_search, "path_search", cx)?;
         let input = tool_use.parse_input::<PathSearchToolInput>()?;
 
         let glob = input.glob;
-        cx.assert(
+        ends_with_filename.assert(
             glob.ends_with(FILENAME),
             format!("glob ends with `{FILENAME}`"),
+            cx,
         )?;
 
         let without_filename = glob.replace(FILENAME, "");
@@ -46,7 +50,7 @@ impl Example for FileSearchExample {
             .unwrap()
             .is_match(&without_filename);
 
-        cx.assert(matches, "glob starts with either `**` or `zed`")?;
+        correct_glob.assert(matches, "glob starts with either `**` or `zed`", cx)?;
 
         Ok(())
     }

--- a/crates/eval/src/examples/mod.rs
+++ b/crates/eval/src/examples/mod.rs
@@ -37,14 +37,14 @@ struct DeclarativeExample {
 impl DeclarativeExample {
     pub fn load(example_path: &Path) -> Result<Self> {
         let name = Self::name_from_path(example_path);
-        let base: ExampleToml = toml::from_str(&fs::read_to_string(&example_path)?)?;
+        let toml: ExampleToml = toml::from_str(&fs::read_to_string(&example_path)?)?;
 
-        let language_server = if base.require_lsp {
+        let language_server = if toml.require_lsp {
             Some(crate::example::LanguageServer {
-                file_extension: base
+                file_extension: toml
                     .language_extension
                     .expect("Language extension is required when require_lsp = true"),
-                allow_preexisting_diagnostics: base.allow_preexisting_diagnostics,
+                allow_preexisting_diagnostics: toml.allow_preexisting_diagnostics,
             })
         } else {
             None
@@ -52,24 +52,29 @@ impl DeclarativeExample {
 
         let metadata = ExampleMetadata {
             name,
-            url: base.url,
-            revision: base.revision,
+            url: toml.url,
+            revision: toml.revision,
             language_server,
-            max_assertions: None,
         };
 
         Ok(DeclarativeExample {
             metadata,
-            prompt: base.prompt,
-            thread_assertions: base
+            prompt: toml.prompt,
+            thread_assertions: toml
                 .thread_assertions
                 .into_iter()
-                .map(|(id, description)| JudgeAssertion { id, description })
+                .map(|(id, description)| JudgeAssertion {
+                    group_id: id,
+                    description,
+                })
                 .collect(),
-            diff_assertions: base
+            diff_assertions: toml
                 .diff_assertions
                 .into_iter()
-                .map(|(id, description)| JudgeAssertion { id, description })
+                .map(|(id, description)| JudgeAssertion {
+                    group_id: id,
+                    description,
+                })
                 .collect(),
         })
     }

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -113,10 +113,6 @@ impl ExampleInstance {
         self.example.meta().url
     }
 
-    pub fn revision(&self) -> String {
-        self.example.meta().revision
-    }
-
     pub fn worktree_name(&self) -> String {
         format!("{}-{}", self.name, self.repetition)
     }
@@ -353,7 +349,7 @@ impl ExampleInstance {
                 });
             })?;
 
-            let mut example_cx = ExampleContext::new(meta.clone(), this.log_prefix.clone(), thread.clone(), model.clone(), cx.clone());
+            let mut example_cx = ExampleContext::new(this.log_prefix.clone(), thread.clone(), model.clone(), cx.clone());
             let result = this.example.conversation(&mut example_cx).await;
 
             if let Err(err) = result {
@@ -599,7 +595,7 @@ impl ExampleInstance {
                 (
                     response,
                     Assertion {
-                        group_id: AssertionGroupId(assertion.group_id.clone().into()),
+                        group_id: AssertionGroupId(assertion.group_id),
                         result,
                     },
                 )
@@ -610,7 +606,7 @@ impl ExampleInstance {
         let mut report = AssertionsReport::default();
 
         for (response, assertion) in future::join_all(assertions).await {
-            writeln!(&mut responses, "# {}", assertion.group_id.to_string()).unwrap();
+            writeln!(&mut responses, "# {}", assertion.group_id).unwrap();
             writeln!(&mut responses, "{}\n\n", response).unwrap();
             report.ran.push(assertion);
         }


### PR DESCRIPTION
This replaces assertion counts with a set of assertion group ids. This will help us understand how many of the different groups possible assertions actually ran and characterize progress without requiring that we manually specify an exact count. You can perform multiple assertions as part of the same group and their results will all be reported.

We also changed the format of the Snowflake event to be a serializable `EvaluatedExample` struct.

Release Notes:

- N/A
