### PR TITLE
bedrock: Fix Claude 3.5 Haiku support

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -324,7 +324,7 @@ impl Model {
 
             // Models available only in US
             (Model::Claude3Opus, "us")
-            | (Model::Claude3_5Sonnet, "us")
+            | (Model::Claude3_5Haiku, "us")
             | (Model::Claude3_7Sonnet, "us")
             | (Model::Claude3_7SonnetThinking, "us")
             | (Model::AmazonNovaPremier, "us")


### PR DESCRIPTION
This PR corrects a mistake introduced in https://github.com/zed-industries/zed/pull/28523.

https://github.com/zed-industries/zed/pull/28523#issuecomment-2872369707

Release Notes:

- N/A
