### PR TITLE
xtask: Ignore `workspace-hack` when checking for non-workspace dependencies

### DIFF
--- a/tooling/xtask/src/tasks/package_conformity.rs
+++ b/tooling/xtask/src/tasks/package_conformity.rs
@@ -36,7 +36,12 @@ pub fn run_package_conformity(_args: PackageConformityArgs) -> Result<()> {
         }
 
         // Extensions should not use workspace dependencies.
-        if is_extension {
+        if is_extension || package.name == "zed_extension_api" {
+            continue;
+        }
+
+        // Ignore `workspace-hack`, as it produces a lot of false positives.
+        if package.name == "workspace-hack" {
             continue;
         }
 


### PR DESCRIPTION
This PR makes it so `workspace-hack` is ignored by `cargo xtask package-conformity` when looking for non-workspace dependencies.

Also added `zed_extension_api` to the exclude list.

Release Notes:

- N/A
