### PR TITLE
docs: Add docs for `hover_popover_delay` and update hover delay

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -114,7 +114,7 @@
   // over symbols in the editor.
   "hover_popover_enabled": true,
   // Time to wait before showing the informational hover box
-  "hover_popover_delay": 350,
+  "hover_popover_delay": 300,
   // Whether to confirm before quitting Zed.
   "confirm_quit": false,
   // Whether to restore last closed project when fresh Zed instance is opened.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -113,7 +113,7 @@
   // Whether to show the informational hover box when moving the mouse
   // over symbols in the editor.
   "hover_popover_enabled": true,
-  // Time to wait before showing the informational hover box
+  // Time to wait in milliseconds before showing the informational hover box.
   "hover_popover_delay": 300,
   // Whether to confirm before quitting Zed.
   "confirm_quit": false,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -369,7 +369,7 @@ pub struct EditorSettingsContent {
     ///
     /// Default: true
     pub hover_popover_enabled: Option<bool>,
-    /// Time to wait before showing the informational hover box
+    /// Time to wait in milliseconds before showing the informational hover box.
     ///
     /// Default: 300
     pub hover_popover_delay: Option<u64>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -371,7 +371,7 @@ pub struct EditorSettingsContent {
     pub hover_popover_enabled: Option<bool>,
     /// Time to wait before showing the informational hover box
     ///
-    /// Default: 350
+    /// Default: 300
     pub hover_popover_delay: Option<u64>,
     /// Toolbar related settings
     pub toolbar: Option<ToolbarContent>,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1751,7 +1751,6 @@ Example:
 
 `integer` values representing milliseconds
 
-
 ## Icon Theme
 
 - Description: The icon theme setting can be specified in two forms - either as the name of an icon theme or as an object containing the `mode`, `dark`, and `light` icon themes for files/folders inside Zed.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1741,6 +1741,17 @@ Example:
 
 `boolean` values
 
+## Hover Popover Delay
+
+- Description: Time to wait in milliseconds before showing the informational hover box.
+- Setting: `hover_popover_delay`
+- Default: `300`
+
+**Options**
+
+`integer` values representing milliseconds
+
+
 ## Icon Theme
 
 - Description: The icon theme setting can be specified in two forms - either as the name of an icon theme or as an object containing the `mode`, `dark`, and `light` icon themes for files/folders inside Zed.


### PR DESCRIPTION

- Add docs for `hover_popover_delay`.
- Set `hover_popover_delay` to `300` from `350` which matches [VSCode's hover delay](https://github.com/microsoft/vscode/blob/ed48873ba23ae0a06a0eafb328ca1ce62b7d4b72/src/vs/editor/common/config/editorOptions.ts#L2219).

Release Notes:

- Added `hover_popover_delay` to settings which determines time to wait in milliseconds before showing the informational hover box.