### PR TITLE
debugger: Extract running state from DebugSession mode and remove mode field

### DIFF
--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -64,7 +64,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             active_item.update(cx, |item, cx| item.pause_thread(cx))
                         }
@@ -75,7 +75,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             active_item.update(cx, |item, cx| item.restart_session(cx))
                         }
@@ -86,7 +86,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             active_item.update(cx, |item, cx| item.step_in(cx))
                         }
@@ -97,7 +97,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             active_item.update(cx, |item, cx| item.step_over(cx))
                         }
@@ -108,7 +108,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             active_item.update(cx, |item, cx| item.step_back(cx))
                         }
@@ -119,7 +119,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             cx.defer(move |cx| {
                                 active_item.update(cx, |item, cx| item.stop_thread(cx))
@@ -132,7 +132,7 @@ pub fn init(cx: &mut App) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
                             panel
                                 .active_session()
-                                .and_then(|session| session.read(cx).mode().as_running().cloned())
+                                .map(|session| session.read(cx).running_state().clone())
                         }) {
                             active_item.update(cx, |item, cx| item.toggle_ignore_breakpoints(cx))
                         }
@@ -209,11 +209,8 @@ pub fn init(cx: &mut App) {
                                 state: debugger::breakpoint_store::BreakpointState::Enabled,
                             };
 
