### PR TITLE
eval: Use workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,7 +4975,7 @@ dependencies = [
  "client",
  "collections",
  "context_server",
- "dirs 5.0.1",
+ "dirs 4.0.0",
  "dotenv",
  "env_logger 0.11.8",
  "extension",

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -3,7 +3,19 @@ name = "eval"
 version = "0.1.0"
 publish.workspace = true
 edition.workspace = true
+license = "GPL-3.0-or-later"
 default-run = "eval"
+
+[lints]
+workspace = true
+
+[[bin]]
+name = "eval"
+path = "src/eval.rs"
+
+[[bin]]
+name = "explorer"
+path = "src/explorer.rs"
 
 [dependencies]
 agent.workspace = true
@@ -18,7 +30,7 @@ clap.workspace = true
 client.workspace = true
 collections.workspace = true
 context_server.workspace = true
-dirs = "5.0"
+dirs.workspace = true
 dotenv.workspace = true
 env_logger.workspace = true
 extension.workspace = true
@@ -33,7 +45,7 @@ language_model.workspace = true
 language_models.workspace = true
 languages = { workspace = true, features = ["load-grammars"] }
 node_runtime.workspace = true
-pathdiff = "0.2"
+pathdiff.workspace = true
 paths.workspace = true
 project.workspace = true
 prompt_store.workspace = true
@@ -49,16 +61,5 @@ telemetry.workspace = true
 toml.workspace = true
 unindent.workspace = true
 util.workspace = true
-uuid = { version = "1.6", features = ["v4"] }
+uuid.workspace = true
 workspace-hack.workspace = true
-
-[[bin]]
-name = "eval"
-path = "src/eval.rs"
-
-[[bin]]
-name = "explorer"
-path = "src/explorer.rs"
-
-[lints]
-workspace = true


### PR DESCRIPTION
This PR updates the `eval` crate to use workspace dependencies.

Also did a bit of cleanup of the `Cargo.toml`.

Release Notes:

- N/A
