### PR TITLE
collab: Add support for extended Zed Pro trial

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -380,11 +380,14 @@ async fn create_billing_subscription(
                 }
             }
 
+            let feature_flags = app.db.get_user_flags(user.id).await?;
+
             stripe_billing
                 .checkout_with_zed_pro_trial(
                     app.config.zed_pro_price_id()?,
                     customer_id,
                     &user.github_login,
+                    feature_flags,
                     &success_url,
                 )
                 .await?


### PR DESCRIPTION
This PR adds support for an extended Zed Pro trial, applied based on the presence of the `agent-extended-trial` feature flag.

Release Notes:

- N/A
