### PR TITLE
zlog: Fix incorrect assumption with filters

### DIFF
--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -200,7 +200,7 @@ macro_rules! crate_name {
 pub mod private {
     use super::*;
 
-    pub const fn extract_crate_name_from_module_path(module_path: &'static str) -> &'static str {
+    pub const fn extract_crate_name_from_module_path(module_path: &str) -> &str {
         let mut i = 0;
         let mod_path_bytes = module_path.as_bytes();
         let mut index = mod_path_bytes.len();


### PR DESCRIPTION
- **do not assume logs over LEVEL_ENABLED_MAX_STATIC (the static global log level) are enabled**
- **make it so filters that are just module names get overridden by submodule path filters**

Closes #ISSUE

Release Notes:

- N/A
