### PR TITLE
editor: Move blame popover from `hover_tooltip` to editor prepaint

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -85,14 +85,14 @@ use code_context_menus::{
 };
 use git::blame::{GitBlame, GlobalBlameRenderer};
 use gpui::{
-    Action, Animation, AnimationExt, AnyElement, AnyWeakEntity, App, AppContext,
-    AsyncWindowContext, AvailableSpace, Background, Bounds, ClickEvent, ClipboardEntry,
-    ClipboardItem, Context, DispatchPhase, Edges, Entity, EntityInputHandler, EventEmitter,
-    FocusHandle, FocusOutEvent, Focusable, FontId, FontWeight, Global, HighlightStyle, Hsla,
-    KeyContext, Modifiers, MouseButton, MouseDownEvent, PaintQuad, ParentElement, Pixels, Render,
-    SharedString, Size, Stateful, Styled, Subscription, Task, TextStyle, TextStyleRefinement,
-    UTF16Selection, UnderlineStyle, UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window,
-    div, impl_actions, point, prelude::*, pulsating_between, px, relative, size,
+    Action, Animation, AnimationExt, AnyElement, App, AppContext, AsyncWindowContext,
+    AvailableSpace, Background, Bounds, ClickEvent, ClipboardEntry, ClipboardItem, Context,
+    DispatchPhase, Edges, Entity, EntityInputHandler, EventEmitter, FocusHandle, FocusOutEvent,
+    Focusable, FontId, FontWeight, Global, HighlightStyle, Hsla, KeyContext, Modifiers,
+    MouseButton, MouseDownEvent, PaintQuad, ParentElement, Pixels, Render, SharedString, Size,
+    Stateful, Styled, Subscription, Task, TextStyle, TextStyleRefinement, UTF16Selection,
+    UnderlineStyle, UniformListScrollHandle, WeakEntity, WeakFocusHandle, Window, div,
+    impl_actions, point, prelude::*, pulsating_between, px, relative, size,
 };
 use highlight_matching_bracket::refresh_matching_bracket_highlights;
 use hover_links::{HoverLink, HoveredLinkState, InlayHighlight, find_file};

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -798,9 +798,12 @@ impl ChangeList {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 struct InlineBlameHoverState {
     position: gpui::Point<Pixels>,
+    show_task: Option<Task<()>>,
+    hide_task: Option<Task<()>>,
+    popover_bounds: Option<Bounds<Pixels>>,
 }
 
 /// Zed's primary implementation of text input, allowing users to edit a [`MultiBuffer`].

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -798,6 +798,7 @@ impl ChangeList {
     }
 }
 
