### PR TITLE
In the edit tool card, use the UI font size for the editor that we use to render the diff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -753,6 +753,7 @@ dependencies = [
  "tempfile",
  "terminal",
  "terminal_view",
+ "theme",
  "tree-sitter-rust",
  "ui",
  "unindent",

--- a/crates/assistant_tools/Cargo.toml
+++ b/crates/assistant_tools/Cargo.toml
@@ -56,6 +56,7 @@ web_search.workspace = true
 workspace-hack.workspace = true
 workspace.workspace = true
 zed_llm_client.workspace = true
+theme.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -8,7 +8,7 @@ use buffer_diff::{BufferDiff, BufferDiffSnapshot};
 use editor::{Editor, EditorMode, MultiBuffer, PathKey};
 use gpui::{
     Animation, AnimationExt, AnyWindowHandle, App, AppContext, AsyncApp, Context, Entity, EntityId,
-    Task, WeakEntity, pulsating_between,
+    Task, TextStyleRefinement, WeakEntity, pulsating_between,
 };
 use language::{
     Anchor, Buffer, Capability, LanguageRegistry, LineEnding, OffsetRangeExt, Rope, TextBuffer,
@@ -18,11 +18,13 @@ use language_model::{LanguageModelRequestMessage, LanguageModelToolSchemaFormat}
 use project::{AgentLocation, Project};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
+use settings::Settings;
 use std::{
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
 };
+use theme::ThemeSettings;
 use ui::{Disclosure, Tooltip, Window, prelude::*};
 use util::ResultExt;
 use workspace::Workspace;
@@ -540,6 +542,13 @@ impl ToolCard for EditFileToolCard {
             });
 
         let (editor, editor_line_height) = self.editor.update(cx, |editor, cx| {
+            let ui_font_size = ThemeSettings::get_global(cx).ui_font_size(cx);
+
+            editor.set_text_style_refinement(TextStyleRefinement {
+                font_size: Some(ui_font_size.into()),
+                ..TextStyleRefinement::default()
+            });
+
             let line_height = editor
                 .style()
                 .map(|style| style.text.line_height_in_pixels(window.rem_size()))


### PR DESCRIPTION
I am currently setting the font size corrrectly by using a custom EditorStyle and building an element. However I need to use the same properties as a normal editor for everything but font size.

Release Notes:

- N/A
