### PR TITLE
editor: Fix signature hover popover incorrect width instead of adapting to its content

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4451,7 +4451,7 @@ impl EditorElement {
         let target_y = selection_row.as_f32() * line_height - scroll_pixel_position.y;
         let target_point = content_origin + point(target_x, target_y);
 
-        let actual_size = element.layout_as_root(max_size.into(), window, cx);
+        let actual_size = element.layout_as_root(Size::<AvailableSpace>::default(), window, cx);
         let overall_height = actual_size.height + HOVER_POPOVER_GAP;
 
         let popover_origin = if target_point.y > overall_height {


### PR DESCRIPTION
Before:

<img width="935" alt="Screenshot 2025-05-13 at 18 03 21" src="https://github.com/user-attachments/assets/5320e559-7c60-4ad6-8ab6-99dcbcd1d42e" />

After:

<img width="349" alt="Screenshot 2025-05-13 at 18 45 21" src="https://github.com/user-attachments/assets/98412e13-b879-490a-a1b4-88f97bb84774" />

----

Release Notes:

- Fixed issue where signature popover displayed at incorrect width instead of adapting to its content.

----
cc @smitbarmase