### PR TITLE
collab: Improve `GET /billing/usage` endpoint

### DIFF
--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -61,6 +61,16 @@ pub enum SubscriptionKind {
     ZedFree,
 }
 
+impl From<SubscriptionKind> for zed_llm_client::Plan {
+    fn from(value: SubscriptionKind) -> Self {
+        match value {
+            SubscriptionKind::ZedPro => Self::ZedPro,
+            SubscriptionKind::ZedProTrial => Self::ZedProTrial,
+            SubscriptionKind::ZedFree => Self::Free,
+        }
+    }
+}
+
 /// The status of a Stripe subscription.
 ///
 /// [Stripe docs](https://docs.stripe.com/api/subscriptions/object#subscription_object-status)


### PR DESCRIPTION
This PR improves the `GET /billing/usage` endpoint.

We now return the usage with the default plan limits when there is no usage record.

Release Notes:

- N/A
