### PR TITLE
Fix error when requesting completion to Copilot Chat without tools

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -437,6 +437,7 @@ impl CopilotChatLanguageModel {
             }
         }
 
+        let mut tool_called = false;
         let mut messages: Vec<ChatMessage> = Vec::new();
         for message in request_messages {
             let text_content = {
@@ -477,6 +478,7 @@ impl CopilotChatLanguageModel {
                     let mut tool_calls = Vec::new();
                     for content in &message.content {
                         if let MessageContent::ToolUse(tool_use) = content {
+                            tool_called = true;
                             tool_calls.push(ToolCall {
                                 id: tool_use.id.to_string(),
                                 content: copilot::copilot_chat::ToolCallContent::Function {
@@ -504,7 +506,7 @@ impl CopilotChatLanguageModel {
             }
         }
 
-        let tools = request
+        let mut tools = request
             .tools
             .iter()
             .map(|tool| Tool::Function {
@@ -514,7 +516,21 @@ impl CopilotChatLanguageModel {
                     parameters: tool.input_schema.clone(),
                 },
             })
-            .collect();
+            .collect::<Vec<_>>();
+
+        // The API will return a Bad Request (with no error message) when tools
+        // were used previously in the conversation but no tools are provided as
+        // part of this request. Inserting a dummy tool seems to circumvent this
+        // error.
+        if tool_called && tools.is_empty() {
+            tools.push(Tool::Function {
+                function: copilot::copilot_chat::Function {
+                    name: "noop".to_string(),
+                    description: "No operation".to_string(),
+                    parameters: serde_json::json!({}),
+                },
+            });
+        }
 
         Ok(CopilotChatRequest {
             intent: true,


### PR DESCRIPTION
The API will return a Bad Request (with no error message) when tools were used previously in the conversation but no tools are provided as part of a new request.

Inserting a dummy tool seems to circumvent this error.

Release Notes:

- Fixed an error that could sometimes occur when editing using Copilot Chat.