### PR TITLE
Fix error when deserializing Gemini streams

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -48,7 +48,10 @@ pub async fn stream_generate_content(
                         if let Some(line) = line.strip_prefix("data: ") {
                             match serde_json::from_str(line) {
                                 Ok(response) => Some(Ok(response)),
-                                Err(error) => Some(Err(anyhow!(error))),
+                                Err(error) => Some(Err(anyhow!(format!(
+                                    "Error parsing JSON: {:?}\n{:?}",
+                                    error, line
+                                )))),
                             }
                         } else {
                             None
@@ -152,6 +155,7 @@ pub struct GenerateContentCandidate {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Content {
+    #[serde(default)]
     pub parts: Vec<Part>,
     pub role: Role,
 }


### PR DESCRIPTION
Sometimes Gemini would report `Content` without a `parts` field.

Release Notes:

- Fixed a bug that would sometimes cause Gemini models to fail streaming their response.
