### PR TITLE
collab: Add `use_new_billing` to `LlmTokenClaims`

### DIFF
--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -32,6 +32,8 @@ pub struct LlmTokenClaims {
     pub has_llm_subscription: bool,
     pub max_monthly_spend_in_cents: u32,
     pub custom_llm_monthly_allowance_in_cents: Option<u32>,
+    #[serde(default)]
+    pub use_new_billing: bool,
     pub plan: Plan,
     #[serde(default)]
     pub has_extended_trial: bool,
@@ -90,6 +92,7 @@ impl LlmTokenClaims {
             custom_llm_monthly_allowance_in_cents: user
                 .custom_llm_monthly_allowance_in_cents
                 .map(|allowance| allowance as u32),
+            use_new_billing: feature_flags.iter().any(|flag| flag == "new-billing"),
             plan: subscription
                 .as_ref()
                 .and_then(|subscription| subscription.kind)


### PR DESCRIPTION
This PR adds a `use_new_billing` field to the LLM token claims, based on the `new-billing` feature flag.

Release Notes:

- N/A
