### PR TITLE
gpui: Fix VRAM leak caused by drawing large textures and resize textures

### DIFF
--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -183,12 +183,20 @@ impl BladeAtlasState {
         min_size: Size<DevicePixels>,
         kind: AtlasTextureKind,
     ) -> &mut BladeAtlasTexture {
+        const MIN_SIZE: i32 = 1024;
         const DEFAULT_ATLAS_SIZE: Size<DevicePixels> = Size {
-            width: DevicePixels(1024),
-            height: DevicePixels(1024),
+            width: DevicePixels(MIN_SIZE),
+            height: DevicePixels(MIN_SIZE),
         };
 
-        let size = min_size.max(&DEFAULT_ATLAS_SIZE);
+        let mut size = min_size.max(&DEFAULT_ATLAS_SIZE);
+
+        // Make sure the size is a multiple of MAX_SIZE, to avoid waste VRAM by creating too many textures.
+        //
+        // See also same thing in Metal.
+        size.width = (((size.width.0 + MIN_SIZE) / MIN_SIZE) * MIN_SIZE).into();
+        size.height = (((size.height.0 + MIN_SIZE) / MIN_SIZE) * MIN_SIZE).into();
+
         let format;
         let usage;
         match kind {

--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -5,10 +5,7 @@ use crate::{
 use anyhow::{Result, anyhow};
 use collections::FxHashMap;
 use derive_more::{Deref, DerefMut};
-use etagere::{
-    BucketedAtlasAllocator,
-    euclid::num::{Ceil, Round},
-};
+use etagere::BucketedAtlasAllocator;
 use metal::Device;
 use parking_lot::Mutex;
 use std::borrow::Cow;
@@ -142,8 +139,6 @@ impl MetalAtlasState {
                 return Some(tile);
             }
         }
-
-        println!("Allocating texture of size {:?}", size);
 
         let texture = self.push_texture(size, texture_kind);
         texture.allocate(size)
@@ -287,7 +282,7 @@ impl MetalAtlasTexture {
             bounds.size.width.into(),
             bounds.size.height.into(),
         );
-        println!("-------------- upload bounds.size: {:?}", bounds.size);
+
         self.metal_texture.replace_region(
             region,
             0,

--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -94,7 +94,7 @@ impl PlatformAtlas for MetalAtlas {
         let textures = match id.kind {
             AtlasTextureKind::Monochrome => &mut lock.monochrome_textures,
             AtlasTextureKind::Polychrome => &mut lock.polychrome_textures,
-            AtlasTextureKind::Path => &mut lock.polychrome_textures,
+            AtlasTextureKind::Path => &mut lock.path_textures,
         };
 
         let Some(texture_slot) = textures

--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -164,7 +164,7 @@ impl MetalAtlasState {
 
         let mut size = min_size.min(&MAX_ATLAS_SIZE).max(&DEFAULT_ATLAS_SIZE);
 
-        // Make sure the size is a multiple of MAX_SIZE, to avoid waste VRAM by creating too many textures.
+        // Make sure the size is a multiple of MIN_SIZE, to avoid waste VRAM by creating too many textures.
         //
         // In most cases, the `min_size` (This actually size of the imgs, icons or paths etc.), it less than 1024x1024.
         //

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -686,6 +686,7 @@ pub struct Path<P: Clone + Default + Debug> {
     start: Point<P>,
     current: Point<P>,
     contour_count: usize,
+    base_scale: f32,
 }
 
 impl Path<Pixels> {
@@ -704,25 +705,35 @@ impl Path<Pixels> {
             content_mask: Default::default(),
             color: Default::default(),
             contour_count: 0,
+            base_scale: 1.0,
         }
     }
 
-    /// Scale this path by the given factor.
-    pub fn scale(&self, factor: f32) -> Path<ScaledPixels> {
+    /// Set the base scale of the path.
+    pub fn scale(mut self, factor: f32) -> Self {
+        self.base_scale = factor;
+        self
+    }
+
+    /// Apply a scale to the path.
+    pub(crate) fn apply_scale(&self, factor: f32) -> Path<ScaledPixels> {
         Path {
             id: self.id,
             order: self.order,
-            bounds: self.bounds.scale(factor),
-            content_mask: self.content_mask.scale(factor),
+            bounds: self.bounds.scale(self.base_scale * factor),
+            content_mask: self.content_mask.scale(self.base_scale * factor),
             vertices: self
                 .vertices
                 .iter()
-                .map(|vertex| vertex.scale(factor))
+                .map(|vertex| vertex.scale(self.base_scale * factor))
                 .collect(),
-            start: self.start.map(|start| start.scale(factor)),
-            current: self.current.scale(factor),
+            start: self
+                .start
+                .map(|start| start.scale(self.base_scale * factor)),
+            current: self.current.scale(self.base_scale * factor),
             contour_count: self.contour_count,
             color: self.color,
+            base_scale: 1.0,
         }
     }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2395,7 +2395,7 @@ impl Window {
         path.color = color.opacity(opacity);
         self.next_frame
             .scene
-            .insert_primitive(path.scale(scale_factor));
+            .insert_primitive(path.apply_scale(scale_factor));
     }
 
     /// Paint an underline into the scene for the next frame at the current z-index.


### PR DESCRIPTION
Release Notes:

- Fixed possible video memory leak by drawing a large texture.

I was recently analyzing some Path scene memory leak issues (some application scenes would leak memory very obviously from 400MB to 3~4GB, on macOS and Windows both), and I first discovered this obvious typo here.

However, Blade's implementation did not find this problem like Metal.

And I also updated the `Path::scale` method to return self, to help `painting` example to scale Path with relative to window width, to appear the VRAM leak case.

---

### UPDATE: 2025/04/28

The primary leak reason of if the texture is larger than 1024, the push_texture will create a new texture again and again when every time resized size (Resize from a small size to larger).

See comment https://github.com/zed-industries/zed/pull/29454#issuecomment-2834380620