### PR TITLE
agent: Improve Gemini tool schema compatibility

### DIFF
--- a/crates/assistant_tool/src/tool_schema.rs
+++ b/crates/assistant_tool/src/tool_schema.rs
@@ -35,26 +35,17 @@ fn adapt_to_json_schema_subset(json: &mut Value) -> Result<()> {
             }
         }
 
-        const KEYS_TO_REMOVE: [&str; 4] = [
+        const KEYS_TO_REMOVE: [&str; 5] = [
             "format",
             "additionalProperties",
             "exclusiveMinimum",
             "exclusiveMaximum",
+            "optional",
         ];
         for key in KEYS_TO_REMOVE {
             obj.remove(key);
         }
 
-        if let Some(default) = obj.get("default") {
-            let is_null = default.is_null();
-            // Default is not supported, so we need to remove it
-            obj.remove("default");
-            if is_null {
-                obj.insert("nullable".to_string(), Value::Bool(true));
-            }
-        }
-
-        // If a type is not specified for an input parameter, add a default type
         if matches!(obj.get("description"), Some(Value::String(_)))
             && !obj.contains_key("type")
             && !(obj.contains_key("anyOf")
@@ -91,26 +82,6 @@ fn adapt_to_json_schema_subset(json: &mut Value) -> Result<()> {
 mod tests {
     use super::*;
     use serde_json::json;
-
-    #[test]
-    fn test_transform_default_null_to_nullable() {
-        let mut json = json!({
-            "description": "A test field",
-            "type": "string",
-            "default": null
-        });
-
-        adapt_to_json_schema_subset(&mut json).unwrap();
-
-        assert_eq!(
-            json,
-            json!({
-                "description": "A test field",
-                "type": "string",
-                "nullable": true
-            })
-        );
-    }
 
     #[test]
     fn test_transform_adds_type_when_missing() {

--- a/crates/assistant_tool/src/tool_schema.rs
+++ b/crates/assistant_tool/src/tool_schema.rs
@@ -129,7 +129,8 @@ mod tests {
             "format": "uint32",
             "exclusiveMinimum": 0,
             "exclusiveMaximum": 100,
-            "additionalProperties": false
+            "additionalProperties": false,
+            "optional": true
         });
 
         adapt_to_json_schema_subset(&mut json).unwrap();

--- a/crates/assistant_tool/src/tool_schema.rs
+++ b/crates/assistant_tool/src/tool_schema.rs
@@ -46,6 +46,7 @@ fn adapt_to_json_schema_subset(json: &mut Value) -> Result<()> {
             obj.remove(key);
         }
 
+        // If a type is not specified for an input parameter, add a default type
         if matches!(obj.get("description"), Some(Value::String(_)))
             && !obj.contains_key("type")
             && !(obj.contains_key("anyOf")


### PR DESCRIPTION
Closes #30056

Apparently the API supports the "default" field now, so we can remove that transformation.
However, optional is not supported

See https://ai.google.dev/api/caching#Schema

Release Notes:

- agent: Improve tool schema compatibility for Gemini models
