### PR TITLE
language_models: Improve subscription states in the Agent configuration view

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -2,7 +2,7 @@ use anthropic::{AnthropicModelMode, parse_prompt_too_long};
 use anyhow::{Result, anyhow};
 use client::{Client, UserStore, zed_urls};
 use collections::BTreeMap;
-use feature_flags::{FeatureFlagAppExt, LlmClosedBetaFeatureFlag, ZedProFeatureFlag};
+use feature_flags::{FeatureFlagAppExt, LlmClosedBetaFeatureFlag};
 use futures::{
     AsyncBufReadExt, FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream,
 };
@@ -1027,48 +1027,56 @@ impl ConfigurationView {
 
 impl Render for ConfigurationView {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        const ZED_AI_URL: &str = "https://zed.dev/ai";
+        const ZED_PRICING_URL: &str = "https://zed.dev/pricing";
 
         let is_connected = !self.state.read(cx).is_signed_out();
-        let plan = self.state.read(cx).user_store.read(cx).current_plan();
+        let user_store = self.state.read(cx).user_store.read(cx);
+        let plan = user_store.current_plan();
+        let subscription_period = user_store.subscription_period();
+        let eligible_for_trial = user_store.trial_started_at().is_none();
         let has_accepted_terms = self.state.read(cx).has_accepted_terms_of_service(cx);
 
         let is_pro = plan == Some(proto::Plan::ZedPro);
-        let subscription_text = Label::new(if is_pro {
-            "You have access to Zed's hosted LLMs through your Zed Pro subscription."
+        let subscription_text = match (plan, subscription_period) {
+            (Some(proto::Plan::ZedPro), Some(_)) => {
+                "You have access to Zed's hosted LLMs through your Zed Pro subscription."
+            }
+            (Some(proto::Plan::ZedProTrial), Some(_)) => {
+                "You have access to Zed's hosted LLMs through your Zed Pro trial."
+            }
+            (Some(proto::Plan::Free), Some(_)) => {
+                "You have basic access to Zed's hosted LLMs through your Zed Free subscription."
+            }
+            _ => {
+                if eligible_for_trial {
+                    "Subscribe for access to Zed's hosted LLMs. Start with a 14 day free trial."
+                } else {
+                    "Subscribe for access to Zed's hosted LLMs."
+                }
+            }
+        };
+        let manage_subscription_buttons = if is_pro {
+            h_flex().child(
+                Button::new("manage_settings", "Manage Subscription")
+                    .style(ButtonStyle::Tinted(TintColor::Accent))
+                    .on_click(cx.listener(|_, _, _, cx| cx.open_url(&zed_urls::account_url(cx)))),
+            )
         } else {
-            "You have basic access to models from Anthropic through the Zed AI Free plan."
-        });
-        let manage_subscription_button = if is_pro {
-            Some(
-                h_flex().child(
-                    Button::new("manage_settings", "Manage Subscription")
-                        .style(ButtonStyle::Tinted(TintColor::Accent))
+            h_flex()
+                .gap_2()
+                .child(
+                    Button::new("learn_more", "Learn more")
+                        .style(ButtonStyle::Subtle)
+                        .on_click(cx.listener(|_, _, _, cx| cx.open_url(ZED_PRICING_URL))),
+                )
+                .child(
+                    Button::new("upgrade", "Upgrade")
+                        .style(ButtonStyle::Subtle)
+                        .color(Color::Accent)
                         .on_click(
                             cx.listener(|_, _, _, cx| cx.open_url(&zed_urls::account_url(cx))),
                         ),
-                ),
-            )
-        } else if cx.has_flag::<ZedProFeatureFlag>() {
-            Some(
-                h_flex()
-                    .gap_2()
-                    .child(
-                        Button::new("learn_more", "Learn more")
-                            .style(ButtonStyle::Subtle)
-                            .on_click(cx.listener(|_, _, _, cx| cx.open_url(ZED_AI_URL))),
-                    )
-                    .child(
-                        Button::new("upgrade", "Upgrade")
-                            .style(ButtonStyle::Subtle)
-                            .color(Color::Accent)
-                            .on_click(
-                                cx.listener(|_, _, _, cx| cx.open_url(&zed_urls::account_url(cx))),
-                            ),
-                    ),
-            )
-        } else {
-            None
+                )
         };
 
         if is_connected {
@@ -1082,7 +1090,7 @@ impl Render for ConfigurationView {
                 ))
                 .when(has_accepted_terms, |this| {
                     this.child(subscription_text)
-                        .children(manage_subscription_button)
+                        .child(manage_subscription_buttons)
                 })
         } else {
             v_flex()

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -26,6 +26,12 @@ message UpdateUserPlan {
     optional uint64 trial_started_at = 2;
     optional bool is_usage_based_billing_enabled = 3;
     optional SubscriptionUsage usage = 4;
+    optional SubscriptionPeriod subscription_period = 5;
+}
+
+message SubscriptionPeriod {
+    uint64 started_at = 1;
+    uint64 ended_at = 2;
 }
 
 message SubscriptionUsage {


### PR DESCRIPTION
This PR improves the subscription states in the Agent configuration view to the new billing system.

Zed Free (legacy):

<img width="638" alt="Screenshot 2025-05-08 at 8 42 59 AM" src="https://github.com/user-attachments/assets/7b62d4c1-2a9c-4c6a-aa8f-060730b6d7b3" />

Zed Free (new):

<img width="640" alt="Screenshot 2025-05-08 at 8 43 56 AM" src="https://github.com/user-attachments/assets/8a48448e-813e-4633-955d-623d3e6d603c" />

Zed Pro trial:

<img width="641" alt="Screenshot 2025-05-08 at 8 45 52 AM" src="https://github.com/user-attachments/assets/1ec7ee62-e954-48e7-8447-4584527307c9" />

Zed Pro:

<img width="636" alt="Screenshot 2025-05-08 at 8 47 21 AM" src="https://github.com/user-attachments/assets/f934b2e3-0943-4b78-b8dc-0a31e731d8fb" />

Release Notes:

- agent: Improved the subscription-related information in the configuration view.
