### PR TITLE
Honor the prompt field of inline assist action

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -2679,7 +2679,7 @@ impl rules_library::InlineAssistDelegate for PromptLibraryInlineAssist {
     fn assist(
         &self,
         prompt_editor: &Entity<Editor>,
-        _initial_prompt: Option<String>,
+        initial_prompt: Option<String>,
         window: &mut Window,
         cx: &mut Context<RulesLibrary>,
     ) {
@@ -2703,6 +2703,7 @@ impl rules_library::InlineAssistDelegate for PromptLibraryInlineAssist {
                 prompt_store,
                 thread_store,
                 text_thread_store,
+                initial_prompt,
                 window,
                 cx,
             )

--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -227,7 +227,7 @@ impl InlineAssistant {
 
     pub fn inline_assist(
         workspace: &mut Workspace,
-        _action: &zed_actions::assistant::InlineAssist,
+        action: &zed_actions::assistant::InlineAssist,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
@@ -273,6 +273,7 @@ impl InlineAssistant {
                             prompt_store,
                             thread_store,
                             text_thread_store,
+                            action.prompt.clone(),
                             window,
                             cx,
                         )
@@ -287,6 +288,7 @@ impl InlineAssistant {
                             prompt_store,
                             thread_store,
                             text_thread_store,
+                            action.prompt.clone(),
                             window,
                             cx,
                         )
@@ -344,6 +346,7 @@ impl InlineAssistant {
         prompt_store: Option<Entity<PromptStore>>,
         thread_store: Option<WeakEntity<ThreadStore>>,
         text_thread_store: Option<WeakEntity<TextThreadStore>>,
+        initial_prompt: Option<String>,
         window: &mut Window,
         cx: &mut App,
     ) {
@@ -442,8 +445,12 @@ impl InlineAssistant {
         }
 
         let assist_group_id = self.next_assist_group_id.post_inc();
-        let prompt_buffer =
-            cx.new(|cx| MultiBuffer::singleton(cx.new(|cx| Buffer::local(String::new(), cx)), cx));
+        let prompt_buffer = cx.new(|cx| {
+            MultiBuffer::singleton(
+                cx.new(|cx| Buffer::local(initial_prompt.unwrap_or_default(), cx)),
+                cx,
+            )
+        });
 
         let mut assists = Vec::new();
         let mut assist_to_focus = None;

--- a/crates/agent/src/terminal_inline_assistant.rs
+++ b/crates/agent/src/terminal_inline_assistant.rs
@@ -72,13 +72,18 @@ impl TerminalInlineAssistant {
         prompt_store: Option<Entity<PromptStore>>,
         thread_store: Option<WeakEntity<ThreadStore>>,
         text_thread_store: Option<WeakEntity<TextThreadStore>>,
+        initial_prompt: Option<String>,
         window: &mut Window,
         cx: &mut App,
     ) {
         let terminal = terminal_view.read(cx).terminal().clone();
         let assist_id = self.next_assist_id.post_inc();
-        let prompt_buffer =
-            cx.new(|cx| MultiBuffer::singleton(cx.new(|cx| Buffer::local(String::new(), cx)), cx));
+        let prompt_buffer = cx.new(|cx| {
+            MultiBuffer::singleton(
+                cx.new(|cx| Buffer::local(initial_prompt.unwrap_or_default(), cx)),
+                cx,
+            )
+        });
         let context_store = cx.new(|_cx| ContextStore::new(project, thread_store.clone()));
         let codegen = cx.new(|_| TerminalCodegen::new(terminal, self.telemetry.clone()));
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/29337

Release Notes:

- Fixed a bug where the `prompt` field was ignored on custom key bindings for `InlineAssist`
