### PR TITLE
vim: Fix end of paragraph deletion when there's no blank lines

### DIFF
--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1318,8 +1318,7 @@ impl Motion {
                     // the first character of a blank line. In that case, we'll
                     // want to move one column to the right, to actually include
                     // all characters of the last non-blank line.
-                    end_point.column += 1;
-                    selection.end = end_point.to_display_point(map);
+                    selection.end = movement::saturating_right(map, selection.end)
                 }
             }
         } else if kind == MotionKind::Inclusive {

--- a/crates/vim/src/normal/delete.rs
+++ b/crates/vim/src/normal/delete.rs
@@ -352,6 +352,29 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_delete_end_of_paragraph(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.simulate(
+            "d }",
+            indoc! {"
+            ˇhello world.
+
+            hello world."},
+        )
+        .await
+        .assert_matches();
+
+        cx.simulate(
+            "d }",
+            indoc! {"
+            ˇhello world.
+            hello world."},
+        )
+        .await
+        .assert_matches();
+    }
+
+    #[gpui::test]
     async fn test_delete_0(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
         cx.simulate(

--- a/crates/vim/test_data/test_delete_end_of_paragraph.json
+++ b/crates/vim/test_data/test_delete_end_of_paragraph.json
@@ -1,0 +1,8 @@
+{"Put":{"state":"ˇhello world.\n\nhello world."}}
+{"Key":"d"}
+{"Key":"}"}
+{"Get":{"state":"ˇ\nhello world.","mode":"Normal"}}
+{"Put":{"state":"ˇhello world.\nhello world."}}
+{"Key":"d"}
+{"Key":"}"}
+{"Get":{"state":"ˇ","mode":"Normal"}}


### PR DESCRIPTION
This Pull Request attempts to fix an issue where using `d}` in vim mode would not delete all characters in case there's no blank lines at the end of the buffer.

When calculating the end point for this motion, if there's no blank lines at the end of the buffer, Zed was calculating it to be the last character in the last line. However, if there's a newline at the end of the buffer, it calculates the end point to be the point at the right of the last character.

Here's an example, for the following buffer contents:

```
Hello!
Hello!
```

If the `d}` command is run at `(0, 0)`, the end point will be set to `(1, 5)`. However, fi the same command is run for this buffer instead:

```
Hello!
Hello!

```

The end point will be set to `(1, 6)`, there's a 1 unit difference in the column, which leads to all characters actually being deleted.

Closes #29393 

Release Notes:

- Fixed deleting to the end of paragraph when there's no blank lines
