### PR TITLE
agent: Do not reuse assistant message across generations

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -453,9 +453,11 @@ impl CopilotChatLanguageModel {
                         }
                     }
 
-                    messages.push(ChatMessage::User {
-                        content: text_content,
-                    });
+                    if !text_content.is_empty() {
+                        messages.push(ChatMessage::User {
+                            content: text_content,
+                        });
+                    }
                 }
                 Role::Assistant => {
                     let mut tool_calls = Vec::new();


### PR DESCRIPTION
Fixes a bug where we would append tool uses to the last assistant message even if it was from a previous request. 

Release Notes:

- N/A
