### PR TITLE
editor: Fix context menu capitalization

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -233,7 +233,7 @@ pub fn deploy_context_menu(
                 .separator()
                 .action("Cut", Box::new(Cut))
                 .action("Copy", Box::new(Copy))
-                .action("Copy and trim", Box::new(CopyAndTrim))
+                .action("Copy and Trim", Box::new(CopyAndTrim))
                 .action("Paste", Box::new(Paste))
                 .separator()
                 .map(|builder| {


### PR DESCRIPTION
Fixes context menu capitalization for consistency.

Release Notes:

- N/A