### PR TITLE
Allow to fetch cargo diagnostics separately

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4372,6 +4372,7 @@ dependencies = [
  "ctor",
  "editor",
  "env_logger 0.11.8",
+ "futures 0.3.31",
  "gpui",
  "indoc",
  "itertools 0.14.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4365,6 +4365,7 @@ name = "diagnostics"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
  "client",
  "collections",
  "component",
@@ -4373,6 +4374,7 @@ dependencies = [
  "env_logger 0.11.8",
  "gpui",
  "indoc",
+ "itertools 0.14.0",
  "language",
  "linkme",
  "log",
@@ -4384,6 +4386,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "smol",
  "text",
  "theme",
  "ui",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -962,5 +962,12 @@
     "bindings": {
       "escape": "menu::Cancel"
     }
+  },
+  {
+    "context": "Diagnostics",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh"
+    }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1068,5 +1068,12 @@
     "bindings": {
       "escape": "menu::Cancel"
     }
+  },
+  {
+    "context": "Diagnostics",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-r": "diagnostics::ToggleDiagnosticsRefresh"
+    }
   }
 ]

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -931,6 +931,24 @@
       // The minimum severity of the diagnostics to show inline.
       // Shows all diagnostics when not specified.
       "max_severity": null
+    },
+    "rust": {
+      // When enabled, Zed runs `cargo check --message-format=json`-based commands and
+      // collect cargo diagnostics instead of rust-analyzer.
+      "fetch_cargo_diagnostics": false,
+      // A command override for fetching the cargo diagnostics.
+      // First argument is the command, followed by the arguments.
+      "diagnostics_fetch_command": [
+        "cargo",
+        "check",
+        "--quiet",
+        "--workspace",
+        "--message-format=json",
+        "--all-targets",
+        "--keep-going"
+      ],
+      // Extra environment variables to pass to the diagnostics fetch command.
+      "env": {}
     }
   },
   // Files or globs of files that will be excluded by Zed entirely. They will be skipped during file

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 anyhow.workspace = true
+cargo_metadata.workspace = true
 collections.workspace = true
 component.workspace = true
 ctor.workspace = true
@@ -21,6 +22,7 @@ editor.workspace = true
 env_logger.workspace = true
 gpui.workspace = true
 indoc.workspace = true
+itertools.workspace = true
 language.workspace = true
 linkme.workspace = true
 log.workspace = true
@@ -29,7 +31,9 @@ markdown.workspace = true
 project.workspace = true
 rand.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 settings.workspace = true
+smol.workspace = true
 text.workspace = true
 theme.workspace = true
 ui.workspace = true

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -20,6 +20,7 @@ component.workspace = true
 ctor.workspace = true
 editor.workspace = true
 env_logger.workspace = true
