### PR TITLE
Allow MIT-0 license in checks

### DIFF
--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -3,6 +3,7 @@ private = { ignore = true }
 accepted = [
     "Apache-2.0",
     "MIT",
+    "MIT-0",
     "Apache-2.0 WITH LLVM-exception",
     "MPL-2.0",
     "BSD-3-Clause",


### PR DESCRIPTION
Part of #29309

The license is on par with other licenses in the list: https://github.com/aws/mit-0

Release Notes:

- N/A