### PR TITLE
title_bar: Add icon for project branch trigger button

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -306,7 +306,7 @@
   // Titlebar related settings
   "title_bar": {
     // Whether to show the branch icon beside branch switcher in the title bar.
-    "show_branch_icon": true
+    "show_branch_icon": false
   },
   // Scrollbar related settings
   "scrollbar": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -303,6 +303,11 @@
     // Whether to show the Selections menu in the editor toolbar
     "selections_menu": true
   },
+  // Titlebar related settings
+  "title_bar": {
+    // Whether to show the branch icon beside branch switcher in the title bar.
+    "show_branch_icon": true
+  },
   // Scrollbar related settings
   "scrollbar": {
     // When to show the scrollbar in the editor.

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -54,7 +54,6 @@ const BOOK_ONBOARDING: &str = "https://dub.sh/zed-c-onboarding";
 
 actions!(collab, [ToggleUserMenu, ToggleProjectMenu, SwitchBranch]);
 
-
 pub fn init(cx: &mut App) {
     TitleBarSettings::register(cx);
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -54,12 +54,9 @@ const BOOK_ONBOARDING: &str = "https://dub.sh/zed-c-onboarding";
 
 actions!(collab, [ToggleUserMenu, ToggleProjectMenu, SwitchBranch]);
 
-pub fn init_settings(cx: &mut App) {
-    TitleBarSettings::register(cx);
-}
 
 pub fn init(cx: &mut App) {
-    init_settings(cx);
+    TitleBarSettings::register(cx);
 
     cx.observe_new(|workspace: &mut Workspace, window, cx| {
         let Some(window) = window else {
@@ -539,34 +536,35 @@ impl TitleBar {
                 })
         }?;
 
-        let mut branch_button = Button::new("project_branch_trigger", branch_name)
-            .color(Color::Muted)
-            .style(ButtonStyle::Subtle)
-            .label_size(LabelSize::Small)
-            .tooltip(move |window, cx| {
-                Tooltip::with_meta(
-                    "Recent Branches",
-                    Some(&zed_actions::git::Branch),
-                    "Local branches only",
-                    window,
-                    cx,
-                )
-            })
-            .on_click(move |_, window, cx| {
-                let _ = workspace.update(cx, |_this, cx| {
-                    window.dispatch_action(zed_actions::git::Branch.boxed_clone(), cx);
-                });
-            });
-
-        let show_branch_icon = TitleBarSettings::get_global(cx).show_branch_icon;
-        if show_branch_icon {
-            branch_button = branch_button
-                .icon(IconName::GitBranch)
-                .icon_position(IconPosition::Start)
-                .icon_color(Color::Muted);
-        }
-
-        Some(branch_button)
+        Some(
+            Button::new("project_branch_trigger", branch_name)
+                .color(Color::Muted)
+                .style(ButtonStyle::Subtle)
+                .label_size(LabelSize::Small)
+                .tooltip(move |window, cx| {
+                    Tooltip::with_meta(
+                        "Recent Branches",
+                        Some(&zed_actions::git::Branch),
+                        "Local branches only",
+                        window,
+                        cx,
+                    )
+                })
+                .on_click(move |_, window, cx| {
+                    let _ = workspace.update(cx, |_this, cx| {
+                        window.dispatch_action(zed_actions::git::Branch.boxed_clone(), cx);
+                    });
+                })
+                .when(
+                    TitleBarSettings::get_global(cx).show_branch_icon,
+                    |branch_button| {
+                        branch_button
+                            .icon(IconName::GitBranch)
+                            .icon_position(IconPosition::Start)
+                            .icon_color(Color::Muted)
+                    },
+                ),
+        )
     }
 
     fn window_activation_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -536,6 +536,9 @@ impl TitleBar {
                 .color(Color::Muted)
                 .style(ButtonStyle::Subtle)
                 .label_size(LabelSize::Small)
+                .icon(IconName::GitBranch)
+                .icon_position(IconPosition::Start)
+                .icon_color(Color::Muted)
                 .tooltip(move |window, cx| {
                     Tooltip::with_meta(
                         "Recent Branches",

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -12,7 +12,7 @@ pub struct TitleBarSettings {
 pub struct TitleBarSettingsContent {
     /// Whether to show the branch icon beside branch switcher in the title bar.
     ///
-    /// Default: true
+    /// Default: false
     pub show_branch_icon: Option<bool>,
 }
 

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -1,0 +1,32 @@
+use db::anyhow;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use settings::{Settings, SettingsSources};
+
+#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+pub struct TitleBarSettings {
+    pub show_branch_icon: bool,
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+pub struct TitleBarSettingsContent {
+    /// Whether to show the branch icon beside branch switcher in the title bar.
+    ///
+    /// Default: true
+    pub show_branch_icon: Option<bool>,
+}
+
+impl Settings for TitleBarSettings {
+    const KEY: Option<&'static str> = Some("title_bar");
+
+    type FileContent = TitleBarSettingsContent;
+
+    fn load(sources: SettingsSources<Self::FileContent>, _: &mut gpui::App) -> anyhow::Result<Self>
+    where
+        Self: Sized,
+    {
+        sources.json_merge()
+    }
+
+    fn import_from_vscode(_: &settings::VsCodeSettings, _: &mut Self::FileContent) {}
+}


### PR DESCRIPTION
Added icon for branch switcher in title bar

| `main`    | This PR |
| -------- | ------- |
| <img width="196" alt="Screenshot 2025-04-27 at 1 02 47 PM" src="https://github.com/user-attachments/assets/5625f6c5-7b11-4f3d-bed8-6ea3b74d9416" />  | <img width="217" alt="Screenshot 2025-04-27 at 1 07 11 PM" src="https://github.com/user-attachments/assets/6c83daa6-fa71-44a8-8f6b-e33b2217b29e" />    |

Release Notes:

- Added icon for branch switcher in title bar
