### PR TITLE
component: Component crate cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3237,6 +3237,7 @@ dependencies = [
  "gpui",
  "linkme",
  "parking_lot",
+ "strum 0.27.1",
  "theme",
  "workspace-hack",
 ]

--- a/crates/component/Cargo.toml
+++ b/crates/component/Cargo.toml
@@ -16,6 +16,7 @@ collections.workspace = true
 gpui.workspace = true
 linkme.workspace = true
 parking_lot.workspace = true
+strum.workspace = true
 theme.workspace = true
 workspace-hack.workspace = true
 

--- a/crates/component/src/component.rs
+++ b/crates/component/src/component.rs
@@ -12,7 +12,6 @@ mod component_layout;
 pub use component_layout::*;
 
 use std::fmt::Display;
-use std::ops::{Deref, DerefMut};
 use std::sync::LazyLock;
 
 use collections::HashMap;
@@ -20,16 +19,15 @@ use gpui::{AnyElement, App, SharedString, Window};
 use linkme::distributed_slice;
 use parking_lot::RwLock;
 
+pub fn components() -> ComponentRegistry {
+    COMPONENT_DATA.read().clone()
+}
+
 pub fn init() {
     let component_fns: Vec<_> = __ALL_COMPONENTS.iter().cloned().collect();
     for f in component_fns {
         f();
     }
-}
-
-pub fn components() -> AllComponents {
-    let data = COMPONENT_DATA.read();
-    AllComponents(data.components.clone())
 }
 
 pub fn register_component<T: Component>() {
@@ -53,9 +51,47 @@ pub static __ALL_COMPONENTS: [fn()] = [..];
 pub static COMPONENT_DATA: LazyLock<RwLock<ComponentRegistry>> =
     LazyLock::new(|| RwLock::new(ComponentRegistry::default()));
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct ComponentRegistry {
     components: HashMap<ComponentId, ComponentMetadata>,
+}
+
+impl ComponentRegistry {
+    pub fn previews(&self) -> Vec<&ComponentMetadata> {
+        self.components
+            .values()
+            .filter(|c| c.preview.is_some())
+            .collect()
+    }
+
+    pub fn sorted_previews(&self) -> Vec<ComponentMetadata> {
+        let mut previews: Vec<ComponentMetadata> = self.previews().into_iter().cloned().collect();
+        previews.sort_by_key(|a| a.name());
+        previews
+    }
+
+    pub fn components(&self) -> Vec<&ComponentMetadata> {
+        self.components.values().collect()
+    }
+
+    pub fn sorted_components(&self) -> Vec<ComponentMetadata> {
+        let mut components: Vec<ComponentMetadata> =
+            self.components().into_iter().cloned().collect();
+        components.sort_by_key(|a| a.name());
+        components
+    }
+
+    pub fn component_map(&self) -> HashMap<ComponentId, ComponentMetadata> {
+        self.components.clone()
+    }
+
+    pub fn get(&self, id: &ComponentId) -> Option<&ComponentMetadata> {
+        self.components.get(id)
+    }
+
+    pub fn len(&self) -> usize {
+        self.components.len()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -75,6 +111,7 @@ impl ComponentMetadata {
     pub fn id(&self) -> ComponentId {
         self.id.clone()
     }
+
     pub fn name(&self) -> SharedString {
         self.name.clone()
     }
@@ -96,98 +133,13 @@ impl ComponentMetadata {
     pub fn scope(&self) -> ComponentScope {
         self.scope.clone()
     }
+
     pub fn description(&self) -> Option<SharedString> {
         self.description.clone()
     }
+
     pub fn preview(&self) -> Option<fn(&mut Window, &mut App) -> Option<AnyElement>> {
         self.preview
-    }
-}
-
-pub struct AllComponents(pub HashMap<ComponentId, ComponentMetadata>);
-
-impl AllComponents {
-    pub fn new() -> Self {
-        AllComponents(HashMap::default())
-    }
-    pub fn all_previews(&self) -> Vec<&ComponentMetadata> {
-        self.0.values().filter(|c| c.preview.is_some()).collect()
-    }
-    pub fn all_previews_sorted(&self) -> Vec<ComponentMetadata> {
-        let mut previews: Vec<ComponentMetadata> =
-            self.all_previews().into_iter().cloned().collect();
-        previews.sort_by_key(|a| a.name());
-        previews
-    }
-    pub fn all(&self) -> Vec<&ComponentMetadata> {
-        self.0.values().collect()
-    }
-    pub fn all_sorted(&self) -> Vec<ComponentMetadata> {
-        let mut components: Vec<ComponentMetadata> = self.all().into_iter().cloned().collect();
-        components.sort_by_key(|a| a.name());
-        components
-    }
-}
-
-impl Deref for AllComponents {
-    type Target = HashMap<ComponentId, ComponentMetadata>;
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
-
-impl DerefMut for AllComponents {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
-
-// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-// pub enum ComponentStatus {
-//     WorkInProgress,
-//     EngineeringReady,
-//     Live,
-//     Deprecated,
-// }
-
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum ComponentScope {
-    Agent,
-    Collaboration,
-    DataDisplay,
-    Editor,
-    Images,
-    Input,
-    Layout,
-    Loading,
-    Navigation,
-    None,
-    Notification,
-    Overlays,
-    Status,
-    Typography,
-    VersionControl,
-}
-
-impl Display for ComponentScope {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ComponentScope::Agent => write!(f, "Agent"),
-            ComponentScope::Collaboration => write!(f, "Collaboration"),
-            ComponentScope::DataDisplay => write!(f, "Data Display"),
-            ComponentScope::Editor => write!(f, "Editor"),
-            ComponentScope::Images => write!(f, "Images & Icons"),
-            ComponentScope::Input => write!(f, "Forms & Input"),
-            ComponentScope::Layout => write!(f, "Layout & Structure"),
-            ComponentScope::Loading => write!(f, "Loading & Progress"),
-            ComponentScope::Navigation => write!(f, "Navigation"),
-            ComponentScope::None => write!(f, "Unsorted"),
-            ComponentScope::Notification => write!(f, "Notification"),
-            ComponentScope::Overlays => write!(f, "Overlays & Layering"),
-            ComponentScope::Status => write!(f, "Status"),
-            ComponentScope::Typography => write!(f, "Typography"),
-            ComponentScope::VersionControl => write!(f, "Version Control"),
-        }
     }
 }
 
@@ -279,5 +231,54 @@ pub trait Component {
     /// tooltip on hover, or a grid of icons showcasing all the icons available.
     fn preview(_window: &mut Window, _cx: &mut App) -> Option<AnyElement> {
         None
+    }
+}
+
+// #[derive(Debug, Clone, PartialEq, Eq, Hash)]
+// pub enum ComponentStatus {
+//     WorkInProgress,
+//     EngineeringReady,
+//     Live,
+//     Deprecated,
+// }
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ComponentScope {
+    Agent,
+    Collaboration,
+    DataDisplay,
+    Editor,
+    Images,
+    Input,
+    Layout,
+    Loading,
+    Navigation,
+    None,
+    Notification,
+    Overlays,
+    Status,
+    Typography,
+    VersionControl,
+}
+
+impl Display for ComponentScope {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ComponentScope::Agent => write!(f, "Agent"),
+            ComponentScope::Collaboration => write!(f, "Collaboration"),
+            ComponentScope::DataDisplay => write!(f, "Data Display"),
+            ComponentScope::Editor => write!(f, "Editor"),
+            ComponentScope::Images => write!(f, "Images & Icons"),
+            ComponentScope::Input => write!(f, "Forms & Input"),
+            ComponentScope::Layout => write!(f, "Layout & Structure"),
+            ComponentScope::Loading => write!(f, "Loading & Progress"),
+            ComponentScope::Navigation => write!(f, "Navigation"),
+            ComponentScope::None => write!(f, "Unsorted"),
+            ComponentScope::Notification => write!(f, "Notification"),
+            ComponentScope::Overlays => write!(f, "Overlays & Layering"),
+            ComponentScope::Status => write!(f, "Status"),
+            ComponentScope::Typography => write!(f, "Typography"),
+            ComponentScope::VersionControl => write!(f, "Version Control"),
+        }
     }
 }

--- a/crates/component/src/component.rs
+++ b/crates/component/src/component.rs
@@ -1,3 +1,12 @@
+//! # Component
+//!
+//! This module provides the Component trait, which is used to define
+//! components for visual testing and debugging.
+//!
+//! Additionally, it includes layouts for rendering component examples
+//! and example groups, as well as the distributed slice mechanism for
+//! registering components.
+
 use std::fmt::Display;
 use std::ops::{Deref, DerefMut};
 use std::sync::LazyLock;

--- a/crates/component/src/component.rs
+++ b/crates/component/src/component.rs
@@ -11,13 +11,13 @@ mod component_layout;
 
 pub use component_layout::*;
 
-use std::fmt::Display;
 use std::sync::LazyLock;
 
 use collections::HashMap;
 use gpui::{AnyElement, App, SharedString, Window};
 use linkme::distributed_slice;
 use parking_lot::RwLock;
+use strum::{Display, EnumString};
 
 pub fn components() -> ComponentRegistry {
     COMPONENT_DATA.read().clone()
@@ -242,43 +242,29 @@ pub trait Component {
 //     Deprecated,
 // }
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Display, EnumString)]
 pub enum ComponentScope {
     Agent,
     Collaboration,
+    #[strum(serialize = "Data Display")]
     DataDisplay,
     Editor,
+    #[strum(serialize = "Images & Icons")]
     Images,
+    #[strum(serialize = "Forms & Input")]
     Input,
+    #[strum(serialize = "Layout & Structure")]
     Layout,
+    #[strum(serialize = "Loading & Progress")]
     Loading,
     Navigation,
+    #[strum(serialize = "Unsorted")]
     None,
     Notification,
+    #[strum(serialize = "Overlays & Layering")]
     Overlays,
     Status,
     Typography,
+    #[strum(serialize = "Version Control")]
     VersionControl,
-}
-
-impl Display for ComponentScope {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            ComponentScope::Agent => write!(f, "Agent"),
-            ComponentScope::Collaboration => write!(f, "Collaboration"),
-            ComponentScope::DataDisplay => write!(f, "Data Display"),
-            ComponentScope::Editor => write!(f, "Editor"),
-            ComponentScope::Images => write!(f, "Images & Icons"),
-            ComponentScope::Input => write!(f, "Forms & Input"),
-            ComponentScope::Layout => write!(f, "Layout & Structure"),
-            ComponentScope::Loading => write!(f, "Loading & Progress"),
-            ComponentScope::Navigation => write!(f, "Navigation"),
-            ComponentScope::None => write!(f, "Unsorted"),
-            ComponentScope::Notification => write!(f, "Notification"),
-            ComponentScope::Overlays => write!(f, "Overlays & Layering"),
-            ComponentScope::Status => write!(f, "Status"),
-            ComponentScope::Typography => write!(f, "Typography"),
-            ComponentScope::VersionControl => write!(f, "Version Control"),
-        }
-    }
 }

