### PR TITLE
workspace: Fix “close all” closing pinned tabs

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -44,8 +44,8 @@ use theme::ThemeSettings;
 use ui::{
     ButtonSize, Color, ContextMenu, ContextMenuEntry, ContextMenuItem, DecoratedIcon, IconButton,
     IconButtonShape, IconDecoration, IconDecorationKind, IconName, IconSize, Indicator, Label,
-    PopoverMenu, PopoverMenuHandle, ScrollableHandle, Tab, TabBar, TabPosition, Tooltip,
-    prelude::*, right_click_menu,
+    PopoverMenu, PopoverMenuHandle, Tab, TabBar, TabPosition, Tooltip, prelude::*,
+    right_click_menu,
 };
 use util::{ResultExt, debug_panic, maybe, truncate_and_remove_front};
 
@@ -123,6 +123,14 @@ pub struct CloseAllItems {
 
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default)]
 #[serde(deny_unknown_fields)]
+pub struct CloseOtherItems {
+    pub save_intent: Option<SaveIntent>,
+    #[serde(default)]
+    pub close_pinned: bool,
+}
+
+#[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default)]
+#[serde(deny_unknown_fields)]
 pub struct CloseCleanItems {
     #[serde(default)]
     pub close_pinned: bool,
@@ -161,6 +169,7 @@ impl_actions!(
     [
         CloseAllItems,
         CloseActiveItem,
+        CloseOtherItems,
         CloseCleanItems,
         CloseItemsToTheLeft,
         CloseItemsToTheRight,
@@ -294,7 +303,7 @@ pub struct Pane {
     toolbar: Entity<Toolbar>,
     pub(crate) workspace: WeakEntity<Workspace>,
     project: WeakEntity<Project>,
-    pub drag_split_direction: Option<SplitDirection>,
+    drag_split_direction: Option<SplitDirection>,
     can_drop_predicate: Option<Arc<dyn Fn(&dyn Any, &mut Window, &mut App) -> bool>>,
     custom_drop_handle: Option<
         Arc<dyn Fn(&mut Pane, &dyn Any, &mut Window, &mut Context<Pane>) -> ControlFlow<(), ()>>,
@@ -309,7 +318,6 @@ pub struct Pane {
             &mut Context<Pane>,
         ) -> (Option<AnyElement>, Option<AnyElement>),
     >,
-    render_tab_bar: Rc<dyn Fn(&mut Pane, &mut Window, &mut Context<Pane>) -> AnyElement>,
     show_tab_bar_buttons: bool,
     _subscriptions: Vec<Subscription>,
     tab_bar_scroll_handle: ScrollHandle,
@@ -436,8 +444,88 @@ impl Pane {
             custom_drop_handle: None,
             can_split_predicate: None,
             should_display_tab_bar: Rc::new(|_, cx| TabBarSettings::get_global(cx).show),
-            render_tab_bar_buttons: Rc::new(default_render_tab_bar_buttons),
-            render_tab_bar: Rc::new(Self::render_tab_bar),
+            render_tab_bar_buttons: Rc::new(move |pane, window, cx| {
+                if !pane.has_focus(window, cx) && !pane.context_menu_focused(window, cx) {
+                    return (None, None);
+                }
+                // Ideally we would return a vec of elements here to pass directly to the [TabBar]'s
+                // `end_slot`, but due to needing a view here that isn't possible.
+                let right_children = h_flex()
+                    // Instead we need to replicate the spacing from the [TabBar]'s `end_slot` here.
+                    .gap(DynamicSpacing::Base04.rems(cx))
+                    .child(
+                        PopoverMenu::new("pane-tab-bar-popover-menu")
+                            .trigger_with_tooltip(
+                                IconButton::new("plus", IconName::Plus).icon_size(IconSize::Small),
+                                Tooltip::text("New..."),
+                            )
+                            .anchor(Corner::TopRight)
+                            .with_handle(pane.new_item_context_menu_handle.clone())
+                            .menu(move |window, cx| {
+                                Some(ContextMenu::build(window, cx, |menu, _, _| {
+                                    menu.action("New File", NewFile.boxed_clone())
+                                        .action(
+                                            "Open File",
+                                            ToggleFileFinder::default().boxed_clone(),
+                                        )
+                                        .separator()
+                                        .action(
+                                            "Search Project",
+                                            DeploySearch {
+                                                replace_enabled: false,
+                                            }
+                                            .boxed_clone(),
+                                        )
+                                        .action(
+                                            "Search Symbols",
+                                            ToggleProjectSymbols.boxed_clone(),
+                                        )
+                                        .separator()
+                                        .action("New Terminal", NewTerminal.boxed_clone())
+                                }))
+                            }),
+                    )
+                    .child(
+                        PopoverMenu::new("pane-tab-bar-split")
+                            .trigger_with_tooltip(
+                                IconButton::new("split", IconName::Split)
+                                    .icon_size(IconSize::Small),
+                                Tooltip::text("Split Pane"),
+                            )
+                            .anchor(Corner::TopRight)
+                            .with_handle(pane.split_item_context_menu_handle.clone())
+                            .menu(move |window, cx| {
+                                ContextMenu::build(window, cx, |menu, _, _| {
+                                    menu.action("Split Right", SplitRight.boxed_clone())
+                                        .action("Split Left", SplitLeft.boxed_clone())
+                                        .action("Split Up", SplitUp.boxed_clone())
+                                        .action("Split Down", SplitDown.boxed_clone())
+                                })
+                                .into()
+                            }),
+                    )
+                    .child({
+                        let zoomed = pane.is_zoomed();
+                        IconButton::new("toggle_zoom", IconName::Maximize)
+                            .icon_size(IconSize::Small)
+                            .toggle_state(zoomed)
+                            .selected_icon(IconName::Minimize)
+                            .on_click(cx.listener(|pane, _, window, cx| {
+                                pane.toggle_zoom(&crate::ToggleZoom, window, cx);
+                            }))
+                            .tooltip(move |window, cx| {
+                                Tooltip::for_action(
+                                    if zoomed { "Zoom Out" } else { "Zoom In" },
+                                    &ToggleZoom,
+                                    window,
+                                    cx,
+                                )
+                            })
+                    })
+                    .into_any_element()
+                    .into();
+                (None, right_children)
+            }),
             show_tab_bar_buttons: TabBarSettings::get_global(cx).show_tab_bar_buttons,
             display_nav_history_buttons: Some(
                 TabBarSettings::get_global(cx).show_nav_history_buttons,
@@ -502,7 +590,6 @@ impl Pane {
     fn focus_in(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         if !self.was_focused {
             self.was_focused = true;
-            self.update_history(self.active_item_index);
             cx.emit(Event::Focus);
             cx.notify();
         }
@@ -644,14 +731,6 @@ impl Pane {
         self.toolbar.update(cx, |toolbar, cx| {
             toolbar.set_can_navigate(can_navigate, cx);
         });
-        cx.notify();
-    }
-
-    pub fn set_render_tab_bar<F>(&mut self, cx: &mut Context<Self>, render: F)
-    where
-        F: 'static + Fn(&mut Pane, &mut Window, &mut Context<Pane>) -> AnyElement,
-    {
-        self.render_tab_bar = Rc::new(render);
         cx.notify();
     }
 
@@ -1096,7 +1175,17 @@ impl Pane {
                     prev_item.deactivated(window, cx);
                 }
             }
-            self.update_history(index);
+            if let Some(newly_active_item) = self.items.get(index) {
+                self.activation_history
+                    .retain(|entry| entry.entity_id != newly_active_item.item_id());
+                self.activation_history.push(ActivationHistoryEntry {
+                    entity_id: newly_active_item.item_id(),
+                    timestamp: self
+                        .next_activation_timestamp
+                        .fetch_add(1, Ordering::SeqCst),
+                });
+            }
+
             self.update_toolbar(window, cx);
             self.update_status_bar(window, cx);
 
@@ -1115,19 +1204,6 @@ impl Pane {
             }
 
             cx.notify();
-        }
-    }
-
-    fn update_history(&mut self, index: usize) {
-        if let Some(newly_active_item) = self.items.get(index) {
-            self.activation_history
-                .retain(|entry| entry.entity_id != newly_active_item.item_id());
-            self.activation_history.push(ActivationHistoryEntry {
-                entity_id: newly_active_item.item_id(),
-                timestamp: self
-                    .next_activation_timestamp
-                    .fetch_add(1, Ordering::SeqCst),
-            });
         }
     }
 
@@ -1267,6 +1343,26 @@ impl Pane {
             cx,
             action.save_intent.unwrap_or(SaveIntent::Close),
             move |item_id| item_id != active_item_id && !non_closeable_items.contains(&item_id),
+        ))
+    }
+
+    pub fn close_other_items(
+        &mut self,
+        item_id_to_skip: EntityId,
+        action: &CloseOtherItems,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Task<Result<()>>> {
+        if self.items.is_empty() {
+            return None;
+        }
+
+        let non_closeable_items = self.get_non_closeable_item_ids(action.close_pinned);
+        Some(self.close_items(
+            window,
+            cx,
+            action.save_intent.unwrap_or(SaveIntent::Close),
+            move |item_id| item_id != item_id_to_skip && !non_closeable_items.contains(&item_id),
         ))
     }
 
@@ -2151,7 +2247,6 @@ impl Pane {
                 detail: Some(detail),
                 selected: is_active,
                 preview: is_preview,
-                deemphasized: !self.has_focus(window, cx),
             },
             window,
             cx,
@@ -2393,16 +2488,23 @@ impl Pane {
                         )
                         .item(ContextMenuItem::Entry(
                             ContextMenuEntry::new("Close Others")
-                                .action(Box::new(CloseInactiveItems {
+                                .action(Box::new(CloseOtherItems {
                                     save_intent: None,
                                     close_pinned: false,
                                 }))
                                 .disabled(total_items == 1)
                                 .handler(window.handler_for(&pane, move |pane, window, cx| {
-                                    pane.close_items(window, cx, SaveIntent::Close, |id| {
-                                        id != item_id
-                                    })
-                                    .detach_and_log_err(cx);
+                                    if let Some(task) = pane.close_other_items(
+                                        item_id,
+                                        &CloseOtherItems {
+                                            save_intent: None,
+                                            close_pinned: false,
+                                        },
+                                        window,
+                                        cx,
+                                    ) {
+                                        task.detach_and_log_err(cx);
+                                    };
                                 })),
                         ))
                         .separator()
@@ -2602,7 +2704,7 @@ impl Pane {
         })
     }
 
-    fn render_tab_bar(&mut self, window: &mut Window, cx: &mut Context<Pane>) -> AnyElement {
+    fn render_tab_bar(&mut self, window: &mut Window, cx: &mut Context<Pane>) -> impl IntoElement {
         let focus_handle = self.focus_handle.clone();
         let navigate_backward = IconButton::new("navigate_backward", IconName::ArrowLeft)
             .icon_size(IconSize::Small)
@@ -2638,7 +2740,7 @@ impl Pane {
             .items
             .iter()
             .enumerate()
-            .zip(tab_details(&self.items, window, cx))
+            .zip(tab_details(&self.items, cx))
             .map(|((ix, item), detail)| {
                 self.render_tab(ix, &**item, detail, &focus_handle, window, cx)
             })
@@ -2667,20 +2769,10 @@ impl Pane {
                 }
             })
             .children(pinned_tabs.len().ne(&0).then(|| {
-                let content_width = self
-                    .tab_bar_scroll_handle
-                    .content_size()
-                    .map(|content_size| content_size.size.width)
-                    .unwrap_or(px(0.));
-                let viewport_width = self.tab_bar_scroll_handle.viewport().size.width;
-                // We need to check both because offset returns delta values even when the scroll handle is not scrollable
-                let is_scrollable = content_width > viewport_width;
-                let is_scrolled = self.tab_bar_scroll_handle.offset().x < px(0.);
                 h_flex()
                     .children(pinned_tabs)
-                    .when(is_scrollable && is_scrolled, |this| {
-                        this.border_r_1().border_color(cx.theme().colors().border)
-                    })
+                    .border_r_2()
+                    .border_color(cx.theme().colors().border)
             }))
             .child(
                 h_flex()
@@ -2735,7 +2827,6 @@ impl Pane {
                             })),
                     ),
             )
-            .into_any_element()
     }
 
     pub fn render_menu_overlay(menu: &Entity<ContextMenu>) -> Div {
@@ -2809,7 +2900,7 @@ impl Pane {
         }
     }
 
-    pub fn handle_tab_drop(
+    fn handle_tab_drop(
         &mut self,
         dragged_tab: &DraggedTab,
         ix: usize,
@@ -3082,86 +3173,6 @@ impl Pane {
     }
 }
 
-fn default_render_tab_bar_buttons(
-    pane: &mut Pane,
-    window: &mut Window,
-    cx: &mut Context<Pane>,
-) -> (Option<AnyElement>, Option<AnyElement>) {
-    if !pane.has_focus(window, cx) && !pane.context_menu_focused(window, cx) {
-        return (None, None);
-    }
-    // Ideally we would return a vec of elements here to pass directly to the [TabBar]'s
-    // `end_slot`, but due to needing a view here that isn't possible.
-    let right_children = h_flex()
-        // Instead we need to replicate the spacing from the [TabBar]'s `end_slot` here.
-        .gap(DynamicSpacing::Base04.rems(cx))
-        .child(
-            PopoverMenu::new("pane-tab-bar-popover-menu")
-                .trigger_with_tooltip(
-                    IconButton::new("plus", IconName::Plus).icon_size(IconSize::Small),
-                    Tooltip::text("New..."),
-                )
-                .anchor(Corner::TopRight)
-                .with_handle(pane.new_item_context_menu_handle.clone())
-                .menu(move |window, cx| {
-                    Some(ContextMenu::build(window, cx, |menu, _, _| {
-                        menu.action("New File", NewFile.boxed_clone())
-                            .action("Open File", ToggleFileFinder::default().boxed_clone())
-                            .separator()
-                            .action(
-                                "Search Project",
-                                DeploySearch {
-                                    replace_enabled: false,
-                                }
-                                .boxed_clone(),
-                            )
-                            .action("Search Symbols", ToggleProjectSymbols.boxed_clone())
-                            .separator()
-                            .action("New Terminal", NewTerminal.boxed_clone())
-                    }))
-                }),
-        )
-        .child(
-            PopoverMenu::new("pane-tab-bar-split")
-                .trigger_with_tooltip(
-                    IconButton::new("split", IconName::Split).icon_size(IconSize::Small),
-                    Tooltip::text("Split Pane"),
-                )
-                .anchor(Corner::TopRight)
-                .with_handle(pane.split_item_context_menu_handle.clone())
-                .menu(move |window, cx| {
-                    ContextMenu::build(window, cx, |menu, _, _| {
-                        menu.action("Split Right", SplitRight.boxed_clone())
-                            .action("Split Left", SplitLeft.boxed_clone())
-                            .action("Split Up", SplitUp.boxed_clone())
-                            .action("Split Down", SplitDown.boxed_clone())
-                    })
-                    .into()
-                }),
-        )
-        .child({
-            let zoomed = pane.is_zoomed();
-            IconButton::new("toggle_zoom", IconName::Maximize)
-                .icon_size(IconSize::Small)
-                .toggle_state(zoomed)
-                .selected_icon(IconName::Minimize)
-                .on_click(cx.listener(|pane, _, window, cx| {
-                    pane.toggle_zoom(&crate::ToggleZoom, window, cx);
-                }))
-                .tooltip(move |window, cx| {
-                    Tooltip::for_action(
-                        if zoomed { "Zoom Out" } else { "Zoom In" },
-                        &ToggleZoom,
-                        window,
-                        cx,
-                    )
-                })
-        })
-        .into_any_element()
-        .into();
-    (None, right_children)
-}
-
 impl Focusable for Pane {
     fn focus_handle(&self, _cx: &App) -> FocusHandle {
         self.focus_handle.clone()
@@ -3326,7 +3337,7 @@ impl Render for Pane {
                 }),
             )
             .when(self.active_item().is_some() && display_tab_bar, |pane| {
-                pane.child((self.render_tab_bar.clone())(self, window, cx))
+                pane.child(self.render_tab_bar(window, cx))
             })
             .child({
                 let has_worktrees = project.read(cx).visible_worktrees(cx).next().is_some();
@@ -3636,7 +3647,7 @@ fn dirty_message_for(buffer_path: Option<ProjectPath>) -> String {
     format!("{path} contains unsaved edits. Do you want to save it?")
 }
 
-pub fn tab_details(items: &[Box<dyn ItemHandle>], _window: &Window, cx: &App) -> Vec<usize> {
+pub fn tab_details(items: &[Box<dyn ItemHandle>], cx: &App) -> Vec<usize> {
     let mut tab_details = items.iter().map(|_| 0).collect::<Vec<_>>();
     let mut tab_descriptions = HashMap::default();
     let mut done = false;
@@ -3645,12 +3656,15 @@ pub fn tab_details(items: &[Box<dyn ItemHandle>], _window: &Window, cx: &App) ->
 
         // Store item indices by their tab description.
         for (ix, (item, detail)) in items.iter().zip(&tab_details).enumerate() {
-            let description = item.tab_content_text(*detail, cx);
-            if *detail == 0 || description != item.tab_content_text(detail - 1, cx) {
-                tab_descriptions
-                    .entry(description)
-                    .or_insert(Vec::new())
-                    .push(ix);
+            if let Some(description) = item.tab_description(*detail, cx) {
+                if *detail == 0
+                    || Some(&description) != item.tab_description(detail - 1, cx).as_ref()
+                {
+                    tab_descriptions
+                        .entry(description)
+                        .or_insert(Vec::new())
+                        .push(ix);
+                }
             }
         }
 
@@ -3689,7 +3703,6 @@ impl Render for DraggedTab {
                 detail: Some(self.detail),
                 selected: false,
                 preview: false,
-                deemphasized: false,
             },
             window,
             cx,
@@ -4356,6 +4369,45 @@ mod tests {
         .await
         .unwrap();
         assert_item_labels(&pane, ["C*"], cx);
+    }
+
+    #[gpui::test]
+    async fn test_close_other_items(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let pane = workspace.update(cx, |workspace, _| workspace.active_pane().clone());
+
+        add_labeled_item(&pane, "A", false, cx);
+        let second_tab = add_labeled_item(&pane, "B", false, cx);
+        add_labeled_item(&pane, "C", false, cx);
+        add_labeled_item(&pane, "D", false, cx);
+        pane.update_in(cx, |pane, window, cx| {
+            pane.pin_tab_at(0, window, cx);
+        });
+        pane.update_in(cx, |pane, window, cx| {
+            pane.activate_item(2, true, true, window, cx);
+        });
+        assert_item_labels(&pane, ["A", "B", "C*", "D"], cx);
+
+        pane.update_in(cx, |pane, window, cx| {
+            pane.close_other_items(
+                second_tab.entity_id(),
+                &CloseOtherItems {
+                    save_intent: None,
+                    close_pinned: false,
+                },
+                window,
+                cx,
+            )
+        })
+        .unwrap()
+        .await
+        .unwrap();
+        assert_item_labels(&pane, ["A*", "B"], cx);
     }
 
     #[gpui::test]


### PR DESCRIPTION
Fixed the bug where the pinned tabs were also being closed with close all when it should not have been this way. closes: https://github.com/zed-industries/zed/issues/28166

Closes #28166

Release Notes:

- N/A *or* Added/Fixed/Improved ...
