### PR TITLE
collab: Add `subscription_usage_meters` table

### DIFF
--- a/crates/collab/migrations_llm/20250425171838_add_subscription_usage_meters.sql
+++ b/crates/collab/migrations_llm/20250425171838_add_subscription_usage_meters.sql
@@ -1,0 +1,8 @@
+create table subscription_usage_meters (
+    id serial primary key,
+    subscription_usage_id integer not null references subscription_usages (id) on delete cascade,
+    model_id integer not null references models (id) on delete cascade,
+    requests integer not null default 0
+);
+
+create unique index uix_subscription_usage_meters_on_subscription_usage_model on subscription_usage_meters (subscription_usage_id, model_id);


### PR DESCRIPTION
This PR adds a new `subscription_usage_meters` table to the LLM database.

We'll use this to track usage of individual models over the number of requests built-in to the plan.

Release Notes:

- N/A
