### PR TITLE
feat: allow using custom commit_message_prompt file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6018,6 +6018,7 @@ dependencies = [
  "multi_buffer",
  "notifications",
  "panel",
+ "paths",
  "picker",
  "postage",
  "pretty_assertions",

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -42,6 +42,7 @@ menu.workspace = true
 multi_buffer.workspace = true
 notifications.workspace = true
 panel.workspace = true
+paths.workspace = true
 picker.workspace = true
 postage.workspace = true
 project.workspace = true


### PR DESCRIPTION
this commit introduces the possibility for users to create their own `commit_message_prompt.txt` file that will override the default prompt when generating a commit message.

discussion : https://github.com/zed-industries/zed/discussions/26503

Release Notes:

- Added the possibility for user to customize the prompt used to generate commit messages.

--- 

Please keep in mind I'm not a Rust expert and there are certainly better ways to do this. I'm definitely open to proposals 🙂 