### PR TITLE
agent: Remove unneeded tracking of request usage

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -29,8 +29,7 @@ use gpui::{
 };
 use language::{Buffer, Language, LanguageRegistry};
 use language_model::{
-    LanguageModelRequestMessage, LanguageModelToolUseId, MessageContent, RequestUsage, Role,
-    StopReason,
+    LanguageModelRequestMessage, LanguageModelToolUseId, MessageContent, Role, StopReason,
 };
 use markdown::parser::{CodeBlockKind, CodeBlockMetadata};
 use markdown::{HeadingLevelStyles, Markdown, MarkdownElement, MarkdownStyle, ParsedMarkdown};
@@ -72,7 +71,6 @@ pub struct ActiveThread {
     expanded_thinking_segments: HashMap<(MessageId, usize), bool>,
     expanded_code_blocks: HashMap<(MessageId, usize), bool>,
     last_error: Option<ThreadError>,
-    last_usage: Option<RequestUsage>,
     notifications: Vec<WindowHandle<AgentNotification>>,
     copied_code_block_ids: HashSet<(MessageId, usize)>,
     _subscriptions: Vec<Subscription>,
@@ -783,7 +781,6 @@ impl ActiveThread {
             hide_scrollbar_task: None,
             editing_message: None,
             last_error: None,
-            last_usage: None,
             copied_code_block_ids: HashSet::default(),
             notifications: Vec::new(),
             _subscriptions: subscriptions,
@@ -838,10 +835,6 @@ impl ActiveThread {
 
     pub fn clear_last_error(&mut self) {
         self.last_error.take();
-    }
-
-    pub fn last_usage(&self) -> Option<RequestUsage> {
-        self.last_usage
     }
 
     /// Returns the editing message id and the estimated token count in the content
@@ -948,9 +941,6 @@ impl ActiveThread {
             }
             ThreadEvent::ShowError(error) => {
                 self.last_error = Some(error.clone());
-            }
-            ThreadEvent::UsageUpdated(usage) => {
-                self.last_usage = Some(*usage);
             }
             ThreadEvent::NewRequest | ThreadEvent::CompletionCanceled => {
                 cx.notify();

--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -1366,7 +1366,6 @@ impl AgentDiff {
             }
             // intentionally being exhaustive in case we add a variant we should handle
             ThreadEvent::Stopped(Ok(StopReason::ToolUse))
-            | ThreadEvent::UsageUpdated(_)
             | ThreadEvent::StreamedCompletion
             | ThreadEvent::ReceivedTextChunk
             | ThreadEvent::StreamedAssistantText(_, _)

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1545,7 +1545,6 @@ impl Thread {
                                             let usage = RequestUsage { limit, amount: amount as i32 };
 
                                             thread.last_usage = Some(usage);
-                                            cx.emit(ThreadEvent::UsageUpdated(usage));
                                         }
                                         CompletionRequestStatus::ToolUseLimitReached => {
                                             thread.tool_use_limit_reached = true;
@@ -1714,11 +1713,11 @@ impl Thread {
                         LanguageModelCompletionEvent::StatusUpdate(
                             CompletionRequestStatus::UsageUpdated { amount, limit },
                         ) => {
-                            this.update(cx, |_, cx| {
-                                cx.emit(ThreadEvent::UsageUpdated(RequestUsage {
+                            this.update(cx, |thread, _cx| {
+                                thread.last_usage = Some(RequestUsage {
                                     limit,
                                     amount: amount as i32,
-                                }));
+                                });
                             })?;
                             continue;
                         }
@@ -2565,7 +2564,6 @@ pub enum ThreadError {
 #[derive(Debug, Clone)]
 pub enum ThreadEvent {
     ShowError(ThreadError),
-    UsageUpdated(RequestUsage),
     StreamedCompletion,
     ReceivedTextChunk,
     NewRequest,

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -283,7 +283,6 @@ impl ExampleContext {
                 | ThreadEvent::ReceivedTextChunk
                 | ThreadEvent::StreamedToolUse { .. }
                 | ThreadEvent::CheckpointChanged
-                | ThreadEvent::UsageUpdated(_)
                 | ThreadEvent::CancelEditing => {
                     tx.try_send(Ok(())).ok();
                     if std::env::var("ZED_EVAL_DEBUG").is_ok() {


### PR DESCRIPTION
This PR removes some unneeded tracking of the model request usage in the `ActiveThread` and `ThreadEvent::UsageUpdated` events.

Release Notes:

- N/A
