### PR TITLE
agent: Do not render unnecessary lines in edit file tool card

### DIFF
--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -576,13 +576,10 @@ impl ToolCard for EditFileToolCard {
                 card.child(
                     v_flex()
                         .relative()
-                        .map(|editor_container| {
-                            if self.full_height_expanded {
-                                editor_container.h_full()
-                            } else {
-                                editor_container
-                                    .h(DEFAULT_COLLAPSED_LINES as f32 * editor_line_height)
-                            }
+                        .h_full()
+                        .when(!self.full_height_expanded, |editor_container| {
+                            editor_container
+                                .max_h(DEFAULT_COLLAPSED_LINES as f32 * editor_line_height)
                         })
                         .overflow_hidden()
                         .border_t_1()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6871,7 +6871,12 @@ impl Element for EditorElement {
                     // The max scroll position for the top of the window
                     let max_scroll_top = if matches!(
                         snapshot.mode,
-                        EditorMode::AutoHeight { .. } | EditorMode::SingleLine { .. }
+                        EditorMode::SingleLine { .. }
+                            | EditorMode::AutoHeight { .. }
+                            | EditorMode::Full {
+                                sized_by_content: true,
+                                ..
+                            }
                     ) {
                         (max_row - height_in_lines + 1.).max(0.)
                     } else {


### PR DESCRIPTION
This PR prevents any unnecessary lines from being rendered in the edit file tool card in the case of small diffs.

I think this (hopefully) addresses the last remaining task from https://github.com/zed-industries/zed/pull/29448.

| `main` | This PR |
| --- | --- |
| <img width="634" alt="main" src="https://github.com/user-attachments/assets/7c06394e-957a-4d36-a484-5974687041e9" /> | <img width="634" alt="PR" src="https://github.com/user-attachments/assets/84206d5a-a93a-4a42-99ca-7cdebb0d91bb" /> | 

(The last empty line in the second image is an empty line present in the file itself)

---

n the second commit I also preemtively disabled vertical overscrolling for full mode editors which are sized by content. This is basically the same fix as in https://github.com/zed-industries/zed/pull/28471. Strictly speaking, this is not needed for the fix here, but I thought it might be nice to have for the future to prevent any issues from occuring due to overscroll.

Release Notes:

- agent: Improved rendering of small diffs for the edit file tool card.