### PR TITLE
Fix hiding editor toolbar and add `agent_review` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -300,8 +300,10 @@
     "breadcrumbs": true,
     // Whether to show quick action buttons.
     "quick_actions": true,
-    // Whether to show the Selections menu in the editor toolbar
-    "selections_menu": true
+    // Whether to show the Selections menu in the editor toolbar.
+    "selections_menu": true,
+    // Whether to show agent review buttons in the editor toolbar.
+    "agent_review": true
   },
   // Scrollbar related settings
   "scrollbar": {
@@ -659,6 +661,8 @@
     "always_allow_tool_actions": false,
     // When enabled, the agent will stream edits.
     "stream_edits": false,
+    // When enabled, agent edits will be displayed in single-file editors for review
+    "single_file_review": true,
     "default_profile": "write",
     "profiles": {
       "ask": {

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -69,7 +69,7 @@ pub enum AssistantProviderContentV1 {
     },
 }
 
-#[derive(Clone, Debug)]
+#[derive(Default, Clone, Debug)]
 pub struct AssistantSettings {
     pub enabled: bool,
     pub button: bool,
@@ -89,31 +89,6 @@ pub struct AssistantSettings {
     pub notify_when_agent_waiting: NotifyWhenAgentWaiting,
     pub stream_edits: bool,
     pub single_file_review: bool,
-}
-
-impl Default for AssistantSettings {
-    fn default() -> Self {
-        Self {
-            enabled: Default::default(),
-            button: Default::default(),
-            dock: Default::default(),
-            default_width: Default::default(),
-            default_height: Default::default(),
-            default_model: Default::default(),
-            inline_assistant_model: Default::default(),
-            commit_message_model: Default::default(),
-            thread_summary_model: Default::default(),
-            inline_alternatives: Default::default(),
-            using_outdated_settings_version: Default::default(),
-            enable_experimental_live_diffs: Default::default(),
-            default_profile: Default::default(),
-            profiles: Default::default(),
-            always_allow_tool_actions: Default::default(),
-            notify_when_agent_waiting: Default::default(),
-            stream_edits: Default::default(),
-            single_file_review: true,
-        }
-    }
 }
 
 impl AssistantSettings {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -101,6 +101,7 @@ pub struct Toolbar {
     pub breadcrumbs: bool,
     pub quick_actions: bool,
     pub selections_menu: bool,
+    pub agent_review: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -400,11 +401,15 @@ pub struct ToolbarContent {
     ///
     /// Default: true
     pub quick_actions: Option<bool>,
-
-    /// Whether to show the selections menu in the editor toolbar
+    /// Whether to show the selections menu in the editor toolbar.
     ///
     /// Default: true
     pub selections_menu: Option<bool>,
+    /// Whether to display Agent review buttons in the editor toolbar.
+    /// Only applicable while reviewing a file edited by the Agent.
+    ///
+    /// Default: true
+    pub agent_review: Option<bool>,
 }
 
 /// Scrollbar related settings

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -915,7 +915,7 @@ fn initialize_pane(
             toolbar.add_item(migration_banner, window, cx);
             let project_diff_toolbar = cx.new(|cx| ProjectDiffToolbar::new(workspace, cx));
             toolbar.add_item(project_diff_toolbar, window, cx);
-            let agent_diff_toolbar = cx.new(|_cx| AgentDiffToolbar::new());
+            let agent_diff_toolbar = cx.new(AgentDiffToolbar::new);
             toolbar.add_item(agent_diff_toolbar, window, cx);
         })
     });

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1034,7 +1034,8 @@ List of `string` values
 "toolbar": {
   "breadcrumbs": true,
   "quick_actions": true,
-  "selections_menu": true
+  "selections_menu": true,
+  "agent_review": true
 },
 ```
 
@@ -3090,7 +3091,8 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "editor_model": {
     "provider": "zed.dev",
     "model": "claude-3-7-sonnet-latest"
-  }
+  },
+  "single_file_review": true,
 }
 ```
 


### PR DESCRIPTION
Closes #29836

The agent diff toolbar item was causing the editor toolbar to show even when all the other elements were disabled via settings. 

This PR fixes this by setting the location to `ToolbarItemLocation::Hidden` in the states where it shouldn't show.

It also adds a new a `toolbar.agent_review` setting to hide the agent review buttons altogether. However, if the other toolbar elements are hidden and the file isn't under review, the editor toolbar will still be hidden. So you only need to set this to `false` if you don't want them to show up even under agent review.

Release Notes:

- N/A 
