### PR TITLE
Query multiple LSPs for more types of requests

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5055,7 +5055,7 @@ async fn test_references(
     lsp_response_tx
         .unbounded_send(Err(anyhow!("can't find references")))
         .unwrap();
-    references.await.unwrap_err();
+    assert_eq!(references.await.unwrap(), []);
 
     // User is informed that the request is no longer pending.
     executor.run_until_parked();

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4819,7 +4819,7 @@ async fn test_definition(
     );
 
     let definitions_1 = project_b
-        .update(cx_b, |p, cx| p.definition(&buffer_b, 23, cx))
+        .update(cx_b, |p, cx| p.definitions(&buffer_b, 23, cx))
         .await
         .unwrap();
     cx_b.read(|cx| {
@@ -4850,7 +4850,7 @@ async fn test_definition(
     );
 
     let definitions_2 = project_b
-        .update(cx_b, |p, cx| p.definition(&buffer_b, 33, cx))
+        .update(cx_b, |p, cx| p.definitions(&buffer_b, 33, cx))
         .await
         .unwrap();
     cx_b.read(|cx| {
@@ -4887,7 +4887,7 @@ async fn test_definition(
     );
 
     let type_definitions = project_b
-        .update(cx_b, |p, cx| p.type_definition(&buffer_b, 7, cx))
+        .update(cx_b, |p, cx| p.type_definitions(&buffer_b, 7, cx))
         .await
         .unwrap();
     cx_b.read(|cx| {
@@ -5639,7 +5639,7 @@ async fn test_open_buffer_while_getting_definition_pointing_to_it(
     let definitions;
     let buffer_b2;
     if rng.r#gen() {
-        definitions = project_b.update(cx_b, |p, cx| p.definition(&buffer_b1, 23, cx));
+        definitions = project_b.update(cx_b, |p, cx| p.definitions(&buffer_b1, 23, cx));
         (buffer_b2, _) = project_b
             .update(cx_b, |p, cx| {
                 p.open_buffer_with_lsp((worktree_id, "b.rs"), cx)
@@ -5653,7 +5653,7 @@ async fn test_open_buffer_while_getting_definition_pointing_to_it(
             })
             .await
             .unwrap();
-        definitions = project_b.update(cx_b, |p, cx| p.definition(&buffer_b1, 23, cx));
+        definitions = project_b.update(cx_b, |p, cx| p.definitions(&buffer_b1, 23, cx));
     }
 
     let definitions = definitions.await.unwrap();

--- a/crates/collab/src/tests/random_project_collaboration_tests.rs
+++ b/crates/collab/src/tests/random_project_collaboration_tests.rs
@@ -838,7 +838,7 @@ impl RandomizedTest for ProjectCollaborationTest {
                         .map(|_| Ok(()))
                         .boxed(),
                     LspRequestKind::Definition => project
-                        .definition(&buffer, offset, cx)
+                        .definitions(&buffer, offset, cx)
                         .map_ok(|_| ())
                         .boxed(),
                     LspRequestKind::Highlights => project

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -21901,10 +21901,10 @@ impl SemanticsProvider for Entity<Project> {
         cx: &mut App,
     ) -> Option<Task<Result<Vec<LocationLink>>>> {
         Some(self.update(cx, |project, cx| match kind {
-            GotoDefinitionKind::Symbol => project.definition(&buffer, position, cx),
-            GotoDefinitionKind::Declaration => project.declaration(&buffer, position, cx),
-            GotoDefinitionKind::Type => project.type_definition(&buffer, position, cx),
-            GotoDefinitionKind::Implementation => project.implementation(&buffer, position, cx),
+            GotoDefinitionKind::Symbol => project.definitions(&buffer, position, cx),
+            GotoDefinitionKind::Declaration => project.declarations(&buffer, position, cx),
+            GotoDefinitionKind::Type => project.type_definitions(&buffer, position, cx),
+            GotoDefinitionKind::Implementation => project.implementations(&buffer, position, cx),
         }))
     }
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -171,27 +171,27 @@ pub(crate) struct PerformRename {
     pub push_to_history: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub struct GetDefinition {
     pub position: PointUtf16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct GetDeclaration {
     pub position: PointUtf16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct GetTypeDefinition {
     pub position: PointUtf16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct GetImplementation {
     pub position: PointUtf16,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct GetReferences {
     pub position: PointUtf16,
 }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -172,22 +172,22 @@ pub(crate) struct PerformRename {
 }
 
 #[derive(Debug, Clone, Copy)]
-pub struct GetDefinition {
+pub struct GetDefinitions {
     pub position: PointUtf16,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GetDeclaration {
+pub(crate) struct GetDeclarations {
     pub position: PointUtf16,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GetTypeDefinition {
+pub(crate) struct GetTypeDefinitions {
     pub position: PointUtf16,
 }
 
 #[derive(Debug, Clone, Copy)]
-pub(crate) struct GetImplementation {
+pub(crate) struct GetImplementations {
     pub position: PointUtf16,
 }
 
@@ -588,7 +588,7 @@ impl LspCommand for PerformRename {
 }
 
 #[async_trait(?Send)]
-impl LspCommand for GetDefinition {
+impl LspCommand for GetDefinitions {
     type Response = Vec<LocationLink>;
     type LspRequest = lsp::request::GotoDefinition;
     type ProtoRequest = proto::GetDefinition;
@@ -690,7 +690,7 @@ impl LspCommand for GetDefinition {
 }
 
 #[async_trait(?Send)]
-impl LspCommand for GetDeclaration {
+impl LspCommand for GetDeclarations {
     type Response = Vec<LocationLink>;
     type LspRequest = lsp::request::GotoDeclaration;
     type ProtoRequest = proto::GetDeclaration;
@@ -793,7 +793,7 @@ impl LspCommand for GetDeclaration {
 }
 
 #[async_trait(?Send)]
-impl LspCommand for GetImplementation {
+impl LspCommand for GetImplementations {
     type Response = Vec<LocationLink>;
     type LspRequest = lsp::request::GotoImplementation;
     type ProtoRequest = proto::GetImplementation;
@@ -895,7 +895,7 @@ impl LspCommand for GetImplementation {
 }
 
 #[async_trait(?Send)]
-impl LspCommand for GetTypeDefinition {
+impl LspCommand for GetTypeDefinitions {
     type Response = Vec<LocationLink>;
     type LspRequest = lsp::request::GotoTypeDefinition;
     type ProtoRequest = proto::GetTypeDefinition;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3661,12 +3661,8 @@ impl LspStore {
         client.add_entity_request_handler(Self::handle_lsp_command::<GetCodeActions>);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetCompletions>);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetHover>);
-        client.add_entity_request_handler(Self::handle_lsp_command::<GetDefinition>);
-        client.add_entity_request_handler(Self::handle_lsp_command::<GetDeclaration>);
-        client.add_entity_request_handler(Self::handle_lsp_command::<GetTypeDefinition>);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetDocumentHighlights>);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetDocumentSymbols>);
-        client.add_entity_request_handler(Self::handle_lsp_command::<GetReferences>);
         client.add_entity_request_handler(Self::handle_lsp_command::<PrepareRename>);
         client.add_entity_request_handler(Self::handle_lsp_command::<PerformRename>);
         client.add_entity_request_handler(Self::handle_lsp_command::<LinkedEditingRange>);

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5254,7 +5254,7 @@ impl LspStore {
         })
     }
 
-    pub fn definition(
+    pub fn definitions(
         &mut self,
         buffer_handle: &Entity<Buffer>,
         position: PointUtf16,
@@ -5269,7 +5269,7 @@ impl LspStore {
                     proto::AllLanguageServers {},
                 )),
                 request: Some(proto::multi_lsp_query::Request::GetDefinition(
-                    GetDefinition { position }.to_proto(project_id, buffer_handle.read(cx)),
+                    GetDefinitions { position }.to_proto(project_id, buffer_handle.read(cx)),
                 )),
             });
             let buffer = buffer_handle.clone();
@@ -5290,9 +5290,9 @@ impl LspStore {
                                 None
                             }
                         })
-                        .map(|definition_response| {
-                            GetDefinition { position }.response_from_proto(
-                                definition_response,
+                        .map(|definitions_response| {
+                            GetDefinitions { position }.response_from_proto(
+                                definitions_response,
                                 project.clone(),
                                 buffer.clone(),
                                 cx.clone(),
@@ -5310,24 +5310,24 @@ impl LspStore {
                     .collect())
             })
         } else {
-            let definition_task = self.request_multiple_lsp_locally(
+            let definitions_task = self.request_multiple_lsp_locally(
                 buffer_handle,
                 Some(position),
-                GetDefinition { position },
+                GetDefinitions { position },
                 cx,
             );
             cx.spawn(async move |_, _| {
-                Ok(definition_task
+                Ok(definitions_task
                     .await
                     .into_iter()
-                    .flat_map(|(_, definition)| definition)
+                    .flat_map(|(_, definitions)| definitions)
                     .dedup()
                     .collect())
             })
         }
     }
 
-    pub fn declaration(
+    pub fn declarations(
         &mut self,
         buffer_handle: &Entity<Buffer>,
         position: PointUtf16,
@@ -5342,7 +5342,7 @@ impl LspStore {
                     proto::AllLanguageServers {},
                 )),
                 request: Some(proto::multi_lsp_query::Request::GetDeclaration(
-                    GetDeclaration { position }.to_proto(project_id, buffer_handle.read(cx)),
+                    GetDeclarations { position }.to_proto(project_id, buffer_handle.read(cx)),
                 )),
             });
             let buffer = buffer_handle.clone();
@@ -5363,9 +5363,9 @@ impl LspStore {
                                 None
                             }
                         })
-                        .map(|declaration_response| {
-                            GetDeclaration { position }.response_from_proto(
-                                declaration_response,
+                        .map(|declarations_response| {
+                            GetDeclarations { position }.response_from_proto(
+                                declarations_response,
                                 project.clone(),
                                 buffer.clone(),
                                 cx.clone(),
@@ -5383,24 +5383,24 @@ impl LspStore {
                     .collect())
             })
         } else {
-            let declaration_task = self.request_multiple_lsp_locally(
+            let declarations_task = self.request_multiple_lsp_locally(
                 buffer_handle,
                 Some(position),
-                GetDeclaration { position },
+                GetDeclarations { position },
                 cx,
             );
             cx.spawn(async move |_, _| {
-                Ok(declaration_task
+                Ok(declarations_task
                     .await
                     .into_iter()
-                    .flat_map(|(_, declaration)| declaration)
+                    .flat_map(|(_, declarations)| declarations)
                     .dedup()
                     .collect())
             })
         }
     }
 
-    pub fn type_definition(
+    pub fn type_definitions(
         &mut self,
         buffer_handle: &Entity<Buffer>,
         position: PointUtf16,
@@ -5415,7 +5415,7 @@ impl LspStore {
                     proto::AllLanguageServers {},
                 )),
                 request: Some(proto::multi_lsp_query::Request::GetTypeDefinition(
-                    GetTypeDefinition { position }.to_proto(project_id, buffer_handle.read(cx)),
+                    GetTypeDefinitions { position }.to_proto(project_id, buffer_handle.read(cx)),
                 )),
             });
             let buffer = buffer_handle.clone();
@@ -5436,9 +5436,9 @@ impl LspStore {
                                 None
                             }
                         })
-                        .map(|type_definition_response| {
-                            GetTypeDefinition { position }.response_from_proto(
-                                type_definition_response,
+                        .map(|type_definitions_response| {
+                            GetTypeDefinitions { position }.response_from_proto(
+                                type_definitions_response,
                                 project.clone(),
                                 buffer.clone(),
                                 cx.clone(),
@@ -5456,24 +5456,24 @@ impl LspStore {
                     .collect())
             })
         } else {
-            let type_definition_task = self.request_multiple_lsp_locally(
+            let type_definitions_task = self.request_multiple_lsp_locally(
                 buffer_handle,
                 Some(position),
-                GetTypeDefinition { position },
+                GetTypeDefinitions { position },
                 cx,
             );
             cx.spawn(async move |_, _| {
-                Ok(type_definition_task
+                Ok(type_definitions_task
                     .await
                     .into_iter()
-                    .flat_map(|(_, type_definition)| type_definition)
+                    .flat_map(|(_, type_definitions)| type_definitions)
                     .dedup()
                     .collect())
             })
         }
     }
 
-    pub fn implementation(
+    pub fn implementations(
         &mut self,
         buffer_handle: &Entity<Buffer>,
         position: PointUtf16,
@@ -5488,7 +5488,7 @@ impl LspStore {
                     proto::AllLanguageServers {},
                 )),
                 request: Some(proto::multi_lsp_query::Request::GetImplementation(
-                    GetImplementation { position }.to_proto(project_id, buffer_handle.read(cx)),
+                    GetImplementations { position }.to_proto(project_id, buffer_handle.read(cx)),
                 )),
             });
             let buffer = buffer_handle.clone();
@@ -5509,9 +5509,9 @@ impl LspStore {
                                 None
                             }
                         })
-                        .map(|implementation_response| {
-                            GetImplementation { position }.response_from_proto(
-                                implementation_response,
+                        .map(|implementations_response| {
+                            GetImplementations { position }.response_from_proto(
+                                implementations_response,
                                 project.clone(),
                                 buffer.clone(),
                                 cx.clone(),
@@ -5529,17 +5529,17 @@ impl LspStore {
                     .collect())
             })
         } else {
-            let implementation_task = self.request_multiple_lsp_locally(
+            let implementations_task = self.request_multiple_lsp_locally(
                 buffer_handle,
                 Some(position),
-                GetImplementation { position },
+                GetImplementations { position },
                 cx,
             );
             cx.spawn(async move |_, _| {
-                Ok(implementation_task
+                Ok(implementations_task
                     .await
                     .into_iter()
-                    .flat_map(|(_, implementation)| implementation)
+                    .flat_map(|(_, implementations)| implementations)
                     .dedup()
                     .collect())
             })
@@ -8250,7 +8250,7 @@ impl LspStore {
                 })
             }
             Some(proto::multi_lsp_query::Request::GetDefinition(message)) => {
-                let get_definition = GetDefinition::from_proto(
+                let get_definitions = GetDefinitions::from_proto(
                     message,
                     lsp_store.clone(),
                     buffer.clone(),
@@ -8258,12 +8258,12 @@ impl LspStore {
                 )
                 .await?;
 
-                let definition = lsp_store
+                let definitions = lsp_store
                     .update(&mut cx, |project, cx| {
                         project.request_multiple_lsp_locally(
                             &buffer,
-                            Some(get_definition.position),
-                            get_definition,
+                            Some(get_definitions.position),
+                            get_definitions,
                             cx,
                         )
                     })?
@@ -8271,12 +8271,12 @@ impl LspStore {
                     .into_iter();
 
                 lsp_store.update(&mut cx, |project, cx| proto::MultiLspQueryResponse {
-                    responses: definition
-                        .map(|(server_id, definition)| proto::LspResponse {
+                    responses: definitions
+                        .map(|(server_id, definitions)| proto::LspResponse {
                             server_id: server_id.to_proto(),
                             response: Some(proto::lsp_response::Response::GetDefinitionResponse(
-                                GetDefinition::response_to_proto(
-                                    definition,
+                                GetDefinitions::response_to_proto(
+                                    definitions,
                                     project,
                                     sender_id,
                                     &buffer_version,
@@ -8288,7 +8288,7 @@ impl LspStore {
                 })
             }
             Some(proto::multi_lsp_query::Request::GetDeclaration(message)) => {
-                let get_declaration = GetDeclaration::from_proto(
+                let get_declarations = GetDeclarations::from_proto(
                     message,
                     lsp_store.clone(),
                     buffer.clone(),
@@ -8296,12 +8296,12 @@ impl LspStore {
                 )
                 .await?;
 
-                let declaration = lsp_store
+                let declarations = lsp_store
                     .update(&mut cx, |project, cx| {
                         project.request_multiple_lsp_locally(
                             &buffer,
-                            Some(get_declaration.position),
-                            get_declaration,
+                            Some(get_declarations.position),
+                            get_declarations,
                             cx,
                         )
                     })?
@@ -8309,12 +8309,12 @@ impl LspStore {
                     .into_iter();
 
                 lsp_store.update(&mut cx, |project, cx| proto::MultiLspQueryResponse {
-                    responses: declaration
-                        .map(|(server_id, declaration)| proto::LspResponse {
+                    responses: declarations
+                        .map(|(server_id, declarations)| proto::LspResponse {
                             server_id: server_id.to_proto(),
                             response: Some(proto::lsp_response::Response::GetDeclarationResponse(
-                                GetDeclaration::response_to_proto(
-                                    declaration,
+                                GetDeclarations::response_to_proto(
+                                    declarations,
                                     project,
                                     sender_id,
                                     &buffer_version,
@@ -8326,7 +8326,7 @@ impl LspStore {
                 })
             }
             Some(proto::multi_lsp_query::Request::GetTypeDefinition(message)) => {
-                let get_type_definition = GetTypeDefinition::from_proto(
+                let get_type_definitions = GetTypeDefinitions::from_proto(
                     message,
                     lsp_store.clone(),
                     buffer.clone(),
@@ -8334,12 +8334,12 @@ impl LspStore {
                 )
                 .await?;
 
-                let type_definition = lsp_store
+                let type_definitions = lsp_store
                     .update(&mut cx, |project, cx| {
                         project.request_multiple_lsp_locally(
                             &buffer,
-                            Some(get_type_definition.position),
-                            get_type_definition,
+                            Some(get_type_definitions.position),
+                            get_type_definitions,
                             cx,
                         )
                     })?
@@ -8347,13 +8347,13 @@ impl LspStore {
                     .into_iter();
 
                 lsp_store.update(&mut cx, |project, cx| proto::MultiLspQueryResponse {
-                    responses: type_definition
-                        .map(|(server_id, type_definition)| proto::LspResponse {
+                    responses: type_definitions
+                        .map(|(server_id, type_definitions)| proto::LspResponse {
                             server_id: server_id.to_proto(),
                             response: Some(
                                 proto::lsp_response::Response::GetTypeDefinitionResponse(
-                                    GetTypeDefinition::response_to_proto(
-                                        type_definition,
+                                    GetTypeDefinitions::response_to_proto(
+                                        type_definitions,
                                         project,
                                         sender_id,
                                         &buffer_version,
@@ -8366,7 +8366,7 @@ impl LspStore {
                 })
             }
             Some(proto::multi_lsp_query::Request::GetImplementation(message)) => {
-                let get_implementation = GetImplementation::from_proto(
+                let get_implementations = GetImplementations::from_proto(
                     message,
                     lsp_store.clone(),
                     buffer.clone(),
@@ -8374,12 +8374,12 @@ impl LspStore {
                 )
                 .await?;
 
-                let implementation = lsp_store
+                let implementations = lsp_store
                     .update(&mut cx, |project, cx| {
                         project.request_multiple_lsp_locally(
                             &buffer,
-                            Some(get_implementation.position),
-                            get_implementation,
+                            Some(get_implementations.position),
+                            get_implementations,
                             cx,
                         )
                     })?
@@ -8387,13 +8387,13 @@ impl LspStore {
                     .into_iter();
 
                 lsp_store.update(&mut cx, |project, cx| proto::MultiLspQueryResponse {
-                    responses: implementation
-                        .map(|(server_id, implementation)| proto::LspResponse {
+                    responses: implementations
+                        .map(|(server_id, implementations)| proto::LspResponse {
                             server_id: server_id.to_proto(),
                             response: Some(
                                 proto::lsp_response::Response::GetImplementationResponse(
-                                    GetImplementation::response_to_proto(
-                                        implementation,
+                                    GetImplementations::response_to_proto(
+                                        implementations,
                                         project,
                                         sender_id,
                                         &buffer_version,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5306,6 +5306,7 @@ impl LspStore {
                     .collect::<Result<Vec<Vec<_>>>>()?
                     .into_iter()
                     .flatten()
+                    .dedup()
                     .collect())
             })
         } else {
@@ -5320,6 +5321,7 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, definition)| definition)
+                    .dedup()
                     .collect())
             })
         }
@@ -5377,6 +5379,7 @@ impl LspStore {
                     .collect::<Result<Vec<Vec<_>>>>()?
                     .into_iter()
                     .flatten()
+                    .dedup()
                     .collect())
             })
         } else {
@@ -5391,6 +5394,7 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, declaration)| declaration)
+                    .dedup()
                     .collect())
             })
         }
@@ -5448,6 +5452,7 @@ impl LspStore {
                     .collect::<Result<Vec<Vec<_>>>>()?
                     .into_iter()
                     .flatten()
+                    .dedup()
                     .collect())
             })
         } else {
@@ -5462,6 +5467,7 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, type_definition)| type_definition)
+                    .dedup()
                     .collect())
             })
         }
@@ -5519,6 +5525,7 @@ impl LspStore {
                     .collect::<Result<Vec<Vec<_>>>>()?
                     .into_iter()
                     .flatten()
+                    .dedup()
                     .collect())
             })
         } else {
@@ -5533,6 +5540,7 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, implementation)| implementation)
+                    .dedup()
                     .collect())
             })
         }
@@ -5590,6 +5598,7 @@ impl LspStore {
                     .collect::<Result<Vec<Vec<_>>>>()?
                     .into_iter()
                     .flatten()
+                    .dedup()
                     .collect())
             })
         } else {
@@ -5604,6 +5613,7 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, references)| references)
+                    .dedup()
                     .collect())
             })
         }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3341,20 +3341,6 @@ impl Project {
         })
     }
 
-    #[inline(never)]
-    fn definition_impl(
-        &mut self,
-        buffer: &Entity<Buffer>,
-        position: PointUtf16,
-        cx: &mut Context<Self>,
-    ) -> Task<Result<Vec<LocationLink>>> {
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetDefinition { position },
-            cx,
-        )
-    }
     pub fn definition<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
@@ -3362,21 +3348,9 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.definition_impl(buffer, position, cx)
-    }
-
-    fn declaration_impl(
-        &mut self,
-        buffer: &Entity<Buffer>,
-        position: PointUtf16,
-        cx: &mut Context<Self>,
-    ) -> Task<Result<Vec<LocationLink>>> {
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetDeclaration { position },
-            cx,
-        )
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.definition(buffer, position, cx)
+        })
     }
 
     pub fn declaration<T: ToPointUtf16>(
@@ -3386,21 +3360,9 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.declaration_impl(buffer, position, cx)
-    }
-
-    fn type_definition_impl(
-        &mut self,
-        buffer: &Entity<Buffer>,
-        position: PointUtf16,
-        cx: &mut Context<Self>,
-    ) -> Task<Result<Vec<LocationLink>>> {
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetTypeDefinition { position },
-            cx,
-        )
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.declaration(buffer, position, cx)
+        })
     }
 
     pub fn type_definition<T: ToPointUtf16>(
@@ -3410,7 +3372,9 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.type_definition_impl(buffer, position, cx)
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.type_definition(buffer, position, cx)
+        })
     }
 
     pub fn implementation<T: ToPointUtf16>(
@@ -3420,12 +3384,9 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetImplementation { position },
-            cx,
-        )
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.implementation(buffer, position, cx)
+        })
     }
 
     pub fn references<T: ToPointUtf16>(
@@ -3435,12 +3396,9 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<Location>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetReferences { position },
-            cx,
-        )
+        self.lsp_store.update(cx, |lsp_store, cx| {
+            lsp_store.references(buffer, position, cx)
+        })
     }
 
     fn document_highlights_impl(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -695,7 +695,7 @@ pub struct MarkupContent {
     pub value: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct LocationLink {
     pub origin: Option<Location>,
     pub target: Location,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3341,7 +3341,7 @@ impl Project {
         })
     }
 
-    pub fn definition<T: ToPointUtf16>(
+    pub fn definitions<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
         position: T,
@@ -3349,11 +3349,11 @@ impl Project {
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.definition(buffer, position, cx)
+            lsp_store.definitions(buffer, position, cx)
         })
     }
 
-    pub fn declaration<T: ToPointUtf16>(
+    pub fn declarations<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
         position: T,
@@ -3361,11 +3361,11 @@ impl Project {
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.declaration(buffer, position, cx)
+            lsp_store.declarations(buffer, position, cx)
         })
     }
 
-    pub fn type_definition<T: ToPointUtf16>(
+    pub fn type_definitions<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
         position: T,
@@ -3373,11 +3373,11 @@ impl Project {
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.type_definition(buffer, position, cx)
+            lsp_store.type_definitions(buffer, position, cx)
         })
     }
 
-    pub fn implementation<T: ToPointUtf16>(
+    pub fn implementations<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
         position: T,
@@ -3385,7 +3385,7 @@ impl Project {
     ) -> Task<Result<Vec<LocationLink>>> {
         let position = position.to_point_utf16(buffer.read(cx));
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.implementation(buffer, position, cx)
+            lsp_store.implementations(buffer, position, cx)
         })
     }
 

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -2993,7 +2993,7 @@ async fn test_definition(cx: &mut gpui::TestAppContext) {
         )))
     });
     let mut definitions = project
-        .update(cx, |project, cx| project.definition(&buffer, 22, cx))
+        .update(cx, |project, cx| project.definitions(&buffer, 22, cx))
         .await
         .unwrap();
 

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -757,6 +757,11 @@ message MultiLspQuery {
         GetCodeLens get_code_lens = 8;
         GetDocumentDiagnostics get_document_diagnostics = 9;
         GetDocumentColor get_document_color = 10;
+        GetDefinition get_definition = 11;
+        GetDeclaration get_declaration = 12;
+        GetTypeDefinition get_type_definition = 13;
+        GetImplementation get_implementation = 14;
+        GetReferences get_references = 15;
     }
 }
 
@@ -795,6 +800,11 @@ message LspResponse {
         GetCodeLensResponse get_code_lens_response = 4;
         GetDocumentDiagnosticsResponse get_document_diagnostics_response = 5;
         GetDocumentColorResponse get_document_color_response = 6;
+        GetDefinitionResponse get_definition_response = 8;
+        GetDeclarationResponse get_declaration_response = 9;
+        GetTypeDefinitionResponse get_type_definition_response = 10;
+        GetImplementationResponse get_implementation_response = 11;
+        GetReferencesResponse get_references_response = 12;
     }
     uint64 server_id = 7;
 }


### PR DESCRIPTION
This fixes an issue where lower-priority language servers cannot provide contentful responses even when the first capable server returned empty responses.

Most of the diffs are copypasted since the existing implementations were also copypasted.

Release Notes:

- Improved Go to Definition / Declaration / Type Definition / Implementation and Find All References to include all results from different language servers
