### PR TITLE
Support global system settings: `/etc/zed/settings.json`

### DIFF
--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -216,7 +216,7 @@ pub fn settings_file() -> &'static PathBuf {
 /// Returns the path to the global `settings.json` file.
 pub fn global_settings_file() -> &'static PathBuf {
     static GLOBAL_SETTINGS_FILE: OnceLock<PathBuf> = OnceLock::new();
-    GLOBAL_SETTINGS_FILE.get_or_init(|| config_dir().join("settings.json"))
+    GLOBAL_SETTINGS_FILE.get_or_init(|| global_config_dir().join("settings.json"))
 }
 
 /// Returns the path to the `settings_backup.json` file.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -23,7 +23,9 @@ The syntax for configuration files is a super-set of JSON that allows `//` comme
 
 ## Default settings
 
-You can find the default settings for your current Zed by running {#action zed::OpenDefaultSettings} from the command palette.
+You can find the default settings for your current Zed by running {#action zed::OpenDefaultSettings} from the command palette or viewing [default.json](https://github.com/zed-industries/zed/blob/main/assets/settings/default.json) in the Zed repo.
+
+In addition to user and project settings described above, if available, Zed will load system-level settings from /etc/zed/settings.json (or `%PROGRAMDATA%\Zed` on Windows).
 
 Extensions that provide language servers may also provide default settings for those language servers.
 


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/issues/22612
- Follow-up to: https://github.com/zed-industries/zed/pull/30444

Release Notes:

- Added support for system Zed settings (`/etc/zed/settings.json`)
