### PR TITLE
editor: Fix punctuation in JSX tags breaks the linked edit to the closing tag

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3623,7 +3623,9 @@ impl Editor {
                 let start_anchor = snapshot.anchor_before(selection.start);
 
                 let is_word_char = text.chars().next().map_or(true, |char| {
-                    let classifier = snapshot.char_classifier_at(start_anchor.to_offset(&snapshot));
+                    let classifier = snapshot
+                        .char_classifier_at(start_anchor.to_offset(&snapshot))
+                        .ignore_punctuation(true);
                     classifier.is_word(char)
                 });
 


### PR DESCRIPTION
Closes #29983

While we only care about `.`, just enabling punctuation in case of linked edits shouldn't hurt.

Release Notes:

- Fixed JSX component names with periods (e.g., <Animated.View>) now maintain linked edits between opening and closing tags.
