### PR TITLE
agent: Fix default cursor position in reviewing editors

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -475,7 +475,7 @@ impl AssistantPanel {
                 cx,
             )
         });
-        AgentDiff::set_active_thread(&workspace, &thread, cx);
+        AgentDiff::set_active_thread(&workspace, &thread, window, cx);
 
         let active_thread_subscription =
             cx.subscribe(&active_thread, |_, _, event, cx| match &event {
@@ -719,7 +719,7 @@ impl AssistantPanel {
                 cx,
             )
         });
-        AgentDiff::set_active_thread(&self.workspace, &thread, cx);
+        AgentDiff::set_active_thread(&self.workspace, &thread, window, cx);
 
         let active_thread_subscription =
             cx.subscribe(&self.thread, |_, _, event, cx| match &event {
@@ -917,7 +917,7 @@ impl AssistantPanel {
                 cx,
             )
         });
-        AgentDiff::set_active_thread(&self.workspace, &thread, cx);
+        AgentDiff::set_active_thread(&self.workspace, &thread, window, cx);
 
         let active_thread_subscription =
             cx.subscribe(&self.thread, |_, _, event, cx| match &event {


### PR DESCRIPTION
When there was a change on the first line, the cursor would be positioned in the next hunk by default. This PR fixes that by explicitly setting the selection instead of relying on `GoToNextHunk`.

Release Notes:

- N/A 
