### PR TITLE
language: Fix indent suggestions for significant indented languages like Python

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -683,6 +683,10 @@ pub struct LanguageConfig {
     pub brackets: BracketPairConfig,
     /// If set to true, auto indentation uses last non empty line to determine
     /// the indentation level for a new line.
+    #[serde(default)]
+    pub language_without_bracket: bool,
+    /// If set to true, auto indentation uses last non empty line to determine
+    /// the indentation level for a new line.
     #[serde(default = "auto_indent_using_last_non_empty_line_default")]
     pub auto_indent_using_last_non_empty_line: bool,
     // Whether indentation of pasted content should be adjusted based on the context.
@@ -884,6 +888,7 @@ impl Default for LanguageConfig {
             jsx_tag_auto_close: None,
             completion_query_characters: Default::default(),
             debuggers: Default::default(),
+            language_without_bracket: Default::default(),
         }
     }
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -681,10 +681,10 @@ pub struct LanguageConfig {
     #[serde(default)]
     #[schemars(schema_with = "bracket_pair_config_json_schema")]
     pub brackets: BracketPairConfig,
-    /// If set to true, auto indentation uses last non empty line to determine
-    /// the indentation level for a new line.
+    /// If set to true, indicates the language uses significant whitespace/indentation
+    /// for syntax structure (like Python) rather than brackets/braces for code blocks.
     #[serde(default)]
-    pub language_without_bracket: bool,
+    pub significant_indentation: bool,
     /// If set to true, auto indentation uses last non empty line to determine
     /// the indentation level for a new line.
     #[serde(default = "auto_indent_using_last_non_empty_line_default")]
@@ -888,7 +888,7 @@ impl Default for LanguageConfig {
             jsx_tag_auto_close: None,
             completion_query_characters: Default::default(),
             debuggers: Default::default(),
-            language_without_bracket: Default::default(),
+            significant_indentation: Default::default(),
         }
     }
 }

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1209,7 +1209,7 @@ mod tests {
             append(&mut buffer, "foo(\n1)", cx);
             assert_eq!(
                 buffer.text(),
-                "def a():\n  \n  if a:\n    b()\n  else:\n    foo(\n      1)"
+                "def a():\n  \n  if a:\n    b()\n  else:\n    foo(\n    1)"
             );
 
             // dedent the closing paren if it is shifted to the beginning of the line
@@ -1255,7 +1255,7 @@ mod tests {
 
             // dedent "else" on the line after a closing paren
             append(&mut buffer, "\n  else:\n", cx);
-            assert_eq!(buffer.text(), "if a:\n  b(\n  )\nelse:\n  ");
+            assert_eq!(buffer.text(), "if a:\n  b(\n  )\nelse:\n");
 
             buffer
         });

--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -28,4 +28,4 @@ brackets = [
 
 auto_indent_using_last_non_empty_line = false
 debuggers = ["Debugpy"]
-language_without_bracket = true
+significant_indentation = true

--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -29,3 +29,5 @@ brackets = [
 auto_indent_using_last_non_empty_line = false
 debuggers = ["Debugpy"]
 significant_indentation = true
+increase_indent_pattern = "^\\s*(try)\\b.*:"
+decrease_indent_pattern = "^\\s*(else|elif|except|finally)\\b.*:"

--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -27,6 +27,5 @@ brackets = [
 ]
 
 auto_indent_using_last_non_empty_line = false
-increase_indent_pattern = "^[^#].*:\\s*$"
-decrease_indent_pattern = "^\\s*(else|elif|except|finally)\\b.*:"
 debuggers = ["Debugpy"]
+language_without_bracket = true

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -2,17 +2,22 @@
 (_ "{" "}" @end) @indent
 (_ "(" ")" @end) @indent
 
-(try_statement
-    body: (_) @start
-    [(except_clause) (finally_clause)] @end
-    ) @indent
+(function_definition (block) @indent)
+(if_statement (block) @indent)
+(else_clause (block) @indent)
+(elif_clause (block) @indent)
 
-(if_statement
-    consequence: (_) @start
-    alternative: (_) @end
-    ) @indent
+; (try_statement
+;     body: (_) @start
+;     [(except_clause) (finally_clause)] @end
+;     ) @indent
 
-(_
-    alternative: (elif_clause) @start
-    alternative: (_) @end
-    ) @indent
+; (if_statement
+;     consequence: (_) @start
+;     alternative: (_) @end
+;     ) @indent
+
+; (_
+;     alternative: (elif_clause) @start
+;     alternative: (_) @end
+;     ) @indent

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -1,6 +1,6 @@
 (function_definition
   ":" @start
-  (block) @indent
+  body: (block) @indent
 )
 
 (if_statement
@@ -11,10 +11,28 @@
 
 (else_clause
   ":" @start
-  (block) @indent
+  body: (block) @indent
 )
 
 (elif_clause
+  ":" @start
+  consequence: (block) @indent
+)
+
+(try_statement
+  ":" @start
+  body: (block) @indent
+  (except_clause)? @outdent
+  (else_clause)? @outdent
+  (finally_clause)? @outdent
+)
+
+(except_clause
+  ":" @start
+  (block) @indent
+)
+
+(finally_clause
   ":" @start
   (block) @indent
 )

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -19,6 +19,11 @@
   consequence: (block) @indent
 )
 
+(for_statement
+  ":" @start
+  body: (block) @indent
+)
+
 (try_statement
   ":" @start
   body: (block) @indent

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -1,8 +1,20 @@
-(_ "[" "]" @end) @indent
-(_ "{" "}" @end) @indent
-(_ "(" ")" @end) @indent
+(function_definition
+  ":" @start
+  (block) @indent
+)
 
-(function_definition (block) @indent)
-(if_statement (block) @indent)
-(else_clause (block) @indent)
-(elif_clause (block) @indent)
+(if_statement
+  ":" @start
+  consequence: (block) @indent
+  alternative: (_)? @outdent
+)
+
+(else_clause
+  ":" @start
+  (block) @indent
+)
+
+(elif_clause
+  ":" @start
+  (block) @indent
+)

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -6,18 +6,3 @@
 (if_statement (block) @indent)
 (else_clause (block) @indent)
 (elif_clause (block) @indent)
-
-; (try_statement
-;     body: (_) @start
-;     [(except_clause) (finally_clause)] @end
-;     ) @indent
-
-; (if_statement
-;     consequence: (_) @start
-;     alternative: (_) @end
-;     ) @indent
-
-; (_
-;     alternative: (elif_clause) @start
-;     alternative: (_) @end
-;     ) @indent


### PR DESCRIPTION
Closes #26157

This fixes multiple cases where Python indentation breaks:
- [x] Adding a new line after `if`, `try`, etc. correctly indents in that scope 
- [x] Multi-cursor tabs correctly preserve relative indents
- [x] Adding a new line after `else`, `finally`, etc. correctly outdents them
- [x] Existing Tests

Future Todo: I need to add new tests for all the above cases.

Before/After:

1. Multi-cursor tabs correctly preserve relative indents

https://github.com/user-attachments/assets/08a46ddf-5371-4e26-ae7d-f8aa0b31c4a2

2. Adding a new line after `if`, `try`, etc. correctly indents in that scope

https://github.com/user-attachments/assets/9affae97-1a50-43c9-9e9f-c1ea3a747813

Release Notes:

- Fixes indentation-related issues involving tab, newline, etc for Python.
