### PR TITLE
language: Reduce allocations

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -2698,7 +2698,7 @@ impl Buffer {
         }
         self.send_operation(
             Operation::UpdateCompletionTriggers {
-                triggers: triggers.iter().cloned().collect(),
+                triggers: triggers.into_iter().collect(),
                 lamport_timestamp: self.completion_triggers_timestamp,
                 server_id,
             },


### PR DESCRIPTION
Another tiny patch to reduce allocations

`.iter().cloned().collect()` calls `Clone` per element, whereas `into_iter().collect()` preallocates memory

Release Notes:

- N/A
