### PR TITLE
editor: Remove extra quotes from outline search term

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4962,7 +4962,7 @@ impl Render for OutlinePanel {
                         .border_color(cx.theme().colors().border)
                         .gap_0p5()
                         .child(Label::new("Searching:").color(Color::Muted))
-                        .child(Label::new(format!("'{}'", search_state.query))),
+                        .child(Label::new(search_state.query.to_string())),
                 )
             })
             .child(self.render_main_contents(query, show_indent_guides, indent_size, window, cx))


### PR DESCRIPTION
The outline panel includes quotes around search terms. The rendering makes it somewhat ambiguous whether these quotes are part of the search term and are unnecessary, especially given other rendering differentiation. This PR removes them.

Release Notes:

- N/A
