### PR TITLE
Fix command palette sorting to maintain frequency during filtering

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -342,7 +342,11 @@ impl PickerDelegate for CommandPaletteDelegate {
                     }
 
                     // Re-sort by adjusted score
-                    matches.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+                    matches.sort_by(|a, b| {
+                        b.score
+                            .partial_cmp(&a.score)
+                            .unwrap_or(std::cmp::Ordering::Equal)
+                    });
 
                     matches
                 };


### PR DESCRIPTION
Follow up after https://github.com/zed-industries/zed/pull/2954. Not sure if this is the best way to do it, but it seems to be working fine.

Release Notes:

- Fixed command palette sorting to maintain frequency during filtering
