### PR TITLE
agent: Fuzzy search in model selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7813,6 +7813,7 @@ version = "0.1.0"
 dependencies = [
  "collections",
  "feature_flags",
+ "fuzzy",
  "gpui",
  "language_model",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7817,6 +7817,7 @@ dependencies = [
  "gpui",
  "language_model",
  "log",
+ "ordered-float 2.10.1",
  "picker",
  "proto",
  "ui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7813,6 +7813,7 @@ version = "0.1.0"
 dependencies = [
  "collections",
  "feature_flags",
+ "futures 0.3.31",
  "fuzzy",
  "gpui",
  "language_model",

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/language_model_selector.rs"
 [dependencies]
 collections.workspace = true
 feature_flags.workspace = true
+fuzzy.workspace = true
 gpui.workspace = true
 language_model.workspace = true
 log.workspace = true

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -11,11 +11,19 @@ workspace = true
 [lib]
 path = "src/language_model_selector.rs"
 
+[features]
+test-support = [
+    "gpui/test-support",
+    # "language/test-support"
+]
+
 [dependencies]
 collections.workspace = true
 feature_flags.workspace = true
+futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+# language.workspace = true
 language_model.workspace = true
 log.workspace = true
 ordered-float.workspace = true
@@ -24,3 +32,7 @@ proto.workspace = true
 ui.workspace = true
 workspace-hack.workspace = true
 zed_actions.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, "features" = ["test-support"] }
+language_model = { workspace = true, "features" = ["test-support"] }

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -18,6 +18,7 @@ fuzzy.workspace = true
 gpui.workspace = true
 language_model.workspace = true
 log.workspace = true
+ordered-float.workspace = true
 picker.workspace = true
 proto.workspace = true
 ui.workspace = true

--- a/crates/language_model_selector/Cargo.toml
+++ b/crates/language_model_selector/Cargo.toml
@@ -14,7 +14,6 @@ path = "src/language_model_selector.rs"
 [features]
 test-support = [
     "gpui/test-support",
-    # "language/test-support"
 ]
 
 [dependencies]
@@ -23,7 +22,6 @@ feature_flags.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
-# language.workspace = true
 language_model.workspace = true
 log.workspace = true
 ordered-float.workspace = true

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -755,7 +755,7 @@ mod tests {
             false
         }
 
-        fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
+        fn supports_tool_choice(&self, _choice: LanguageModelToolChoice) -> bool {
             false
         }
 

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -711,7 +711,7 @@ mod tests {
     use language_model::{
         LanguageModelCompletionError, LanguageModelCompletionEvent, LanguageModelId,
         LanguageModelName, LanguageModelProviderId, LanguageModelProviderName,
-        LanguageModelRequest,
+        LanguageModelRequest, LanguageModelToolChoice,
     };
     use ui::IconName;
 
@@ -752,6 +752,10 @@ mod tests {
         }
 
         fn supports_tools(&self) -> bool {
+            false
+        }
+
+        fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
             false
         }
 
@@ -878,7 +882,7 @@ mod tests {
         assert_models_eq(results, vec!["ollama/mistral", "ollama/deepseek"]);
 
         // Fuzzy search
-        let results = matcher.fuzzy_search("z4n"); // meaning "ollama"
+        let results = matcher.fuzzy_search("z4n");
         assert_models_eq(results, vec!["zed/gpt-4.1-nano"]);
     }
 }

--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -878,7 +878,7 @@ mod tests {
         );
 
         // Model provider should be searchable as well
-        let results = matcher.fuzzy_search("oll"); // meaning "ollama"
+        let results = matcher.fuzzy_search("ol"); // meaning "ollama"
         assert_models_eq(results, vec!["ollama/mistral", "ollama/deepseek"]);
 
         // Fuzzy search


### PR DESCRIPTION
This change enables fuzzy search on model providers and names. For example, the query "z41" will match "zed/gpt-4.1".

Release Notes:

- Agent: Improved model selection with fuzzy search support