### PR TITLE
debugger: Fix debug scenario's defined in debug.json not using passed in build task

### DIFF
--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -237,7 +237,7 @@ impl PickerDelegate for AttachModalDelegate {
             .flatten();
         if let Some(panel) = panel {
             panel.update(cx, |panel, cx| {
-                panel.start_session(scenario, Default::default(), None, window, cx);
+                panel.start_session(scenario, Default::default(), None, None, window, cx);
             });
         }
 

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -22,8 +22,8 @@ use gpui::{
 };
 
 use language::Buffer;
-use project::Fs;
 use project::debugger::session::{Session, SessionStateEvent};
+use project::{Fs, WorktreeId};
 use project::{Project, debugger::session::ThreadStatus};
 use rpc::proto::{self};
 use settings::Settings;
@@ -208,6 +208,7 @@ impl DebugPanel {
         scenario: DebugScenario,
         task_context: TaskContext,
         active_buffer: Option<Entity<Buffer>>,
+        worktree_id: Option<WorktreeId>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -233,6 +234,7 @@ impl DebugPanel {
                                 scenario,
                                 task_context,
                                 active_buffer,
+                                worktree_id,
                                 window,
                                 cx,
                             )
@@ -1283,7 +1285,7 @@ impl workspace::DebuggerProvider for DebuggerProvider {
     ) {
         self.0.update(cx, |_, cx| {
             cx.defer_in(window, |this, window, cx| {
-                this.start_session(definition, context, buffer, window, cx);
+                this.start_session(definition, context, buffer, None, window, cx);
             })
         })
     }

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -761,6 +761,7 @@ impl RunningState {
                     anyhow::bail!("Build failed");
                 }
 
+                dbg!("Running locator");
                 dap_store
                     .update(cx, |this, cx| this.run_debug_locator(task.resolved, cx))?
                     .await?

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -29,7 +29,7 @@ use language::Buffer;
 use loaded_source_list::LoadedSourceList;
 use module_list::ModuleList;
 use project::{
-    Project,
+    Project, WorktreeId,
     debugger::session::{Session, SessionEvent, ThreadId, ThreadStatus},
     terminals::TerminalKind,
 };
@@ -684,6 +684,7 @@ impl RunningState {
         scenario: DebugScenario,
         task_context: TaskContext,
         buffer: Option<Entity<Buffer>>,
+        worktree_id: Option<WorktreeId>,
         window: &Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<DebugTaskDefinition>> {
@@ -712,7 +713,7 @@ impl RunningState {
                     this.task_inventory().and_then(|inventory| {
                         inventory
                             .read(cx)
-                            .task_template_by_label(buffer, &build, cx)
+                            .task_template_by_label(buffer, worktree_id, &build, cx)
                     })
                 })?
                 else {
@@ -761,7 +762,6 @@ impl RunningState {
                     anyhow::bail!("Build failed");
                 }
 
-                dbg!("Running locator");
                 dap_store
                     .update(cx, |this, cx| this.run_debug_locator(task.resolved, cx))?
                     .await?

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -348,6 +348,7 @@ impl DapStore {
                 if !locators.is_empty() {
                     cx.background_spawn(async move {
                         for locator in locators {
+                            dbg!("Running locator");
                             let result = locator
                                 .run(build_command.clone())
                                 .await

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -348,7 +348,6 @@ impl DapStore {
                 if !locators.is_empty() {
                     cx.background_spawn(async move {
                         for locator in locators {
-                            dbg!("Running locator");
                             let result = locator
                                 .run(build_command.clone())
                                 .await

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -229,10 +229,11 @@ impl Inventory {
     pub fn task_template_by_label(
         &self,
         buffer: Option<Entity<Buffer>>,
+        worktree_id: Option<WorktreeId>,
         label: &str,
         cx: &App,
     ) -> Option<TaskTemplate> {
-        let (worktree_id, file, language) = buffer
+        let (buffer_worktree_id, file, language) = buffer
             .map(|buffer| {
                 let buffer = buffer.read(cx);
                 let file = buffer.file().cloned();
@@ -244,7 +245,7 @@ impl Inventory {
             })
             .unwrap_or((None, None, None));
 
-        self.list_tasks(file, language, worktree_id, cx)
+        self.list_tasks(file, language, worktree_id.or(buffer_worktree_id), cx)
             .iter()
             .find(|(_, template)| template.label == label)
             .map(|val| val.1.clone())


### PR DESCRIPTION
There were two bugs that caused user-defined debug scenarios from being able to run a build task. 

1. DebugRequest would be deserialized to `Attach` even when `process_id` wasn't defined in a user's configuration file. This has been fixed by adding our own deserializer that defaults to None if there are no fields present instead of `Attach`, and I added tests to prevent regressions.
2. Debug scenario resolve phase never got the active buffer when spawning a debug session from the new session modal. This has been worked around by passing in the worktree_id of a debug scenario in the scenario picker and the active worktree_id otherwise.

Release Notes:

- N/A
