### PR TITLE
collab: Return feature flags with authenticated user

### DIFF
--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -152,6 +152,7 @@ struct AuthenticatedUserParams {
 struct AuthenticatedUserResponse {
     user: User,
     metrics_id: String,
+    feature_flags: Vec<String>,
 }
 
 async fn get_authenticated_user(
@@ -172,7 +173,12 @@ async fn get_authenticated_user(
         )
         .await?;
     let metrics_id = app.db.get_user_metrics_id(user.id).await?;
-    Ok(Json(AuthenticatedUserResponse { user, metrics_id }))
+    let feature_flags = app.db.get_user_flags(user.id).await?;
+    Ok(Json(AuthenticatedUserResponse {
+        user,
+        metrics_id,
+        feature_flags,
+    }))
 }
 
 #[derive(Deserialize, Debug)]


### PR DESCRIPTION
This PR makes it so the `GET /user` endpoint returns the user's feature flags with the authenticated user.

Release Notes:

- N/A
