### PR TITLE
collab: Add ability to initiate a checkout session for the Zed Free plan

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -256,6 +256,7 @@ async fn list_billing_subscriptions(
 enum ProductCode {
     ZedPro,
     ZedProTrial,
+    ZedFree,
 }
 
 #[derive(Debug, Deserialize)]
@@ -384,6 +385,11 @@ async fn create_billing_subscription(
                     feature_flags,
                     &success_url,
                 )
+                .await?
+        }
+        Some(ProductCode::ZedFree) => {
+            stripe_billing
+                .checkout_with_zed_free(customer_id, &user.github_login, &success_url)
                 .await?
         }
         None => {


### PR DESCRIPTION
This PR adds the ability to initiate a checkout session for the Zed Free plan.

Release Notes:

- N/A
