### PR TITLE
Fix apply buffer font features to completion tooltip (#30362)

### DIFF
--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -467,7 +467,7 @@ impl TextStyle {
             len,
             font: Font {
                 family: self.font_family.clone(),
-                features: Default::default(),
+                features: self.font_features.clone(),
                 fallbacks: self.font_fallbacks.clone(),
                 weight: self.font_weight,
                 style: self.font_style,


### PR DESCRIPTION
Closes #30362

Release Notes:

- Fixed completion tooltip to respect custom font features set in `buffer_font_features`
