### PR TITLE
docs: Redirect `docs/ai` to `docs/ai/overview`

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -25,6 +25,7 @@ enable = false
 "/assistant.html" = "/docs/assistant/assistant.html"
 "/developing-zed.html" = "/docs/development.html"
 "/conversations.html" = "/community-links"
+"/ai.html" = "/docs/ai/overview.html"
 "/assistant/assistant.html" = "/docs/ai/overview.html"
 "/assistant/configuration.html" = "/docs/ai/custom-api-keys.html"
 "/assistant/assistant-panel.html" = "/docs/ai/agent-panel.html"


### PR DESCRIPTION
This PR adds a redirect from `zed.dev/docs/ai` to `zed.dev/docs/ai/overview`.

Not 100% sure this will work, but want to give it a try.

Release Notes:

- N/A
