### PR TITLE
zeta: Add edit prediction URL setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18781,6 +18781,7 @@ dependencies = [
  "release_channel",
  "reqwest_client",
  "rpc",
+ "schemars",
  "serde",
  "serde_json",
  "settings",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1586,5 +1586,7 @@
     "stepping_granularity": "line",
     "save_breakpoints": true,
     "button": true
-  }
+  },
+  // Specifies the URL of the endpoint that will be used for edit prediction requests.
+  "predict_edits_url": ""
 }

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -41,6 +41,7 @@ postage.workspace = true
 project.workspace = true
 regex.workspace = true
 release_channel.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true

--- a/crates/zeta/src/init.rs
+++ b/crates/zeta/src/init.rs
@@ -5,6 +5,8 @@ use feature_flags::{FeatureFlagAppExt as _, PredictEditsRateCompletionsFeatureFl
 use gpui::actions;
 use language::language_settings::{AllLanguageSettings, EditPredictionProvider};
 use settings::update_settings_file;
+use crate::{ZetaSettings};
+use settings::Settings;
 use ui::App;
 use workspace::Workspace;
 
@@ -13,6 +15,8 @@ use crate::{RateCompletionModal, onboarding_modal::ZedPredictModal};
 actions!(edit_prediction, [ResetOnboarding, RateCompletions]);
 
 pub fn init(cx: &mut App) {
+    ZetaSettings::register(cx);
+
     cx.observe_new(move |workspace: &mut Workspace, _, _cx| {
         workspace.register_action(|workspace, _: &RateCompletions, window, cx| {
             if cx.has_flag::<PredictEditsRateCompletionsFeatureFlag>() {


### PR DESCRIPTION
This PR adds a new setting `predict_edits_url` which is intended to mimic the behaviour of the `ZED_PREDICT_EDITS_URL` environment variable on a more permanent basis. I imagine the purpose of this environment variable was for development or debugging, however being able to set this URL permanently makes self hosting edit predictions significantly easier, and paves the way for enterprise adoption.

This is my first Rust contribution, so please do not hesitate to call out any un-idiomatic practices that I've adopted. 

Release Notes:

- Added a setting to set the edit prediction URL