### PR TITLE
python: Do not look up venv path from source file path

### DIFF
--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -318,14 +318,19 @@ impl LocalToolchainStore {
         cx: &App,
     ) -> Task<Option<ToolchainList>> {
         let registry = self.languages.clone();
-        let Some(abs_path) = self.worktree_store.read(cx).absolutize(&path, cx) else {
+        let Some(abs_path) = self
+            .worktree_store
+            .read(cx)
+            .worktree_for_id(path.worktree_id, cx)
+            .map(|worktree| worktree.read(cx).abs_path())
+        else {
             return Task::ready(None);
         };
         let environment = self.project_environment.clone();
         cx.spawn(async move |cx| {
             let project_env = environment
                 .update(cx, |environment, cx| {
-                    environment.get_directory_environment(abs_path.as_path().into(), cx)
+                    environment.get_directory_environment(abs_path.clone(), cx)
                 })
                 .ok()?
                 .await;


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- N/A
