### PR TITLE
language_models: Use `POST /completions` endpoint for Zed provider

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -531,7 +531,7 @@ impl CloudLanguageModel {
             {
                 request_builder.uri(completions_url)
             } else {
-                request_builder.uri(http_client.build_zed_llm_url("/completion", &[])?.as_ref())
+                request_builder.uri(http_client.build_zed_llm_url("/completions", &[])?.as_ref())
             };
             let request = request_builder
                 .header("Content-Type", "application/json")


### PR DESCRIPTION
This PR updates the Zed provider to use the `POST /completions` endpoint.

There is no functional difference from `POST /completion`, but the pluralized version reads better.

Release Notes:

- N/A