+#[derive(Debug, Clone)]
 struct InlineBlameHoverState {
     position: gpui::Point<Pixels>,
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -931,7 +931,6 @@ pub struct Editor {
     show_git_blame_gutter: bool,
     show_git_blame_inline: bool,
     show_git_blame_inline_delay_task: Option<Task<()>>,
-    pub git_blame_inline_tooltip: Option<AnyWeakEntity>,
     git_blame_inline_enabled: bool,
     render_diff_hunk_controls: RenderDiffHunkControlsFn,
     serialize_dirty_buffers: bool,
@@ -1740,7 +1739,6 @@ impl Editor {
             show_git_blame_inline: false,
             show_selection_menu: None,
             show_git_blame_inline_delay_task: None,
-            git_blame_inline_tooltip: None,
             git_blame_inline_enabled: ProjectSettings::get_global(cx).git.inline_blame_enabled(),
             render_diff_hunk_controls: Arc::new(render_diff_hunk_controls),
             serialize_dirty_buffers: ProjectSettings::get_global(cx)
@@ -16715,12 +16713,7 @@ impl Editor {
 
     pub fn render_git_blame_inline(&self, window: &Window, cx: &App) -> bool {
         self.show_git_blame_inline
-            && (self.focus_handle.is_focused(window)
-                || self
-                    .git_blame_inline_tooltip
-                    .as_ref()
-                    .and_then(|t| t.upgrade())
-                    .is_some())
+            && (self.focus_handle.is_focused(window) || self.inline_blame_popover.is_some())
             && !self.newest_selection_head_on_empty_line(cx)
             && self.has_blame_entries(cx)
     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -798,6 +798,10 @@ impl ChangeList {
     }
 }
 
+struct InlineBlameHoverState {
+    position: gpui::Point<Pixels>,
+}
+
 /// Zed's primary implementation of text input, allowing users to edit a [`MultiBuffer`].
 ///
 /// See the [module level documentation](self) for more information.
@@ -866,6 +870,7 @@ pub struct Editor {
     context_menu_options: Option<ContextMenuOptions>,
     mouse_context_menu: Option<MouseContextMenu>,
     completion_tasks: Vec<(CompletionId, Task<Option<()>>)>,
+    inline_blame_hover_state: Option<InlineBlameHoverState>,
     signature_help_state: SignatureHelpState,
     auto_signature_help: Option<bool>,
     find_all_references_task_sources: Vec<Anchor>,
@@ -1665,6 +1670,7 @@ impl Editor {
             context_menu_options: None,
             mouse_context_menu: None,
             completion_tasks: Default::default(),
+            inline_blame_hover_state: Default::default(),
             signature_help_state: SignatureHelpState::default(),
             auto_signature_help: None,
             find_all_references_task_sources: Vec::new(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5510,6 +5510,7 @@ impl Editor {
     ) {
         if let Some(state) = &mut self.inline_blame_popover {
             state.hide_task.take();
+            cx.notify();
         } else {
             let delay = EditorSettings::get_global(cx).hover_popover_delay;
             let show_task = cx.spawn(async move |editor, cx| {
@@ -5517,9 +5518,10 @@ impl Editor {
                     .timer(std::time::Duration::from_millis(delay))
                     .await;
                 editor
-                    .update(cx, |editor, _| {
+                    .update(cx, |editor, cx| {
                         if let Some(state) = &mut editor.inline_blame_popover {
                             state.show_task = None;
+                            cx.notify();
                         }
                     })
                     .ok();
@@ -5558,14 +5560,16 @@ impl Editor {
         if let Some(state) = &mut self.inline_blame_popover {
             if state.show_task.is_some() {
                 self.inline_blame_popover.take();
+                cx.notify();
             } else {
                 let hide_task = cx.spawn(async move |editor, cx| {
                     cx.background_executor()
-                        .timer(std::time::Duration::from_millis(50))
+                        .timer(std::time::Duration::from_millis(100))
                         .await;
                     editor
-                        .update(cx, |editor, _| {
+                        .update(cx, |editor, cx| {
                             editor.inline_blame_popover.take();
+                            cx.notify();
                         })
                         .ok();
                 });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1849,7 +1849,7 @@ impl EditorElement {
         let mouse_over_inline_blame = parent_bounds.contains(&mouse_position);
         let mouse_over_popover = self.editor.update(cx, |editor, _| {
             editor
-                .inline_blame_hover_state
+                .inline_blame_popover
                 .as_ref()
                 .and_then(|state| state.popover_bounds)
                 .map_or(false, |bounds| bounds.contains(&mouse_position))
@@ -1865,7 +1865,7 @@ impl EditorElement {
 
         let should_draw = self.editor.update(cx, |editor, _| {
             editor
-                .inline_blame_hover_state
+                .inline_blame_popover
                 .as_ref()
                 .map_or(false, |state| state.show_task.is_none())
         });
@@ -1884,7 +1884,7 @@ impl EditorElement {
                 let size = element.layout_as_root(AvailableSpace::min_size(), window, cx);
                 let origin = self.editor.update(cx, |editor, _| {
                     let target_point = editor
-                        .inline_blame_hover_state
+                        .inline_blame_popover
                         .as_ref()
                         .map_or(mouse_position, |state| state.position);
 
@@ -1908,7 +1908,7 @@ impl EditorElement {
 
                 let popover_bounds = Bounds::new(origin, size);
                 self.editor.update(cx, |editor, _| {
-                    if let Some(state) = &mut editor.inline_blame_hover_state {
+                    if let Some(state) = &mut editor.inline_blame_popover {
                         state.popover_bounds = Some(popover_bounds);
                     }
                 });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1846,10 +1846,6 @@ impl EditorElement {
         window: &mut Window,
         cx: &mut App,
     ) {
-        if !self.editor.focus_handle(cx).is_focused(window) {
-            return;
-        }
-
         let mouse_position = window.mouse_position();
         let mouse_over_inline_blame = parent_bounds.contains(&mouse_position);
         let mouse_over_popover = self.editor.update(cx, |editor, _| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1910,7 +1910,7 @@ impl EditorElement {
             let maybe_element = self.editor.update(cx, |editor, cx| {
                 editor
                     .workspace()
-                    .and_then(|workspace| Some(workspace.downgrade()))
+                    .map(|workspace| workspace.downgrade())
                     .and_then(|workspace| {
                         render_blame_entry_popover(blame_entry, workspace, &blame, cx)
                     })

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1903,9 +1903,7 @@ impl EditorElement {
             editor
                 .inline_blame_hover_state
                 .as_ref()
-                .map_or(false, |state| {
-                    state.show_task.is_none() && state.hide_task.is_none()
-                })
+                .map_or(false, |state| state.show_task.is_none())
         });
 
         if should_draw {

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -98,10 +98,15 @@ pub trait BlameRenderer {
         &self,
         _: &TextStyle,
         _: BlameEntry,
+        _: &mut App,
+    ) -> Option<AnyElement>;
+
+    fn render_blame_entry_popover(
+        &self,
+        _: BlameEntry,
         _: Option<ParsedCommitMessage>,
         _: Entity<Repository>,
         _: WeakEntity<Workspace>,
-        _: Entity<Editor>,
         _: &mut App,
     ) -> Option<AnyElement>;
 
@@ -139,10 +144,17 @@ impl BlameRenderer for () {
         &self,
         _: &TextStyle,
         _: BlameEntry,
+        _: &mut App,
+    ) -> Option<AnyElement> {
+        None
+    }
+
+    fn render_blame_entry_popover(
+        &self,
+        _: BlameEntry,
         _: Option<ParsedCommitMessage>,
         _: Entity<Repository>,
         _: WeakEntity<Workspace>,
-        _: Entity<Editor>,
         _: &mut App,
     ) -> Option<AnyElement> {
         None

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -7,10 +7,11 @@ use git::{
     parse_git_remote_url,
 };
 use gpui::{
-    AnyElement, App, AppContext as _, Context, Entity, Hsla, Subscription, Task, TextStyle,
-    WeakEntity, Window,
+    AnyElement, App, AppContext as _, Context, Entity, Hsla, ScrollHandle, Subscription, Task,
+    TextStyle, WeakEntity, Window,
 };
 use language::{Bias, Buffer, BufferSnapshot, Edit};
+use markdown::Markdown;
 use multi_buffer::RowInfo;
 use project::{
     Project, ProjectItem,
@@ -104,9 +105,12 @@ pub trait BlameRenderer {
     fn render_blame_entry_popover(
         &self,
         _: BlameEntry,
+        _: ScrollHandle,
         _: Option<ParsedCommitMessage>,
+        _: Entity<Markdown>,
         _: Entity<Repository>,
         _: WeakEntity<Workspace>,
+        _: &mut Window,
         _: &mut App,
     ) -> Option<AnyElement>;
 
@@ -152,9 +156,12 @@ impl BlameRenderer for () {
     fn render_blame_entry_popover(
         &self,
         _: BlameEntry,
+        _: ScrollHandle,
         _: Option<ParsedCommitMessage>,
+        _: Entity<Markdown>,
         _: Entity<Repository>,
         _: WeakEntity<Workspace>,
+        _: &mut Window,
         _: &mut App,
     ) -> Option<AnyElement> {
         None

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -957,6 +957,7 @@ impl Item for Editor {
             cx.subscribe(&workspace, |editor, _, event: &workspace::Event, _cx| {
                 if matches!(event, workspace::Event::ModalOpened) {
                     editor.mouse_context_menu.take();
+                    editor.inline_blame_popover.take();
                 }
             })
             .detach();

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -1,20 +1,23 @@
-use crate::{commit_tooltip::CommitTooltip, commit_view::CommitView};
-use editor::{BlameRenderer, Editor};
+use crate::{
+    commit_tooltip::{CommitAvatar, CommitDetails, CommitTooltip},
+    commit_view::CommitView,
+};
+use editor::{BlameRenderer, Editor, hover_markdown_style};
 use git::{
     blame::{BlameEntry, ParsedCommitMessage},
     repository::CommitSummary,
 };
 use gpui::{
-    AnyElement, App, AppContext as _, ClipboardItem, Element as _, Entity, Hsla,
-    InteractiveElement as _, MouseButton, Pixels, StatefulInteractiveElement as _, Styled as _,
-    Subscription, TextStyle, WeakEntity, Window, div,
+    ClipboardItem, Entity, Hsla, MouseButton, ScrollHandle, Subscription, TextStyle, WeakEntity,
+    prelude::*,
 };
+use markdown::{Markdown, MarkdownElement};
 use project::{git_store::Repository, project_settings::ProjectSettings};
 use settings::Settings as _;
-use ui::{
-    ActiveTheme, Color, ContextMenu, FluentBuilder as _, Icon, IconName, IntoElement,
-    ParentElement as _, h_flex,
-};
+use theme::ThemeSettings;
+use time::OffsetDateTime;
+use time_format::format_local_timestamp;
+use ui::{ContextMenu, Divider, IconButtonShape, prelude::*};
 use workspace::Workspace;
 
 const GIT_BLAME_MAX_AUTHOR_CHARS_DISPLAYED: usize = 20;
@@ -147,23 +150,213 @@ impl BlameRenderer for GitBlameRenderer {
 
     fn render_blame_entry_popover(
         &self,
-        blame_entry: BlameEntry,
+        blame: BlameEntry,
+        scroll_handle: ScrollHandle,
         details: Option<ParsedCommitMessage>,
+        markdown: Entity<Markdown>,
         repository: Entity<Repository>,
         workspace: WeakEntity<Workspace>,
+        window: &mut Window,
         cx: &mut App,
     ) -> Option<AnyElement> {
+        let commit_time = blame
+            .committer_time
+            .and_then(|t| OffsetDateTime::from_unix_timestamp(t).ok())
+            .unwrap_or(OffsetDateTime::now_utc());
+
+        let commit_details = CommitDetails {
+            sha: blame.sha.to_string().into(),
+            commit_time,
+            author_name: blame
+                .author
+                .clone()
+                .unwrap_or("<no name>".to_string())
+                .into(),
+            author_email: blame.author_mail.clone().unwrap_or("".to_string()).into(),
+            message: details,
+        };
+
+        let avatar = CommitAvatar::new(&commit_details).render(window, cx);
+
+        let author = commit_details.author_name.clone();
+        let author_email = commit_details.author_email.clone();
+
+        let short_commit_id = commit_details
+            .sha
+            .get(0..8)
+            .map(|sha| sha.to_string().into())
+            .unwrap_or_else(|| commit_details.sha.clone());
+        let full_sha = commit_details.sha.to_string().clone();
+        let absolute_timestamp = format_local_timestamp(
+            commit_details.commit_time,
+            OffsetDateTime::now_utc(),
+            time_format::TimestampFormat::MediumAbsolute,
+        );
+        let markdown_style = {
+            let mut style = hover_markdown_style(window, cx);
+            if let Some(code_block) = &style.code_block.text {
+                style.base_text_style.refine(code_block);
+            }
+            style
+        };
+
+        let message = commit_details
+            .message
+            .as_ref()
+            .map(|_| MarkdownElement::new(markdown.clone(), markdown_style).into_any())
+            .unwrap_or("<no commit message>".into_any());
+
+        let pull_request = commit_details
+            .message
+            .as_ref()
+            .and_then(|details| details.pull_request.clone());
+
+        let ui_font_size = ThemeSettings::get_global(cx).ui_font_size(cx);
+        let message_max_height = window.line_height() * 12 + (ui_font_size / 0.4);
+        let commit_summary = CommitSummary {
+            sha: commit_details.sha.clone(),
+            subject: commit_details
+                .message
+                .as_ref()
+                .map_or(Default::default(), |message| {
+                    message
+                        .message
+                        .split('\n')
+                        .next()
+                        .unwrap()
+                        .trim_end()
+                        .to_string()
+                        .into()
+                }),
+            commit_timestamp: commit_details.commit_time.unix_timestamp(),
+            has_parent: false,
+        };
+
+        let ui_font = ThemeSettings::get_global(cx).ui_font.clone();
+
+        // padding to avoid tooltip appearing right below the mouse cursor
         Some(
-            cx.new(|cx| {
-                CommitTooltip::blame_entry(
-                    &blame_entry,
-                    details.clone(),
-                    repository.clone(),
-                    workspace.clone(),
-                    cx,
+            div()
+                .pl_2()
+                .pt_2p5()
+                .child(
+                    v_flex()
+                        .elevation_2(cx)
+                        .font(ui_font)
+                        .text_ui(cx)
+                        .text_color(cx.theme().colors().text)
+                        .py_1()
+                        .px_2()
+                        .map(|el| {
+                            el.occlude()
+                                .on_mouse_move(|_, _, cx| cx.stop_propagation())
+                                .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
+                                .child(
+                                    v_flex()
+                                        .w(gpui::rems(30.))
+                                        .gap_4()
+                                        .child(
+                                            h_flex()
+                                                .pb_1p5()
+                                                .gap_x_2()
+                                                .overflow_x_hidden()
+                                                .flex_wrap()
+                                                .children(avatar)
+                                                .child(author)
+                                                .when(!author_email.is_empty(), |this| {
+                                                    this.child(
+                                                        div()
+                                                            .text_color(
+                                                                cx.theme().colors().text_muted,
+                                                            )
+                                                            .child(author_email),
+                                                    )
+                                                })
+                                                .border_b_1()
+                                                .border_color(cx.theme().colors().border_variant),
+                                        )
+                                        .child(
+                                            div()
+                                                .id("inline-blame-commit-message")
+                                                .child(message)
+                                                .max_h(message_max_height)
+                                                .overflow_y_scroll()
+                                                .track_scroll(&scroll_handle),
+                                        )
+                                        .child(
+                                            h_flex()
+                                                .text_color(cx.theme().colors().text_muted)
+                                                .w_full()
+                                                .justify_between()
+                                                .pt_1p5()
+                                                .border_t_1()
+                                                .border_color(cx.theme().colors().border_variant)
+                                                .child(absolute_timestamp)
+                                                .child(
+                                                    h_flex()
+                                                        .gap_1p5()
+                                                        .when_some(pull_request, |this, pr| {
+                                                            this.child(
+                                                                Button::new(
+                                                                    "pull-request-button",
+                                                                    format!("#{}", pr.number),
+                                                                )
+                                                                .color(Color::Muted)
+                                                                .icon(IconName::PullRequest)
+                                                                .icon_color(Color::Muted)
+                                                                .icon_position(IconPosition::Start)
+                                                                .style(ButtonStyle::Subtle)
+                                                                .on_click(move |_, _, cx| {
+                                                                    cx.stop_propagation();
+                                                                    cx.open_url(pr.url.as_str())
+                                                                }),
+                                                            )
+                                                        })
+                                                        .child(Divider::vertical())
+                                                        .child(
+                                                            Button::new(
+                                                                "commit-sha-button",
+                                                                short_commit_id.clone(),
+                                                            )
+                                                            .style(ButtonStyle::Subtle)
+                                                            .color(Color::Muted)
+                                                            .icon(IconName::FileGit)
+                                                            .icon_color(Color::Muted)
+                                                            .icon_position(IconPosition::Start)
+                                                            .on_click(move |_, window, cx| {
+                                                                CommitView::open(
+                                                                    commit_summary.clone(),
+                                                                    repository.downgrade(),
+                                                                    workspace.clone(),
+                                                                    window,
+                                                                    cx,
+                                                                );
+                                                                cx.stop_propagation();
+                                                            }),
+                                                        )
+                                                        .child(
+                                                            IconButton::new(
+                                                                "copy-sha-button",
+                                                                IconName::Copy,
+                                                            )
+                                                            .shape(IconButtonShape::Square)
+                                                            .icon_size(IconSize::Small)
+                                                            .icon_color(Color::Muted)
+                                                            .on_click(move |_, _, cx| {
+                                                                cx.stop_propagation();
+                                                                cx.write_to_clipboard(
+                                                                    ClipboardItem::new_string(
+                                                                        full_sha.clone(),
+                                                                    ),
+                                                                )
+                                                            }),
+                                                        ),
+                                                ),
+                                        ),
+                                )
+                        }),
                 )
-            })
-            .into_any_element(),
+                .into_any_element(),
         )
     }
 

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -235,6 +235,7 @@ impl BlameRenderer for GitBlameRenderer {
         let ui_font = ThemeSettings::get_global(cx).ui_font.clone();
 
         // padding to avoid tooltip appearing right below the mouse cursor
+        // TODO: use tooltip_container here
         Some(
             div()
                 .pl_2()

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -12,7 +12,8 @@ use gpui::{
 use project::{git_store::Repository, project_settings::ProjectSettings};
 use settings::Settings as _;
 use ui::{
-    ActiveTheme, Color, ContextMenu, FluentBuilder as _, Icon, IconName, ParentElement as _, h_flex,
+    ActiveTheme, Color, ContextMenu, FluentBuilder as _, Icon, IconName, IntoElement,
+    ParentElement as _, h_flex,
 };
 use workspace::Workspace;
 
@@ -115,10 +116,6 @@ impl BlameRenderer for GitBlameRenderer {
         &self,
         style: &TextStyle,
         blame_entry: BlameEntry,
-        details: Option<ParsedCommitMessage>,
-        repository: Entity<Repository>,
-        workspace: WeakEntity<Workspace>,
-        editor: Entity<Editor>,
         cx: &mut App,
     ) -> Option<AnyElement> {
         let relative_timestamp = blame_entry_relative_timestamp(&blame_entry);
@@ -144,22 +141,29 @@ impl BlameRenderer for GitBlameRenderer {
                 .child(Icon::new(IconName::FileGit).color(Color::Hint))
                 .child(text)
                 .gap_2()
-                .hoverable_tooltip(move |_window, cx| {
-                    let tooltip = cx.new(|cx| {
-                        CommitTooltip::blame_entry(
-                            &blame_entry,
-                            details.clone(),
-                            repository.clone(),
-                            workspace.clone(),
-                            cx,
-                        )
-                    });
-                    editor.update(cx, |editor, _| {
-                        editor.git_blame_inline_tooltip = Some(tooltip.downgrade().into())
-                    });
-                    tooltip.into()
-                })
                 .into_any(),
+        )
+    }
+
+    fn render_blame_entry_popover(
+        &self,
+        blame_entry: BlameEntry,
+        details: Option<ParsedCommitMessage>,
+        repository: Entity<Repository>,
+        workspace: WeakEntity<Workspace>,
+        cx: &mut App,
+    ) -> Option<AnyElement> {
+        Some(
+            cx.new(|cx| {
+                CommitTooltip::blame_entry(
+                    &blame_entry,
+                    details.clone(),
+                    repository.clone(),
+                    workspace.clone(),
+                    cx,
+                )
+            })
+            .into_any_element(),
         )
     }
 

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -27,22 +27,18 @@ pub struct CommitDetails {
     pub message: Option<ParsedCommitMessage>,
 }
 
-struct CommitAvatar<'a> {
+pub struct CommitAvatar<'a> {
     commit: &'a CommitDetails,
 }
 
 impl<'a> CommitAvatar<'a> {
-    fn new(details: &'a CommitDetails) -> Self {
+    pub fn new(details: &'a CommitDetails) -> Self {
         Self { commit: details }
     }
 }
 
 impl<'a> CommitAvatar<'a> {
-    fn render(
-        &'a self,
-        window: &mut Window,
-        cx: &mut Context<CommitTooltip>,
-    ) -> Option<impl IntoElement + use<>> {
+    pub fn render(&'a self, window: &mut Window, cx: &mut App) -> Option<impl IntoElement + use<>> {
         let remote = self
             .commit
             .message


### PR DESCRIPTION
In light of having more control over blame popover from editor.

This fixes: https://github.com/zed-industries/zed/issues/28645, https://github.com/zed-industries/zed/issues/26304

- [x] Initial rendering
- [x] Handle smart positioning (edge detection, etc)
- [x] Delayed hovering, release, etc
- [x] Test blame message selection
- [x] Fix tagged issues

Release Notes:

- Git inline blame popover now dismisses when the cursor is moved, the editor is scrolled, or the command palette is opened.