### PR TITLE
Add JSDoc scope

### DIFF
--- a/crates/languages/src/jsdoc/highlights.scm
+++ b/crates/languages/src/jsdoc/highlights.scm
@@ -1,2 +1,2 @@
-(tag_name) @keyword
-(type) @type
+(tag_name) @keyword.jsdoc
+(type) @type.jsdoc


### PR DESCRIPTION
This is a small PR that adds a `.jsdoc` scope to JSDoc tokens, just like [JSX](https://github.com/zed-industries/zed/blob/3fdbc3090d2cc5c2e24014009cccbe5e7c55d217/crates/languages/src/javascript/highlights.scm#L239) has a specific scope.
This effectively allows differentiating between JavaScript keywords and JSDoc tags in comments.

Release Notes:

  - Add scope for JSDoc

