### PR TITLE
Remove `block_mouse_down` in favor of `stop_mouse_events_except_scroll`

### DIFF
--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -1445,7 +1445,7 @@ impl InlineAssistant {
                     style: BlockStyle::Flex,
                     render: Arc::new(move |cx| {
                         div()
-                            .block_mouse_down()
+                            .block_mouse_except_scroll()
                             .bg(cx.theme().status().deleted_background)
                             .size_full()
                             .h(height as f32 * cx.window.line_height())

--- a/crates/agent/src/inline_prompt_editor.rs
+++ b/crates/agent/src/inline_prompt_editor.rs
@@ -100,7 +100,7 @@ impl<T: 'static> Render for PromptEditor<T> {
         v_flex()
             .key_context("PromptEditor")
             .bg(cx.theme().colors().editor_background)
-            .block_mouse_down()
+            .block_mouse_except_scroll()
             .gap_0p5()
             .border_y_1()
             .border_color(cx.theme().status().info_border)

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15021,7 +15021,7 @@ impl Editor {
                                         text_style = text_style.highlight(highlight_style);
                                     }
                                     div()
-                                        .block_mouse_down()
+                                        .block_mouse_except_scroll()
                                         .pl(cx.anchor_x)
                                         .child(EditorElement::new(
                                             &rename_editor,

--- a/crates/extensions_ui/src/components/extension_card.rs
+++ b/crates/extensions_ui/src/components/extension_card.rs
@@ -48,7 +48,7 @@ impl RenderOnce for ExtensionCard {
                             .absolute()
                             .top_0()
                             .left_0()
-                            .block_mouse_down()
+                            .block_mouse_except_scroll()
                             .cursor_default()
                             .size_full()
                             .items_center()

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -958,11 +958,6 @@ pub trait InteractiveElement: Sized {
         self
     }
 
-    /// Stops propagation of left mouse down event.
-    fn block_mouse_down(mut self) -> Self {
-        self.on_mouse_down(MouseButton::Left, |_, _, cx| cx.stop_propagation())
-    }
-
     /// Block non-scroll mouse interactions with elements behind this element's hitbox. See
     /// [`Hitbox::is_hovered`] for details.
     ///

--- a/crates/repl/src/session.rs
+++ b/crates/repl/src/session.rs
@@ -162,7 +162,7 @@ impl EditorBlock {
 
             div()
                 .id(cx.block_id)
-                .block_mouse_down()
+                .block_mouse_except_scroll()
                 .flex()
                 .items_start()
                 .min_h(text_line_height)


### PR DESCRIPTION
This method was added in #20649 to be an alternative of `occlude` which allows scroll events. It seems a bit arbitrary to only stop left mouse downs, so this seems like it's probably an improvement.

Release Notes:

- N/A