### PR TITLE
agent: Use correct timezone for thread history separators

### DIFF
--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -250,6 +250,14 @@ impl ThreadHistory {
 
     fn matched_count(&self) -> usize {
         match &self.search_state {
+            SearchState::Empty => self.all_entries.len(),
+            SearchState::Searching { .. } => 0,
+            SearchState::Searched { matches, .. } => matches.len(),
+        }
+    }
+
+    fn list_item_count(&self) -> usize {
+        match &self.search_state {
             SearchState::Empty => self.separated_items.len(),
             SearchState::Searching { .. } => 0,
             SearchState::Searched { matches, .. } => matches.len(),
@@ -579,7 +587,7 @@ impl Render for ThreadHistory {
                             uniform_list(
                                 cx.entity().clone(),
                                 "thread-history",
-                                self.matched_count(),
+                                self.list_item_count(),
                                 Self::list_items,
                             )
                             .p_1()

--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -3,7 +3,7 @@ use std::ops::Range;
 use std::sync::Arc;
 
 use assistant_context_editor::SavedContextMetadata;
-use chrono::{Datelike as _, NaiveDate, TimeDelta, Utc};
+use chrono::{Datelike as _, Local, NaiveDate, TimeDelta};
 use editor::{Editor, EditorEvent};
 use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
@@ -140,10 +140,14 @@ impl ThreadHistory {
 
         let bg_task = cx.background_spawn(async move {
             let mut bucket = None;
-            let today = Utc::now().naive_local().date();
+            let today = Local::now().naive_local().date();
 
             for (index, entry) in all_entries.iter().enumerate() {
-                let entry_date = entry.updated_at().naive_local().date();
+                let entry_date = entry
+                    .updated_at()
+                    .with_timezone(&Local)
+                    .naive_local()
+                    .date();
                 let entry_bucket = TimeBucket::from_dates(today, entry_date);
 
                 if Some(entry_bucket) != bucket {

--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -246,7 +246,7 @@ impl ThreadHistory {
 
     fn matched_count(&self) -> usize {
         match &self.search_state {
-            SearchState::Empty => self.all_entries.len(),
+            SearchState::Empty => self.separated_items.len(),
             SearchState::Searching { .. } => 0,
             SearchState::Searched { matches, .. } => matches.len(),
         }


### PR DESCRIPTION
Turns out `naive_local` doesn't actually offset a `DateTime<Utc>` to the local timezone before creating a `NaiveDate`.

Release Notes:

- agent: Use correct timezone for thread history separators
