### PR TITLE
editor: Fix multicursor indent edge case where few lines would indent incorrectly

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8805,8 +8805,10 @@ impl Editor {
                             row_delta = suggested_indent.len - cursor.column;
                         } else {
                             row_delta = suggested_indent.len - current_indent.len;
-                            continue;
                         }
+                    }
+                    if !is_any_cursor_at_word_boundary {
+                        continue;
                     }
                 }
             }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -8760,7 +8760,10 @@ impl Editor {
             .any(|selection| {
                 let cursor = selection.head();
                 let current_indent = snapshot.indent_size_for_line(MultiBufferRow(cursor.row));
-                cursor.column == current_indent.len
+                let final_column_in_line = snapshot
+                    .buffer_line_for_row(MultiBufferRow(cursor.row))
+                    .map_or(0, |(_, range)| range.end.column);
+                cursor.column == current_indent.len && final_column_in_line != cursor.column
             });
 
         let mut edits = Vec::new();

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2871,7 +2871,7 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
     );
     cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
 
-    // when all cursors are to the left of the suggested indent, then auto-indent all.
+    // when all cursors are on whitespace it should just move the cursors to suggested indents
     cx.set_state(indoc! {"
         const a: B = (
             c(
@@ -2887,10 +2887,17 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
             ˇ)
         );
     "});
+    // when any one of cursor is at word boundary, it should indent as well as move cursor
+    cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
+    cx.assert_editor_state(indoc! {"
+        const a: B = (
+            c(
+                    ˇ
+                ˇ)
+        );
+    "});
 
-    // cursors that are already at the suggested indent level do not move
-    // until other cursors that are to the left of the suggested indent
-    // auto-indent.
+    // when all cursors are on whitespace it should just move the cursors to suggested indents
     cx.set_state(indoc! {"
         ˇ
         const a: B = (
@@ -2904,7 +2911,7 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
     "});
     cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
     cx.assert_editor_state(indoc! {"
-        ˇ
+            ˇ
         const a: B = (
             c(
                 d(
@@ -2914,11 +2921,10 @@ async fn test_tab_in_leading_whitespace_auto_indents_lines(cx: &mut TestAppConte
             ˇ)
         );
     "});
-    // once all multi-cursors are at the suggested
-    // indent level, they all insert a soft tab together.
+    // when any one of cursor is at word boundary, it should indent as well as move cursor
     cx.update_editor(|e, window, cx| e.tab(&Tab, window, cx));
     cx.assert_editor_state(indoc! {"
-            ˇ
+                ˇ
         const a: B = (
             c(
                 d(


### PR DESCRIPTION
This should have been part of [editor: Fix inconsistent relative indent when using tab with multi cursors](https://github.com/zed-industries/zed/pull/29519)

Before / After:

https://github.com/user-attachments/assets/b7ab0eef-2764-44dc-b51f-b96dccd5ecb3

Release Notes:

- N/A
