### PR TITLE
Normalize language model selector configure button sizing

### DIFF
--- a/crates/language_model_selector/src/language_model_selector.rs
+++ b/crates/language_model_selector/src/language_model_selector.rs
@@ -592,8 +592,9 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                 })
                 .child(
                     Button::new("configure", "Configure")
+                        .label_size(LabelSize::XSmall)
                         .icon(IconName::Settings)
-                        .icon_size(IconSize::Small)
+                        .icon_size(IconSize::XSmall)
                         .icon_color(Color::Muted)
                         .icon_position(IconPosition::Start)
                         .on_click(|_, window, cx| {


### PR DESCRIPTION
Part of #30200

Release Notes:

- Fixed sizing for agent panel language model selector configure button
