### PR TITLE
Use outline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,6 +690,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rand 0.8.5",
+ "regex",
  "serde",
  "serde_json",
  "settings",

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -21,10 +21,6 @@ use util::{ResultExt as _, post_inc};
 
 use crate::thread::Thread;
 
-/// If the context from a file exceeds this size, then
-/// the context will include an outline instead of the full file content.
-const MAX_FILE_SIZE: usize = 16384;
-
 pub const RULES_ICON: IconName = IconName::Context;
 
 pub enum ContextKind {
@@ -192,7 +188,7 @@ impl FileContextHandle {
 
         // For large files, use outline instead of full content
         // For large files, use outline instead of full content
-        if file_size > MAX_FILE_SIZE {
+        if file_size > outline::AUTO_OUTLINE_SIZE {
             let buffer = buffer.clone();
 
             cx.spawn(async move |cx| {

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -1069,13 +1069,8 @@ mod tests {
         init_test_settings(cx);
 
         // Create a large file that exceeds AUTO_OUTLINE_SIZE
-        let large_content = {
-            const LINE: &str = "Line with some text\n";
-            std::iter::repeat(LINE)
-                .take(2 * (outline::AUTO_OUTLINE_SIZE / LINE.len()))
-                .collect::<String>()
-        };
-
+        const LINE: &str = "Line with some text\n";
+        let large_content = LINE.repeat(2 * (outline::AUTO_OUTLINE_SIZE / LINE.len()));
         let content_len = large_content.len();
 
         assert!(content_len > outline::AUTO_OUTLINE_SIZE);

--- a/crates/assistant_tool/Cargo.toml
+++ b/crates/assistant_tool/Cargo.toml
@@ -24,6 +24,7 @@ language.workspace = true
 language_model.workspace = true
 parking_lot.workspace = true
 project.workspace = true
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 text.workspace = true

--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -1,4 +1,5 @@
 mod action_log;
+pub mod outline;
 mod tool_registry;
 mod tool_schema;
 mod tool_working_set;

--- a/crates/assistant_tool/src/outline.rs
+++ b/crates/assistant_tool/src/outline.rs
@@ -1,0 +1,128 @@
+use crate::ActionLog;
+use anyhow::{Result, anyhow};
+use gpui::{AsyncApp, Entity};
+use language::{OutlineItem, ParseStatus};
+use project::Project;
+use regex::Regex;
+use std::fmt::Write;
+use text::Point;
+
+pub async fn file_outline(
+    project: Entity<Project>,
+    path: String,
+    action_log: Entity<ActionLog>,
+    regex: Option<Regex>,
+    cx: &mut AsyncApp,
+) -> anyhow::Result<String> {
+    let buffer = {
+        let project_path = project.read_with(cx, |project, cx| {
+            project
+                .find_project_path(&path, cx)
+                .ok_or_else(|| anyhow!("Path {path} not found in project"))
+        })??;
+
+        project
+            .update(cx, |project, cx| project.open_buffer(project_path, cx))?
+            .await?
+    };
+
+    action_log.update(cx, |action_log, cx| {
+        action_log.track_buffer(buffer.clone(), cx);
+    })?;
+
+    // Wait until the buffer has been fully parsed, so that we can read its outline.
+    let mut parse_status = buffer.read_with(cx, |buffer, _| buffer.parse_status())?;
+    while *parse_status.borrow() != ParseStatus::Idle {
+        parse_status.changed().await?;
+    }
+
+    let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
+    let Some(outline) = snapshot.outline(None) else {
+        return Err(anyhow!("No outline information available for this file."));
+    };
+
+    render_outline(
+        outline
+            .items
+            .into_iter()
+            .map(|item| item.to_point(&snapshot)),
+        regex,
+        0,
+        usize::MAX,
+    )
+    .await
+}
+
+pub async fn render_outline(
+    items: impl IntoIterator<Item = OutlineItem<Point>>,
+    regex: Option<Regex>,
+    offset: usize,
+    results_per_page: usize,
+) -> Result<String> {
+    let mut items = items.into_iter().skip(offset);
+
+    let entries = items
+        .by_ref()
+        .filter(|item| {
+            regex
+                .as_ref()
+                .is_none_or(|regex| regex.is_match(&item.text))
+        })
+        .take(results_per_page)
+        .collect::<Vec<_>>();
+    let has_more = items.next().is_some();
+
+    let mut output = String::new();
+    let entries_rendered = render_entries(&mut output, entries);
+
+    // Calculate pagination information
+    let page_start = offset + 1;
+    let page_end = offset + entries_rendered;
+    let total_symbols = if has_more {
+        format!("more than {}", page_end)
+    } else {
+        page_end.to_string()
+    };
+
+    // Add pagination information
+    if has_more {
+        writeln!(&mut output, "\nShowing symbols {page_start}-{page_end} (there were more symbols found; use offset: {page_end} to see next page)",
+        )
+    } else {
+        writeln!(
+            &mut output,
+            "\nShowing symbols {page_start}-{page_end} (total symbols: {total_symbols})",
+        )
+    }
+    .ok();
+
+    Ok(output)
+}
+
+fn render_entries(
+    output: &mut String,
+    items: impl IntoIterator<Item = OutlineItem<Point>>,
+) -> usize {
+    let mut entries_rendered = 0;
+
+    for item in items {
+        // Indent based on depth ("" for level 0, "  " for level 1, etc.)
+        for _ in 0..item.depth {
+            output.push(' ');
+        }
+        output.push_str(&item.text);
+
+        // Add position information - convert to 1-based line numbers for display
+        let start_line = item.range.start.row + 1;
+        let end_line = item.range.end.row + 1;
+
+        if start_line == end_line {
+            writeln!(output, " [L{}]", start_line).ok();
+        } else {
+            writeln!(output, " [L{}-{}]", start_line, end_line).ok();
+        }
+        entries_rendered += 1;
+    }
+
+    entries_rendered
+}

--- a/crates/assistant_tool/src/outline.rs
+++ b/crates/assistant_tool/src/outline.rs
@@ -7,6 +7,10 @@ use regex::Regex;
 use std::fmt::Write;
 use text::Point;
 
+/// For files over this size, instead of reading them (or including them in context),
+/// we automatically provide the file's symbol outline instead, with line numbers.
+pub const AUTO_OUTLINE_SIZE: usize = 16384;
+
 pub async fn file_outline(
     project: Entity<Project>,
     path: String,

--- a/crates/assistant_tools/src/code_symbols_tool.rs
+++ b/crates/assistant_tools/src/code_symbols_tool.rs
@@ -4,10 +4,10 @@ use std::sync::Arc;
 
 use crate::schema::json_schema_for;
 use anyhow::{Result, anyhow};
+use assistant_tool::outline;
 use assistant_tool::{ActionLog, Tool, ToolResult};
 use collections::IndexMap;
 use gpui::{AnyWindowHandle, App, AsyncApp, Entity, Task};
-use language::{OutlineItem, ParseStatus, Point};
 use language_model::{LanguageModelRequestMessage, LanguageModelToolSchemaFormat};
 use project::{Project, Symbol};
 use regex::{Regex, RegexBuilder};
@@ -148,57 +148,11 @@ impl Tool for CodeSymbolsTool {
         };
 
         cx.spawn(async move |cx| match input.path {
-            Some(path) => file_outline(project, path, action_log, regex, cx).await,
+            Some(path) => outline::file_outline(project, path, action_log, regex, cx).await,
             None => project_symbols(project, regex, input.offset, cx).await,
         })
         .into()
     }
-}
-
-pub async fn file_outline(
-    project: Entity<Project>,
-    path: String,
-    action_log: Entity<ActionLog>,
-    regex: Option<Regex>,
-    cx: &mut AsyncApp,
-) -> anyhow::Result<String> {
-    let buffer = {
-        let project_path = project.read_with(cx, |project, cx| {
-            project
-                .find_project_path(&path, cx)
-                .ok_or_else(|| anyhow!("Path {path} not found in project"))
-        })??;
-
-        project
-            .update(cx, |project, cx| project.open_buffer(project_path, cx))?
-            .await?
-    };
-
-    action_log.update(cx, |action_log, cx| {
-        action_log.track_buffer(buffer.clone(), cx);
-    })?;
-
-    // Wait until the buffer has been fully parsed, so that we can read its outline.
-    let mut parse_status = buffer.read_with(cx, |buffer, _| buffer.parse_status())?;
-    while *parse_status.borrow() != ParseStatus::Idle {
-        parse_status.changed().await?;
-    }
-
-    let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
-    let Some(outline) = snapshot.outline(None) else {
-        return Err(anyhow!("No outline information available for this file."));
-    };
-
-    render_outline(
-        outline
-            .items
-            .into_iter()
-            .map(|item| item.to_point(&snapshot)),
-        regex,
-        0,
-        usize::MAX,
-    )
-    .await
 }
 
 async fn project_symbols(
@@ -290,78 +244,4 @@ async fn project_symbols(
     } else {
         output
     })
-}
-
-async fn render_outline(
-    items: impl IntoIterator<Item = OutlineItem<Point>>,
-    regex: Option<Regex>,
-    offset: usize,
-    results_per_page: usize,
-) -> Result<String> {
-    let mut items = items.into_iter().skip(offset);
-
-    let entries = items
-        .by_ref()
-        .filter(|item| {
-            regex
-                .as_ref()
-                .is_none_or(|regex| regex.is_match(&item.text))
-        })
-        .take(results_per_page)
-        .collect::<Vec<_>>();
-    let has_more = items.next().is_some();
-
-    let mut output = String::new();
-    let entries_rendered = render_entries(&mut output, entries);
-
-    // Calculate pagination information
-    let page_start = offset + 1;
-    let page_end = offset + entries_rendered;
-    let total_symbols = if has_more {
-        format!("more than {}", page_end)
-    } else {
-        page_end.to_string()
-    };
-
-    // Add pagination information
-    if has_more {
-        writeln!(&mut output, "\nShowing symbols {page_start}-{page_end} (there were more symbols found; use offset: {page_end} to see next page)",
-        )
-    } else {
-        writeln!(
-            &mut output,
-            "\nShowing symbols {page_start}-{page_end} (total symbols: {total_symbols})",
-        )
-    }
-    .ok();
-
-    Ok(output)
-}
-
-fn render_entries(
-    output: &mut String,
-    items: impl IntoIterator<Item = OutlineItem<Point>>,
-) -> usize {
-    let mut entries_rendered = 0;
-
-    for item in items {
-        // Indent based on depth ("" for level 0, "  " for level 1, etc.)
-        for _ in 0..item.depth {
-            output.push(' ');
-        }
-        output.push_str(&item.text);
-
-        // Add position information - convert to 1-based line numbers for display
-        let start_line = item.range.start.row + 1;
-        let end_line = item.range.end.row + 1;
-
-        if start_line == end_line {
-            writeln!(output, " [L{}]", start_line).ok();
-        } else {
-            writeln!(output, " [L{}-{}]", start_line, end_line).ok();
-        }
-        entries_rendered += 1;
-    }
-
-    entries_rendered
 }

--- a/crates/assistant_tools/src/contents_tool.rs
+++ b/crates/assistant_tools/src/contents_tool.rs
@@ -14,10 +14,6 @@ use ui::IconName;
 use util::markdown::MarkdownInlineCode;
 
 /// If the model requests to read a file whose size exceeds this, then
-/// the tool will return the file's symbol outline instead of its contents,
-/// and suggest trying again using line ranges from the outline.
-const MAX_FILE_SIZE_TO_READ: usize = 16384;
-
 /// If the model requests to list the entries in a directory with more
 /// entries than this, then the tool will return a subset of the entries
 /// and suggest trying again.
@@ -218,7 +214,7 @@ impl Tool for ContentsTool {
                     // No line ranges specified, so check file size to see if it's too big.
                     let file_size = buffer.read_with(cx, |buffer, _cx| buffer.text().len())?;
 
-                    if file_size <= MAX_FILE_SIZE_TO_READ {
+                    if file_size <= outline::AUTO_OUTLINE_SIZE {
                         let result = buffer.read_with(cx, |buffer, _cx| buffer.text())?;
 
                         action_log.update(cx, |log, cx| {

--- a/crates/assistant_tools/src/contents_tool.rs
+++ b/crates/assistant_tools/src/contents_tool.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use crate::{code_symbols_tool::file_outline, schema::json_schema_for};
+use crate::schema::json_schema_for;
 use anyhow::{Result, anyhow};
-use assistant_tool::{ActionLog, Tool, ToolResult};
+use assistant_tool::{ActionLog, Tool, ToolResult, outline};
 use gpui::{AnyWindowHandle, App, Entity, Task};
 use itertools::Itertools;
 use language_model::{LanguageModelRequestMessage, LanguageModelToolSchemaFormat};
@@ -229,7 +229,7 @@ impl Tool for ContentsTool {
                     } else {
                         // File is too big, so return its outline and a suggestion to
                         // read again with a line number range specified.
-                        let outline = file_outline(project, file_path, action_log, None, cx).await?;
+                        let outline = outline::file_outline(project, file_path, action_log, None, cx).await?;
 
                         Ok(format!("This file was too big to read all at once. Here is an outline of its symbols:\n\n{outline}\n\nUsing the line numbers in this outline, you can call this tool again while specifying the start and end fields to see the implementations of symbols in the outline."))
                     }

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -1,5 +1,6 @@
-use crate::{code_symbols_tool::file_outline, schema::json_schema_for};
+use crate::schema::json_schema_for;
 use anyhow::{Result, anyhow};
+use assistant_tool::outline;
 use assistant_tool::{ActionLog, Tool, ToolResult};
 use gpui::{AnyWindowHandle, App, Entity, Task};
 
@@ -154,9 +155,9 @@ impl Tool for ReadFileTool {
 
                     Ok(result)
                 } else {
-                    // File is too big, so return an error with the outline
+                    // File is too big, so return the outline
                     // and a suggestion to read again with line numbers.
-                    let outline = file_outline(project, file_path, action_log, None, cx).await?;
+                    let outline = outline::file_outline(project, file_path, action_log, None, cx).await?;
                     Ok(formatdoc! {"
                         This file was too big to read all at once. Here is an outline of its symbols:
 

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -15,10 +15,6 @@ use ui::IconName;
 use util::markdown::MarkdownInlineCode;
 
 /// If the model requests to read a file whose size exceeds this, then
-/// the tool will return an error along with the model's symbol outline,
-/// and suggest trying again using line ranges from the outline.
-const MAX_FILE_SIZE_TO_READ: usize = 16384;
-
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 pub struct ReadFileToolInput {
     /// The relative path of the file to read.
@@ -145,7 +141,7 @@ impl Tool for ReadFileTool {
                 // No line ranges specified, so check file size to see if it's too big.
                 let file_size = buffer.read_with(cx, |buffer, _cx| buffer.text().len())?;
 
-                if file_size <= MAX_FILE_SIZE_TO_READ {
+                if file_size <= outline::AUTO_OUTLINE_SIZE {
                     // File is small enough, so return its contents.
                     let result = buffer.read_with(cx, |buffer, _cx| buffer.text())?;
 


### PR DESCRIPTION
## Before

![Screenshot 2025-04-30 at 10 56 36 AM](https://github.com/user-attachments/assets/3a435f4c-ad45-4f26-a847-2d5c9d03648e)

## After

![Screenshot 2025-04-30 at 10 55 27 AM](https://github.com/user-attachments/assets/cc3a8144-b6fe-4a15-8a47-b2487ce4f66e)

Release Notes:

- Context picker and `@`-mentions now work with very large files.