### PR TITLE
markdown: Fix out of range panic in parser

### DIFF
--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -510,6 +510,9 @@ pub(crate) fn extract_code_block_content_range(text: &str) -> Range<usize> {
     if !range.is_empty() && text.ends_with("```") {
         range.end -= 3;
     }
+    if range.start > range.end {
+        range.end = range.start;
+    }
     range
 }
 
@@ -686,6 +689,10 @@ mod tests {
 
         let input = "```python\nprint('hello')\nprint('world')\n```";
         assert_eq!(extract_code_block_content_range(input), 10..40);
+
+        // Malformed input
+        let input = "`````";
+        assert_eq!(extract_code_block_content_range(input), 3..3);
     }
 
     #[test]


### PR DESCRIPTION
For some reason `pulldown_cmark` treats \````` as a codeblock, meaning that we could end up with an invalid range generated from `extract_code_block_content_range` (3..2)

Closes #30495

Release Notes:

- agent: Fix an edge case where the editor would crash when model generated malformed markdown
