### PR TITLE
collab: Set billing-related fields for Zed staff

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -180,6 +180,10 @@ impl Session {
     }
 
     pub async fn current_plan(&self, db: &MutexGuard<'_, DbHandle>) -> anyhow::Result<proto::Plan> {
+        if self.is_staff() {
+            return Ok(proto::Plan::ZedPro);
+        }
+
         let user_id = self.user_id();
 
         let subscription = db.get_active_billing_subscription(user_id).await?;


### PR DESCRIPTION
This PR sets the billing-related fields in the LLM token claims for Zed staff.

Staff members are automatically in the Zed Pro plan with a subscription periods that spans the entirety of each month.

Release Notes:

- N/A
