### PR TITLE
Fix zero-sized message editors when context strip is empty

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -637,7 +637,7 @@ impl MessageEditor {
                         this.h(vh(0.8, window)).justify_between()
                     })
                     .child(
-                        div()
+                        v_flex()
                             .min_h_16()
                             .when(is_editor_expanded, |this| this.h_full())
                             .child({


### PR DESCRIPTION
Release Notes:

- Fixed a bug that would cause the message composer in the agent panel to not render when the context strip was empty.
