### PR TITLE
Remove unnecessary use of `MarkdownElementBuilder::flush_text`

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1048,7 +1048,6 @@ impl Element for MarkdownElement {
                             copy_button: true, ..
                         } = &self.code_block_renderer
                         {
-                            builder.flush_text();
                             builder.modify_current_div(|el| {
                                 let content_range = parser::extract_code_block_content_range(
                                     parsed_markdown.source()[range.clone()].trim(),


### PR DESCRIPTION
The next statement calls `modify_current_div` which immediately does `flush_text`.

Release Notes:

- N/A