### PR TITLE
debugger: Show language icons in debug scenario picker

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -8,7 +8,7 @@ use dap_types::{StartDebuggingRequestArguments, StartDebuggingRequestArgumentsRe
 use futures::io::BufReader;
 use gpui::{AsyncApp, SharedString};
 pub use http_client::{HttpClient, github::latest_github_release};
-use language::LanguageToolchainStore;
+use language::{LanguageName, LanguageToolchainStore};
 use node_runtime::NodeRuntime;
 use serde::{Deserialize, Serialize};
 use settings::WorktreeId;
@@ -418,6 +418,11 @@ pub trait DebugAdapter: 'static + Send + Sync {
         user_installed_path: Option<PathBuf>,
         cx: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary>;
+
+    /// Returns the language name of an adapter if it only supports one language
+    fn adapter_language_name(&self) -> Option<LanguageName> {
+        None
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/dap/src/registry.rs
+++ b/crates/dap/src/registry.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use collections::FxHashMap;
 use gpui::{App, Global, SharedString};
+use language::LanguageName;
 use parking_lot::RwLock;
 use task::{DebugRequest, DebugScenario, SpawnInTerminal, TaskTemplate};
 
@@ -57,6 +58,11 @@ impl DapRegistry {
             _previous_value.is_none(),
             "Attempted to insert a new debug adapter when one is already registered"
         );
+    }
+
+    pub fn adapter_language(&self, adapter_name: &str) -> Option<LanguageName> {
+        self.adapter(adapter_name)
+            .and_then(|adapter| adapter.adapter_language_name())
     }
 
     pub fn add_locator(&self, locator: Arc<dyn DapLocator>) {

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -1,5 +1,6 @@
 use dap::{StartDebuggingRequestArguments, adapters::DebugTaskDefinition};
-use gpui::AsyncApp;
+use gpui::{AsyncApp, SharedString};
+use language::LanguageName;
 use std::{collections::HashMap, ffi::OsStr, path::PathBuf};
 
 use crate::*;
@@ -41,6 +42,10 @@ impl GoDebugAdapter {
 impl DebugAdapter for GoDebugAdapter {
     fn name(&self) -> DebugAdapterName {
         DebugAdapterName(Self::ADAPTER_NAME.into())
+    }
+
+    fn adapter_language_name(&self) -> Option<LanguageName> {
+        Some(SharedString::new_static("Go").into())
     }
 
     async fn get_binary(

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -1,6 +1,7 @@
 use adapters::latest_github_release;
 use dap::adapters::{DebugTaskDefinition, TcpArguments};
-use gpui::AsyncApp;
+use gpui::{AsyncApp, SharedString};
+use language::LanguageName;
 use std::{collections::HashMap, path::PathBuf, sync::OnceLock};
 use util::ResultExt;
 
@@ -117,6 +118,10 @@ impl PhpDebugAdapter {
 impl DebugAdapter for PhpDebugAdapter {
     fn name(&self) -> DebugAdapterName {
         DebugAdapterName(Self::ADAPTER_NAME.into())
+    }
+
+    fn adapter_language_name(&self) -> Option<LanguageName> {
+        Some(SharedString::new_static("PHP").into())
     }
 
     async fn get_binary(

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -1,6 +1,7 @@
 use crate::*;
 use dap::{DebugRequest, StartDebuggingRequestArguments, adapters::DebugTaskDefinition};
-use gpui::AsyncApp;
+use gpui::{AsyncApp, SharedString};
+use language::LanguageName;
 use std::{collections::HashMap, ffi::OsStr, path::PathBuf, sync::OnceLock};
 use util::ResultExt;
 
@@ -163,6 +164,10 @@ impl PythonDebugAdapter {
 impl DebugAdapter for PythonDebugAdapter {
     fn name(&self) -> DebugAdapterName {
         DebugAdapterName(Self::ADAPTER_NAME.into())
+    }
+
+    fn adapter_language_name(&self) -> Option<LanguageName> {
+        Some(SharedString::new_static("Python").into())
     }
 
     async fn get_binary(

--- a/crates/dap_adapters/src/ruby.rs
+++ b/crates/dap_adapters/src/ruby.rs
@@ -6,7 +6,8 @@ use dap::{
         self, DapDelegate, DebugAdapter, DebugAdapterBinary, DebugAdapterName, DebugTaskDefinition,
     },
 };
-use gpui::AsyncApp;
+use gpui::{AsyncApp, SharedString};
+use language::LanguageName;
 use std::path::PathBuf;
 use util::command::new_smol_command;
 
@@ -23,6 +24,10 @@ impl RubyDebugAdapter {
 impl DebugAdapter for RubyDebugAdapter {
     fn name(&self) -> DebugAdapterName {
         DebugAdapterName(Self::ADAPTER_NAME.into())
+    }
+
+    fn adapter_language_name(&self) -> Option<LanguageName> {
+        Some(SharedString::new_static("Ruby").into())
     }
 
     async fn get_binary(


### PR DESCRIPTION
We attempt to resolve the language name in this order

1. Based on debug adapter if they're for a singular language e.g. Delve
2. File extension if it exists
3. If a language name exists within a debug scenario's label

In the future I want to use locators to also determine the language as well and refresh scenario list when a new scenario has been saved

Release Notes:

- N/A
