### PR TITLE
Fix tasks not being stopped on reruns

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -6,7 +6,7 @@ use crate::{
     persistence,
 };
 use crate::{new_session_modal::NewSessionModal, session::DebugSession};
-use anyhow::{Result, anyhow};
+use anyhow::{Context as _, Result, anyhow};
 use collections::{HashMap, HashSet};
 use command_palette_hooks::CommandPaletteFilter;
 use dap::DebugRequest;
@@ -500,7 +500,7 @@ impl DebugPanel {
                     workspace.spawn_in_terminal(task.resolved.clone(), window, cx)
                 })?;
 
-                let exit_status = run_build.await?;
+                let exit_status = run_build.await.transpose()?.context("task cancelled")?;
                 if !exit_status.success() {
                     anyhow::bail!("Build failed");
                 }

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -46,7 +46,7 @@ use smol::channel::{Receiver, Sender};
 use task::{HideStrategy, Shell, TaskId};
 use terminal_settings::{AlternateScroll, CursorShape, TerminalSettings};
 use theme::{ActiveTheme, Theme};
-use util::{ResultExt, paths::home_dir, truncate_and_trailoff};
+use util::{paths::home_dir, truncate_and_trailoff};
 
 use std::{
     cmp::{self, min},
@@ -1851,8 +1851,7 @@ impl Terminal {
         if let Some(task) = self.task() {
             if task.status == TaskStatus::Running {
                 let completion_receiver = task.completion_rx.clone();
-                return cx
-                    .spawn(async move |_| completion_receiver.recv().await.log_err().flatten());
+                return cx.spawn(async move |_| completion_receiver.recv().await.ok().flatten());
             } else if let Ok(status) = task.completion_rx.try_recv() {
                 return Task::ready(status);
             }

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -1466,9 +1466,22 @@ impl ShellExec {
                     show_command: false,
                     show_rerun: false,
                 };
-                workspace
-                    .spawn_in_terminal(spawn_in_terminal, window, cx)
-                    .detach_and_log_err(cx);
+
+                let task_status = workspace.spawn_in_terminal(spawn_in_terminal, window, cx);
+                cx.background_spawn(async move {
+                    match task_status.await {
+                        Some(Ok(status)) => {
+                            if status.success() {
+                                log::debug!("Vim shell exec succeeded");
+                            } else {
+                                log::debug!("Vim shell exec failed, code: {:?}", status.code());
+                            }
+                        }
+                        Some(Err(e)) => log::error!("Vim shell exec failed: {e}"),
+                        None => log::debug!("Vim shell exec got cancelled"),
+                    }
+                })
+                .detach();
             });
             return;
         };

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -1,7 +1,7 @@
 use std::process::ExitStatus;
 
-use anyhow::{Result, anyhow};
-use gpui::{Context, Entity, Task};
+use anyhow::Result;
+use gpui::{AppContext, Context, Entity, Task};
 use language::Buffer;
 use project::TaskSourceKind;
 use remote::ConnectionState;
@@ -68,9 +68,21 @@ impl Workspace {
         }
 
         if let Some(terminal_provider) = self.terminal_provider.as_ref() {
-            terminal_provider
-                .spawn(spawn_in_terminal, window, cx)
-                .detach_and_log_err(cx);
+            let task_status = terminal_provider.spawn(spawn_in_terminal, window, cx);
+            cx.background_spawn(async move {
+                match task_status.await {
+                    Some(Ok(status)) => {
+                        if status.success() {
+                            log::debug!("Task spawn succeeded");
+                        } else {
+                            log::debug!("Task spawn failed, code: {:?}", status.code());
+                        }
+                    }
+                    Some(Err(e)) => log::error!("Task spawn failed: {e}"),
+                    None => log::debug!("Task spawn got cancelled"),
+                }
+            })
+            .detach();
         }
     }
 
@@ -92,11 +104,11 @@ impl Workspace {
         spawn_in_terminal: SpawnInTerminal,
         window: &mut Window,
         cx: &mut Context<Workspace>,
-    ) -> Task<Result<ExitStatus>> {
+    ) -> Task<Option<Result<ExitStatus>>> {
         if let Some(terminal_provider) = self.terminal_provider.as_ref() {
             terminal_provider.spawn(spawn_in_terminal, window, cx)
         } else {
-            Task::ready(Err(anyhow!("No terminal provider")))
+            Task::ready(None)
         }
     }
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -136,7 +136,7 @@ pub trait TerminalProvider {
         task: SpawnInTerminal,
         window: &mut Window,
         cx: &mut App,
-    ) -> Task<Result<ExitStatus>>;
+    ) -> Task<Option<Result<ExitStatus>>>;
 }
 
 pub trait DebuggerProvider {


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/28993

* Tone down tasks' cancellation logging
* Fix task terminals' leak, disallowing to fully cancel the task by dropping the terminal off the pane:
https://github.com/zed-industries/zed/blob/f619d5f02af100c34e286af294a42a01dcfb238c/crates/terminal_view/src/terminal_panel.rs#L1464-L1471

Release Notes:

- Fixed tasks not being stopped on reruns
