### PR TITLE
Use image cache to stop leaking images

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18537,9 +18537,9 @@ dependencies = [
 
 [[package]]
 name = "zed_llm_client"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1666cd923c5eb4635f3743e69c6920d0ed71f29b26920616a5d220607df7c4"
+checksum = "cc9ec491b7112cb8c2fba3c17d9a349d8ab695fb1a4ef6c5c4b9fd8d7aa975c1"
 dependencies = [
  "anyhow",
  "serde",

--- a/crates/gpui/examples/image_gallery.rs
+++ b/crates/gpui/examples/image_gallery.rs
@@ -44,8 +44,8 @@ impl Render for ImageGallery {
             .text_color(gpui::white())
             .child("Manually managed image cache:")
             .child(
-                image_cache(self.image_cache.clone()).child(
                 div()
+                    .image_cache(self.image_cache.clone())
                     .id("main")
                     .font_family(".SystemUIFont")
                     .text_color(gpui::black())
@@ -95,7 +95,7 @@ impl Render for ImageGallery {
                                     .map(|ix| img(format!("{}-{}", image_url, ix)).size_20()),
                             ),
                     ),
-            ))
+            )
             .child(
                 "Automatically managed image cache:"
             )

--- a/crates/gpui/examples/image_gallery.rs
+++ b/crates/gpui/examples/image_gallery.rs
@@ -1,9 +1,9 @@
 use futures::FutureExt;
 use gpui::{
     App, AppContext, Application, Asset as _, AssetLogger, Bounds, ClickEvent, Context, ElementId,
-    Entity, HashMapImageCache, ImageAssetLoader, ImageCache, ImageCacheProvider, KeyBinding, Menu,
-    MenuItem, SharedString, TitlebarOptions, Window, WindowBounds, WindowOptions, actions, div,
-    hash, image_cache, img, prelude::*, px, rgb, size,
+    Entity, ImageAssetLoader, ImageCache, ImageCacheProvider, KeyBinding, Menu, MenuItem,
+    RetainAllImageCache, SharedString, TitlebarOptions, Window, WindowBounds, WindowOptions,
+    actions, div, hash, image_cache, img, prelude::*, px, rgb, size,
 };
 use reqwest_client::ReqwestClient;
 use std::{collections::HashMap, sync::Arc};
@@ -14,7 +14,7 @@ struct ImageGallery {
     image_key: String,
     items_count: usize,
     total_count: usize,
-    image_cache: Entity<HashMapImageCache>,
+    image_cache: Entity<RetainAllImageCache>,
 }
 
 impl ImageGallery {
@@ -282,7 +282,7 @@ fn main() {
                 image_key: "".into(),
                 items_count: IMAGES_IN_GALLERY,
                 total_count: 0,
-                image_cache: HashMapImageCache::new(ctx),
+                image_cache: RetainAllImageCache::new(ctx),
             })
         })
         .unwrap();

