### PR TITLE
zed: Reinstate default `file_scan_exclusions` in Zed repo project settings

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -46,5 +46,17 @@
   "formatter": "auto",
   "remove_trailing_whitespace_on_save": true,
   "ensure_final_newline_on_save": true,
-  "file_scan_exclusions": ["crates/eval/worktrees/", "crates/eval/repos/"]
+  "file_scan_exclusions": [
+    "crates/eval/worktrees/",
+    "crates/eval/repos/",
+    "**/.git",
+    "**/.svn",
+    "**/.hg",
+    "**/.jj",
+    "**/CVS",
+    "**/.DS_Store",
+    "**/Thumbs.db",
+    "**/.classpath",
+    "**/.settings"
+  ]
 }


### PR DESCRIPTION
Closes #ISSUE

Re-adds default `file_scan_exclusions` to [project settings](https://github.com/zed-industries/zed/blob/84e4891d544f14e7e22348b89ecaf261b44ca611/.zed/settings.json) that were overridden in #29106

Notably: `.git`

Release Notes:

- N/A *or* Added/Fixed/Improved ...
