### PR TITLE
openai: Don't append tool calls to prior assistant messages

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -372,14 +372,10 @@ pub fn into_open_ai(
                         },
                     };
 
-                    if let Some(last_assistant_message) = messages.iter_mut().rfind(|message| {
-                        matches!(message, open_ai::RequestMessage::Assistant { .. })
-                    }) {
-                        if let open_ai::RequestMessage::Assistant { tool_calls, .. } =
-                            last_assistant_message
-                        {
-                            tool_calls.push(tool_call);
-                        }
+                    if let Some(open_ai::RequestMessage::Assistant { tool_calls, .. }) =
+                        messages.last_mut()
+                    {
+                        tool_calls.push(tool_call);
                     } else {
                         messages.push(open_ai::RequestMessage::Assistant {
                             content: None,


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/29821

Release Notes:

- Fixed an issue in the agent panel where OpenAI requests would fail if the assistant begins its response with a tool call.
