### PR TITLE
search: Ensure inputs located in the toolbar match the background color of the toolbar

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -143,7 +143,7 @@ impl BufferSearchBar {
         };
 
         let mut editor_style = EditorStyle {
-            background: cx.theme().colors().editor_background,
+            background: cx.theme().colors().toolbar_background,
             local_player: cx.theme().players().local(),
             text: text_style,
             ..EditorStyle::default()

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1760,7 +1760,7 @@ impl ProjectSearchBar {
         };
 
         let mut editor_style = EditorStyle {
-            background: cx.theme().colors().editor_background,
+            background: cx.theme().colors().toolbar_background,
             local_player: cx.theme().players().local(),
             text: text_style,
             ..EditorStyle::default()


### PR DESCRIPTION
Closes #30267

This ensures they do not differ in color as described in the issue.

Currently: 
<img width="1182" alt="grafik" src="https://github.com/user-attachments/assets/7ccc5116-f6b4-4ffc-80fc-b5b51c49a8f2" /> 

This PR: 
<img width="1182" alt="grafik" src="https://github.com/user-attachments/assets/dcff631a-c1a8-423e-847c-8678a77e7a8e" /> 

Alternatively, we could potentially color the surrounding containers with the editor background, but I think this way around is more reasonable for the toolbar.

Release Notes:

- Improved background coloring for search inputs located in the toolbar.
