### PR TITLE
language_models: Change default fast model for Zed provider

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -269,13 +269,13 @@ impl LanguageModelProvider for CloudLanguageModelProvider {
 
     fn default_model(&self, cx: &App) -> Option<Arc<dyn LanguageModel>> {
         let llm_api_token = self.state.read(cx).llm_api_token.clone();
-        let model = CloudModel::Anthropic(anthropic::Model::default());
+        let model = CloudModel::Anthropic(anthropic::Model::Claude3_7Sonnet);
         Some(self.create_language_model(model, llm_api_token))
     }
 
     fn default_fast_model(&self, cx: &App) -> Option<Arc<dyn LanguageModel>> {
         let llm_api_token = self.state.read(cx).llm_api_token.clone();
-        let model = CloudModel::Anthropic(anthropic::Model::default_fast());
+        let model = CloudModel::Anthropic(anthropic::Model::Claude3_5Sonnet);
         Some(self.create_language_model(model, llm_api_token))
     }
 


### PR DESCRIPTION
This PR changes the default fast model for the Zed provider from Claude 3.5 Haiku to Claude 3.5 Sonnet.

We don't offer Claude 3.5 Haiku to users.

Closes https://github.com/zed-industries/zed/issues/29505.

Release Notes:

- agent: Changed the default fast model for the Zed provider to Claude 3.5 Sonnet.
