### PR TITLE
agent: Discourage long-running commands

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -15,6 +15,7 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 3. DO NOT use tools to access items that are already available in the context section.
 4. Use only the tools that are currently available.
 5. DO NOT use a tool that is not available just because it appears in the conversation. This means the user turned it off.
+6. NEVER run commands that don't terminate on their own such as web servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers.
 
 ## Searching and Reading
 

--- a/crates/assistant_tools/src/terminal_tool/description.md
+++ b/crates/assistant_tools/src/terminal_tool/description.md
@@ -6,6 +6,6 @@ The output results will be shown to the user already, only list it again if nece
 
 Make sure you use the `cd` parameter to navigate to one of the root directories of the project. NEVER do it as part of the `command` itself, otherwise it will error.
 
-Do not use this tool for commands that run indefinitely, such as servers (e.g., `python -m http.server`) or file watchers that don't terminate on their own.
+Do not use this tool for commands that run indefinitely, such as servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers that don't terminate on their own.
 
 Remember that each invocation of this tool will spawn a new shell process, so you can't rely on any state from previous invocations.


### PR DESCRIPTION
Adds popular examples of long-running commands to system prompt. 

Unfortunately, I couldn't add an eval example as the new terminal tool no longer works in `eval`. We can look into that tomorrow, but I'm seeing improvements when manually testing this, so I'd like to merge it.

<img src="https://github.com/user-attachments/assets/ac24e617-e068-466f-875d-c30e1f2465c4" width=400></img>


Release Notes:

- agent: Discourage long-running commands