### PR TITLE
Avoid backticks in AI-generated Git commit messages

### DIFF
--- a/crates/git_ui/src/commit_message_prompt.txt
+++ b/crates/git_ui/src/commit_message_prompt.txt
@@ -4,7 +4,7 @@ If you can accurately express the change in just the subject line, don't include
 
 Don't repeat information from the subject line in the message body.
 
-Only return the commit message in your response. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the commit message.
+Only return the commit message in your response. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the commit message. Do not include any code block backtics (```) or similar around the response.
 
 Follow good Git style:
 

--- a/crates/git_ui/src/commit_message_prompt.txt
+++ b/crates/git_ui/src/commit_message_prompt.txt
@@ -4,7 +4,7 @@ If you can accurately express the change in just the subject line, don't include
 
 Don't repeat information from the subject line in the message body.
 
-Only return the commit message in your response. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the commit message. Do not include any code block backtics (```) or similar around the response.
+Only return the commit message in your response. Do not include any additional meta-commentary about the task. Do not include the raw diff output in the commit message. Do not include any code block backtics (```) or similar around the commit message.
 
 Follow good Git style:
 


### PR DESCRIPTION
This fixes an issue where the AI-generated git commit message includes backticks around the message itself.

![image](https://github.com/user-attachments/assets/0ceb25da-79e3-425f-81b0-6ca4d9542742)

Release Notes:

- Fixed an issue where the AI-generated git commit message would include backticks around the message itself
