### PR TITLE
windows: Remove extra empty line when loading default settings

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2340,7 +2340,7 @@ impl Fs for FakeFs {
 fn chunks(rope: &Rope, line_ending: LineEnding) -> impl Iterator<Item = &str> {
     rope.chunks().flat_map(move |chunk| {
         let mut newline = false;
-        let end_with_newline = chunk.ends_with('\n').then_some("\r\n");
+        let end_with_newline = chunk.ends_with('\n').then_some(line_ending.as_str());
         chunk
             .lines()
             .flat_map(move |line| {

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2340,15 +2340,19 @@ impl Fs for FakeFs {
 fn chunks(rope: &Rope, line_ending: LineEnding) -> impl Iterator<Item = &str> {
     rope.chunks().flat_map(move |chunk| {
         let mut newline = false;
-        chunk.lines().flat_map(move |line| {
-            let ending = if newline {
-                Some(line_ending.as_str())
-            } else {
-                None
-            };
-            newline = true;
-            ending.into_iter().chain([line])
-        })
+        let end_with_newline = chunk.ends_with('\n').then_some("\r\n");
+        chunk
+            .lines()
+            .flat_map(move |line| {
+                let ending = if newline {
+                    Some(line_ending.as_str())
+                } else {
+                    None
+                };
+                newline = true;
+                ending.into_iter().chain([line])
+            })
+            .chain(end_with_newline)
     })
 }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2340,34 +2340,15 @@ impl Fs for FakeFs {
 fn chunks(rope: &Rope, line_ending: LineEnding) -> impl Iterator<Item = &str> {
     rope.chunks().flat_map(move |chunk| {
         let mut newline = false;
-        #[cfg(not(target_os = "windows"))]
-        {
-            chunk.split('\n').flat_map(move |line| {
-                let ending = if newline {
-                    Some(line_ending.as_str())
-                } else {
-                    None
-                };
-                newline = true;
-                ending.into_iter().chain([line])
-            })
-        }
-        #[cfg(target_os = "windows")]
-        {
-            chunk.split('\n').flat_map(move |line| {
-                let ending = if newline {
-                    Some(line_ending.as_str())
-                } else {
-                    None
-                };
-                newline = true;
-                if line.ends_with('\r') {
-                    ending.into_iter().chain([line.trim_end_matches('\r')])
-                } else {
-                    ending.into_iter().chain([line])
-                }
-            })
-        }
+        chunk.lines().flat_map(move |line| {
+            let ending = if newline {
+                Some(line_ending.as_str())
+            } else {
+                None
+            };
+            newline = true;
+            ending.into_iter().chain([line])
+        })
     })
 }
 


### PR DESCRIPTION
On Windows, lines in a file end with `\r\n`, so using `chunk.split('\n')` leaves a trailing `\r` at the end of each line. This ends up introducing extra blank lines in the final output.

I didn't use `chunk.split('\r\n')` because some of the input have already had its line endings normalized to just `\n`. If we switch to splitting on `\r\n`, that input wouldn't be handled correctly.

#### Before

https://github.com/user-attachments/assets/22cc5a79-c3a7-4824-a3bc-d66d2261852f

#### After


https://github.com/user-attachments/assets/720f1d67-75e6-482d-b6a5-9f3aa9f321ce



Release Notes:

- N/A