### PR TITLE
agent: Render the max mode toggle using a muted color

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -428,6 +428,7 @@ impl MessageEditor {
         Some(
             IconButton::new("max-mode", IconName::ZedMaxMode)
                 .icon_size(IconSize::Small)
+                .icon_color(Color::Muted)
                 .toggle_state(active_completion_mode == Some(CompletionMode::Max))
                 .on_click(cx.listener(move |this, _event, _window, cx| {
                     this.thread.update(cx, |thread, _cx| {


### PR DESCRIPTION
This PR updates the max mode toggle to use the muted color.

This makes it fit in more with the rest of the controls.

<img width="243" alt="Screenshot 2025-05-01 at 5 24 01 PM" src="https://github.com/user-attachments/assets/57267d29-3c7b-4ea9-b6b9-81c42f6b7e1c" />

Release Notes:

- agent: Adjusted the color of the max mode toggle.
