### PR TITLE
askpass: Shell escape Zed path in askpass script

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -446,6 +446,7 @@ dependencies = [
  "anyhow",
  "futures 0.3.31",
  "gpui",
+ "shlex",
  "smol",
  "tempfile",
  "util",

--- a/crates/askpass/Cargo.toml
+++ b/crates/askpass/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/askpass.rs"
 anyhow.workspace = true
 futures.workspace = true
 gpui.workspace = true
+shlex.workspace = true
 smol.workspace = true
 tempfile.workspace = true
 util.workspace = true

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -10,7 +10,6 @@ use futures::{AsyncBufReadExt as _, io::BufReader};
 use futures::{AsyncWriteExt as _, FutureExt as _, select_biased};
 use futures::{SinkExt, StreamExt};
 use gpui::{AsyncApp, BackgroundExecutor, Task};
-use shlex;
 #[cfg(unix)]
 use smol::fs;
 #[cfg(unix)]

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -10,6 +10,7 @@ use futures::{AsyncBufReadExt as _, io::BufReader};
 use futures::{AsyncWriteExt as _, FutureExt as _, select_biased};
 use futures::{SinkExt, StreamExt};
 use gpui::{AsyncApp, BackgroundExecutor, Task};
+use shlex;
 #[cfg(unix)]
 use smol::fs;
 #[cfg(unix)]
@@ -72,8 +73,7 @@ impl AskPassSession {
         let (askpass_opened_tx, askpass_opened_rx) = oneshot::channel::<()>();
         let listener =
             UnixListener::bind(&askpass_socket).context("failed to create askpass socket")?;
-        let zed_path = std::env::current_exe()
-            .context("Failed to figure out current executable path for use in askpass")?;
+        let zed_path = get_shell_safe_zed_path()?;
 
         let (askpass_kill_master_tx, askpass_kill_master_rx) = oneshot::channel::<()>();
         let mut kill_tx = Some(askpass_kill_master_tx);
@@ -115,7 +115,7 @@ impl AskPassSession {
         // Create an askpass script that communicates back to this process.
         let askpass_script = format!(
             "{shebang}\n{print_args} | {zed_exe} --askpass={askpass_socket} 2> /dev/null \n",
-            zed_exe = zed_path.display(),
+            zed_exe = zed_path,
             askpass_socket = askpass_socket.display(),
             print_args = "printf '%s\\0' \"$@\"",
             shebang = "#!/bin/sh",
@@ -159,6 +159,34 @@ impl AskPassSession {
             }
         }
     }
+}
+
+fn get_shell_safe_zed_path() -> anyhow::Result<String> {
+    let zed_path = std::env::current_exe()
+        .context("Failed to figure out current executable path for use in askpass")?
+        .to_string_lossy()
+        .to_string();
+
+    // sanity check on unix systems that the path exists and is executable
+    // todo(windows): implement this check for windows (or just use `is-executable` crate)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::MetadataExt;
+        let metadata = std::fs::metadata(&zed_path)
+            .context("Failed to check metadata of Zed executable path for use in askpass")?;
+        let is_executable = metadata.is_file() && metadata.mode() & 0o111 != 0;
+        anyhow::ensure!(
+            is_executable,
+            "Failed to verify Zed executable path for use in askpass"
+        );
+    }
+    // As of writing, this can only be fail if the path contains a null byte, which shouldn't be possible
+    // but shlex has annotated the error as #[non_exhaustive] so we can't make it a compile error if other
+    // errors are introduced in the future :(
+    let zed_path_escaped = shlex::try_quote(&zed_path)
+        .context("Failed to shell-escape Zed executable path for use in askpass")?;
+
+    return Ok(zed_path_escaped.to_string());
 }
 
 /// The main function for when Zed is running in netcat mode for use in askpass.

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -161,6 +161,7 @@ impl AskPassSession {
     }
 }
 
+#[cfg(unix)]
 fn get_shell_safe_zed_path() -> anyhow::Result<String> {
     let zed_path = std::env::current_exe()
         .context("Failed to figure out current executable path for use in askpass")?
@@ -169,17 +170,14 @@ fn get_shell_safe_zed_path() -> anyhow::Result<String> {
 
     // sanity check on unix systems that the path exists and is executable
     // todo(windows): implement this check for windows (or just use `is-executable` crate)
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::MetadataExt;
-        let metadata = std::fs::metadata(&zed_path)
-            .context("Failed to check metadata of Zed executable path for use in askpass")?;
-        let is_executable = metadata.is_file() && metadata.mode() & 0o111 != 0;
-        anyhow::ensure!(
-            is_executable,
-            "Failed to verify Zed executable path for use in askpass"
-        );
-    }
+    use std::os::unix::fs::MetadataExt;
+    let metadata = std::fs::metadata(&zed_path)
+        .context("Failed to check metadata of Zed executable path for use in askpass")?;
+    let is_executable = metadata.is_file() && metadata.mode() & 0o111 != 0;
+    anyhow::ensure!(
+        is_executable,
+        "Failed to verify Zed executable path for use in askpass"
+    );
     // As of writing, this can only be fail if the path contains a null byte, which shouldn't be possible
     // but shlex has annotated the error as #[non_exhaustive] so we can't make it a compile error if other
     // errors are introduced in the future :(


### PR DESCRIPTION
Closes #29439

Add shell escaping as well as additional sanity check for Zed path when used in askpass. This caused issues on preview and nightly as the standard paths for those releases contain spaces which were not escaped appropriately leading to erroneous "Permission denied" errors from SSH when the askpass script failed

Release Notes:

- Fixed a missing shell-escape in askpass resulting in erroneous "Permission denied" errors when trying to connect to a remote server over ssh (effecting preview release v0.184.1 and nightly only)
