### PR TITLE
zeta: Don't require sign-in when using ZED_PREDICT_EDITS_URL

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -240,7 +240,9 @@ impl Render for InlineCompletionButton {
                 let has_subscription = self.user_store.read(cx).current_plan().is_some()
                     && self.user_store.read(cx).subscription_period().is_some();
 
-                if !has_subscription || !current_user_terms_accepted.unwrap_or(false) {
+                if std::env::var("ZED_PREDICT_EDITS_URL").is_err()
+                    && (!has_subscription || !current_user_terms_accepted.unwrap_or(false))
+                {
                     let signed_in = current_user_terms_accepted.is_some();
                     let tooltip_meta = if signed_in {
                         if has_subscription {

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -242,7 +242,9 @@ fn assign_edit_prediction_provider(
             }
         }
         EditPredictionProvider::Zed => {
-            if client.status().borrow().is_connected() {
+            if client.status().borrow().is_connected()
+                || std::env::var("ZED_PREDICT_EDITS_URL").is_ok()
+            {
                 let mut worktree = None;
 
                 if let Some(buffer) = &singleton_buffer {


### PR DESCRIPTION
- Fixes issue where zeta requires a valid LLM token even when hosting zeta yourself
- Lets zeta work without signing in if the override env variable is set

Release Notes:

- N/A
