### PR TITLE
collab: Improve error message when requesting an LLM token without a subscription

### DIFF
--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -66,7 +66,7 @@ impl LlmTokenClaims {
         let subscription_period =
             billing_subscription::Model::current_period(subscription, is_staff)
                 .map(|(start, end)| (start.naive_utc(), end.naive_utc()))
-                .ok_or_else(|| anyhow!("missing subscription period"))?;
+                .ok_or_else(|| anyhow!("A plan is required to use Zed's hosted models or edit predictions. Visit https://zed.dev/account to get started."))?;
 
         let now = Utc::now();
         let claims = Self {


### PR DESCRIPTION
This PR improves the error message when trying to obtain an LLM token without a subscription:

<img width="411" alt="Screenshot 2025-05-09 at 12 30 41 PM" src="https://github.com/user-attachments/assets/c53326ba-4a99-4d9c-88ba-674e520f941f" />

Release Notes:

- N/A
