### PR TITLE
Add default tab_size for Elm

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1288,6 +1288,9 @@
     "Elixir": {
       "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
     },
+    "Elm": {
+      "tab_size": 4
+    },
     "Erlang": {
       "language_servers": ["erlang-ls", "!elp", "..."]
     },


### PR DESCRIPTION
This PR updates the default tab size to 4 spaces, aligning with the standard adopted by the Elm community and the official language formatter (elm-format).

Reference: [elm-format tab size default](https://github.com/avh4/elm-format/blob/main/elm-format-lib/src/Box.hs#L249)
