### PR TITLE
Replace `std::sync::Mutex` with `parking_lot::Mutex` in `languages/src/python.rs`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7992,6 +7992,7 @@ dependencies = [
  "log",
  "lsp",
  "node_runtime",
+ "parking_lot",
  "paths",
  "pet",
  "pet-conda",

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -46,6 +46,7 @@ language.workspace = true
 log.workspace = true
 lsp.workspace = true
 node_runtime.workspace = true
+parking_lot.workspace = true
 paths.workspace = true
 pet-conda.workspace = true
 pet-core.workspace = true


### PR DESCRIPTION
This appears to be the only place `std::sync::Mutex` is used, Zed always prefers `parking_lot`.

Release Notes:

- N/A