### PR TITLE
Move Show Code Actions lower in editor context menu

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -207,14 +207,6 @@ pub fn deploy_context_menu(
         ui::ContextMenu::build(window, cx, |menu, _window, _cx| {
             let builder = menu
                 .on_blur_subscription(Subscription::new(|| {}))
-                .action(
-                    "Show Code Actions",
-                    Box::new(ToggleCodeActions {
-                        deployed_from_indicator: None,
-                        quick_launch: false,
-                    }),
-                )
-                .separator()
                 .when(evaluate_selection && has_selections, |builder| {
                     builder
                         .action("Evaluate Selection", Box::new(DebuggerEvaluateSelectedText))
@@ -231,6 +223,13 @@ pub fn deploy_context_menu(
                 .when(has_selections, |cx| {
                     cx.action("Format Selections", Box::new(FormatSelections))
                 })
+                .action(
+                    "Show Code Actions",
+                    Box::new(ToggleCodeActions {
+                        deployed_from_indicator: None,
+                        quick_launch: false,
+                    }),
+                )
                 .separator()
                 .action("Cut", Box::new(Cut))
                 .action("Copy", Box::new(Copy))


### PR DESCRIPTION
The 'Go to Definition' action is more commonly used.

Release Notes:

- N/A
