### PR TITLE
debugger: Add debug task picker to new session modal

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -949,6 +949,7 @@ impl DebugPanel {
                                                     past_debug_definition,
                                                     weak_panel,
                                                     workspace,
+                                                    None,
                                                     window,
                                                     cx,
                                                 )

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -407,7 +407,6 @@ impl DebugPanel {
     pub fn resolve_scenario(
         &self,
         scenario: DebugScenario,
-
         task_context: TaskContext,
         buffer: Option<Entity<Buffer>>,
         window: &Window,
@@ -428,7 +427,7 @@ impl DebugPanel {
                 stop_on_entry,
             } = scenario;
             let request = if let Some(mut request) = request {
-                // Resolve task variables within the request.
+                // Resolve task variables within the request. todo!(this needs to be fixed for task env variables to work in debug tasks)
                 if let DebugRequest::Launch(_) = &mut request {}
 
                 request

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -7,6 +7,7 @@ use crate::{
 };
 use crate::{new_session_modal::NewSessionModal, session::DebugSession};
 use anyhow::{Result, anyhow};
+use collections::{HashMap, HashSet};
 use command_palette_hooks::CommandPaletteFilter;
 use dap::DebugRequest;
 use dap::{
@@ -26,6 +27,7 @@ use project::{Project, debugger::session::ThreadStatus};
 use rpc::proto::{self};
 use settings::Settings;
 use std::any::TypeId;
+use std::path::PathBuf;
 use task::{DebugScenario, TaskContext};
 use ui::{ContextMenu, Divider, DropdownMenu, Tooltip, prelude::*};
 use workspace::SplitDirection;
@@ -427,8 +429,58 @@ impl DebugPanel {
                 stop_on_entry,
             } = scenario;
             let request = if let Some(mut request) = request {
-                // Resolve task variables within the request. todo!(this needs to be fixed for task env variables to work in debug tasks)
-                if let DebugRequest::Launch(_) = &mut request {}
+                if let DebugRequest::Launch(launch_config) = &mut request {
+                    let mut variable_names = HashMap::default();
+                    let mut substituted_variables = HashSet::default();
+                    let task_variables = task_context
+                        .task_variables
+                        .iter()
+                        .map(|(key, value)| {
+                            let key_string = key.to_string();
+                            if !variable_names.contains_key(&key_string) {
+                                variable_names.insert(key_string.clone(), key.clone());
+                            }
+                            (key_string, value.as_str())
+                        })
+                        .collect::<HashMap<_, _>>();
+
+                    let cwd = launch_config
+                        .cwd
+                        .as_ref()
+                        .and_then(|cwd| cwd.to_str())
+                        .and_then(|cwd| {
+                            task::substitute_all_template_variables_in_str(
+                                cwd,
+                                &task_variables,
+                                &variable_names,
+                                &mut substituted_variables,
+                            )
+                        });
+
+                    if let Some(cwd) = cwd {
+                        launch_config.cwd = Some(PathBuf::from(cwd))
+                    }
+
+                    if let Some(program) = task::substitute_all_template_variables_in_str(
+                        &launch_config.program,
+                        &task_variables,
+                        &variable_names,
+                        &mut substituted_variables,
+                    ) {
+                        launch_config.program = program;
+                    }
+
+                    for arg in launch_config.args.iter_mut() {
+                        if let Some(substitued_arg) = task::substitute_all_template_variables_in_str(
+                            &arg,
+                            &task_variables,
+                            &variable_names,
+                            &mut substituted_variables,
+                        ) {
+                            *arg = substitued_arg;
+                        }
+                    }
+                }
 
                 request
             } else if let Some(build) = build {

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -471,13 +471,15 @@ impl DebugPanel {
                     }
 
                     for arg in launch_config.args.iter_mut() {
-                        if let Some(substitued_arg) = task::substitute_all_template_variables_in_str(
-                            &arg,
-                            &task_variables,
-                            &variable_names,
-                            &mut substituted_variables,
-                        ) {
-                            *arg = substitued_arg;
+                        if let Some(substituted_arg) =
+                            task::substitute_all_template_variables_in_str(
+                                &arg,
+                                &task_variables,
+                                &variable_names,
+                                &mut substituted_variables,
+                            )
+                        {
+                            *arg = substituted_arg;
                         }
                     }
                 }

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -158,6 +158,7 @@ pub fn init(cx: &mut App) {
                                     debug_panel.read(cx).past_debug_definition.clone(),
                                     weak_panel,
                                     weak_workspace,
+                                    None,
                                     window,
                                     cx,
                                 )
@@ -166,14 +167,22 @@ pub fn init(cx: &mut App) {
                     },
                 )
                 .register_action(|workspace: &mut Workspace, _: &Start, window, cx| {
-                    tasks_ui::toggle_modal(
-                        workspace,
-                        None,
-                        task::TaskModal::DebugModal,
-                        window,
-                        cx,
-                    )
-                    .detach();
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        let weak_panel = debug_panel.downgrade();
+                        let weak_workspace = cx.weak_entity();
+                        let task_store = workspace.project().read(cx).task_store().clone();
+
+                        workspace.toggle_modal(window, cx, |window, cx| {
+                            NewSessionModal::new(
+                                debug_panel.read(cx).past_debug_definition.clone(),
+                                weak_panel,
+                                weak_workspace,
+                                Some(task_store),
+                                window,
+                                cx,
+                            )
+                        });
+                    }
                 });
         })
     })

