### PR TITLE
collab: Add LLM request overage columns to `billing_preferences`

### DIFF
--- a/crates/collab/migrations/20250425201930_add_model_request_overages_to_billing_preferences.sql
+++ b/crates/collab/migrations/20250425201930_add_model_request_overages_to_billing_preferences.sql
@@ -1,0 +1,3 @@
+alter table billing_preferences
+    add column model_request_overages_enabled bool not null default false,
+    add column model_request_overages_spend_limit_in_cents integer not null default 0;

--- a/crates/collab/src/db/tables/billing_preference.rs
+++ b/crates/collab/src/db/tables/billing_preference.rs
@@ -9,6 +9,8 @@ pub struct Model {
     pub created_at: DateTime,
     pub user_id: UserId,
     pub max_monthly_llm_usage_spending_in_cents: i32,
+    pub model_request_overages_enabled: bool,
+    pub model_request_overages_spend_limit_in_cents: i32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]


### PR DESCRIPTION
This PR adds two new columns to the `billing_preferences` table to allow users to opt in to overages on LLM requests.

Release Notes:

- N/A
