### PR TITLE
Respect cursor_pointer when a ButtonLike is disabled

### DIFF
--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -535,9 +535,15 @@ impl RenderOnce for ButtonLike {
                 ButtonSize::None => this,
             })
             .bg(style.enabled(self.layer, cx).background)
-            .when(self.disabled, |this| this.cursor_not_allowed())
+            .when(self.disabled, |this| {
+                if self.cursor_style == CursorStyle::PointingHand {
+                    this.cursor_not_allowed()
+                } else {
+                    this.cursor(self.cursor_style)
+                }
+            })
             .when(!self.disabled, |this| {
-                this.cursor_pointer()
+                this.cursor(self.cursor_style)
                     .hover(|hover| hover.bg(style.hovered(self.layer, cx).background))
                     .active(|active| active.bg(style.active(cx).background))
             })


### PR DESCRIPTION
This is desirable for when we want to use a `ButtonLike` to show a tooltip over an icon, and we don't want it to show the "not allowed" cursor on hover.

Release Notes:

- N/A
