### PR TITLE
In helix mode, don't overwrite the selection while pasting

### DIFF
--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -124,7 +124,17 @@ impl Vim {
                     }
 
                     let display_range = if !selection.is_empty() {
-                        selection.start..selection.end
+                        if vim.mode == Mode::HelixNormal {
+                            // Helix doesn't replace the selection while pasting
+                            let point = if before {
+                                selection.start
+                            } else {
+                                selection.end
+                            };
+                            point..point
+                        } else {
+                            selection.start..selection.end
+                        }
                     } else if line_mode {
                         let point = if before {
                             movement::line_beginning(&display_map, selection.start, false)


### PR DESCRIPTION
Release Notes:

- Improves paste in Helix mode, by not overwriting the current selection