### PR TITLE
feature_flags: Remove `remoting` feature flag

### DIFF
--- a/crates/collab/src/seed.rs
+++ b/crates/collab/src/seed.rs
@@ -46,7 +46,7 @@ pub async fn seed(config: &Config, db: &Database, force: bool) -> anyhow::Result
     let mut first_user = None;
     let mut others = vec![];
 
-    let flag_names = ["remoting", "language-models"];
+    let flag_names = ["language-models"];
     let mut flags = Vec::new();
 
     let existing_feature_flags = db.list_feature_flags().await?;

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -64,11 +64,6 @@ impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";
 }
 
-pub struct Remoting {}
-impl FeatureFlag for Remoting {
-    const NAME: &'static str = "remoting";
-}
-
 pub struct LanguageModels {}
 impl FeatureFlag for LanguageModels {
     const NAME: &'static str = "language-models";


### PR DESCRIPTION
This PR removes the `remoting` feature flag.

The feature is shipped, and we aren't referencing the flag anywhere anymore.

Release Notes:

- N/A
