### PR TITLE
indexed_docs: Reduce allocations

### DIFF
--- a/crates/indexed_docs/src/providers/rustdoc.rs
+++ b/crates/indexed_docs/src/providers/rustdoc.rs
@@ -79,7 +79,7 @@ impl IndexedDocsProvider for LocalRustdocProvider {
 
         *WORKSPACE_CRATES.write() = Some((workspace_crates.clone(), Instant::now()));
 
-        Ok(workspace_crates.iter().cloned().collect())
+        Ok(workspace_crates.into_iter().collect())
     }
 
     async fn index(&self, package: PackageName, database: Arc<IndexedDocsDatabase>) -> Result<()> {


### PR DESCRIPTION
Other small patch to reduce allocations. I'll likely start bundling these together going forward, since using the full test suite on each change is pretty wasteful. 

`.iter().cloned().collect()` calls `Clone` per element, whereas `.into_iter().collect()` preallocates the `Vec`.

The Zed repo for example has up to 1700 packages on some build configurations, meaning this change theoretically saves up to 1699 allocations. It's likely the compiler has already optimized this away, but it's good to be explicit.

Release Notes:

- N/A
