### PR TITLE
assistant_tool: Remove additionalProperties from tool schema

### DIFF
--- a/crates/assistant_tool/src/tool_schema.rs
+++ b/crates/assistant_tool/src/tool_schema.rs
@@ -36,6 +36,7 @@ fn adapt_to_json_schema_subset(json: &mut Value) -> Result<()> {
         }
 
         obj.remove("format");
+        obj.remove("additionalProperties");
 
         if let Some(default) = obj.get("default") {
             let is_null = default.is_null();


### PR DESCRIPTION
Gemini API does not support additionalProperties field in function call schemas.

Ref Docs: https://ai.google.dev/gemini-api/docs/function-calling?example=meeting#use_model_context_protocol_mcp

Closes #29394

Release Notes:

- NA
