### PR TITLE
terminal: Implement basic Japanese IME support on macOS

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1313,28 +1313,10 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
 
             drop(lock);
 
-            // --- Add Log before is_composing calculation ---
-            log::debug!(
-                "handle_key_event: About to calculate is_composing by calling marked_text_range..."
-            );
-            // --- End Log ---
-
-            let is_composing = with_input_handler(this, |input_handler| {
-                // input_handler is likely &mut dyn InputHandler
-                log::debug!("handle_key_event: Calling input_handler.marked_text_range()...");
-                // --- Call marked_text_range without extra arguments ---
-                let range = input_handler.marked_text_range();
-                // --- End call ---
-                log::debug!("handle_key_event: marked_text_range returned: {:?}", range);
-                range // Return the result (Option<Range<usize>>)
-            }) // with_input_handler returns Option<Option<Range<usize>>>
-            .flatten() // Flatten to Option<Range<usize>>
-            .is_some(); // Check if Some
-
-            log::debug!(
-                "handle_key_event: Calculated is_composing: {}",
-                is_composing
-            );
+            let is_composing =
+                with_input_handler(this, |input_handler| input_handler.marked_text_range())
+                    .flatten()
+                    .is_some();
 
             // If we're composing, send the key to the input handler first;
             // otherwise we only send to the input handler if we don't have a matching binding.
@@ -1356,39 +1338,15 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
                     drop(lock);
                 }
 
-                // --- Add Log Before handleEvent ---
-                let key_desc = key_down_event.keystroke.key.clone(); // Clone key for logging
-                log::debug!(
-                    "handle_key_event: Calling handleEvent: for key: {:?}, is_composing: {}",
-                    key_desc,
-                    is_composing
-                );
-                // --- End Log ---
-
                 let handled: BOOL = unsafe {
                     let input_context: id = msg_send![this, inputContext];
                     msg_send![input_context, handleEvent: native_event]
                 };
