### PR TITLE
ci: Add no-op job for "Run Agent Eval" workflow

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -25,6 +25,15 @@ env:
   ZED_EVAL_TELEMETRY: 1
 
 jobs:
+  # This is a no-op job that we run to prevent GitHub from making the workflow
+  # as failed for PRs that don't have the `run-eval` label.
+  noop:
+    name: No-op
+    runs-on: ubuntu-latest
+    steps:
+      - name: No-op
+        run: echo "Nothing to do"
+
   run_eval:
     timeout-minutes: 60
     name: Run Agent Eval


### PR DESCRIPTION
This PR adds a no-op job for the "Run Agent Eval" workflow.

This aims to avoid marking the check as failed on a PR that does not include the `run-eval` label.

Release Notes:

- N/A
