### PR TITLE
agent: Only show the trial upsell in the thread view

### DIFF
--- a/crates/agent/src/assistant_panel.rs
+++ b/crates/agent/src/assistant_panel.rs
@@ -1805,6 +1805,10 @@ impl AssistantPanel {
     }
 
     fn should_render_upsell(&self, cx: &mut Context<Self>) -> bool {
+        if !matches!(self.active_view, ActiveView::Thread { .. }) {
+            return false;
+        }
+
         if self.hide_trial_upsell || dismissed_trial_upsell() {
             return false;
         }


### PR DESCRIPTION
This PR makes it so we only show the trial upsell in the thread view.

Fixes https://github.com/zed-industries/zed/issues/30037.

Release Notes:

- Agent Beta: Changed the trial upsell to only be visible in the thread view.
