### PR TITLE
debugger: Fix removal of running sessions when spawning a debug session

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -291,7 +291,7 @@ impl DebugPanel {
 
         let (debug_session, workspace) = this.update_in(cx, |this, window, cx| {
             this.sessions.retain(|session| {
-                session
+                !session
                     .read(cx)
                     .running_state()
                     .read(cx)


### PR DESCRIPTION
Fixed regression introduced in https://github.com/zed-industries/zed/pull/29646/files#diff-85cbb0a26f1949431ec63870fc2d52b583227a5a00b6e10b64dcdb7fe7ef13afL314

Release Notes:

- N/A
