### PR TITLE
agent: Add enabled indicator in Max Mode tooltip

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -468,6 +468,7 @@ impl MessageEditor {
         }
 
         let active_completion_mode = thread.completion_mode();
+        let max_mode_enabled = active_completion_mode == CompletionMode::Max;
 
         Some(
             Button::new("max-mode", "Max Mode")
@@ -477,7 +478,7 @@ impl MessageEditor {
                 .icon_size(IconSize::Small)
                 .icon_color(Color::Muted)
                 .icon_position(IconPosition::Start)
-                .toggle_state(active_completion_mode == CompletionMode::Max)
+                .toggle_state(max_mode_enabled)
                 .on_click(cx.listener(move |this, _event, _window, cx| {
                     this.thread.update(cx, |thread, _cx| {
                         thread.set_completion_mode(match active_completion_mode {
@@ -486,7 +487,10 @@ impl MessageEditor {
                         });
                     });
                 }))
-                .tooltip(|_, cx| cx.new(MaxModeTooltip::new).into())
+                .tooltip(move |_window, cx| {
+                    cx.new(|_| MaxModeTooltip::new().selected(max_mode_enabled))
+                        .into()
+                })
                 .into_any_element(),
         )
     }

--- a/crates/agent/src/ui/max_mode_tooltip.rs
+++ b/crates/agent/src/ui/max_mode_tooltip.rs
@@ -1,24 +1,50 @@
 use gpui::{Context, IntoElement, Render, Window};
 use ui::{prelude::*, tooltip_container};
 
-pub struct MaxModeTooltip;
+pub struct MaxModeTooltip {
+    selected: bool,
+}
 
 impl MaxModeTooltip {
-    pub fn new(_cx: &mut Context<Self>) -> Self {
-        Self
+    pub fn new() -> Self {
+        Self { selected: false }
+    }
+
+    pub fn selected(mut self, selected: bool) -> Self {
+        self.selected = selected;
+        self
     }
 }
 
 impl Render for MaxModeTooltip {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        tooltip_container(_window, cx, |this, _, _| {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        tooltip_container(window, cx, |this, _, _| {
             this.gap_1()
-                .child(
-                    h_flex()
-                        .gap_1p5()
-                        .child(Icon::new(IconName::ZedMaxMode).size(IconSize::Small))
-                        .child(Label::new("Zed's Max Mode"))
-                )
+                .map(|header| if self.selected {
+                    header.child(
+                        h_flex()
+                            .justify_between()
+                            .child(
+                                h_flex()
+                                    .gap_1p5()
+                                    .child(Icon::new(IconName::ZedMaxMode).size(IconSize::Small).color(Color::Accent))
+                                    .child(Label::new("Zed's Max Mode"))
+                            )
+                            .child(
+                                h_flex()
+                                    .gap_0p5()
+                                    .child(Icon::new(IconName::Check).size(IconSize::XSmall).color(Color::Accent))
+                                    .child(Label::new("Turned On").size(LabelSize::XSmall).color(Color::Accent))
+                            )
+                    )
+                } else {
+                    header.child(
+                        h_flex()
+                            .gap_1p5()
+                            .child(Icon::new(IconName::ZedMaxMode).size(IconSize::Small))
+                            .child(Label::new("Zed's Max Mode"))
+                    )
+                })
                 .child(
                     div()
                         .max_w_72()


### PR DESCRIPTION
This PR adds an enabled indicator in the Max Mode tooltip to show when it is enabled:

<img width="409" alt="Screenshot 2025-05-06 at 9 49 48 AM" src="https://github.com/user-attachments/assets/43d3f6dd-5658-467a-9df9-606ce326426a" />

Release Notes:

- Agent Beta: Added an indicator in the Max Mode tooltip to show when it is enabled.
