### PR TITLE
zeta: Restore `ZED_PREDICT_EDITS_URL` environment variable

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -740,13 +740,18 @@ and then another
             let mut did_retry = false;
 
             loop {
-                let request = http_client::Request::builder()
-                    .method(Method::POST)
-                    .uri(
-                        http_client
-                            .build_zed_llm_url("/predict_edits/v2", &[])?
-                            .as_ref(),
-                    )
+                let request_builder = http_client::Request::builder().method(Method::POST);
+                let request_builder =
+                    if let Ok(predict_edits_url) = std::env::var("ZED_PREDICT_EDITS_URL") {
+                        request_builder.uri(predict_edits_url)
+                    } else {
+                        request_builder.uri(
+                            http_client
+                                .build_zed_llm_url("/predict_edits/v2", &[])?
+                                .as_ref(),
+                        )
+                    };
+                let request = request_builder
                     .header("Content-Type", "application/json")
                     .header("Authorization", format!("Bearer {}", token))
                     .header(ZED_VERSION_HEADER_NAME, app_version.to_string())


### PR DESCRIPTION
This PR restores the `ZED_PREDICT_EDITS_URL` that was removed in https://github.com/zed-industries/zed/pull/30290.

While we don't need to use it anymore for local development against the LLM Worker, some folks reported using it to run versions of Zeta hosted elsewhere.

Since we don't yet have an officially-supported mechanism today for bringing your own Zeta for edit predictions, I'm putting the environment variable back to not break that use case.

Closes https://github.com/zed-industries/zed/issues/30308.

Release Notes:

- N/A
