### PR TITLE
git_ui: Only register conflict addon for full mode editors

### DIFF
--- a/crates/git_ui/src/conflict_view.rs
+++ b/crates/git_ui/src/conflict_view.rs
@@ -46,8 +46,9 @@ impl editor::Addon for ConflictAddon {
 
 pub fn register_editor(editor: &mut Editor, buffer: Entity<MultiBuffer>, cx: &mut Context<Editor>) {
     // Only show conflict UI for singletons and in the project diff.
-    if !editor.buffer().read(cx).is_singleton()
-        && !editor.buffer().read(cx).all_diff_hunks_expanded()
+    if !editor.mode().is_full()
+        || (!editor.buffer().read(cx).is_singleton()
+            && !editor.buffer().read(cx).all_diff_hunks_expanded())
     {
         return;
     }


### PR DESCRIPTION
Noticed this whilst working on #26893 

This PR prevents that single line and auto height editors have a conflict addon attached (and are observed for any excerpt changes).


From how I understand it, it does not really make sense to register the conflict addon for single line or auto height editors. 

These editors will never show a conflict nor will they be used to resolve one. Furthermore, neither of these ever have a project attached upon creation:

https://github.com/zed-industries/zed/blob/00c5f57575b5de69a5007ba724b4a8fb10db91ac/crates/editor/src/editor.rs#L1385

https://github.com/zed-industries/zed/blob/00c5f57575b5de69a5007ba724b4a8fb10db91ac/crates/editor/src/editor.rs#L1403

https://github.com/zed-industries/zed/blob/00c5f57575b5de69a5007ba724b4a8fb10db91ac/crates/editor/src/editor.rs#L1415

so their buffers will never be added here:

https://github.com/zed-industries/zed/blob/00c5f57575b5de69a5007ba724b4a8fb10db91ac/crates/git_ui/src/conflict_view.rs#L116-L120

Thus, we could potentially even extend the check with an additional `|| editor.project.is_none()`. Yet, as I am not entirely sure how all of this exactly works, I left this out for now, but I can definitely add this if wanted.

Release Notes:

- N/A
