### PR TITLE
bash: Fix bracket autoclose behavior

### DIFF
--- a/crates/languages/src/bash/config.toml
+++ b/crates/languages/src/bash/config.toml
@@ -4,6 +4,7 @@ grammar = "bash"
 path_suffixes = ["sh", "bash", "bashrc", "bash_profile", "bash_aliases", "bash_logout", "bats", "profile", "zsh", "zshrc", "zshenv", "zsh_profile", "zsh_aliases", "zsh_histfile", "zlogin", "zprofile", ".env", "PKGBUILD", "APKBUILD"]
 line_comments = ["# "]
 first_line_pattern = '^#!.*\b(?:ash|bash|bats|dash|sh|zsh)\b'
+autoclose_before = "}])"
 brackets = [
     { start = "[", end = "]", close = true, newline = false },
     { start = "(", end = ")", close = true, newline = true },


### PR DESCRIPTION
Add `autoclose_before` configuration for Bash.

Closes #23627

Release Notes:

- Bash: Fixed bracket autoclose behavior.
