### PR TITLE
Add setting for enabling/disabling feedback

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -750,6 +750,8 @@
     "stream_edits": false,
     // When enabled, agent edits will be displayed in single-file editors for review
     "single_file_review": true,
+    // When enabled, show voting thumbs for feedback on agent edits.
+    "enable_feedback": true,
     "default_profile": "write",
     "profiles": {
       "write": {

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1863,7 +1863,8 @@ impl ActiveThread {
                         .child(open_as_markdown),
                 )
                 .into_any_element(),
-            None => feedback_container
+            None if AssistantSettings::get_global(cx).enable_feedback =>
+                feedback_container
                 .child(
                     div().visible_on_hover("feedback_container").child(
                         Label::new(
@@ -1905,6 +1906,9 @@ impl ActiveThread {
                         )
                         .child(open_as_markdown),
                 )
+                .into_any_element(),
+            None => feedback_container
+                .child(h_flex().child(open_as_markdown))
                 .into_any_element(),
         };
 

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -93,6 +93,7 @@ pub struct AssistantSettings {
     pub single_file_review: bool,
     pub model_parameters: Vec<LanguageModelParameters>,
     pub preferred_completion_mode: CompletionMode,
+    pub enable_feedback: bool,
 }
 
 impl AssistantSettings {
@@ -260,6 +261,7 @@ impl AssistantSettingsContent {
                     single_file_review: None,
                     model_parameters: Vec::new(),
                     preferred_completion_mode: None,
+                    enable_feedback: None,
                 },
                 VersionedAssistantSettingsContent::V2(ref settings) => settings.clone(),
             },
@@ -290,6 +292,7 @@ impl AssistantSettingsContent {
                 single_file_review: None,
                 model_parameters: Vec::new(),
                 preferred_completion_mode: None,
+                enable_feedback: None,
             },
             None => AssistantSettingsContentV2::default(),
         }
@@ -571,6 +574,7 @@ impl Default for VersionedAssistantSettingsContent {
             single_file_review: None,
             model_parameters: Vec::new(),
             preferred_completion_mode: None,
+            enable_feedback: None,
         })
     }
 }
@@ -644,6 +648,10 @@ pub struct AssistantSettingsContentV2 {
     ///
     /// Default: normal
     preferred_completion_mode: Option<CompletionMode>,
+    /// Whether to show thumb buttons for feedback in the agent panel.
+    ///
+    /// Default: true
+    enable_feedback: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
@@ -848,6 +856,7 @@ impl Settings for AssistantSettings {
                 &mut settings.preferred_completion_mode,
                 value.preferred_completion_mode,
             );
+            merge(&mut settings.enable_feedback, value.enable_feedback);
 
             settings
                 .model_parameters
@@ -984,6 +993,7 @@ mod tests {
                                 notify_when_agent_waiting: None,
                                 stream_edits: None,
                                 single_file_review: None,
+                                enable_feedback: None,
                                 model_parameters: Vec::new(),
                                 preferred_completion_mode: None,
                             },


### PR DESCRIPTION
This is useful for enterprises, especially in combination with #30444, to ensure code never gets sent to Zed.

Release Notes:

- N/A
