### PR TITLE
collab: Don't require payment method to subscribe to Zed Free

### DIFF
--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -248,6 +248,8 @@ impl StripeBilling {
 
         let mut params = stripe::CreateCheckoutSession::new();
         params.mode = Some(stripe::CheckoutSessionMode::Subscription);
+        params.payment_method_collection =
+            Some(stripe::CheckoutSessionPaymentMethodCollection::IfRequired);
         params.customer = Some(customer_id);
         params.client_reference_id = Some(github_login);
         params.line_items = Some(vec![stripe::CreateCheckoutSessionLineItems {


### PR DESCRIPTION
This PR makes it so we don't require a payment method to subscribe to the Zed Free plan.

Release Notes:

- N/A
