### PR TITLE
agent: Show delete thread icon buttons on hover/focus

### DIFF
--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -55,10 +55,10 @@ use zed_llm_client::UsageLimit;
 use crate::active_thread::{self, ActiveThread, ActiveThreadEvent};
 use crate::agent_configuration::{AgentConfiguration, AssistantConfigurationEvent};
 use crate::agent_diff::AgentDiff;
-use crate::history_store::{HistoryEntry, HistoryStore, RecentEntry};
+use crate::history_store::{HistoryStore, RecentEntry};
 use crate::message_editor::{MessageEditor, MessageEditorEvent};
 use crate::thread::{Thread, ThreadError, ThreadId, TokenUsageRatio};
-use crate::thread_history::{EntryTimeFormat, PastContext, PastThread, ThreadHistory};
+use crate::thread_history::{HistoryEntryElement, ThreadHistory};
 use crate::thread_store::ThreadStore;
 use crate::ui::AgentOnboardingModal;
 use crate::{
@@ -356,6 +356,7 @@ pub struct AgentPanel {
     previous_view: Option<ActiveView>,
     history_store: Entity<HistoryStore>,
     history: Entity<ThreadHistory>,
+    hovered_recent_history_item: Option<usize>,
     assistant_dropdown_menu_handle: PopoverMenuHandle<ContextMenu>,
     assistant_navigation_menu_handle: PopoverMenuHandle<ContextMenu>,
     assistant_navigation_menu: Option<Entity<ContextMenu>>,
@@ -696,6 +697,7 @@ impl AgentPanel {
             previous_view: None,
             history_store: history_store.clone(),
             history: cx.new(|cx| ThreadHistory::new(weak_self, history_store, window, cx)),
+            hovered_recent_history_item: None,
             assistant_dropdown_menu_handle: PopoverMenuHandle::default(),
             assistant_navigation_menu_handle: PopoverMenuHandle::default(),
             assistant_navigation_menu: None,
@@ -2237,18 +2239,20 @@ impl AgentPanel {
                         v_flex()
                             .gap_1()
                             .children(
-                                recent_history.into_iter().map(|entry| {
+                                recent_history.into_iter().enumerate().map(|(index, entry)| {
                                     // TODO: Add keyboard navigation.
-                                    match entry {
-                                        HistoryEntry::Thread(thread) => {
-                                            PastThread::new(thread, cx.entity().downgrade(), false, vec![], EntryTimeFormat::DateAndTime)
-                                                .into_any_element()
-                                        }
-                                        HistoryEntry::Context(context) => {
-                                            PastContext::new(context, cx.entity().downgrade(), false, vec![], EntryTimeFormat::DateAndTime)
-                                                .into_any_element()
-                                        }
-                                    }
+                                    let is_hovered = self.hovered_recent_history_item == Some(index);
+                                    HistoryEntryElement::new(entry.clone(), cx.entity().downgrade())
+                                        .hovered(is_hovered)
+                                        .on_hover(cx.listener(move |this, is_hovered, _window, cx| {
+                                            if *is_hovered {
+                                                this.hovered_recent_history_item = Some(index);
+                                            } else if this.hovered_recent_history_item == Some(index) {
+                                                this.hovered_recent_history_item = None;
+                                            }
+                                            cx.notify();
+                                        }))
+                                        .into_any_element()
                                 }),
                             )
                     )

--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -2212,7 +2212,7 @@ impl AgentPanel {
                             .border_b_1()
                             .border_color(cx.theme().colors().border_variant)
                             .child(
-                                Label::new("Past Interactions")
+                                Label::new("Recent")
                                     .size(LabelSize::Small)
                                     .color(Color::Muted),
                             )

--- a/crates/agent/src/thread_history.rs
+++ b/crates/agent/src/thread_history.rs
@@ -664,40 +664,40 @@ impl RenderOnce for PastThread {
             .toggle_state(self.selected)
             .spacing(ListItemSpacing::Sparse)
             .start_slot(
-                div().max_w_4_5().child(
-                    HighlightedLabel::new(summary, self.highlight_positions)
-                        .size(LabelSize::Small)
-                        .truncate(),
-                ),
-            )
-            .end_slot(
                 h_flex()
-                    .gap_1p5()
+                    .w_full()
+                    .gap_2()
+                    .justify_between()
+                    .child(
+                        HighlightedLabel::new(summary, self.highlight_positions)
+                            .size(LabelSize::Small)
+                            .truncate(),
+                    )
                     .child(
                         Label::new(thread_timestamp)
                             .color(Color::Muted)
                             .size(LabelSize::XSmall),
-                    )
-                    .child(
-                        IconButton::new("delete", IconName::TrashAlt)
-                            .shape(IconButtonShape::Square)
-                            .icon_size(IconSize::XSmall)
-                            .icon_color(Color::Muted)
-                            .tooltip(move |window, cx| {
-                                Tooltip::for_action("Delete", &RemoveSelectedThread, window, cx)
-                            })
-                            .on_click({
-                                let agent_panel = self.agent_panel.clone();
-                                let id = self.thread.id.clone();
-                                move |_event, _window, cx| {
-                                    agent_panel
-                                        .update(cx, |this, cx| {
-                                            this.delete_thread(&id, cx).detach_and_log_err(cx);
-                                        })
-                                        .ok();
-                                }
-                            }),
                     ),
+            )
+            .end_slot_conditional(
+                IconButton::new("delete", IconName::TrashAlt)
+                    .shape(IconButtonShape::Square)
+                    .icon_size(IconSize::XSmall)
+                    .icon_color(Color::Muted)
+                    .tooltip(move |window, cx| {
+                        Tooltip::for_action("Delete", &RemoveSelectedThread, window, cx)
+                    })
+                    .on_click({
+                        let agent_panel = self.agent_panel.clone();
+                        let id = self.thread.id.clone();
+                        move |_event, _window, cx| {
+                            agent_panel
+                                .update(cx, |this, cx| {
+                                    this.delete_thread(&id, cx).detach_and_log_err(cx);
+                                })
+                                .ok();
+                        }
+                    }),
             )
             .on_click({
                 let agent_panel = self.agent_panel.clone();
@@ -757,41 +757,40 @@ impl RenderOnce for PastContext {
         .toggle_state(self.selected)
         .spacing(ListItemSpacing::Sparse)
         .start_slot(
-            div().max_w_4_5().child(
-                HighlightedLabel::new(summary, self.highlight_positions)
-                    .size(LabelSize::Small)
-                    .truncate(),
-            ),
-        )
-        .end_slot(
             h_flex()
-                .gap_1p5()
+                .w_full()
+                .gap_2()
+                .justify_between()
+                .child(
+                    HighlightedLabel::new(summary, self.highlight_positions)
+                        .size(LabelSize::Small)
+                        .truncate(),
+                )
                 .child(
                     Label::new(context_timestamp)
                         .color(Color::Muted)
                         .size(LabelSize::XSmall),
-                )
-                .child(
-                    IconButton::new("delete", IconName::TrashAlt)
-                        .shape(IconButtonShape::Square)
-                        .icon_size(IconSize::XSmall)
-                        .icon_color(Color::Muted)
-                        .tooltip(move |window, cx| {
-                            Tooltip::for_action("Delete", &RemoveSelectedThread, window, cx)
-                        })
-                        .on_click({
-                            let agent_panel = self.agent_panel.clone();
-                            let path = self.context.path.clone();
-                            move |_event, _window, cx| {
-                                agent_panel
-                                    .update(cx, |this, cx| {
-                                        this.delete_context(path.clone(), cx)
-                                            .detach_and_log_err(cx);
-                                    })
-                                    .ok();
-                            }
-                        }),
                 ),
+        )
+        .end_slot_conditional(
+            IconButton::new("delete", IconName::TrashAlt)
+                .shape(IconButtonShape::Square)
+                .icon_size(IconSize::XSmall)
+                .icon_color(Color::Muted)
+                .tooltip(move |window, cx| {
+                    Tooltip::for_action("Delete", &RemoveSelectedThread, window, cx)
+                })
+                .on_click({
+                    let agent_panel = self.agent_panel.clone();
+                    let path = self.context.path.clone();
+                    move |_event, _window, cx| {
+                        agent_panel
+                            .update(cx, |this, cx| {
+                                this.delete_context(path.clone(), cx).detach_and_log_err(cx);
+                            })
+                            .ok();
+                    }
+                }),
         )
         .on_click({
             let agent_panel = self.agent_panel.clone();

--- a/crates/ui/src/components/list/list_item.rs
+++ b/crates/ui/src/components/list/list_item.rs
@@ -31,7 +31,7 @@ pub struct ListItem {
     /// It will obscure the `end_slot` when visible.
     end_hover_slot: Option<AnyElement>,
     /// A slot for content that only renders on hover or focus,
-    /// This slot doesn't use any `visibility`-related approach to rendering elements inside of it.
+    /// This slot doesn't use visibility to render elements inside of it.
     end_slot_conditional: Option<AnyElement>,
     toggle: Option<bool>,
     inset: bool,


### PR DESCRIPTION
This PR's main goal is to show the delete thread button when the list item is either focused or hovered. In order to do that, we ended up refactoring (i.e., merging) the `PastThread` and `PastContext` elements into a single `HistoryElementEntry` that already matches to the entry type (i.e., context or thread). 

Release Notes:

- agent: Simplify the UI by showing the delete thread icon button only on hover or focus.
