### PR TITLE
agent: Prevent duplicate inline assistants per file

### DIFF
--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -335,6 +335,17 @@ impl InlineAssistant {
         window: &mut Window,
         cx: &mut App,
     ) {
+        // Check if this editor already has active assistants
+        if let Some(editor_assists) = self.assists_by_editor.get(&editor.downgrade()) {
+            if !editor_assists.assist_ids.is_empty() {
+                // Focus the first assist in the editor rather than creating a new one
+                if let Some(&assist_id) = editor_assists.assist_ids.first() {
+                    self.focus_assist(assist_id, window, cx);
+                    return;
+                }
+            }
+        }
+
         let (snapshot, initial_selections) = editor.update(cx, |editor, cx| {
             (
                 editor.snapshot(window, cx),


### PR DESCRIPTION
Currently in terminal if click on the assistant icon it opens only one inline assistant but in case of the file it opens multiple. To make sure both of them have similar behaviour I have added a check to open a new one only if it doesn't exits.

Implementation:

* This behaviour exists in the old inline assistant code as well but I haven't touched it as I didn't want to make any unnecessary changes which were not required.

Behaviour before changes:

https://github.com/user-attachments/assets/4b849518-79c7-4c20-a4ec-bc8b872c04ba

Behaviour after changes:

https://github.com/user-attachments/assets/7e2a16c7-166f-4658-b871-145a1d8f81aa

Tested:
	* Multicursor works as it used to.


Release Notes:

- agent: Prevent duplicate inline assistants per file and focus existing one
