### PR TITLE
feature_flags: Add `FeatureFlag` suffix to feature flag types

### DIFF
--- a/crates/agent/src/inline_prompt_editor.rs
+++ b/crates/agent/src/inline_prompt_editor.rs
@@ -13,7 +13,7 @@ use editor::{
     Editor, EditorElement, EditorEvent, EditorMode, EditorStyle, GutterDimensions, MultiBuffer,
     actions::{MoveDown, MoveUp},
 };
-use feature_flags::{FeatureFlagAppExt as _, ZedPro};
+use feature_flags::{FeatureFlagAppExt as _, ZedProFeatureFlag};
 use fs::Fs;
 use gpui::{
     AnyElement, App, ClickEvent, Context, CursorStyle, Entity, EventEmitter, FocusHandle,
@@ -132,7 +132,7 @@ impl<T: 'static> Render for PromptEditor<T> {
 
                                 let error_message = SharedString::from(error.to_string());
                                 if error.error_code() == proto::ErrorCode::RateLimitExceeded
-                                    && cx.has_flag::<ZedPro>()
+                                    && cx.has_flag::<ZedProFeatureFlag>()
                                 {
                                     el.child(
                                         v_flex()
@@ -931,7 +931,7 @@ impl PromptEditor<BufferCodegen> {
                     .update(cx, |editor, _| editor.set_read_only(false));
             }
             CodegenStatus::Error(error) => {
-                if cx.has_flag::<ZedPro>()
+                if cx.has_flag::<ZedProFeatureFlag>()
                     && error.error_code() == proto::ErrorCode::RateLimitExceeded
                     && !dismissed_rate_limit_notice()
                 {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2097,7 +2097,7 @@ impl Thread {
     }
 
     pub fn auto_capture_telemetry(&mut self, cx: &mut Context<Self>) {
-        if !cx.has_flag::<feature_flags::ThreadAutoCapture>() {
+        if !cx.has_flag::<feature_flags::ThreadAutoCaptureFeatureFlag>() {
             return;
         }
 

--- a/crates/assistant/src/inline_assistant.rs
+++ b/crates/assistant/src/inline_assistant.rs
@@ -18,7 +18,7 @@ use editor::{
     },
 };
 use feature_flags::{
-    Assistant2FeatureFlag, FeatureFlagAppExt as _, FeatureFlagViewExt as _, ZedPro,
+    Assistant2FeatureFlag, FeatureFlagAppExt as _, FeatureFlagViewExt as _, ZedProFeatureFlag,
 };
 use fs::Fs;
 use futures::{
@@ -1652,7 +1652,7 @@ impl Render for PromptEditor {
 
                         let error_message = SharedString::from(error.to_string());
                         if error.error_code() == proto::ErrorCode::RateLimitExceeded
-                            && cx.has_flag::<ZedPro>()
+                            && cx.has_flag::<ZedProFeatureFlag>()
                         {
                             el.child(
                                 v_flex()
@@ -1966,7 +1966,7 @@ impl PromptEditor {
                     .update(cx, |editor, _| editor.set_read_only(false));
             }
             CodegenStatus::Error(error) => {
-                if cx.has_flag::<ZedPro>()
+                if cx.has_flag::<ZedProFeatureFlag>()
                     && error.error_code() == proto::ErrorCode::RateLimitExceeded
                     && !dismissed_rate_limit_notice()
                 {

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -1,7 +1,7 @@
 use dap::debugger_settings::DebuggerSettings;
 use debugger_panel::{DebugPanel, ToggleFocus};
 use editor::Editor;
-use feature_flags::{Debugger, FeatureFlagViewExt};
+use feature_flags::{DebuggerFeatureFlag, FeatureFlagViewExt};
 use gpui::{App, EntityInputHandler, actions};
 use new_session_modal::NewSessionModal;
 use project::debugger::{self, breakpoint_store::SourceBreakpoint};
@@ -47,7 +47,7 @@ pub fn init(cx: &mut App) {
             return;
         };
 
-        cx.when_flag_enabled::<Debugger>(window, |workspace, _, _| {
+        cx.when_flag_enabled::<DebuggerFeatureFlag>(window, |workspace, _, _| {
             workspace
                 .register_action(|workspace, _: &ToggleFocus, window, cx| {
                     workspace.toggle_panel_focus::<DebugPanel>(window, cx);

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1,4 +1,4 @@
-use feature_flags::{Debugger, FeatureFlagAppExt as _};
+use feature_flags::{DebuggerFeatureFlag, FeatureFlagAppExt as _};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     AnyElement, BackgroundExecutor, Entity, Focusable, FontWeight, ListSizingBehavior,
@@ -812,7 +812,7 @@ impl CodeActionContents {
         actions: Option<Rc<[AvailableCodeAction]>>,
         cx: &App,
     ) -> Self {
-        if !cx.has_flag::<Debugger>() {
+        if !cx.has_flag::<DebuggerFeatureFlag>() {
             if let Some(tasks) = &mut tasks {
                 tasks
                     .templates

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -71,7 +71,7 @@ use element::{AcceptEditPredictionBinding, LineWithInvisibles, PositionMap, layo
 pub use element::{
     CursorLayout, EditorElement, HighlightedRange, HighlightedRangeLine, PointForPosition,
 };
-use feature_flags::{Debugger, FeatureFlagAppExt};
+use feature_flags::{DebuggerFeatureFlag, FeatureFlagAppExt};
 use futures::{
     FutureExt,
     future::{self, Shared, join},
@@ -5159,7 +5159,7 @@ impl Editor {
                                 Self::build_tasks_context(&project, &buffer, buffer_row, tasks, cx)
                             });
 
-                    let debugger_flag = cx.has_flag::<Debugger>();
+                    let debugger_flag = cx.has_flag::<DebuggerFeatureFlag>();
 
                     Some(cx.spawn_in(window, async move |editor, cx| {
                         let task_context = match task_context {
@@ -9150,7 +9150,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !cx.has_flag::<Debugger>() {
+        if !cx.has_flag::<DebuggerFeatureFlag>() {
             return;
         }
         let source = self

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -30,7 +30,7 @@ use crate::{
 use buffer_diff::{DiffHunkStatus, DiffHunkStatusKind};
 use client::ParticipantIndex;
 use collections::{BTreeMap, HashMap};
-use feature_flags::{Debugger, FeatureFlagAppExt};
+use feature_flags::{DebuggerFeatureFlag, FeatureFlagAppExt};
 use file_icons::FileIcons;
 use git::{
     Oid,
@@ -547,7 +547,7 @@ impl EditorElement {
         register_action(editor, window, Editor::insert_uuid_v4);
         register_action(editor, window, Editor::insert_uuid_v7);
         register_action(editor, window, Editor::open_selections_in_multibuffer);
-        if cx.has_flag::<Debugger>() {
+        if cx.has_flag::<DebuggerFeatureFlag>() {
             register_action(editor, window, Editor::toggle_breakpoint);
             register_action(editor, window, Editor::edit_log_breakpoint);
             register_action(editor, window, Editor::enable_breakpoint);
@@ -7037,7 +7037,7 @@ impl Element for EditorElement {
                     let mut breakpoint_rows = self.editor.update(cx, |editor, cx| {
                         editor.active_breakpoints(start_row..end_row, window, cx)
                     });
-                    if cx.has_flag::<Debugger>() {
+                    if cx.has_flag::<DebuggerFeatureFlag>() {
                         for display_row in breakpoint_rows.keys() {
                             active_rows.entry(*display_row).or_default().breakpoint = true;
                         }
@@ -7060,7 +7060,7 @@ impl Element for EditorElement {
                     // We add the gutter breakpoint indicator to breakpoint_rows after painting
                     // line numbers so we don't paint a line number debug accent color if a user
                     // has their mouse over that line when a breakpoint isn't there
-                    if cx.has_flag::<Debugger>() {
+                    if cx.has_flag::<DebuggerFeatureFlag>() {
                         let gutter_breakpoint_indicator =
                             self.editor.read(cx).gutter_breakpoint_indicator.0;
                         if let Some((gutter_breakpoint_point, _)) =
@@ -7576,7 +7576,7 @@ impl Element for EditorElement {
                     let show_breakpoints = snapshot
                         .show_breakpoints
                         .unwrap_or(gutter_settings.breakpoints);
-                    let breakpoints = if cx.has_flag::<Debugger>() && show_breakpoints {
+                    let breakpoints = if cx.has_flag::<DebuggerFeatureFlag>() && show_breakpoints {
                         self.layout_breakpoints(
                             line_height,
                             start_row..end_row,

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -64,18 +64,18 @@ impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";
 }
 
-pub struct LanguageModels {}
-impl FeatureFlag for LanguageModels {
+pub struct LanguageModelsFeatureFlag {}
+impl FeatureFlag for LanguageModelsFeatureFlag {
     const NAME: &'static str = "language-models";
 }
 
-pub struct LlmClosedBeta {}
-impl FeatureFlag for LlmClosedBeta {
+pub struct LlmClosedBetaFeatureFlag {}
+impl FeatureFlag for LlmClosedBetaFeatureFlag {
     const NAME: &'static str = "llm-closed-beta";
 }
 
-pub struct ZedPro {}
-impl FeatureFlag for ZedPro {
+pub struct ZedProFeatureFlag {}
+impl FeatureFlag for ZedProFeatureFlag {
     const NAME: &'static str = "zed-pro";
 }
 
@@ -85,13 +85,13 @@ impl FeatureFlag for NotebookFeatureFlag {
     const NAME: &'static str = "notebooks";
 }
 
-pub struct Debugger {}
-impl FeatureFlag for Debugger {
+pub struct DebuggerFeatureFlag {}
+impl FeatureFlag for DebuggerFeatureFlag {
     const NAME: &'static str = "debugger";
 }
 
-pub struct ThreadAutoCapture {}
-impl FeatureFlag for ThreadAutoCapture {
+pub struct ThreadAutoCaptureFeatureFlag {}
+impl FeatureFlag for ThreadAutoCaptureFeatureFlag {
     const NAME: &'static str = "thread-auto-capture";
 
     fn enabled_for_staff() -> bool {

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use collections::{HashSet, IndexMap};
-use feature_flags::{Assistant2FeatureFlag, ZedPro};
+use feature_flags::{Assistant2FeatureFlag, ZedProFeatureFlag};
 use gpui::{
     Action, AnyElement, AnyView, App, Corner, DismissEvent, Entity, EventEmitter, FocusHandle,
     Focusable, Subscription, Task, WeakEntity, action_with_deprecated_aliases,
@@ -584,7 +584,7 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                 .p_1()
                 .gap_4()
                 .justify_between()
-                .when(cx.has_flag::<ZedPro>(), |this| {
+                .when(cx.has_flag::<ZedProFeatureFlag>(), |this| {
                     this.child(match plan {
                         Plan::ZedPro => Button::new("zed-pro", "Zed Pro")
                             .icon(IconName::ZedAssistant)

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -71,7 +71,7 @@ fn register_language_model_providers(
     );
     registry.register_provider(CopilotChatLanguageModelProvider::new(cx), cx);
 
-    cx.observe_flag::<feature_flags::LanguageModels, _>(move |enabled, cx| {
+    cx.observe_flag::<feature_flags::LanguageModelsFeatureFlag, _>(move |enabled, cx| {
         let user_store = user_store.clone();
         let client = client.clone();
         LanguageModelRegistry::global(cx).update(cx, move |registry, cx| {

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -2,7 +2,7 @@ use anthropic::{AnthropicError, AnthropicModelMode, parse_prompt_too_long};
 use anyhow::{Result, anyhow};
 use client::{Client, UserStore, zed_urls};
 use collections::BTreeMap;
-use feature_flags::{FeatureFlagAppExt, LlmClosedBeta, ZedPro};
+use feature_flags::{FeatureFlagAppExt, LlmClosedBetaFeatureFlag, ZedProFeatureFlag};
 use futures::{
     AsyncBufReadExt, FutureExt, Stream, StreamExt, TryStreamExt as _, future::BoxFuture,
     stream::BoxStream,
@@ -324,7 +324,7 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
             );
         }
 
-        let llm_closed_beta_models = if cx.has_flag::<LlmClosedBeta>() {
+        let llm_closed_beta_models = if cx.has_flag::<LlmClosedBetaFeatureFlag>() {
             zed_cloud_provider_additional_models()
         } else {
             &[]
@@ -945,7 +945,7 @@ impl Render for ConfigurationView {
                         ),
                 ),
             )
-        } else if cx.has_flag::<ZedPro>() {
+        } else if cx.has_flag::<ZedProFeatureFlag>() {
             Some(
                 h_flex()
                     .gap_2()

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -18,7 +18,7 @@ use crate::platforms::{platform_linux, platform_mac, platform_windows};
 use auto_update::AutoUpdateStatus;
 use call::ActiveCall;
 use client::{Client, UserStore};
-use feature_flags::{FeatureFlagAppExt, ZedPro};
+use feature_flags::{FeatureFlagAppExt, ZedProFeatureFlag};
 use gpui::{
     Action, AnyElement, App, Context, Corner, Decorations, Element, Entity, InteractiveElement,
     Interactivity, IntoElement, MouseButton, ParentElement, Render, Stateful,
@@ -663,7 +663,7 @@ impl TitleBar {
                 .anchor(Corner::TopRight)
                 .menu(move |window, cx| {
                     ContextMenu::build(window, cx, |menu, _, cx| {
-                        menu.when(cx.has_flag::<ZedPro>(), |menu| {
+                        menu.when(cx.has_flag::<ZedProFeatureFlag>(), |menu| {
                             menu.action(
                                 format!(
                                     "Current Plan: {}",

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -20,7 +20,7 @@ use command_palette_hooks::CommandPaletteFilter;
 use debugger_ui::debugger_panel::DebugPanel;
 use editor::ProposedChangesEditorToolbar;
 use editor::{Editor, MultiBuffer, scroll::Autoscroll};
-use feature_flags::{Debugger, FeatureFlagAppExt, FeatureFlagViewExt};
+use feature_flags::{DebuggerFeatureFlag, FeatureFlagAppExt, FeatureFlagViewExt};
 use futures::{StreamExt, channel::mpsc, select_biased};
 use git_ui::git_panel::GitPanel;
 use git_ui::project_diff::ProjectDiffToolbar;
@@ -279,7 +279,7 @@ fn feature_gate_zed_pro_actions(cx: &mut App) {
         filter.hide_action_types(&zed_pro_actions);
     });
 
-    cx.observe_flag::<feature_flags::ZedPro, _>({
+    cx.observe_flag::<feature_flags::ZedProFeatureFlag, _>({
         move |is_enabled, cx| {
             CommandPaletteFilter::update_global(cx, |filter, _cx| {
                 if is_enabled {
@@ -439,7 +439,7 @@ fn initialize_panels(
             workspace.add_panel(channels_panel, window, cx);
             workspace.add_panel(chat_panel, window, cx);
             workspace.add_panel(notification_panel, window, cx);
-            cx.when_flag_enabled::<Debugger>(window, |_, window, cx| {
+            cx.when_flag_enabled::<DebuggerFeatureFlag>(window, |_, window, cx| {
                 cx.spawn_in(
                     window,
                     async move |workspace: gpui::WeakEntity<Workspace>,


### PR DESCRIPTION
This PR adds the `FeatureFlag` suffix to the feature flag types that were missing them.

This makes the names easier to search in the codebase.

Release Notes:

- N/A
