### PR TITLE
vim: Add `g M` motion to go to the middle of a line

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -152,7 +152,7 @@
       "g end": ["vim::EndOfLine", { "display_lines": true }],
       "g 0": ["vim::StartOfLine", { "display_lines": true }],
       "g home": ["vim::StartOfLine", { "display_lines": true }],
-      "g M": ["vim::MiddleOfLine", { "display_lines": true }],
+      "g shift-m": ["vim::MiddleOfLine", { "display_lines": true }],
       "g ^": ["vim::FirstNonWhitespace", { "display_lines": true }],
       "g v": "vim::RestoreVisualSelection",
       "g ]": "editor::GoToDiagnostic",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -152,6 +152,7 @@
       "g end": ["vim::EndOfLine", { "display_lines": true }],
       "g 0": ["vim::StartOfLine", { "display_lines": true }],
       "g home": ["vim::StartOfLine", { "display_lines": true }],
+      "g M": ["vim::MiddleOfLine", { "display_lines": true }],
       "g ^": ["vim::FirstNonWhitespace", { "display_lines": true }],
       "g v": "vim::RestoreVisualSelection",
       "g ]": "editor::GoToDiagnostic",

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -3953,6 +3953,61 @@ mod test {
     }
 
     #[gpui::test]
+    async fn test_forced_motion_delete_to_middle_of_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_shared_state(indoc! {"
+             ˇthe quick brown fox
+             jumped over the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("d v g M").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+             ˇbrown fox
+             jumped over the lazy dog"});
+        assert_eq!(cx.cx.forced_motion(), false);
+
+        cx.set_shared_state(indoc! {"
+            the quick bˇrown fox
+            jumped over the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("d v g M").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            the quickˇown fox
+            jumped over the lazy dog"});
+        assert_eq!(cx.cx.forced_motion(), false);
+
+        cx.set_shared_state(indoc! {"
+            the quick brown foˇx
+            jumped over the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("d v g M").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            the quicˇk
+            jumped over the lazy dog"});
+        assert_eq!(cx.cx.forced_motion(), false);
+
+        cx.set_shared_state(indoc! {"
+            ˇthe quick brown fox
+            jumped over the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("d v 7 5 g M").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            ˇ fox
+            jumped over the lazy dog"});
+        assert_eq!(cx.cx.forced_motion(), false);
+
+        cx.set_shared_state(indoc! {"
+            ˇthe quick brown fox
+            jumped over the lazy dog"})
+            .await;
+        cx.simulate_shared_keystrokes("d v 2 3 g M").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+            ˇuick brown fox
+            jumped over the lazy dog"});
+        assert_eq!(cx.cx.forced_motion(), false);
+    }
+
+    #[gpui::test]
     async fn test_forced_motion_delete_to_end_of_line(cx: &mut gpui::TestAppContext) {
         let mut cx = NeovimBackedTestContext::new(cx).await;
 

--- a/crates/vim/test_data/test_forced_motion_delete_to_middle_of_line.json
+++ b/crates/vim/test_data/test_forced_motion_delete_to_middle_of_line.json
@@ -1,0 +1,6 @@
+{"Put":{"state":"ˇthe quick brown fox\njumped over the lazy dog"}}
+{"Key":"d"}
+{"Key":"v"}
+{"Key":"g"}
+{"Key":"M"}
+{"Get":{"state":"ˇbrown fox\njumped over the lazy dog","mode":"Normal"}}

--- a/crates/vim/test_data/test_forced_motion_delete_to_middle_of_line.json
+++ b/crates/vim/test_data/test_forced_motion_delete_to_middle_of_line.json
@@ -2,5 +2,33 @@
 {"Key":"d"}
 {"Key":"v"}
 {"Key":"g"}
-{"Key":"M"}
+{"Key":"shift-m"}
 {"Get":{"state":"ˇbrown fox\njumped over the lazy dog","mode":"Normal"}}
+{"Put":{"state":"the quick bˇrown fox\njumped over the lazy dog"}}
+{"Key":"d"}
+{"Key":"v"}
+{"Key":"g"}
+{"Key":"shift-m"}
+{"Get":{"state":"the quickˇown fox\njumped over the lazy dog","mode":"Normal"}}
+{"Put":{"state":"the quick brown foˇx\njumped over the lazy dog"}}
+{"Key":"d"}
+{"Key":"v"}
+{"Key":"g"}
+{"Key":"shift-m"}
+{"Get":{"state":"the quicˇk\njumped over the lazy dog","mode":"Normal"}}
+{"Put":{"state":"ˇthe quick brown fox\njumped over the lazy dog"}}
+{"Key":"d"}
+{"Key":"v"}
+{"Key":"7"}
+{"Key":"5"}
+{"Key":"g"}
+{"Key":"shift-m"}
+{"Get":{"state":"ˇ fox\njumped over the lazy dog","mode":"Normal"}}
+{"Put":{"state":"ˇthe quick brown fox\njumped over the lazy dog"}}
+{"Key":"d"}
+{"Key":"v"}
+{"Key":"2"}
+{"Key":"3"}
+{"Key":"g"}
+{"Key":"shift-m"}
+{"Get":{"state":"ˇuick brown fox\njumped over the lazy dog","mode":"Normal"}}


### PR DESCRIPTION
Adds the "g M" vim motion to go to the middle of the line.

Release notes:

- vim: Added support for `gM` to go to the middle of a line