### PR TITLE
agent: Cancel pending in-edit user message upon new message submit

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -903,6 +903,11 @@ impl ActiveThread {
         cx: &mut Context<Self>,
     ) {
         match event {
+            ThreadEvent::CancelEditing => {
+                if self.editing_message.is_some() {
+                    self.cancel_editing_message(&menu::Cancel, window, cx);
+                }
+            }
             ThreadEvent::ShowError(error) => {
                 self.last_error = Some(error.clone());
             }

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -245,6 +245,10 @@ impl MessageEditor {
             return;
         }
 
+        self.thread.update(cx, |thread, cx| {
+            thread.cancel_editing(cx);
+        });
+
         if self.thread.read(cx).is_generating() {
             self.stop_current_and_send_new_message(window, cx);
             return;
@@ -337,6 +341,10 @@ impl MessageEditor {
     }
 
     fn stop_current_and_send_new_message(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.thread.update(cx, |thread, cx| {
+            thread.cancel_editing(cx);
+        });
+
         let cancelled = self.thread.update(cx, |thread, cx| {
             thread.cancel_last_completion(Some(window.window_handle()), cx)
         });

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1784,6 +1784,14 @@ impl Thread {
         canceled
     }
 
+    /// Signals that any in-progress editing should be canceled.
+    ///
+    /// This method is used to notify listeners (like ActiveThread) that
+    /// they should cancel any editing operations.
+    pub fn cancel_editing(&mut self, cx: &mut Context<Self>) {
+        cx.emit(ThreadEvent::CancelEditing);
+    }
+
     pub fn feedback(&self) -> Option<ThreadFeedback> {
         self.feedback
     }
@@ -2302,6 +2310,7 @@ pub enum ThreadEvent {
     },
     CheckpointChanged,
     ToolConfirmationNeeded,
+    CancelEditing,
 }
 
 impl EventEmitter<ThreadEvent> for Thread {}

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -276,7 +276,8 @@ impl ExampleContext {
                 | ThreadEvent::ReceivedTextChunk
                 | ThreadEvent::StreamedToolUse { .. }
                 | ThreadEvent::CheckpointChanged
-                | ThreadEvent::UsageUpdated(_) => {
+                | ThreadEvent::UsageUpdated(_)
+                | ThreadEvent::CancelEditing => {
                     tx.try_send(Ok(())).ok();
                     if std::env::var("ZED_EVAL_DEBUG").is_ok() {
                         println!("{}Event: {:#?}", log_prefix, event);


### PR DESCRIPTION
Previously, if you clicked on a user message to edit it, and then, while the user message has the editor pending, sent a new message via the textarea, the whole thread would be grayed out because we hadn't dismissed the to-be-edited pending user message. That's now fixed.

Release Notes:

- agent: Fixed a bug that would make the whole thread be grayed out upon sending a new message while a user message had a pending edit.
