### PR TITLE
Less log spam (non git worktrees; saving with no LSP)

### DIFF
--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -506,7 +506,7 @@ impl GitBlame {
                     } else {
                         // If we weren't triggered by a user, we just log errors in the background, instead of sending
                         // notifications.
-                        log::error!("failed to get git blame data: {error:?}");
+                        log::debug!("failed to get git blame data: {error:?}");
                     }
                 }),
             })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1426,7 +1426,7 @@ impl LocalLspStore {
                     };
 
                     let Some(language_server) = language_server else {
-                        log::warn!(
+                        log::debug!(
                             "No language server found to format buffer '{:?}'. Skipping",
                             buffer_path_abs.as_path().to_string_lossy()
                         );


### PR DESCRIPTION
- See: https://github.com/zed-industries/zed/discussions/29541
- `failed to get git blame data:` occurred whenever opening a file that does not have git blame data and with `git.inline_blame.enabled` = true (the default). Notably this would be triggered whenever you opened your settings or keymap (unless ~/.config/zed was git managed).
- `No language server found to format buffer` triggered whenever you saved a buffer with `format_on_save` (the default for most languages) but had no LSP configured for this file type (e.g. Plain Text).


Release Notes:

- N/A
