### PR TITLE
snippets: Add icons and file names to snippet scope selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13490,11 +13490,14 @@ dependencies = [
 name = "snippets_ui"
 version = "0.1.0"
 dependencies = [
+ "file_finder",
+ "file_icons",
  "fuzzy",
  "gpui",
  "language",
  "paths",
  "picker",
+ "settings",
  "ui",
  "util",
  "workspace",

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -996,7 +996,7 @@ impl Project {
             let (tx, rx) = mpsc::unbounded();
             cx.spawn(async move |this, cx| Self::send_buffer_ordered_messages(this, rx, cx).await)
                 .detach();
-            let global_snippets_dir = paths::config_dir().join("snippets");
+            let global_snippets_dir = paths::snippets_dir().to_owned();
             let snippets =
                 SnippetProvider::new(fs.clone(), BTreeSet::from_iter([global_snippets_dir]), cx);
 

--- a/crates/snippet_provider/src/lib.rs
+++ b/crates/snippet_provider/src/lib.rs
@@ -141,15 +141,13 @@ struct GlobalSnippetWatcher(Entity<SnippetProvider>);
 
 impl GlobalSnippetWatcher {
     fn new(fs: Arc<dyn Fs>, cx: &mut App) -> Self {
-        let global_snippets_dir = paths::config_dir().join("snippets");
+        let global_snippets_dir = paths::snippets_dir();
         let provider = cx.new(|_cx| SnippetProvider {
             fs,
             snippets: Default::default(),
             watch_tasks: vec![],
         });
-        provider.update(cx, |this, cx| {
-            this.watch_directory(&global_snippets_dir, cx)
-        });
+        provider.update(cx, |this, cx| this.watch_directory(global_snippets_dir, cx));
         Self(provider)
     }
 }

--- a/crates/snippets_ui/Cargo.toml
+++ b/crates/snippets_ui/Cargo.toml
@@ -12,12 +12,15 @@ workspace = true
 path = "src/snippets_ui.rs"
 
 [dependencies]
+file_finder.workspace = true
+file_icons.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
 language.workspace = true
 paths.workspace = true
 picker.workspace = true
+settings.workspace = true
 ui.workspace = true
 util.workspace = true
-workspace.workspace = true
 workspace-hack.workspace = true
+workspace.workspace = true

--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -6,7 +6,7 @@ use gpui::{
     WeakEntity, Window, actions,
 };
 use language::{LanguageMatcher, LanguageName, LanguageRegistry};
-use paths::config_dir;
+use paths::snippets_dir;
 use picker::{Picker, PickerDelegate};
 use settings::Settings;
 use std::{borrow::Borrow, collections::HashSet, fs, path::Path, sync::Arc};
@@ -76,8 +76,8 @@ fn open_folder(
     _: &mut Window,
     cx: &mut Context<Workspace>,
 ) {
-    fs::create_dir_all(config_dir().join("snippets")).notify_err(workspace, cx);
-    cx.open_with_system(config_dir().join("snippets").borrow());
+    fs::create_dir_all(snippets_dir()).notify_err(workspace, cx);
+    cx.open_with_system(snippets_dir().borrow());
 }
 
 pub struct ScopeSelector {
@@ -143,7 +143,7 @@ impl ScopeSelectorDelegate {
 
         let mut existing_scopes = HashSet::new();
 
-        if let Some(read_dir) = fs::read_dir(config_dir().join("snippets")).log_err() {
+        if let Some(read_dir) = fs::read_dir(snippets_dir()).log_err() {
             for entry in read_dir {
                 if let Some(entry) = entry.log_err() {
                     let path = entry.path();
@@ -236,9 +236,7 @@ impl PickerDelegate for ScopeSelectorDelegate {
                     workspace.update_in(cx, |workspace, window, cx| {
                         workspace
                             .open_abs_path(
-                                config_dir()
-                                    .join("snippets")
-                                    .join(scope_file_name.with_extension()),
+                                snippets_dir().join(scope_file_name.with_extension()),
                                 OpenOptions {
                                     visible: Some(OpenVisible::None),
                                     ..Default::default()


### PR DESCRIPTION
I added the language icons to the snippet scope selector so that it matches the language selector.

The file names are displayed for each scope where there is a existing snippets file since it wasn't clear if a scope had a file already or not.

| Before | After |
| - | - |
| ![before](https://github.com/user-attachments/assets/89f62889-d4a9-4681-999a-00c00f7bec3b)| ![after](https://github.com/user-attachments/assets/2d64f04c-ef8f-40f5-aedd-eca239c960e9) |


Release Notes:

- Added language icons and file names to snippet scope selector