### PR TITLE
chore: remove redundant word in comment

### DIFF
--- a/crates/gpui/src/color.rs
+++ b/crates/gpui/src/color.rs
@@ -706,7 +706,7 @@ pub fn solid_background(color: impl Into<Hsla>) -> Background {
 
 /// Creates a LinearGradient background color.
 ///
-/// The gradient line's angle of direction. A value of `0.` is equivalent to to top; increasing values rotate clockwise from there.
+/// The gradient line's angle of direction. A value of `0.` is equivalent to top; increasing values rotate clockwise from there.
 ///
 /// The `angle` is in degrees value in the range 0.0 to 360.0.
 ///

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -291,7 +291,7 @@ pub fn monitor_main_thread_hangs(
                     // ASYNC SIGNAL SAFETY: This lock is only accessed one other time,
                     // which can only be triggered by This signal handler. In addition,
                     // this signal handler is immediately removed by SA_RESETHAND, and this
-                    // signal handler cannot be re-entrant due to to the SIGUSR2 mask defined
+                    // signal handler cannot be re-entrant due to the SIGUSR2 mask defined
                     // below
                     let mut bt = BACKTRACE.lock();
                     bt.clear();

--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -6,7 +6,7 @@ Deno support is available through the [Deno extension](https://github.com/zed-ex
 
 ## Deno Configuration
 
-To use the Deno Language Server with TypeScript and TSX files, you will likely wish to to disable the default language servers and enable deno by adding the following to your settings.json:
+To use the Deno Language Server with TypeScript and TSX files, you will likely wish to disable the default language servers and enable deno by adding the following to your settings.json:
 
 ```json
 {

--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -34,7 +34,7 @@ By default, Zed maintains two themes: one for light mode and one for dark mode. 
 
 To override specific attributes of a theme, use the `experimental.theme_overrides` setting.
 
-For example, add the following to your `settings.json` if you wish to to override the background color of the editor and display comments and doc comments as italics:
+For example, add the following to your `settings.json` if you wish to override the background color of the editor and display comments and doc comments as italics:
 
 ```json
 {


### PR DESCRIPTION
remove redundant word in comment

Release Notes:

- remove redundant word in comment
