### PR TITLE
Fix toolbar being stuck at the top

### DIFF
--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -925,15 +925,18 @@ impl ToolbarItemView for AgentDiffToolbar {
             if let Some(editor) = item.act_as::<Editor>(cx) {
                 if editor.read(cx).mode().is_full() {
                     let agent_diff = AgentDiff::global(cx);
+                    let editor_state = agent_diff.read(cx).editor_state(&editor);
 
-                    self.active_item = Some(AgentDiffToolbarItem::Editor {
-                        editor: editor.downgrade(),
-                        _diff_subscription: cx.observe(&agent_diff, |_, _, cx| {
-                            cx.notify();
-                        }),
-                    });
+                    if matches!(editor_state, EditorState::Reviewing) {
+                        self.active_item = Some(AgentDiffToolbarItem::Editor {
+                            editor: editor.downgrade(),
+                            _diff_subscription: cx.observe(&agent_diff, |_, _, cx| {
+                                cx.notify();
+                            }),
+                        });
 
-                    return ToolbarItemLocation::PrimaryLeft;
+                        return ToolbarItemLocation::PrimaryLeft;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Closes #29836

I'm not sure if this is the best approach, and I haven't had a chance to test the new Agent mode to determine if it introduces any issues. That said, I'm also unsure whether we should also display the toolbar during generation if it's not already displayed.

Release Notes:

- Fixed: Toolbar being stuck at the top.
