### PR TITLE
Fix tab and shift+tab scroll behavior in picker

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -888,7 +888,8 @@
       "escape": "menu::Cancel",
       "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
-      "tab": "picker::ConfirmCompletion",
+      "tab": "menu::SelectNext",
+      "shift-tab": "menu::SelectPrevious",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }]
     }
   },

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -959,7 +959,8 @@
       "escape": "menu::Cancel",
       "up": "menu::SelectPrevious",
       "down": "menu::SelectNext",
-      "tab": "picker::ConfirmCompletion",
+      "tab": "menu::SelectNext",
+      "shift-tab": "menu::SelectPrevious",
       "alt-enter": ["picker::ConfirmInput", { "secondary": false }],
       "cmd-alt-enter": ["picker::ConfirmInput", { "secondary": true }]
     }

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -1,11 +1,6 @@
 mod persistence;
 
-use std::{
-    cmp::{self, Reverse},
-    collections::HashMap,
-    sync::Arc,
-    time::Duration,
-};
+use std::{cmp::Reverse, collections::HashMap, sync::Arc, time::Duration};
 
 use client::parse_zed_link;
 use command_palette_hooks::{

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -236,11 +236,7 @@ impl CommandPaletteDelegate {
         new_matches.append(&mut matches);
         self.commands = commands;
         self.matches = new_matches;
-        if self.matches.is_empty() {
-            self.selected_ix = 0;
-        } else {
-            self.selected_ix = cmp::min(self.selected_ix, self.matches.len() - 1);
-        }
+        self.selected_ix = 0;
     }
     ///
     /// Hit count for each command in the palette.


### PR DESCRIPTION
Previously when the picker (command palette, file finder) was open and tab was pressed, space would be inserted into the editor. When shift+tab was pressed, nothing would happen.

Based on other binds in the default keymap, the expected behavior is for tab to the next item and shift+tab to navigate to the previous. This default behavior is also what I, and I imagine others, expect to happen based on defaults in other editing software.

Also, after typing into the file picker, the selection is reset to the first item, whereas for the command palette, the index of the item selected is kept after typing and potentially changing the returned matched items.

This PR changes the command palette to function like the file picker in this regard (reset to select first item after typing) and changes the default binds under `Picker > Editor` to allow for tab and shift+tab navigation.

Release Notes:

- Fixed tab and shift+tab behavior when using command palette and file picker