### PR TITLE
agent: Fix instruction list item with multiple buttons not working

### DIFF
--- a/crates/language_models/src/ui/instruction_list_item.rs
+++ b/crates/language_models/src/ui/instruction_list_item.rs
@@ -38,8 +38,10 @@ impl IntoElement for InstructionListItem {
             (self.button_label, self.button_link)
         {
             let link = button_link.clone();
+            let unique_id = SharedString::from(format!("{}-button", self.label));
+
             h_flex().flex_wrap().child(Label::new(self.label)).child(
-                Button::new("link-button", button_label)
+                Button::new(unique_id, button_label)
                     .style(ButtonStyle::Subtle)
                     .icon(IconName::ArrowUpRight)
                     .icon_size(IconSize::XSmall)


### PR DESCRIPTION
This was a particular problem in the Amazon Bedrock section (at least for now) where there were multiple buttons and none of them actually worked because they all had the same id. 

Release Notes:

- agent: Fixed Amazon Bedrock settings link buttons not working.
