### PR TITLE
editor: Add back minimap width setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -393,7 +393,9 @@
     // 1. `null` to inherit the editor `current_line_highlight` setting (default)
     // 2. "line" or "all" to highlight the current line in the minimap.
     // 3. "gutter" or "none" to not highlight the current line in the minimap.
-    "current_line_highlight": null
+    "current_line_highlight": null,
+    // The width of the minimap in pixels.
+    "width": 100
   },
   // Enable middle-click paste on Linux.
   "middle_click_paste": true,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -123,6 +123,7 @@ pub struct Minimap {
     pub thumb: MinimapThumb,
     pub thumb_border: MinimapThumbBorder,
     pub current_line_highlight: Option<CurrentLineHighlight>,
+    pub width: u32,
 }
 
 impl Minimap {
@@ -532,6 +533,11 @@ pub struct MinimapContent {
     ///
     /// Default: inherits editor line highlights setting
     pub current_line_highlight: Option<Option<CurrentLineHighlight>>,
+
+    /// The width of the minimap in pixels
+    ///
+    /// Default: 100
+    pub width: Option<u32>,
 }
 
 /// Forcefully enable or disable the scrollbar for each axis

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7162,9 +7162,7 @@ impl Element for EditorElement {
                         .then(|| match settings.minimap.show {
                             ShowMinimap::Never => None,
                             ShowMinimap::Always => Some(minimap_setting_width),
-                            ShowMinimap::Auto => {
-                                scrollbars_shown.then_some(minimap_setting_width)
-                            }
+                            ShowMinimap::Auto => scrollbars_shown.then_some(minimap_setting_width),
                         })
                         .flatten()
                         .filter(|minimap_width| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7155,14 +7155,15 @@ impl Element for EditorElement {
                             .read_with(cx, |editor, _| editor.show_scrollbars))
                     .then_some(style.scrollbar_width)
                     .unwrap_or_default();
+                    let minimap_setting_width = px(settings.minimap.width as f32);
                     let minimap_width = self
                         .editor
                         .read_with(cx, |editor, _| editor.minimap().is_some())
                         .then(|| match settings.minimap.show {
                             ShowMinimap::Never => None,
-                            ShowMinimap::Always => Some(MinimapLayout::MINIMAP_WIDTH),
+                            ShowMinimap::Always => Some(minimap_setting_width),
                             ShowMinimap::Auto => {
-                                scrollbars_shown.then_some(MinimapLayout::MINIMAP_WIDTH)
+                                scrollbars_shown.then_some(minimap_setting_width)
                             }
                         })
                         .flatten()
@@ -8715,7 +8716,6 @@ struct MinimapLayout {
 }
 
 impl MinimapLayout {
-    const MINIMAP_WIDTH: Pixels = px(100.);
     /// Calculates the scroll top offset the minimap editor has to have based on the
     /// current scroll progress.
     fn calculate_minimap_top_offset(


### PR DESCRIPTION
recloses #30250
Superseded #30253 

@SomeoneToIgnore 

I add minimap width settings back

At least I'd love to tweak the width on my own

Release Notes:

- N/A
