### PR TITLE
Use fit instead of center for Agent following

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -372,7 +372,7 @@ impl FollowableItem for Editor {
         };
         drop(buffer);
         self.set_selections_from_remote(vec![selection], None, window, cx);
-        self.request_autoscroll_remotely(Autoscroll::center(), cx);
+        self.request_autoscroll_remotely(Autoscroll::fit(), cx);
     }
 }
 


### PR DESCRIPTION
Makes it easier to review the Agent edits since more of the previous
edits will be visible on screen.

Release Notes:

- N/A
