### PR TITLE
Fix bug where deleted toolchains stay selected on startup

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1369,7 +1369,13 @@ impl Workspace {
             };
 
             let toolchains = DB.toolchains(workspace_id).await?;
+
             for (toolchain, worktree_id, path) in toolchains {
+                let toolchain_path = PathBuf::from(toolchain.path.clone().to_string());
+                if !app_state.fs.is_file(toolchain_path.as_path()).await {
+                    continue;
+                }
+
                 project_handle
                     .update(cx, |this, cx| {
                         this.activate_toolchain(ProjectPath { worktree_id, path }, toolchain, cx)


### PR DESCRIPTION
This affects python's when debugging because the selected toolchain is used as the python binary to spawn Debugpy 

Release Notes:

- Fix bug where selected toolchain didn't exist
