### PR TITLE
assistant_context_editor: Register `ContextEditor` actions that were lost

### DIFF
--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -79,6 +79,10 @@ pub fn init(cx: &mut App) {
     cx.observe_new(
         |workspace: &mut Workspace, _window, _cx: &mut Context<Workspace>| {
             workspace
+                .register_action(ContextEditor::quote_selection)
+                .register_action(ContextEditor::insert_selection)
+                .register_action(ContextEditor::copy_code)
+                .register_action(ContextEditor::handle_insert_dragged_files)
                 .register_action(|workspace, action: &NewThread, window, cx| {
                     if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
                         panel.update(cx, |panel, cx| panel.new_thread(action, window, cx));

--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -79,10 +79,6 @@ pub fn init(cx: &mut App) {
     cx.observe_new(
         |workspace: &mut Workspace, _window, _cx: &mut Context<Workspace>| {
             workspace
-                .register_action(ContextEditor::quote_selection)
-                .register_action(ContextEditor::insert_selection)
-                .register_action(ContextEditor::copy_code)
-                .register_action(ContextEditor::handle_insert_dragged_files)
                 .register_action(|workspace, action: &NewThread, window, cx| {
                     if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
                         panel.update(cx, |panel, cx| panel.new_thread(action, window, cx));

--- a/crates/assistant_context_editor/src/assistant_context_editor.rs
+++ b/crates/assistant_context_editor/src/assistant_context_editor.rs
@@ -8,7 +8,8 @@ mod slash_command_picker;
 use std::sync::Arc;
 
 use client::Client;
-use gpui::App;
+use gpui::{App, Context};
+use workspace::Workspace;
 
 pub use crate::context::*;
 pub use crate::context_editor::*;
@@ -16,6 +17,18 @@ pub use crate::context_history::*;
 pub use crate::context_store::*;
 pub use crate::slash_command::*;
 
-pub fn init(client: Arc<Client>, _cx: &mut App) {
+pub fn init(client: Arc<Client>, cx: &mut App) {
     context_store::init(&client.into());
+    workspace::FollowableViewRegistry::register::<ContextEditor>(cx);
+
+    cx.observe_new(
+        |workspace: &mut Workspace, _window, _cx: &mut Context<Workspace>| {
+            workspace
+                .register_action(ContextEditor::quote_selection)
+                .register_action(ContextEditor::insert_selection)
+                .register_action(ContextEditor::copy_code)
+                .register_action(ContextEditor::handle_insert_dragged_files);
+        },
+    )
+    .detach();
 }


### PR DESCRIPTION
This PR restores the `ContextEditor` actions that were lost in https://github.com/zed-industries/zed/pull/30168.

Closes https://github.com/zed-industries/zed/issues/30356.

Release Notes:

- agent: Added back some missing actions, including `assistant: quote selection`.
