### PR TITLE
Deny unknown keys in settings in JSON schema so user gets warnings but settings still parses

### DIFF
--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -41,6 +41,7 @@ pub enum NotifyWhenAgentWaiting {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 #[serde(tag = "name", rename_all = "snake_case")]
+#[schemars(deny_unknown_fields)]
 pub enum AssistantProviderContentV1 {
     #[serde(rename = "zed.dev")]
     ZedDotDev { default_model: Option<CloudModel> },
@@ -152,6 +153,7 @@ impl LanguageModelParameters {
 
 /// Assistant panel settings
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
+#[schemars(deny_unknown_fields)]
 pub struct AssistantSettingsContent {
     #[serde(flatten)]
     pub inner: Option<AssistantSettingsContentInner>,
@@ -543,6 +545,7 @@ impl AssistantSettingsContent {
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
 #[serde(tag = "version")]
+#[schemars(deny_unknown_fields)]
 pub enum VersionedAssistantSettingsContent {
     #[serde(rename = "1")]
     V1(AssistantSettingsContentV1),
@@ -576,6 +579,7 @@ impl Default for VersionedAssistantSettingsContent {
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug, Default)]
+#[schemars(deny_unknown_fields)]
 pub struct AssistantSettingsContentV2 {
     /// Whether the Assistant is enabled.
     ///
@@ -734,6 +738,7 @@ pub struct ContextServerPresetContent {
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
+#[schemars(deny_unknown_fields)]
 pub struct AssistantSettingsContentV1 {
     /// Whether the Assistant is enabled.
     ///
@@ -763,6 +768,7 @@ pub struct AssistantSettingsContentV1 {
 }
 
 #[derive(Clone, Serialize, Deserialize, JsonSchema, Debug)]
+#[schemars(deny_unknown_fields)]
 pub struct LegacyAssistantSettingsContent {
     /// Whether to show the assistant panel button in the status bar.
     ///

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -153,7 +153,6 @@ impl LanguageModelParameters {
 
 /// Assistant panel settings
 #[derive(Clone, Serialize, Deserialize, Debug, Default)]
-#[schemars(deny_unknown_fields)]
 pub struct AssistantSettingsContent {
     #[serde(flatten)]
     pub inner: Option<AssistantSettingsContentInner>,

--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -12,6 +12,7 @@ pub struct CallSettings {
 
 /// Configuration of voice calls in Zed.
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+#[schemars(deny_unknown_fields)]
 pub struct CallSettingsContent {
     /// Whether the microphone should be muted when joining a channel or a call.
     ///

--- a/crates/collab_ui/src/panel_settings.rs
+++ b/crates/collab_ui/src/panel_settings.rs
@@ -28,6 +28,7 @@ pub struct ChatPanelSettings {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+#[schemars(deny_unknown_fields)]
 pub struct ChatPanelSettingsContent {
     /// When to show the panel button in the status bar.
     ///
@@ -51,6 +52,7 @@ pub struct NotificationPanelSettings {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+#[schemars(deny_unknown_fields)]
 pub struct PanelSettingsContent {
     /// Whether to show the panel button in the status bar.
     ///
@@ -67,6 +69,7 @@ pub struct PanelSettingsContent {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+#[schemars(deny_unknown_fields)]
 pub struct MessageEditorSettings {
     /// Whether to automatically replace emoji shortcodes with emoji characters.
     /// For example: typing `:wave:` gets replaced with `👋`.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -332,6 +332,7 @@ pub enum SnippetSortOrder {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct EditorSettingsContent {
     /// Whether the cursor blinks in the editor.
     ///

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -29,11 +29,6 @@ use util::serde::default_true;
 /// Initializes the language settings.
 pub fn init(cx: &mut App) {
     AllLanguageSettings::register(cx);
-    cx.observe_global::<SettingsStore>(move |cx| {
-        let settings = AllLanguageSettings::get_global(cx);
-        dbg!(settings.language(None, Some(&LanguageName::new("Markdown")), cx));
-    })
-    .detach();
 }
 
 /// Returns the settings for the specified language from the provided file.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -29,6 +29,11 @@ use util::serde::default_true;
 /// Initializes the language settings.
 pub fn init(cx: &mut App) {
     AllLanguageSettings::register(cx);
+    cx.observe_global::<SettingsStore>(move |cx| {
+        let settings = AllLanguageSettings::get_global(cx);
+        dbg!(settings.language(None, Some(&LanguageName::new("Markdown")), cx));
+    })
+    .detach();
 }
 
 /// Returns the settings for the specified language from the provided file.
@@ -381,6 +386,7 @@ fn default_lsp_fetch_timeout_ms() -> u64 {
 
 /// The settings for a particular language.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct LanguageSettingsContent {
     /// How many columns a tab should occupy.
     ///

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -36,6 +36,7 @@ use crate::{
 };
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[schemars(deny_unknown_fields)]
 pub struct ProjectSettings {
     /// Configuration for language servers.
     ///

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1967,7 +1967,7 @@ mod tests {
 
     #[derive(Default, Clone, Serialize, Deserialize, JsonSchema)]
     #[schemars(deny_unknown_fields)]
-    struct UserSettingsJson {
+    struct UserSettingsContent {
         name: Option<String>,
         age: Option<u32>,
         staff: Option<bool>,
@@ -1975,7 +1975,7 @@ mod tests {
 
     impl Settings for UserSettings {
         const KEY: Option<&'static str> = Some("user");
-        type FileContent = UserSettingsJson;
+        type FileContent = UserSettingsContent;
 
         fn load(sources: SettingsSources<Self::FileContent>, _: &mut App) -> Result<Self> {
             sources.json_merge()

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1966,6 +1966,7 @@ mod tests {
     }
 
     #[derive(Default, Clone, Serialize, Deserialize, JsonSchema)]
+    #[schemars(deny_unknown_fields)]
     struct UserSettingsJson {
         name: Option<String>,
         age: Option<u32>,
@@ -2008,6 +2009,7 @@ mod tests {
     }
 
     #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
+    #[schemars(deny_unknown_fields)]
     struct MultiKeySettingsJson {
         key1: Option<String>,
         key2: Option<String>,
@@ -2046,6 +2048,7 @@ mod tests {
     }
 
     #[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema)]
+    #[schemars(deny_unknown_fields)]
     struct JournalSettingsJson {
         pub path: Option<String>,
         pub hour_format: Option<HourFormat>,
@@ -2076,6 +2079,7 @@ mod tests {
     }
 
     #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+    #[schemars(deny_unknown_fields)]
     struct LanguageSettingEntry {
         language_setting_1: Option<bool>,
         language_setting_2: Option<bool>,


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Improved checking of Zed settings so that unrecognized keys show warnings while editing them
