### PR TITLE
agent: Thread history update improvements

### DIFF
--- a/crates/agent/src/history_store.rs
+++ b/crates/agent/src/history_store.rs
@@ -36,6 +36,16 @@ impl HistoryEntry {
     }
 }
 
+impl PartialEq for HistoryEntry {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Thread(l), Self::Thread(r)) => l.id == r.id,
+            (Self::Context(l), Self::Context(r)) => l.path == r.path,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) enum RecentEntry {
     Thread(ThreadId, Entity<Thread>),

--- a/crates/agent/src/history_store.rs
+++ b/crates/agent/src/history_store.rs
@@ -1,4 +1,4 @@
-use std::{collections::VecDeque, path::Path};
+use std::{collections::VecDeque, path::Path, sync::Arc};
 
 use anyhow::{Context as _, anyhow};
 use assistant_context_editor::{AssistantContext, SavedContextMetadata};
@@ -34,16 +34,20 @@ impl HistoryEntry {
             HistoryEntry::Context(context) => context.mtime.to_utc(),
         }
     }
-}
 
-impl PartialEq for HistoryEntry {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (Self::Thread(l), Self::Thread(r)) => l.id == r.id,
-            (Self::Context(l), Self::Context(r)) => l.path == r.path,
-            _ => false,
+    pub fn id(&self) -> HistoryEntryId {
+        match self {
+            HistoryEntry::Thread(thread) => HistoryEntryId::Thread(thread.id.clone()),
+            HistoryEntry::Context(context) => HistoryEntryId::Context(context.path.clone()),
         }
     }
+}
+
+/// Generic identifier for a history entry.
+#[derive(Clone, PartialEq, Eq)]
+pub enum HistoryEntryId {
+    Thread(ThreadId),
+    Context(Arc<Path>),
 }
 
 #[derive(Clone, Debug)]


### PR DESCRIPTION
- Try to preserve previously selected item on update
- Do not clear list items while updating to avoid a frame with no items rendered

Release Notes:

- agent: Preserve previously selected item in Thread History on update
