### PR TITLE
Allow toggling border visibility in centered layout mode

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -95,7 +95,10 @@
     "left_padding": 0.2,
     // The relative width of the right padding of the central pane from the
     // workspace when the centered layout is used.
-    "right_padding": 0.2
+    "right_padding": 0.2,
+    // Whether to show the borders of the padding areas when the centered
+    // layout is used.
+    "show_border": true
   },
   // All settings related to the image viewer.
   "image_viewer": {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -262,6 +262,15 @@ pub struct CenteredLayoutSettings {
     ///
     /// Default: 0.2
     pub right_padding: Option<f32>,
+    /// Whether to show the border around panes.
+    ///
+    /// Default: true
+    #[serde(default = "default_show_border")]
+    pub show_border: bool,
+}
+
+fn default_show_border() -> bool {
+    true
 }
 
 impl Settings for WorkspaceSettings {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -409,6 +409,7 @@ For example, to use `Nerd Font` as a fallback, add the following to your setting
 "centered_layout": {
   "left_padding": 0.2,
   "right_padding": 0.2,
+  "show_border": true,
 }
 ```
 


### PR DESCRIPTION
Closes #22971

Release Notes:

- Added `show_border` option to centered layout configuration to allow hiding borders for a cleaner appearance
