### PR TITLE
debugger: Fix unzipping of codelldb on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3999,6 +3999,7 @@ dependencies = [
  "async-pipe",
  "async-tar",
  "async-trait",
+ "async_zip",
  "client",
  "collections",
  "dap-types",

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -49,6 +49,7 @@ smol.workspace = true
 task.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
+async_zip.workspace = true
 
 [dev-dependencies]
 async-pipe.workspace = true


### PR DESCRIPTION
Bug：
in windows before：
![图片](https://github.com/user-attachments/assets/131da24e-441c-4a30-9a09-34c92cb4f417)
log：Checking latest version of CodeLLDB...
Downloading from https://github.com/vadimcn/codelldb/releases/download/v1.11.4/codelldb-win32-x64.vsix...
error: program not found

now fix it：
![PixPin_2025-05-10_17-03-27](https://github.com/user-attachments/assets/3d0a1eaa-0d8d-43cd-a67f-30faac02e03b)


Release Notes:

- debugger: Fix debugger codelldb unzip bug in windows
