### PR TITLE
editor: Fix TypeScript auto-import breaking generic function calls

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4955,10 +4955,10 @@ impl Editor {
         let snippet;
         let new_text;
         if completion.is_snippet() {
-            // LSP returns function signatures with parentheses and args in "new_text"
-            // when configured, even when renaming a function
+            // lsp returns function definition with placeholders in "new_text"
+            // when configured from language server, even when renaming a function
             //
-            // In such cases, we use the label instead
+            // in such cases, we use the label instead
             // https://github.com/zed-industries/zed/issues/29982
             let snippet_source = completion
                 .label()

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5179,7 +5179,7 @@ impl Completion {
     pub fn label(&self) -> Option<String> {
         self.source
             .lsp_completion(false)
-            .and_then(|lsp_completion| Some(lsp_completion.label.clone()))
+            .map(|lsp_completion| lsp_completion.label.clone())
     }
 
     /// A key that can be used to sort completions when displaying

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -5169,15 +5169,25 @@ impl ProjectItem for Buffer {
 }
 
 impl Completion {
+    pub fn kind(&self) -> Option<CompletionItemKind> {
+        self.source
+            // `lsp::CompletionListItemDefaults` has no `kind` field
+            .lsp_completion(false)
+            .and_then(|lsp_completion| lsp_completion.kind)
+    }
+
+    pub fn label(&self) -> Option<String> {
+        self.source
+            .lsp_completion(false)
+            .and_then(|lsp_completion| Some(lsp_completion.label.clone()))
+    }
+
     /// A key that can be used to sort completions when displaying
     /// them to the user.
     pub fn sort_key(&self) -> (usize, &str) {
         const DEFAULT_KIND_KEY: usize = 3;
         let kind_key = self
-            .source
-            // `lsp::CompletionListItemDefaults` has no `kind` field
-            .lsp_completion(false)
-            .and_then(|lsp_completion| lsp_completion.kind)
+            .kind()
             .and_then(|lsp_completion_kind| match lsp_completion_kind {
                 lsp::CompletionItemKind::KEYWORD => Some(0),
                 lsp::CompletionItemKind::VARIABLE => Some(1),


### PR DESCRIPTION
Closes #29982

When auto-importing TypeScript functions with generic type arguments (like `useRef<HTMLDivElement>(null)`), the language server returns snippets with placeholders (e.g., `useRef(${1:initialValue})$0`). While useful for new function calls, this behavior breaks existing code when renaming functions that already have parameters.

For example, completing `useR^<HTMLDivElement>(null)` incorrectly results in `useRef(initialValue)^<HTMLDivElement>(null)`.

Related upstream issue: https://github.com/microsoft/TypeScript/issues/51758
Similar workaround fix: https://github.com/pmizio/typescript-tools.nvim/pull/147

Release Notes:

- Fixed TypeScript auto-import behavior where functions with generic type arguments (like `useRef<HTMLDivElement>(null)`) would incorrectly insert snippet placeholders, breaking the syntax.
