### PR TITLE
vim: Fix incorrect escaping parenthesis of replacement string

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -542,7 +542,7 @@ impl Replacement {
                 if phase == 1 && c.is_ascii_digit() {
                     buffer.push('$')
                 // unescape escaped parens
-                } else if phase == 0 && c == '(' || c == ')' {
+                } else if phase == 0 && (c == '(' || c == ')') {
                 } else if c != delimiter {
                     buffer.push('\\')
                 }
@@ -561,7 +561,7 @@ impl Replacement {
                 }
             } else {
                 // escape unescaped parens
-                if phase == 0 && c == '(' || c == ')' {
+                if phase == 0 && (c == '(' || c == ')') {
                     buffer.push('\\')
                 }
                 buffer.push(c)


### PR DESCRIPTION
Closes #29356

![Screenshot 2025-04-28 233018](https://github.com/user-attachments/assets/22998e70-8430-45fc-8d51-14e862e585eb)


Release Notes:

- vim: Fixed a bug when escaping `(` and `)` in command-palette find and replace

