### PR TITLE
debugger: Fix panics when debugging with inline values or confirming in console

### DIFF
--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -150,8 +150,9 @@ impl Console {
     pub fn evaluate(&mut self, _: &Confirm, window: &mut Window, cx: &mut Context<Self>) {
         let expression = self.query_bar.update(cx, |editor, cx| {
             let expression = editor.text(cx);
-
-            editor.clear(window, cx);
+            cx.defer_in(window, |editor, window, cx| {
+                editor.clear(window, cx);
+            });
 
             expression
         });

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3580,7 +3580,9 @@ impl Project {
 
         let snapshot = buffer_handle.read(cx).snapshot();
 
-        let root_node = snapshot.syntax_root_ancestor(range.end).unwrap();
+        let Some(root_node) = snapshot.syntax_root_ancestor(range.end) else {
+            return Task::ready(Ok(vec![]));
+        };
 
         let row = snapshot
             .summary_for_anchor::<text::PointUtf16>(&range.end)


### PR DESCRIPTION
The first panic was caused by an unwrap that assumed a file would always have a root syntax node.

The second was caused by a double lease panic when clicking enter in the debug console while there was a completion menu open

Release Notes:

- N/A
