### PR TITLE
collab: Use new subscription usage tables

### DIFF
--- a/crates/collab/src/llm/db/queries/subscription_usages.rs
+++ b/crates/collab/src/llm/db/queries/subscription_usages.rs
@@ -69,7 +69,7 @@ impl LlmDatabase {
 
         Ok(
             subscription_usage::Entity::insert(subscription_usage::ActiveModel {
-                id: ActiveValue::not_set(),
+                id: ActiveValue::set(Uuid::now_v7()),
                 user_id: ActiveValue::set(user_id),
                 period_start_at: ActiveValue::set(period_start_at),
                 period_end_at: ActiveValue::set(period_end_at),

--- a/crates/collab/src/llm/db/tables/subscription_usage.rs
+++ b/crates/collab/src/llm/db/tables/subscription_usage.rs
@@ -4,10 +4,10 @@ use sea_orm::entity::prelude::*;
 use time::PrimitiveDateTime;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-#[sea_orm(table_name = "subscription_usages")]
+#[sea_orm(table_name = "subscription_usages_v2")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub user_id: UserId,
     pub period_start_at: PrimitiveDateTime,
     pub period_end_at: PrimitiveDateTime,

--- a/crates/collab/src/llm/db/tables/subscription_usage_meter.rs
+++ b/crates/collab/src/llm/db/tables/subscription_usage_meter.rs
@@ -4,10 +4,10 @@ use serde::Serialize;
 use crate::llm::db::ModelId;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
-#[sea_orm(table_name = "subscription_usage_meters")]
+#[sea_orm(table_name = "subscription_usage_meters_v2")]
 pub struct Model {
     #[sea_orm(primary_key)]
-    pub id: i32,
+    pub id: Uuid,
     pub subscription_usage_id: i32,
     pub model_id: ModelId,
     pub mode: CompletionMode,


### PR DESCRIPTION
This PR updates Collab to use the new subscription usage tables added in #29847.

Release Notes:

- N/A
