### PR TITLE
language_models: Remove `language-models` feature flag

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -64,11 +64,6 @@ impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";
 }
 
-pub struct LanguageModelsFeatureFlag {}
-impl FeatureFlag for LanguageModelsFeatureFlag {
-    const NAME: &'static str = "language-models";
-}
-
 pub struct LlmClosedBetaFeatureFlag {}
 impl FeatureFlag for LlmClosedBetaFeatureFlag {
     const NAME: &'static str = "llm-closed-beta";

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use client::{Client, UserStore};
 use fs::Fs;
 use gpui::{App, Context, Entity};
-use language_model::{LanguageModelProviderId, LanguageModelRegistry, ZED_CLOUD_PROVIDER_ID};
+use language_model::LanguageModelRegistry;
 use provider::deepseek::DeepSeekLanguageModelProvider;
 
 pub mod provider;
@@ -35,7 +35,10 @@ fn register_language_model_providers(
     client: Arc<Client>,
     cx: &mut Context<LanguageModelRegistry>,
 ) {
-    use feature_flags::FeatureFlagAppExt;
+    registry.register_provider(
+        CloudLanguageModelProvider::new(user_store.clone(), client.clone(), cx),
+        cx,
+    );
 
     registry.register_provider(
         AnthropicLanguageModelProvider::new(client.http_client(), cx),
@@ -70,23 +73,4 @@ fn register_language_model_providers(
         cx,
     );
     registry.register_provider(CopilotChatLanguageModelProvider::new(cx), cx);
-
-    cx.observe_flag::<feature_flags::LanguageModelsFeatureFlag, _>(move |enabled, cx| {
-        let user_store = user_store.clone();
-        let client = client.clone();
-        LanguageModelRegistry::global(cx).update(cx, move |registry, cx| {
-            if enabled {
-                registry.register_provider(
-                    CloudLanguageModelProvider::new(user_store.clone(), client.clone(), cx),
-                    cx,
-                );
-            } else {
-                registry.unregister_provider(
-                    LanguageModelProviderId::from(ZED_CLOUD_PROVIDER_ID.to_string()),
-                    cx,
-                );
-            }
-        });
-    })
-    .detach();
 }


### PR DESCRIPTION
This PR removes the `language-models` feature flag.

This feature is already generally available, so we no longer need the feature flag.

Release Notes:

- N/A
