### PR TITLE
git_ui: Fix co-author tooltip message

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2765,9 +2765,9 @@ impl GitPanel {
         let potential_co_authors = self.potential_co_authors(cx);
 
         let (tooltip_label, icon) = if self.add_coauthors {
-            ("Add co-authored-by", IconName::UserCheck)
-        } else {
             ("Remove co-authored-by", IconName::Person)
+        } else {
+            ("Add co-authored-by", IconName::UserCheck)
         };
 
         if potential_co_authors.is_empty() {


### PR DESCRIPTION
It should show "Remove co-authored-by" when hovering on co-author is already added state. And should say
"Add co-authored-by" when it is at disabled state.

Release Notes:

- N/A
