### PR TITLE
fix(vim): Store up to the 9th numbered register instead of 7th

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -757,7 +757,7 @@ impl VimGlobals {
                 }
                 if kind.linewise() || contains_newline {
                     let mut content = content;
-                    for i in '1'..'8' {
+                    for i in '1'..='9' {
                         if let Some(moved) = self.registers.insert(i, content) {
                             content = moved;
                         } else {


### PR DESCRIPTION
Release Notes:

- Fixed an issue where we only automatically stored 7 numbered registers instead of 9
