### PR TITLE
agent: Add action to close agent panel

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -242,6 +242,7 @@
       "ctrl-i": "agent::ToggleProfileSelector",
       "ctrl-alt-/": "agent::ToggleModelSelector",
       "ctrl-shift-a": "agent::ToggleContextPicker",
+      "ctrl-w": "agent::Close",
       "ctrl-shift-o": "agent::ToggleNavigationMenu",
       "ctrl-shift-i": "agent::ToggleOptionsMenu",
       "shift-escape": "agent::ExpandMessageEditor",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -288,6 +288,7 @@
       "cmd-i": "agent::ToggleProfileSelector",
       "cmd-alt-/": "agent::ToggleModelSelector",
       "cmd-shift-a": "agent::ToggleContextPicker",
+      "cmd-w": "agent::Close",
       "cmd-shift-o": "agent::ToggleNavigationMenu",
       "cmd-shift-i": "agent::ToggleOptionsMenu",
       "shift-escape": "agent::ExpandMessageEditor",

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -85,6 +85,7 @@ actions!(
         KeepAll,
         Follow,
         ResetTrialUpsell,
+        Close,
     ]
 );
 

--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -62,10 +62,10 @@ use crate::thread_history::{EntryTimeFormat, PastContext, PastThread, ThreadHist
 use crate::thread_store::ThreadStore;
 use crate::ui::AgentOnboardingModal;
 use crate::{
-    AddContextServer, AgentDiffPane, ContextStore, DeleteRecentlyOpenThread, ExpandMessageEditor,
-    Follow, InlineAssistant, NewTextThread, NewThread, OpenActiveThreadAsMarkdown, OpenAgentDiff,
-    OpenHistory, ResetTrialUpsell, TextThreadStore, ThreadEvent, ToggleContextPicker,
-    ToggleNavigationMenu, ToggleOptionsMenu,
+    AddContextServer, AgentDiffPane, Close, ContextStore, DeleteRecentlyOpenThread,
+    ExpandMessageEditor, Follow, InlineAssistant, NewTextThread, NewThread,
+    OpenActiveThreadAsMarkdown, OpenAgentDiff, OpenHistory, ResetTrialUpsell, TextThreadStore,
+    ThreadEvent, ToggleContextPicker, ToggleNavigationMenu, ToggleOptionsMenu,
 };
 
 const AGENT_PANEL_KEY: &str = "agent_panel";
@@ -156,6 +156,11 @@ pub fn init(cx: &mut App) {
                 })
                 .register_action(|_workspace, _: &ResetTrialUpsell, _window, cx| {
                     set_trial_upsell_dismissed(false, cx);
+                })
+                .register_action(|workspace, _: &Close, window, cx| {
+                    if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                        panel.update(cx, |panel, cx| panel.close_panel(window, cx));
+                    }
                 });
         },
     )
@@ -367,6 +372,10 @@ pub struct AgentPanel {
 }
 
 impl AgentPanel {
+    fn close_panel(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(PanelEvent::Close);
+    }
+
     fn serialize(&mut self, cx: &mut Context<Self>) {
         let width = self.width;
         self.pending_serialization = Some(cx.background_spawn(async move {


### PR DESCRIPTION
Adds an action to close the Agent panel, as well as binds it to cmd-w when focused on the panel.

Release Notes:

- N/A
