### PR TITLE
gpui: Relax AssetLogger trait bounds

### DIFF
--- a/crates/gpui/src/asset_cache.rs
+++ b/crates/gpui/src/asset_cache.rs
@@ -51,7 +51,7 @@ pub trait Asset: 'static {
     ) -> impl Future<Output = Self::Output> + Send + 'static;
 }
 
-/// An asset Loader that logs whatever errors pass through it
+/// An asset Loader which logs the [`Err`] variant of a [`Result`] during loading
 pub enum AssetLogger<T> {
     #[doc(hidden)]
     _Phantom(PhantomData<T>, &'static dyn crate::seal::Sealed),

--- a/crates/gpui/src/asset_cache.rs
+++ b/crates/gpui/src/asset_cache.rs
@@ -51,13 +51,13 @@ pub trait Asset: 'static {
     ) -> impl Future<Output = Self::Output> + Send + 'static;
 }
 
-/// An asset Loader that logs whatever passes through it
+/// An asset Loader that logs whatever errors pass through it
 pub enum AssetLogger<T> {
     #[doc(hidden)]
     _Phantom(PhantomData<T>, &'static dyn crate::seal::Sealed),
 }
 
-impl<R: Clone + Send, E: Clone + Send + std::error::Error, T: Asset<Output = Result<R, E>>> Asset
+impl<R: Clone + Send, E: Clone + Send + std::fmt::Display, T: Asset<Output = Result<R, E>>> Asset
     for AssetLogger<T>
 {
     type Source = T::Source;

--- a/crates/gpui/src/asset_cache.rs
+++ b/crates/gpui/src/asset_cache.rs
@@ -1,5 +1,5 @@
 use crate::{App, SharedString, SharedUri};
-use futures::Future;
+use futures::{Future, TryFutureExt};
 
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
@@ -72,10 +72,7 @@ where
         cx: &mut App,
     ) -> impl Future<Output = Self::Output> + Send + 'static {
         let load = T::load(source, cx);
-        async {
-            load.await
-                .inspect_err(|e| log::error!("Failed to load asset: {}", e))
-        }
+        load.inspect_err(|e| log::error!("Failed to load asset: {}", e))
     }
 }
 

--- a/crates/gpui/src/asset_cache.rs
+++ b/crates/gpui/src/asset_cache.rs
@@ -57,8 +57,11 @@ pub enum AssetLogger<T> {
     _Phantom(PhantomData<T>, &'static dyn crate::seal::Sealed),
 }
 
-impl<R: Clone + Send, E: Clone + Send + std::fmt::Display, T: Asset<Output = Result<R, E>>> Asset
-    for AssetLogger<T>
+impl<T, R, E> Asset for AssetLogger<T>
+where
+    T: Asset<Output = Result<R, E>>,
+    R: Clone + Send,
+    E: Clone + Send + std::fmt::Display,
 {
     type Source = T::Source;
 


### PR DESCRIPTION
Loosen trait bounds from `std::error::Error` to `std::fmt::Display`, since it's not required for the `log::error!` macro or any other bounds.

Specify that `AssetLogger` specifically logs errors in its documentation.

Use the `futures::TryFutureExt` trait extension to use `inspect_err` directly on a future.

Release Notes:

- N/A
