### PR TITLE
gpui: Fix typo in doc comment

### DIFF
--- a/crates/gpui/src/util.rs
+++ b/crates/gpui/src/util.rs
@@ -40,7 +40,7 @@ pub trait FluentBuilder {
             }
         })
     }
-    /// Conditionally unwrap and modify self with the given closure, if the given option is Some.
+    /// Conditionally unwrap and modify self with the given closure, if the given option is None.
     fn when_none<T>(self, option: &Option<T>, then: impl FnOnce(Self) -> Self) -> Self
     where
         Self: Sized,


### PR DESCRIPTION
Fixes a typo in gpui docs

Release Notes:

- N/A
