### PR TITLE
Add setting to hide onboarding banners

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -312,7 +312,9 @@
     // Whether to show the branch icon beside branch switcher in the titlebar.
     "show_branch_icon": false,
     // Whether to show onboarding banners in the titlebar.
-    "show_onboarding_banner": true
+    "show_onboarding_banner": true,
+    // Whether to show user picture in the titlebar.
+    "show_user_picture": true
   },
   // Scrollbar related settings
   "scrollbar": {
@@ -1606,8 +1608,6 @@
   //   "W": "workspace::Save"
   // }
   "command_aliases": {},
-  // Whether to show user picture in titlebar.
-  "show_user_picture": true,
   // ssh_connections is an array of ssh connections.
   // You can configure these from `project: Open Remote` in the command palette.
   // Zed's ssh support will pull configuration from your ~/.ssh too.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -309,8 +309,10 @@
   },
   // Titlebar related settings
   "title_bar": {
-    // Whether to show the branch icon beside branch switcher in the title bar.
-    "show_branch_icon": false
+    // Whether to show the branch icon beside branch switcher in the titlebar.
+    "show_branch_icon": false,
+    // Whether to show onboarding banners in the titlebar.
+    "show_onboarding_banner": true
   },
   // Scrollbar related settings
   "scrollbar": {
@@ -1606,8 +1608,6 @@
   "command_aliases": {},
   // Whether to show user picture in titlebar.
   "show_user_picture": true,
-  // Whether to show onboarding banners in titlebar.
-  "show_onboarding_banner": true,
   // ssh_connections is an array of ssh connections.
   // You can configure these from `project: Open Remote` in the command palette.
   // Zed's ssh support will pull configuration from your ~/.ssh too.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1606,6 +1606,8 @@
   "command_aliases": {},
   // Whether to show user picture in titlebar.
   "show_user_picture": true,
+  // Whether to show onboarding banners in titlebar.
+  "show_onboarding_banner": true,
   // ssh_connections is an array of ssh connections.
   // You can configure these from `project: Open Remote` in the command palette.
   // Zed's ssh support will pull configuration from your ~/.ssh too.

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -726,7 +726,7 @@ impl TitleBar {
                             h_flex()
                                 .gap_0p5()
                                 .children(
-                                    workspace::WorkspaceSettings::get_global(cx)
+                                    TitleBarSettings::get_global(cx)
                                         .show_user_picture
                                         .then(|| Avatar::new(user.avatar_uri.clone())),
                                 )

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -208,7 +208,9 @@ impl Render for TitleBar {
                             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation()),
                     )
                     .child(self.render_collaborator_list(window, cx))
-                    .child(self.banner.clone())
+                    .when(workspace::WorkspaceSettings::get_global(cx).show_onboarding_banner,
+                        |title_bar| title_bar.child(self.banner.clone())
+                    )
                     .child(
                         h_flex()
                             .gap_1()

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -208,8 +208,9 @@ impl Render for TitleBar {
                             .on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation()),
                     )
                     .child(self.render_collaborator_list(window, cx))
-                    .when(workspace::WorkspaceSettings::get_global(cx).show_onboarding_banner,
-                        |title_bar| title_bar.child(self.banner.clone())
+                    .when(
+                        TitleBarSettings::get_global(cx).show_onboarding_banner,
+                        |title_bar| title_bar.child(self.banner.clone()),
                     )
                     .child(
                         h_flex()

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -6,6 +6,7 @@ use settings::{Settings, SettingsSources};
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
 pub struct TitleBarSettings {
     pub show_branch_icon: bool,
+    pub show_onboarding_banner: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -14,6 +15,10 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: false
     pub show_branch_icon: Option<bool>,
+    /// Whether to show onboarding banners in the title bar.
+    ///
+    /// Default: true
+    pub show_onboarding_banner: Option<bool>,
 }
 
 impl Settings for TitleBarSettings {

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -7,6 +7,7 @@ use settings::{Settings, SettingsSources};
 pub struct TitleBarSettings {
     pub show_branch_icon: bool,
     pub show_onboarding_banner: bool,
+    pub show_user_picture: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -19,6 +20,10 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: true
     pub show_onboarding_banner: Option<bool>,
+    /// Whether to show user avatar in the title bar.
+    ///
+    /// Default: true
+    pub show_user_picture: Option<bool>,
 }
 
 impl Settings for TitleBarSettings {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -24,6 +24,7 @@ pub struct WorkspaceSettings {
     pub use_system_prompts: bool,
     pub command_aliases: HashMap<String, String>,
     pub show_user_picture: bool,
+    pub show_onboarding_banner: bool,
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub on_last_window_closed: OnLastWindowClosed,
@@ -193,6 +194,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub show_user_picture: Option<bool>,
+    /// Whether to show onboarding banners in the title bar.
+    ///
+    /// Default: true
+    pub show_onboarding_banner: Option<bool>,
     /// Maximum open tabs in a pane. Will not close an unsaved
     /// tab. Set to `None` for unlimited tabs.
     ///

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -23,7 +23,6 @@ pub struct WorkspaceSettings {
     pub use_system_path_prompts: bool,
     pub use_system_prompts: bool,
     pub command_aliases: HashMap<String, String>,
-    pub show_user_picture: bool,
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub on_last_window_closed: OnLastWindowClosed,
@@ -189,10 +188,6 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub command_aliases: Option<HashMap<String, String>>,
-    /// Whether to show user avatar in the title bar.
-    ///
-    /// Default: true
-    pub show_user_picture: Option<bool>,
     /// Maximum open tabs in a pane. Will not close an unsaved
     /// tab. Set to `None` for unlimited tabs.
     ///

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -24,7 +24,6 @@ pub struct WorkspaceSettings {
     pub use_system_prompts: bool,
     pub command_aliases: HashMap<String, String>,
     pub show_user_picture: bool,
-    pub show_onboarding_banner: bool,
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub on_last_window_closed: OnLastWindowClosed,
@@ -194,10 +193,6 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: true
     pub show_user_picture: Option<bool>,
-    /// Whether to show onboarding banners in the title bar.
-    ///
-    /// Default: true
-    pub show_onboarding_banner: Option<bool>,
     /// Maximum open tabs in a pane. Will not close an unsaved
     /// tab. Set to `None` for unlimited tabs.
     ///


### PR DESCRIPTION
Closes #28637 aka #29219.

Release Notes:

- Added `workspace.title_bar.show_onboarding_banner` preference to hide onboarding banners.
- Relocated `workspace.show_user_picture` preference to `workspace.title_bar.show_user_picture`.