### PR TITLE
agent: Add keybindings to open the panel's extra menu

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -246,6 +246,7 @@
       "ctrl-alt-/": "assistant::ToggleModelSelector",
       "ctrl-shift-a": "agent::ToggleContextPicker",
       "ctrl-shift-o": "agent::ToggleNavigationMenu",
+      "ctrl-shift-i": "agent::ToggleOptionsMenu",
       "shift-escape": "agent::ExpandMessageEditor",
       "ctrl-e": "agent::ChatMode",
       "ctrl-alt-e": "agent::RemoveAllContext"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -291,6 +291,7 @@
       "cmd-alt-/": "assistant::ToggleModelSelector",
       "cmd-shift-a": "agent::ToggleContextPicker",
       "cmd-shift-o": "agent::ToggleNavigationMenu",
+      "cmd-shift-i": "agent::ToggleOptionsMenu",
       "shift-escape": "agent::ExpandMessageEditor",
       "cmd-e": "agent::ChatMode",
       "cmd-alt-e": "agent::RemoveAllContext"

--- a/crates/agent/src/assistant.rs
+++ b/crates/agent/src/assistant.rs
@@ -51,6 +51,7 @@ actions!(
         NewTextThread,
         ToggleContextPicker,
         ToggleNavigationMenu,
+        ToggleOptionsMenu,
         DeleteRecentlyOpenThread,
         ToggleProfileSelector,
         RemoveAllContext,


### PR DESCRIPTION
Maybe "extra" isn't the best word, but I'm referring to the ellipsis menu on the far right of the panel that holds "extra" or "additional options". There is a known issue with context menus, at least if implemented this way, that makes hitting enter to select an option not work. Will leave this fix to a later PR.

Release Notes:

- N/A
