### PR TITLE
keymap: Move 'project_panel::NewSearchInDirectory' to a dedicated bind

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -769,7 +769,7 @@
       "alt-ctrl-r": "project_panel::RevealInFileManager",
       "ctrl-shift-enter": "project_panel::OpenWithSystem",
       "shift-find": "project_panel::NewSearchInDirectory",
-      "ctrl-shift-f": "project_panel::NewSearchInDirectory",
+      "ctrl-alt-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "escape": "menu::Cancel"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -827,7 +827,7 @@
       "alt-cmd-r": "project_panel::RevealInFileManager",
       "ctrl-shift-enter": "project_panel::OpenWithSystem",
       "cmd-alt-backspace": ["project_panel::Delete", { "skip_prompt": false }],
-      "cmd-shift-f": "project_panel::NewSearchInDirectory",
+      "cmd-alt-shift-f": "project_panel::NewSearchInDirectory",
       "shift-down": "menu::SelectNext",
       "shift-up": "menu::SelectPrevious",
       "escape": "menu::Cancel"


### PR DESCRIPTION
Previously cmd-shift-f / ctrl-shift-f had different behavior when invoked from the project panel context than from an editor (for project panel `include` field was populated from the currently select project panel directory).

Change this so that it has it's own keybind of cmd-alt-shift-f / ctrl-alt-shift-f so cmd-shift-f and ctrl-shift-f has consistent behavior (`pane::DeploySearch`) everywhere.

Release Notes:

- Add dedicated keybind for "Find in Folder..." from the project panel (cmd-alt-shift-f, ctrl-alt-shift-f).