### PR TITLE
bash: Don't treat `raw_string` as bracket

### DIFF
--- a/crates/languages/src/bash/brackets.scm
+++ b/crates/languages/src/bash/brackets.scm
@@ -3,4 +3,3 @@
 ("{" @open "}" @close)
 ("\"" @open "\"" @close)
 ("`" @open "`" @close)
-((raw_string) @open @close)


### PR DESCRIPTION
Closes #29222

Release Notes:

- Fixed a crash when inputting `ciq` in vim mode inside of a raw string in a bash file
