### PR TITLE
extension_host: Include more details about error messages

### DIFF
--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -806,6 +806,6 @@ trait ToWasmtimeResult<T> {
 
 impl<T> ToWasmtimeResult<T> for Result<T> {
     fn to_wasmtime_result(self) -> wasmtime::Result<Result<T, String>> {
-        Ok(self.map_err(|error| error.to_string()))
+        Ok(self.map_err(|error| format!("{error:?}")))
     }
 }


### PR DESCRIPTION
This PR makes it so the error messages surfaced to extensions will contain more information.

Supersedes https://github.com/zed-industries/zed/pull/28491.

Release Notes:

- N/A
