### PR TITLE
Revert "Load Profile state from Thread and tie visibility to the thread's model"

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -199,21 +199,11 @@ impl MessageEditor {
             )
         });
 
-        let profile_selector = cx.new(|cx| {
-            ProfileSelector::new(
-                fs,
-                thread.clone(),
-                thread_store,
-                editor.focus_handle(cx),
-                cx,
-            )
-        });
-
         Self {
             editor: editor.clone(),
             project: thread.read(cx).project().clone(),
             user_store,
-            thread,
+            thread: thread.clone(),
             incompatible_tools_state: incompatible_tools.clone(),
             workspace,
             context_store,
@@ -225,7 +215,9 @@ impl MessageEditor {
             model_selector,
             edits_expanded: false,
             editor_is_expanded: false,
-            profile_selector,
+            profile_selector: cx.new(|cx| {
+                ProfileSelector::new(fs, thread_store, thread, editor.focus_handle(cx), cx)
+            }),
             last_estimated_token_count: None,
             update_token_count_task: None,
             _subscriptions: subscriptions,

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -199,11 +199,21 @@ impl MessageEditor {
             )
         });
 
+        let profile_selector = cx.new(|cx| {
+            ProfileSelector::new(
+                fs,
+                thread.clone(),
+                thread_store,
+                editor.focus_handle(cx),
+                cx,
+            )
+        });
+
         Self {
             editor: editor.clone(),
             project: thread.read(cx).project().clone(),
             user_store,
-            thread: thread.clone(),
+            thread,
             incompatible_tools_state: incompatible_tools.clone(),
             workspace,
             context_store,
@@ -215,9 +225,7 @@ impl MessageEditor {
             model_selector,
             edits_expanded: false,
             editor_is_expanded: false,
-            profile_selector: cx.new(|cx| {
-                ProfileSelector::new(fs, thread_store, thread, editor.focus_handle(cx), cx)
-            }),
+            profile_selector,
             last_estimated_token_count: None,
             update_token_count_task: None,
             _subscriptions: subscriptions,

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -29,8 +29,8 @@ pub struct ProfileSelector {
 impl ProfileSelector {
     pub fn new(
         fs: Arc<dyn Fs>,
-        thread: Entity<Thread>,
         thread_store: WeakEntity<ThreadStore>,
+        thread: Entity<Thread>,
         focus_handle: FocusHandle,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -41,8 +41,8 @@ impl ProfileSelector {
         Self {
             profiles: GroupedAgentProfiles::from_settings(AssistantSettings::get_global(cx)),
             fs,
-            thread,
             thread_store,
+            thread,
             menu_handle: PopoverMenuHandle::default(),
             focus_handle,
             _subscriptions: vec![settings_subscription],
@@ -101,7 +101,7 @@ impl ProfileSelector {
         profile_id: AgentProfileId,
         profile: &AgentProfile,
         settings: &AssistantSettings,
-        cx: &App,
+        _cx: &App,
     ) -> ContextMenuEntry {
         let documentation = match profile.name.to_lowercase().as_str() {
             builtin_profiles::WRITE => Some("Get help to write anything."),
@@ -110,12 +110,8 @@ impl ProfileSelector {
             _ => None,
         };
 
-        let current_profile_id = self.thread.read(cx).configured_profile_id();
-
-        let entry = ContextMenuEntry::new(profile.name.clone()).toggleable(
-            IconPosition::End,
-            Some(profile_id.clone()) == current_profile_id,
-        );
+        let entry = ContextMenuEntry::new(profile.name.clone())
+            .toggleable(IconPosition::End, profile_id == settings.default_profile);
 
         let entry = if let Some(doc_text) = documentation {
             entry.documentation_aside(documentation_side(settings.dock), move |_| {
@@ -129,13 +125,7 @@ impl ProfileSelector {
             let fs = self.fs.clone();
             let thread_store = self.thread_store.clone();
             let profile_id = profile_id.clone();
-            let thread = self.thread.clone();
-
             move |_window, cx| {
-                thread.update(cx, |thread, cx| {
-                    thread.set_configured_profile_id(Some(profile_id.clone()), cx);
-                });
-
                 update_settings_file::<AssistantSettings>(fs.clone(), cx, {
                     let profile_id = profile_id.clone();
                     move |settings, _cx| {
@@ -156,12 +146,8 @@ impl ProfileSelector {
 impl Render for ProfileSelector {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let settings = AssistantSettings::get_global(cx);
-        let profile_id = self
-            .thread
-            .read(cx)
-            .configured_profile_id()
-            .unwrap_or(settings.default_profile.clone());
-        let profile = settings.profiles.get(&profile_id).cloned();
+        let profile_id = &settings.default_profile;
+        let profile = settings.profiles.get(profile_id);
 
         let selected_profile = profile
             .map(|profile| profile.name.clone())

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -29,8 +29,8 @@ pub struct ProfileSelector {
 impl ProfileSelector {
     pub fn new(
         fs: Arc<dyn Fs>,
-        thread_store: WeakEntity<ThreadStore>,
         thread: Entity<Thread>,
+        thread_store: WeakEntity<ThreadStore>,
         focus_handle: FocusHandle,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -41,8 +41,8 @@ impl ProfileSelector {
         Self {
             profiles: GroupedAgentProfiles::from_settings(AssistantSettings::get_global(cx)),
             fs,
-            thread_store,
             thread,
+            thread_store,
             menu_handle: PopoverMenuHandle::default(),
             focus_handle,
             _subscriptions: vec![settings_subscription],

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use anyhow::{Result, anyhow};
-use assistant_settings::{AgentProfileId, AssistantSettings, CompletionMode};
+use assistant_settings::{AssistantSettings, CompletionMode};
 use assistant_tool::{ActionLog, AnyToolCard, Tool, ToolWorkingSet};
 use chrono::{DateTime, Utc};
 use collections::HashMap;
@@ -359,7 +359,6 @@ pub struct Thread {
     >,
     remaining_turns: u32,
     configured_model: Option<ConfiguredModel>,
-    configured_profile_id: Option<AgentProfileId>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -380,8 +379,6 @@ impl Thread {
     ) -> Self {
         let (detailed_summary_tx, detailed_summary_rx) = postage::watch::channel();
         let configured_model = LanguageModelRegistry::read_global(cx).default_model();
-        let assistant_settings = AssistantSettings::get_global(cx);
-        let configured_profile_id = assistant_settings.default_profile.clone();
 
         Self {
             id: ThreadId::new(),
@@ -424,7 +421,6 @@ impl Thread {
             request_callback: None,
             remaining_turns: u32::MAX,
             configured_model,
-            configured_profile_id: Some(configured_profile_id),
         }
     }
 
@@ -471,8 +467,6 @@ impl Thread {
         let completion_mode = serialized
             .completion_mode
             .unwrap_or_else(|| AssistantSettings::get_global(cx).preferred_completion_mode);
-
-        let configured_profile_id = serialized.profile.clone();
 
         Self {
             id,
@@ -547,7 +541,6 @@ impl Thread {
             request_callback: None,
             remaining_turns: u32::MAX,
             configured_model,
-            configured_profile_id,
         }
     }
 
@@ -600,19 +593,6 @@ impl Thread {
 
     pub fn set_configured_model(&mut self, model: Option<ConfiguredModel>, cx: &mut Context<Self>) {
         self.configured_model = model;
-        cx.notify();
-    }
-
-    pub fn configured_profile_id(&self) -> Option<AgentProfileId> {
-        self.configured_profile_id.clone()
-    }
-
-    pub fn set_configured_profile_id(
-        &mut self,
-        id: Option<AgentProfileId>,
-        cx: &mut Context<Self>,
-    ) {
-        self.configured_profile_id = id;
         cx.notify();
     }
 
@@ -1120,7 +1100,6 @@ impl Thread {
                         provider: model.provider.id().0.to_string(),
                         model: model.model.id().0.to_string(),
                     }),
-                profile: this.configured_profile_id.clone(),
                 completion_mode: Some(this.completion_mode),
             })
         })

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -657,8 +657,6 @@ pub struct SerializedThread {
     pub model: Option<SerializedLanguageModel>,
     #[serde(default)]
     pub completion_mode: Option<CompletionMode>,
-    #[serde(default)]
-    pub profile: Option<AgentProfileId>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -804,7 +802,6 @@ impl LegacySerializedThread {
             exceeded_window_error: None,
             model: None,
             completion_mode: None,
-            profile: None,
         }
     }
 }


### PR DESCRIPTION
This reverts commit 3615d6d96c5d1c8fd0ccb1ee0bc176e9c94ac730.

Ultimately, we want to restore the ability to store a profile per-thread, but for now reverting this fixes a fairly disruptive bug.

Release Notes:

- Fixed a bug causing the agent to use the wrong profile in some cases.