### PR TITLE
gpui: Fix markdown wrapped background not correctly rendering

### DIFF
--- a/crates/gpui/src/text_system/line.rs
+++ b/crates/gpui/src/text_system/line.rs
@@ -482,6 +482,16 @@ fn paint_line_background(
                         background_origin.x = origin.x;
                         background_origin.y += line_height;
                     }
+
+                    glyph_origin.x = aligned_origin_x(
+                        origin,
+                        align_width.unwrap_or(layout.width),
+                        glyph.position.x,
+                        &align,
+                        layout,
+                        wraps.peek(),
+                    );
+                    glyph_origin.y += line_height;
                 }
                 prev_glyph_position = glyph.position;
 


### PR DESCRIPTION
Closes #29532

Fixes case where the markdown background was not rendering correctly. This regression was introduced in  https://github.com/zed-industries/zed/pull/26454.

<img src="https://github.com/user-attachments/assets/1e64930f-c98e-4042-a20e-46eed03293d6" alt="image" width="400" />


Release Notes:

- Fixed an issue where markdown code blocks did not wrap correctly.
