### PR TITLE
Bump font-kit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5548,9 +5548,9 @@ dependencies = [
 
 [[package]]
 name = "fontconfig-parser"
-version = "0.5.7"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1fcfcd44ca6e90c921fee9fa665d530b21ef1327a4c1a6c5250ea44b776ada7"
+checksum = "bbc773e24e02d4ddd8395fd30dc147524273a83e54e0f312d986ea30de5f5646"
 dependencies = [
  "roxmltree",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5515,15 +5515,15 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "font-kit"
-version = "0.14.1"
-source = "git+https://github.com/zed-industries/font-kit?rev=5474cfad4b719a72ec8ed2cb7327b2b01fd10568#5474cfad4b719a72ec8ed2cb7327b2b01fd10568"
+version = "0.14.2"
+source = "git+https://github.com/zed-industries/font-kit?rev=13dd2eae3b07045d0f51df9a3ff93070b92e2693#13dd2eae3b07045d0f51df9a3ff93070b92e2693"
 dependencies = [
  "bitflags 2.9.0",
  "byteorder",
  "core-foundation 0.10.0",
  "core-graphics 0.24.0",
  "core-text",
- "dirs 5.0.1",
+ "dirs 6.0.0",
  "dwrote",
  "float-ord",
  "freetype-sys",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -136,7 +136,7 @@ core-foundation-sys.workspace = true
 core-graphics = "0.24"
 core-video.workspace = true
 core-text = "21"
-font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "5474cfad4b719a72ec8ed2cb7327b2b01fd10568", optional = true }
+font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "13dd2eae3b07045d0f51df9a3ff93070b92e2693", optional = true }
 foreign-types = "0.5"
 log.workspace = true
 media.workspace = true
@@ -164,7 +164,7 @@ blade-macros = { workspace = true, optional = true }
 blade-util = { workspace = true, optional = true }
 bytemuck = { version = "1", optional = true }
 cosmic-text = { version = "0.14.0", optional = true }
-font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "5474cfad4b719a72ec8ed2cb7327b2b01fd10568", features = [
+font-kit = { git = "https://github.com/zed-industries/font-kit", rev = "13dd2eae3b07045d0f51df9a3ff93070b92e2693", features = [
     "source-fontconfig-dlopen",
 ], optional = true }
 scap = { workspace = true, optional = true }


### PR DESCRIPTION
https://github.com/zed-industries/font-kit/pull/5

Updates #20026

Release Notes:

- linux: Fix font loading in flatpak sandbox
