### PR TITLE
editor: Fix inconsistent relative indent when using tab with multi cursors

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8588,23 +8588,14 @@ impl Editor {
         let rows_iter = selections.iter().map(|s| s.head().row);
         let suggested_indents = snapshot.suggested_indents(rows_iter, cx);
 
-        let has_mixed_cursors = {
-            let mut in_whitespace = false;
-            let mut at_boundary = false;
-            for selection in selections.iter().filter(|selection| selection.is_empty()) {
+        let has_some_cursor_in_whitespace = selections
+            .iter()
+            .filter(|selection| selection.is_empty())
+            .any(|selection| {
                 let cursor = selection.head();
                 let current_indent = snapshot.indent_size_for_line(MultiBufferRow(cursor.row));
-                if cursor.column < current_indent.len {
-                    in_whitespace = true;
-                } else if cursor.column == current_indent.len {
-                    at_boundary = true;
-                }
-                if in_whitespace && at_boundary {
-                    break;
-                }
-            }
-            in_whitespace && at_boundary
-        };
+                cursor.column < current_indent.len
+            });
 
         let mut edits = Vec::new();
         let mut prev_edited_row = 0;
@@ -8629,9 +8620,9 @@ impl Editor {
             if let Some(suggested_indent) =
                 suggested_indents.get(&MultiBufferRow(cursor.row)).copied()
             {
-                // If there exist mixed empty selections (some in the leading whitespace and
-                // some at the boundary), then skip indent for selections at the boundary.
-                if has_mixed_cursors
+                // If there exist any empty selection in the leading whitespace, then skip
+                // indent for selections at the boundary.
+                if has_some_cursor_in_whitespace
                     && cursor.column == current_indent.len
                     && current_indent.len == suggested_indent.len
                 {


### PR DESCRIPTION
Do not insert hard/soft tabs for cursors at the suggested indent level if any other cursor lies before the suggested indent level. This PR brings us one step closer to fixing https://github.com/zed-industries/zed/issues/26157.

Before:

https://github.com/user-attachments/assets/8fd5cde4-99f4-4363-9292-5da8dadab658

After:

https://github.com/user-attachments/assets/17c9f8ca-5842-452b-8665-7c7138d50162

Release Notes:

- Fixed an issue where using tab with multiple cursors would result in inconsistent relative indentation across lines.
