### PR TITLE
Avoid panic when opening thread as markdown in non-local project

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -3448,6 +3448,11 @@ pub(crate) fn open_active_thread_as_markdown(
                 .unwrap_or_else(|| "Thread".to_string());
 
             let project = workspace.project().clone();
+
+            if !project.read(cx).is_local() {
+                anyhow::bail!("failed to open active thread as markdown in remote project");
+            }
+
             let buffer = project.update(cx, |project, cx| {
                 project.create_local_buffer(&markdown, Some(markdown_language), cx)
             });


### PR DESCRIPTION
Right now `agent: open active thread as markdown` will always panic when you try to use it over collab or when SSH remoting. This PR makes it log an error instead (we should follow up by restoring full remote support).

Release Notes:

- Prevented `agent: open active thread as markdown` from panicking when used in a non-local project.