-                            active_session
-                                .update(cx, |session_item, _| {
-                                    session_item.mode().as_running().cloned()
-                                })?
-                                .update(cx, |state, cx| {
+                            active_session.update(cx, |session, cx| {
+                                session.running_state().update(cx, |state, cx| {
                                     if let Some(thread_id) = state.selected_thread_id() {
                                         state.session().update(cx, |session, cx| {
                                             session.run_to_position(
@@ -224,6 +221,7 @@ pub fn init(cx: &mut App) {
                                         })
                                     }
                                 });
+                            });
 
                             Some(())
                         });
@@ -246,17 +244,16 @@ pub fn init(cx: &mut App) {
                                 cx,
                             )?;
 
-                            active_session
-                                .update(cx, |session_item, _| {
-                                    session_item.mode().as_running().cloned()
-                                })?
-                                .update(cx, |state, cx| {
+                            active_session.update(cx, |session, cx| {
+                                session.running_state().update(cx, |state, cx| {
                                     let stack_id = state.selected_stack_frame_id(cx);
 
                                     state.session().update(cx, |session, cx| {
                                         session.evaluate(text, None, stack_id, None, cx).detach();
                                     });
                                 });
+                            });
+
                             Some(())
                         });
                     },

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -5,7 +5,7 @@ use std::sync::OnceLock;
 use dap::client::SessionId;
 use gpui::{App, Entity, EventEmitter, FocusHandle, Focusable, Subscription, Task, WeakEntity};
 use project::Project;
-use project::debugger::{dap_store::DapStore, session::Session};
+use project::debugger::session::Session;
 use project::worktree_store::WorktreeStore;
 use rpc::proto::{self, PeerId};
 use running::RunningState;
@@ -18,23 +18,10 @@ use workspace::{
 use crate::debugger_panel::DebugPanel;
 use crate::persistence::SerializedPaneLayout;
 
-pub(crate) enum DebugSessionState {
-    Running(Entity<running::RunningState>),
-}
-
-impl DebugSessionState {
-    pub(crate) fn as_running(&self) -> Option<&Entity<running::RunningState>> {
-        match &self {
-            DebugSessionState::Running(entity) => Some(entity),
-        }
-    }
-}
-
 pub struct DebugSession {
     remote_id: Option<workspace::ViewId>,
-    mode: DebugSessionState,
+    running_state: Entity<RunningState>,
     label: OnceLock<SharedString>,
-    dap_store: WeakEntity<DapStore>,
     _debug_panel: WeakEntity<DebugPanel>,
     _worktree_store: WeakEntity<WorktreeStore>,
     _workspace: WeakEntity<Workspace>,
@@ -57,7 +44,7 @@ impl DebugSession {
         window: &mut Window,
         cx: &mut App,
     ) -> Entity<Self> {
-        let mode = cx.new(|cx| {
+        let running_state = cx.new(|cx| {
             RunningState::new(
                 session.clone(),
                 project.clone(),
@@ -69,13 +56,12 @@ impl DebugSession {
         });
 
         cx.new(|cx| Self {
-            _subscriptions: [cx.subscribe(&mode, |_, _, _, cx| {
+            _subscriptions: [cx.subscribe(&running_state, |_, _, _, cx| {
                 cx.notify();
             })],
             remote_id: None,
-            mode: DebugSessionState::Running(mode),
+            running_state,
             label: OnceLock::new(),
-            dap_store: project.read(cx).dap_store().downgrade(),
             _debug_panel,
             _worktree_store: project.read(cx).worktree_store().downgrade(),
             _workspace: workspace,
@@ -83,25 +69,16 @@ impl DebugSession {
     }
 
     pub(crate) fn session_id(&self, cx: &App) -> SessionId {
-        match &self.mode {
-            DebugSessionState::Running(entity) => entity.read(cx).session_id(),
-        }
+        self.running_state.read(cx).session_id()
     }
 
     pub fn session(&self, cx: &App) -> Entity<Session> {
-        match &self.mode {
-            DebugSessionState::Running(entity) => entity.read(cx).session().clone(),
-        }
+        self.running_state.read(cx).session().clone()
     }
 
     pub(crate) fn shutdown(&mut self, cx: &mut Context<Self>) {
-        match &self.mode {
-            DebugSessionState::Running(state) => state.update(cx, |state, cx| state.shutdown(cx)),
-        }
-    }
-
-    pub(crate) fn mode(&self) -> &DebugSessionState {
-        &self.mode
+        self.running_state
+            .update(cx, |state, cx| state.shutdown(cx));
     }
 
     pub(crate) fn label(&self, cx: &App) -> SharedString {
@@ -109,43 +86,40 @@ impl DebugSession {
             return label.clone();
         }
 
-        let session_id = match &self.mode {
-            DebugSessionState::Running(running_state) => running_state.read(cx).session_id(),
-        };
-
-        let Ok(Some(session)) = self
-            .dap_store
-            .read_with(cx, |store, _| store.session_by_id(session_id))
-        else {
-            return "".into();
-        };
+        let session = self.running_state.read(cx).session();
 
         self.label
             .get_or_init(|| session.read(cx).label())
             .to_owned()
     }
 
-    #[allow(unused)]
-    pub(crate) fn running_state(&self) -> Entity<RunningState> {
-        match &self.mode {
-            DebugSessionState::Running(running_state) => running_state.clone(),
-        }
+    pub(crate) fn running_state(&self) -> &Entity<RunningState> {
+        &self.running_state
     }
 
     pub(crate) fn label_element(&self, cx: &App) -> AnyElement {
         let label = self.label(cx);
 
-        let icon = match &self.mode {
-            DebugSessionState::Running(state) => {
-                if state.read(cx).session().read(cx).is_terminated() {
-                    Some(Indicator::dot().color(Color::Error))
-                } else {
-                    match state.read(cx).thread_status(cx).unwrap_or_default() {
-                        project::debugger::session::ThreadStatus::Stopped => {
-                            Some(Indicator::dot().color(Color::Conflict))
-                        }
-                        _ => Some(Indicator::dot().color(Color::Success)),
+        let icon = {
+            if self
+                .running_state
+                .read(cx)
+                .session()
+                .read(cx)
+                .is_terminated()
+            {
+                Some(Indicator::dot().color(Color::Error))
+            } else {
+                match self
+                    .running_state
+                    .read(cx)
+                    .thread_status(cx)
+                    .unwrap_or_default()
+                {
+                    project::debugger::session::ThreadStatus::Stopped => {
+                        Some(Indicator::dot().color(Color::Conflict))
                     }
+                    _ => Some(Indicator::dot().color(Color::Success)),
                 }
             }
         };
@@ -163,9 +137,7 @@ impl EventEmitter<DebugPanelItemEvent> for DebugSession {}
 
 impl Focusable for DebugSession {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
-        match &self.mode {
-            DebugSessionState::Running(running_state) => running_state.focus_handle(cx),
-        }
+        self.running_state.focus_handle(cx)
     }
 }
 
@@ -244,10 +216,7 @@ impl FollowableItem for DebugSession {
 
 impl Render for DebugSession {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        match &self.mode {
-            DebugSessionState::Running(running_state) => {
-                running_state.update(cx, |this, cx| this.render(window, cx).into_any_element())
-            }
-        }
+        self.running_state
+            .update(cx, |this, cx| this.render(window, cx).into_any_element())
     }
 }

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -118,8 +118,8 @@ pub fn start_debug_session_with<T: Fn(&Arc<DebugAdapterClient>) + 'static>(
         workspace
             .panel::<DebugPanel>(cx)
             .and_then(|panel| panel.read(cx).active_session())
-            .and_then(|session| session.read(cx).mode().as_running().cloned())
-            .map(|running| running.read(cx).session().clone())
+            .map(|session| session.read(cx).running_state().read(cx).session())
+            .cloned()
             .ok_or_else(|| anyhow!("Failed to get active session"))
     })??;
 

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -87,10 +87,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
     let running_state =
         active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
             cx.focus_self(window);
-            item.mode()
-                .as_running()
-                .expect("Session should be running by this point")
-                .clone()
+            item.running_state().clone()
         });
 
     cx.run_until_parked();
@@ -105,7 +102,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
 
             assert_eq!(
                 "First console output line before thread stopped!\nFirst output line before thread stopped!\n",
-                active_debug_session_panel.read(cx).mode().as_running().unwrap().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
+                active_debug_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
             );
         })
         .unwrap();
@@ -154,7 +151,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
 
             assert_eq!(
                 "First console output line before thread stopped!\nFirst output line before thread stopped!\nSecond output line after thread stopped!\nSecond console output line after thread stopped!\n",
-                active_session_panel.read(cx).mode().as_running().unwrap().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
+                active_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
             );
         })
         .unwrap();

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -84,11 +84,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
                 debug_panel.update(cx, |debug_panel, _| debug_panel.active_session().unwrap());
 
             let running_state = active_session.update(cx, |active_session, _| {
-                active_session
-                    .mode()
-                    .as_running()
-                    .expect("Session should be running by this point")
-                    .clone()
+                active_session.running_state().clone()
             });
 
             debug_panel.update(cx, |this, cx| {
@@ -120,11 +116,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
                 .unwrap();
 
             let running_state = active_session.update(cx, |active_session, _| {
-                active_session
-                    .mode()
-                    .as_running()
-                    .expect("Session should be running by this point")
-                    .clone()
+                active_session.running_state().clone()
             });
 
             assert_eq!(client.id(), running_state.read(cx).session_id());
@@ -153,11 +145,7 @@ async fn test_basic_show_debug_panel(executor: BackgroundExecutor, cx: &mut Test
                 .unwrap();
 
             let running_state = active_session.update(cx, |active_session, _| {
-                active_session
-                    .mode()
-                    .as_running()
-                    .expect("Session should be running by this point")
-                    .clone()
+                active_session.running_state().clone()
             });
 
             debug_panel.update(cx, |this, cx| {
@@ -247,11 +235,7 @@ async fn test_we_can_only_have_one_panel_per_debug_session(
                 .unwrap();
 
             let running_state = active_session.update(cx, |active_session, _| {
-                active_session
-                    .mode()
-                    .as_running()
-                    .expect("Session should be running by this point")
-                    .clone()
+                active_session.running_state().clone()
             });
 
             assert_eq!(client.id(), active_session.read(cx).session_id(cx));
@@ -284,11 +268,7 @@ async fn test_we_can_only_have_one_panel_per_debug_session(
                 .unwrap();
 
             let running_state = active_session.update(cx, |active_session, _| {
-                active_session
-                    .mode()
-                    .as_running()
-                    .expect("Session should be running by this point")
-                    .clone()
+                active_session.running_state().clone()
             });
 
             assert_eq!(client.id(), active_session.read(cx).session_id(cx));
@@ -316,11 +296,7 @@ async fn test_we_can_only_have_one_panel_per_debug_session(
                 .unwrap();
 
             let running_state = active_session.update(cx, |active_session, _| {
-                active_session
-                    .mode()
-                    .as_running()
-                    .expect("Session should be running by this point")
-                    .clone()
+                active_session.running_state().clone()
             });
 
             debug_panel.update(cx, |this, cx| {
@@ -1009,12 +985,8 @@ async fn test_debug_panel_item_thread_status_reset_on_failure(
 
     cx.run_until_parked();
 
-    let running_state = active_debug_session_panel(workspace, cx).update_in(cx, |item, _, _| {
-        item.mode()
-            .as_running()
-            .expect("Session should be running by this point")
-            .clone()
-    });
+    let running_state = active_debug_session_panel(workspace, cx)
+        .update(cx, |item, _| item.running_state().clone());
 
     cx.run_until_parked();
     let thread_id = ThreadId(1);

--- a/crates/debugger_ui/src/tests/module_list.rs
+++ b/crates/debugger_ui/src/tests/module_list.rs
@@ -106,10 +106,7 @@ async fn test_module_list(executor: BackgroundExecutor, cx: &mut TestAppContext)
     let running_state =
         active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
             cx.focus_self(window);
-            item.mode()
-                .as_running()
-                .expect("Session should be running by this point")
-                .clone()
+            item.running_state().clone()
         });
 
     running_state.update_in(cx, |this, window, cx| {

--- a/crates/debugger_ui/src/tests/stack_frame_list.rs
+++ b/crates/debugger_ui/src/tests/stack_frame_list.rs
@@ -138,43 +138,33 @@ async fn test_fetch_initial_stack_frames_and_go_to_stack_frame(
 
     // trigger to load threads
     active_debug_session_panel(workspace, cx).update(cx, |session, cx| {
-        session
-            .mode()
-            .as_running()
-            .unwrap()
-            .update(cx, |running_state, cx| {
-                running_state
-                    .session()
-                    .update(cx, |session, cx| session.threads(cx));
-            });
+        session.running_state().update(cx, |running_state, cx| {
+            running_state
+                .session()
+                .update(cx, |session, cx| session.threads(cx));
+        });
     });
 
     cx.run_until_parked();
 
     // select first thread
     active_debug_session_panel(workspace, cx).update_in(cx, |session, window, cx| {
-        session
-            .mode()
-            .as_running()
-            .unwrap()
-            .update(cx, |running_state, cx| {
-                running_state.select_current_thread(
-                    &running_state
-                        .session()
-                        .update(cx, |session, cx| session.threads(cx)),
-                    window,
-                    cx,
-                );
-            });
+        session.running_state().update(cx, |running_state, cx| {
+            running_state.select_current_thread(
+                &running_state
+                    .session()
+                    .update(cx, |session, cx| session.threads(cx)),
+                window,
+                cx,
+            );
+        });
     });
 
     cx.run_until_parked();
 
     active_debug_session_panel(workspace, cx).update(cx, |session, cx| {
         let stack_frame_list = session
-            .mode()
-            .as_running()
-            .unwrap()
+            .running_state()
             .update(cx, |state, _| state.stack_frame_list().clone());
 
         stack_frame_list.update(cx, |stack_frame_list, cx| {
@@ -309,34 +299,26 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
 
     // trigger threads to load
     active_debug_session_panel(workspace, cx).update(cx, |session, cx| {
-        session
-            .mode()
-            .as_running()
-            .unwrap()
-            .update(cx, |running_state, cx| {
-                running_state
-                    .session()
-                    .update(cx, |session, cx| session.threads(cx));
-            });
+        session.running_state().update(cx, |running_state, cx| {
+            running_state
+                .session()
+                .update(cx, |session, cx| session.threads(cx));
+        });
     });
 
     cx.run_until_parked();
 
     // select first thread
     active_debug_session_panel(workspace, cx).update_in(cx, |session, window, cx| {
-        session
-            .mode()
-            .as_running()
-            .unwrap()
-            .update(cx, |running_state, cx| {
-                running_state.select_current_thread(
-                    &running_state
-                        .session()
-                        .update(cx, |session, cx| session.threads(cx)),
-                    window,
-                    cx,
-                );
-            });
+        session.running_state().update(cx, |running_state, cx| {
+            running_state.select_current_thread(
+                &running_state
+                    .session()
+                    .update(cx, |session, cx| session.threads(cx)),
+                window,
+                cx,
+            );
+        });
     });
 
     cx.run_until_parked();
@@ -383,9 +365,7 @@ async fn test_select_stack_frame(executor: BackgroundExecutor, cx: &mut TestAppC
 
             active_debug_panel_item
                 .read(cx)
-                .mode()
-                .as_running()
-                .unwrap()
+                .running_state()
                 .read(cx)
                 .stack_frame_list()
                 .clone()
@@ -676,34 +656,26 @@ async fn test_collapsed_entries(executor: BackgroundExecutor, cx: &mut TestAppCo
 
     // trigger threads to load
     active_debug_session_panel(workspace, cx).update(cx, |session, cx| {
-        session
-            .mode()
-            .as_running()
-            .unwrap()
-            .update(cx, |running_state, cx| {
-                running_state
-                    .session()
-                    .update(cx, |session, cx| session.threads(cx));
-            });
+        session.running_state().update(cx, |running_state, cx| {
+            running_state
+                .session()
+                .update(cx, |session, cx| session.threads(cx));
+        });
     });
 
     cx.run_until_parked();
 
     // select first thread
     active_debug_session_panel(workspace, cx).update_in(cx, |session, window, cx| {
-        session
-            .mode()
-            .as_running()
-            .unwrap()
-            .update(cx, |running_state, cx| {
-                running_state.select_current_thread(
-                    &running_state
-                        .session()
-                        .update(cx, |session, cx| session.threads(cx)),
-                    window,
-                    cx,
-                );
-            });
+        session.running_state().update(cx, |running_state, cx| {
+            running_state.select_current_thread(
+                &running_state
+                    .session()
+                    .update(cx, |session, cx| session.threads(cx)),
+                window,
+                cx,
+            );
+        });
     });
 
     cx.run_until_parked();
@@ -711,9 +683,7 @@ async fn test_collapsed_entries(executor: BackgroundExecutor, cx: &mut TestAppCo
     // trigger stack frames to loaded
     active_debug_session_panel(workspace, cx).update(cx, |debug_panel_item, cx| {
         let stack_frame_list = debug_panel_item
-            .mode()
-            .as_running()
-            .unwrap()
+            .running_state()
             .update(cx, |state, _| state.stack_frame_list().clone());
 
         stack_frame_list.update(cx, |stack_frame_list, cx| {
@@ -725,9 +695,7 @@ async fn test_collapsed_entries(executor: BackgroundExecutor, cx: &mut TestAppCo
 
     active_debug_session_panel(workspace, cx).update_in(cx, |debug_panel_item, window, cx| {
         let stack_frame_list = debug_panel_item
-            .mode()
-            .as_running()
-            .unwrap()
+            .running_state()
             .update(cx, |state, _| state.stack_frame_list().clone());
 
         stack_frame_list.update(cx, |stack_frame_list, cx| {

--- a/crates/debugger_ui/src/tests/variable_list.rs
+++ b/crates/debugger_ui/src/tests/variable_list.rs
@@ -183,10 +183,7 @@ async fn test_basic_fetch_initial_scope_and_variables(
     let running_state =
         active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
             cx.focus_self(window);
-            item.mode()
-                .as_running()
-                .expect("Session should be running by this point")
-                .clone()
+            item.running_state().clone()
         });
     cx.run_until_parked();
 
@@ -427,10 +424,7 @@ async fn test_fetch_variables_for_multiple_scopes(
     let running_state =
         active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
             cx.focus_self(window);
-            item.mode()
-                .as_running()
-                .expect("Session should be running by this point")
-                .clone()
+            item.running_state().clone()
         });
     cx.run_until_parked();
 
@@ -710,11 +704,7 @@ async fn test_keyboard_navigation(executor: BackgroundExecutor, cx: &mut TestApp
     let running_state =
         active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
             cx.focus_self(window);
-            let running = item
-                .mode()
-                .as_running()
-                .expect("Session should be running by this point")
-                .clone();
+            let running = item.running_state().clone();
 
             let variable_list = running.read_with(cx, |state, _| state.variable_list().clone());
             variable_list.update(cx, |_, cx| cx.focus_self(window));
@@ -1440,11 +1430,7 @@ async fn test_variable_list_only_sends_requests_when_rendering(
     cx.run_until_parked();
 
     let running_state = active_debug_session_panel(workspace, cx).update_in(cx, |item, _, _| {
-        let state = item
-            .mode()
-            .as_running()
-            .expect("Session should be running by this point")
-            .clone();
+        let state = item.running_state().clone();
 
         state
     });
@@ -1742,10 +1728,7 @@ async fn test_it_fetches_scopes_variables_when_you_select_a_stack_frame(
     let running_state =
         active_debug_session_panel(workspace, cx).update_in(cx, |item, window, cx| {
             cx.focus_self(window);
-            item.mode()
-                .as_running()
-                .expect("Session should be running by this point")
-                .clone()
+            item.running_state().clone()
         });
 
     running_state.update(cx, |running_state, cx| {


### PR DESCRIPTION
DebugSession.mode is no longer needed because project::debugger::Session manages its own state now (booting, running, terminated), and removing mode simplifies a lot of the code that uses running state.

I used Zed AI to do a good chunk of the refactor, but I doubled-checked everything it did and changed a good amount of its updates.

Release Notes:

- N/A