-
-                // --- Add Log After handleEvent ---
-                log::debug!(
-                    "handle_key_event: handleEvent: returned: {}, for key: {:?}",
-                    if handled == YES { "YES" } else { "NO" },
-                    key_desc
-                );
-                // --- End Log ---
-
                 window_state.as_ref().lock().keystroke_for_do_command.take();
                 if let Some(handled) = window_state.as_ref().lock().do_command_handled.take() {
-                    log::debug!("handle_key_event: Returning early due to do_command_handled"); // Add log
                     return handled as BOOL;
                 } else if handled == YES {
-                    log::debug!(
-                        "handle_key_event: Returning YES because handleEvent: returned YES"
-                    ); // Add log
                     return YES;
-                } else {
-                    log::debug!("handle_key_event: handleEvent: returned NO, proceeding..."); // Add log
                 }
 
                 let handled = run_callback(PlatformInput::KeyDown(key_down_event));

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -776,7 +776,7 @@ impl Element for TerminalElement {
 
                 // Layout cursor. Rectangle is used for IME, so we should lay it out even
                 // if we don't end up showing it.
-                let cursor_layout = if let AlacCursorShape::Hidden = cursor.shape {
+                let cursor = if let AlacCursorShape::Hidden = cursor.shape {
                     None
                 } else {
                     let cursor_point = DisplayCursor::from(cursor.point, display_offset);
@@ -860,7 +860,7 @@ impl Element for TerminalElement {
                 LayoutState {
                     hitbox,
                     cells,
-                    cursor: cursor_layout,
+                    cursor,
                     background_color,
                     dimensions,
                     rects,
@@ -900,11 +900,11 @@ impl Element for TerminalElement {
             let terminal_input_handler = TerminalInputHandler {
                 terminal: self.terminal.clone(),
                 terminal_view: self.terminal_view.clone(),
-                workspace: self.workspace.clone(),
                 cursor_bounds: layout
                     .cursor
                     .as_ref()
                     .map(|cursor| cursor.bounding_rect(origin)),
+                workspace: self.workspace.clone(),
             };
 
             self.register_mouse_listeners(layout.mode, &layout.hitbox, window);
@@ -1116,7 +1116,7 @@ impl InputHandler for TerminalInputHandler {
 
     fn replace_and_mark_text_in_range(
         &mut self,
-        _range_utf16: Option<std::ops::Range<usize>>, // TODO: Pass range to set_marked_text if needed
+        _range_utf16: Option<std::ops::Range<usize>>,
         new_text: &str,
         new_marked_range: Option<std::ops::Range<usize>>,
         _window: &mut Window,

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1126,15 +1126,6 @@ impl InputHandler for TerminalInputHandler {
             self.terminal_view.update(cx, |view, view_cx| {
                 view.set_marked_text(new_text.to_string(), range, view_cx);
             });
-        } else {
-            log::warn!(
-                "replace_and_mark_text_in_range called with no marked range, text: '{}'",
-                new_text
-            );
-            // Optionally, clear marked text here:
-            // self.terminal_view.update(_cx, |view, view_cx| {
-            //     view.clear_marked_text(view_cx);
-            // }).log_err();
         }
     }
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1147,7 +1147,7 @@ impl InputHandler for TerminalInputHandler {
     fn bounds_for_range(
         &mut self,
         range_utf16: std::ops::Range<usize>,
-        window: &mut Window,
+        _window: &mut Window,
         cx: &mut App,
     ) -> Option<Bounds<Pixels>> {
         log::debug!(
@@ -1158,7 +1158,7 @@ impl InputHandler for TerminalInputHandler {
         // --- Get layout info from TerminalView ---
         let layout_info = self.terminal_view.read(cx).get_layout_info_for_ime(cx); // Pass cx if needed by helper
 
-        if let Some((term_bounds, cursor_point, display_offset)) = layout_info {
+        if let Some((term_bounds, _cursor_point, _display_offset)) = layout_info {
             // --- Calculate bounds based on info from TerminalView ---
             // Need element bounds origin, get it from window? Or store it?
             // Let's try getting element bounds via window/focus handle if possible,
@@ -1185,8 +1185,8 @@ impl InputHandler for TerminalInputHandler {
                 log::warn!(
                     "bounds_for_range: cursor_bounds is None, calculating approximate bounds"
                 );
-                let line_height = term_bounds.line_height;
-                let cell_width = term_bounds.cell_width;
+                let _line_height = term_bounds.line_height;
+                let _cell_width = term_bounds.cell_width;
                 // We don't have element_bounds.origin here easily.
                 // Return None or a very rough estimate. Let's return None for now.
                 return None;

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -222,23 +222,16 @@ impl TerminalView {
         }
     }
 
-    // --- Add IME Helper Methods ---
-
     /// Sets the marked (pre-edit) text from the IME.
     pub(crate) fn set_marked_text(
         &mut self,
         text: String,
-        range: Range<usize>, // UTF-16 range within the text
+        range: Range<usize>,
         cx: &mut Context<Self>,
     ) {
-        log::debug!(
-            "TerminalView::set_marked_text: text='{}', range={:?}",
-            text,
-            range
-        );
         self.marked_text = Some(text);
         self.marked_range_utf16 = Some(range);
-        cx.notify(); // Request repaint to show marked text
+        cx.notify();
     }
 
     /// Gets the current marked range (UTF-16).
@@ -252,20 +245,16 @@ impl TerminalView {
         if self.marked_text.is_some() {
             self.marked_text = None;
             self.marked_range_utf16 = None;
-            cx.notify(); // Request repaint to clear marked text
+            cx.notify();
         }
     }
 
     /// Commits (sends) the given text to the PTY. Called by InputHandler::replace_text_in_range.
     pub(crate) fn commit_text(&mut self, text: &str, cx: &mut Context<Self>) {
-        log::debug!("TerminalView::commit_text: text='{}'", text);
-        // Clear any existing marked text first (should be done by caller via clear_marked_text, but belt-and-suspenders)
         self.clear_marked_text(cx);
 
-        // Send text to PTY
         if !text.is_empty() {
             self.terminal.update(cx, |term, _| {
-                log::debug!("Sending committed text to PTY: {}", text);
                 term.input(text.to_string());
             });
         }
@@ -283,8 +272,6 @@ impl TerminalView {
             content.display_offset,
         ))
     }
-
-    // --- End IME Helper Methods ---
 
     pub fn entity(&self) -> &Entity<Terminal> {
         &self.terminal

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -235,13 +235,12 @@ impl TerminalView {
     }
 
     /// Gets the current marked range (UTF-16).
-    pub(crate) fn get_marked_range(&self) -> Option<Range<usize>> {
+    pub(crate) fn marked_text_range(&self) -> Option<Range<usize>> {
         self.marked_range_utf16.clone()
     }
 
     /// Clears the marked (pre-edit) text state.
     pub(crate) fn clear_marked_text(&mut self, cx: &mut Context<Self>) {
-        log::debug!("TerminalView::clear_marked_text");
         if self.marked_text.is_some() {
             self.marked_text = None;
             self.marked_range_utf16 = None;
@@ -251,8 +250,6 @@ impl TerminalView {
 
     /// Commits (sends) the given text to the PTY. Called by InputHandler::replace_text_in_range.
     pub(crate) fn commit_text(&mut self, text: &str, cx: &mut Context<Self>) {
-        self.clear_marked_text(cx);
-
         if !text.is_empty() {
             self.terminal.update(cx, |term, _| {
                 term.input(text.to_string());
@@ -260,17 +257,8 @@ impl TerminalView {
         }
     }
 
-    /// Gets layout information needed for IME bounds calculation.
-    pub(crate) fn get_layout_info_for_ime(
-        &self,
-        cx: &App,
-    ) -> Option<(TerminalBounds, Point, usize)> {
-        let content = self.terminal.read(cx).last_content(); // read takes &App
-        Some((
-            content.terminal_bounds,
-            content.cursor.point,
-            content.display_offset,
-        ))
+    pub(crate) fn terminal_bounds(&self, cx: &App) -> TerminalBounds {
+        self.terminal.read(cx).last_content().terminal_bounds
     }
 
     pub fn entity(&self) -> &Entity<Terminal> {


### PR DESCRIPTION
## Description

This PR implements basic support for Japanese Input Method Editors (IMEs) in the Zed terminal on macOS, addressing issue #9900. Previously, users had to switch input modes to confirm Japanese text, and pre-edit (marked) text was not displayed.

With these changes:

-   **Marked Text Display:** Pre-edit text (e.g., underlined characters during Japanese composition) is now rendered directly in the terminal at the cursor's current position.
-   **Composition Confirmation:** Pressing Enter correctly finalizes the IME composition, clears the marked text, and sends the confirmed string to the underlying PTY process. This allows for a more natural input flow similar to other macOS applications like iTerm2.
-   **State Management:** IME state (marked text and its selected range within the marked text) is now managed within the `TerminalView` struct.
-   **Input Handling:** `TerminalInputHandler` has been updated to correctly process IME callbacks (`replace_and_mark_text_in_range`, `replace_text_in_range`, `unmark_text`, `marked_text_range`) by interacting with `TerminalView`.
-   **Painting Logic:** `TerminalElement::paint` now fetches the marked text and its range from `TerminalView` and renders it with an underline. The standard terminal cursor is hidden when marked text is present to avoid visual clutter.
-   **Candidate Window Positioning:** `TerminalInputHandler::bounds_for_range` now attempts to provide more accurate bounds for the IME candidate window by using the actual painted bounds of the pre-edit text, falling back to a cursor-based approximation if necessary.

This significantly improves the usability of the Zed terminal for users who need to input Japanese characters, bringing the experience closer to system-standard IME behavior.

## Movies

https://github.com/user-attachments/assets/be6c7597-7b65-49a6-b376-e1adff6da974

---

Closes #9900

Release Notes:

- **Terminal:** Implemented basic support for Japanese Input Method Editors (IMEs) on macOS. Users can now see pre-edit (marked) text as they type Japanese and confirm their input with the Enter key directly in the terminal. This provides a more natural and efficient experience for Japanese language input. (Fixes #9900)