--- a/crates/gpui/src/elements/image_cache.rs
+++ b/crates/gpui/src/elements/image_cache.rs
@@ -109,7 +109,7 @@ impl Element for ImageCacheElement {
         cx: &mut App,
     ) -> (LayoutId, Self::RequestLayoutState) {
         let image_cache = self.image_cache_provider.provide(window, cx);
-        window.with_image_cache(image_cache, |window| {
+        window.with_image_cache(Some(image_cache), |window| {
             let child_layout_ids = self
                 .children
                 .iter_mut()
@@ -145,7 +145,7 @@ impl Element for ImageCacheElement {
         cx: &mut App,
     ) {
         let image_cache = self.image_cache_provider.provide(window, cx);
-        window.with_image_cache(image_cache, |window| {
+        window.with_image_cache(Some(image_cache), |window| {
             for child in &mut self.children {
                 child.paint(window, cx);
             }

--- a/crates/gpui/src/elements/image_cache.rs
+++ b/crates/gpui/src/elements/image_cache.rs
@@ -317,3 +317,29 @@ impl ImageCache for RetainAllImageCache {
         RetainAllImageCache::load(self, resource, window, cx)
     }
 }
+
+/// Constructs a retain-all image cache that uses the element state associated with the given ID.
+pub fn retain_all(id: impl Into<ElementId>) -> RetainAllImageCacheProvider {
+    RetainAllImageCacheProvider { id: id.into() }
+}
+
+/// A provider struct for creating a retain-all image cache inline
+pub struct RetainAllImageCacheProvider {
+    id: ElementId,
+}
+
+impl ImageCacheProvider for RetainAllImageCacheProvider {
+    fn provide(&mut self, window: &mut Window, cx: &mut App) -> AnyImageCache {
+        window
+            .with_global_id(self.id.clone(), |global_id, window| {
+                window.with_element_state::<Entity<RetainAllImageCache>, _>(
+                    global_id,
+                    |cache, _window| {
+                        let mut cache = cache.unwrap_or_else(|| RetainAllImageCache::new(cx));
+                        (cache.clone(), cache)
+                    },
+                )
+            })
+            .into()
+    }
+}

--- a/crates/gpui/src/elements/image_cache.rs
+++ b/crates/gpui/src/elements/image_cache.rs
@@ -217,9 +217,9 @@ impl<T: ImageCache> ImageCacheProvider for Entity<T> {
 }
 
 /// An implementation of ImageCache, that uses an LRU caching strategy to unload images when the cache is full
-pub struct HashMapImageCache(HashMap<u64, ImageCacheItem>);
+pub struct RetainAllImageCache(HashMap<u64, ImageCacheItem>);
 
-impl fmt::Debug for HashMapImageCache {
+impl fmt::Debug for RetainAllImageCache {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HashMapImageCache")
             .field("num_images", &self.0.len())
@@ -227,11 +227,11 @@ impl fmt::Debug for HashMapImageCache {
     }
 }
 
-impl HashMapImageCache {
+impl RetainAllImageCache {
     /// Create a new image cache.
     #[inline]
     pub fn new(cx: &mut App) -> Entity<Self> {
-        let e = cx.new(|_cx| HashMapImageCache(HashMap::new()));
+        let e = cx.new(|_cx| RetainAllImageCache(HashMap::new()));
         cx.observe_release(&e, |image_cache, cx| {
             for (_, mut item) in std::mem::replace(&mut image_cache.0, HashMap::new()) {
                 if let Some(Ok(image)) = item.get() {
@@ -307,13 +307,13 @@ impl HashMapImageCache {
     }
 }
 
-impl ImageCache for HashMapImageCache {
+impl ImageCache for RetainAllImageCache {
     fn load(
         &mut self,
         resource: &Resource,
         window: &mut Window,
         cx: &mut App,
     ) -> Option<Result<Arc<RenderImage>, ImageCacheError>> {
-        HashMapImageCache::load(self, resource, window, cx)
+        RetainAllImageCache::load(self, resource, window, cx)
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1522,6 +1522,22 @@ impl Image {
             .and_then(|result| result.ok())
     }
 
+    /// Use the GPUI `get_asset` API to make this image renderable
+    pub fn get_render_image(
+        self: Arc<Self>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> Option<Arc<RenderImage>> {
+        ImageSource::Image(self)
+            .get_data(None, window, cx)
+            .and_then(|result| result.ok())
+    }
+
+    /// Use the GPUI `remove_asset` API to drop this image, if possible.
+    pub fn remove_asset(self: Arc<Self>, cx: &mut App) {
+        ImageSource::Image(self).remove_asset(cx);
+    }
+
     /// Convert the clipboard image to an `ImageData` object.
     pub fn to_image_data(&self, svg_renderer: SvgRenderer) -> Result<Arc<RenderImage>> {
         fn frames_for_image(

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2884,14 +2884,18 @@ impl Window {
     }
 
     /// Executes the provided function with the specified image cache.
-    pub(crate) fn with_image_cache<F, R>(&mut self, image_cache: AnyImageCache, f: F) -> R
+    pub fn with_image_cache<F, R>(&mut self, image_cache: Option<AnyImageCache>, f: F) -> R
     where
         F: FnOnce(&mut Self) -> R,
     {
-        self.image_cache_stack.push(image_cache);
-        let result = f(self);
-        self.image_cache_stack.pop();
-        result
+        if let Some(image_cache) = image_cache {
+            self.image_cache_stack.push(image_cache);
+            let result = f(self);
+            self.image_cache_stack.pop();
+            result
+        } else {
+            f(self)
+        }
     }
 
     /// Sets an input handler, such as [`ElementInputHandler`][element_input_handler], which interfaces with the

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2115,6 +2115,16 @@ impl Window {
             None
         })
     }
+
+    /// Asynchronously load an asset, if the asset hasn't finished loading or doesn't exist this will return None.
+    /// Your view will not be re-drawn once the asset has finished loading.
+    ///
+    /// Note that the multiple calls to this method will only result in one `Asset::load` call at a
+    /// time.
+    pub fn get_asset<A: Asset>(&mut self, source: &A::Source, cx: &mut App) -> Option<A::Output> {
+        let (task, _) = cx.fetch_asset::<A>(source);
+        task.clone().now_or_never()
+    }
     /// Obtain the current element offset. This method should only be called during the
     /// prepaint phase of element drawing.
     pub fn element_offset(&self) -> Point<Pixels> {

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -35,9 +35,19 @@ impl ImageView {
     pub fn new(
         image_item: Entity<ImageItem>,
         project: Entity<Project>,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         cx.subscribe(&image_item, Self::on_image_event).detach();
+        cx.on_release_in(window, |this, window, cx| {
+            let image_data = this.image_item.read(cx).image.clone();
+            if let Some(image) = image_data.clone().get_render_image(window, cx) {
+                cx.drop_image(image, None);
+            }
+            image_data.remove_asset(cx);
+        })
+        .detach();
+
         Self {
             image_item,
             project,
@@ -231,7 +241,9 @@ impl SerializableItem for ImageView {
                 .update(cx, |project, cx| project.open_image(project_path, cx))?
                 .await?;
 
-            cx.update(|_, cx| Ok(cx.new(|cx| ImageView::new(image_item, project, cx))))?
+            cx.update(
+                |window, cx| Ok(cx.new(|cx| ImageView::new(image_item, project, window, cx))),
+            )?
         })
     }
 
@@ -359,13 +371,13 @@ impl ProjectItem for ImageView {
         project: Entity<Project>,
         _: &Pane,
         item: Entity<Self::Item>,
-        _: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self
     where
         Self: Sized,
     {
-        Self::new(item, project, cx)
+        Self::new(item, project, window, cx)
     }
 }
 

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -8,7 +8,7 @@ use editor::{Editor, EditorEvent};
 use gpui::{
     App, ClickEvent, Context, Entity, EventEmitter, FocusHandle, Focusable, InteractiveElement,
     IntoElement, ListState, ParentElement, Render, RetainAllImageCache, Styled, Subscription, Task,
-    WeakEntity, Window, image_cache, list,
+    WeakEntity, Window, list,
 };
 use language::LanguageRegistry;
 use settings::Settings;
@@ -517,21 +517,21 @@ impl Render for MarkdownPreviewView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let buffer_size = ThemeSettings::get_global(cx).buffer_font_size(cx);
         let buffer_line_height = ThemeSettings::get_global(cx).buffer_line_height;
-        image_cache(self.image_cache.clone()).child(
-            v_flex()
-                .id("MarkdownPreview")
-                .key_context("MarkdownPreview")
-                .track_focus(&self.focus_handle(cx))
-                .size_full()
-                .bg(cx.theme().colors().editor_background)
-                .p_4()
-                .text_size(buffer_size)
-                .line_height(relative(buffer_line_height.value()))
-                .child(
-                    div()
-                        .flex_grow()
-                        .map(|this| this.child(list(self.list_state.clone()).size_full())),
-                ),
-        )
+
+        v_flex()
+            .image_cache(self.image_cache.clone())
+            .id("MarkdownPreview")
+            .key_context("MarkdownPreview")
+            .track_focus(&self.focus_handle(cx))
+            .size_full()
+            .bg(cx.theme().colors().editor_background)
+            .p_4()
+            .text_size(buffer_size)
+            .line_height(relative(buffer_line_height.value()))
+            .child(
+                div()
+                    .flex_grow()
+                    .map(|this| this.child(list(self.list_state.clone()).size_full())),
+            )
     }
 }

--- a/crates/markdown_preview/src/markdown_renderer.rs
+++ b/crates/markdown_preview/src/markdown_renderer.rs
@@ -139,7 +139,6 @@ pub fn render_parsed_markdown(
             .map(|block| render_markdown_block(block, &mut cx)),
     )
 }
-
 pub fn render_markdown_block(block: &ParsedMarkdownElement, cx: &mut RenderContext) -> AnyElement {
     use ParsedMarkdownElement::*;
     match block {

--- a/crates/repl/src/notebook/cell.rs
+++ b/crates/repl/src/notebook/cell.rs
@@ -407,18 +407,17 @@ impl Render for MarkdownCell {
                     .child(self.gutter(window, cx))
                     .child(
                         v_flex()
+                            .image_cache(self.image_cache.clone())
                             .size_full()
                             .flex_1()
                             .p_3()
                             .font_ui(cx)
                             .text_size(TextSize::Default.rems(cx))
-                            .child(image_cache(self.image_cache.clone()).children(
-                                parsed.children.iter().map(|child| {
-                                    div().relative().child(div().relative().child(
-                                        render_markdown_block(child, &mut markdown_render_context),
-                                    ))
-                                }),
-                            )),
+                            .children(parsed.children.iter().map(|child| {
+                                div().relative().child(div().relative().child(
+                                    render_markdown_block(child, &mut markdown_render_context),
+                                ))
+                            })),
                     ),
             )
             // TODO: Move base cell render into trait impl so we don't have to repeat this

--- a/crates/repl/src/outputs/markdown.rs
+++ b/crates/repl/src/outputs/markdown.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use gpui::{
-    App, ClipboardItem, Context, Entity, RetainAllImageCache, Task, Window, div, image_cache,
-    prelude::*,
+    App, ClipboardItem, Context, Entity, RetainAllImageCache, Task, Window, div, prelude::*,
 };
 use language::Buffer;
 use markdown_preview::{
@@ -79,19 +78,16 @@ impl Render for MarkdownView {
             markdown_preview::markdown_renderer::RenderContext::new(None, window, cx);
 
         v_flex()
+            .image_cache(self.image_cache.clone())
             .gap_3()
             .py_4()
-            .child(
-                image_cache(self.image_cache.clone()).children(parsed.children.iter().map(
-                    |child| {
-                        div().relative().child(
-                            div()
-                                .relative()
-                                .child(render_markdown_block(child, &mut markdown_render_context)),
-                        )
-                    },
-                )),
-            )
+            .children(parsed.children.iter().map(|child| {
+                div().relative().child(
+                    div()
+                        .relative()
+                        .child(render_markdown_block(child, &mut markdown_render_context)),
+                )
+            }))
             .into_any_element()
     }
 }

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -27,8 +27,8 @@ use git_ui::project_diff::ProjectDiffToolbar;
 use gpui::{
     Action, App, AppContext as _, AsyncWindowContext, Context, DismissEvent, Element, Entity,
     Focusable, KeyBinding, ParentElement, PathPromptOptions, PromptLevel, ReadGlobal, SharedString,
-    Styled, Task, TitlebarOptions, UpdateGlobal, Window, WindowKind, WindowOptions, actions, point,
-    px,
+    Styled, Task, TitlebarOptions, UpdateGlobal, Window, WindowKind, WindowOptions, actions,
+    image_cache, point, px, retain_all,
 };
 use image_viewer::ImageInfo;
 use migrate::{MigrationBanner, MigrationEvent, MigrationNotification, MigrationType};
@@ -1361,7 +1361,7 @@ fn show_markdown_app_notification<F>(
                 let primary_button_on_click = primary_button_on_click.clone();
                 cx.new(move |cx| {
                     MessageNotification::new_from_builder(cx, move |window, cx| {
-                        gpui::div()
+                        image_cache(retain_all("notification-cache"))
                             .text_xs()
                             .child(markdown_preview::markdown_renderer::render_parsed_markdown(
                                 &parsed_markdown.clone(),


### PR DESCRIPTION
This PR fixes several possible memory leaks due to loading images in markdown files and the image viewer, using the new image cache APIs

TODO: 
- [x] Ensure this didn't break rendering in any of the affected components.

Release Notes:

- Fixed several image related memory leaks
