### PR TITLE
Avoid empty schema in copilot dummy tool

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -526,7 +526,9 @@ impl CopilotChatLanguageModel {
                 function: copilot::copilot_chat::Function {
                     name: "noop".to_string(),
                     description: "No operation".to_string(),
-                    parameters: serde_json::json!({}),
+                    parameters: serde_json::json!({
+                        "type": "object"
+                    }),
                 },
             });
         }


### PR DESCRIPTION
Copilot chat still returns a 400 if the dummy tool uses the `{}` schema.

This is a follow-up to https://github.com/zed-industries/zed/pull/30007.

Release Notes:

- Fixed a bug where agent edits would fail when using GitHub Copilot Chat.
