### PR TITLE
Remove `linked_edits` issue description from Elm doc

### DIFF
--- a/docs/src/languages/elm.md
+++ b/docs/src/languages/elm.md
@@ -38,15 +38,3 @@ Elm language server can be configured in your `settings.json`, e.g.:
 ```
 
 `elm-format`, `elm-review` and `elm` need to be installed and made available in the environment or configured in the settings. See the [full list of server settings here](https://github.com/elm-tooling/elm-language-server?tab=readme-ov-file#server-settings).
-
-## Known Issues
-
-There is an [upstream issue](https://github.com/elm-tooling/elm-language-server/issues/1311) with `elm-language-server` incorrectly supporting `linked_edits`. It is recommend you disable that feature in your Zed settings.json with:
-
-```
-  "languages": {
-    "Elm": {
-      "linked_edits": false
-    }
-  }
-```


### PR DESCRIPTION
The known issue with `linked_edits` seems to be fixed in this PR: https://github.com/elm-tooling/elm-language-server/pull/1364. This PR removes the section from Zeds documentation to avoid confusion.

Release Notes:

- Remove known issues section from Elm documentation.