### PR TITLE
agent: Directly link to zed pro upgrade page where it makes sense.

### DIFF
--- a/crates/agent/src/ui/preview/usage_callouts.rs
+++ b/crates/agent/src/ui/preview/usage_callouts.rs
@@ -44,13 +44,13 @@ impl RenderOnce for UsageCallout {
                     "Upgrade to continue, wait for the next reset, or switch to API key."
                         .to_string(),
                     "Upgrade",
-                    zed_urls::account_url(cx),
+                    zed_urls::account_upgrade_url(cx),
                 ),
                 Plan::ZedProTrial => (
                     "Out of trial prompts",
                     "Upgrade to Zed Pro to continue, or switch to API key.".to_string(),
                     "Upgrade",
-                    zed_urls::account_url(cx),
+                    zed_urls::account_upgrade_url(cx),
                 ),
                 Plan::ZedPro => (
                     "Out of included prompts",
@@ -67,7 +67,7 @@ impl RenderOnce for UsageCallout {
                         "{remaining} remaining - Upgrade to increase limit, or switch providers",
                     ),
                     "Upgrade",
-                    zed_urls::account_url(cx),
+                    zed_urls::account_upgrade_url(cx),
                 ),
                 Plan::ZedProTrial => (
                     "Reaching trial limit soon",
@@ -75,7 +75,7 @@ impl RenderOnce for UsageCallout {
                         "{remaining} remaining - Upgrade to increase limit, or switch providers",
                     ),
                     "Upgrade",
-                    zed_urls::account_url(cx),
+                    zed_urls::account_upgrade_url(cx),
                 ),
                 _ => return div().into_any_element(),
             }

--- a/crates/assistant_context_editor/src/context_editor.rs
+++ b/crates/assistant_context_editor/src/context_editor.rs
@@ -2672,7 +2672,7 @@ impl ContextEditor {
                     .child(Button::new("subscribe", "Subscribe").on_click(cx.listener(
                         |this, _, _window, cx| {
                             this.last_error = None;
-                            cx.open_url(&zed_urls::account_url(cx));
+                            cx.open_url(&zed_urls::account_upgrade_url(cx));
                             cx.notify();
                         },
                     )))

--- a/crates/client/src/zed_urls.rs
+++ b/crates/client/src/zed_urls.rs
@@ -17,3 +17,8 @@ fn server_url(cx: &App) -> &str {
 pub fn account_url(cx: &App) -> String {
     format!("{server_url}/account", server_url = server_url(cx))
 }
+
+/// Returns the URL to the page to upgrade a trial or start a new zed pro subscription.
+pub fn account_upgrade_url(cx: &App) -> String {
+    format!("{server_url}/account/upgrade", server_url = server_url(cx))
+}


### PR DESCRIPTION
Clicking "Upgrade" links will now send users directly to `zed.dev/account/upgrade`.

Release Notes:

- N/A
