### PR TITLE
feature_flags: Add a constant to control Agent-related feature flags

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -19,12 +19,11 @@ pub static ZED_DISABLE_STAFF: LazyLock<bool> = LazyLock::new(|| {
 
 impl FeatureFlags {
     fn has_flag<T: FeatureFlag>(&self) -> bool {
-        if self.staff && T::enabled_for_staff() {
+        if T::enabled_for_all() {
             return true;
         }
 
-        #[cfg(debug_assertions)]
-        if T::enabled_in_development() {
+        if self.staff && T::enabled_for_staff() {
             return true;
         }
 
@@ -48,21 +47,38 @@ pub trait FeatureFlag {
         true
     }
 
-    fn enabled_in_development() -> bool {
-        Self::enabled_for_staff() && !*ZED_DISABLE_STAFF
+    /// Returns whether this feature flag is enabled for everyone.
+    ///
+    /// This is generally done on the server, but we provide this as a way to entirely enable a feature flag client-side
+    /// without needing to remove all of the call sites.
+    fn enabled_for_all() -> bool {
+        false
     }
 }
+
+/// Controls the values of various feature flags for the Agent launch.
+///
+/// Change this to `true` when we're ready to build the release candidate.
+const AGENT_LAUNCH: bool = false;
 
 pub struct Assistant2FeatureFlag;
 
 impl FeatureFlag for Assistant2FeatureFlag {
     const NAME: &'static str = "assistant2";
+
+    fn enabled_for_all() -> bool {
+        AGENT_LAUNCH
+    }
 }
 
 pub struct AgentStreamEditsFeatureFlag;
 
 impl FeatureFlag for AgentStreamEditsFeatureFlag {
     const NAME: &'static str = "agent-stream-edits";
+
+    fn enabled_for_all() -> bool {
+        AGENT_LAUNCH
+    }
 }
 
 pub struct NewBillingFeatureFlag;
@@ -70,8 +86,8 @@ pub struct NewBillingFeatureFlag;
 impl FeatureFlag for NewBillingFeatureFlag {
     const NAME: &'static str = "new-billing";
 
-    fn enabled_for_staff() -> bool {
-        false
+    fn enabled_for_all() -> bool {
+        AGENT_LAUNCH
     }
 }
 
@@ -144,7 +160,6 @@ where
         if self
             .try_global::<FeatureFlags>()
             .is_some_and(|f| f.has_flag::<T>())
-            || cfg!(debug_assertions) && T::enabled_in_development()
         {
             self.defer_in(window, move |view, window, cx| {
                 callback(view, window, cx);


### PR DESCRIPTION
This PR adds a singular constant that controls the Agent-related feature flags.

This way we can tweak this one value when we're ready to build the final build for the launch.

Release Notes:

- N/A
