### PR TITLE
WIP: Create an ActiveThread in component preview

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,6 +3219,7 @@ dependencies = [
  "serde",
  "ui",
  "ui_input",
+ "util",
  "workspace",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3203,7 +3203,9 @@ dependencies = [
 name = "component_preview"
 version = "0.1.0"
 dependencies = [
+ "agent",
  "anyhow",
+ "assistant_tool",
  "client",
  "collections",
  "component",
@@ -3213,6 +3215,7 @@ dependencies = [
  "log",
  "notifications",
  "project",
+ "prompt_store",
  "serde",
  "ui",
  "ui_input",

--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -973,8 +973,8 @@ mod tests {
                 ThreadStore::load(
                     project.clone(),
                     cx.new(|_| ToolWorkingSet::default()),
-                    prompt_store,
                     Arc::new(PromptBuilder::new(None).unwrap()),
+                    prompt_store,
                     cx,
                 )
             })

--- a/crates/agent/src/assistant.rs
+++ b/crates/agent/src/assistant.rs
@@ -34,7 +34,7 @@ use prompt_store::PromptBuilder;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::Settings as _;
-use thread::ThreadId;
+pub use thread::{MessageSegment, ThreadId};
 
 pub use crate::active_thread::ActiveThread;
 use crate::assistant_configuration::{AddContextServerModal, ManageProfilesModal};

--- a/crates/agent/src/assistant.rs
+++ b/crates/agent/src/assistant.rs
@@ -42,7 +42,7 @@ pub use crate::assistant_panel::{AssistantPanel, ConcreteAssistantPanelDelegate}
 pub use crate::context::{ContextLoadResult, LoadedContext};
 pub use crate::inline_assistant::InlineAssistant;
 pub use crate::thread::{Message, Thread, ThreadEvent};
-pub use crate::thread_store::ThreadStore;
+pub use crate::thread_store::{SharedProjectContext, ThreadStore};
 pub use agent_diff::{AgentDiff, AgentDiffToolbar};
 
 actions!(

--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -302,8 +302,8 @@ impl AssistantPanel {
                     ThreadStore::load(
                         project,
                         tools.clone(),
-                        prompt_store.clone(),
                         prompt_builder.clone(),
+                        prompt_store.clone(),
                         cx,
                     )
                 })?

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2850,8 +2850,8 @@ fn main() {{
                 ThreadStore::load(
                     project.clone(),
                     cx.new(|_| ToolWorkingSet::default()),
-                    None,
                     Arc::new(PromptBuilder::new(None).unwrap()),
+                    None,
                     cx,
                 )
             })

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -81,8 +81,8 @@ impl ThreadStore {
     pub fn load(
         project: Entity<Project>,
         tools: Entity<ToolWorkingSet>,
-        prompt_store: Option<Entity<PromptStore>>,
         prompt_builder: Arc<PromptBuilder>,
+        prompt_store: Option<Entity<PromptStore>>,
         cx: &mut App,
     ) -> Task<Result<Entity<Self>>> {
         cx.spawn(async move |cx| {
@@ -101,7 +101,7 @@ impl ThreadStore {
         })
     }
 
-    pub fn new(
+    fn new(
         project: Entity<Project>,
         tools: Entity<ToolWorkingSet>,
         prompt_builder: Arc<PromptBuilder>,

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -101,7 +101,7 @@ impl ThreadStore {
         })
     }
 
-    fn new(
+    pub fn new(
         project: Entity<Project>,
         tools: Entity<ToolWorkingSet>,
         prompt_builder: Arc<PromptBuilder>,

--- a/crates/agent/src/ui/usage_banner.rs
+++ b/crates/agent/src/ui/usage_banner.rs
@@ -98,6 +98,10 @@ impl RenderOnce for UsageBanner {
 }
 
 impl Component for UsageBanner {
+    fn scope() -> ComponentScope {
+        ComponentScope::Agent
+    }
+
     fn sort_name() -> &'static str {
         "AgentUsageBanner"
     }

--- a/crates/component_preview/Cargo.toml
+++ b/crates/component_preview/Cargo.toml
@@ -30,6 +30,7 @@ ui.workspace = true
 ui_input.workspace = true
 workspace-hack.workspace = true
 workspace.workspace = true
+util.workspace = true
 
 # Dependencies for supporting specific previews
 agent.workspace = true

--- a/crates/component_preview/Cargo.toml
+++ b/crates/component_preview/Cargo.toml
@@ -15,18 +15,23 @@ path = "src/component_preview.rs"
 default = []
 
 [dependencies]
+anyhow.workspace = true
 client.workspace = true
 collections.workspace = true
 component.workspace = true
+db.workspace = true
 gpui.workspace = true
 languages.workspace = true
-notifications.workspace = true
 log.workspace = true
+notifications.workspace = true
 project.workspace = true
+serde.workspace = true
 ui.workspace = true
 ui_input.workspace = true
 workspace-hack.workspace = true
 workspace.workspace = true
-db.workspace = true
-anyhow.workspace = true
-serde.workspace = true
+
+# Dependencies for supporting specific previews
+agent.workspace = true
+assistant_tool.workspace = true
+prompt_store.workspace = true

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -3,6 +3,7 @@
 //! A view for exploring Zed components.
 
 mod persistence;
+mod preview_support;
 
 use std::iter::Iterator;
 use std::sync::Arc;

--- a/crates/component_preview/src/preview_support.rs
+++ b/crates/component_preview/src/preview_support.rs
@@ -1,1 +1,1 @@
-mod active_thread;
+pub mod active_thread;

--- a/crates/component_preview/src/preview_support.rs
+++ b/crates/component_preview/src/preview_support.rs
@@ -1,0 +1,1 @@
+mod active_thread;

--- a/crates/component_preview/src/preview_support/active_thread.rs
+++ b/crates/component_preview/src/preview_support/active_thread.rs
@@ -1,0 +1,35 @@
+use std::sync::Arc;
+
+use agent::{ActiveThread, Thread, ThreadStore};
+use assistant_tool::ToolWorkingSet;
+use gpui::{AppContext, WeakEntity};
+use prompt_store::PromptBuilder;
+use ui::App;
+use workspace::Workspace;
+
+fn static_active_thread(
+    weak_workspace: WeakEntity<Workspace>,
+    cx: &mut App,
+) -> anyhow::Result<ActiveThread> {
+    if let Some(workspace) = weak_workspace.upgrade() {
+        let project = workspace.read(cx).project().clone();
+        let tools = cx.new(|_| ToolWorkingSet::default());
+        let prompt_builder = Arc::new(PromptBuilder::new(None)?);
+        // let system_prompt = cx.new(|_| SystemPrompt::default());
+
+        let thread_store = cx.new(|cx| {
+            Ok(ThreadStore::new(
+                project.clone(),
+                tools.clone(),
+                prompt_builder.clone(),
+                None,
+                cx,
+            ))
+        });
+
+        let thread = Thread::new(project.clone(), tools, prompt_builder, system_prompt, cx);
+        Ok(ActiveThread::new(thread))
+    } else {
+        anyhow::bail!("Workspace is no longer available")
+    }
+}

--- a/crates/component_preview/src/preview_support/active_thread.rs
+++ b/crates/component_preview/src/preview_support/active_thread.rs
@@ -2,7 +2,7 @@ use languages::LanguageRegistry;
 use project::Project;
 use std::sync::Arc;
 
-use agent::{ActiveThread, ThreadStore};
+use agent::{ActiveThread, MessageSegment, ThreadStore};
 use assistant_tool::ToolWorkingSet;
 use gpui::{AppContext, AsyncApp, Entity, Task, WeakEntity};
 use prompt_store::PromptBuilder;
@@ -37,7 +37,20 @@ pub fn static_active_thread(
     cx: &mut App,
 ) -> Entity<ActiveThread> {
     let thread = thread_store.update(cx, |thread_store, cx| thread_store.create_thread(cx));
-
+    thread.update(cx, |thread, cx| {
+        thread.insert_assistant_message(vec![
+            MessageSegment::Text("I'll help you fix the lifetime error in your `cx.spawn` call. When working with async operations in GPUI, there are specific patterns to follow for proper lifetime management.".to_string()),
+            MessageSegment::Text("\n\nLet's look at what's happening in your code:".to_string()),
+            MessageSegment::Text("\n\n---\n\nLet's check the current state of the active_thread.rs file to understand what might have changed:".to_string()),
+            MessageSegment::Text("\n\n---\n\nLooking at the implementation of `load_preview_thread_store` and understanding GPUI's async patterns, here's the issue:".to_string()),
+            MessageSegment::Text("\n\n1. `load_preview_thread_store` returns a `Task<anyhow::Result<Entity<ThreadStore>>>`, which means it's already a task".to_string()),
+            MessageSegment::Text("\n2. When you call this function inside another `spawn` call, you're nesting tasks incorrectly".to_string()),
+            MessageSegment::Text("\n3. The `this` parameter you're trying to use in your closure has the wrong context".to_string()),
+            MessageSegment::Text("\n\nHere's the correct way to implement this:".to_string()),
+            MessageSegment::Text("\n\n---\n\nThe problem is in how you're setting up the async closure and trying to reference variables like `window` and `language_registry` that aren't accessible in that scope.".to_string()),
+            MessageSegment::Text("\n\nHere's how to fix it:".to_string()),
+        ], cx);
+    });
     cx.new(|cx| {
         ActiveThread::new(
             thread,

--- a/crates/component_preview/src/preview_support/active_thread.rs
+++ b/crates/component_preview/src/preview_support/active_thread.rs
@@ -1,9 +1,8 @@
 use languages::LanguageRegistry;
 use project::Project;
-use std::{cell::RefCell, rc::Rc, sync::Arc};
-use util::ResultExt;
+use std::sync::Arc;
 
-use agent::{ActiveThread, Thread, ThreadStore};
+use agent::{ActiveThread, ThreadStore};
 use assistant_tool::ToolWorkingSet;
 use gpui::{AppContext, AsyncApp, Entity, Task, WeakEntity};
 use prompt_store::PromptBuilder;

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -222,8 +222,8 @@ impl ExampleInstance {
         let thread_store = ThreadStore::load(
             project.clone(),
             tools,
-            prompt_store,
             app_state.prompt_builder.clone(),
+            prompt_store,
             cx,
         );
         let meta = self.thread.meta();


### PR DESCRIPTION
This PR unblocks previewing agent UI that requires a thread or active thread.

Todo:
- Remove .expects() on ComponentPreview::new() usages if possible
- Add something to the default thread so it doesn't render a blank screen

Release Notes:

- N/A