--- a/crates/component/src/component_layout.rs
+++ b/crates/component/src/component_layout.rs
@@ -1,0 +1,205 @@
+use gpui::{
+    AnyElement, App, IntoElement, Pixels, RenderOnce, SharedString, Window, div, pattern_slash,
+    prelude::*, px, rems,
+};
+use theme::ActiveTheme;
+
+/// A single example of a component.
+#[derive(IntoElement)]
+pub struct ComponentExample {
+    pub variant_name: SharedString,
+    pub description: Option<SharedString>,
+    pub element: AnyElement,
+    pub width: Option<Pixels>,
+}
+
+impl RenderOnce for ComponentExample {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        div()
+            .pt_2()
+            .map(|this| {
+                if let Some(width) = self.width {
+                    this.w(width)
+                } else {
+                    this.w_full()
+                }
+            })
+            .flex()
+            .flex_col()
+            .gap_3()
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .child(
+                        div()
+                            .child(self.variant_name.clone())
+                            .text_size(rems(1.0))
+                            .text_color(cx.theme().colors().text),
+                    )
+                    .when_some(self.description, |this, description| {
+                        this.child(
+                            div()
+                                .text_size(rems(0.875))
+                                .text_color(cx.theme().colors().text_muted)
+                                .child(description.clone()),
+                        )
+                    }),
+            )
+            .child(
+                div()
+                    .flex()
+                    .w_full()
+                    .rounded_xl()
+                    .min_h(px(100.))
+                    .justify_center()
+                    .p_8()
+                    .border_1()
+                    .border_color(cx.theme().colors().border.opacity(0.5))
+                    .bg(pattern_slash(
+                        cx.theme().colors().surface_background.opacity(0.5),
+                        12.0,
+                        12.0,
+                    ))
+                    .shadow_sm()
+                    .child(self.element),
+            )
+            .into_any_element()
+    }
+}
+
+impl ComponentExample {
+    pub fn new(variant_name: impl Into<SharedString>, element: AnyElement) -> Self {
+        Self {
+            variant_name: variant_name.into(),
+            element,
+            description: None,
+            width: None,
+        }
+    }
+
+    pub fn description(mut self, description: impl Into<SharedString>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
+    pub fn width(mut self, width: Pixels) -> Self {
+        self.width = Some(width);
+        self
+    }
+}
+
+/// A group of component examples.
+#[derive(IntoElement)]
+pub struct ComponentExampleGroup {
+    pub title: Option<SharedString>,
+    pub examples: Vec<ComponentExample>,
+    pub width: Option<Pixels>,
+    pub grow: bool,
+    pub vertical: bool,
+}
+
+impl RenderOnce for ComponentExampleGroup {
+    fn render(self, _window: &mut Window, cx: &mut App) -> impl IntoElement {
+        div()
+            .flex_col()
+            .text_sm()
+            .text_color(cx.theme().colors().text_muted)
+            .map(|this| {
+                if let Some(width) = self.width {
+                    this.w(width)
+                } else {
+                    this.w_full()
+                }
+            })
+            .when_some(self.title, |this, title| {
+                this.gap_4().child(
+                    div()
+                        .flex()
+                        .items_center()
+                        .gap_3()
+                        .pb_1()
+                        .child(div().h_px().w_4().bg(cx.theme().colors().border))
+                        .child(
+                            div()
+                                .flex_none()
+                                .text_size(px(10.))
+                                .child(title.to_uppercase()),
+                        )
+                        .child(
+                            div()
+                                .h_px()
+                                .w_full()
+                                .flex_1()
+                                .bg(cx.theme().colors().border),
+                        ),
+                )
+            })
+            .child(
+                div()
+                    .flex()
+                    .flex_col()
+                    .items_start()
+                    .w_full()
+                    .gap_6()
+                    .children(self.examples)
+                    .into_any_element(),
+            )
+            .into_any_element()
+    }
+}
+
+impl ComponentExampleGroup {
+    pub fn new(examples: Vec<ComponentExample>) -> Self {
+        Self {
+            title: None,
+            examples,
+            width: None,
+            grow: false,
+            vertical: false,
+        }
+    }
+    pub fn with_title(title: impl Into<SharedString>, examples: Vec<ComponentExample>) -> Self {
+        Self {
+            title: Some(title.into()),
+            examples,
+            width: None,
+            grow: false,
+            vertical: false,
+        }
+    }
+    pub fn width(mut self, width: Pixels) -> Self {
+        self.width = Some(width);
+        self
+    }
+    pub fn grow(mut self) -> Self {
+        self.grow = true;
+        self
+    }
+    pub fn vertical(mut self) -> Self {
+        self.vertical = true;
+        self
+    }
+}
+
+pub fn single_example(
+    variant_name: impl Into<SharedString>,
+    example: AnyElement,
+) -> ComponentExample {
+    ComponentExample::new(variant_name, example)
+}
+
+pub fn empty_example(variant_name: impl Into<SharedString>) -> ComponentExample {
+    ComponentExample::new(variant_name, div().w_full().text_center().items_center().text_xs().opacity(0.4).child("This space is intentionally left blank. It indicates a case that should render nothing.").into_any_element())
+}
+
+pub fn example_group(examples: Vec<ComponentExample>) -> ComponentExampleGroup {
+    ComponentExampleGroup::new(examples)
+}
+
+pub fn example_group_with_title(
+    title: impl Into<SharedString>,
+    examples: Vec<ComponentExample>,
+) -> ComponentExampleGroup {
+    ComponentExampleGroup::with_title(title, examples)
+}

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -5,8 +5,9 @@
 mod persistence;
 mod preview_support;
 
-use std::iter::Iterator;
 use std::sync::Arc;
+
+use std::iter::Iterator;
 
 use agent::{ActiveThread, TextThreadStore, ThreadStore};
 use client::UserStore;
@@ -164,7 +165,8 @@ impl ComponentPreview {
         })
         .detach();
 
