### PR TITLE
editor: Do not offset text in single line editors by default

### DIFF
--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -107,6 +107,7 @@ impl MessageEditor {
         let this = cx.entity().downgrade();
         editor.update(cx, |editor, cx| {
             editor.set_soft_wrap_mode(SoftWrap::EditorWidth, cx);
+            editor.set_offset_content(false, cx);
             editor.set_use_autoclose(false);
             editor.set_show_gutter(false, cx);
             editor.set_show_wrap_guides(false, cx);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1760,7 +1760,7 @@ impl Editor {
             show_local_selections: true,
             show_scrollbars: full_mode,
             minimap_visibility: MinimapVisibility::for_mode(&mode, cx),
-            offset_content: true,
+            offset_content: !matches!(mode, EditorMode::SingleLine { .. }),
             show_breadcrumbs: EditorSettings::get_global(cx).toolbar.breadcrumbs,
             show_gutter: mode.is_full(),
             show_line_numbers: None,
@@ -14573,7 +14573,6 @@ impl Editor {
                     this.show_local_selections = false;
                     let rename_editor = cx.new(|cx| {
                         let mut editor = Editor::single_line(window, cx);
-                        editor.disable_content_offset(cx);
                         editor.buffer.update(cx, |buffer, cx| {
                             buffer.edit([(0..0, old_name.clone())], None, cx)
                         });
@@ -16702,14 +16701,14 @@ impl Editor {
         self.set_minimap_visibility(MinimapVisibility::Disabled, window, cx);
     }
 
-    /// Normally the text in editors is padded on the left side by roughly half a
-    /// character width for improved hit testing.
+    /// Normally the text in full mode and auto height editors is padded on the
+    /// left side by roughly half a character width for improved hit testing.
     ///
-    /// For cases where this is not wanted (e.g. if you want to align the editor text
-    /// with some other text above or below), you can disable the behavior via
-    /// this method.
-    pub fn disable_content_offset(&mut self, cx: &mut Context<Self>) {
-        self.offset_content = false;
+    /// Use this method to disable this for cases where this is not wanted (e.g.
+    /// if you want to align the editor text with some other text above or below)
+    /// or if you want to add this padding to single-line editors.
+    pub fn set_offset_content(&mut self, offset_content: bool, cx: &mut Context<Self>) {
+        self.offset_content = offset_content;
         cx.notify();
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -921,6 +921,7 @@ pub struct Editor {
     show_gutter: bool,
     show_scrollbars: bool,
     minimap_visibility: MinimapVisibility,
+    offset_content: bool,
     disable_expand_excerpt_buttons: bool,
     show_line_numbers: Option<bool>,
     use_relative_line_numbers: Option<bool>,
@@ -1759,6 +1760,7 @@ impl Editor {
             show_local_selections: true,
             show_scrollbars: full_mode,
             minimap_visibility: MinimapVisibility::for_mode(&mode, cx),
+            offset_content: true,
             show_breadcrumbs: EditorSettings::get_global(cx).toolbar.breadcrumbs,
             show_gutter: mode.is_full(),
             show_line_numbers: None,
@@ -14571,6 +14573,7 @@ impl Editor {
                     this.show_local_selections = false;
                     let rename_editor = cx.new(|cx| {
                         let mut editor = Editor::single_line(window, cx);
+                        editor.disable_content_offset(cx);
                         editor.buffer.update(cx, |buffer, cx| {
                             buffer.edit([(0..0, old_name.clone())], None, cx)
                         });
@@ -16697,6 +16700,17 @@ impl Editor {
     pub fn disable_scrollbars_and_minimap(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         self.set_show_scrollbars(false, cx);
         self.set_minimap_visibility(MinimapVisibility::Disabled, window, cx);
+    }
+
+    /// Normally the text in editors is padded on the left side by roughly half a
+    /// character width for improved hit testing.
+    ///
+    /// For cases where this is not wanted (e.g. if you want to align the editor text
+    /// with some other text above or below), you can disable the behavior via
+    /// this method.
+    pub fn disable_content_offset(&mut self, cx: &mut Context<Self>) {
+        self.offset_content = false;
+        cx.notify();
     }
 
     pub fn set_show_line_numbers(&mut self, show_line_numbers: bool, cx: &mut Context<Self>) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7139,9 +7139,12 @@ impl Element for EditorElement {
                             self.max_line_number_width(&snapshot, window, cx),
                             cx,
                         )
-                        .unwrap_or_else(|| {
-                            GutterDimensions::default_with_margin(font_id, font_size, cx)
-                        });
+                        .or_else(|| {
+                            self.editor.read(cx).offset_content.then(|| {
+                                GutterDimensions::default_with_margin(font_id, font_size, cx)
+                            })
+                        })
+                        .unwrap_or_default();
                     let text_width = bounds.size.width - gutter_dimensions.width;
 
                     let settings = EditorSettings::get_global(cx);
@@ -9180,7 +9183,12 @@ fn compute_auto_height_layout(
     let mut snapshot = editor.snapshot(window, cx);
     let gutter_dimensions = snapshot
         .gutter_dimensions(font_id, font_size, max_line_number_width, cx)
-        .unwrap_or_else(|| GutterDimensions::default_with_margin(font_id, font_size, cx));
+        .or_else(|| {
+            editor
+                .offset_content
+                .then(|| GutterDimensions::default_with_margin(font_id, font_size, cx))
+        })
+        .unwrap_or_default();
 
     editor.gutter_dimensions = gutter_dimensions;
     let text_width = width - gutter_dimensions.width;

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -415,7 +415,11 @@ impl ProjectPanel {
                 });
             }
 
-            let filename_editor = cx.new(|cx| Editor::single_line(window, cx));
+            let filename_editor = cx.new(|cx| {
+                let mut editor = Editor::single_line(window, cx);
+                editor.disable_content_offset(cx);
+                editor
+            });
 
             cx.subscribe(
                 &filename_editor,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -415,11 +415,7 @@ impl ProjectPanel {
                 });
             }
 
-            let filename_editor = cx.new(|cx| {
-                let mut editor = Editor::single_line(window, cx);
-                editor.disable_content_offset(cx);
-                editor
-            });
+            let filename_editor = cx.new(|cx| Editor::single_line(window, cx));
 
             cx.subscribe(
                 &filename_editor,


### PR DESCRIPTION
Follow-up to #30138

In the linked PR, I enabled the content offset for all editors by default. However, this introduced a small regression: There are some editors where we do not want the text to be offset, most notably the rename and the filename editor.

This PR adds a method to disable the content offset for specific editors. I specifically decided on an opt-out approach, since I think that having the small offset for most editors is actually a benefit instead of a disadvantage. However, open to change that or to disable the offset for all editors but full mode editors by default if that should be preferred.

| `main` | This PR |
| --- | --- |
| ![main](https://github.com/user-attachments/assets/a7e9249e-ac5c-422f-9f30-021ebf21850b) | ![pr](https://github.com/user-attachments/assets/c5eef4e6-fad8-46ab-9f2d-d0ebdca01e2c) |


Release Notes:

- N/A
