### PR TITLE
Show prompt usage in agent overflow menu

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -1371,7 +1371,6 @@ impl AssistantPanel {
         let thread = active_thread.thread().read(cx);
         let thread_id = thread.id().clone();
         let is_empty = active_thread.is_empty();
-        // todo!("update")
         let last_usage = active_thread.thread().read(cx).last_usage();
         let account_url = zed_urls::account_url(cx);
 

--- a/crates/ui/src/components/list/list_sub_header.rs
+++ b/crates/ui/src/components/list/list_sub_header.rs
@@ -5,6 +5,7 @@ use crate::{Icon, IconName, IconSize, Label, h_flex};
 pub struct ListSubHeader {
     label: SharedString,
     start_slot: Option<IconName>,
+    end_slot: Option<AnyElement>,
     inset: bool,
     selected: bool,
 }
@@ -14,6 +15,7 @@ impl ListSubHeader {
         Self {
             label: label.into(),
             start_slot: None,
+            end_slot: None,
             inset: false,
             selected: false,
         }
@@ -21,6 +23,11 @@ impl ListSubHeader {
 
     pub fn left_icon(mut self, left_icon: Option<IconName>) -> Self {
         self.start_slot = left_icon;
+        self
+    }
+
+    pub fn end_slot(mut self, end_slot: AnyElement) -> Self {
+        self.end_slot = Some(end_slot);
         self
     }
 
@@ -73,7 +80,8 @@ impl RenderOnce for ListSubHeader {
                                     .color(Color::Muted)
                                     .size(LabelSize::Small),
                             ),
-                    ),
+                    )
+                    .children(self.end_slot),
             )
     }
 }


### PR DESCRIPTION
This PR adds prompt usage information, and easy access to managing your account, to the agent overflow menu:

![CleanShot 2025-05-05 at 10 04 20@2x](https://github.com/user-attachments/assets/337a1a0b-6f71-49a0-9fe7-4fbf2ec1fc27)

Currently this UI will only show after making a request. We'll work on eagerly getting the usage info later.

Release Notes:

- Added current prompt usage information to the agent menu (`...`) for Zed AI users
