### PR TITLE
agent: Always render past messages as editors

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -18,7 +18,7 @@ use assistant_tool::ToolUseStatus;
 use collections::{HashMap, HashSet, hash_map::Entry};
 use editor::actions::{MoveUp, Paste};
 use editor::scroll::Autoscroll;
-use editor::{Editor, EditorElement, EditorEvent, EditorStyle, MultiBuffer};
+use editor::{Editor, EditorElement, EditorEvent, EditorMode, EditorStyle, MultiBuffer};
 use gpui::{
     AbsoluteLength, Animation, AnimationExt, AnyElement, App, ClickEvent, ClipboardEntry,
     ClipboardItem, DefiniteLength, EdgesRefinement, Empty, Entity, EventEmitter, Focusable, Hsla,
@@ -1641,6 +1641,7 @@ impl ActiveThread {
                 let message_text = message_text.clone();
 
                 let editor = crate::message_editor::create_editor(
+                    usize::MAX, // XXX
                     self.workspace.clone(),
                     self.context_store.downgrade(),
                     self.thread_store.downgrade(),

--- a/crates/agent/src/context_strip.rs
+++ b/crates/agent/src/context_strip.rs
@@ -84,7 +84,7 @@ impl ContextStrip {
         }
     }
 
-    fn added_contexts(&self, cx: &App) -> Vec<AddedContext> {
+    pub fn added_contexts(&self, cx: &App) -> Vec<AddedContext> {
         if let Some(workspace) = self.workspace.upgrade() {
             let project = workspace.read(cx).project().read(cx);
             let prompt_store = self

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -80,6 +80,7 @@ pub struct MessageEditor {
 const MAX_EDITOR_LINES: usize = 8;
 
 pub(crate) fn create_editor(
+    max_lines: usize,
     workspace: WeakEntity<Workspace>,
     context_store: WeakEntity<ContextStore>,
     thread_store: WeakEntity<ThreadStore>,
@@ -99,9 +100,7 @@ pub(crate) fn create_editor(
         let buffer = cx.new(|cx| Buffer::local("", cx).with_language(Arc::new(language), cx));
         let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
         let mut editor = Editor::new(
-            editor::EditorMode::AutoHeight {
-                max_lines: MAX_EDITOR_LINES,
-            },
+            EditorMode::AutoHeight { max_lines },
             buffer,
             None,
             window,
@@ -159,6 +158,7 @@ impl MessageEditor {
         let model_selector_menu_handle = PopoverMenuHandle::default();
 
         let editor = create_editor(
+            MAX_EDITOR_LINES,
             workspace.clone(),
             context_store.downgrade(),
             thread_store.clone(),


### PR DESCRIPTION
WIP

- [ ] Find a good approach to rendering the context strip for past messages
- [x] ~~Fix occlude on later messages blocking scrolling~~ (fixed on main)
- [ ] Replace focus out handler with something more scoped
- [ ] Blur past messages when clicking away

Release Notes:

- TODO