### PR TITLE
agent: Fix tool use in Gemini

### DIFF
--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -628,6 +628,7 @@ impl GoogleEventMapper {
         // responds with `finish_reason: STOP`
         if wants_to_use_tool {
             self.stop_reason = StopReason::ToolUse;
+            events.push(Ok(LanguageModelCompletionEvent::Stop(StopReason::ToolUse)));
         }
         events
     }


### PR DESCRIPTION
Thread doesn't run pending tools when `stop_reason` is not `ToolUse`. Perhaps we should change that so that it always runs pending tools if there are some, but for now this change just fixes setting `stop_reason` for Google models.

Release Notes:

- N/A