### PR TITLE
languages: Fix python indent block for more keywords

### DIFF
--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -24,6 +24,31 @@
   body: (block) @indent
 )
 
+(with_statement
+  ":" @start
+  body: (block) @indent
+)
+
+(while_statement
+  ":" @start
+  body: (block) @indent
+)
+
+(match_statement
+  ":" @start
+  body: (block) @indent
+)
+
+(class_definition
+  ":" @start
+  body: (block) @indent
+)
+
+(case_clause
+  ":" @start
+  consequence: (block) @indent
+)
+
 (try_statement
   ":" @start
   body: (block) @indent


### PR DESCRIPTION
Add `with`, `while`, `match`, `class` and `case` keywords as indent block.

Release Notes:

- N/A
