### PR TITLE
agent: Ensure context meter updates when context is cleared

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1463,7 +1463,7 @@ impl ActiveThread {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.context_store.update(cx, |store, _cx| store.clear());
+        self.context_store.update(cx, |store, cx| store.clear(cx));
         cx.notify();
     }
 

--- a/crates/agent/src/context_store.rs
+++ b/crates/agent/src/context_store.rs
@@ -58,9 +58,10 @@ impl ContextStore {
         self.context_set.iter().map(|entry| entry.as_ref())
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&mut self, cx: &mut Context<Self>) {
         self.context_set.clear();
         self.context_thread_ids.clear();
+        cx.notify();
     }
 
     pub fn new_context_for_thread(

--- a/crates/agent/src/inline_prompt_editor.rs
+++ b/crates/agent/src/inline_prompt_editor.rs
@@ -373,7 +373,7 @@ impl<T: 'static> PromptEditor<T> {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.context_store.update(cx, |store, _cx| store.clear());
+        self.context_store.update(cx, |store, cx| store.clear(cx));
         cx.notify();
     }
 

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -272,7 +272,7 @@ impl MessageEditor {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.context_store.update(cx, |store, _cx| store.clear());
+        self.context_store.update(cx, |store, cx| store.clear(cx));
         cx.notify();
     }
 


### PR DESCRIPTION
Addresses an issue where the agent context token meter in the panel toolbar (showing usage like "X / Y tokens") failed to update its count after the user cleared the current context via the context editor UI. While the meter updated correctly when adding items, clearing them left the display showing the old count.

The root cause was traced to the `ContextStore::clear` method in `crates/agent/src/context_store.rs`. This method correctly cleared the internal data structures holding the context items but neglected to call `cx.notify()` to inform listeners of the state change. Consequently, the UI components responsible for displaying the token count were not triggered to re-render with the new (presumably lower) count.

This PR fixes the issue by adding the missing `cx.notify()` call to the `ContextStore::clear` method. This ensures listeners are notified when the context set is cleared, allowing the token meter UI to update correctly.

Release Notes:

- Fixed an issue where the agent context token meter did not update when the context was cleared.