### PR TITLE
keymap: Move main editor keybinds to `Editor && mode == full` 

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -60,8 +60,6 @@
       "shift-tab": "editor::Backtab",
       "ctrl-k": "editor::CutToEndOfLine",
       // "ctrl-t": "editor::Transpose",
-      "ctrl-k ctrl-q": "editor::Rewrap",
-      "ctrl-k q": "editor::Rewrap",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd",
       "cut": "editor::Cut",
@@ -106,28 +104,7 @@
       "ctrl-shift-end": "editor::SelectToEnd",
       "ctrl-a": "editor::SelectAll",
       "ctrl-l": "editor::SelectLine",
-      "ctrl-shift-i": "editor::Format",
-      "alt-shift-o": "editor::OrganizeImports",
-      // "cmd-shift-left": ["editor::SelectToBeginningOfLine", {"stop_at_soft_wraps": true, "stop_at_indent": true }],
-      // "ctrl-shift-a": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
-      "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
-      // "cmd-shift-right": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
-      // "ctrl-shift-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
-      "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
-      // "alt-v": ["editor::MovePageUp", { "center_cursor": true }],
-      "ctrl-alt-space": "editor::ShowCharacterPalette",
-      "ctrl-;": "editor::ToggleLineNumbers",
-      "ctrl-'": "editor::ToggleSelectedDiffHunks",
-      "ctrl-\"": "editor::ExpandAllDiffHunks",
-      "ctrl-i": "editor::ShowSignatureHelp",
-      "alt-g b": "editor::ToggleGitBlame",
-      "menu": "editor::OpenContextMenu",
-      "shift-f10": "editor::OpenContextMenu",
-      "ctrl-shift-e": "editor::ToggleEditPrediction",
-      "f9": "editor::ToggleBreakpoint",
-      "shift-f9": "editor::EditLogBreakpoint",
-      "ctrl-shift-backspace": "editor::GoToPreviousChange",
-      "ctrl-shift-alt-backspace": "editor::GoToNextChange"
+      "ctrl-alt-space": "editor::ShowCharacterPalette"
     }
   },
   {
@@ -146,7 +123,30 @@
       "ctrl->": "assistant::QuoteSelection",
       "ctrl-<": "assistant::InsertIntoEditor",
       "ctrl-alt-e": "editor::SelectEnclosingSymbol",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
+      "alt-enter": "editor::OpenSelectionsInMultibuffer",
+      "ctrl-k ctrl-q": "editor::Rewrap",
+      "ctrl-k q": "editor::Rewrap",
+      "ctrl-shift-i": "editor::Format",
+      "alt-shift-o": "editor::OrganizeImports",
+      // "cmd-shift-left": ["editor::SelectToBeginningOfLine", {"stop_at_soft_wraps": true, "stop_at_indent": true }],
+      // "ctrl-shift-a": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
+      "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
+      // "cmd-shift-right": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
+      // "ctrl-shift-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
+      "shift-end": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
+      // "alt-v": ["editor::MovePageUp", { "center_cursor": true }],
+      "ctrl-;": "editor::ToggleLineNumbers",
+      "ctrl-'": "editor::ToggleSelectedDiffHunks",
+      "ctrl-\"": "editor::ExpandAllDiffHunks",
+      "ctrl-i": "editor::ShowSignatureHelp",
+      "alt-g b": "editor::ToggleGitBlame",
+      "menu": "editor::OpenContextMenu",
+      "shift-f10": "editor::OpenContextMenu",
+      "ctrl-shift-e": "editor::ToggleEditPrediction",
+      "f9": "editor::ToggleBreakpoint",
+      "shift-f9": "editor::EditLogBreakpoint",
+      "ctrl-shift-backspace": "editor::GoToPreviousChange",
+      "ctrl-shift-alt-backspace": "editor::GoToNextChange"
     }
   },
   {
@@ -445,8 +445,6 @@
       "alt-down": "editor::MoveLineDown",
       "ctrl-alt-shift-up": "editor::DuplicateLineUp",
       "ctrl-alt-shift-down": "editor::DuplicateLineDown",
-      "alt-shift-right": "editor::SelectLargerSyntaxNode", // Expand Selection
-      "alt-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
       "ctrl-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "ctrl-f2": "editor::SelectAllMatches", // Select all occurrences of current word
       "ctrl-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch  / find_under_expand
@@ -454,10 +452,20 @@
       "ctrl-shift-up": ["editor::SelectPrevious", { "replace_newest": false }], // editor.action.addSelectionToPreviousFindMatch
       "ctrl-k ctrl-d": ["editor::SelectNext", { "replace_newest": true }], // editor.action.moveSelectionToNextFindMatch  / find_under_expand_skip
       "ctrl-k ctrl-shift-d": ["editor::SelectPrevious", { "replace_newest": true }], // editor.action.moveSelectionToPreviousFindMatch
-      "ctrl-k ctrl-i": "editor::Hover",
-      "ctrl-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "ctrl-u": "editor::UndoSelection",
       "ctrl-shift-u": "editor::RedoSelection",
+      "ctrl-\\": "pane::SplitRight"
+    }
+  },
+  {
+    "context": "Editor && mode == full",
+    "bindings": {
+      "ctrl-shift-o": "outline::Toggle",
+      "ctrl-g": "go_to_line::Toggle",
+      "alt-shift-right": "editor::SelectLargerSyntaxNode", // Expand Selection
+      "alt-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
+      "ctrl-k ctrl-i": "editor::Hover",
+      "ctrl-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "f8": "editor::GoToDiagnostic",
       "shift-f8": "editor::GoToPreviousDiagnostic",
       "f2": "editor::Rename",
@@ -491,19 +499,11 @@
       "ctrl-.": "editor::ToggleCodeActions",
       "ctrl-k r": "editor::RevealInFileManager",
       "ctrl-k p": "editor::CopyPath",
-      "ctrl-\\": "pane::SplitRight",
       "ctrl-k v": "markdown::OpenPreviewToTheSide",
       "ctrl-shift-v": "markdown::OpenPreview",
       "ctrl-alt-shift-c": "editor::DisplayCursorNames",
       "alt-.": "editor::GoToHunk",
       "alt-,": "editor::GoToPreviousHunk"
-    }
-  },
-  {
-    "context": "Editor && mode == full",
-    "bindings": {
-      "ctrl-shift-o": "outline::Toggle",
-      "ctrl-g": "go_to_line::Toggle"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -62,6 +62,10 @@
     }
   },
   {
+    // `Editor` context applies to all editor modes
+    // - auto_height (multi-line: inline assistant, git commit messages, etc)
+    // - single_line (command palette, renaming a file, etc)
+    // - full (main editor buffers, assistant text threads)
     "context": "Editor",
     "use_key_equivalents": true,
     "bindings": {
@@ -76,8 +80,6 @@
       "ctrl-t": "editor::Transpose",
       "ctrl-k": "editor::KillRingCut",
       "ctrl-y": "editor::KillRingYank",
-      "cmd-k cmd-q": "editor::Rewrap",
-      "cmd-k q": "editor::Rewrap",
       "cmd-backspace": "editor::DeleteToBeginningOfLine",
       "cmd-delete": "editor::DeleteToEndOfLine",
       "alt-backspace": "editor::DeleteToPreviousWordStart",
@@ -106,7 +108,6 @@
       "left": "editor::MoveLeft",
       "ctrl-f": "editor::MoveRight",
       "right": "editor::MoveRight",
-      "ctrl-l": "editor::ScrollCursorCenter",
       "alt-left": "editor::MoveToPreviousWordStart",
       "alt-right": "editor::MoveToNextWordEnd",
       "cmd-left": ["editor::MoveToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
@@ -135,8 +136,6 @@
       "cmd-shift-down": "editor::SelectToEnd",
       "cmd-a": "editor::SelectAll",
       "cmd-l": "editor::SelectLine",
-      "cmd-shift-i": "editor::Format",
-      "alt-shift-o": "editor::OrganizeImports",
       "cmd-shift-left": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
       "shift-home": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
       "ctrl-shift-a": ["editor::SelectToBeginningOfLine", { "stop_at_soft_wraps": true, "stop_at_indent": true }],
@@ -145,17 +144,7 @@
       "ctrl-shift-e": ["editor::SelectToEndOfLine", { "stop_at_soft_wraps": true }],
       "ctrl-v": ["editor::MovePageDown", { "center_cursor": true }],
       "ctrl-shift-v": ["editor::MovePageUp", { "center_cursor": true }],
-      "ctrl-cmd-space": "editor::ShowCharacterPalette",
-      "cmd-;": "editor::ToggleLineNumbers",
-      "cmd-'": "editor::ToggleSelectedDiffHunks",
-      "cmd-\"": "editor::ExpandAllDiffHunks",
-      "cmd-alt-g b": "editor::ToggleGitBlame",
-      "cmd-i": "editor::ShowSignatureHelp",
-      "f9": "editor::ToggleBreakpoint",
-      "shift-f9": "editor::EditLogBreakpoint",
-      "ctrl-f12": "editor::GoToDeclaration",
-      "alt-ctrl-f12": "editor::GoToDeclarationSplit",
-      "ctrl-cmd-e": "editor::ToggleEditPrediction"
+      "ctrl-cmd-space": "editor::ShowCharacterPalette"
     }
   },
   {
@@ -174,7 +163,22 @@
       "cmd->": "assistant::QuoteSelection",
       "cmd-<": "assistant::InsertIntoEditor",
       "cmd-alt-e": "editor::SelectEnclosingSymbol",
-      "alt-enter": "editor::OpenSelectionsInMultibuffer"
+      "cmd-k cmd-q": "editor::Rewrap",
+      "cmd-k q": "editor::Rewrap",
+      "ctrl-l": "editor::ScrollCursorCenter",
+      "cmd-i": "editor::ShowSignatureHelp",
+      "cmd-shift-i": "editor::Format",
+      "alt-shift-o": "editor::OrganizeImports",
+      "ctrl-cmd-e": "editor::ToggleEditPrediction",
+      "f9": "editor::ToggleBreakpoint",
+      "shift-f9": "editor::EditLogBreakpoint",
+      "ctrl-f12": "editor::GoToDeclaration",
+      "alt-ctrl-f12": "editor::GoToDeclarationSplit",
+      "alt-enter": "editor::OpenSelectionsInMultibuffer",
+      "cmd-;": "editor::ToggleLineNumbers",
+      "cmd-'": "editor::ToggleSelectedDiffHunks",
+      "cmd-\"": "editor::ExpandAllDiffHunks",
+      "cmd-alt-g b": "editor::ToggleGitBlame"
     }
   },
   {
@@ -509,21 +513,18 @@
       //   defaults write com.apple.symbolichotkeys AppleSymbolicHotKeys -dict-add 70 '<dict><key>enabled</key><false/></dict>'
       "ctrl-cmd-d": ["editor::SelectPrevious", { "replace_newest": false }], // editor.action.addSelectionToPreviousFindMatch
       "cmd-k ctrl-cmd-d": ["editor::SelectPrevious", { "replace_newest": true }], // editor.action.moveSelectionToPreviousFindMatch
-      "cmd-k cmd-i": "editor::Hover",
-      "cmd-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "cmd-u": "editor::UndoSelection",
       "cmd-shift-u": "editor::RedoSelection",
-      "f8": "editor::GoToDiagnostic",
-      "shift-f8": "editor::GoToPreviousDiagnostic",
-      "f2": "editor::Rename",
-      "f12": "editor::GoToDefinition",
-      "alt-f12": "editor::GoToDefinitionSplit",
-      "cmd-f12": "editor::GoToTypeDefinition",
-      "shift-f12": "editor::GoToImplementation",
-      "alt-cmd-f12": "editor::GoToTypeDefinitionSplit",
-      "alt-shift-f12": "editor::FindAllReferences",
       "cmd-|": "editor::MoveToEnclosingBracket",
       "ctrl-m": "editor::MoveToEnclosingBracket",
+      "cmd-\\": "pane::SplitRight"
+    }
+  },
+  // VSCode Bindings full Editors (e.g. buffers)
+  {
+    "context": "Editor && mode == full",
+    "use_key_equivalents": true,
+    "bindings": {
       "alt-cmd-[": "editor::Fold",
       "alt-cmd-]": "editor::UnfoldLines",
       "cmd-k cmd-l": "editor::ToggleFold",
@@ -547,20 +548,24 @@
       "cmd-.": "editor::ToggleCodeActions",
       "cmd-k r": "editor::RevealInFileManager",
       "cmd-k p": "editor::CopyPath",
-      "cmd-\\": "pane::SplitRight",
+      "cmd-k cmd-i": "editor::Hover",
+      "cmd-/": ["editor::ToggleComments", { "advance_downwards": false }],
+      "f8": "editor::GoToDiagnostic",
+      "shift-f8": "editor::GoToPreviousDiagnostic",
+      "f2": "editor::Rename",
+      "f12": "editor::GoToDefinition",
+      "alt-f12": "editor::GoToDefinitionSplit",
+      "cmd-f12": "editor::GoToTypeDefinition",
+      "shift-f12": "editor::GoToImplementation",
+      "alt-cmd-f12": "editor::GoToTypeDefinitionSplit",
+      "alt-shift-f12": "editor::FindAllReferences",
       "cmd-k v": "markdown::OpenPreviewToTheSide",
       "cmd-shift-v": "markdown::OpenPreview",
       "ctrl-cmd-c": "editor::DisplayCursorNames",
+      "cmd-shift-o": "outline::Toggle",
+      "ctrl-g": "go_to_line::Toggle",
       "cmd-shift-backspace": "editor::GoToPreviousChange",
       "cmd-shift-alt-backspace": "editor::GoToNextChange"
-    }
-  },
-  {
-    "context": "Editor && mode == full",
-    "use_key_equivalents": true,
-    "bindings": {
-      "cmd-shift-o": "outline::Toggle",
-      "ctrl-g": "go_to_line::Toggle"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -502,8 +502,6 @@
       "alt-down": "editor::MoveLineDown",
       "alt-shift-up": "editor::DuplicateLineUp",
       "alt-shift-down": "editor::DuplicateLineDown",
-      "ctrl-shift-right": "editor::SelectLargerSyntaxNode", // Expand Selection
-      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
       "cmd-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch / find_under_expand
       "cmd-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "cmd-f2": "editor::SelectAllMatches", // Select all occurrences of current word
@@ -548,6 +546,8 @@
       "cmd-.": "editor::ToggleCodeActions",
       "cmd-k r": "editor::RevealInFileManager",
       "cmd-k p": "editor::CopyPath",
+      "ctrl-shift-right": "editor::SelectLargerSyntaxNode", // Expand Selection
+      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
       "cmd-k cmd-i": "editor::Hover",
       "cmd-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "f8": "editor::GoToDiagnostic",

--- a/assets/keymaps/linux/atom.json
+++ b/assets/keymaps/linux/atom.json
@@ -10,11 +10,6 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-l": "language_selector::Toggle", // grammar-selector:show
-      "ctrl-|": "pane::RevealInProjectPanel", // tree-view:reveal-active-file
-      "ctrl-b": "editor::GoToDefinition", // fuzzy-finder:toggle-buffer-finder
-      "ctrl-alt-b": "editor::GoToDefinitionSplit", // N/A: From JetBrains
-      "ctrl-<": "editor::ScrollCursorCenter", // editor:scroll-to-cursor
       "f3": ["editor::SelectNext", { "replace_newest": true }], // find-and-replace:find-next
       "shift-f3": ["editor::SelectPrevious", { "replace_newest": true }], //find-and-replace:find-previous
       "alt-shift-down": "editor::AddSelectionBelow", // editor:add-selection-below
@@ -25,14 +20,19 @@
       "ctrl-shift-d": "editor::DuplicateLineDown", // editor:duplicate-lines
       "ctrl-up": "editor::MoveLineUp", // editor:move-line-up
       "ctrl-down": "editor::MoveLineDown", // editor:move-line-down
-      "ctrl-\\": "workspace::ToggleLeftDock", // tree-view:toggle
-      "ctrl-shift-m": "markdown::OpenPreviewToTheSide" // markdown-preview:toggle
+      "ctrl-\\": "workspace::ToggleLeftDock" // tree-view:toggle (overrides bind in default keymap)
     }
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "ctrl-r": "outline::Toggle" // symbols-view:toggle-project-symbols
+      "ctrl-shift-l": "language_selector::Toggle", // grammar-selector:show
+      "ctrl-|": "pane::RevealInProjectPanel", // tree-view:reveal-active-file
+      "ctrl-b": "editor::GoToDefinition", // fuzzy-finder:toggle-buffer-finder
+      "ctrl-alt-b": "editor::GoToDefinitionSplit", // N/A: From JetBrains
+      "ctrl-<": "editor::ScrollCursorCenter", // editor:scroll-to-cursor
+      "ctrl-r": "outline::Toggle", // symbols-view:toggle-project-symbols
+      "ctrl-shift-m": "markdown::OpenPreviewToTheSide" // markdown-preview:toggle
     }
   },
   {

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -32,24 +32,15 @@
       "ctrl-alt-down": "editor::AddSelectionBelow",
       "ctrl-shift-up": "editor::MoveLineUp",
       "ctrl-shift-down": "editor::MoveLineDown",
-      "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-l": "editor::SplitSelectionIntoLines",
-      "ctrl-shift-a": "editor::SelectLargerSyntaxNode",
       "ctrl-shift-d": "editor::DuplicateSelection",
       "alt-f3": "editor::SelectAllMatches", // find_all_under
       // "ctrl-f3": "", // find_under (cancels any selections)
       // "cmd-alt-shift-g": "" // find_under_prev (cancels any selections)
       "f9": "editor::SortLinesCaseSensitive",
       "ctrl-f9": "editor::SortLinesCaseInsensitive",
-      "f12": "editor::GoToDefinition",
-      "ctrl-f12": "editor::GoToDefinitionSplit",
-      "shift-f12": "editor::FindAllReferences",
-      "ctrl-shift-f12": "editor::FindAllReferences",
-      "ctrl-.": "editor::GoToHunk",
-      "ctrl-,": "editor::GoToPreviousHunk",
       "ctrl-k ctrl-u": "editor::ConvertToUpperCase",
       "ctrl-k ctrl-l": "editor::ConvertToLowerCase",
-      "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd",
       "f3": "editor::FindNextMatch",
@@ -59,7 +50,16 @@
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "ctrl-r": "outline::Toggle"
+      "ctrl-r": "outline::Toggle",
+      "ctrl-shift-m": "editor::SelectLargerSyntaxNode",
+      "ctrl-shift-a": "editor::SelectLargerSyntaxNode",
+      "f12": "editor::GoToDefinition",
+      "ctrl-f12": "editor::GoToDefinitionSplit",
+      "shift-f12": "editor::FindAllReferences",
+      "ctrl-shift-f12": "editor::FindAllReferences",
+      "ctrl-.": "editor::GoToHunk",
+      "ctrl-,": "editor::GoToPreviousHunk",
+      "shift-alt-m": "markdown::OpenPreviewToTheSide"
     }
   },
   {

--- a/assets/keymaps/macos/atom.json
+++ b/assets/keymaps/macos/atom.json
@@ -10,11 +10,6 @@
   {
     "context": "Editor",
     "bindings": {
-      "ctrl-shift-l": "language_selector::Toggle",
-      "cmd-|": "pane::RevealInProjectPanel",
-      "cmd-b": "editor::GoToDefinition",
-      "alt-cmd-b": "editor::GoToDefinitionSplit",
-      "cmd-<": "editor::ScrollCursorCenter",
       "cmd-g": ["editor::SelectNext", { "replace_newest": true }],
       "cmd-shift-g": ["editor::SelectPrevious", { "replace_newest": true }],
       "ctrl-shift-down": "editor::AddSelectionBelow",
@@ -26,13 +21,18 @@
       "cmd-shift-d": "editor::DuplicateLineDown",
       "ctrl-cmd-up": "editor::MoveLineUp",
       "ctrl-cmd-down": "editor::MoveLineDown",
-      "cmd-\\": "workspace::ToggleLeftDock",
+      "cmd-\\": "workspace::ToggleLeftDock", // overrides bind in default keymap
       "ctrl-shift-m": "markdown::OpenPreviewToTheSide"
     }
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
+      "ctrl-shift-l": "language_selector::Toggle",
+      "cmd-|": "pane::RevealInProjectPanel",
+      "cmd-b": "editor::GoToDefinition",
+      "alt-cmd-b": "editor::GoToDefinitionSplit",
+      "cmd-<": "editor::ScrollCursorCenter",
       "cmd-r": "outline::Toggle"
     }
   },


### PR DESCRIPTION
This moves a number of keybinds from `Editor` to `Editor && mode == full`.

These keybinds only operate in the full editor (e.g. normal buffers) and don't make sense when inside a `auto_height` (git commit, inline assistant, etc) or `single_line` (search fields, command palette, renaming a file, etc) context. 

If I have successfully moved these actions correctly, this should be a no-op.  If not, we can fast follow with fixes.

Release Notes:

- N/A