### PR TITLE
collab: Don't try to sync usage to Stripe for staff users

### DIFF
--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -65,6 +65,18 @@ impl Database {
         .await
     }
 
+    /// Returns all users flagged as staff.
+    pub async fn get_staff_users(&self) -> Result<Vec<user::Model>> {
+        self.transaction(|tx| async {
+            let tx = tx;
+            Ok(user::Entity::find()
+                .filter(user::Column::Admin.eq(true))
+                .all(&*tx)
+                .await?)
+        })
+        .await
+    }
+
     /// Returns a user by email address. There are no access checks here, so this should only be used internally.
     pub async fn get_user_by_email(&self, email: &str) -> Result<Option<User>> {
         self.transaction(|tx| async move {


### PR DESCRIPTION
This PR makes it so we don't try to sync billing usage to Stripe for staff users.

Release Notes:

- N/A
