### PR TITLE
danger: Update PR prefix pattern

### DIFF
--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -2,7 +2,7 @@ import { danger, message, warn } from "danger";
 const { prHygiene } = require("danger-plugin-pr-hygiene");
 
 prHygiene({
-  prefixPattern: new RegExp("^([a-z\\d\\(\\)_\\s]+):(.*)"),
+  prefixPattern: /^([a-z\d\(\)_\s]+):(.*)/g,
   rules: {
     // Don't enable this rule just yet, as it can have false positives.
     useImperativeMood: "off",

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -2,6 +2,7 @@ import { danger, message, warn } from "danger";
 const { prHygiene } = require("danger-plugin-pr-hygiene");
 
 prHygiene({
+  prefixPattern: new RegExp("^([a-z\\d\\(\\)_\\s]+):(.*)"),
   rules: {
     // Don't enable this rule just yet, as it can have false positives.
     useImperativeMood: "off",


### PR DESCRIPTION
This PR updates the Danger PR prefix pattern to allow underscores (`_`) and spaces (` `) in the prefix.

Release Notes:

- N/A
