### PR TITLE
Add a way to clear activity indicator

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -335,9 +335,13 @@ impl AutoUpdater {
         self.status.clone()
     }
 
-    pub fn dismiss_error(&mut self, cx: &mut Context<Self>) {
+    pub fn dismiss_error(&mut self, cx: &mut Context<Self>) -> bool {
+        if self.status == AutoUpdateStatus::Idle {
+            return false;
+        }
         self.status = AutoUpdateStatus::Idle;
         cx.notify();
+        true
     }
 
     // If you are packaging Zed and need to override the place it downloads SSH remotes from,

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -22,6 +22,7 @@ use ui::{
     Avatar, Button, Icon, IconButton, IconName, Label, Tab, Tooltip, h_flex, prelude::*, v_flex,
 };
 use util::{ResultExt, TryFutureExt};
+use workspace::SuppressNotification;
 use workspace::notifications::{
     Notification as WorkspaceNotification, NotificationId, SuppressEvent,
 };
@@ -823,11 +824,19 @@ impl Render for NotificationToast {
             .child(Label::new(self.text.clone()))
             .child(
                 IconButton::new("close", IconName::Close)
+                    .tooltip(|window, cx| Tooltip::for_action("Close", &menu::Cancel, window, cx))
                     .on_click(cx.listener(|_, _, _, cx| cx.emit(DismissEvent))),
             )
             .child(
-                IconButton::new("suppress", IconName::XCircle)
-                    .tooltip(Tooltip::text("Do not show until restart"))
+                IconButton::new("suppress", IconName::SquareMinus)
+                    .tooltip(|window, cx| {
+                        Tooltip::for_action(
+                            "Do not show until restart",
+                            &SuppressNotification,
+                            window,
+                            cx,
+                        )
+                    })
                     .on_click(cx.listener(|_, _, _, cx| cx.emit(SuppressEvent))),
             )
             .on_click(cx.listener(|this, _, window, cx| {

--- a/crates/workspace/src/notifications.rs
+++ b/crates/workspace/src/notifications.rs
@@ -1,4 +1,4 @@
-use crate::{Toast, Workspace};
+use crate::{SuppressNotification, Toast, Workspace};
 use gpui::{
     AnyView, App, AppContext as _, AsyncWindowContext, ClipboardItem, Context, DismissEvent,
     Entity, EventEmitter, FocusHandle, Focusable, PromptLevel, Render, ScrollHandle, Task, svg,
@@ -290,8 +290,15 @@ impl Render for LanguageServerPrompt {
                                 h_flex()
                                     .gap_2()
                                     .child(
-                                        IconButton::new("suppress", IconName::XCircle)
-                                            .tooltip(Tooltip::text("Do not show until restart"))
+                                        IconButton::new("suppress", IconName::SquareMinus)
+                                            .tooltip(|window, cx| {
+                                                Tooltip::for_action(
+                                                    "Do not show until restart",
+                                                    &SuppressNotification,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
                                             .on_click(
                                                 cx.listener(|_, _, _, cx| cx.emit(SuppressEvent)),
                                             ),
@@ -308,9 +315,20 @@ impl Render for LanguageServerPrompt {
                                             })
                                             .tooltip(Tooltip::text("Copy Description")),
                                     )
-                                    .child(IconButton::new("close", IconName::Close).on_click(
-                                        cx.listener(|_, _, _, cx| cx.emit(gpui::DismissEvent)),
-                                    )),
+                                    .child(
+                                        IconButton::new("close", IconName::Close)
+                                            .tooltip(|window, cx| {
+                                                Tooltip::for_action(
+                                                    "Close",
+                                                    &menu::Cancel,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
+                                            .on_click(cx.listener(|_, _, _, cx| {
+                                                cx.emit(gpui::DismissEvent)
+                                            })),
+                                    ),
                             ),
                     )
                     .child(Label::new(request.message.to_string()).size(LabelSize::Small))
@@ -442,6 +460,8 @@ pub mod simple_message_notification {
         SharedString, Styled, div,
     };
     use ui::{Tooltip, prelude::*};
+
+    use crate::SuppressNotification;
 
     use super::{Notification, SuppressEvent};
 
@@ -640,8 +660,15 @@ pub mod simple_message_notification {
                                 .gap_2()
                                 .when(self.show_suppress_button, |this| {
                                     this.child(
-                                        IconButton::new("suppress", IconName::XCircle)
-                                            .tooltip(Tooltip::text("Do not show until restart"))
+                                        IconButton::new("suppress", IconName::SquareMinus)
+                                            .tooltip(|window, cx| {
+                                                Tooltip::for_action(
+                                                    "Do not show until restart",
+                                                    &SuppressNotification,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
                                             .on_click(cx.listener(|_, _, _, cx| {
                                                 cx.emit(SuppressEvent);
                                             })),
@@ -649,9 +676,18 @@ pub mod simple_message_notification {
                                 })
                                 .when(self.show_close_button, |this| {
                                     this.child(
-                                        IconButton::new("close", IconName::Close).on_click(
-                                            cx.listener(|this, _, _, cx| this.dismiss(cx)),
-                                        ),
+                                        IconButton::new("close", IconName::Close)
+                                            .tooltip(|window, cx| {
+                                                Tooltip::for_action(
+                                                    "Close",
+                                                    &menu::Cancel,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
+                                            .on_click(
+                                                cx.listener(|this, _, _, cx| this.dismiss(cx)),
+                                            ),
                                     )
                                 }),
                         ),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -869,6 +869,7 @@ pub enum Event {
     },
     ZoomChanged,
     ModalOpened,
+    ClearActivityIndicator,
 }
 
 #[derive(Debug)]
@@ -5496,6 +5497,7 @@ impl Workspace {
             return;
         }
 
+        cx.emit(Event::ClearActivityIndicator);
         cx.propagate();
     }
 }


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/30015

* Restyles the dismiss and close buttons a bit: change the dismiss icon and add tooltips with the bindings to both
* Allows ESC to clear any status that's in the activity indicator now, if all notifications are cleared: this won't suppress any further status additions though, so statuses may resurface later

Release Notes:

- Added a way to clear activity indicator
