### PR TITLE
semantic_index: Reduce allocations

### DIFF
--- a/crates/semantic_index/src/embedding/lmstudio.rs
+++ b/crates/semantic_index/src/embedding/lmstudio.rs
@@ -16,9 +16,9 @@ pub struct LmStudioEmbeddingProvider {
 }
 
 #[derive(Serialize)]
-struct LmStudioEmbeddingRequest {
-    model: String,
-    prompt: String,
+struct LmStudioEmbeddingRequest<'a> {
+    model: &'a str,
+    prompt: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -40,8 +40,8 @@ impl EmbeddingProvider for LmStudioEmbeddingProvider {
 
         futures::future::try_join_all(texts.iter().map(|to_embed| {
             let request = LmStudioEmbeddingRequest {
-                model: model.to_string(),
-                prompt: to_embed.text.to_string(),
+                model,
+                prompt: to_embed.text,
             };
 
             let request = serde_json::to_string(&request).unwrap();

--- a/crates/semantic_index/src/embedding/ollama.rs
+++ b/crates/semantic_index/src/embedding/ollama.rs
@@ -17,9 +17,9 @@ pub struct OllamaEmbeddingProvider {
 }
 
 #[derive(Serialize)]
-struct OllamaEmbeddingRequest {
-    model: String,
-    prompt: String,
+struct OllamaEmbeddingRequest<'a> {
+    model: &'a str,
+    prompt: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -35,7 +35,6 @@ impl OllamaEmbeddingProvider {
 
 impl EmbeddingProvider for OllamaEmbeddingProvider {
     fn embed<'a>(&'a self, texts: &'a [TextToEmbed<'a>]) -> BoxFuture<'a, Result<Vec<Embedding>>> {
-        //
         let model = match self.model {
             OllamaEmbeddingModel::NomicEmbedText => "nomic-embed-text",
             OllamaEmbeddingModel::MxbaiEmbedLarge => "mxbai-embed-large",
@@ -43,8 +42,8 @@ impl EmbeddingProvider for OllamaEmbeddingProvider {
 
         futures::future::try_join_all(texts.iter().map(|to_embed| {
             let request = OllamaEmbeddingRequest {
-                model: model.to_string(),
-                prompt: to_embed.text.to_string(),
+                model,
+                prompt: to_embed.text,
             };
 
             let request = serde_json::to_string(&request).unwrap();


### PR DESCRIPTION
Reduces allocations used in `EmbeddingProvider::embed` for the ollama and LMStudio providers. We were using owned `String` types for a temporary serialization, which means we save `2*texts.len()` allocations per call. `text.len()` is often the value returned by `EmbeddingProvider::batch_size`, which in the case of LmStudio for example is 256. This means we are possibly saving **512 allocations** per call to this function.



Release Notes:

- N/A
