### PR TITLE
debugger: Shutdown debug adapter client on terminated event

### DIFF
--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1172,8 +1172,7 @@ impl Session {
                 self.clear_active_debug_line(cx);
             }
             Events::Terminated(_) => {
-                self.is_session_terminated = true;
-                self.clear_active_debug_line(cx);
+                self.shutdown(cx).detach();
             }
             Events::Thread(event) => {
                 let thread_id = ThreadId(event.thread_id);


### PR DESCRIPTION
I noticed some problems where we have hanging debug sessions after they've been terminated. This should hopefully fix most cases of this, if not all.

Release Notes:

- N/A
