### PR TITLE
Add npm package version override capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9043,6 +9043,7 @@ dependencies = [
  "async-trait",
  "async-watch",
  "async_zip",
+ "collections",
  "futures 0.3.31",
  "http_client",
  "log",

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -413,6 +413,7 @@ pub fn init(cx: &mut App) -> Arc<AgentAppState> {
                     }),
                 )
             }),
+            version_overrides: settings.version_overrides.clone(),
         };
         tx.send(Some(options)).log_err();
     })

--- a/crates/node_runtime/Cargo.toml
+++ b/crates/node_runtime/Cargo.toml
@@ -22,6 +22,7 @@ async-watch.workspace = true
 async-tar.workspace = true
 async-trait.workspace = true
 async_zip.workspace = true
+collections.workspace = true
 futures.workspace = true
 http_client.workspace = true
 log.workspace = true

--- a/crates/node_runtime/src/node_runtime.rs
+++ b/crates/node_runtime/src/node_runtime.rs
@@ -4,6 +4,7 @@ use anyhow::{Context, Result, anyhow, bail};
 pub use archive::extract_zip;
 use async_compression::futures::bufread::GzipDecoder;
 use async_tar::Archive;
+use collections::HashMap;
 use futures::AsyncReadExt;
 use http_client::{HttpClient, Url};
 use semver::Version;
@@ -15,7 +16,6 @@ use std::ffi::OsString;
 use std::io;
 use std::process::{Output, Stdio};
 use std::{
-    collections::HashMap,
     env::consts,
     path::{Path, PathBuf},
     sync::Arc,
@@ -139,10 +139,10 @@ impl NodeRuntime {
                 }
             }
         }
-        
+
         let http = state.http.clone();
-        drop(state);  // Release the lock before awaiting instance()
-        
+        drop(state); // Release the lock before awaiting instance()
+
         let output = self
             .instance()
             .await?

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -105,6 +105,8 @@ pub struct NodeBinarySettings {
     /// If enabled, Zed will download its own copy of Node.
     #[serde(default)]
     pub ignore_system_version: Option<bool>,
+    /// Map of package names to version overrides
+    pub version_overrides: Option<HashMap<String, String>>,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -105,7 +105,7 @@ pub struct NodeBinarySettings {
     /// If enabled, Zed will download its own copy of Node.
     #[serde(default)]
     pub ignore_system_version: Option<bool>,
-    /// Map of package names to version overrides
+    /// Map of package names to version overrides.
     pub version_overrides: Option<HashMap<String, String>>,
 }
 

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -813,6 +813,7 @@ fn initialize_settings(
                     }),
                 )
             }),
+            version_overrides: settings.version_overrides.clone(),
         };
         tx.send(Some(options)).log_err();
     })

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -403,6 +403,7 @@ fn main() {
                         }),
                     )
                 }),
+                version_overrides: settings.version_overrides.clone(),
             };
             tx.send(Some(options)).log_err();
         })


### PR DESCRIPTION
For enterprises which use an internal NPM repo to limit package installations to approved versions, the behavior of always looking for the actual latest version means that functionality like Github Copilot breaks. This provides the ability to pin packages like the copilot LSP to specific approved versions so they keep working.

Release Notes:

- N/A