### PR TITLE
editor: Fix function completion expansion in string contexts and call expressions

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -828,6 +828,8 @@ pub struct LanguageConfigOverride {
     pub completion_query_characters: Override<HashSet<char>>,
     #[serde(default)]
     pub opt_into_language_servers: Vec<LanguageServerName>,
+    #[serde(default)]
+    pub prefer_label_for_snippet: Option<bool>,
 }
 
 #[derive(Clone, Deserialize, Debug, Serialize, JsonSchema)]
@@ -1786,6 +1788,18 @@ impl LanguageScope {
                 .map(|o| &o.completion_query_characters),
             Some(&self.language.config.completion_query_characters),
         )
+    }
+
+    /// Returns whether to prefer snippet `label` over `new_text` to replace text when
+    /// completion is accepted.
+    ///
+    /// In cases like when cursor is in string or renaming existing function,
+    /// you don't want to expand function signature instead just want function name
+    /// to replace existing one.
+    pub fn prefers_label_for_snippet_in_completion(&self) -> bool {
+        self.config_override()
+            .and_then(|o| o.prefer_label_for_snippet)
+            .unwrap_or(false)
     }
 
     /// Returns a list of bracket pairs for a given language with an additional

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -34,3 +34,7 @@ opt_into_language_servers = ["emmet-language-server"]
 [overrides.string]
 completion_query_characters = ["-", "."]
 opt_into_language_servers = ["tailwindcss-language-server"]
+prefer_label_for_snippet = true
+
+[overrides.call_expression]
+prefer_label_for_snippet = true

--- a/crates/languages/src/tsx/overrides.scm
+++ b/crates/languages/src/tsx/overrides.scm
@@ -13,3 +13,5 @@
   (jsx_self_closing_element)
   (jsx_expression)
 ] @default
+
+(_ value: (call_expression) @call_expression)

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -21,3 +21,7 @@ debuggers = ["JavaScript"]
 
 [overrides.string]
 completion_query_characters = ["."]
+prefer_label_for_snippet = true
+
+[overrides.call_expression]
+prefer_label_for_snippet = true

--- a/crates/languages/src/typescript/overrides.scm
+++ b/crates/languages/src/typescript/overrides.scm
@@ -1,2 +1,4 @@
 (comment) @comment.inclusive
 (string) @string
+
+(_ value: (call_expression) @call_expression)


### PR DESCRIPTION
Closes #27582

Now, when accepting function completion, it doesn't expand with parentheses and arguments in the following cases:
1. If it's in a string (like `type Foo = MyClass["sayHello"]` instead of `type Foo = MyClass["sayHello(name)"]`)
2. If it's in a call expression (like `useRef<HTMLDivElement>(null)` over `useRef(initialValue)<HTMLDivElement>(null)`)

This is a follow-up to https://github.com/zed-industries/zed/pull/30312, more like cleaner version of it.

Release Notes:

- Fixed an issue where accepting a method as an object string in JavaScript would incorrectly expand. E.g. `MyClass["sayHello(name)"]` instead of `MyClass["sayHello"]`.
