### PR TITLE
git: Load prompt from prompt store

### DIFF
--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -60,6 +60,7 @@ util.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 workspace-hack.workspace = true
+prompt_store.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 windows.workspace = true


### PR DESCRIPTION
This is a humble first attempt to address [discussion #26503](https://github.com/zed-industries/zed/discussions/26503) [issue#26823](https://github.com/zed-industries/zed/issues/26823) which highlights a pain point I’ve also been running into across many repos — especially around conventional commits and the need to manually tweak generated commit messages.

The solution here is a bit rough around the edges and may not align perfectly with the direction you’re aiming for, but I figured it was worth sharing as a starting point. It’s also my first time working with the codebase, so this is very much the product of me learning and experimenting with rustc until things worked the way I needed.

That said, I’d love to help move the git prompt conversation forward, and hopefully this can be a useful step in that direction!

Release Notes:

- Support user customizable Git Commit message LLM prompts via Zed Prompt Library