### PR TITLE
agent: Add label to Max Mode toggle

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -470,9 +470,13 @@ impl MessageEditor {
         let active_completion_mode = thread.completion_mode();
 
         Some(
-            IconButton::new("max-mode", IconName::ZedMaxMode)
+            Button::new("max-mode", "Max Mode")
+                .label_size(LabelSize::Small)
+                .color(Color::Muted)
+                .icon(IconName::ZedMaxMode)
                 .icon_size(IconSize::Small)
                 .icon_color(Color::Muted)
+                .icon_position(IconPosition::Start)
                 .toggle_state(active_completion_mode == CompletionMode::Max)
                 .on_click(cx.listener(move |this, _event, _window, cx| {
                     this.thread.update(cx, |thread, _cx| {


### PR DESCRIPTION
This PR adds a label to the Max Mode toggle, for increased clarity:

<img width="647" alt="Screenshot 2025-05-06 at 9 16 35 AM" src="https://github.com/user-attachments/assets/38cd55fb-43ad-430b-8b4c-5adf707317cf" />

Release Notes:

- Agent Beta: Added a label to the Max Mode toggle.
