### PR TITLE
Code block evals

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4993,6 +4993,7 @@ dependencies = [
  "language_model",
  "language_models",
  "languages",
+ "markdown",
  "node_runtime",
  "pathdiff",
  "paths",

--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -38,18 +38,17 @@ If appropriate, use tool calls to explore the current project, which contains th
 
 ## Code Block Formatting
 
-Whenever you mention a code block, you MUST use ONLY use the following format when the code in the block comes from a file
-in the project:
-
+Whenever you mention a code block, you MUST use ONLY use the following format:
 ```path/to/Something.blah#L123-456
 (code goes here)
 ```
-
 The `#L123-456` means the line number range 123 through 456, and the path/to/Something.blah
-is a path in the project. (If this code block does not come from a file in the project, then you may instead use
-the normal markdown style of three backticks followed by language name. However, you MUST use this format if
-the code in the block comes from a file in the project.)
-
+is a path in the project. (If there is no valid path in the project, then you can use
+/dev/null/path.extension for its path.) This is the ONLY valid way to format code blocks, because the Markdown parser
+does not understand the more common ```language syntax, or bare ``` blocks. It only
+understands this path-based syntax, and if the path is missing, then it will error and you will have to do it over again.
+Just to be really clear about this, if you ever find yourself writing three backticks followed by a language name, STOP!
+You have made a mistake. You can only ever put paths after triple backticks!
 <example>
 Based on all the information I've gathered, here's a summary of how this system works:
 1. The README file is loaded into the system.
@@ -66,7 +65,51 @@ This is the last header in the README.
 ```
 4. Finally, it passes this information on to the next process.
 </example>
-
+<example>
+In Markdown, hash marks signify headings. For example:
+```/dev/null/example.md#L1-3
+# Level 1 heading
+## Level 2 heading
+### Level 3 heading
+```
+</example>
+Here are examples of ways you must never render code blocks:
+<bad_example_do_not_do_this>
+In Markdown, hash marks signify headings. For example:
+```
+# Level 1 heading
+## Level 2 heading
+### Level 3 heading
+```
+</bad_example_do_not_do_this>
+This example is unacceptable because it does not include the path.
+<bad_example_do_not_do_this>
+In Markdown, hash marks signify headings. For example:
+```markdown
+# Level 1 heading
+## Level 2 heading
+### Level 3 heading
+```
+</bad_example_do_not_do_this>
+This example is unacceptable because it has the language instead of the path.
+<bad_example_do_not_do_this>
+In Markdown, hash marks signify headings. For example:
+    # Level 1 heading
+    ## Level 2 heading
+    ### Level 3 heading
+</bad_example_do_not_do_this>
+This example is unacceptable because it uses indentation to mark the code block
+instead of backticks with a path.
+<bad_example_do_not_do_this>
+In Markdown, hash marks signify headings. For example:
+```markdown
+/dev/null/example.md#L1-3
+# Level 1 heading
+## Level 2 heading
+### Level 3 heading
+```
+</bad_example_do_not_do_this>
+This example is unacceptable because the path is in the wrong place. The path must be directly after the opening backticks.
 ## Fixing Diagnostics
 
 1. Make 1-2 attempts at fixing diagnostics, then defer to the user.

--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -50,6 +50,23 @@ is a path in the project. (If this code block does not come from a file in the p
 the normal markdown style of three backticks followed by language name. However, you MUST use this format if
 the code in the block comes from a file in the project.)
 
+<example>
+Based on all the information I've gathered, here's a summary of how this system works:
+1. The README file is loaded into the system.
+2. The system finds the first two headers, including everything in between. In this case, that would be:
+```path/to/README.md#L8-12
+# First Header
+This is the info under the first header.
+## Sub-header
+```
+3. Then the system finds the last header in the README:
+```path/to/README.md#L27-29
+## Last Header
+This is the last header in the README.
+```
+4. Finally, it passes this information on to the next process.
+</example>
+
 ## Fixing Diagnostics
 
 1. Make 1-2 attempts at fixing diagnostics, then defer to the user.

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -174,6 +174,7 @@ impl Tool for EditFileTool {
                     "The `old_string` and `new_string` are identical, so no changes would be made."
                 ));
             }
+            let old_string = input.old_string.clone();
 
             let result = cx
                 .background_spawn(async move {
@@ -213,6 +214,22 @@ impl Tool for EditFileTool {
                             input.path.display()
                         )
                     } else {
+                        let old_string_with_buffer = format!(
+                            "old_string:\n\n{}\n\n-------file-------\n\n{}",
+                            &old_string,
+                            buffer.text()
+                        );
+                        let path = {
+                            use std::collections::hash_map::DefaultHasher;
+                            use std::hash::{Hash, Hasher};
+
+                            let mut hasher = DefaultHasher::new();
+                            old_string_with_buffer.hash(&mut hasher);
+
+                            PathBuf::from(format!("failed_tool_{}.txt", hasher.finish()))
+                        };
+                        dbg!(&path.display());
+                        std::fs::write(path, old_string_with_buffer).unwrap();
                         anyhow!("Failed to match the provided `old_string`")
                     }
                 })?;

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -228,7 +228,6 @@ impl Tool for EditFileTool {
 
                             PathBuf::from(format!("failed_tool_{}.txt", hasher.finish()))
                         };
-                        dbg!(&path.display());
                         std::fs::write(path, old_string_with_buffer).unwrap();
                         anyhow!("Failed to match the provided `old_string`")
                     }

--- a/crates/eval/Cargo.toml
+++ b/crates/eval/Cargo.toml
@@ -44,6 +44,7 @@ language_extension.workspace = true
 language_model.workspace = true
 language_models.workspace = true
 languages = { workspace = true, features = ["load-grammars"] }
+markdown.workspace = true
 node_runtime.workspace = true
 pathdiff.workspace = true
 paths.workspace = true

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -314,7 +314,7 @@ impl ExampleContext {
             for message in thread.messages().skip(message_count_before) {
                 messages.push(Message {
                     _role: message.role,
-                    _text: message.to_string(),
+                    text: message.to_string(),
                     tool_use: thread
                         .tool_uses_for_message(message.id, cx)
                         .into_iter()
@@ -391,12 +391,16 @@ impl Response {
     pub fn tool_uses(&self) -> impl Iterator<Item = &ToolUse> {
         self.messages.iter().flat_map(|msg| &msg.tool_use)
     }
+
+    pub fn texts(&self) -> impl Iterator<Item = &str> {
+        self.messages.iter().map(|msg| msg.text.as_str())
+    }
 }
 
 #[derive(Debug)]
 pub struct Message {
     _role: Role,
-    _text: String,
+    text: String,
     tool_use: Vec<ToolUse>,
 }
 

--- a/crates/eval/src/examples/code_block_citations.rs
+++ b/crates/eval/src/examples/code_block_citations.rs
@@ -1,0 +1,144 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use markdown::PathWithRange;
+
+use crate::example::{Example, ExampleContext, ExampleMetadata, JudgeAssertion, LanguageServer};
+
+pub struct CodeBlockCitations;
+
+const FENCE: &str = "```";
+
+#[async_trait(?Send)]
+impl Example for CodeBlockCitations {
+    fn meta(&self) -> ExampleMetadata {
+        ExampleMetadata {
+            name: "code_block_citations".to_string(),
+            url: "https://github.com/zed-industries/zed.git".to_string(),
+            revision: "f69aeb6311dde3c0b8979c293d019d66498d54f2".to_string(),
+            language_server: Some(LanguageServer {
+                file_extension: "rs".to_string(),
+                allow_preexisting_diagnostics: false,
+            }),
+            max_assertions: None,
+        }
+    }
+
+    async fn conversation(&self, cx: &mut ExampleContext) -> Result<()> {
+        let todo = (); // TODO change max_assertions from being on ExampleMetadata to being something we can set on cx.
+
+        const FILENAME: &str = "assistant_tool.rs";
+        cx.push_user_message(format!(
+            r#"
+            Show me the method bodies of all the methods of the `Tool` trait in {FILENAME}.
+            "#
+        ));
+
+        // Verify that the messages all have the correct formatting.
+        for mut text in cx.run_to_end().await?.texts() {
+            while let Some(index) = text.find(FENCE) {
+                // Advance text past the opening backticks.
+                text = &text[index + FENCE.len()..];
+
+                let content_len = text.find(FENCE);
+
+                // Verify the citation format - e.g. ```path/to/foo.txt#L123-456
+                if let Some(citation_len) = text.find('\n') {
+                    let citation = &text[..citation_len];
+
+                    if let Ok(()) = cx.assert(
+                        citation.contains("/"),
+                        format!("{citation:?} contains a slash.",),
+                    ) {
+                        let path_range = PathWithRange::new(citation);
+                        let path_exists = {
+                            let todo = (); // TODO look this up in the project.
+                            true
+                        };
+
+                        if let Ok(()) =
+                            cx.assert(path_exists, format!("{citation:?} has valid path"))
+                        {
+                            if let Some(content_len) = text.find(FENCE) {
+                                let content = &text[..content_len];
+                                let todo = (); // TODO verify that the file contents actually contain this content.
+
+                                // Advance past the closing backticks.
+                                text = &text[content_len..];
+                            } else {
+                                cx.assert(false, format!("Code block has closing {FENCE}"))
+                                    .ok();
+                            }
+
+                            let valid_line_range = {
+                                let todo = (); // TODO look this up in the project.
+                                true
+                            };
+
+                            if let Ok(()) = cx.assert(
+                                valid_line_range,
+                                format!("{citation:?} has valid line range in file."),
+                            ) {
+                                let diff = {
+                                    let todo = (); // TODO look this up in the project. Note that this requires looking up the closing ``` and getting what's in between there.
+                                    ""
+                                };
+                                cx.assert(
+                                    diff.is_empty(),
+                                    format!("{citation:?} snippet matches line range contents."),
+                                )
+                                .ok();
+                            } else {
+                                let todo = (); // TODO there was no valid line range (or no line range at all?) but we can still check if the file contained the snippet.
+                            }
+                        }
+                    }
+                } else {
+                    cx.assert(
+                        false,
+                        format!("Opening {FENCE} did not have a newline anywhere after it."),
+                    )
+                    .ok();
+                }
+
+                if let Some(content_len) = content_len {
+                    // Advance past the closing backticks
+                    text = &text[content_len + FENCE.len()..];
+                } else {
+                    // There were no closing backticks associated with these opening backticks.
+                    cx.assert(
+                        false,
+                        "Code block opening had matching closing backticks.".to_string(),
+                    )
+                    .ok();
+
+                    // There are no more code blocks to parse, so we're done.
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn thread_assertions(&self) -> Vec<JudgeAssertion> {
+        vec![
+            JudgeAssertion {
+                id: "trait method bodies are shown".to_string(),
+                description:
+                    "All method bodies of the Tool trait are shown."
+                        .to_string(),
+            },
+            JudgeAssertion {
+                id: "code blocks used".to_string(),
+                description:
+                   "All code snippets are rendered inside markdown code blocks (as opposed to any other formatting besides code blocks)."
+                        .to_string(),
+            },
+            JudgeAssertion {
+              id: "code blocks use backticks".to_string(),
+              description:
+                  format!("All markdown code blocks use backtick fences ({FENCE}) rather than indentation.")
+            }
+        ]
+    }
+}

--- a/crates/eval/src/examples/code_block_citations.rs
+++ b/crates/eval/src/examples/code_block_citations.rs
@@ -50,7 +50,6 @@ impl Example for CodeBlockCitations {
                 // Verify the citation format - e.g. ```path/to/foo.txt#L123-456
                 if let Some(citation_len) = text.find('\n') {
                     let citation = &text[..citation_len];
-                    dbg!(&citation);
 
                     if let Ok(()) =
                         cx.assert(citation.contains("/"), format!("Slash in {citation:?}",))
@@ -98,9 +97,6 @@ impl Example for CodeBlockCitations {
                             };
 
                             if let Some(content_len) = content_len {
-                                dbg!(&text[..content_len]);
-                                dbg!(&text[citation.len()..content_len - citation.len()]);
-
                                 // + 1 because there's a newline character after the citation.
                                 let content =
                                     &text[(citation.len() + 1)..content_len - (citation.len() + 1)];

--- a/crates/eval/src/examples/mod.rs
+++ b/crates/eval/src/examples/mod.rs
@@ -12,12 +12,14 @@ use util::serde::default_true;
 use crate::example::{Example, ExampleContext, ExampleMetadata, JudgeAssertion};
 
 mod add_arg_to_trait_method;
+mod code_block_citations;
 mod file_search;
 
 pub fn all(examples_dir: &Path) -> Vec<Rc<dyn Example>> {
     let mut threads: Vec<Rc<dyn Example>> = vec![
         Rc::new(file_search::FileSearchExample),
         Rc::new(add_arg_to_trait_method::AddArgToTraitMethod),
+        Rc::new(code_block_citations::CodeBlockCitations),
     ];
 
     for example_path in list_declarative_examples(examples_dir).unwrap() {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1,6 +1,8 @@
 pub mod parser;
 mod path_range;
 
+pub use path_range::{LineCol, PathWithRange};
+
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::iter;

--- a/crates/markdown/src/path_range.rs
+++ b/crates/markdown/src/path_range.rs
@@ -32,6 +32,20 @@ impl LineCol {
 }
 
 impl PathWithRange {
+    // Note: We could try out this as an alternative, and see how it does on evals.
+    //
+    // The closest to a standard way of including a filename is this:
+    // ```rust filename="path/to/file.rs#42:43"
+    // ```
+    //
+    // or, alternatively,
+    // ```rust filename="path/to/file.rs" lines="42:43"
+    // ```
+    //
+    // Examples where it's used this way:
+    // - https://mdxjs.com/guides/syntax-highlighting/#syntax-highlighting-with-the-meta-field
+    // - https://docusaurus.io/docs/markdown-features/code-blocks
+    // - https://spec.commonmark.org/0.31.2/#example-143
     pub fn new(str: impl AsRef<str>) -> Self {
         let str = str.as_ref();
         // Sometimes the model will include a language at the start,


### PR DESCRIPTION
Add a targeted eval for code block formatting, and revise the system prompt accordingly.

### Eval before, n=8

<img width="728" alt="eval before" src="https://github.com/user-attachments/assets/552b6146-3d26-4eaa-86f9-9fc36c0cadf2" />

### Eval after prompt change, n=8 (excluding the new evals, so just testing the prompt change)

<img width="717" alt="eval after" src="https://github.com/user-attachments/assets/c78c7a54-4c65-470c-b135-8691584cd73e" />

Release Notes:

- Code snippets in agent panel now link to source files when possible.