### PR TITLE
Fix typo in `typos.toml`

### DIFF
--- a/typos.toml
+++ b/typos.toml
@@ -66,7 +66,7 @@ extend-ignore-re = [
     "Big Sur",
     # Not an actual typo but an intentionally invalid color, in `color_extractor`
     "#fof",
-    # Stropped version of reserved keyword `type`
+    # Stripped version of reserved keyword `type`
     "typ"
 ]
 check-filename = true


### PR DESCRIPTION
This PR fixes a typo in `typos.toml`. How ironic.

Release Notes:

- N/A
