### PR TITLE
Fix user rules ignored by agent

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -135,7 +135,7 @@ Otherwise, follow debugging best practices:
 Operating System: {{os}}
 Default Shell: {{shell}}
 
-{{#if (or has_rules has_default_user_rules)}}
+{{#if (or has_rules has_user_rules)}}
 ## User's Custom Instructions
 
 The following additional instructions are provided by the user, and should be followed to the best of your ability without interfering with the tool use guidelines.


### PR DESCRIPTION
Closes #29753

The template contains an error: `has_default_user_rules` is always undefined and should be `has_user_rules` instead.

Release Notes:

- Fixed default user rules ignored during prompt building.