### PR TITLE
collab: Drop legacy subscription usage and meter tables

### DIFF
--- a/crates/collab/migrations_llm/20250504132836_drop_legacy_subscription_usage_and_meter_tables.sql
+++ b/crates/collab/migrations_llm/20250504132836_drop_legacy_subscription_usage_and_meter_tables.sql
@@ -1,0 +1,2 @@
+drop table subscription_usage_meters;
+drop table subscription_usages;


### PR DESCRIPTION
This PR adds a migration to drop the `subscription_usages` and `subscription_usage_meters` tables from the database.

We're now using `subscription_usages_v2` and `subscription_usage_meters_v2` everywhere.

Release Notes:

- N/A
