### PR TITLE
Display model name with assistant messages in chat UI

### DIFF
--- a/crates/assistant/src/assistant_panel.rs
+++ b/crates/assistant/src/assistant_panel.rs
@@ -2655,19 +2655,40 @@ impl ContextEditor {
                                 Label::new("You").color(Color::Default).into_any_element()
                             }
                             Role::Assistant => {
-                                let label = Label::new("Assistant").color(Color::Info);
-                                if show_spinner {
-                                    label
-                                        .with_animation(
-                                            "pulsating-label",
-                                            Animation::new(Duration::from_secs(2))
-                                                .repeat()
-                                                .with_easing(pulsating_between(0.4, 0.8)),
-                                            |label, delta| label.alpha(delta),
-                                        )
-                                        .into_any_element()
+                                // If we have model info, display it alongside the Assistant label
+                                if let Some(model_info) = message.model_info.as_ref() {
+                                    let label_text = format!("Assistant ({})", model_info.model_name);
+                                    let label = Label::new(label_text).color(Color::Info);
+                                    
+                                    if show_spinner {
+                                        label
+                                            .with_animation(
+                                                "pulsating-label",
+                                                Animation::new(Duration::from_secs(2))
+                                                    .repeat()
+                                                    .with_easing(pulsating_between(0.4, 0.8)),
+                                                |label, delta| label.alpha(delta),
+                                            )
+                                            .into_any_element()
+                                    } else {
+                                        label.into_any_element()
+                                    }
                                 } else {
-                                    label.into_any_element()
+                                    // Default behavior when no model info is available
+                                    let label = Label::new("Assistant").color(Color::Info);
+                                    if show_spinner {
+                                        label
+                                            .with_animation(
+                                                "pulsating-label",
+                                                Animation::new(Duration::from_secs(2))
+                                                    .repeat()
+                                                    .with_easing(pulsating_between(0.4, 0.8)),
+                                                |label, delta| label.alpha(delta),
+                                            )
+                                            .into_any_element()
+                                    } else {
+                                        label.into_any_element()
+                                    }
                                 }
                             }
 


### PR DESCRIPTION
## Summary
- Add model information to assistant messages in the chat UI
- Show which model generated each response (e.g., 'Assistant (Claude 3 Opus)' instead of just 'Assistant')
- Store model ID, name, and provider ID with each message
- Support multiple models in a single conversation with clear visual distinction

## Implementation
- Added ModelInfo struct to store model details
- Extended MessageMetadata to include optional model information
- Modified assist method to capture and store model info with assistant messages
- Updated UI rendering to display model name alongside 'Assistant' label
- Added serialization support with backward compatibility

## Test Plan
- Open the Assistant panel and have conversations with different models
- Switch between models during a conversation
- Verify that each assistant message displays the correct model name
- Check serialization/deserialization by saving and reopening conversations
