### PR TITLE
Allow opening the FS root dir as a remote project

### DIFF
--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -1,7 +1,7 @@
 use futures::channel::oneshot;
 use fuzzy::{StringMatch, StringMatchCandidate};
 use picker::{Picker, PickerDelegate};
-use project::DirectoryLister;
+use project::{DirectoryItem, DirectoryLister};
 use std::{
     path::{MAIN_SEPARATOR_STR, Path, PathBuf},
     sync::{
@@ -137,6 +137,7 @@ impl PickerDelegate for OpenPathDelegate {
         } else {
             (query, String::new())
         };
+
         if dir == "" {
             #[cfg(not(target_os = "windows"))]
             {
@@ -171,6 +172,13 @@ impl PickerDelegate for OpenPathDelegate {
                 this.update(cx, |this, _| {
                     this.delegate.directory_state = Some(match paths {
                         Ok(mut paths) => {
+                            if dir == "/" {
+                                paths.push(DirectoryItem {
+                                    is_dir: true,
+                                    path: Default::default(),
+                                });
+                            }
+
                             paths.sort_by(|a, b| compare_paths((&a.path, true), (&b.path, true)));
                             let match_candidates = paths
                                 .iter()
@@ -309,12 +317,16 @@ impl PickerDelegate for OpenPathDelegate {
         let Some(candidate) = directory_state.match_candidates.get(*m) else {
             return;
         };
-        let result = Path::new(
-            self.lister
-                .resolve_tilde(&directory_state.path, cx)
-                .as_ref(),
-        )
-        .join(&candidate.path.string);
+        let result = if directory_state.path == "/" && candidate.path.string.is_empty() {
+            PathBuf::from("/")
+        } else {
+            Path::new(
+                self.lister
+                    .resolve_tilde(&directory_state.path, cx)
+                    .as_ref(),
+            )
+            .join(&candidate.path.string)
+        };
         if let Some(tx) = self.tx.take() {
             tx.send(Some(vec![result])).ok();
         }
@@ -355,7 +367,11 @@ impl PickerDelegate for OpenPathDelegate {
                 .inset(true)
                 .toggle_state(selected)
                 .child(HighlightedLabel::new(
-                    candidate.path.string.clone(),
+                    if directory_state.path == "/" {
+                        format!("/{}", candidate.path.string)
+                    } else {
+                        candidate.path.string.clone()
+                    },
                     highlight_positions,
                 )),
         )

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3904,11 +3904,7 @@ impl Project {
         })
     }
 
-    pub fn resolve_abs_path(
-        &self,
-        path: &str,
-        cx: &mut Context<Self>,
-    ) -> Task<Option<ResolvedPath>> {
+    pub fn resolve_abs_path(&self, path: &str, cx: &App) -> Task<Option<ResolvedPath>> {
         if self.is_local() {
             let expanded = PathBuf::from(shellexpand::tilde(&path).into_owned());
             let fs = self.fs.clone();
@@ -5120,6 +5116,13 @@ impl ResolvedPath {
     pub fn abs_path(&self) -> Option<&Path> {
         match self {
             Self::AbsPath { path, .. } => Some(path.as_path()),
+            _ => None,
+        }
+    }
+
+    pub fn into_abs_path(self) -> Option<PathBuf> {
+        match self {
+            Self::AbsPath { path, .. } => Some(path),
             _ => None,
         }
     }

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -262,7 +262,7 @@ impl WorktreeStore {
         if abs_path.starts_with("/~") {
             abs_path = abs_path[1..].to_string();
         }
-        if abs_path.is_empty() || abs_path == "/" {
+        if abs_path.is_empty() {
             abs_path = "~/".to_string();
         }
         cx.spawn(async move |this, cx| {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2855,13 +2855,7 @@ impl ProjectPanel {
                 }
                 let worktree_abs_path = worktree.read(cx).abs_path();
                 let (depth, path) = if Some(entry.entry) == worktree.read(cx).root_entry() {
-                    let Some(path_name) = worktree_abs_path
-                        .file_name()
-                        .with_context(|| {
-                            format!("Worktree abs path has no file name, root entry: {entry:?}")
-                        })
-                        .log_err()
-                    else {
+                    let Some(path_name) = worktree_abs_path.file_name() else {
                         continue;
                     };
                     let path = ArcCow::Borrowed(Path::new(path_name));

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2648,7 +2648,7 @@ impl Snapshot {
     }
 
     pub fn root_entry(&self) -> Option<&Entry> {
-        self.entry_for_path("")
+        self.entries_by_path.first()
     }
 
     /// TODO: what's the difference between `root_dir` and `abs_path`?


### PR DESCRIPTION
### Todo

* [x] Allow opening `ssh://username@host:/` from the CLI
* [x] Allow selecting `/` in the `open path` picker
* [x] Allow selecting the home directory in the `open path` picker

Release Notes:

- Changed the initial state of the SSH project picker to show the full path to your home directory on the remote machine, instead of `~`.
- Added the ability to open `/` as a project folder over SSH
