### PR TITLE
editor: Return code actions item to original position

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -260,7 +260,14 @@ pub fn deploy_context_menu(
                     } else {
                         builder.disabled_action(COPY_PERMALINK_LABEL, Box::new(CopyPermalinkToLine))
                     }
-                });
+                })
+                .separator()
+                .action(
+                    "Show Code Actions",
+                    Box::new(ToggleCodeActions {
+                        deployed_from_indicator: None,
+                    }),
+                );
             match focus {
                 Some(focus) => builder.context(focus),
                 None => builder,


### PR DESCRIPTION
Recent work in #28677 and #28988 moves the code actions item to the top of the mouse context menu, apparently to improve its visibility. Previously, the item was at the bottom of the menu. This is a fairly breaking change from a UX perspective, as it interferes with muscle memory for (I argue) no particular benefit.

This PR (perhaps controversially) moves the item back to its original position to undo the breaking change. Happy to have discussion on this.

Release Notes:

- N/A
