### PR TITLE
agent: Disable claude-3-7-sonnet-thinking tool support for Copilot Chat

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -192,8 +192,7 @@ impl LanguageModel for CopilotChatLanguageModel {
             | CopilotChatModel::Gpt4_1
             | CopilotChatModel::O4Mini
             | CopilotChatModel::Claude3_5Sonnet
-            | CopilotChatModel::Claude3_7Sonnet
-            | CopilotChatModel::Claude3_7SonnetThinking => true,
+            | CopilotChatModel::Claude3_7Sonnet => true,
             _ => false,
         }
     }


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/29711

We started getting Bad Requests from the Copilot Chat API.
Seems like Microsoft stopped supporting this:
<img width="331" alt="image" src="https://github.com/user-attachments/assets/46050063-f031-4836-82ff-219bdd45639a" />


Release Notes:

- agent: Disable `claude-3-7-sonnet-thinking` for Copilot Chat Provider because it is not supported by Copilot Chat
