### PR TITLE
collab: Bump axum

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1591,7 +1591,7 @@ dependencies = [
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tracing",
 ]
 
@@ -1729,20 +1729,20 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
- "async-trait",
  "axum-core",
- "base64 0.21.7",
- "bitflags 1.3.2",
+ "base64 0.22.1",
  "bytes 1.10.1",
+ "form_urlencoded",
  "futures-util",
- "headers",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -1755,50 +1755,58 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite 0.20.1",
- "tower 0.4.13",
+ "tokio-tungstenite 0.26.2",
+ "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
 dependencies = [
- "async-trait",
  "bytes 1.10.1",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
+ "futures-core",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-extra"
-version = "0.4.2"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a320103719de37b7b4da4c8eb629d4573f6bcfd3dfe80d3208806895ccf81d"
+checksum = "45bf463831f5131b7d3c756525b305d40f1185b688565648a92e1392ca35713d"
 dependencies = [
  "axum",
+ "axum-core",
  "bytes 1.10.1",
  "futures-util",
- "http 0.2.12",
+ "headers 0.4.0",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
  "mime",
  "pin-project-lite",
+ "rustversion",
  "serde",
  "serde_json",
- "tokio",
- "tower 0.4.13",
- "tower-http 0.3.5",
+ "tower",
  "tower-layer",
  "tower-service",
+ "typed-json",
 ]
 
 [[package]]
@@ -3037,8 +3045,8 @@ dependencies = [
  "time",
  "tokio",
  "toml 0.8.20",
- "tower 0.4.13",
- "tower-http 0.4.4",
+ "tower",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "unindent",
@@ -6451,8 +6459,23 @@ checksum = "06683b93020a07e3dbcf5f8c0f6d40080d725bea7936fc01ad345c01b97dc270"
 dependencies = [
  "base64 0.21.7",
  "bytes 1.10.1",
- "headers-core",
+ "headers-core 0.2.0",
  "http 0.2.12",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
+dependencies = [
+ "base64 0.21.7",
+ "bytes 1.10.1",
+ "headers-core 0.3.0",
+ "http 1.3.1",
  "httpdate",
  "mime",
  "sha1",
@@ -6465,6 +6488,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
 dependencies = [
  "http 0.2.12",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
 ]
 
 [[package]]
@@ -6699,12 +6731,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http-range-header"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
-
-[[package]]
 name = "http-types"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6811,6 +6837,7 @@ dependencies = [
  "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -8632,9 +8659,9 @@ dependencies = [
 
 [[package]]
 name = "matchit"
-version = "0.7.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
 name = "maybe-owned"
@@ -12047,7 +12074,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -12094,7 +12121,7 @@ dependencies = [
  "tokio-rustls 0.26.2",
  "tokio-socks",
  "tokio-util",
- "tower 0.5.2",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -15058,18 +15085,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "212d5dcb2a1ce06d81107c3d0ffa3121fe974b73f068c8282cb1c32328113b6c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite 0.20.1",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
@@ -15176,22 +15191,6 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
@@ -15203,39 +15202,19 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "tower-http"
-version = "0.3.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f873044bf02dd1e8239e9c1293ea39dad76dc594ec16185d0a1bf31d8dc8d858"
-dependencies = [
- "bitflags 1.3.2",
- "bytes 1.10.1",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
- "pin-project-lite",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "0fdb0c213ca27a9f57ab69ddb290fd80d970922355b83ae380b395d3986b8a2e"
 dependencies = [
  "bitflags 2.9.0",
  "bytes 1.10.1",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "http-body 0.4.6",
- "http-range-header",
+ "http 1.3.1",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower-layer",
  "tower-service",
@@ -15604,25 +15583,6 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
-dependencies = [
- "byteorder",
- "bytes 1.10.1",
- "data-encoding",
- "http 0.2.12",
- "httparse",
- "log",
- "rand 0.8.5",
- "sha1",
- "thiserror 1.0.69",
- "url",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
@@ -15657,6 +15617,16 @@ dependencies = [
  "sha1",
  "thiserror 2.0.12",
  "utf-8",
+]
+
+[[package]]
+name = "typed-json"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6024a8d0025400b3f6b189366e9aa92012cf9c4fe1cd2620848dd61425c49eed"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -16210,7 +16180,7 @@ dependencies = [
  "bytes 1.10.1",
  "futures-channel",
  "futures-util",
- "headers",
+ "headers 0.3.9",
  "http 0.2.12",
  "hyper 0.14.32",
  "log",
@@ -18195,7 +18165,7 @@ dependencies = [
  "tokio-util",
  "toml_datetime",
  "toml_edit",
- "tower 0.5.2",
+ "tower",
  "tracing",
  "tracing-core",
  "tungstenite 0.26.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -563,7 +563,7 @@ tiny_http = "0.8"
 tokio = { version = "1" }
 tokio-tungstenite = { version = "0.26", features = ["__rustls-tls"] }
 toml = "0.8"
-tower-http = "0.4.4"
+tower-http = "0.6.4"
 tree-sitter = { version = "0.25.3", features = ["wasm"] }
 tree-sitter-bash = "0.23"
 tree-sitter-c = "0.23"

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -24,8 +24,8 @@ async-tungstenite.workspace = true
 aws-config = { version = "1.1.5" }
 aws-sdk-s3 = { version = "1.15.0" }
 aws-sdk-kinesis = "1.51.0"
-axum = { version = "0.6", features = ["json", "headers", "ws"] }
-axum-extra = { version = "0.4", features = ["erased-json"] }
+axum = { version = "0.8", features = ["ws"] }
+axum-extra = { version = "0.10", features = ["erased-json", "typed-header"] }
 base64.workspace = true
 chrono.workspace = true
 clock.workspace = true
@@ -66,7 +66,7 @@ thiserror.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml.workspace = true
-tower = "0.4"
+tower = "0.5.2"
 tower-http = { workspace = true, features = ["trace"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry", "tracing-log"] } # workaround for https://github.com/tokio-rs/tracing/issues/2927

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -2,11 +2,11 @@ use anyhow::{Context, anyhow, bail};
 use axum::{
     Extension, Json, Router,
     extract::{self, Query},
+    http::StatusCode,
     routing::{get, post},
 };
 use chrono::{DateTime, SecondsFormat, Utc};
 use collections::HashSet;
-use reqwest::StatusCode;
 use sea_orm::ActiveValue;
 use serde::{Deserialize, Serialize};
 use serde_json::json;

--- a/crates/collab/src/api/events.rs
+++ b/crates/collab/src/api/events.rs
@@ -4,12 +4,12 @@ use crate::{AppState, Error, Result, api::slack};
 use anyhow::anyhow;
 use aws_sdk_s3::primitives::ByteStream;
 use axum::{
-    Extension, Router, TypedHeader,
+    Extension, Router,
     body::Bytes,
-    headers::Header,
     http::{HeaderMap, HeaderName, StatusCode},
     routing::post,
 };
+use axum_extra::{TypedHeader, headers::Header};
 use chrono::Duration;
 use semantic_version::SemanticVersion;
 use serde::{Deserialize, Serialize};
@@ -38,18 +38,18 @@ impl Header for ZedChecksumHeader {
         ZED_CHECKSUM_HEADER.get_or_init(|| HeaderName::from_static("x-zed-checksum"))
     }
 
-    fn decode<'i, I>(values: &mut I) -> Result<Self, axum::headers::Error>
+    fn decode<'i, I>(values: &mut I) -> Result<Self, axum_extra::headers::Error>
     where
         Self: Sized,
         I: Iterator<Item = &'i axum::http::HeaderValue>,
     {
         let checksum = values
             .next()
-            .ok_or_else(axum::headers::Error::invalid)?
+            .ok_or_else(axum_extra::headers::Error::invalid)?
             .to_str()
-            .map_err(|_| axum::headers::Error::invalid())?;
+            .map_err(|_| axum_extra::headers::Error::invalid())?;
 
-        let bytes = hex::decode(checksum).map_err(|_| axum::headers::Error::invalid())?;
+        let bytes = hex::decode(checksum).map_err(|_| axum_extra::headers::Error::invalid())?;
         Ok(Self(bytes))
     }
 

--- a/crates/collab/src/auth.rs
+++ b/crates/collab/src/auth.rs
@@ -5,7 +5,8 @@ use crate::{
 };
 use anyhow::{Context as _, anyhow};
 use axum::{
-    http::{self, Request, StatusCode},
+    extract::Request,
+    http::{self, StatusCode},
     middleware::Next,
     response::IntoResponse,
 };
@@ -27,7 +28,7 @@ use subtle::ConstantTimeEq;
 ///   <token> can be an access_token attached to that user, or an access token of an admin
 ///   or (in development) the string ADMIN:<config.api_token>.
 /// Authorization: "dev-server-token" <token>
-pub async fn validate_header<B>(mut req: Request<B>, next: Next<B>) -> impl IntoResponse {
+pub async fn validate_header(mut req: Request, next: Next) -> impl IntoResponse {
     let mut auth_header = req
         .headers()
         .get(http::header::AUTHORIZATION)

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4044,8 +4044,8 @@ async fn get_llm_api_token(
 fn to_axum_message(message: TungsteniteMessage) -> anyhow::Result<AxumMessage> {
     let message = match message {
         TungsteniteMessage::Text(payload) => AxumMessage::Text(payload.to_string().into()),
-        TungsteniteMessage::Binary(payload) => AxumMessage::Binary(payload.into()),
-        TungsteniteMessage::Ping(payload) => AxumMessage::Ping(payload.into()),
+        TungsteniteMessage::Binary(payload) => AxumMessage::Binary(payload),
+        TungsteniteMessage::Ping(payload) => AxumMessage::Ping(payload),
         TungsteniteMessage::Pong(payload) => AxumMessage::Pong(payload),
         TungsteniteMessage::Close(frame) => AxumMessage::Close(frame.map(|frame| AxumCloseFrame {
             code: frame.code.into(),
@@ -4070,9 +4070,9 @@ fn to_axum_message(message: TungsteniteMessage) -> anyhow::Result<AxumMessage> {
 fn to_tungstenite_message(message: AxumMessage) -> TungsteniteMessage {
     match message {
         AxumMessage::Text(payload) => TungsteniteMessage::Text(payload.to_string().into()),
-        AxumMessage::Binary(payload) => TungsteniteMessage::Binary(payload.into()),
-        AxumMessage::Ping(payload) => TungsteniteMessage::Ping(payload.into()),
-        AxumMessage::Pong(payload) => TungsteniteMessage::Pong(payload.into()),
+        AxumMessage::Binary(payload) => TungsteniteMessage::Binary(payload),
+        AxumMessage::Ping(payload) => TungsteniteMessage::Ping(payload),
+        AxumMessage::Pong(payload) => TungsteniteMessage::Pong(payload),
         AxumMessage::Close(frame) => {
             TungsteniteMessage::Close(frame.map(|frame| TungsteniteCloseFrame {
                 code: frame.code.into(),


### PR DESCRIPTION
This PR moves the collab server from axum 0.6 to axum 0.8. The motivation behind this is to prevent buildup of technical debt by having years outdated dependencies. Axum has non-negligible performance improvements and overall improved the ergonomics of the library.

The PR aims to do the minimal work necessary to move to the new version. It for example doesn't make use of the new State extractors instead of using an Extension to wrap state. However these should be done in a later PR.

I don't necessarily expect this PR to get merged, but this keeps tabs on how much work is necessary for the migration. (which is surprisingly little)

The only part I still find a little iffy is converting between axum and tungstenite WebSocket messages. The `Text` variant of a ws message now requires an additional allocation because axum does not expose the inner workings of its `Utf8Bytes` implementation. There is work trying to unify this common abstraction https://github.com/tokio-rs/bytes/pull/783 However it is not in use today

Release Notes:

- N/A