-        let sorted_components = components().sorted_components();
+        let component_registry = Arc::new(components());
+        let sorted_components = component_registry.sorted_components();
         let selected_index = selected_index.into().unwrap_or(0);
         let active_page = active_page.unwrap_or(PreviewPage::AllComponents);
         let filter_editor =
@@ -197,7 +199,7 @@ impl ComponentPreview {
             workspace,
             project,
             active_page,
-            component_map: components().component_map(),
+            component_map: component_registry.component_map(),
             components: sorted_components,
             component_list,
             cursor_index: selected_index,

--- a/crates/component_preview/src/component_preview.rs
+++ b/crates/component_preview/src/component_preview.rs
@@ -164,7 +164,7 @@ impl ComponentPreview {
         })
         .detach();
 
-        let sorted_components = components().all_sorted();
+        let sorted_components = components().sorted_components();
         let selected_index = selected_index.into().unwrap_or(0);
         let active_page = active_page.unwrap_or(PreviewPage::AllComponents);
         let filter_editor =
@@ -197,7 +197,7 @@ impl ComponentPreview {
             workspace,
             project,
             active_page,
-            component_map: components().0,
+            component_map: components().component_map(),
             components: sorted_components,
             component_list,
             cursor_index: selected_index,
@@ -971,7 +971,7 @@ impl SerializableItem for ComponentPreview {
         } else {
             let component_str = deserialized_active_page.0;
             let component_registry = components();
-            let all_components = component_registry.all();
+            let all_components = component_registry.components();
             let found_component = all_components.iter().find(|c| c.id().0 == component_str);
 
             if let Some(component) = found_component {

--- a/crates/ui/src/component_prelude.rs
+++ b/crates/ui/src/component_prelude.rs
@@ -1,5 +1,6 @@
 pub use component::{
-    Component, ComponentScope, example_group, example_group_with_title, single_example,
+    Component, ComponentId, ComponentScope, ComponentStatus, example_group,
+    example_group_with_title, single_example,
 };
 pub use documented::Documented;
 pub use ui_macros::RegisterComponent;

--- a/crates/ui/src/components/notification/alert_modal.rs
+++ b/crates/ui/src/components/notification/alert_modal.rs
@@ -1,3 +1,4 @@
+use crate::component_prelude::*;
 use crate::prelude::*;
 use gpui::IntoElement;
 use smallvec::{SmallVec, smallvec};
@@ -79,6 +80,10 @@ impl ParentElement for AlertModal {
 impl Component for AlertModal {
     fn scope() -> ComponentScope {
         ComponentScope::Notification
+    }
+
+    fn status() -> ComponentStatus {
+        ComponentStatus::WorkInProgress
     }
 
     fn description() -> Option<&'static str> {


### PR DESCRIPTION
This PR further organizes and documents the component crate. It:

- Simplifies the component registry
- Gives access to `ComponentMetadata` sooner
- Enables lookup by id in preview extension implementations (`ComponentId` -> `ComponentMetadata`)
- Should slightly improve the performance of ComponentPreview

It also brings component statuses to the Component trait:

![CleanShot 2025-05-05 at 23 27 11@2x](https://github.com/user-attachments/assets/dd95ede6-bc90-4de4-90c6-3e5e064fd676)

![CleanShot 2025-05-05 at 23 27 40@2x](https://github.com/user-attachments/assets/9520aece-04c2-418b-95e1-c11aa60a66ca)

![CleanShot 2025-05-05 at 23 27 57@2x](https://github.com/user-attachments/assets/db1713d5-9831-4d00-9b29-1fd51c25fcba)

Release Notes:

- N/A