### PR TITLE
Make context pills clickable while editing

### DIFF
--- a/crates/agent/src/ui/context_pill.rs
+++ b/crates/agent/src/ui/context_pill.rs
@@ -216,9 +216,10 @@ impl RenderOnce for ContextPill {
                     })
                     .when_some(on_click.as_ref(), |element, on_click| {
                         let on_click = on_click.clone();
-                        element
-                            .cursor_pointer()
-                            .on_click(move |event, window, cx| on_click(event, window, cx))
+                        element.cursor_pointer().on_click(move |event, window, cx| {
+                            on_click(event, window, cx);
+                            cx.stop_propagation();
+                        })
                     })
                     .into_any_element()
             }
@@ -254,7 +255,10 @@ impl RenderOnce for ContextPill {
                 })
                 .when_some(on_click.as_ref(), |element, on_click| {
                     let on_click = on_click.clone();
-                    element.on_click(move |event, window, cx| on_click(event, window, cx))
+                    element.on_click(move |event, window, cx| {
+                        on_click(event, window, cx);
+                        cx.stop_propagation();
+                    })
                 })
                 .into_any(),
         }


### PR DESCRIPTION
Release Notes:

- Fixed a bug where clicking context pills switched into the "editing message" state instead of clicking the pill.
