### PR TITLE
Highlight shebang in TypeScript and JavaScript

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -77,6 +77,8 @@
 
 (comment) @comment
 
+(hash_bang_line) @comment
+
 [
   (string)
   (template_string)

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -104,6 +104,8 @@
 
 (comment) @comment
 
+(hash_bang_line) @comment
+
 [
   (string)
   (template_string)


### PR DESCRIPTION
After:
![image](https://github.com/user-attachments/assets/8ae1049d-96c7-45e2-b905-1f0fba7f862c)

Before:
![image](https://github.com/user-attachments/assets/56317b12-d745-45f4-a7b6-880507884bae)


Release Notes:

- Typescript and javascript highlight shebang-line
