### PR TITLE
Fix migrate banner not showing markdown on file changes

### DIFF
--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -76,15 +76,15 @@ impl MigrationBanner {
                 migration_type,
                 migrated,
             } => {
-                if self.migration_type == Some(*migration_type) {
-                    let location = if *migrated {
-                        ToolbarItemLocation::Secondary
-                    } else {
-                        ToolbarItemLocation::Hidden
-                    };
-                    cx.emit(ToolbarItemEvent::ChangeLocation(location));
-                    cx.notify();
-                }
+                if *migrated {
+                    self.migration_type = Some(migration_type.clone());
+                    self.show(cx);
+                } else {
+                    cx.emit(ToolbarItemEvent::ChangeLocation(
+                        ToolbarItemLocation::Hidden,
+                    ));
+                    self.reset(cx);
+                };
             }
         }
     }

--- a/crates/zed/src/zed/migrate.rs
+++ b/crates/zed/src/zed/migrate.rs
@@ -77,7 +77,7 @@ impl MigrationBanner {
                 migrated,
             } => {
                 if *migrated {
-                    self.migration_type = Some(migration_type.clone());
+                    self.migration_type = Some(*migration_type);
                     self.show(cx);
                 } else {
                     cx.emit(ToolbarItemEvent::ChangeLocation(


### PR DESCRIPTION
Fixes case where on file (settings/keymap) changes banner would appear but markdown was not visible. 
Regression caused by refactor happened in https://github.com/zed-industries/zed/pull/30456.

Release Notes:

- N/A
