### PR TITLE
project_settings: Fix default settings values for `DiagnosticsSettings`

### DIFF
--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -143,33 +143,29 @@ impl DiagnosticsSettings {
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct InlineDiagnosticsSettings {
     /// Whether or not to show inline diagnostics
     ///
     /// Default: false
-    #[serde(default)]
     pub enabled: bool,
     /// Whether to only show the inline diagnostics after a delay after the
     /// last editor event.
     ///
     /// Default: 150
-    #[serde(default = "default_inline_diagnostics_debounce_ms")]
     pub update_debounce_ms: u64,
     /// The amount of padding between the end of the source line and the start
     /// of the inline diagnostic in units of columns.
     ///
     /// Default: 4
-    #[serde(default = "default_inline_diagnostics_padding")]
     pub padding: u32,
     /// The minimum column to display inline diagnostics. This setting can be
     /// used to horizontally align inline diagnostics at some position. Lines
     /// longer than this value will still push diagnostics further to the right.
     ///
     /// Default: 0
-    #[serde(default)]
     pub min_column: u32,
 
-    #[serde(default)]
     pub max_severity: Option<DiagnosticSeverity>,
 }
 
@@ -223,20 +219,12 @@ impl Default for InlineDiagnosticsSettings {
     fn default() -> Self {
         Self {
             enabled: false,
-            update_debounce_ms: default_inline_diagnostics_debounce_ms(),
-            padding: default_inline_diagnostics_padding(),
+            update_debounce_ms: 150,
+            padding: 4,
             min_column: 0,
             max_severity: None,
         }
     }
-}
-
-fn default_inline_diagnostics_debounce_ms() -> u64 {
-    150
-}
-
-fn default_inline_diagnostics_padding() -> u32 {
-    4
 }
 
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -118,22 +118,19 @@ pub enum DirenvSettings {
     Direct,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct DiagnosticsSettings {
     /// Whether to show the project diagnostics button in the status bar.
-    #[serde(default = "default_true")]
     pub button: bool,
 
     /// Whether or not to include warning diagnostics.
-    #[serde(default = "default_true")]
     pub include_warnings: bool,
 
     /// Settings for showing inline diagnostics.
-    #[serde(default)]
     pub inline: InlineDiagnosticsSettings,
 
     /// Configuration, related to Rust language diagnostics.
-    #[serde(default)]
     pub cargo: Option<CargoDiagnosticsSettings>,
 }
 
@@ -207,6 +204,17 @@ impl DiagnosticSeverity {
             DiagnosticSeverity::Warning => Some(lsp::DiagnosticSeverity::WARNING),
             DiagnosticSeverity::Info => Some(lsp::DiagnosticSeverity::INFORMATION),
             DiagnosticSeverity::Hint => Some(lsp::DiagnosticSeverity::HINT),
+        }
+    }
+}
+
+impl Default for DiagnosticsSettings {
+    fn default() -> Self {
+        Self {
+            button: true,
+            include_warnings: true,
+            inline: Default::default(),
+            cargo: Default::default(),
         }
     }
 }

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -2,50 +2,48 @@ use db::anyhow;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
-use util::serde::default_true;
 
-#[derive(Deserialize, Debug, Clone, Copy, PartialEq)]
+#[derive(Copy, Clone, Serialize, Deserialize, JsonSchema, Debug)]
+#[serde(default)]
 pub struct TitleBarSettings {
-    #[serde(default)]
-    pub show_branch_icon: bool,
-    #[serde(default = "default_true")]
-    pub show_branch_name: bool,
-    #[serde(default = "default_true")]
-    pub show_project_items: bool,
-    #[serde(default = "default_true")]
-    pub show_onboarding_banner: bool,
-    #[serde(default = "default_true")]
-    pub show_user_picture: bool,
-}
-
-#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
-pub struct TitleBarSettingsContent {
     /// Whether to show the branch icon beside branch switcher in the title bar.
     ///
     /// Default: false
-    pub show_branch_icon: Option<bool>,
+    pub show_branch_icon: bool,
     /// Whether to show onboarding banners in the title bar.
     ///
     /// Default: true
-    pub show_onboarding_banner: Option<bool>,
+    pub show_onboarding_banner: bool,
     /// Whether to show user avatar in the title bar.
     ///
     /// Default: true
-    pub show_user_picture: Option<bool>,
+    pub show_user_picture: bool,
     /// Whether to show the branch name button in the titlebar.
     ///
     /// Default: true
-    pub show_branch_name: Option<bool>,
+    pub show_branch_name: bool,
     /// Whether to show the project host and name in the titlebar.
     ///
     /// Default: true
-    pub show_project_items: Option<bool>,
+    pub show_project_items: bool,
+}
+
+impl Default for TitleBarSettings {
+    fn default() -> Self {
+        Self {
+            show_branch_icon: false,
+            show_onboarding_banner: true,
+            show_user_picture: true,
+            show_branch_name: true,
+            show_project_items: true,
+        }
+    }
 }
 
 impl Settings for TitleBarSettings {
     const KEY: Option<&'static str> = Some("title_bar");
 
-    type FileContent = TitleBarSettingsContent;
+    type FileContent = Self;
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut gpui::App) -> anyhow::Result<Self>
     where


### PR DESCRIPTION
Follow-up to #30565

This PR fixes the default settings values for the `DiagnosticsSettings`. The issue here was that due to the `#[derive(Default)]`, `button` would be false by default, which unintentionally hid the diagnostics button by default. The `#[serde(default = `default_true`)]` would only apply iff the diagnostics key was already present in the user's settings. Thus, if you have 

```json
{
    "diagnostics": {...}
}
```

in your settings, the button would show (given it was not disabled). However, if the key was not present, the button was not shown: Due to the derived default for the entire struct, the value would be false.

This PR fixes this by implementing the default instead and moving the `#[serde(default)]` up to the level of the struct.
I also did the same for the inline diagnostics settings, which already had a default impl and thus only needed the serde default on the struct instead of on all the struct fields.

Lastly, I simplified the title bar settings, since the serde attributes previously had no effect anyway (deserialization happened in the `TitlebarSettingsContent`, so these attributes had no effect) and we can remove the `TitlebarSettingsContent` as well as the attributes if we implement a proper default implementation instead.

Release Notes:

- Fixed the diagnostics status bar button being hidden by default. 