### PR TITLE
docs: Fix links in ai section

### DIFF
--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -14,7 +14,7 @@ After you've configured some LLM providers, you're ready to start working with t
 Type at the message editor and hit `enter` to submit your prompt to the LLM.
 If you need extra room to type, you can expand the message editor with {#kb agent::ExpandMessageEditor}.
 
-You should start to see the responses stream in with indications of which [tools](/ai/tools.md) the AI is using to fulfill your prompt.
+You should start to see the responses stream in with indications of which [tools](./tools.md) the AI is using to fulfill your prompt.
 For example, if the AI chooses to perform an edit, you will see a card with the diff.
 
 ### Editing Messages {#editing-messages}
@@ -67,14 +67,14 @@ You can also do this at any time with an ongoing thread via the "Agent Options" 
 
 ## Changing Models {#changing-models}
 
-After you've configured your LLM providers—either via [a custom API key](/ai/custom-api-keys.md) or through [Zed's hosted models](/ai/models.md)—you can switch between them by clicking on the model selector on the message editor or by using the {#kb agent::ToggleModelSelector} keybinding.
+After you've configured your LLM providers—either via [a custom API key](./custom-api-keys.md) or through [Zed's hosted models](./models.md)—you can switch between them by clicking on the model selector on the message editor or by using the {#kb agent::ToggleModelSelector} keybinding.
 
 ## Using Tools {#using-tools}
 
 The new Agent Panel supports tool calling, which enables agentic collaboration with AI.
-Zed comes with [several built-in tools](/ai/tools.md) that allow models to perform tasks such as searching through your codebase, editing files, running commands, and others.
+Zed comes with [several built-in tools](./tools.md) that allow models to perform tasks such as searching through your codebase, editing files, running commands, and others.
 
-You can also extend the set of available tools via [MCP Servers](/ai/mcp.md).
+You can also extend the set of available tools via [MCP Servers](./mcp.md).
 
 ### Profiles {#profiles}
 
@@ -149,7 +149,7 @@ Every change we make to Zed's system prompt and tool set, needs to be backed by 
 Every time the LLM performs a weird change or investigates a certain topic in your codebase completely incorrectly, it's an indication that there's an improvement opportunity.
 
 > Note that rating responses will send your data related to that response to Zed's servers.
-> See [AI Improvement](./ai-improvement.md) and [Privacy and Security](/ai/privacy-and-security.md) for more information about Zed's approach to AI improvement, privacy, and security.
+> See [AI Improvement](./ai-improvement.md) and [Privacy and Security](./privacy-and-security.md) for more information about Zed's approach to AI improvement, privacy, and security.
 > **_If you don't want data persisted on Zed's servers, don't rate_**. We will not collect data for improving our Agentic offering without you explicitly rating responses.
 
 The best way you can help influence the next change to Zed's system prompt and tools is by rating the LLM's response via the thumbs up/down buttons at the end of every response.


### PR DESCRIPTION
There were a number of broken links in the new agent panel docs. This fixes them by replacing `(/ai/` with `(./`

Release Notes:

- N/A 
