### PR TITLE
freebsd: Fix failure to build

### DIFF
--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -293,6 +293,8 @@ impl settings::Settings for TerminalSettings {
         let platform = "linux";
         #[cfg(target_os = "macos")]
         let platform = "osx";
+        #[cfg(target_os = "freebsd")]
+        let platform = "freebsd";
 
         // TODO: handle arguments
         let shell_name = format!("{platform}Exec");


### PR DESCRIPTION
main was failing to build on FreeBSD. [joblink](https://github.com/zed-industries/zed/actions/runs/14721383651/job/41315738893)

```
  error[E0425]: cannot find value `platform` in this scope
     --> crates/terminal/src/terminal_settings.rs:298:36
      |
  298 |         let shell_name = format!("{platform}Exec");
      |                                    ^^^^^^^^ not found in this scope
  
  error[E0425]: cannot find value `platform` in this scope
     --> crates/terminal/src/terminal_settings.rs:304:46
      |
  304 |             .read_value(&name(&format!("env.{platform}")))
      |                                              ^^^^^^^^ not found in this scope
```

CC: @P1n3appl3 

Release Notes:

- N/A