### PR TITLE
Fix text overlap with markdown code block in list in agent response

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -600,14 +600,8 @@ fn render_markdown_code_block(
         .bg(cx.theme().colors().editor_background)
         .child(codeblock_header)
         .when(
-            metadata.line_count > MAX_UNCOLLAPSED_LINES_IN_CODE_BLOCK,
-            |this| {
-                if is_expanded {
-                    this.h_full()
-                } else {
-                    this.max_h_80()
-                }
-            },
+            metadata.line_count > MAX_UNCOLLAPSED_LINES_IN_CODE_BLOCK && !is_expanded,
+            |this| this.max_h_80(),
         )
 }
 


### PR DESCRIPTION
Seems that `h_full` was causing it to use the height of the overall list item for some reason.

Closes #30002 

Release Notes:

- Agent Panel: Fixed text overlap for code blocks nested in lists in agent response.