### PR TITLE
agent: Allow to explictly disable tools when using `enable_all_context_servers`

### DIFF
--- a/crates/agent/src/assistant_configuration/tool_picker.rs
+++ b/crates/agent/src/assistant_configuration/tool_picker.rs
@@ -272,7 +272,7 @@ impl PickerDelegate for ToolPickerDelegate {
                 .get(id.as_ref())
                 .and_then(|preset| preset.tools.get(&tool.name))
                 .copied()
-                .unwrap_or(false),
+                .unwrap_or(self.profile.enable_all_context_servers),
         };
 
         Some(

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -494,6 +494,22 @@ impl ThreadStore {
                     );
                 });
             }
+            // Enable all the tools from all context servers, but disable the ones that are explicitly disabled
+            for (context_server_id, preset) in &profile.context_servers {
+                self.tools.update(cx, |tools, cx| {
+                    tools.disable(
+                        ToolSource::ContextServer {
+                            id: context_server_id.clone().into(),
+                        },
+                        &preset
+                            .tools
+                            .iter()
+                            .filter_map(|(tool, enabled)| (!enabled).then(|| tool.clone()))
+                            .collect::<Vec<_>>(),
+                        cx,
+                    )
+                })
+            }
         } else {
             for (context_server_id, preset) in &profile.context_servers {
                 self.tools.update(cx, |tools, cx| {


### PR DESCRIPTION
Previously, all MCP tools would be completed regardless if they were disabled/enabled for the profile. This meant that the "Write" profile was always using all MCP tools, even if you disabled them in the settings.

Now, when `enable_all_context_servers` is set to `true`, we will enable all tools from all MCP servers by default but disable the ones that are explicitly disabled for the profile.

Also fixes an issue where the tools would not show up as enabled when using `enable_all_context_servers: true`

Release Notes:

- agent: Fix an issue where MCP tools could not be enabled/disabled
