### PR TITLE
Add `ZED_BLADE_VALIDATE` flag for enabling blade validation on Linux

### DIFF
--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -21,11 +21,12 @@ impl BladeContext {
                 None
             }
         };
+        let do_validation = std::env::var("ZED_BLADE_VALIDATE").is_ok();
         let gpu = Arc::new(
             unsafe {
                 gpu::Context::init(gpu::ContextDesc {
                     presentation: true,
-                    validation: false,
+                    validation: do_validation,
                     device_id: device_id_forced.unwrap_or(0),
                     ..Default::default()
                 })


### PR DESCRIPTION
Closes #ISSUE

Stems from https://github.com/zed-industries/zed/issues/28851#issuecomment-2869970976

Release Notes:

- linux: Add `ZED_BLADE_VALIDATE` flag for enabling blade validation
