### PR TITLE
Update `zed_llm_client` to v0.8.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18742,9 +18742,9 @@ dependencies = [
 
 [[package]]
 name = "zed_llm_client"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23b2fd00776b0c55072f389654910ceb501eb0083d7f78905ab0e5cc86949ec"
+checksum = "16d993fc42f9ec43ab76fa46c6eb579a66e116bb08cd2bc9a67f3afcaa05d39d"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -608,7 +608,7 @@ wasmtime-wasi = "29"
 which = "6.0.0"
 wit-component = "0.221"
 workspace-hack = "0.1.0"
-zed_llm_client = "0.8.0"
+zed_llm_client = "0.8.1"
 zstd = "0.11"
 
 [workspace.dependencies.async-stripe]

--- a/crates/agent/src/debug.rs
+++ b/crates/agent/src/debug.rs
@@ -75,7 +75,7 @@ impl Default for DebugAccountState {
         Self {
             enabled: false,
             trial_expired: false,
-            plan: Plan::Free,
+            plan: Plan::ZedFree,
             custom_prompt_usage: RequestUsage {
                 limit: UsageLimit::Unlimited,
                 amount: 0,

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -1085,11 +1085,11 @@ impl MessageEditor {
         let plan = user_store
             .current_plan()
             .map(|plan| match plan {
-                Plan::Free => zed_llm_client::Plan::Free,
+                Plan::Free => zed_llm_client::Plan::ZedFree,
                 Plan::ZedPro => zed_llm_client::Plan::ZedPro,
                 Plan::ZedProTrial => zed_llm_client::Plan::ZedProTrial,
             })
-            .unwrap_or(zed_llm_client::Plan::Free);
+            .unwrap_or(zed_llm_client::Plan::ZedFree);
         let usage = self.thread.read(cx).last_usage().or_else(|| {
             maybe!({
                 let amount = user_store.model_request_usage_amount()?;

--- a/crates/agent/src/ui/preview/usage_callouts.rs
+++ b/crates/agent/src/ui/preview/usage_callouts.rs
@@ -39,7 +39,7 @@ impl RenderOnce for UsageCallout {
 
         let (title, message, button_text, url) = if is_limit_reached {
             match self.plan {
-                Plan::Free => (
+                Plan::ZedFree => (
                     "Out of free prompts",
                     "Upgrade to continue, wait for the next reset, or switch to API key."
                         .to_string(),
@@ -61,7 +61,7 @@ impl RenderOnce for UsageCallout {
             }
         } else {
             match self.plan {
-                Plan::Free => (
+                Plan::ZedFree => (
                     "Reaching free plan limit soon",
                     format!(
                         "{remaining} remaining - Upgrade to increase limit, or switch providers",
@@ -120,7 +120,7 @@ impl Component for UsageCallout {
                 single_example(
                     "Approaching limit (90%)",
                     UsageCallout::new(
-                        Plan::Free,
+                        Plan::ZedFree,
                         RequestUsage {
                             limit: UsageLimit::Limited(50),
                             amount: 45, // 90% of limit
@@ -131,7 +131,7 @@ impl Component for UsageCallout {
                 single_example(
                     "Limit reached (100%)",
                     UsageCallout::new(
-                        Plan::Free,
+                        Plan::ZedFree,
                         RequestUsage {
                             limit: UsageLimit::Limited(50),
                             amount: 50, // 100% of limit

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -1274,7 +1274,7 @@ async fn get_current_usage(
             subscription
                 .kind
                 .map(Into::into)
-                .unwrap_or(zed_llm_client::Plan::Free)
+                .unwrap_or(zed_llm_client::Plan::ZedFree)
         });
 
     let model_requests_limit = match plan.model_requests_limit() {

--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -99,7 +99,7 @@ impl From<SubscriptionKind> for zed_llm_client::Plan {
         match value {
             SubscriptionKind::ZedPro => Self::ZedPro,
             SubscriptionKind::ZedProTrial => Self::ZedProTrial,
-            SubscriptionKind::ZedFree => Self::Free,
+            SubscriptionKind::ZedFree => Self::ZedFree,
         }
     }
 }

--- a/crates/collab/src/llm/token.rs
+++ b/crates/collab/src/llm/token.rs
@@ -57,8 +57,8 @@ impl LlmTokenClaims {
             subscription
                 .as_ref()
                 .and_then(|subscription| subscription.kind)
-                .map_or(Plan::Free, |kind| match kind {
-                    SubscriptionKind::ZedFree => Plan::Free,
+                .map_or(Plan::ZedFree, |kind| match kind {
+                    SubscriptionKind::ZedFree => Plan::ZedFree,
                     SubscriptionKind::ZedPro => Plan::ZedPro,
                     SubscriptionKind::ZedProTrial => Plan::ZedProTrial,
                 })

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -2740,7 +2740,7 @@ async fn update_user_plan(user_id: UserId, session: &Session) -> Result<()> {
                 }),
                 usage: usage.map(|usage| {
                     let plan = match plan {
-                        proto::Plan::Free => zed_llm_client::Plan::Free,
+                        proto::Plan::Free => zed_llm_client::Plan::ZedFree,
                         proto::Plan::ZedPro => zed_llm_client::Plan::ZedPro,
                         proto::Plan::ZedProTrial => zed_llm_client::Plan::ZedProTrial,
                     };

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -611,7 +611,7 @@ impl CloudLanguageModel {
                         .and_then(|plan| zed_llm_client::Plan::from_str(plan).ok())
                     {
                         let plan = match plan {
-                            zed_llm_client::Plan::Free => Plan::Free,
+                            zed_llm_client::Plan::ZedFree => Plan::Free,
                             zed_llm_client::Plan::ZedPro => Plan::ZedPro,
                             zed_llm_client::Plan::ZedProTrial => Plan::ZedProTrial,
                         };


### PR DESCRIPTION
This PR updates the `zed_llm_client` crate to v0.8.1.

The name of `Plan::Free` changed to `Plan::ZedFree` in this version.

Release Notes:

- N/A
