### PR TITLE
Improve system prompt when no tools are enabled

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -8,6 +8,7 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 4. NEVER lie or make things up.
 5. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain the circumstances to the user without apologizing.
 
+{{#if has_tools}}
 ## Tool Use
 
 1. Make sure to adhere to the tools schema.
@@ -16,12 +17,14 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 4. Use only the tools that are currently available.
 5. DO NOT use a tool that is not available just because it appears in the conversation. This means the user turned it off.
 6. NEVER run commands that don't terminate on their own such as web servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers.
+{{/if}}
 
 ## Searching and Reading
 
-If you are unsure how to fulfill the user's request, gather more information with tool calls and/or clarifying questions.
+If you are unsure how to fulfill the user's request, gather more information with {{#if has_tools}}tool calls and/or {{/if}}clarifying questions.
 
 {{! TODO: If there are files, we should mention it but otherwise omit that fact }}
+{{#if has_tools}}
 If appropriate, use tool calls to explore the current project, which contains the following root directories:
 
 {{#each worktrees}}
@@ -35,6 +38,7 @@ If appropriate, use tool calls to explore the current project, which contains th
 - When looking for symbols in the project, prefer the `grep` tool.
 - As you learn about the structure of the project, use that information to scope `grep` searches to targeted subtrees of the project.
 - The user might specify a partial file path. If you don't know the full path, use `find_path` (not `grep`) before you read the file.
+{{/if}}
 {{/if}}
 
 ## Code Block Formatting
@@ -138,7 +142,7 @@ Default Shell: {{shell}}
 {{#if (or has_rules has_default_user_rules)}}
 ## User's Custom Instructions
 
-The following additional instructions are provided by the user, and should be followed to the best of your ability without interfering with the tool use guidelines.
+The following additional instructions are provided by the user, and should be followed to the best of your ability{{#if has_tools}} without interfering with the tool use guidelines{{/if}}.
 
 {{#if has_rules}}
 There are project rules that apply to these root directories:

--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -3,7 +3,7 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 ## Communication
 
 1. Be conversational but professional.
-2. Refer to the USER in the second person and yourself in the first person.
+2. Refer to the user in the second person and yourself in the first person.
 3. Format your responses in markdown. Use backticks to format file, directory, function, and class names.
 4. NEVER lie or make things up.
 5. Refrain from apologizing all the time when results are unexpected. Instead, just try your best to proceed or explain the circumstances to the user without apologizing.
@@ -17,11 +17,10 @@ You are a highly skilled software engineer with extensive knowledge in many prog
 4. Use only the tools that are currently available.
 5. DO NOT use a tool that is not available just because it appears in the conversation. This means the user turned it off.
 6. NEVER run commands that don't terminate on their own such as web servers (like `npm run start`, `npm run dev`, `python -m http.server`, etc) or file watchers.
-{{/if}}
 
 ## Searching and Reading
 
-If you are unsure how to fulfill the user's request, gather more information with {{#if has_tools}}tool calls and/or {{/if}}clarifying questions.
+If you are unsure how to fulfill the user's request, gather more information with tool calls and/or clarifying questions.
 
 {{! TODO: If there are files, we should mention it but otherwise omit that fact }}
 {{#if has_tools}}
@@ -38,6 +37,7 @@ If appropriate, use tool calls to explore the current project, which contains th
 - When looking for symbols in the project, prefer the `grep` tool.
 - As you learn about the structure of the project, use that information to scope `grep` searches to targeted subtrees of the project.
 - The user might specify a partial file path. If you don't know the full path, use `find_path` (not `grep`) before you read the file.
+{{/if}}
 {{/if}}
 {{/if}}
 
@@ -115,6 +115,8 @@ In Markdown, hash marks signify headings. For example:
 ```
 </bad_example_do_not_do_this>
 This example is unacceptable because the path is in the wrong place. The path must be directly after the opening backticks.
+
+{{#if has_tools}}
 ## Fixing Diagnostics
 
 1. Make 1-2 attempts at fixing diagnostics, then defer to the user.
@@ -128,10 +130,11 @@ Otherwise, follow debugging best practices:
 2. Add descriptive logging statements and error messages to track variable and code state.
 3. Add test functions and statements to isolate the problem.
 
+{{/if}}
 ## Calling External APIs
 
 1. Unless explicitly requested by the user, use the best suited external APIs and packages to solve the task. There is no need to ask the user for permission.
-2. When selecting which version of an API or package to use, choose one that is compatible with the user's dependency management file. If no such file exists or if the package is not present, use the latest version that is in your training data.
+2. When selecting which version of an API or package to use, choose one that is compatible with the user's dependency management file(s). If no such file exists or if the package is not present, use the latest version that is in your training data.
 3. If an external API requires an API Key, be sure to point this out to the user. Adhere to best security practices (e.g. DO NOT hardcode an API key in a place where it can be exposed)
 
 ## System Information

--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -39,6 +39,12 @@ If appropriate, use tool calls to explore the current project, which contains th
 - The user might specify a partial file path. If you don't know the full path, use `find_path` (not `grep`) before you read the file.
 {{/if}}
 {{/if}}
+{{else}}
+You are being tasked with providing a response, but you have no ability to use tools or to read or write any aspect of the user's system (other than any context the user might have provided to you).
+
+As such, if you need the user to perform any actions for you, you must request them explicitly. Bias towards giving a response to the best of your ability, and then making requests for the user to take action (e.g. to give you more context) only optionally.
+
+The one exception to this is if the user references something you don't know about - for example, the name of a source code file, function, type, or other piece of code that you have no awareness of. In this case, you MUST NOT MAKE SOMETHING UP, or assume you know what that thing is or how it works. Instead, you must ask the user for clarification rather than giving a response.
 {{/if}}
 
 ## Code Block Formatting

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -843,7 +843,7 @@ pub fn load_context(
         text.push_str(
             "\n<context>\n\
             The following items were attached by the user. \
-            You don't need to use other tools to read them.\n\n",
+            They are up-to-date and don't need to be re-read.\n\n",
         );
 
         if !file_context.is_empty() {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2509,7 +2509,7 @@ mod tests {
         let expected_context = format!(
             r#"
 <context>
-The following items were attached by the user. You don't need to use other tools to read them.
+The following items were attached by the user. They are up-to-date and don't need to be re-read.
 
 <files>
 ```rs {path_part}

--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -60,6 +60,8 @@ struct PromptTemplateContext {
 
     #[serde(flatten)]
     model: ModelContext,
+    
+    has_tools: bool,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -328,6 +330,7 @@ impl PromptBuilder {
         let template_context = PromptTemplateContext {
             project: context.clone(),
             model: model_context.clone(),
+            has_tools: !model_context.available_tools.is_empty(),
         };
 
         self.handlebars

--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -60,7 +60,7 @@ struct PromptTemplateContext {
 
     #[serde(flatten)]
     model: ModelContext,
-    
+
     has_tools: bool,
 }
 


### PR DESCRIPTION
Now instead of the model hallucinating tool calls, we get requests for more context:

<img width="620" alt="Screenshot 2025-05-01 at 12 45 49 PM" src="https://github.com/user-attachments/assets/847d5c14-82f6-4234-b85a-8cd2bc7ab11d" />

It still knows how to answer general questions:
<img width="624" alt="Screenshot 2025-05-01 at 12 47 44 PM" src="https://github.com/user-attachments/assets/43ab0fc3-4cc8-452f-b26b-474b5d31919f" />

Release Notes:

- Fixed the model still trying to do tool calls when no tools selected (e.g. in `Manual` profile).