### PR TITLE
Revert "python: Enable subroot detection for pylsp and pyright (#27364)"

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -2,7 +2,6 @@ use anyhow::Context as _;
 use gpui::{App, UpdateGlobal};
 use json::json_task_context;
 use node_runtime::NodeRuntime;
-use python::PyprojectTomlManifestProvider;
 use rust::CargoManifestProvider;
 use rust_embed::RustEmbed;
 use settings::SettingsStore;
@@ -303,13 +302,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
         anyhow::Ok(())
     })
     .detach();
-    let manifest_providers: [Arc<dyn ManifestProvider>; 2] = [
-        Arc::from(CargoManifestProvider),
-        Arc::from(PyprojectTomlManifestProvider),
-    ];
-    for provider in manifest_providers {
-        project::ManifestProviders::global(cx).register(provider);
-    }
+    project::ManifestProviders::global(cx).register(Arc::from(CargoManifestProvider));
 }
 
 #[derive(Default)]

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -4,13 +4,13 @@ use async_trait::async_trait;
 use collections::HashMap;
 use gpui::{App, Task};
 use gpui::{AsyncApp, SharedString};
+use language::LanguageName;
 use language::LanguageToolchainStore;
 use language::Toolchain;
 use language::ToolchainList;
 use language::ToolchainLister;
 use language::language_settings::language_settings;
 use language::{ContextProvider, LspAdapter, LspAdapterDelegate};
-use language::{LanguageName, ManifestName, ManifestProvider, ManifestQuery};
 use lsp::LanguageServerBinary;
 use lsp::LanguageServerName;
 use node_runtime::NodeRuntime;
@@ -37,32 +37,6 @@ use std::{
 };
 use task::{TaskTemplate, TaskTemplates, VariableName};
 use util::ResultExt;
-
-pub(crate) struct PyprojectTomlManifestProvider;
-
-impl ManifestProvider for PyprojectTomlManifestProvider {
-    fn name(&self) -> ManifestName {
-        SharedString::new_static("pyproject.toml").into()
-    }
-
-    fn search(
-        &self,
-        ManifestQuery {
-            path,
-            depth,
-            delegate,
-        }: ManifestQuery,
-    ) -> Option<Arc<Path>> {
-        for path in path.ancestors().take(depth) {
-            let p = path.join("pyproject.toml");
-            if delegate.exists(&p, Some(false)) {
-                return Some(path.into());
-            }
-        }
-
-        None
-    }
-}
 
 const SERVER_PATH: &str = "node_modules/pyright/langserver.index.js";
 const NODE_MODULE_RELATIVE_SERVER_PATH: &str = "pyright/langserver.index.js";
@@ -326,9 +300,6 @@ impl LspAdapter for PythonLspAdapter {
             }
             user_settings
         })
-    }
-    fn manifest_name(&self) -> Option<ManifestName> {
-        Some(SharedString::new_static("pyproject.toml").into())
     }
 }
 
@@ -1178,9 +1149,6 @@ impl LspAdapter for PyLspAdapter {
 
             user_settings
         })
-    }
-    fn manifest_name(&self) -> Option<ManifestName> {
-        Some(SharedString::new_static("pyproject.toml").into())
     }
 }
 


### PR DESCRIPTION
This reverts commit e661a0afd64e3e6e1e51c981cb7bda4e0af724fd.

Closes #ISSUE

Release Notes:

- Reverted changes to Python subroot detection which could have caused multiple python processes to be spawned when working in projects with multiple `pyproject.toml` files. 
