### PR TITLE
build: Remove -all_load linker argument on macOS

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -13,12 +13,6 @@ rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 linker = "clang"
 rustflags = ["-C", "link-arg=-fuse-ld=mold"]
 
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-args=-all_load"]
-
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-args=-all_load"]
-
 [target.'cfg(target_os = "windows")']
 rustflags = [
     "--cfg",

--- a/flake.lock
+++ b/flake.lock
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1743906877,
-        "narHash": "sha256-Thah1oU8Vy0gs9bh5QhNcQh1iuQiowMnZPbrkURonZA=",
+        "lastModified": 1747363019,
+        "narHash": "sha256-N4dwkRBmpOosa4gfFkFf/LTD8oOcNkAyvZ07JvRDEf0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9d00c6b69408dd40d067603012938d9fbe95cfcd",
+        "rev": "0e624f2b1972a34be1a9b35290ed18ea4b419b6f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This fixes builds in nix development shell on macOS

Release Notes:

- N/A
