### PR TITLE
pane: Fix pin tabs double border not visible when unpinned tab is active

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2677,10 +2677,13 @@ impl Pane {
                 // We need to check both because offset returns delta values even when the scroll handle is not scrollable
                 let is_scrollable = content_width > viewport_width;
                 let is_scrolled = self.tab_bar_scroll_handle.offset().x < px(0.);
+                let has_active_unpinned_tab = self.active_item_index >= self.pinned_tab_count;
                 h_flex()
                     .children(pinned_tabs)
                     .when(is_scrollable && is_scrolled, |this| {
-                        this.border_r_1().border_color(cx.theme().colors().border)
+                        this.when(has_active_unpinned_tab, |this| this.border_r_2())
+                            .when(!has_active_unpinned_tab, |this| this.border_r_1())
+                            .border_color(cx.theme().colors().border)
                     })
             }))
             .child(


### PR DESCRIPTION

Before:

https://github.com/user-attachments/assets/7bf39b99-d589-49c5-aba9-ae804c50af74

After:

https://github.com/user-attachments/assets/c0f15b78-6103-4f1c-9392-ec738d2e091b

Release Notes:

- N/A
