### PR TITLE
agent: Add support for Google Gemini 2.5 Pro Preview 05-06 model

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -483,6 +483,8 @@ pub enum Model {
     Gemini25ProExp0325,
     #[serde(rename = "gemini-2.5-pro-preview-03-25")]
     Gemini25ProPreview0325,
+    #[serde(rename = "gemini-2.5-pro-preview-05-06")]
+    Gemini25ProPreview0506,
     #[serde(rename = "gemini-2.5-flash-preview-04-17")]
     Gemini25FlashPreview0417,
     #[serde(rename = "custom")]
@@ -509,6 +511,7 @@ impl Model {
             Model::Gemini20FlashLite => "gemini-2.0-flash-lite-preview",
             Model::Gemini25ProExp0325 => "gemini-2.5-pro-exp-03-25",
             Model::Gemini25ProPreview0325 => "gemini-2.5-pro-preview-03-25",
+            Model::Gemini25ProPreview0506 => "gemini-2.5-pro-preview-05-06",
             Model::Gemini25FlashPreview0417 => "gemini-2.5-flash-preview-04-17",
             Model::Custom { name, .. } => name,
         }
@@ -523,7 +526,8 @@ impl Model {
             Model::Gemini20FlashThinking => "Gemini 2.0 Flash Thinking",
             Model::Gemini20FlashLite => "Gemini 2.0 Flash Lite",
             Model::Gemini25ProExp0325 => "Gemini 2.5 Pro Exp",
-            Model::Gemini25ProPreview0325 => "Gemini 2.5 Pro Preview",
+            Model::Gemini25ProPreview0325 => "Gemini 2.5 Pro Preview 03-25",
+            Model::Gemini25ProPreview0506 => "Gemini 2.5 Pro Preview 05-06",
             Model::Gemini25FlashPreview0417 => "Gemini 2.5 Flash Preview",
             Self::Custom {
                 name, display_name, ..
@@ -543,6 +547,7 @@ impl Model {
             Model::Gemini20FlashLite => ONE_MILLION,
             Model::Gemini25ProExp0325 => ONE_MILLION,
             Model::Gemini25ProPreview0325 => ONE_MILLION,
+            Model::Gemini25ProPreview0506 => ONE_MILLION,
             Model::Gemini25FlashPreview0417 => ONE_MILLION,
             Model::Custom { max_tokens, .. } => *max_tokens,
         }

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -105,6 +105,7 @@ impl CloudModel {
                 | google_ai::Model::Gemini20FlashLite
                 | google_ai::Model::Gemini25ProExp0325
                 | google_ai::Model::Gemini25ProPreview0325
+                | google_ai::Model::Gemini25ProPreview0506
                 | google_ai::Model::Gemini25FlashPreview0417
                 | google_ai::Model::Custom { .. } => {
                     LanguageModelAvailability::RequiresPlan(Plan::ZedPro)


### PR DESCRIPTION
- Adds support for the new gemini-2.5-pro-preview-05-06.
- Updates "Gemini 2.5 Pro Preview" to "Gemini 2.5 Pro Preview 03-25" to distinguish between different preview versions.

Release Notes:

- Added support for gemini-2.5-pro-preview-05-06 in the assistant
