### PR TITLE
editor: Ensure minimap is shown when `show_minimap` is toggled to `true`

### DIFF
--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -132,6 +132,13 @@ impl Minimap {
     pub fn minimap_enabled(&self) -> bool {
         self.show != ShowMinimap::Never
     }
+
+    pub fn with_show_override(self) -> Self {
+        Self {
+            show: ShowMinimap::Always,
+            ..self
+        }
+    }
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1539,7 +1539,7 @@ impl EditorElement {
             || minimap_width.is_zero()
             || matches!(
                 minimap_settings.show,
-                ShowMinimap::Never | ShowMinimap::Auto if scrollbar_layout.is_none_or(|layout| !layout.visible)
+                ShowMinimap::Auto if scrollbar_layout.is_none_or(|layout| !layout.visible)
             )
         {
             return None;
@@ -7161,11 +7161,10 @@ impl Element for EditorElement {
                         .editor
                         .read_with(cx, |editor, _| editor.minimap().is_some())
                         .then(|| match settings.minimap.show {
-                            ShowMinimap::Never => None,
-                            ShowMinimap::Always => Some(MinimapLayout::MINIMAP_WIDTH),
                             ShowMinimap::Auto => {
                                 scrollbars_shown.then_some(MinimapLayout::MINIMAP_WIDTH)
                             }
+                            _ => Some(MinimapLayout::MINIMAP_WIDTH),
                         })
                         .flatten()
                         .filter(|minimap_width| {

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -105,7 +105,7 @@ impl Render for QuickActionBar {
         let show_edit_predictions = editor_value.edit_predictions_enabled();
         let edit_predictions_enabled_at_cursor =
             editor_value.edit_predictions_enabled_at_cursor(cx);
-        let supports_minimap = editor_value.supports_minimap();
+        let supports_minimap = editor_value.supports_minimap(cx);
         let minimap_enabled = supports_minimap && editor_value.minimap().is_some();
 
         let focus_handle = editor_value.focus_handle(cx);


### PR DESCRIPTION
Follow-up of #30285

This PR ensures the action added in the linked PR also works when the user does not have the minimap enabled via settings. Currently, the toggle only works when the user has already enabled the minimap in their settings.

This happens because in

https://github.com/zed-industries/zed/blob/b4fbb9bc085733d2f771cd440ff57305cf6eebeb/crates/editor/src/element.rs#L7160-L7164

as well as

https://github.com/zed-industries/zed/blob/b4fbb9bc085733d2f771cd440ff57305cf6eebeb/crates/editor/src/element.rs#L1542

we check for the user configuration before reserving space for the minimap as well as layouting it and because in 
https://github.com/zed-industries/zed/blob/b4fbb9bc085733d2f771cd440ff57305cf6eebeb/crates/editor/src/editor.rs#L16404

with

https://github.com/zed-industries/zed/blob/b4fbb9bc085733d2f771cd440ff57305cf6eebeb/crates/editor/src/editor_settings.rs#L132-L134

we would not even create a minimap when the user disabled it via their settings.

---

This PR fixes this by ensuring a minimap is created on the toggle issue as well as lifting some of the restrictions. Since we are always only returning a minimap in 

https://github.com/zed-industries/zed/blob/b4fbb9bc085733d2f771cd440ff57305cf6eebeb/crates/editor/src/editor.rs#L16443-L16445

when `show_minimap` is set to `true`, we can assume in the rendering code that if a minimap is present, it should be layouted and rendered no matter if `ShowMinimap` is currently set to `Never`. We can do this since `show_minimap` always reflects the current user configuration, see 

https://github.com/zed-industries/zed/blob/b4fbb9bc085733d2f771cd440ff57305cf6eebeb/crates/editor/src/editor.rs#L18163-L18164

I also removed the minimap deletion/recreation on the toggling of `show_minimap`, since this is not really needed - once we have stored a minimap editor within the editor, `show_minimap` is sufficient to ensure that it is only shown when the user requests it. Notice that we still will never create a minimap unless neccesary.

Lastly, I updated the `supports_minimap` check to account for the fact that the minimap is currently disabled entirely for multibuffers. 

--- 

One thing I ~~did not tackle here~~ tackled in the second commit is that due to `show_minimap` now being exposed to the user, it is possible to enable the minimap for all full mode editors, e.g. the agent text thread editor

<img width="592" alt="grafik" src="https://github.com/user-attachments/assets/5f6c0e8b-45f9-44e8-9625-9d51c1480f98" />

which should most likely not be possible when the minimap is programmatically disabled.

Release Notes:

- N/A