### PR TITLE
title_bar: Add link indicator to current plan entry in user menu

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -678,7 +678,7 @@ impl TitleBar {
                 .anchor(Corner::TopRight)
                 .menu(move |window, cx| {
                     ContextMenu::build(window, cx, |menu, _, _cx| {
-                        menu.action(
+                        menu.link(
                             format!(
                                 "Current Plan: {}",
                                 match plan {


### PR DESCRIPTION
This PR adds a link indicator to the `Current Plan: ...` entry in the user menu

<img width="232" alt="link_indicator" src="https://github.com/user-attachments/assets/89c6247c-08cb-4cac-b136-5c5b71f1a975" />

to indicate this opens an external link and not something within Zed.

Release Notes:

- N/A
