### PR TITLE
zed: Don't feature-gate `zed: open account settings` action

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18405,7 +18405,6 @@ dependencies = [
  "collab_ui",
  "collections",
  "command_palette",
- "command_palette_hooks",
  "component_preview",
  "copilot",
  "dap",

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -39,7 +39,6 @@ client.workspace = true
 collab_ui.workspace = true
 collections.workspace = true
 command_palette.workspace = true
-command_palette_hooks.workspace = true
 component_preview.workspace = true
 copilot.workspace = true
 dap_adapters.workspace = true

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -16,7 +16,6 @@ use assistant_context_editor::AssistantPanelDelegate;
 use breadcrumbs::Breadcrumbs;
 use client::zed_urls;
 use collections::VecDeque;
-use command_palette_hooks::CommandPaletteFilter;
 use debugger_ui::debugger_panel::DebugPanel;
 use editor::ProposedChangesEditorToolbar;
 use editor::{Editor, MultiBuffer, scroll::Autoscroll};
@@ -52,7 +51,6 @@ use settings::{
     SettingsStore, VIM_KEYMAP_PATH, initial_debug_tasks_content, initial_project_settings_content,
     initial_tasks_content, update_settings_file,
 };
-use std::any::TypeId;
 use std::path::PathBuf;
 use std::sync::atomic::{self, AtomicBool};
 use std::time::Duration;
@@ -266,29 +264,6 @@ pub fn initialize_workspace(
         register_actions(app_state.clone(), workspace, window, cx);
 
         workspace.focus_handle(cx).focus(window);
-    })
-    .detach();
-
-    feature_gate_zed_pro_actions(cx);
-}
-
-fn feature_gate_zed_pro_actions(cx: &mut App) {
-    let zed_pro_actions = [TypeId::of::<OpenAccountSettings>()];
-
-    CommandPaletteFilter::update_global(cx, |filter, _cx| {
-        filter.hide_action_types(&zed_pro_actions);
-    });
-
-    cx.observe_flag::<feature_flags::ZedProFeatureFlag, _>({
-        move |is_enabled, cx| {
-            CommandPaletteFilter::update_global(cx, |filter, _cx| {
-                if is_enabled {
-                    filter.show_action_types(zed_pro_actions.iter());
-                } else {
-                    filter.hide_action_types(&zed_pro_actions);
-                }
-            });
-        }
     })
     .detach();
 }


### PR DESCRIPTION
This PR removes the feature-gating of the `zed: open account settings` action, as everyone has access to the account page now.

Release Notes:

- N/A
