### PR TITLE
vim: Fix `r enter` indentation

### DIFF
--- a/crates/vim/test_data/test_r.json
+++ b/crates/vim/test_data/test_r.json
@@ -29,3 +29,12 @@
 {"Key":"-"}
 {"Key":""}
 {"Get":{"state":"ˇhello world\n","mode":"Normal"}}
+{"Put":{"state":"  helloˇ world\n"}}
+{"Key":"r"}
+{"Key":"enter"}
+{"Get":{"state":"  hello\n ˇ world\n","mode":"Normal"}}
+{"Put":{"state":"  helloˇ world\n"}}
+{"Key":"2"}
+{"Key":"r"}
+{"Key":"enter"}
+{"Get":{"state":"  hello\n ˇ orld\n","mode":"Normal"}}


### PR DESCRIPTION
Release Notes:

- `r enter` now maintains indentation, matching vim

Useful info for this implementation can be found here:
https://github.com/vim/vim/blob/c3f48e3a76c61884d7801171ced327b76965bf29/src/normal.c#L4865 