### PR TITLE
Rename debug: commands to dev:

### DIFF
--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -684,7 +684,7 @@ impl Render for DapLogView {
     }
 }
 
-actions!(dev, [OpenDebuggerAdapterLogs]);
+actions!(dev, [OpenDebugAdapterLogs]);
 
 pub fn init(cx: &mut App) {
     let log_store = cx.new(|cx| LogStore::new(cx));
@@ -702,7 +702,7 @@ pub fn init(cx: &mut App) {
         }
 
         let log_store = log_store.clone();
-        workspace.register_action(move |workspace, _: &OpenDebuggerAdapterLogs, window, cx| {
+        workspace.register_action(move |workspace, _: &OpenDebugAdapterLogs, window, cx| {
             let project = workspace.project().read(cx);
             if project.is_local() {
                 workspace.add_item_to_active_pane(

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -684,7 +684,7 @@ impl Render for DapLogView {
     }
 }
 
-actions!(debug, [OpenDebuggerAdapterLogs]);
+actions!(dev, [OpenDebuggerAdapterLogs]);
 
 pub fn init(cx: &mut App) {
     let log_store = cx.new(|cx| LogStore::new(cx));

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -13,7 +13,7 @@ use ui::{
 };
 use workspace::{Item, SplitDirection, Workspace};
 
-actions!(debug, [OpenKeyContextView]);
+actions!(dev, [OpenKeyContextView]);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -201,7 +201,7 @@ pub(crate) struct LogMenuItem {
     pub server_kind: LanguageServerKind,
 }
 
-actions!(debug, [OpenLanguageServerLogs]);
+actions!(dev, [OpenLanguageServerLogs]);
 
 pub fn init(cx: &mut App) {
     let log_store = cx.new(LogStore::new);

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -15,7 +15,7 @@ use workspace::{
     item::{Item, ItemHandle},
 };
 
-actions!(debug, [OpenSyntaxTreeView]);
+actions!(dev, [OpenSyntaxTreeView]);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -91,7 +91,7 @@ impl JsonLspAdapter {
         let tsconfig_schema = serde_json::Value::from_str(TSCONFIG_SCHEMA).unwrap();
         let package_json_schema = serde_json::Value::from_str(PACKAGE_JSON_SCHEMA).unwrap();
 
-        // This can be viewed via `debug: open language server logs` -> `json-language-server` ->
+        // This can be viewed via `dev: open language server logs` -> `json-language-server` ->
         // `Server Info`
         serde_json::json!({
             "json": {

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -584,7 +584,7 @@ impl KeymapFile {
             .definitions
             .insert(KeymapAction::schema_name(), action_schema);
 
-        // This and other json schemas can be viewed via `debug: open language server logs` ->
+        // This and other json schemas can be viewed via `dev: open language server logs` ->
         // `json-language-server` -> `Server Info`.
         serde_json::to_value(root_schema).unwrap()
     }

--- a/crates/workspace/src/theme_preview.rs
+++ b/crates/workspace/src/theme_preview.rs
@@ -11,7 +11,7 @@ use ui::{
 
 use crate::{Item, Workspace};
 
-actions!(debug, [OpenThemePreview]);
+actions!(dev, [OpenThemePreview]);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -47,7 +47,7 @@ For example:
 
 You can see all of Zed's default bindings in the default keymaps for [MacOS](https://github.com/zed-industries/zed/blob/main/assets/keymaps/default-macos.json) or [Linux](https://github.com/zed-industries/zed/blob/main/assets/keymaps/default-linux.json).
 
-If you want to debug problems with custom keymaps you can use `debug: Open Key Context View` from the command palette. Please file [an issue](https://github.com/zed-industries/zed) if you run into something you think should work but isn't.
+If you want to debug problems with custom keymaps you can use `dev: Open Key Context View` from the command palette. Please file [an issue](https://github.com/zed-industries/zed) if you run into something you think should work but isn't.
 
 ### Keybinding syntax
 
@@ -85,7 +85,7 @@ It is possible to match against typing a modifier key on its own. For example `s
 
 If a binding group has a `"context"` key it will be matched against the currently active contexts in Zed.
 
-Zed's contexts make up a tree, with the root being `Workspace`. Workspaces contain Panes and Panels, and Panes contain Editors, etc. The easiest way to see what contexts are active at a given moment is the key context view, which you can get to with `debug: Open Key Context View` in the command palette.
+Zed's contexts make up a tree, with the root being `Workspace`. Workspaces contain Panes and Panels, and Panes contain Editors, etc. The easiest way to see what contexts are active at a given moment is the key context view, which you can get to with `dev: Open Key Context View` in the command palette.
 
 Contexts can contain extra attributes in addition to the name, so that you can (for example) match only in markdown files with `"context": "Editor && extension==md"`. It's worth noting that you can only use attributes at the level they are defined.
 

--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -23,7 +23,7 @@ They both have an overlapping feature set of autocomplete, diagnostics, code act
 
 In addition to these two language servers, Zed also supports [rubocop](https://github.com/rubocop/rubocop) which is a static code analyzer and linter for Ruby. Under the hood, it's also used by Zed as a language server, but its functionality is complimentary to that of solargraph and ruby-lsp.
 
-When configuring a language server, it helps to open the LSP Logs window using the 'debug: open language server logs' command. You can then choose the corresponding language instance to see any logged information.
+When configuring a language server, it helps to open the LSP Logs window using the 'dev: Open Language Server Logs' command. You can then choose the corresponding language instance to see any logged information.
 
 ## Configuring a language server
 


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Breaking change: The actions used while developing Zed have been renamed from `debug:` to `dev:` to avoid confusion with the new debugger feature:
- - `dev::OpenDebugAdapterLogs`
- - `dev::OpenSyntaxTreeView`
- - `dev::OpenThemePreview`
- - `dev::OpenLanguageServerLogs`
- - `dev::OpenKeyContextView`
