### PR TITLE
Add a `terminal::RerunTask` action

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -952,7 +952,10 @@
       "shift-down": "terminal::ScrollLineDown",
       "shift-home": "terminal::ScrollToTop",
       "shift-end": "terminal::ScrollToBottom",
-      "ctrl-shift-space": "terminal::ToggleViMode"
+      "ctrl-shift-space": "terminal::ToggleViMode",
+      "ctrl-shift-r": "terminal::RerunTask",
+      "ctrl-alt-r": "terminal::RerunTask",
+      "alt-t": "terminal::RerunTask"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1038,7 +1038,8 @@
       "ctrl-alt-up": "pane::SplitUp",
       "ctrl-alt-down": "pane::SplitDown",
       "ctrl-alt-left": "pane::SplitLeft",
-      "ctrl-alt-right": "pane::SplitRight"
+      "ctrl-alt-right": "pane::SplitRight",
+      "cmd-alt-r": "terminal::RerunTask"
     }
   },
   {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/23779

Bounded this action to the same defaults `task::Rerun` is bound to.

Unlike the `task::Rerun` which will always rerun the latest task, this command reruns the current task tab, if focused.
The task is not in scope when the terminal pane is not focused, and falls back to the regular rerun if invoked on a task-less terminal tab.

This way, we can add a proper tooltip to the terminal tab reruns:

<img width="231" alt="image" src="https://github.com/user-attachments/assets/2cdd7458-5ba2-4cc7-a10b-3e2db059f1ca" />


Release Notes:

- Added `terminal::RerunTask` task action
