### PR TITLE
windows: Remove `SmartGlobal`

### DIFF
--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -50,30 +50,3 @@ impl Deref for SafeCursor {
         &self.raw
     }
 }
-
-#[derive(Debug, Clone)]
-pub(crate) struct SmartGlobal {
-    raw: HGLOBAL,
-}
-
-impl SmartGlobal {
-    pub(crate) fn from_raw_ptr(ptr: *mut std::ffi::c_void) -> Self {
-        Self { raw: HGLOBAL(ptr) }
-    }
-
-    pub(crate) fn lock(&self) -> *mut std::ffi::c_void {
-        unsafe { GlobalLock(self.raw) }
-    }
-
-    pub(crate) fn size(&self) -> usize {
-        unsafe { GlobalSize(self.raw) }
-    }
-}
-
-impl Drop for SmartGlobal {
-    fn drop(&mut self) {
-        unsafe {
-            GlobalUnlock(self.raw).log_err();
-        }
-    }
-}

--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -1,11 +1,6 @@
 use std::ops::Deref;
 
-use util::ResultExt;
-use windows::Win32::{
-    Foundation::{HANDLE, HGLOBAL},
-    System::Memory::{GlobalLock, GlobalSize, GlobalUnlock},
-    UI::WindowsAndMessaging::HCURSOR,
-};
+use windows::Win32::{Foundation::HANDLE, UI::WindowsAndMessaging::HCURSOR};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SafeHandle {


### PR DESCRIPTION
Closes #29657

Using `with_clipboard_data()` to ensure that `GlobalLock` and `GlobalUnlock` are called correctly.

Release Notes:

- N/A
