### PR TITLE
agent: Allow to collapse provider sections in the settings view

### DIFF
--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -137,11 +137,13 @@ impl AgentConfiguration {
             .configuration_views_by_provider
             .get(&provider.id())
             .cloned();
+
         let is_expanded = self
             .expanded_provider_configurations
             .get(&provider.id())
             .copied()
             .unwrap_or(false); // Default to collapsed
+            .unwrap_or(true);
 
         v_flex()
             .pt_3()

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -204,7 +204,7 @@ impl AgentConfiguration {
                                         let is_open = this
                                             .expanded_provider_configurations
                                             .entry(provider_id.clone())
-                                            .or_insert(false);
+                                            .or_insert(true);
 
                                         *is_open = !*is_open;
                                     }

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -159,7 +159,7 @@ impl AgentConfiguration {
                                     .color(Color::Muted),
                             )
                             .child(Label::new(provider_name.clone()).size(LabelSize::Large))
-                            .when(provider.is_authenticated(cx), |parent| {
+                            .when(provider.is_authenticated(cx) && !is_expanded, |parent| {
                                 parent.child(
                                     h_flex()
                                         .child(

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -153,7 +153,6 @@ impl AgentConfiguration {
                     .child(
                         h_flex()
                             .gap_2()
-                            .items_center()
                             .child(
                                 Icon::new(provider.icon())
                                     .size(IconSize::Small)
@@ -163,7 +162,6 @@ impl AgentConfiguration {
                             .when(provider.is_authenticated(cx), |parent| {
                                 parent.child(
                                     h_flex()
-                                        .items_center()
                                         .child(
                                             Icon::new(IconName::Check)
                                                 .size(IconSize::Medium)

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -185,7 +185,6 @@ impl AgentConfiguration {
                                     .icon_position(IconPosition::Start)
                                     .icon(IconName::Plus)
                                     .icon_size(IconSize::Small)
-                                    .style(ButtonStyle::Filled)
                                     .layer(ElevationIndex::ModalSurface)
                                     .label_size(LabelSize::Small)
                                     .on_click(cx.listener({

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -142,7 +142,6 @@ impl AgentConfiguration {
             .expanded_provider_configurations
             .get(&provider.id())
             .copied()
-            .unwrap_or(false); // Default to collapsed
             .unwrap_or(true);
 
         v_flex()
@@ -163,20 +162,12 @@ impl AgentConfiguration {
                             )
                             .child(Label::new(provider_name.clone()).size(LabelSize::Large))
                             .when(provider.is_authenticated(cx) && !is_expanded, |parent| {
-                                parent.child(
-                                    h_flex()
-                                        .child(
-                                            Icon::new(IconName::Check)
-                                                .size(IconSize::Medium)
-                                                .color(Color::Success)
-                                        )
-                                )
+                                parent.child(Icon::new(IconName::Check).color(Color::Success))
                             }),
                     )
                     .child(
                         h_flex()
-                            .gap_2()
-                            .items_center()
+                            .gap_1()
                             .when(provider.is_authenticated(cx), |parent| {
                                 parent.child(
                                     Button::new(
@@ -200,8 +191,10 @@ impl AgentConfiguration {
                             })
                             .child(
                                 Disclosure::new(
-                                    SharedString::from(format!("provider-disclosure-{provider_id}")),
-                                    is_expanded
+                                    SharedString::from(format!(
+                                        "provider-disclosure-{provider_id}"
+                                    )),
+                                    is_expanded,
                                 )
                                 .opened_icon(IconName::ChevronUp)
                                 .closed_icon(IconName::ChevronDown)
@@ -219,13 +212,11 @@ impl AgentConfiguration {
                             ),
                     ),
             )
-            .when(is_expanded, |parent| {
-                match configuration_view {
-                    Some(configuration_view) => parent.child(configuration_view),
-                    _ => parent.child(div().child(Label::new(format!(
-                        "No configuration view for {provider_name}",
-                    )))),
-                }
+            .when(is_expanded, |parent| match configuration_view {
+                Some(configuration_view) => parent.child(configuration_view),
+                None => parent.child(div().child(Label::new(format!(
+                    "No configuration view for {provider_name}",
+                )))),
             })
     }
 

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -98,6 +98,7 @@ impl AgentConfiguration {
 
     fn remove_provider_configuration_view(&mut self, provider_id: &LanguageModelProviderId) {
         self.configuration_views_by_provider.remove(provider_id);
+        self.expanded_provider_configurations.remove(provider_id);
     }
 
     fn add_provider_configuration_view(


### PR DESCRIPTION
This is my first time contributing, so happy to make changes as needed.

## Problem

I found the LLM Provider settings to be pretty difficult to scan as I was looking to enter my API credentials for a provider. Because all of the provider configuration is exposed by default, providers that come at the end of the list are pushed fairly far down and require scrolling. As this list increases the problem only get worse.

## Solution

This is strictly a UI change.

* I put each provider configuration in a Disclosure that is closed by default. This made scanning for my provider easy, and exposing the configuration takes a single click. No scrolling is required to see all providers on my 956px high laptop screen.
* I also added the success checkmark to authenticated providers to make it even easier to find them to update a key or sign out.
* The `Start New Thread` had a class applied that was overriding the default hover behavior of other buttons, so I removed it.

## Before
![CleanShot 2025-05-09 at 14 06 04@2x](https://github.com/user-attachments/assets/48d1e7ea-0dc8-4adc-845c-5227ec965130)

## After
![CleanShot 2025-05-09 at 14 33 23](https://github.com/user-attachments/assets/67e842a7-3251-46e5-ab18-7c4e600b84d8)

Release Notes:

- Improved Agent Panel settings view scannability by making each provider block collapsible by default.