### PR TITLE
Remove deprecated models

### DIFF
--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -46,8 +46,6 @@ pub enum Model {
     Claude3_5Haiku,
     #[serde(rename = "claude-3-opus", alias = "claude-3-opus-latest")]
     Claude3Opus,
-    #[serde(rename = "claude-3-sonnet", alias = "claude-3-sonnet-latest")]
-    Claude3Sonnet,
     #[serde(rename = "claude-3-haiku", alias = "claude-3-haiku-latest")]
     Claude3Haiku,
     #[serde(rename = "custom")]
@@ -85,8 +83,6 @@ impl Model {
             Ok(Self::Claude3_5Haiku)
         } else if id.starts_with("claude-3-opus") {
             Ok(Self::Claude3Opus)
-        } else if id.starts_with("claude-3-sonnet") {
-            Ok(Self::Claude3Sonnet)
         } else if id.starts_with("claude-3-haiku") {
             Ok(Self::Claude3Haiku)
         } else {
@@ -101,7 +97,6 @@ impl Model {
             Model::Claude3_7SonnetThinking => "claude-3-7-sonnet-thinking-latest",
             Model::Claude3_5Haiku => "claude-3-5-haiku-latest",
             Model::Claude3Opus => "claude-3-opus-latest",
-            Model::Claude3Sonnet => "claude-3-sonnet-20240229",
             Model::Claude3Haiku => "claude-3-haiku-20240307",
             Self::Custom { name, .. } => name,
         }
@@ -114,7 +109,6 @@ impl Model {
             Model::Claude3_7Sonnet | Model::Claude3_7SonnetThinking => "claude-3-7-sonnet-latest",
             Model::Claude3_5Haiku => "claude-3-5-haiku-latest",
             Model::Claude3Opus => "claude-3-opus-latest",
-            Model::Claude3Sonnet => "claude-3-sonnet-20240229",
             Model::Claude3Haiku => "claude-3-haiku-20240307",
             Self::Custom { name, .. } => name,
         }
@@ -127,7 +121,6 @@ impl Model {
             Self::Claude3_7SonnetThinking => "Claude 3.7 Sonnet Thinking",
             Self::Claude3_5Haiku => "Claude 3.5 Haiku",
             Self::Claude3Opus => "Claude 3 Opus",
-            Self::Claude3Sonnet => "Claude 3 Sonnet",
             Self::Claude3Haiku => "Claude 3 Haiku",
             Self::Custom {
                 name, display_name, ..
@@ -161,7 +154,6 @@ impl Model {
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking
             | Self::Claude3Opus
-            | Self::Claude3Sonnet
             | Self::Claude3Haiku => 200_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
@@ -169,7 +161,7 @@ impl Model {
 
     pub fn max_output_tokens(&self) -> u32 {
         match self {
-            Self::Claude3Opus | Self::Claude3Sonnet | Self::Claude3Haiku => 4_096,
+            Self::Claude3Opus | Self::Claude3Haiku => 4_096,
             Self::Claude3_5Sonnet
             | Self::Claude3_7Sonnet
             | Self::Claude3_7SonnetThinking
@@ -187,7 +179,6 @@ impl Model {
             | Self::Claude3_7SonnetThinking
             | Self::Claude3_5Haiku
             | Self::Claude3Opus
-            | Self::Claude3Sonnet
             | Self::Claude3Haiku => 1.0,
             Self::Custom {
                 default_temperature,
@@ -202,7 +193,6 @@ impl Model {
             | Self::Claude3_7Sonnet
             | Self::Claude3_5Haiku
             | Self::Claude3Opus
-            | Self::Claude3Sonnet
             | Self::Claude3Haiku => AnthropicModelMode::Default,
             Self::Claude3_7SonnetThinking => AnthropicModelMode::Thinking {
                 budget_tokens: Some(4_096),

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -35,8 +35,6 @@ pub enum Model {
     Gpt4,
     #[serde(alias = "gpt-4.1", rename = "gpt-4.1")]
     Gpt4_1,
-    #[serde(alias = "gpt-3.5-turbo", rename = "gpt-3.5-turbo")]
-    Gpt3_5Turbo,
     #[serde(alias = "o1", rename = "o1")]
     O1,
     #[serde(alias = "o1-mini", rename = "o3-mini")]
@@ -70,7 +68,6 @@ impl Model {
             Self::Gpt4o
             | Self::Gpt4
             | Self::Gpt4_1
-            | Self::Gpt3_5Turbo
             | Self::O3
             | Self::O4Mini
             | Self::Claude3_5Sonnet
@@ -85,7 +82,6 @@ impl Model {
             "gpt-4o" => Ok(Self::Gpt4o),
             "gpt-4" => Ok(Self::Gpt4),
             "gpt-4.1" => Ok(Self::Gpt4_1),
-            "gpt-3.5-turbo" => Ok(Self::Gpt3_5Turbo),
             "o1" => Ok(Self::O1),
             "o3-mini" => Ok(Self::O3Mini),
             "o3" => Ok(Self::O3),
@@ -101,7 +97,6 @@ impl Model {
 
     pub fn id(&self) -> &'static str {
         match self {
-            Self::Gpt3_5Turbo => "gpt-3.5-turbo",
             Self::Gpt4 => "gpt-4",
             Self::Gpt4_1 => "gpt-4.1",
             Self::Gpt4o => "gpt-4o",
@@ -119,7 +114,6 @@ impl Model {
 
     pub fn display_name(&self) -> &'static str {
         match self {
-            Self::Gpt3_5Turbo => "GPT-3.5",
             Self::Gpt4 => "GPT-4",
             Self::Gpt4_1 => "GPT-4.1",
             Self::Gpt4o => "GPT-4o",
@@ -140,7 +134,6 @@ impl Model {
             Self::Gpt4o => 64_000,
             Self::Gpt4 => 32_768,
             Self::Gpt4_1 => 128_000,
-            Self::Gpt3_5Turbo => 12_288,
             Self::O3Mini => 64_000,
             Self::O1 => 20_000,
             Self::O3 => 128_000,

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -496,7 +496,7 @@ pub enum Model {
 
 impl Model {
     pub fn default_fast() -> Model {
-        Model::Gemini15Flash
+        Model::Gemini20FlashLite
     }
 
     pub fn id(&self) -> &str {

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -70,7 +70,6 @@ impl CloudModel {
                     LanguageModelAvailability::RequiresPlan(Plan::Free)
                 }
                 anthropic::Model::Claude3Opus
-                | anthropic::Model::Claude3Sonnet
                 | anthropic::Model::Claude3Haiku
                 | anthropic::Model::Claude3_5Haiku
                 | anthropic::Model::Custom { .. } => {
@@ -78,8 +77,7 @@ impl CloudModel {
                 }
             },
             Self::OpenAi(model) => match model {
-                open_ai::Model::ThreePointFiveTurbo
-                | open_ai::Model::Four
+                open_ai::Model::Four
                 | open_ai::Model::FourTurbo
                 | open_ai::Model::FourOmni
                 | open_ai::Model::FourOmniMini

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -222,7 +222,6 @@ impl LanguageModel for CopilotChatLanguageModel {
                     CopilotChatModel::Gpt4o => open_ai::Model::FourOmni,
                     CopilotChatModel::Gpt4 => open_ai::Model::Four,
                     CopilotChatModel::Gpt4_1 => open_ai::Model::FourPointOne,
-                    CopilotChatModel::Gpt3_5Turbo => open_ai::Model::ThreePointFiveTurbo,
                     CopilotChatModel::O1 => open_ai::Model::O1,
                     CopilotChatModel::O3Mini => open_ai::Model::O3Mini,
                     CopilotChatModel::O3 => open_ai::Model::O3,

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -56,8 +56,6 @@ impl From<Role> for String {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
-    #[serde(rename = "gpt-3.5-turbo", alias = "gpt-3.5-turbo")]
-    ThreePointFiveTurbo,
     #[serde(rename = "gpt-4", alias = "gpt-4")]
     Four,
     #[serde(rename = "gpt-4-turbo", alias = "gpt-4-turbo")]
@@ -104,7 +102,6 @@ impl Model {
 
     pub fn from_id(id: &str) -> Result<Self> {
         match id {
-            "gpt-3.5-turbo" => Ok(Self::ThreePointFiveTurbo),
             "gpt-4" => Ok(Self::Four),
             "gpt-4-turbo-preview" => Ok(Self::FourTurbo),
             "gpt-4o" => Ok(Self::FourOmni),
@@ -124,7 +121,6 @@ impl Model {
 
     pub fn id(&self) -> &str {
         match self {
-            Self::ThreePointFiveTurbo => "gpt-3.5-turbo",
             Self::Four => "gpt-4",
             Self::FourTurbo => "gpt-4-turbo",
             Self::FourOmni => "gpt-4o",
@@ -144,7 +140,6 @@ impl Model {
 
     pub fn display_name(&self) -> &str {
         match self {
-            Self::ThreePointFiveTurbo => "gpt-3.5-turbo",
             Self::Four => "gpt-4",
             Self::FourTurbo => "gpt-4-turbo",
             Self::FourOmni => "gpt-4o",
@@ -166,7 +161,6 @@ impl Model {
 
     pub fn max_token_count(&self) -> usize {
         match self {
-            Self::ThreePointFiveTurbo => 16_385,
             Self::Four => 8_192,
             Self::FourTurbo => 128_000,
             Self::FourOmni => 128_000,
@@ -198,8 +192,7 @@ impl Model {
     /// If the model does not support the parameter, do not pass it up, or the API will return an error.
     pub fn supports_parallel_tool_calls(&self) -> bool {
         match self {
-            Self::ThreePointFiveTurbo
-            | Self::Four
+            Self::Four
             | Self::FourTurbo
             | Self::FourOmni
             | Self::FourOmniMini


### PR DESCRIPTION
Release Notes:

- Remove older deprecated AI models (OpenAI gpt-3.5-turbo, Anthropic claude-3-sonnet, Google gemini-1.5-flash)