### PR TITLE
search: Do not consider filters if they are toggled off

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2768,7 +2768,7 @@ pub mod tests {
                         .results_editor
                         .update(cx, |editor, cx| editor.display_text(cx)),
                     "\n\nconst FOUR: usize = one::ONE + three::THREE;",
-                    "Search view results should contain the queried result in the previosly excluded file with filters disabled"
+                    "Search view results should contain the queried result in the previously excluded file with filters toggled off"
                 );
             });
             })


### PR DESCRIPTION
Closes #30134

This PR ensures that path filters are only applied to searches when the filters are actually enabled (and visible). 

Release Notes:

- Fixed the project search considering included and excluded filters after toggling them off.
