### PR TITLE
debugger: Transition to path! macro to create paths in debugger tests

### DIFF
--- a/crates/debugger_ui/src/tests/attach_modal.rs
+++ b/crates/debugger_ui/src/tests/attach_modal.rs
@@ -7,6 +7,7 @@ use project::{FakeFs, Project};
 use serde_json::json;
 use task::{AttachRequest, TcpArgumentsTemplate};
 use tests::{init_test, init_test_workspace};
+use util::path;
 
 #[gpui::test]
 async fn test_direct_attach_to_process(executor: BackgroundExecutor, cx: &mut TestAppContext) {
@@ -15,14 +16,14 @@ async fn test_direct_attach_to_process(executor: BackgroundExecutor, cx: &mut Te
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -79,14 +80,14 @@ async fn test_show_attach_modal_and_select_process(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
     // Set up handlers for sessions spawned via modal.

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -7,6 +7,7 @@ use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
 use project::{FakeFs, Project};
 use serde_json::json;
 use tests::{init_test, init_test_workspace};
+use util::path;
 
 #[gpui::test]
 async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestAppContext) {
@@ -15,14 +16,14 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
     workspace

--- a/crates/debugger_ui/src/tests/dap_logger.rs
+++ b/crates/debugger_ui/src/tests/dap_logger.rs
@@ -5,6 +5,7 @@ use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
 use project::Project;
 use serde_json::json;
 use std::cell::OnceCell;
+use util::path;
 
 #[gpui::test]
 async fn test_dap_logger_captures_all_session_rpc_messages(
@@ -28,7 +29,7 @@ async fn test_dap_logger_captures_all_session_rpc_messages(
     // Create a filesystem with a simple project
     let fs = project::FakeFs::new(executor.clone());
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "fn main() {\n    println!(\"Hello, world!\");\n}"
         }),
@@ -42,7 +43,7 @@ async fn test_dap_logger_captures_all_session_rpc_messages(
         "log_store shouldn't contain any session IDs before any sessions were created"
     );
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
 
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -44,14 +44,14 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -181,14 +181,14 @@ async fn test_we_can_only_have_one_panel_per_debug_session(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -346,14 +346,14 @@ async fn test_handle_successful_run_in_terminal_reverse_request(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -417,14 +417,14 @@ async fn test_handle_start_debugging_request(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -493,14 +493,14 @@ async fn test_handle_error_run_in_terminal_reverse_request(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -523,7 +523,7 @@ async fn test_handle_error_run_in_terminal_reverse_request(
         .fake_reverse_request::<RunInTerminal>(RunInTerminalRequestArguments {
             kind: None,
             title: None,
-            cwd: "/non-existing/path".into(), // invalid/non-existing path will cause the terminal spawn to fail
+            cwd: path!("/non-existing/path").into(), // invalid/non-existing path will cause the terminal spawn to fail
             args: vec![],
             env: None,
             args_can_be_interpreted_by_shell: None,
@@ -561,14 +561,14 @@ async fn test_handle_start_debugging_reverse_request(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -657,14 +657,14 @@ async fn test_shutdown_children_when_parent_session_shutdown(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let dap_store = project.update(cx, |project, _| project.dap_store());
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
@@ -763,14 +763,14 @@ async fn test_shutdown_parent_session_if_all_children_are_shutdown(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let dap_store = project.update(cx, |project, _| project.dap_store());
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
@@ -883,14 +883,14 @@ async fn test_debug_panel_item_thread_status_reset_on_failure(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -1326,7 +1326,7 @@ async fn test_unsetting_breakpoints_on_clear_breakpoint_action(
                 .expect("We should always send a breakpoint's path")
                 .as_str()
             {
-                "/project/main.rs" | "/project/second.rs" => {}
+                path!("/project/main.rs") | path!("/project/second.rs") => {}
                 _ => {
                     panic!("Unset breakpoints for path that doesn't have any")
                 }
@@ -1354,14 +1354,14 @@ async fn test_debug_session_is_shutdown_when_attach_and_launch_request_fails(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
@@ -1402,14 +1402,14 @@ async fn test_we_send_arguments_from_user_config(
     let fs = FakeFs::new(executor.clone());
 
     fs.insert_tree(
-        "/project",
+        path!("/project"),
         json!({
             "main.rs": "First line\nSecond line\nThird line\nFourth line",
         }),
     )
     .await;
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
     let debug_definition = DebugTaskDefinition {
@@ -1417,7 +1417,7 @@ async fn test_we_send_arguments_from_user_config(
         request: dap::DebugRequest::Launch(LaunchRequest {
             program: "main.rs".to_owned(),
             args: vec!["arg1".to_owned(), "arg2".to_owned()],
-            cwd: Some("/Random_path".into()),
+            cwd: Some(path!("/Random_path").into()),
             env: HashMap::from_iter(vec![("KEY".to_owned(), "VALUE".to_owned())]),
         }),
         label: "test".into(),

--- a/crates/debugger_ui/src/tests/module_list.rs
+++ b/crates/debugger_ui/src/tests/module_list.rs
@@ -12,6 +12,7 @@ use std::sync::{
     Arc,
     atomic::{AtomicBool, AtomicI32, Ordering},
 };
+use util::path;
 
 #[gpui::test]
 async fn test_module_list(executor: BackgroundExecutor, cx: &mut TestAppContext) {
@@ -19,7 +20,7 @@ async fn test_module_list(executor: BackgroundExecutor, cx: &mut TestAppContext)
 
     let fs = FakeFs::new(executor.clone());
 
-    let project = Project::test(fs, ["/project".as_ref()], cx).await;
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
     let workspace = init_test_workspace(&project, cx).await;
     workspace
         .update(cx, |workspace, window, cx| {


### PR DESCRIPTION
This should prevent some cases where a test passes on one platform and not another

Release Notes:

- N/A
