### PR TITLE
title_bar: Put plan behind `new-billing` feature flag

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -59,6 +59,16 @@ impl FeatureFlag for Assistant2FeatureFlag {
     const NAME: &'static str = "assistant2";
 }
 
+pub struct NewBillingFeatureFlag;
+
+impl FeatureFlag for NewBillingFeatureFlag {
+    const NAME: &'static str = "new-billing";
+
+    fn enabled_for_staff() -> bool {
+        false
+    }
+}
+
 pub struct PredictEditsRateCompletionsFeatureFlag;
 impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -18,7 +18,7 @@ use crate::platforms::{platform_linux, platform_mac, platform_windows};
 use auto_update::AutoUpdateStatus;
 use call::ActiveCall;
 use client::{Client, UserStore};
-use feature_flags::{FeatureFlagAppExt, ZedProFeatureFlag};
+use feature_flags::{FeatureFlagAppExt, NewBillingFeatureFlag};
 use gpui::{
     Action, AnyElement, App, Context, Corner, Decorations, Element, Entity, InteractiveElement,
     Interactivity, IntoElement, MouseButton, ParentElement, Render, Stateful,
@@ -663,7 +663,7 @@ impl TitleBar {
                 .anchor(Corner::TopRight)
                 .menu(move |window, cx| {
                     ContextMenu::build(window, cx, |menu, _, cx| {
-                        menu.when(cx.has_flag::<ZedProFeatureFlag>(), |menu| {
+                        menu.when(cx.has_flag::<NewBillingFeatureFlag>(), |menu| {
                             menu.action(
                                 format!(
                                     "Current Plan: {}",


### PR DESCRIPTION
This PR puts the displaying of the plan in the user menu behind the `new-billing` feature flag instead of the old `zed-pro` feature flag.

Release Notes:

- N/A
