### PR TITLE
agent: Encourage model to include displayed fields first

### DIFF
--- a/crates/assistant_tools/src/create_file_tool.rs
+++ b/crates/assistant_tools/src/create_file_tool.rs
@@ -24,6 +24,9 @@ pub struct CreateFileToolInput {
     ///
     /// You can create a new file by providing a path of "directory1/new_file.txt"
     /// </example>
+    ///
+    /// Make sure to include this field before the `contents` field in the input object
+    /// so that we can display it immediately.
     pub path: String,
 
     /// The text contents of the file to create.

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -26,6 +26,15 @@ use workspace::Workspace;
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct EditFileToolInput {
+    /// A user-friendly markdown description of what's being replaced. This will be shown in the UI.
+    ///
+    /// <example>Fix API endpoint URLs</example>
+    /// <example>Update copyright year in `page_footer`</example>
+    ///
+    /// Make sure to include this field before all the others in the input object
+    /// so that we can display it immediately.
+    pub display_description: String,
+
     /// The full path of the file to modify in the project.
     ///
     /// WARNING: When specifying which file path need changing, you MUST
@@ -46,12 +55,6 @@ pub struct EditFileToolInput {
     /// `frontend/db.js`
     /// </example>
     pub path: PathBuf,
-
-    /// A user-friendly markdown description of what's being replaced. This will be shown in the UI.
-    ///
-    /// <example>Fix API endpoint URLs</example>
-    /// <example>Update copyright year in `page_footer`</example>
-    pub display_description: String,
 
     /// The text to replace.
     pub old_string: String,


### PR DESCRIPTION
Instructs the model to include the fields that we display first in the input object, so that e.g the user can see the path of a file while the model generates the content.

Release Notes:

- N/A 