--- a/crates/debugger_ui/src/new_session_modal.rs
+++ b/crates/debugger_ui/src/new_session_modal.rs
@@ -811,7 +811,7 @@ mod session_modes {
                     .into_iter()
                     .enumerate()
                     .map(|(index, (_, candidate))| {
-                        StringMatchCandidate::new(index, &candidate.label.to_string())
+                        StringMatchCandidate::new(index, candidate.label.as_ref())
                     })
                     .collect(),
                 None => {
@@ -838,7 +838,7 @@ mod session_modes {
                         .into_iter()
                         .enumerate()
                         .map(|(index, (_, candidate))| {
-                            StringMatchCandidate::new(index, &candidate.label.to_string())
+                            StringMatchCandidate::new(index, candidate.label.as_ref())
                         })
                         .collect()
                 }

--- a/crates/debugger_ui/src/new_session_modal.rs
+++ b/crates/debugger_ui/src/new_session_modal.rs
@@ -62,6 +62,7 @@ impl NewSessionModal {
         past_debug_definition: Option<DebugTaskDefinition>,
         debug_panel: WeakEntity<DebugPanel>,
         workspace: WeakEntity<Workspace>,
+        task_store: Option<Entity<TaskStore>>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -76,6 +77,25 @@ impl NewSessionModal {
         let launch_config = match past_debug_definition.map(|def| def.request) {
             Some(DebugRequest::Launch(launch_config)) => Some(launch_config),
             _ => None,
+        };
+
+        if let Some(task_store) = task_store {
+            cx.defer_in(window, |this, window, cx| {
+                let picker = cx.new(|cx| {
+                    Picker::uniform_list(
+                        DebugScenarioDelegate::new(
+                            this.debug_panel.clone(),
+                            this.workspace.clone(),
+                            task_store,
+                        ),
+                        window,
+                        cx,
+                    )
+                    .modal(false)
+                });
+
+                this.mode = NewSessionMode::Scenario(picker);
+            });
         };
 
         Self {

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -188,7 +188,7 @@ impl Render for SubView {
                 cx.notify();
             }))
             .size_full()
-            // Add border uncoditionally to prevent layout shifts on focus changes.
+            // Add border unconditionally to prevent layout shifts on focus changes.
             .border_1()
             .when(self.pane_focus_handle.contains_focused(window, cx), |el| {
                 el.border_color(cx.theme().colors().pane_focused_border)

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -588,7 +588,9 @@ impl<D: PickerDelegate> Picker<D> {
                 self.update_matches(query, window, cx);
             }
             editor::EditorEvent::Blurred => {
-                self.cancel(&menu::Cancel, window, cx);
+                if self.is_modal {
+                    self.cancel(&menu::Cancel, window, cx);
+                }
             }
             _ => {}
         }

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -206,14 +206,14 @@ impl Inventory {
         cx.new(|_| Self::default())
     }
 
-    pub fn list_debug_scenarios(&self, worktree: Option<WorktreeId>) -> Vec<DebugScenario> {
+    pub fn list_debug_scenarios(
+        &self,
+        worktree: Option<WorktreeId>,
+    ) -> Vec<(TaskSourceKind, DebugScenario)> {
         let global_scenarios = self.global_debug_scenarios_from_settings();
         let worktree_scenarios = self.worktree_scenarios_from_settings(worktree);
 
-        worktree_scenarios
-            .chain(global_scenarios)
-            .map(|(_, scenario)| scenario)
-            .collect()
+        worktree_scenarios.chain(global_scenarios).collect()
     }
 
     pub fn task_template_by_label(

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -179,6 +179,14 @@ impl TaskContexts {
             })
             .copied()
     }
+
+    pub fn task_context_for_worktree_id(&self, worktree_id: WorktreeId) -> Option<&TaskContext> {
+        self.active_worktree_context
+            .iter()
+            .chain(self.other_worktree_contexts.iter())
+            .find(|(id, _)| *id == worktree_id)
+            .map(|(_, context)| context)
+    }
 }
 
 impl TaskSourceKind {
@@ -208,12 +216,14 @@ impl Inventory {
 
     pub fn list_debug_scenarios(
         &self,
-        worktree: Option<WorktreeId>,
+        worktrees: impl Iterator<Item = WorktreeId>,
     ) -> Vec<(TaskSourceKind, DebugScenario)> {
         let global_scenarios = self.global_debug_scenarios_from_settings();
-        let worktree_scenarios = self.worktree_scenarios_from_settings(worktree);
 
-        worktree_scenarios.chain(global_scenarios).collect()
+        worktrees
+            .flat_map(|tree_id| self.worktree_scenarios_from_settings(Some(tree_id)))
+            .chain(global_scenarios)
+            .collect()
     }
 
     pub fn task_template_by_label(

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -19,7 +19,7 @@ pub use debug_format::{
     AttachRequest, DebugRequest, DebugScenario, DebugTaskFile, LaunchRequest, TcpArgumentsTemplate,
 };
 pub use task_template::{
-    DebugArgsRequest, HideStrategy, RevealStrategy, TaskModal, TaskTemplate, TaskTemplates,
+    DebugArgsRequest, HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates,
 };
 pub use vscode_debug_format::VsCodeDebugTaskFile;
 pub use vscode_format::VsCodeTaskFile;

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -20,6 +20,7 @@ pub use debug_format::{
 };
 pub use task_template::{
     DebugArgsRequest, HideStrategy, RevealStrategy, TaskTemplate, TaskTemplates,
+    substitute_all_template_variables_in_str,
 };
 pub use vscode_debug_format::VsCodeDebugTaskFile;
 pub use vscode_format::VsCodeTaskFile;
@@ -265,6 +266,10 @@ impl TaskVariables {
                 true
             }
         })
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (&VariableName, &String)> {
+        self.0.iter()
     }
 }
 

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -83,15 +83,6 @@ pub enum DebugArgsRequest {
     Attach(AttachRequest),
 }
 
-#[derive(Clone, Debug, PartialEq, Eq)]
-/// The type of task modal to spawn
-pub enum TaskModal {
-    /// Show regular tasks
-    ScriptModal,
-    /// Show debug tasks
-    DebugModal,
-}
-
 /// What to do with the terminal pane and tab, after the command was started.
 #[derive(Default, Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -293,7 +293,7 @@ fn to_hex_hash(object: impl Serialize) -> anyhow::Result<String> {
     Ok(hex::encode(hasher.finalize()))
 }
 
-fn substitute_all_template_variables_in_str<A: AsRef<str>>(
+pub fn substitute_all_template_variables_in_str<A: AsRef<str>>(
     template_str: &str,
     task_variables: &HashMap<String, A>,
     variable_names: &HashMap<String, VariableName>,

--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -5,9 +5,7 @@ use editor::Editor;
 use gpui::{App, AppContext as _, Context, Entity, Task, Window};
 use modal::TaskOverrides;
 use project::{Location, TaskContexts, TaskSourceKind, Worktree};
-use task::{
-    RevealTarget, TaskContext, TaskId, TaskModal, TaskTemplate, TaskVariables, VariableName,
-};
+use task::{RevealTarget, TaskContext, TaskId, TaskTemplate, TaskVariables, VariableName};
 use workspace::Workspace;
 
 mod modal;
@@ -83,7 +81,7 @@ pub fn init(cx: &mut App) {
                             );
                         }
                     } else {
-                        toggle_modal(workspace, None, TaskModal::ScriptModal, window, cx).detach();
+                        toggle_modal(workspace, None, window, cx).detach();
                     };
                 });
         },
