### PR TITLE
Load Profile state from Thread and tie visibility to the thread's model

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -200,12 +200,7 @@ impl MessageEditor {
         });
 
         let profile_selector = cx.new(|cx| {
-            ProfileSelector::new(
-                thread.clone(),
-                thread_store,
-                editor.focus_handle(cx),
-                cx,
-            )
+            ProfileSelector::new(thread.clone(), thread_store, editor.focus_handle(cx), cx)
         });
 
         Self {

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -199,6 +199,16 @@ impl MessageEditor {
             )
         });
 
+        let profile_selector = cx.new(|cx| {
+            ProfileSelector::new(
+                fs,
+                thread.clone(),
+                thread_store,
+                editor.focus_handle(cx),
+                cx,
+            )
+        });
+
         Self {
             editor: editor.clone(),
             project: thread.read(cx).project().clone(),
@@ -215,8 +225,7 @@ impl MessageEditor {
             model_selector,
             edits_expanded: false,
             editor_is_expanded: false,
-            profile_selector: cx
-                .new(|cx| ProfileSelector::new(fs, thread_store, editor.focus_handle(cx), cx)),
+            profile_selector,
             last_estimated_token_count: None,
             update_token_count_task: None,
             _subscriptions: subscriptions,

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -201,7 +201,6 @@ impl MessageEditor {
 
         let profile_selector = cx.new(|cx| {
             ProfileSelector::new(
-                fs,
                 thread.clone(),
                 thread_store,
                 editor.focus_handle(cx),

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -133,11 +133,11 @@ impl ProfileSelector {
 
 impl Render for ProfileSelector {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let settings = AssistantSettings::get_global(cx);
         let profile = self
             .thread
             .read_with(cx, |thread, _cx| thread.configured_profile())
             .or_else(|| {
-                let settings = AssistantSettings::get_global(cx);
                 let profile_id = &settings.default_profile;
                 let profile = settings.profiles.get(profile_id);
                 profile.cloned()

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
-use assistant_settings::{AssistantSettings, CompletionMode};
+use assistant_settings::{AgentProfile, AgentProfileId, AssistantSettings, CompletionMode};
 use assistant_tool::{ActionLog, AnyToolCard, Tool, ToolWorkingSet};
 use chrono::{DateTime, Utc};
 use collections::HashMap;
@@ -359,6 +359,7 @@ pub struct Thread {
     >,
     remaining_turns: u32,
     configured_model: Option<ConfiguredModel>,
+    configured_profile: Option<AgentProfile>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -379,6 +380,9 @@ impl Thread {
     ) -> Self {
         let (detailed_summary_tx, detailed_summary_rx) = postage::watch::channel();
         let configured_model = LanguageModelRegistry::read_global(cx).default_model();
+        let assistant_settings = AssistantSettings::get_global(cx);
+        let profile_id = &assistant_settings.default_profile;
+        let configured_profile = assistant_settings.profiles.get(profile_id).cloned();
 
         Self {
             id: ThreadId::new(),
@@ -421,6 +425,7 @@ impl Thread {
             request_callback: None,
             remaining_turns: u32::MAX,
             configured_model,
+            configured_profile,
         }
     }
 
@@ -467,6 +472,13 @@ impl Thread {
         let completion_mode = serialized
             .completion_mode
             .unwrap_or_else(|| AssistantSettings::get_global(cx).preferred_completion_mode);
+
+        let configured_profile = serialized.profile.and_then(|profile| {
+            AssistantSettings::get_global(cx)
+                .profiles
+                .get(&profile)
+                .cloned()
+        });
 
         Self {
             id,
@@ -541,6 +553,7 @@ impl Thread {
             request_callback: None,
             remaining_turns: u32::MAX,
             configured_model,
+            configured_profile,
         }
     }
 
@@ -593,6 +606,19 @@ impl Thread {
 
     pub fn set_configured_model(&mut self, model: Option<ConfiguredModel>, cx: &mut Context<Self>) {
         self.configured_model = model;
+        cx.notify();
+    }
+
+    pub fn configured_profile(&self) -> Option<AgentProfile> {
+        self.configured_profile.clone()
+    }
+
+    pub fn set_configured_profile(
+        &mut self,
+        profile: Option<AgentProfile>,
+        cx: &mut Context<Self>,
+    ) {
+        self.configured_profile = profile;
         cx.notify();
     }
 
@@ -1100,6 +1126,10 @@ impl Thread {
                         provider: model.provider.id().0.to_string(),
                         model: model.model.id().0.to_string(),
                     }),
+                profile: this
+                    .configured_profile
+                    .as_ref()
+                    .map(|profile| AgentProfileId(profile.name.clone().into())),
                 completion_mode: Some(this.completion_mode),
             })
         })

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -657,6 +657,8 @@ pub struct SerializedThread {
     pub model: Option<SerializedLanguageModel>,
     #[serde(default)]
     pub completion_mode: Option<CompletionMode>,
+    #[serde(default)]
+    pub profile: Option<AgentProfileId>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -802,6 +804,7 @@ impl LegacySerializedThread {
             exceeded_window_error: None,
             model: None,
             completion_mode: None,
+            profile: None,
         }
     }
 }


### PR DESCRIPTION
When deciding if a model supports tools or not, we weren't reading from
the configured model in a given thread.

This also stores the profile on the thread, which matches the behavior of the Model and Max Mode, which we also already store per thread.

Hopefully this helps alleviate some confusion.

Release Notes:

- agent: Save profile selection per-Agent thread
