### PR TITLE
zed: Fix migration message sometimes showing up on other tabs

### DIFF
--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -7,7 +7,7 @@ use util::ResultExt;
 
 use std::sync::Arc;
 
-use gpui::{Entity, EventEmitter, Global};
+use gpui::{Entity, EventEmitter, Global, Task};
 use ui::prelude::*;
 use workspace::item::ItemHandle;
 use workspace::{ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace};
@@ -20,6 +20,7 @@ pub enum MigrationType {
 
 pub struct MigrationBanner {
     migration_type: Option<MigrationType>,
+    should_migrate_task: Option<Task<()>>,
 }
 
 pub enum MigrationEvent {
@@ -61,6 +62,7 @@ impl MigrationBanner {
         }
         Self {
             migration_type: None,
+            should_migrate_task: None,
         }
     }
 
@@ -110,6 +112,7 @@ impl ToolbarItemView for MigrationBanner {
         cx: &mut Context<Self>,
     ) -> ToolbarItemLocation {
         cx.notify();
+        self.should_migrate_task.take();
         let Some(target) = active_pane_item
             .and_then(|item| item.act_as::<Editor>(cx))
             .and_then(|editor| editor.update(cx, |editor, cx| editor.target_file_abs_path(cx)))
@@ -121,7 +124,7 @@ impl ToolbarItemView for MigrationBanner {
             self.migration_type = Some(MigrationType::Keymap);
             let fs = <dyn Fs>::global(cx);
             let should_migrate = should_migrate_keymap(fs);
-            cx.spawn_in(window, async move |this, cx| {
+            self.should_migrate_task = Some(cx.spawn_in(window, async move |this, cx| {
                 if let Ok(true) = should_migrate.await {
                     this.update(cx, |_, cx| {
                         cx.emit(ToolbarItemEvent::ChangeLocation(
@@ -131,13 +134,12 @@ impl ToolbarItemView for MigrationBanner {
                     })
                     .log_err();
                 }
-            })
-            .detach();
+            }));
         } else if &target == paths::settings_file() {
             self.migration_type = Some(MigrationType::Settings);
             let fs = <dyn Fs>::global(cx);
             let should_migrate = should_migrate_settings(fs);
-            cx.spawn_in(window, async move |this, cx| {
+            self.should_migrate_task = Some(cx.spawn_in(window, async move |this, cx| {
                 if let Ok(true) = should_migrate.await {
                     this.update(cx, |_, cx| {
                         cx.emit(ToolbarItemEvent::ChangeLocation(
@@ -147,8 +149,7 @@ impl ToolbarItemView for MigrationBanner {
                     })
                     .log_err();
                 }
-            })
-            .detach();
+            }));
         }
 
         return ToolbarItemLocation::Hidden;


### PR DESCRIPTION

<img width="1178" alt="image" src="https://github.com/user-attachments/assets/6b76fe7d-0621-4d61-936e-bfe4f72cc614" />


Release Notes:

- Fixed an issue where the keymap/settings migration message sometimes showing up on tabs other than `settings.json` and `keymap.json`.

