### PR TITLE
collab: Add `mode` column to `subscription_usage_meters` table

### DIFF
--- a/crates/collab/migrations_llm/20250429143553_add_mode_to_subscription_usage_meters.sql
+++ b/crates/collab/migrations_llm/20250429143553_add_mode_to_subscription_usage_meters.sql
@@ -1,0 +1,6 @@
+alter table subscription_usage_meters
+    add column mode text not null default 'normal';
+
+drop index uix_subscription_usage_meters_on_subscription_usage_model;
+
+create unique index uix_subscription_usage_meters_on_subscription_usage_model_mode on subscription_usage_meters (subscription_usage_id, model_id, mode);


### PR DESCRIPTION
This PR adds a `mode` column to the `subscription_usage_meters` table in the LLM database.

Release Notes:

- N/A
