### PR TITLE
collab: Fix `subscription_usage_id` column type

### DIFF
--- a/crates/collab/src/llm/db/tables/subscription_usage_meter.rs
+++ b/crates/collab/src/llm/db/tables/subscription_usage_meter.rs
@@ -8,7 +8,7 @@ use crate::llm::db::ModelId;
 pub struct Model {
     #[sea_orm(primary_key)]
     pub id: Uuid,
-    pub subscription_usage_id: i32,
+    pub subscription_usage_id: Uuid,
     pub model_id: ModelId,
     pub mode: CompletionMode,
     pub requests: i32,


### PR DESCRIPTION
This PR fixes the type of the `subscription_usage_id` column on the `SubscriptionUsageMeter` model.

Release Notes:

- N/A