@@ -125,21 +123,15 @@ fn spawn_task_or_modal(
             )
             .detach_and_log_err(cx)
         }
-        Spawn::ViaModal { reveal_target } => toggle_modal(
-            workspace,
-            *reveal_target,
-            TaskModal::ScriptModal,
-            window,
-            cx,
-        )
-        .detach(),
+        Spawn::ViaModal { reveal_target } => {
+            toggle_modal(workspace, *reveal_target, window, cx).detach()
+        }
     }
 }
 
 pub fn toggle_modal(
     workspace: &mut Workspace,
     reveal_target: Option<RevealTarget>,
-    task_type: TaskModal,
     window: &mut Window,
     cx: &mut Context<Workspace>,
 ) -> Task<()> {
@@ -162,7 +154,6 @@ pub fn toggle_modal(
                                 reveal_target: Some(target),
                             }),
                             workspace_handle,
-                            task_type,
                             window,
                             cx,
                         )


### PR DESCRIPTION
## Preview 
![image](https://github.com/user-attachments/assets/203a577f-3b38-4017-9571-de1234415162)


### TODO
- [x] Add scenario picker to new session modal
- [x] Make debugger start action open new session modal instead of task modal
- [x] Fix `esc` not clearing the cancelling the new session modal while it's in scenario or attach mode
- [x] Resolve debug scenario's correctly

Release Notes:

- N/A
