### PR TITLE
In error text of cloud LLM API: `completion failed` -> `request failed`

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -645,7 +645,7 @@ impl CloudLanguageModel {
 }
 
 #[derive(Debug, Error)]
-#[error("cloud language model completion failed with status {status}: {body}")]
+#[error("cloud language model request failed with status {status}: {body}")]
 struct ApiError {
     status: StatusCode,
     body: String,


### PR DESCRIPTION
This error is used for more requests than completion requests

Release Notes:

- N/A