### PR TITLE
agent: Write latest profile change to default setting

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -200,7 +200,13 @@ impl MessageEditor {
         });
 
         let profile_selector = cx.new(|cx| {
-            ProfileSelector::new(thread.clone(), thread_store, editor.focus_handle(cx), cx)
+            ProfileSelector::new(
+                fs,
+                thread.clone(),
+                thread_store,
+                editor.focus_handle(cx),
+                cx,
+            )
         });
 
         Self {

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -1,10 +1,13 @@
+use std::sync::Arc;
+
 use assistant_settings::{
     AgentProfile, AgentProfileId, AssistantDockPosition, AssistantSettings, GroupedAgentProfiles,
     builtin_profiles,
 };
+use fs::Fs;
 use gpui::{Action, Entity, FocusHandle, Subscription, WeakEntity, prelude::*};
 use language_model::LanguageModelRegistry;
-use settings::{Settings as _, SettingsStore};
+use settings::{Settings as _, SettingsStore, update_settings_file};
 use ui::{
     ContextMenu, ContextMenuEntry, DocumentationSide, PopoverMenu, PopoverMenuHandle, Tooltip,
     prelude::*,
@@ -15,6 +18,7 @@ use crate::{ManageProfiles, Thread, ThreadStore, ToggleProfileSelector};
 
 pub struct ProfileSelector {
     profiles: GroupedAgentProfiles,
+    fs: Arc<dyn Fs>,
     thread: Entity<Thread>,
     thread_store: WeakEntity<ThreadStore>,
     menu_handle: PopoverMenuHandle<ContextMenu>,
@@ -24,6 +28,7 @@ pub struct ProfileSelector {
 
 impl ProfileSelector {
     pub fn new(
+        fs: Arc<dyn Fs>,
         thread: Entity<Thread>,
         thread_store: WeakEntity<ThreadStore>,
         focus_handle: FocusHandle,
@@ -35,6 +40,7 @@ impl ProfileSelector {
 
         Self {
             profiles: GroupedAgentProfiles::from_settings(AssistantSettings::get_global(cx)),
+            fs,
             thread,
             thread_store,
             menu_handle: PopoverMenuHandle::default(),
@@ -120,6 +126,7 @@ impl ProfileSelector {
         };
 
         entry.handler({
+            let fs = self.fs.clone();
             let thread_store = self.thread_store.clone();
             let profile_id = profile_id.clone();
             let thread = self.thread.clone();
@@ -127,6 +134,13 @@ impl ProfileSelector {
             move |_window, cx| {
                 thread.update(cx, |thread, cx| {
                     thread.set_configured_profile_id(Some(profile_id.clone()), cx);
+                });
+
+                update_settings_file::<AssistantSettings>(fs.clone(), cx, {
+                    let profile_id = profile_id.clone();
+                    move |settings, _cx| {
+                        settings.set_profile(profile_id.clone());
+                    }
                 });
 
                 thread_store


### PR DESCRIPTION
Reverts back to previous behavior where we update your settings so we can load a new thread from your last configuration.

Release Notes:

- agent: Persist profile changes for new threads