+futures.workspace = true
 gpui.workspace = true
 indoc.workspace = true
 itertools.workspace = true

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -38,7 +38,7 @@ pub fn fetch_cargo_diagnostics(
 ) -> Option<(Task<()>, Receiver<CargoCheckMessage>)> {
     let diagnostics_settings = ProjectSettings::get_global(cx)
         .diagnostics
-        .rust
+        .cargo
         .as_ref()
         .filter(|settings| settings.fetch_cargo_diagnostics)?;
     let command_string = diagnostics_settings

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -61,6 +61,7 @@ pub fn cargo_diagnostics_sources(
         .collect()
 }
 
+// TODO kb send back some progress
 pub fn fetch_worktree_diagnostics(
     worktree_root: &Path,
     cx: &App,
@@ -81,6 +82,7 @@ pub fn fetch_worktree_diagnostics(
         .current_dir(worktree_root)
         .stdout(Stdio::piped())
         .stderr(Stdio::null())
+        .kill_on_drop(true)
         .spawn()
         .log_err()?;
 
@@ -90,6 +92,7 @@ pub fn fetch_worktree_diagnostics(
     let error_threshold = 10;
 
     let cargo_diagnostics_fetch_task = cx.background_spawn(async move {
+        let _command = command;
         let mut errors = 0;
         loop {
             let mut line = String::new();

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -1,6 +1,12 @@
-use std::{path::Path, process::Stdio};
+use std::{
+    path::{Component, Path, Prefix},
+    process::Stdio,
+};
 
-use cargo_metadata::diagnostic::Diagnostic as CargoDiagnostic;
+use cargo_metadata::diagnostic::{
+    Applicability, Diagnostic as CargoDiagnostic, DiagnosticLevel, DiagnosticSpan,
+};
+use collections::HashMap;
 use gpui::{AppContext, Entity, Task};
 use itertools::Itertools as _;
 use project::{Worktree, project_settings::ProjectSettings};
@@ -15,6 +21,19 @@ use ui::App;
 use util::ResultExt;
 
 use crate::ProjectDiagnosticsEditor;
+
+/// Appends formatted string to a `String`.
+macro_rules! format_to {
+    ($buf:expr) => ();
+    ($buf:expr, $lit:literal $($arg:tt)*) => {
+        {
+            use ::std::fmt::Write as _;
+            // We can't do ::std::fmt::Write::write_fmt($buf, format_args!($lit $($arg)*))
+            // unfortunately, as that loses out on autoref behavior.
+            _ = $buf.write_fmt(format_args!($lit $($arg)*))
+        }
+    };
+}
 
 pub fn worktrees_for_diagnostics_fetch(
     editor: Entity<ProjectDiagnosticsEditor>,
@@ -99,6 +118,425 @@ pub fn fetch_worktree_diagnostics(
     Some((cargo_diagnostics_fetch_task, rx))
 }
 
-pub fn cargo_to_lsp(diagnostics: Vec<CargoDiagnostic>) -> lsp::PublishDiagnosticsParams {
-    todo!("TODO kb")
+/// Converts a Rust root diagnostic to LSP form
+///
+/// This flattens the Rust diagnostic by:
+///
+/// 1. Creating a LSP diagnostic with the root message and primary span.
+/// 2. Adding any labelled secondary spans to `relatedInformation`
+/// 3. Categorising child diagnostics as either `SuggestedFix`es,
+///    `relatedInformation` or additional message lines.
+///
+/// If the diagnostic has no primary span this will return `None`
+///
+/// Taken from https://github.com/rust-lang/rust-analyzer/blob/fe7b4f2ad96f7c13cc571f45edc2c578b35dddb4/crates/rust-analyzer/src/diagnostics/to_proto.rs#L275-L285
+pub(crate) fn map_rust_diagnostic_to_lsp(
+    worktree_root: &Path,
+    cargo_diagnostic: &CargoDiagnostic,
+) -> Vec<(lsp::Url, lsp::Diagnostic)> {
+    let primary_spans: Vec<&DiagnosticSpan> = cargo_diagnostic
+        .spans
+        .iter()
+        .filter(|s| s.is_primary)
+        .collect();
+    if primary_spans.is_empty() {
+        return Vec::new();
+    }
+
+    let severity = diagnostic_severity(cargo_diagnostic.level);
+
+    let mut source = String::from("rustc");
+    let mut code = cargo_diagnostic.code.as_ref().map(|c| c.code.clone());
+
+    if let Some(code_val) = &code {
+        // See if this is an RFC #2103 scoped lint (e.g. from Clippy)
+        let scoped_code: Vec<&str> = code_val.split("::").collect();
+        if scoped_code.len() == 2 {
+            source = String::from(scoped_code[0]);
+            code = Some(String::from(scoped_code[1]));
+        }
+    }
+
+    let mut needs_primary_span_label = true;
+    let mut subdiagnostics = Vec::new();
+    let mut tags = Vec::new();
+
+    for secondary_span in cargo_diagnostic.spans.iter().filter(|s| !s.is_primary) {
+        if let Some(label) = secondary_span.label.clone() {
+            subdiagnostics.push(lsp::DiagnosticRelatedInformation {
+                location: location(worktree_root, secondary_span),
+                message: label,
+            });
+        }
+    }
+
+    let mut message = cargo_diagnostic.message.clone();
+    for child in &cargo_diagnostic.children {
+        let child = map_rust_child_diagnostic(worktree_root, child);
+        match child {
+            MappedRustChildDiagnostic::SubDiagnostic(sub) => {
+                subdiagnostics.push(sub);
+            }
+            MappedRustChildDiagnostic::MessageLine(message_line) => {
+                format_to!(message, "\n{message_line}");
+
+                // These secondary messages usually duplicate the content of the
+                // primary span label.
+                needs_primary_span_label = false;
+            }
+        }
+    }
+
+    if let Some(code) = &cargo_diagnostic.code {
+        let code = code.code.as_str();
+        if matches!(
+            code,
+            "dead_code"
+                | "unknown_lints"
+                | "unreachable_code"
+                | "unused_attributes"
+                | "unused_imports"
+                | "unused_macros"
+                | "unused_variables"
+        ) {
+            tags.push(lsp::DiagnosticTag::UNNECESSARY);
+        }
+
+        if matches!(code, "deprecated") {
+            tags.push(lsp::DiagnosticTag::DEPRECATED);
+        }
+    }
+
+    let code_description = match source.as_str() {
+        "rustc" => rustc_code_description(code.as_deref()),
+        "clippy" => clippy_code_description(code.as_deref()),
+        _ => None,
+    };
+
+    primary_spans
+        .iter()
+        .flat_map(|primary_span| {
+            let primary_location = primary_location(worktree_root, primary_span);
+            let message = {
+                let mut message = message.clone();
+                if needs_primary_span_label {
+                    if let Some(primary_span_label) = &primary_span.label {
+                        format_to!(message, "\n{primary_span_label}");
+                    }
+                }
+                message
+            };
+            // Each primary diagnostic span may result in multiple LSP diagnostics.
+            let mut diagnostics = Vec::new();
+
+            let mut related_info_macro_calls = vec![];
+
+            // If error occurs from macro expansion, add related info pointing to
+            // where the error originated
+            // Also, we would generate an additional diagnostic, so that exact place of macro
+            // will be highlighted in the error origin place.
+            let span_stack = std::iter::successors(Some(*primary_span), |span| {
+                Some(&span.expansion.as_ref()?.span)
+            });
+            for (i, span) in span_stack.enumerate() {
+                if is_dummy_macro_file(&span.file_name) {
+                    continue;
+                }
+
+                // First span is the original diagnostic, others are macro call locations that
+                // generated that code.
+                let is_in_macro_call = i != 0;
+
+                let secondary_location = location(worktree_root, span);
+                if secondary_location == primary_location {
+                    continue;
+                }
+                related_info_macro_calls.push(lsp::DiagnosticRelatedInformation {
+                    location: secondary_location.clone(),
+                    message: if is_in_macro_call {
+                        "Error originated from macro call here".to_owned()
+                    } else {
+                        "Actual error occurred here".to_owned()
+                    },
+                });
+                // For the additional in-macro diagnostic we add the inverse message pointing to the error location in code.
+                let information_for_additional_diagnostic =
+                    vec![lsp::DiagnosticRelatedInformation {
+                        location: primary_location.clone(),
+                        message: "Exact error occurred here".to_owned(),
+                    }];
+
+                let diagnostic = lsp::Diagnostic {
+                    range: secondary_location.range,
+                    // downgrade to hint if we're pointing at the macro
+                    severity: Some(lsp::DiagnosticSeverity::HINT),
+                    code: code.clone().map(lsp::NumberOrString::String),
+                    code_description: code_description.clone(),
+                    source: Some(source.clone()),
+                    message: message.clone(),
+                    related_information: Some(information_for_additional_diagnostic),
+                    tags: if tags.is_empty() {
+                        None
+                    } else {
+                        Some(tags.clone())
+                    },
+                    data: Some(serde_json::json!({ "rendered": cargo_diagnostic.rendered })),
+                };
+                diagnostics.push((secondary_location.uri, diagnostic));
+            }
+
+            // Emit the primary diagnostic.
+            diagnostics.push((
+                primary_location.uri.clone(),
+                lsp::Diagnostic {
+                    range: primary_location.range,
+                    severity,
+                    code: code.clone().map(lsp::NumberOrString::String),
+                    code_description: code_description.clone(),
+                    source: Some(source.clone()),
+                    message,
+                    related_information: {
+                        let info = related_info_macro_calls
+                            .iter()
+                            .cloned()
+                            .chain(subdiagnostics.iter().cloned())
+                            .collect::<Vec<_>>();
+                        if info.is_empty() { None } else { Some(info) }
+                    },
+                    tags: if tags.is_empty() {
+                        None
+                    } else {
+                        Some(tags.clone())
+                    },
+                    data: Some(serde_json::json!({ "rendered": cargo_diagnostic.rendered })),
+                },
+            ));
+
+            // Emit hint-level diagnostics for all `related_information` entries such as "help"s.
+            // This is useful because they will show up in the user's editor, unlike
+            // `related_information`, which just produces hard-to-read links, at least in VS Code.
+            let back_ref = lsp::DiagnosticRelatedInformation {
+                location: primary_location,
+                message: "original diagnostic".to_owned(),
+            };
+            for sub in &subdiagnostics {
+                diagnostics.push((
+                    sub.location.uri.clone(),
+                    lsp::Diagnostic {
+                        range: sub.location.range,
+                        severity: Some(lsp::DiagnosticSeverity::HINT),
+                        code: code.clone().map(lsp::NumberOrString::String),
+                        code_description: code_description.clone(),
+                        source: Some(source.clone()),
+                        message: sub.message.clone(),
+                        related_information: Some(vec![back_ref.clone()]),
+                        tags: None, // don't apply modifiers again
+                        data: None,
+                    },
+                ));
+            }
+
+            diagnostics
+        })
+        .collect()
+}
+
+fn rustc_code_description(code: Option<&str>) -> Option<lsp::CodeDescription> {
+    code.filter(|code| {
+        let mut chars = code.chars();
+        chars.next() == Some('E')
+            && chars.by_ref().take(4).all(|c| c.is_ascii_digit())
+            && chars.next().is_none()
+    })
+    .and_then(|code| {
+        lsp::Url::parse(&format!(
+            "https://doc.rust-lang.org/error-index.html#{code}"
+        ))
+        .ok()
+        .map(|href| lsp::CodeDescription { href })
+    })
+}
+
+fn clippy_code_description(code: Option<&str>) -> Option<lsp::CodeDescription> {
+    code.and_then(|code| {
+        lsp::Url::parse(&format!(
+            "https://rust-lang.github.io/rust-clippy/master/index.html#{code}"
+        ))
+        .ok()
+        .map(|href| lsp::CodeDescription { href })
+    })
+}
+
+/// Determines the LSP severity from a diagnostic
+fn diagnostic_severity(level: DiagnosticLevel) -> Option<lsp::DiagnosticSeverity> {
+    let res = match level {
+        DiagnosticLevel::Ice => lsp::DiagnosticSeverity::ERROR,
+        DiagnosticLevel::Error => lsp::DiagnosticSeverity::ERROR,
+        DiagnosticLevel::Warning => lsp::DiagnosticSeverity::WARNING,
+        DiagnosticLevel::Note => lsp::DiagnosticSeverity::INFORMATION,
+        DiagnosticLevel::Help => lsp::DiagnosticSeverity::HINT,
+        _ => return None,
+    };
+    Some(res)
+}
+
+enum MappedRustChildDiagnostic {
+    SubDiagnostic(lsp::DiagnosticRelatedInformation),
+    MessageLine(String),
+}
+
+fn map_rust_child_diagnostic(
+    worktree_root: &Path,
+    cargo_diagnostic: &CargoDiagnostic,
+) -> MappedRustChildDiagnostic {
+    let spans: Vec<&DiagnosticSpan> = cargo_diagnostic
+        .spans
+        .iter()
+        .filter(|s| s.is_primary)
+        .collect();
+    if spans.is_empty() {
+        // `rustc` uses these spanless children as a way to print multi-line
+        // messages
+        return MappedRustChildDiagnostic::MessageLine(cargo_diagnostic.message.clone());
+    }
+
+    let mut edit_map: HashMap<lsp::Url, Vec<lsp::TextEdit>> = HashMap::default();
+    let mut suggested_replacements = Vec::new();
+    for &span in &spans {
+        if let Some(suggested_replacement) = &span.suggested_replacement {
+            if !suggested_replacement.is_empty() {
+                suggested_replacements.push(suggested_replacement);
+            }
+            let location = location(worktree_root, span);
+            let edit = lsp::TextEdit::new(location.range, suggested_replacement.clone());
+
+            // Only actually emit a quickfix if the suggestion is "valid enough".
+            // We accept both "MaybeIncorrect" and "MachineApplicable". "MaybeIncorrect" means that
+            // the suggestion is *complete* (contains no placeholders where code needs to be
+            // inserted), but might not be what the user wants, or might need minor adjustments.
+            if matches!(
+                span.suggestion_applicability,
+                None | Some(Applicability::MaybeIncorrect | Applicability::MachineApplicable)
+            ) {
+                edit_map.entry(location.uri).or_default().push(edit);
+            }
+        }
+    }
+
+    // rustc renders suggestion diagnostics by appending the suggested replacement, so do the same
+    // here, otherwise the diagnostic text is missing useful information.
+    let mut message = cargo_diagnostic.message.clone();
+    if !suggested_replacements.is_empty() {
+        message.push_str(": ");
+        let suggestions = suggested_replacements
+            .iter()
+            .map(|suggestion| format!("`{suggestion}`"))
+            .join(", ");
+        message.push_str(&suggestions);
+    }
+
+    MappedRustChildDiagnostic::SubDiagnostic(lsp::DiagnosticRelatedInformation {
+        location: location(worktree_root, spans[0]),
+        message,
+    })
+}
+
+/// Converts a Rust span to a LSP location
+fn location(worktree_root: &Path, span: &DiagnosticSpan) -> lsp::Location {
+    let file_name = worktree_root.join(&span.file_name);
+    let uri = url_from_abs_path(&file_name);
+
+    let range = {
+        lsp::Range::new(
+            position(span, span.line_start, span.column_start.saturating_sub(1)),
+            position(span, span.line_end, span.column_end.saturating_sub(1)),
+        )
+    };
+    lsp::Location::new(uri, range)
+}
+
+/// Returns a `Url` object from a given path, will lowercase drive letters if present.
+/// This will only happen when processing windows paths.
+///
+/// When processing non-windows path, this is essentially the same as `Url::from_file_path`.
+pub(crate) fn url_from_abs_path(path: &Path) -> lsp::Url {
+    let url = lsp::Url::from_file_path(path).unwrap();
+    match path.components().next() {
+        Some(Component::Prefix(prefix))
+            if matches!(prefix.kind(), Prefix::Disk(_) | Prefix::VerbatimDisk(_)) =>
+        {
+            // Need to lowercase driver letter
+        }
+        _ => return url,
+    }
+
+    let driver_letter_range = {
+        let (scheme, drive_letter, _rest) = match url.as_str().splitn(3, ':').collect_tuple() {
+            Some(it) => it,
+            None => return url,
+        };
+        let start = scheme.len() + ':'.len_utf8();
+        start..(start + drive_letter.len())
+    };
+
+    // Note: lowercasing the `path` itself doesn't help, the `Url::parse`
+    // machinery *also* canonicalizes the drive letter. So, just massage the
+    // string in place.
+    let mut url: String = url.into();
+    url[driver_letter_range].make_ascii_lowercase();
+    lsp::Url::parse(&url).unwrap()
+}
+
+fn position(
+    span: &DiagnosticSpan,
+    line_number: usize,
+    column_offset_utf32: usize,
+) -> lsp::Position {
+    let line_index = line_number - span.line_start;
+
+    let column_offset_encoded = match span.text.get(line_index) {
+        // Fast path.
+        Some(line) if line.text.is_ascii() => column_offset_utf32,
+        Some(line) => {
+            let line_prefix_len = line
+                .text
+                .char_indices()
+                .take(column_offset_utf32)
+                .last()
+                .map(|(pos, c)| pos + c.len_utf8())
+                .unwrap_or(0);
+            let line_prefix = &line.text[..line_prefix_len];
+            line_prefix.len()
+        }
+        None => column_offset_utf32,
+    };
+
+    lsp::Position {
+        line: (line_number as u32).saturating_sub(1),
+        character: column_offset_encoded as u32,
+    }
+}
+
+/// Checks whether a file name is from macro invocation and does not refer to an actual file.
+fn is_dummy_macro_file(file_name: &str) -> bool {
+    // FIXME: current rustc does not seem to emit `<macro file>` files anymore?
+    file_name.starts_with('<') && file_name.ends_with('>')
+}
+
+/// Extracts a suitable "primary" location from a rustc diagnostic.
+///
+/// This takes locations pointing into the standard library, or generally outside the current
+/// workspace into account and tries to avoid those, in case macros are involved.
+fn primary_location(worktree_root: &Path, span: &DiagnosticSpan) -> lsp::Location {
+    let span_stack = std::iter::successors(Some(span), |span| Some(&span.expansion.as_ref()?.span));
+    for span in span_stack.clone() {
+        let abs_path = worktree_root.join(&span.file_name);
+        if !is_dummy_macro_file(&span.file_name) && abs_path.starts_with(worktree_root) {
+            return location(worktree_root, span);
+        }
+    }
+
+    // Fall back to the outermost macro invocation if no suitable span comes up.
+    let last_span = span_stack.last().unwrap();
+    location(worktree_root, last_span)
 }

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -13,7 +13,7 @@ use gpui::{AppContext, Entity, Task};
 use itertools::Itertools as _;
 use language::Diagnostic;
 use project::{
-    Worktree, lsp_store::rust_analyzer_ext::ZED_CARGO_DIAGNOSTICS_SOURCE_NAME,
+    Worktree, lsp_store::rust_analyzer_ext::CARGO_DIAGNOSTICS_SOURCE_NAME,
     project_settings::ProjectSettings,
 };
 use serde::{Deserialize, Serialize};
@@ -165,8 +165,7 @@ pub fn is_outdated_cargo_fetch_diagnostic(diagnostic: &Diagnostic) -> bool {
     if let Some(data) = diagnostic
         .data
         .clone()
-        .map(|data| serde_json::from_value::<CargoFetchDiagnosticData>(data).ok())
-        .flatten()
+        .and_then(|data| serde_json::from_value::<CargoFetchDiagnosticData>(data).ok())
     {
         let current_generation = CARGO_DIAGNOSTICS_FETCH_GENERATION.load(atomic::Ordering::Acquire);
         data.generation < current_generation
@@ -202,7 +201,7 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
 
     let severity = diagnostic_severity(cargo_diagnostic.level);
 
-    let mut source = String::from(ZED_CARGO_DIAGNOSTICS_SOURCE_NAME);
+    let mut source = String::from(CARGO_DIAGNOSTICS_SOURCE_NAME);
     let mut code = cargo_diagnostic.code.as_ref().map(|c| c.code.clone());
 
     if let Some(code_val) = &code {

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -12,7 +12,10 @@ use collections::HashMap;
 use gpui::{AppContext, Entity, Task};
 use itertools::Itertools as _;
 use language::Diagnostic;
-use project::{Worktree, project_settings::ProjectSettings};
+use project::{
+    Worktree, lsp_store::rust_analyzer_ext::ZED_CARGO_DIAGNOSTICS_SOURCE_NAME,
+    project_settings::ProjectSettings,
+};
 use serde::{Deserialize, Serialize};
 use settings::Settings;
 use smol::{
@@ -166,11 +169,10 @@ pub fn is_outdated_cargo_fetch_diagnostic(diagnostic: &Diagnostic) -> bool {
         .flatten()
     {
         let current_generation = CARGO_DIAGNOSTICS_FETCH_GENERATION.load(atomic::Ordering::Acquire);
-        data.generation < dbg!(current_generation)
+        data.generation < current_generation
     } else {
         false
     }
-    //
 }
 
 /// Converts a Rust root diagnostic to LSP form
@@ -200,7 +202,7 @@ pub(crate) fn map_rust_diagnostic_to_lsp(
 
     let severity = diagnostic_severity(cargo_diagnostic.level);
 
-    let mut source = String::from("rustc");
+    let mut source = String::from(ZED_CARGO_DIAGNOSTICS_SOURCE_NAME);
     let mut code = cargo_diagnostic.code.as_ref().map(|c| c.code.clone());
 
     if let Some(code_val) = &code {

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -43,8 +43,8 @@ macro_rules! format_to {
     };
 }
 
-pub fn worktrees_for_diagnostics_fetch(
-    editor: Entity<ProjectDiagnosticsEditor>,
+pub fn cargo_diagnostics_sources(
+    editor: &ProjectDiagnosticsEditor,
     cx: &App,
 ) -> Vec<Entity<Worktree>> {
     let fetch_cargo_diagnostics = ProjectSettings::get_global(cx)
@@ -54,7 +54,6 @@ pub fn worktrees_for_diagnostics_fetch(
         return Vec::new();
     }
     editor
-        .read(cx)
         .project
         .read(cx)
         .worktrees(cx)

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -87,7 +87,7 @@ pub fn fetch_worktree_diagnostics(
         .diagnostics
         .cargo
         .as_ref()
-        .filter(|settings| settings.fetch_cargo_diagnostics)?;
+        .filter(|cargo_diagnostics| cargo_diagnostics.fetch_cargo_diagnostics)?;
     let command_string = diagnostics_settings
         .diagnostics_fetch_command
         .iter()

--- a/crates/diagnostics/src/cargo.rs
+++ b/crates/diagnostics/src/cargo.rs
@@ -581,7 +581,6 @@ fn position(
 
 /// Checks whether a file name is from macro invocation and does not refer to an actual file.
 fn is_dummy_macro_file(file_name: &str) -> bool {
-    // FIXME: current rustc does not seem to emit `<macro file>` files anymore?
     file_name.starts_with('<') && file_name.ends_with('>')
 }
 

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -1,4 +1,5 @@
 pub mod items;
+mod rust;
 mod toolbar_controls;
 
 mod diagnostic_renderer;
@@ -68,6 +69,7 @@ pub(crate) struct ProjectDiagnosticsEditor {
     paths_to_update: BTreeSet<ProjectPath>,
     include_warnings: bool,
     update_excerpts_task: Option<Task<Result<()>>>,
+    cargo_diagnostics_task: Option<Task<()>>,
     _subscription: Subscription,
 }
 
@@ -229,6 +231,7 @@ impl ProjectDiagnosticsEditor {
             editor,
             paths_to_update: Default::default(),
             update_excerpts_task: None,
+            cargo_diagnostics_task: None,
             _subscription: project_event_subscription,
         };
         this.update_all_excerpts(window, cx);
@@ -239,11 +242,6 @@ impl ProjectDiagnosticsEditor {
         if self.update_excerpts_task.is_some() {
             return;
         }
-
-        let zed_provides_cargo_diagnostics = ProjectSettings::get_global(cx)
-            .diagnostics
-            .fetch_cargo_diagnostics();
-        dbg!(zed_provides_cargo_diagnostics);
 
         let project_handle = self.project.clone();
         self.update_excerpts_task = Some(cx.spawn_in(window, async move |this, cx| {
@@ -324,6 +322,14 @@ impl ProjectDiagnosticsEditor {
         {
             self.update_stale_excerpts(window, cx);
         }
+    }
+
+    fn fetch_cargo_diagnostics(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.cargo_diagnostics_task =
+            Some(cx.spawn(async move |project_diagnostics_editor, cx| {
+                // TODO kb
+                // diagnostics.update_all_excerpts(window, cx);
+            }));
     }
 
     /// Enqueue an update of all excerpts. Updates all paths that either

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -358,6 +358,7 @@ impl ProjectDiagnosticsEditor {
                 self.update_all_diagnostics(window, cx);
             }
         }
+        cx.notify();
     }
 
     fn focus_in(&mut self, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -37,7 +37,7 @@ use project::{
 use settings::Settings;
 use std::{
     any::{Any, TypeId},
-    cmp,
+    cmp::{self, Ordering},
     ops::{Range, RangeInclusive},
     sync::Arc,
     time::Duration,
@@ -480,6 +480,7 @@ impl ProjectDiagnosticsEditor {
                                                     .binary_search_by(|probe| {
                                                         probe.range.start.cmp(&diagnostic.range.start)
                                                             .then(probe.range.end.cmp(&diagnostic.range.end))
+                                                            .then(Ordering::Greater)
                                                     })
                                                     .unwrap_or_else(|i| i);
                                                 file_diagnostics.insert(i, diagnostic);
@@ -779,6 +780,7 @@ impl ProjectDiagnosticsEditor {
                                 .start
                                 .cmp(&item.initial_range.start)
                                 .then(probe.initial_range.end.cmp(&item.initial_range.end))
+                                .then(Ordering::Greater)
                         })
                         .unwrap_or_else(|i| i);
                     blocks.insert(i, item);
@@ -801,6 +803,9 @@ impl ProjectDiagnosticsEditor {
                             .start
                             .cmp(&excerpt_range.start)
                             .then(probe.context.end.cmp(&excerpt_range.end))
+                            .then(probe.primary.start.cmp(&b.initial_range.start))
+                            .then(probe.primary.end.cmp(&b.initial_range.end))
+                            .then(cmp::Ordering::Greater)
                     })
                     .unwrap_or_else(|i| i);
                 excerpt_ranges.insert(

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -239,6 +239,12 @@ impl ProjectDiagnosticsEditor {
         if self.update_excerpts_task.is_some() {
             return;
         }
+
+        let zed_provides_cargo_diagnostics = ProjectSettings::get_global(cx)
+            .diagnostics
+            .fetch_cargo_diagnostics();
+        dbg!(zed_provides_cargo_diagnostics);
+
         let project_handle = self.project.clone();
         self.update_excerpts_task = Some(cx.spawn_in(window, async move |this, cx| {
             cx.background_executor()

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -1,5 +1,5 @@
+mod cargo;
 pub mod items;
-mod rust;
 mod toolbar_controls;
 
 mod diagnostic_renderer;

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -465,7 +465,7 @@ impl ProjectDiagnosticsEditor {
                                                                         version: None,
                                                                     },
                                                                     &[],
-                                                                    |diagnostic| {
+                                                                    |diagnostic, _| {
                                                                         !is_outdated_cargo_fetch_diagnostic(diagnostic)
                                                                     },
                                                                     cx,
@@ -473,7 +473,6 @@ impl ProjectDiagnosticsEditor {
                                                                 }
                                                                 anyhow::Ok(())
                                                             })?;
-                                                        // TODO kb old cargo diagnostics are removed
                                                         editor.update_all_excerpts(window, cx);
                                                         anyhow::Ok(())
                                                     })

--- a/crates/diagnostics/src/rust.rs
+++ b/crates/diagnostics/src/rust.rs
@@ -1,0 +1,120 @@
+use std::{path::Path, process::Stdio, sync::Arc};
+
+use gpui::{AppContext, Task};
+use itertools::Itertools as _;
+use project::project_settings::ProjectSettings;
+use serde::Deserialize as _;
+use settings::Settings;
+use smol::{
+    channel::Receiver,
+    io::{AsyncBufReadExt, BufReader},
+    process::Command,
+};
+use ui::App;
+use util::ResultExt;
+
+use cargo_metadata::{Artifact, Message, PackageId, diagnostic::Diagnostic};
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(untagged)]
+enum JsonMessage {
+    Cargo(Message),
+    Rustc(Diagnostic),
+}
+
+#[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
+pub enum CargoCheckMessage {
+    CompilerArtifact(Artifact),
+    Diagnostic {
+        diagnostic: Diagnostic,
+        package_id: Option<Arc<PackageId>>,
+    },
+}
+
+pub fn fetch_cargo_diagnostics(
+    cwd: &Path,
+    cx: &App,
+) -> Option<(Task<()>, Receiver<CargoCheckMessage>)> {
+    let diagnostics_settings = ProjectSettings::get_global(cx)
+        .diagnostics
+        .rust
+        .as_ref()
+        .filter(|settings| settings.fetch_cargo_diagnostics)?;
+    let command_string = diagnostics_settings
+        .diagnostics_fetch_command
+        .iter()
+        .join(" ");
+    let mut command_parts = diagnostics_settings.diagnostics_fetch_command.iter();
+    let mut command = Command::new(command_parts.next()?)
+        .args(command_parts)
+        .envs(diagnostics_settings.env.clone())
+        .current_dir(cwd)
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .log_err()?;
+
+    let stdout = command.stdout.take()?;
+    let mut reader = BufReader::new(stdout);
+    let (tx, rx) = smol::channel::unbounded();
+    let error_threshold = 10;
+
+    let cargo_diagnostics_fetch_task = cx.background_spawn(async move {
+        let mut errors = 0;
+        loop {
+            let mut line = String::new();
+            match reader.read_line(&mut line).await {
+                Ok(0) => {
+                    return;
+                },
+                Ok(_) => {
+                    errors = 0;
+                    let mut deserializer = serde_json::Deserializer::from_str(&line);
+                    deserializer.disable_recursion_limit();
+                    let cargo_check_message =
+                        JsonMessage::deserialize(&mut deserializer).map(|json_message| {
+                            match json_message {
+                                JsonMessage::Cargo(message) => match message {
+                                    Message::CompilerArtifact(artifact) if !artifact.fresh => {
+                                        Some(CargoCheckMessage::CompilerArtifact(artifact))
+                                    }
+                                    Message::CompilerMessage(msg) => {
+                                        Some(CargoCheckMessage::Diagnostic {
+                                            diagnostic: msg.message,
+                                            package_id: Some(Arc::new(msg.package_id)),
+                                        })
+                                    }
+                                    _ => None,
+                                },
+                                JsonMessage::Rustc(message) => Some(CargoCheckMessage::Diagnostic {
+                                    diagnostic: message,
+                                    package_id: None,
+                                }),
+                            }
+                        });
+
+                    match cargo_check_message {
+                        Ok(Some(message)) => {
+                            if tx.send(message).await.is_err() {
+                                return;
+                            }
+                        }
+                        Ok(None) => {}
+                        Err(e) => log::error!("Failed to parse cargo diagnostics from line '{line}': {e}"),
+                    };
+                },
+                Err(e) => {
+                    log::error!("Failed to read line from {command_string} command output when fetching cargo diagnostics: {e}");
+                    errors += 1;
+                    if errors >= error_threshold {
+                        log::error!("Failed {error_threshold} times, aborting the diagnostics fetch");
+                        return;
+                    }
+                },
+            }
+        }
+    });
+
+    Some((cargo_diagnostics_fetch_task, rx))
+}

--- a/crates/diagnostics/src/toolbar_controls.rs
+++ b/crates/diagnostics/src/toolbar_controls.rs
@@ -27,7 +27,7 @@ impl Render for ToolbarControls {
             include_warnings = diagnostics.include_warnings;
             has_stale_excerpts = !diagnostics.paths_to_update.is_empty();
             is_updating = diagnostics.update_excerpts_task.is_some()
-                || diagnostics.cargo_diagnostics_fetch.is_some()
+                || diagnostics.cargo_diagnostics_fetch.task.is_some()
                 || diagnostics
                     .project
                     .read(cx)

--- a/crates/diagnostics/src/toolbar_controls.rs
+++ b/crates/diagnostics/src/toolbar_controls.rs
@@ -27,7 +27,7 @@ impl Render for ToolbarControls {
             include_warnings = diagnostics.include_warnings;
             has_stale_excerpts = !diagnostics.paths_to_update.is_empty();
             is_updating = diagnostics.update_excerpts_task.is_some()
-                || diagnostics.cargo_diagnostics_task.is_some()
+                || diagnostics.cargo_diagnostics_fetch.is_some()
                 || diagnostics
                     .project
                     .read(cx)
@@ -63,7 +63,7 @@ impl Render for ToolbarControls {
                             .on_click(cx.listener(move |toolbar_controls, _, _, cx| {
                                 if let Some(diagnostics) = toolbar_controls.diagnostics() {
                                     diagnostics.update(cx, |diagnostics, cx| {
-                                        diagnostics.cargo_diagnostics_task = None;
+                                        diagnostics.stop_cargo_diagnostics_fetch(cx);
                                         diagnostics.update_excerpts_task = None;
                                         cx.notify();
                                     });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2276,6 +2276,9 @@ impl EditorElement {
                     }
 
                     let display_row = multibuffer_point.to_display_point(snapshot).row();
+                    if !range.contains(&display_row) {
+                        return None;
+                    }
                     if row_infos
                         .get((display_row - range.start).0 as usize)
                         .is_some_and(|row_info| row_info.expand_info.is_some())

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -239,6 +239,10 @@ impl CachedLspAdapter {
             .process_diagnostics(params, server_id, existing_diagnostics)
     }
 
+    pub fn retain_old_diagnostic(&self, previous_diagnostic: &Diagnostic, cx: &App) -> bool {
+        self.adapter.retain_old_diagnostic(previous_diagnostic, cx)
+    }
+
     pub fn diagnostic_message_to_markdown(&self, message: &str) -> Option<String> {
         self.adapter.diagnostic_message_to_markdown(message)
     }
@@ -459,6 +463,11 @@ pub trait LspAdapter: 'static + Send + Sync {
         _: LanguageServerId,
         _: Option<&'_ Buffer>,
     ) {
+    }
+
+    /// When processing new `lsp::PublishDiagnosticsParams` diagnostics, whether to retain previous one(s) or not.
+    fn retain_old_diagnostic(&self, _previous_diagnostic: &Diagnostic, _cx: &App) -> bool {
+        false
     }
 
     /// Post-processes completions provided by the language server.

--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -298,9 +298,9 @@ impl super::LspAdapter for CLspAdapter {
         &self,
         params: &mut lsp::PublishDiagnosticsParams,
         server_id: LanguageServerId,
-        buffer_access: Option<&'_ Buffer>,
+        buffer: Option<&'_ Buffer>,
     ) {
-        if let Some(buffer) = buffer_access {
+        if let Some(buffer) = buffer {
             let snapshot = buffer.snapshot();
             let inactive_regions = buffer
                 .get_diagnostics(server_id)

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -8,9 +8,7 @@ use http_client::github::AssetKind;
 use http_client::github::{GitHubLspBinaryVersion, latest_github_release};
 pub use language::*;
 use lsp::{InitializeParams, LanguageServerBinary};
-use project::lsp_store::rust_analyzer_ext::{
-    CARGO_DIAGNOSTICS_SOURCE_NAME, ZED_CARGO_DIAGNOSTICS_SOURCE_NAME,
-};
+use project::lsp_store::rust_analyzer_ext::CARGO_DIAGNOSTICS_SOURCE_NAME;
 use project::project_settings::ProjectSettings;
 use regex::Regex;
 use serde_json::json;
@@ -268,7 +266,7 @@ impl LspAdapter for RustLspAdapter {
             .fetch_cargo_diagnostics();
         // Zed manages the lifecycle of cargo diagnostics when configured so.
         zed_provides_cargo_diagnostics
-            && previous_diagnostic.source.as_deref() == Some(ZED_CARGO_DIAGNOSTICS_SOURCE_NAME)
+            && previous_diagnostic.source.as_deref() == Some(CARGO_DIAGNOSTICS_SOURCE_NAME)
     }
 
     fn process_diagnostics(

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -499,12 +499,31 @@ impl LspAdapter for RustLspAdapter {
                     "kinds": [ "cargo", "shell" ],
                 },
             });
-            if let Some(ref mut original_experimental) = original.capabilities.experimental {
+            if let Some(original_experimental) = &mut original.capabilities.experimental {
                 merge_json_value_into(experimental, original_experimental);
             } else {
                 original.capabilities.experimental = Some(experimental);
             }
         }
+
+        let zed_provides_rustc_diagnostics = ProjectSettings::get_global(cx)
+            .diagnostics
+            .rust
+            .as_ref()
+            .map_or(false, |rust_diagnostics| {
+                rust_diagnostics.fetch_cargo_diagnostics
+            });
+        if zed_provides_rustc_diagnostics {
+            let disable_check_on_save = json!({
+                "checkOnSave": false,
+            });
+            if let Some(initialization_options) = &mut original.initialization_options {
+                merge_json_value_into(disable_check_on_save, initialization_options);
+            } else {
+                original.initialization_options = Some(disable_check_on_save);
+            }
+        }
+
         Ok(original)
     }
 }

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -506,14 +506,10 @@ impl LspAdapter for RustLspAdapter {
             }
         }
 
-        let zed_provides_rustc_diagnostics = ProjectSettings::get_global(cx)
+        let zed_provides_cargo_diagnostics = ProjectSettings::get_global(cx)
             .diagnostics
-            .rust
-            .as_ref()
-            .map_or(false, |rust_diagnostics| {
-                rust_diagnostics.fetch_cargo_diagnostics
-            });
-        if zed_provides_rustc_diagnostics {
+            .fetch_cargo_diagnostics();
+        if zed_provides_cargo_diagnostics {
             let disable_check_on_save = json!({
                 "checkOnSave": false,
             });

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -1686,7 +1686,10 @@ impl MultiBuffer {
         let mut counts: Vec<usize> = Vec::new();
         for range in expanded_ranges {
             if let Some(last_range) = merged_ranges.last_mut() {
-                debug_assert!(last_range.context.start <= range.context.start);
+                debug_assert!(
+                    last_range.context.start <= range.context.start,
+                    "Last range: {last_range:?} Range: {range:?}"
+                );
                 if last_range.context.end >= range.context.start {
                     last_range.context.end = range.context.end.max(last_range.context.end);
                     *counts.last_mut().unwrap() += 1;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6237,6 +6237,13 @@ impl LspStore {
         })
     }
 
+    pub fn language_server_with_name(&self, name: &str, cx: &App) -> Option<LanguageServerId> {
+        self.as_local()?
+            .lsp_tree
+            .read(cx)
+            .server_id_for_name(&LanguageServerName::from(name))
+    }
+
     pub fn language_servers_for_local_buffer<'a>(
         &'a self,
         buffer: &Buffer,
@@ -7021,27 +7028,38 @@ impl LspStore {
         envelope: TypedEnvelope<proto::LanguageServerIdForName>,
         mut cx: AsyncApp,
     ) -> Result<proto::LanguageServerIdForNameResponse> {
-        let buffer_id = BufferId::new(envelope.payload.buffer_id)?;
         let name = &envelope.payload.name;
-        lsp_store
-            .update(&mut cx, |lsp_store, cx| {
-                let buffer = lsp_store.buffer_store.read(cx).get_existing(buffer_id)?;
-                let server_id = buffer.update(cx, |buffer, cx| {
-                    lsp_store
-                        .language_servers_for_local_buffer(buffer, cx)
-                        .find_map(|(adapter, server)| {
-                            if adapter.name.0.as_ref() == name {
-                                Some(server.server_id())
-                            } else {
-                                None
-                            }
-                        })
-                });
-                Ok(server_id)
-            })?
-            .map(|server_id| proto::LanguageServerIdForNameResponse {
-                server_id: server_id.map(|id| id.to_proto()),
-            })
+        match envelope.payload.buffer_id {
+            Some(buffer_id) => {
+                let buffer_id = BufferId::new(buffer_id)?;
+                lsp_store
+                    .update(&mut cx, |lsp_store, cx| {
+                        let buffer = lsp_store.buffer_store.read(cx).get_existing(buffer_id)?;
+                        let server_id = buffer.update(cx, |buffer, cx| {
+                            lsp_store
+                                .language_servers_for_local_buffer(buffer, cx)
+                                .find_map(|(adapter, server)| {
+                                    if adapter.name.0.as_ref() == name {
+                                        Some(server.server_id())
+                                    } else {
+                                        None
+                                    }
+                                })
+                        });
+                        Ok(server_id)
+                    })?
+                    .map(|server_id| proto::LanguageServerIdForNameResponse {
+                        server_id: server_id.map(|id| id.to_proto()),
+                    })
+            }
+            None => lsp_store.update(&mut cx, |lsp_store, cx| {
+                proto::LanguageServerIdForNameResponse {
+                    server_id: lsp_store
+                        .language_server_with_name(name, cx)
+                        .map(|id| id.to_proto()),
+                }
+            }),
+        }
     }
 
     async fn handle_rename_project_entry(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3395,7 +3395,7 @@ pub struct LanguageServerStatus {
     pub name: String,
     pub pending_work: BTreeMap<String, LanguageServerProgress>,
     pub has_pending_diagnostic_updates: bool,
-    progress_tokens: HashSet<String>,
+    pub progress_tokens: HashSet<String>,
 }
 
 #[derive(Clone, Debug)]
@@ -7535,7 +7535,7 @@ impl LspStore {
         }
     }
 
-    fn on_lsp_progress(
+    pub fn on_lsp_progress(
         &mut self,
         progress: lsp::ProgressParams,
         language_server_id: LanguageServerId,

--- a/crates/project/src/lsp_store/clangd_ext.rs
+++ b/crates/project/src/lsp_store/clangd_ext.rs
@@ -75,7 +75,7 @@ pub fn register_notifications(
                         server_id,
                         mapped_diagnostics,
                         &adapter.disk_based_diagnostic_sources,
-                        |diag| !is_inactive_region(diag),
+                        |diag, _| !is_inactive_region(diag),
                         cx,
                     )
                     .log_err();

--- a/crates/project/src/lsp_store/rust_analyzer_ext.rs
+++ b/crates/project/src/lsp_store/rust_analyzer_ext.rs
@@ -5,6 +5,8 @@ use lsp::LanguageServer;
 use crate::{LanguageServerPromptRequest, LspStore, LspStoreEvent};
 
 pub const RUST_ANALYZER_NAME: &str = "rust-analyzer";
+pub const CARGO_DIAGNOSTICS_SOURCE_NAME: &str = "rustc";
+pub const ZED_CARGO_DIAGNOSTICS_SOURCE_NAME: &str = "zed_rustc";
 
 /// Experimental: Informs the end user about the state of the server
 ///

--- a/crates/project/src/lsp_store/rust_analyzer_ext.rs
+++ b/crates/project/src/lsp_store/rust_analyzer_ext.rs
@@ -6,7 +6,6 @@ use crate::{LanguageServerPromptRequest, LspStore, LspStoreEvent};
 
 pub const RUST_ANALYZER_NAME: &str = "rust-analyzer";
 pub const CARGO_DIAGNOSTICS_SOURCE_NAME: &str = "rustc";
-pub const ZED_CARGO_DIAGNOSTICS_SOURCE_NAME: &str = "zed_rustc";
 
 /// Experimental: Informs the end user about the state of the server
 ///

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -247,6 +247,20 @@ impl LanguageServerTree {
         self.languages.adapter_for_name(name)
     }
 
+    pub fn server_id_for_name(&self, name: &LanguageServerName) -> Option<LanguageServerId> {
+        self.instances
+            .values()
+            .flat_map(|instance| instance.roots.values())
+            .flatten()
+            .find_map(|(server_name, (data, _))| {
+                if server_name == name {
+                    data.id.get().copied()
+                } else {
+                    None
+                }
+            })
+    }
+
     fn adapters_for_language(
         &self,
         settings_location: SettingsLocation,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -99,7 +99,7 @@ pub enum DirenvSettings {
     Direct,
 }
 
-#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct DiagnosticsSettings {
     /// Whether or not to include warning diagnostics
     #[serde(default = "true_value")]
@@ -108,6 +108,10 @@ pub struct DiagnosticsSettings {
     /// Settings for showing inline diagnostics
     #[serde(default)]
     pub inline: InlineDiagnosticsSettings,
+
+    /// Configuration, related to Rust language diagnostics.
+    #[serde(default)]
+    pub rust: Option<RustDiagnosticsSettings>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
@@ -139,6 +143,41 @@ pub struct InlineDiagnosticsSettings {
 
     #[serde(default)]
     pub max_severity: Option<DiagnosticSeverity>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+pub struct RustDiagnosticsSettings {
+    /// When enabled, Zed runs `cargo check --message-format=json`-based commands and
+    /// collect cargo diagnostics instead of rust-analyzer.
+    ///
+    /// Default: false
+    #[serde(default)]
+    pub fetch_cargo_diagnostics: bool,
+
+    /// A command override for fetching the cargo diagnostics.
+    /// First argument is the command, followed by the arguments.
+    ///
+    /// Default: ["cargo", "check", "--quiet", "--workspace", "--message-format=json", "--all-targets", "--keep-going"]
+    #[serde(default = "default_diagnostics_fetch_command")]
+    pub diagnostics_fetch_command: Vec<String>,
+
+    /// Extra environment variables to pass to the diagnostics fetch command.
+    ///
+    /// Default: {}
+    #[serde(default)]
+    pub env: HashMap<String, String>,
+}
+
+fn default_diagnostics_fetch_command() -> Vec<String> {
+    vec![
+        "cargo".to_string(),
+        "check".to_string(),
+        "--quiet".to_string(),
+        "--workspace".to_string(),
+        "--message-format=json".to_string(),
+        "--all-targets".to_string(),
+        "--keep-going".to_string(),
+    ]
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -116,9 +116,9 @@ pub struct DiagnosticsSettings {
 
 impl DiagnosticsSettings {
     pub fn fetch_cargo_diagnostics(&self) -> bool {
-        self.cargo
-            .as_ref()
-            .map_or(false, |rust| rust.fetch_cargo_diagnostics)
+        self.cargo.as_ref().map_or(false, |cargo_diagnostics| {
+            cargo_diagnostics.fetch_cargo_diagnostics
+        })
     }
 }
 

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -111,12 +111,12 @@ pub struct DiagnosticsSettings {
 
     /// Configuration, related to Rust language diagnostics.
     #[serde(default)]
-    pub rust: Option<RustDiagnosticsSettings>,
+    pub cargo: Option<CargoDiagnosticsSettings>,
 }
 
 impl DiagnosticsSettings {
     pub fn fetch_cargo_diagnostics(&self) -> bool {
-        self.rust
+        self.cargo
             .as_ref()
             .map_or(false, |rust| rust.fetch_cargo_diagnostics)
     }
@@ -154,7 +154,7 @@ pub struct InlineDiagnosticsSettings {
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-pub struct RustDiagnosticsSettings {
+pub struct CargoDiagnosticsSettings {
     /// When enabled, Zed runs `cargo check --message-format=json`-based commands and
     /// collect cargo diagnostics instead of rust-analyzer.
     ///

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -114,6 +114,14 @@ pub struct DiagnosticsSettings {
     pub rust: Option<RustDiagnosticsSettings>,
 }
 
+impl DiagnosticsSettings {
+    pub fn fetch_cargo_diagnostics(&self) -> bool {
+        self.rust
+            .as_ref()
+            .map_or(false, |rust| rust.fetch_cargo_diagnostics)
+    }
+}
+
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 pub struct InlineDiagnosticsSettings {
     /// Whether or not to show inline diagnostics

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -696,7 +696,7 @@ message LspResponse {
 
 message LanguageServerIdForName {
     uint64 project_id = 1;
-    uint64 buffer_id = 2;
+    optional uint64 buffer_id = 2;
     string name = 3;
 }
 


### PR DESCRIPTION
Adjusts the way `cargo` and `rust-analyzer` diagnostics are fetched into Zed.

Nothing is changed for defaults: in this mode, Zed does nothing but reports file updates, which trigger rust-analyzers' 
mechanisms:

* generating internal diagnostics, which it is able to produce on the fly, without blocking cargo lock.
Unfortunately, there are not that many diagnostics in r-a, and some of them have false-positives compared to rustc ones

* running `cargo check --workspace --all-targets` on each file save, taking the cargo lock
For large projects like Zed, this might take a while, reducing the ability to choose how to work with the project: e.g. it's impossible to save multiple times without long diagnostics refreshes (may happen automatically on e.g. focus loss), save the project and run it instantly without waiting for cargo check to finish, etc.

In addition, it's relatively tricky to reconfigure r-a to run a different command, with different arguments and maybe different env vars: that would require a language server restart (and a large project reindex) and fiddling with multiple JSON fields.

The new mode aims to separate out cargo diagnostics into its own loop so that all Zed diagnostics features are supported still.


For that, an extra mode was introduced:

```jsonc
"rust": {
  // When enabled, Zed disables rust-analyzer's check on save and starts to query
  // Cargo diagnostics separately.
  "fetch_cargo_diagnostics": false,
}
```

which calls to cargo, parses its output and mixes in with the existing diagnostics:



https://github.com/user-attachments/assets/e986f955-b452-4995-8aac-3049683dd22c




Release Notes:

- Added a way to get diagnostics from cargo and rust-analyzer without mutually locking each other
- Added `ctrl-r` binding to refresh diagnostics in the project diagnostics editor context
