### PR TITLE
breadcrumbs: Stylize filename in breadcrumbs when tab-bar is off and file is dirty

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2175,6 +2175,7 @@ dependencies = [
  "editor",
  "gpui",
  "itertools 0.14.0",
+ "settings",
  "theme",
  "ui",
  "workspace",

--- a/crates/breadcrumbs/Cargo.toml
+++ b/crates/breadcrumbs/Cargo.toml
@@ -16,6 +16,7 @@ doctest = false
 editor.workspace = true
 gpui.workspace = true
 itertools.workspace = true
+settings.workspace = true
 theme.workspace = true
 ui.workspace = true
 workspace.workspace = true


### PR DESCRIPTION
Closes [#18870](https://github.com/zed-industries/zed/issues/18870)


- I like to use Zed with tab_bar off
- when the file is modified there is no indicator when tab_bar is off
- this PR aims to fix that

Thanks to @Qkessler for initial PR - #22418 

This is style decided in this discussion - #22418 
@iamnbutler @mikayla-maki  [subtle style decided](https://github.com/zed-industries/zed/pull/22418#issuecomment-2605253667)

Release Notes:
- When tab_bar is off, filename in the breadcrumbs will be the indicator when file is unsaved.


#### Changes
- when tab_bar is off and file is dirty (unsaved)
<img width="834" alt="image" src="https://github.com/user-attachments/assets/f205731b-c8e3-4d7a-9214-cbe706e372bf" />


- when tab_bar is off and file is not dirty (saved)
<img width="846" alt="image" src="https://github.com/user-attachments/assets/88ea96eb-16a2-48e8-900d-64a921f0b5c3" />


- when tab_bar is on
<img width="741" alt="image" src="https://github.com/user-attachments/assets/cc543544-9949-46ed-8e09-cdcbe2f47ab8" />

<img width="740" alt="image" src="https://github.com/user-attachments/assets/8d347258-26f7-4bd7-82d4-8f23dbe63d61" />

Release Notes:

- Changed the highlighting of the current file to represent the current saved state, when the tab bar is turned off.