### PR TITLE
editor: Fix broken mouse scrolling on main

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1594,7 +1594,7 @@ impl Editor {
             blink_manager: blink_manager.clone(),
             show_local_selections: true,
             show_scrollbars: true,
-            disable_scrolling: true,
+            disable_scrolling: false,
             mode,
             show_breadcrumbs: EditorSettings::get_global(cx).toolbar.breadcrumbs,
             show_gutter: mode.is_full(),


### PR DESCRIPTION
This PR is a quick follow-up to #29234 , which unfortunately broke scrolling with the mouse in editors on main. 

The linked PR introduced the possiblilty to completely disable scrolling for editors. Unfortunately, it also disabled scrolling for editors by default. This PR fixes this by re-enabling it by default.

This change also needs to be backported to v0.184.x. Otherwise, mouse scrolling in the next preview release will not work!

Release Notes:

- N/A 
