### PR TITLE
windows: Fix atomic write

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2494,19 +2494,28 @@ async fn file_id(path: impl AsRef<Path>) -> Result<u64> {
 #[cfg(target_os = "windows")]
 fn persist<P: AsRef<Path>>(replaced_file: P, replacement_file: P) -> windows::core::Result<()> {
     use windows::{
-        Win32::Storage::FileSystem::{REPLACE_FILE_FLAGS, ReplaceFileW},
+        Win32::Storage::FileSystem::{MoveFileW, REPLACE_FILE_FLAGS, ReplaceFileW},
         core::HSTRING,
     };
 
-    unsafe {
-        ReplaceFileW(
-            &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
-            &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
-            None,
-            REPLACE_FILE_FLAGS::default(),
-            None,
-            None,
-        )
+    if !replaced_file.as_ref().exists() {
+        unsafe {
+            MoveFileW(
+                &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
+                &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
+            )
+        }
+    } else {
+        unsafe {
+            ReplaceFileW(
+                &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
+                &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
+                None,
+                REPLACE_FILE_FLAGS::default(),
+                None,
+                None,
+            )
+        }
     }
 }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -553,8 +553,9 @@ impl Fs for RealFs {
             //
             // failed to persist temporary file:
             // The system cannot move the file to a different disk drive. (os error 17)
+            //
             // This is because `ReplaceFileW` does not support cross volume moves.
-            // See the remark section: "The backup file, replaced file, and replacement file must all reside on the same volume.""
+            // See the remark section: "The backup file, replaced file, and replacement file must all reside on the same volume."
             // https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-replacefilew#remarks
             //
             // So we use the directory of the destination as a temp dir to avoid it.

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -566,6 +566,7 @@ impl Fs for RealFs {
                 let mut file = std::fs::OpenOptions::new()
                     .write(true)
                     .create(true)
+                    .truncate(true)
                     .open(&temp_file_path)?;
                 file.write_all(data.as_bytes())?;
                 temp_file_path

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -563,11 +563,7 @@ impl Fs for RealFs {
             let temp_dir = TempDir::new_in(path.parent().unwrap_or(paths::temp_dir()))?;
             let temp_file = {
                 let temp_file_path = temp_dir.path().join("temp_file");
-                let mut file = std::fs::OpenOptions::new()
-                    .write(true)
-                    .create(true)
-                    .truncate(true)
-                    .open(&temp_file_path)?;
+                let mut file = std::fs::File::create_new(&temp_file_path)?;
                 file.write_all(data.as_bytes())?;
                 temp_file_path
             };
@@ -2948,12 +2944,7 @@ mod tests {
         };
         let temp_dir = TempDir::new().unwrap();
         let file_to_be_replaced = temp_dir.path().join("file.txt");
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&file_to_be_replaced)
-            .unwrap();
+        let mut file = std::fs::File::create_new(&file_to_be_replaced).unwrap();
         file.write_all(b"Hello").unwrap();
         // drop(file);  // We still hold the file handle here
         let content = std::fs::read_to_string(&file_to_be_replaced).unwrap();

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2499,28 +2499,22 @@ fn atomic_replace<P: AsRef<Path>>(
     replacement_file: P,
 ) -> windows::core::Result<()> {
     use windows::{
-        Win32::Storage::FileSystem::{MoveFileW, REPLACE_FILE_FLAGS, ReplaceFileW},
+        Win32::Storage::FileSystem::{REPLACE_FILE_FLAGS, ReplaceFileW},
         core::HSTRING,
     };
 
-    if !replaced_file.as_ref().exists() {
-        unsafe {
-            MoveFileW(
-                &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
-                &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
-            )
-        }
-    } else {
-        unsafe {
-            ReplaceFileW(
-                &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
-                &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
-                None,
-                REPLACE_FILE_FLAGS::default(),
-                None,
-                None,
-            )
-        }
+    // If the file does not exist, create it.
+    let _ = std::fs::File::create_new(replaced_file.as_ref());
+
+    unsafe {
+        ReplaceFileW(
+            &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
+            &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
+            None,
+            REPLACE_FILE_FLAGS::default(),
+            None,
+            None,
+        )
     }
 }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2501,8 +2501,8 @@ fn persist<P: AsRef<Path>>(replaced_file: P, replacement_file: P) -> windows::co
     if !replaced_file.as_ref().exists() {
         unsafe {
             MoveFileW(
-                &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
                 &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
+                &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
             )
         }
     } else {
@@ -2961,5 +2961,18 @@ mod tests {
         smol::block_on(fs.atomic_write(file_to_be_replaced.clone(), "World".into())).unwrap();
         let content = std::fs::read_to_string(&file_to_be_replaced).unwrap();
         assert_eq!(content, "World");
+    }
+
+    #[gpui::test]
+    async fn test_realfs_atomic_write_non_existing_file(executor: BackgroundExecutor) {
+        let fs = RealFs {
+            git_binary_path: None,
+            executor,
+        };
+        let temp_dir = TempDir::new().unwrap();
+        let file_to_be_replaced = temp_dir.path().join("file.txt");
+        smol::block_on(fs.atomic_write(file_to_be_replaced.clone(), "Hello".into())).unwrap();
+        let content = std::fs::read_to_string(&file_to_be_replaced).unwrap();
+        assert_eq!(content, "Hello");
     }
 }

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -570,7 +570,7 @@ impl Fs for RealFs {
                 file.write_all(data.as_bytes())?;
                 temp_file_path
             };
-            persist(path.as_path(), temp_file.as_path())?;
+            atomic_replace(path.as_path(), temp_file.as_path())?;
             Ok::<(), anyhow::Error>(())
         })
         .await?;
@@ -2493,7 +2493,10 @@ async fn file_id(path: impl AsRef<Path>) -> Result<u64> {
 }
 
 #[cfg(target_os = "windows")]
-fn persist<P: AsRef<Path>>(replaced_file: P, replacement_file: P) -> windows::core::Result<()> {
+fn atomic_replace<P: AsRef<Path>>(
+    replaced_file: P,
+    replacement_file: P,
+) -> windows::core::Result<()> {
     use windows::{
         Win32::Storage::FileSystem::{MoveFileW, REPLACE_FILE_FLAGS, ReplaceFileW},
         core::HSTRING,

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2956,6 +2956,7 @@ mod tests {
         let mut file = std::fs::OpenOptions::new()
             .write(true)
             .create(true)
+            .truncate(true)
             .open(&file_to_be_replaced)
             .unwrap();
         file.write_all(b"Hello").unwrap();


### PR DESCRIPTION
Superseded #30222

On Windows, `MoveFileExW` fails if another process is holding a handle to the file. This PR fixes that issue by switching to `ReplaceFileW` instead.

I’ve also added corresponding tests.

According to [this Microsoft research paper](https://www.microsoft.com/en-us/research/wp-content/uploads/2006/04/tr-2006-45.pdf) and the [official documentation](https://learn.microsoft.com/en-us/windows/win32/fileio/deprecation-of-txf#applications-updating-a-single-file-with-document-like-data), `ReplaceFileW` is considered an atomic operation. even though the official docs don’t explicitly state whether `MoveFileExW` or `ReplaceFileW` is guaranteed to be atomic.

Release Notes:

- N/A
