### PR TITLE
agent: Move up no longer focuses context strip

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1467,12 +1467,10 @@ impl ActiveThread {
         cx.notify();
     }
 
-    fn move_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
+    fn move_up(&mut self, _: &MoveUp, _window: &mut Window, cx: &mut Context<Self>) {
         if let Some((_, state)) = self.editing_message.as_mut() {
             if state.context_picker_menu_handle.is_deployed() {
                 cx.propagate();
-            } else {
-                state.context_strip.focus_handle(cx).focus(window);
             }
         }
     }

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -392,11 +392,9 @@ impl MessageEditor {
         }
     }
 
-    fn move_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
+    fn move_up(&mut self, _: &MoveUp, _window: &mut Window, cx: &mut Context<Self>) {
         if self.context_picker_menu_handle.is_deployed() {
             cx.propagate();
-        } else {
-            self.context_strip.focus_handle(cx).focus(window);
         }
     }
 


### PR DESCRIPTION
This led to some confusing/unintuitive behavior, especially in-thread
where the context strip is at the bottom.

Release Notes:

- N/A 
