### PR TITLE
Remove individual URL overrides for LLM service

### DIFF
--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -231,7 +231,7 @@ impl HttpClientWithUrl {
         let base_api_url = match base_url.as_ref() {
             "https://zed.dev" => "https://llm.zed.dev",
             "https://staging.zed.dev" => "https://llm-staging.zed.dev",
-            "http://localhost:3000" => "http://localhost:8080",
+            "http://localhost:3000" => "http://localhost:8787",
             other => other,
         };
 

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -540,13 +540,9 @@ impl CloudLanguageModel {
         let mut retry_delay = Duration::from_secs(1);
 
         loop {
-            let request_builder = http_client::Request::builder().method(Method::POST);
-            let request_builder = if let Ok(completions_url) = std::env::var("ZED_COMPLETIONS_URL")
-            {
-                request_builder.uri(completions_url)
-            } else {
-                request_builder.uri(http_client.build_zed_llm_url("/completions", &[])?.as_ref())
-            };
+            let request_builder = http_client::Request::builder()
+                .method(Method::POST)
+                .uri(http_client.build_zed_llm_url("/completions", &[])?.as_ref());
             let request_builder = if let Some(app_version) = app_version {
                 request_builder.header(ZED_VERSION_HEADER_NAME, app_version.to_string())
             } else {
@@ -743,17 +739,6 @@ impl LanguageModel for CloudLanguageModel {
                     let http_client = &client.http_client();
                     let token = llm_api_token.acquire(&client).await?;
 
-                    let request_builder = http_client::Request::builder().method(Method::POST);
-                    let request_builder =
-                        if let Ok(completions_url) = std::env::var("ZED_COUNT_TOKENS_URL") {
-                            request_builder.uri(completions_url)
-                        } else {
-                            request_builder.uri(
-                                http_client
-                                    .build_zed_llm_url("/count_tokens", &[])?
-                                    .as_ref(),
-                            )
-                        };
                     let request_body = CountTokensBody {
                         provider: zed_llm_client::LanguageModelProvider::Google,
                         model: model_id,
@@ -761,7 +746,13 @@ impl LanguageModel for CloudLanguageModel {
                             generate_content_request,
                         })?,
                     };
-                    let request = request_builder
+                    let request = http_client::Request::builder()
+                        .method(Method::POST)
+                        .uri(
+                            http_client
+                                .build_zed_llm_url("/count_tokens", &[])?
+                                .as_ref(),
+                        )
                         .header("Content-Type", "application/json")
                         .header("Authorization", format!("Bearer {token}"))
                         .body(serde_json::to_string(&request_body)?.into())?;

--- a/crates/web_search_providers/src/cloud.rs
+++ b/crates/web_search_providers/src/cloud.rs
@@ -77,13 +77,9 @@ async fn perform_web_search(
 
     let token = llm_api_token.acquire(&client).await?;
 
-    let request_builder = http_client::Request::builder().method(Method::POST);
-    let request_builder = if let Ok(web_search_url) = std::env::var("ZED_WEB_SEARCH_URL") {
-        request_builder.uri(web_search_url)
-    } else {
-        request_builder.uri(http_client.build_zed_llm_url("/web_search", &[])?.as_ref())
-    };
-    let request = request_builder
+    let request = http_client::Request::builder()
+        .method(Method::POST)
+        .uri(http_client.build_zed_llm_url("/web_search", &[])?.as_ref())
         .header("Content-Type", "application/json")
         .header("Authorization", format!("Bearer {token}"))
         .header(CLIENT_SUPPORTS_EXA_WEB_SEARCH_PROVIDER_HEADER_NAME, "true")

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -740,18 +740,13 @@ and then another
             let mut did_retry = false;
 
             loop {
-                let request_builder = http_client::Request::builder().method(Method::POST);
-                let request_builder =
-                    if let Ok(predict_edits_url) = std::env::var("ZED_PREDICT_EDITS_URL") {
-                        request_builder.uri(predict_edits_url)
-                    } else {
-                        request_builder.uri(
-                            http_client
-                                .build_zed_llm_url("/predict_edits/v2", &[])?
-                                .as_ref(),
-                        )
-                    };
-                let request = request_builder
+                let request = http_client::Request::builder()
+                    .method(Method::POST)
+                    .uri(
+                        http_client
+                            .build_zed_llm_url("/predict_edits/v2", &[])?
+                            .as_ref(),
+                    )
                     .header("Content-Type", "application/json")
                     .header("Authorization", format!("Bearer {}", token))
                     .header(ZED_VERSION_HEADER_NAME, app_version.to_string())


### PR DESCRIPTION
This PR removes the individual URL overrides for the LLM service.

We initially had `ZED_PREDICT_EDITS_URL` to allow for directing traffic to the LLM Worker back when there was still the split of the Collab-based LLM Service and the Cloudflare-based LLM Worker.

But now that all of the LLM functionality has been moved into the Worker, we can just direct all traffic there.

Release Notes:

- N/A
