### PR TITLE
language: Treat .h files as C files

### DIFF
--- a/crates/languages/src/c/config.toml
+++ b/crates/languages/src/c/config.toml
@@ -1,6 +1,6 @@
 name = "C"
 grammar = "c"
-path_suffixes = ["c"]
+path_suffixes = ["c", "h"]
 line_comments = ["// "]
 autoclose_before = ";:.,=}])>"
 brackets = [

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -1,6 +1,6 @@
 name = "C++"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "ixx", "cu", "cuh", "C", "H"]
+path_suffixes = ["cc", "hh", "cpp", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "ixx", "cu", "cuh", "C", "H"]
 line_comments = ["// ", "/// ", "//! "]
 autoclose_before = ";:.,=}])>"
 brackets = [


### PR DESCRIPTION
Closes #29214 

Release Notes:

- Fixed treat .h to treat as C file rather than C++ file
