### PR TITLE
Fix deadlock loading node from the command line

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -309,6 +309,8 @@ fn main() {
                 shell_env_loaded_tx.send(()).ok();
             })
             .detach()
+    } else {
+        drop(shell_env_loaded_tx)
     }
 
     app.on_open_urls({


### PR DESCRIPTION
Before this change the the load env task never completed, leading to the node runtime lock being held permanently.

Release Notes:

- N/A
