### PR TITLE
editor: Handle more completion sort cases

### DIFF
--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -1998,3 +1998,80 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
         "Match order not expected"
     );
 }
+
+#[gpui::test]
+fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
+    // Case 1: "serial"
+    let query: Option<&str> = Some("serial");
+    let mut matches: Vec<SortableMatch<'_>> = vec![
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 33,
+                score: 0.6666666666666666,
+                positions: vec![],
+                string: "serialize".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("80000000"),
+            sort_key: (3, "serialize"),
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 32,
+                score: 0.6666666666666666,
+                positions: vec![],
+                string: "serialize".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("80000000"),
+            sort_key: (3, "serialize"),
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 103,
+                score: 0.3529411764705882,
+                positions: vec![],
+                string: "serialization_key".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("7ffffffe"),
+            sort_key: (1, "serialization_key"),
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 18,
+                score: 0.3529411764705882,
+                positions: vec![],
+                string: "serialize_version".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("80000000"),
+            sort_key: (3, "serialize_version"),
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 65,
+                score: 0.32727272727272727,
+                positions: vec![],
+                string: "deserialize".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("80000000"),
+            sort_key: (3, "deserialize"),
+        },
+    ];
+    CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
+    assert_eq!(
+        matches
+            .iter()
+            .map(|m| m.string_match.string.as_str())
+            .collect::<Vec<&str>>(),
+        vec![
+            "serialization_key",
+            "serialize",
+            "serialize",
+            "serialize_version",
+            "deserialize"
+        ]
+    );
+}

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -2221,3 +2221,162 @@ fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
         ]
     );
 }
+
+#[gpui::test]
+fn test_sort_matches_for_local_methods_over_library(_cx: &mut TestAppContext) {
+    // Case 1: "setis"
+    let query: Option<&str> = Some("setis");
+    let mut matches: Vec<SortableMatch<'_>> = vec![
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1200,
+                score: 0.5555555555555556,
+                positions: vec![],
+                string: "setISODay".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 1,
+            sort_label: "setISODay",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1216,
+                score: 0.5,
+                positions: vec![],
+                string: "setISOWeek".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 1,
+            sort_label: "setISOWeek",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1232,
+                score: 0.3571428571428571,
+                positions: vec![],
+                string: "setISOWeekYear".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 1,
+            sort_label: "setISOWeekYear",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1217,
+                score: 0.3571428571428571,
+                positions: vec![],
+                string: "setISOWeekYear".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 3,
+            sort_label: "setISOWeekYear",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 53,
+                score: 0.3333333333333333,
+                positions: vec![],
+                string: "setIsRefreshing".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("11"),
+            sort_kind: 1,
+            sort_label: "setIsRefreshing",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1180,
+                score: 0.2571428571428571,
+                positions: vec![],
+                string: "setFips".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 3,
+            sort_label: "setFips",
+        },
+    ];
+    CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
+    assert_eq!(
+        matches
+            .iter()
+            .map(|m| m.string_match.string.as_str())
+            .collect::<Vec<&str>>(),
+        vec![
+            "setIsRefreshing",
+            "setISODay",
+            "setISOWeek",
+            "setISOWeekYear",
+            "setISOWeekYear",
+            "setFips"
+        ]
+    );
+}
+
+#[gpui::test]
+fn test_sort_matches_for_priotize_not_exact_match(_cx: &mut TestAppContext) {
+    // Case 1: "item"
+    let query: Option<&str> = Some("item");
+    let mut matches: Vec<SortableMatch<'_>> = vec![
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1115,
+                score: 1.0,
+                positions: vec![],
+                string: "Item".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 3,
+            sort_label: "Item",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1108,
+                score: 1.0,
+                positions: vec![],
+                string: "Item".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 1,
+            sort_label: "Item",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 26,
+                score: 0.8,
+                positions: vec![],
+                string: "items".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("11"),
+            sort_kind: 1,
+            sort_label: "items",
+        },
+        SortableMatch {
+            string_match: StringMatch {
+                candidate_id: 1138,
+                score: 0.5,
+                positions: vec![],
+                string: "ItemText".to_string(),
+            },
+            is_snippet: false,
+            sort_text: Some("16"),
+            sort_kind: 3,
+            sort_label: "ItemText",
+        },
+    ];
+    CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
+    assert_eq!(
+        matches
+            .iter()
+            .map(|m| m.string_match.string.as_str())
+            .collect::<Vec<&str>>(),
+        vec!["items", "Item", "Item", "ItemText"]
+    );
+}

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -19,7 +19,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "foo_bar_baz"),
+            sort_kind: 2,
+            sort_label: "foo_bar_baz",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -30,7 +31,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("7ffffffe"),
-            sort_key: (1, "foo_bar_qux"),
+            sort_kind: 1,
+            sort_label: "foo_bar_qux",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -41,7 +43,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "floorf64"),
+            sort_kind: 2,
+            sort_label: "floorf64",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -52,7 +55,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "floorf32"),
+            sort_kind: 2,
+            sort_label: "floorf32",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -63,7 +67,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "floorf16"),
+            sort_kind: 2,
+            sort_label: "floorf16",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -74,7 +79,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "floorf128"),
+            sort_kind: 2,
+            sort_label: "floorf128",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -111,7 +117,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "foo_bar_baz"),
+            sort_kind: 2,
+            sort_label: "foo_bar_baz",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -122,7 +129,8 @@ fn test_sort_matches_local_variable_over_global_variable(_cx: &mut TestAppContex
             },
             is_snippet: false,
             sort_text: Some("7ffffffe"),
-            sort_key: (1, "foo_bar_qux"),
+            sort_kind: 1,
+            sort_label: "foo_bar_qux",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -152,7 +160,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "ElementType"),
+            sort_kind: 2,
+            sort_label: "ElementType",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -163,7 +172,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffffe"),
-            sort_key: (1, "element_type"),
+            sort_kind: 1,
+            sort_label: "element_type",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -174,7 +184,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "simd_select"),
+            sort_kind: 2,
+            sort_label: "simd_select",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -185,7 +196,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (0, "while let"),
+            sort_kind: 0,
+            sort_label: "while let",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -212,7 +224,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "ElementType"),
+            sort_kind: 2,
+            sort_label: "ElementType",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -223,7 +236,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffffe"),
-            sort_key: (1, "element_type"),
+            sort_kind: 1,
+            sort_label: "element_type",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -234,7 +248,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "REPLACEMENT_CHARACTER"),
+            sort_kind: 2,
+            sort_label: "REPLACEMENT_CHARACTER",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -261,7 +276,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "ElementType"),
+            sort_kind: 2,
+            sort_label: "ElementType",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -272,7 +288,8 @@ fn test_sort_matches_local_variable_over_global_enum(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffffe"),
-            sort_key: (1, "element_type"),
+            sort_kind: 1,
+            sort_label: "element_type",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -302,7 +319,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unreachable"),
+            sort_kind: 2,
+            sort_label: "unreachable",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -313,7 +331,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "unreachable!(…)"),
+            sort_kind: 2,
+            sort_label: "unreachable!(…)",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -324,7 +343,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unchecked_rem"),
+            sort_kind: 2,
+            sort_label: "unchecked_rem",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -335,7 +355,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unreachable_unchecked"),
+            sort_kind: 2,
+            sort_label: "unreachable_unchecked",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -357,7 +378,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("80000000"),
-            sort_key: (3, "unreachable"),
+            sort_kind: 3,
+            sort_label: "unreachable",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -368,7 +390,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "unreachable!(…)"),
+            sort_kind: 3,
+            sort_label: "unreachable!(…)",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -379,7 +402,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("80000000"),
-            sort_key: (3, "unreachable_unchecked"),
+            sort_kind: 3,
+            sort_label: "unreachable_unchecked",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -401,7 +425,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unreachable"),
+            sort_kind: 2,
+            sort_label: "unreachable",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -412,7 +437,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "unreachable!(…)"),
+            sort_kind: 2,
+            sort_label: "unreachable!(…)",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -423,7 +449,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unreachable_unchecked"),
+            sort_kind: 2,
+            sort_label: "unreachable_unchecked",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -445,7 +472,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "unreachable"),
+            sort_kind: 3,
+            sort_label: "unreachable",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -456,7 +484,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "unreachable!(…)"),
+            sort_kind: 3,
+            sort_label: "unreachable!(…)",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -467,7 +496,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "unreachable_unchecked"),
+            sort_kind: 3,
+            sort_label: "unreachable_unchecked",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -489,7 +519,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unreachable"),
+            sort_kind: 2,
+            sort_label: "unreachable",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -500,7 +531,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "unreachable!(…)"),
+            sort_kind: 2,
+            sort_label: "unreachable!(…)",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -511,7 +543,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "unreachable_unchecked"),
+            sort_kind: 2,
+            sort_label: "unreachable_unchecked",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -536,7 +569,8 @@ fn test_sort_matches_variable_and_constants_over_function(_cx: &mut TestAppConte
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "var"), // function
+            sort_kind: 3,
+            sort_label: "var", // function
         },
         SortableMatch {
             string_match: StringMatch {
@@ -547,7 +581,8 @@ fn test_sort_matches_variable_and_constants_over_function(_cx: &mut TestAppConte
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (1, "var"), // variable
+            sort_kind: 1,
+            sort_label: "var", // variable
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -572,7 +607,8 @@ fn test_sort_matches_variable_and_constants_over_function(_cx: &mut TestAppConte
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "var"), // function
+            sort_kind: 3,
+            sort_label: "var", // function
         },
         SortableMatch {
             string_match: StringMatch {
@@ -583,7 +619,8 @@ fn test_sort_matches_variable_and_constants_over_function(_cx: &mut TestAppConte
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (2, "var"), // constant
+            sort_kind: 2,
+            sort_label: "var", // constant
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -598,7 +635,7 @@ fn test_sort_matches_variable_and_constants_over_function(_cx: &mut TestAppConte
 }
 
 #[gpui::test]
-fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
+fn test_sort_matches_for_jsx_event_handler(_cx: &mut TestAppContext) {
     // Case 1: "on"
     let query: Option<&str> = Some("on");
     let mut matches: Vec<SortableMatch<'_>> = vec![
@@ -611,7 +648,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onCut?"),
+            sort_kind: 3,
+            sort_label: "onCut?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -622,7 +660,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onPlay?"),
+            sort_kind: 3,
+            sort_label: "onPlay?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -633,7 +672,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "color?"),
+            sort_kind: 3,
+            sort_label: "color?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -644,7 +684,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "defaultValue?"),
+            sort_kind: 3,
+            sort_label: "defaultValue?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -655,7 +696,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "style?"),
+            sort_kind: 3,
+            sort_label: "style?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -666,7 +708,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "className?"),
+            sort_kind: 3,
+            sort_label: "className?",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -691,7 +734,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAbort?"),
+            sort_kind: 3,
+            sort_label: "onAbort?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -702,7 +746,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAuxClick?"),
+            sort_kind: 3,
+            sort_label: "onAuxClick?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -713,7 +758,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onPlay?"),
+            sort_kind: 3,
+            sort_label: "onPlay?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -724,7 +770,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onLoad?"),
+            sort_kind: 3,
+            sort_label: "onLoad?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -735,7 +782,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDrag?"),
+            sort_kind: 3,
+            sort_label: "onDrag?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -746,7 +794,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onPause?"),
+            sort_kind: 3,
+            sort_label: "onPause?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -757,7 +806,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onPaste?"),
+            sort_kind: 3,
+            sort_label: "onPaste?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -768,7 +818,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAnimationEnd?"),
+            sort_kind: 3,
+            sort_label: "onAnimationEnd?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -779,7 +830,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAbortCapture?"),
+            sort_kind: 3,
+            sort_label: "onAbortCapture?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -790,7 +842,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onChange?"),
+            sort_kind: 3,
+            sort_label: "onChange?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -801,7 +854,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onWaiting?"),
+            sort_kind: 3,
+            sort_label: "onWaiting?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -812,7 +866,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onCanPlay?"),
+            sort_kind: 3,
+            sort_label: "onCanPlay?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -823,7 +878,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAnimationStart?"),
+            sort_kind: 3,
+            sort_label: "onAnimationStart?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -834,7 +890,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAuxClickCapture?"),
+            sort_kind: 3,
+            sort_label: "onAuxClickCapture?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -845,7 +902,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onStalled?"),
+            sort_kind: 3,
+            sort_label: "onStalled?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -856,7 +914,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onPlaying?"),
+            sort_kind: 3,
+            sort_label: "onPlaying?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -867,7 +926,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDragEnd?"),
+            sort_kind: 3,
+            sort_label: "onDragEnd?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -878,7 +938,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onInvalid?"),
+            sort_kind: 3,
+            sort_label: "onInvalid?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -889,7 +950,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDragOver?"),
+            sort_kind: 3,
+            sort_label: "onDragOver?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -900,7 +962,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDragExit?"),
+            sort_kind: 3,
+            sort_label: "onDragExit?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -911,7 +974,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAnimationIteration?"),
+            sort_kind: 3,
+            sort_label: "onAnimationIteration?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -922,7 +986,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onRateChange?"),
+            sort_kind: 3,
+            sort_label: "onRateChange?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -933,7 +998,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onLoadStart?"),
+            sort_kind: 3,
+            sort_label: "onLoadStart?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -944,7 +1010,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDragStart?"),
+            sort_kind: 3,
+            sort_label: "onDragStart?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -955,7 +1022,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDragLeave?"),
+            sort_kind: 3,
+            sort_label: "onDragLeave?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -966,7 +1034,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onDragEnter?"),
+            sort_kind: 3,
+            sort_label: "onDragEnter?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -977,7 +1046,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onAnimationEndCapture?"),
+            sort_kind: 3,
+            sort_label: "onAnimationEndCapture?",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -988,7 +1058,8 @@ fn test_sort_matches_jsx_event_handler(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("12"),
-            sort_key: (3, "onLoadedData?"),
+            sort_kind: 3,
+            sort_label: "onLoadedData?",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -1029,7 +1100,8 @@ fn test_sort_matches_for_snippets(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (2, "println"),
+            sort_kind: 2,
+            sort_label: "println",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1040,7 +1112,8 @@ fn test_sort_matches_for_snippets(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("80000000"),
-            sort_key: (2, "println!(…)"),
+            sort_kind: 2,
+            sort_label: "println!(…)",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1065,7 +1138,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_text"),
+            sort_kind: 3,
+            sort_label: "set_text",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1076,7 +1150,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_placeholder_text"),
+            sort_kind: 3,
+            sort_label: "set_placeholder_text",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1087,7 +1162,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_text_style_refinement"),
+            sort_kind: 3,
+            sort_label: "set_text_style_refinement",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1098,7 +1174,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_context_menu_options"),
+            sort_kind: 3,
+            sort_label: "set_context_menu_options",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1109,7 +1186,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_next_word_end"),
+            sort_kind: 3,
+            sort_label: "select_to_next_word_end",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1120,7 +1198,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_next_subword_end"),
+            sort_kind: 3,
+            sort_label: "select_to_next_subword_end",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1131,7 +1210,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_custom_context_menu"),
+            sort_kind: 3,
+            sort_label: "set_custom_context_menu",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1142,7 +1222,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_end_of_excerpt"),
+            sort_kind: 3,
+            sort_label: "select_to_end_of_excerpt",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1153,7 +1234,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_start_of_excerpt"),
+            sort_kind: 3,
+            sort_label: "select_to_start_of_excerpt",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1164,7 +1246,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_start_of_next_excerpt"),
+            sort_kind: 3,
+            sort_label: "select_to_start_of_next_excerpt",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1175,7 +1258,8 @@ fn test_sort_matches_for_exact_match(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_end_of_previous_excerpt"),
+            sort_kind: 3,
+            sort_label: "select_to_end_of_previous_excerpt",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1214,7 +1298,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_beginning"),
+            sort_kind: 3,
+            sort_label: "select_to_beginning",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1225,7 +1310,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_collapse_matches"),
+            sort_kind: 3,
+            sort_label: "set_collapse_matches",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1236,7 +1322,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_autoindent"),
+            sort_kind: 3,
+            sort_label: "set_autoindent",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1247,7 +1334,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "set_all_diagnostics_active"),
+            sort_kind: 3,
+            sort_label: "set_all_diagnostics_active",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1258,7 +1346,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_to_end_of_line"),
+            sort_kind: 3,
+            sort_label: "select_to_end_of_line",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1269,7 +1358,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_all"),
+            sort_kind: 3,
+            sort_label: "select_all",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1280,7 +1370,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_line"),
+            sort_kind: 3,
+            sort_label: "select_line",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1291,7 +1382,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_left"),
+            sort_kind: 3,
+            sort_label: "select_left",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1302,7 +1394,8 @@ fn test_sort_matches_for_prefix_matches(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "select_down"),
+            sort_kind: 3,
+            sort_label: "select_down",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1339,7 +1432,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (0, "await"),
+            sort_kind: 0,
+            sort_label: "await",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1350,7 +1444,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000010"),
-            sort_key: (3, "await.ne"),
+            sort_kind: 3,
+            sort_label: "await.ne",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1361,7 +1456,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000010"),
-            sort_key: (3, "await.eq"),
+            sort_kind: 3,
+            sort_label: "await.eq",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1372,7 +1468,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffff8"),
-            sort_key: (3, "await.or"),
+            sort_kind: 3,
+            sort_label: "await.or",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1383,7 +1480,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000006"),
-            sort_key: (3, "await.zip"),
+            sort_kind: 3,
+            sort_label: "await.zip",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1394,7 +1492,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffff8"),
-            sort_key: (3, "await.xor"),
+            sort_kind: 3,
+            sort_label: "await.xor",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1405,7 +1504,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000006"),
-            sort_key: (3, "await.and"),
+            sort_kind: 3,
+            sort_label: "await.and",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1416,7 +1516,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000006"),
-            sort_key: (3, "await.map"),
+            sort_kind: 3,
+            sort_label: "await.map",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1427,7 +1528,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffff8"),
-            sort_key: (3, "await.take"),
+            sort_kind: 3,
+            sort_label: "await.take",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1460,7 +1562,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (0, "await"),
+            sort_kind: 0,
+            sort_label: "await",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1471,7 +1574,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000010"),
-            sort_key: (3, "await.ne"),
+            sort_kind: 3,
+            sort_label: "await.ne",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1482,7 +1586,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000010"),
-            sort_key: (3, "await.eq"),
+            sort_kind: 3,
+            sort_label: "await.eq",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1493,7 +1598,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffff8"),
-            sort_key: (3, "await.or"),
+            sort_kind: 3,
+            sort_label: "await.or",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1504,7 +1610,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000006"),
-            sort_key: (3, "await.zip"),
+            sort_kind: 3,
+            sort_label: "await.zip",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1515,7 +1622,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffff8"),
-            sort_key: (3, "await.xor"),
+            sort_kind: 3,
+            sort_label: "await.xor",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1526,7 +1634,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000006"),
-            sort_key: (3, "await.and"),
+            sort_kind: 3,
+            sort_label: "await.and",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1537,7 +1646,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000006"),
-            sort_key: (3, "await.map"),
+            sort_kind: 3,
+            sort_label: "await.map",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1548,7 +1658,8 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffff8"),
-            sort_key: (3, "await.take"),
+            sort_kind: 3,
+            sort_label: "await.take",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1585,7 +1696,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0003.__init__"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1596,7 +1708,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0003"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1607,7 +1720,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0005.__instancecheck__"),
-            sort_key: (3, "__instancecheck__"),
+            sort_kind: 3,
+            sort_label: "__instancecheck__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1618,7 +1732,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0004.__init_subclass__"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1629,7 +1744,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0005"),
-            sort_key: (3, "__instancecheck__"),
+            sort_kind: 3,
+            sort_label: "__instancecheck__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1640,7 +1756,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0004"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1670,7 +1787,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0004.__init__"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1681,7 +1799,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0004"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1692,7 +1811,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0003.__init_subclass__"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1703,7 +1823,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0003"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1731,7 +1852,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0000.__init__"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1742,7 +1864,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0000"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1753,7 +1876,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0001.__init_subclass__"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1764,7 +1888,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0001"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1792,7 +1917,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("11.9999.__init__"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1803,7 +1929,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("11.9999"),
-            sort_key: (3, "__init__"),
+            sort_kind: 3,
+            sort_label: "__init__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1814,7 +1941,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0000.__init_subclass__"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1825,7 +1953,8 @@ fn test_sort_matches_for_python_init(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("05.0000"),
-            sort_key: (3, "__init_subclass__"),
+            sort_kind: 3,
+            sort_label: "__init_subclass__",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::Top);
@@ -1857,7 +1986,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000004"),
-            sort_key: (3, "into"),
+            sort_kind: 3,
+            sort_label: "into",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1868,7 +1998,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000004"),
-            sort_key: (3, "try_into"),
+            sort_kind: 3,
+            sort_label: "try_into",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1879,7 +2010,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("80000004"),
-            sort_key: (3, "println"),
+            sort_kind: 3,
+            sort_label: "println",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1890,7 +2022,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000004"),
-            sort_key: (3, "clone_into"),
+            sort_kind: 3,
+            sort_label: "clone_into",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1901,7 +2034,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "into_searcher"),
+            sort_kind: 3,
+            sort_label: "into_searcher",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1912,7 +2046,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: true,
             sort_text: Some("80000004"),
-            sort_key: (3, "eprintln"),
+            sort_kind: 3,
+            sort_label: "eprintln",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -1933,7 +2068,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000004"),
-            sort_key: (3, "into"),
+            sort_kind: 3,
+            sort_label: "into",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1944,7 +2080,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000004"),
-            sort_key: (3, "try_into"),
+            sort_kind: 3,
+            sort_label: "try_into",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1955,7 +2092,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000004"),
-            sort_key: (3, "clone_into"),
+            sort_kind: 3,
+            sort_label: "clone_into",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1966,7 +2104,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "into_searcher"),
+            sort_kind: 3,
+            sort_label: "into_searcher",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1977,7 +2116,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "split_terminator"),
+            sort_kind: 3,
+            sort_label: "split_terminator",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -1988,7 +2128,8 @@ fn test_sort_matches_for_rust_into(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7fffffff"),
-            sort_key: (3, "rsplit_terminator"),
+            sort_kind: 3,
+            sort_label: "rsplit_terminator",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
@@ -2013,7 +2154,8 @@ fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "serialize"),
+            sort_kind: 3,
+            sort_label: "serialize",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -2024,7 +2166,8 @@ fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "serialize"),
+            sort_kind: 3,
+            sort_label: "serialize",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -2035,7 +2178,8 @@ fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("7ffffffe"),
-            sort_key: (1, "serialization_key"),
+            sort_kind: 1,
+            sort_label: "serialization_key",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -2046,7 +2190,8 @@ fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "serialize_version"),
+            sort_kind: 3,
+            sort_label: "serialize_version",
         },
         SortableMatch {
             string_match: StringMatch {
@@ -2057,7 +2202,8 @@ fn test_sort_matches_for_variable_over_function(_cx: &mut TestAppContext) {
             },
             is_snippet: false,
             sort_text: Some("80000000"),
-            sort_key: (3, "deserialize"),
+            sort_kind: 3,
+            sort_label: "deserialize",
         },
     ];
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());

--- a/crates/editor/src/code_completion_tests.rs
+++ b/crates/editor/src/code_completion_tests.rs
@@ -550,8 +550,8 @@ fn test_sort_matches_for_unreachable(_cx: &mut TestAppContext) {
     CompletionsMenu::sort_matches(&mut matches, query, SnippetSortOrder::default());
     assert_eq!(
         matches[0].string_match.string.as_str(),
-        "unreachable",
-        "Perfect fuzzy match should be preferred over others"
+        "unreachable!(…)",
+        "LSP should take over even when fuzzy perfect matches"
     );
 }
 
@@ -1541,13 +1541,13 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
         vec![
             "await",
             "await.or",
+            "await.eq",
+            "await.ne",
             "await.xor",
             "await.take",
             "await.and",
             "await.map",
-            "await.zip",
-            "await.eq",
-            "await.ne"
+            "await.zip"
         ]
     );
     // Case 2: "await"
@@ -1671,13 +1671,13 @@ fn test_sort_matches_for_await(_cx: &mut TestAppContext) {
         vec![
             "await",
             "await.or",
+            "await.eq",
+            "await.ne",
             "await.xor",
             "await.take",
             "await.and",
             "await.map",
-            "await.zip",
-            "await.eq",
-            "await.ne"
+            "await.zip"
         ]
     );
 }

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -664,7 +664,6 @@ impl CompletionsMenu {
         #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
         enum MatchTier<'a> {
             WordStartMatch {
-                sort_perfect_score: Reverse<usize>,
                 sort_mixed_case_prefix_length: Reverse<usize>,
                 sort_snippet: Reverse<i32>,
                 sort_kind: usize,
@@ -682,12 +681,12 @@ impl CompletionsMenu {
         // balance the raw fuzzy match score with hints from the language server
 
         // In a fuzzy bracket, matches with a score of 1.0 are prioritized.
-        // The remaining matches are partitioned into two groups at 2/3 of the max_score.
+        // The remaining matches are partitioned into two groups at 3/5 of the max_score.
         let max_score = matches
             .iter()
             .map(|mat| mat.string_match.score)
             .fold(0.0, f64::max);
-        let fuzzy_bracket_threshold = max_score * (2.0 / 3.0);
+        let fuzzy_bracket_threshold = max_score * (3.0 / 5.0);
 
         let query_start_lower = query
             .and_then(|q| q.chars().next())
@@ -711,7 +710,6 @@ impl CompletionsMenu {
             if query_start_doesnt_match_split_words {
                 MatchTier::OtherMatch { sort_score }
             } else {
-                let sort_perfect_score = Reverse(if score == 1.0 { 1 } else { 0 });
                 let sort_fuzzy_bracket = Reverse(if score >= fuzzy_bracket_threshold {
                     1
                 } else {
@@ -742,7 +740,6 @@ impl CompletionsMenu {
                         .unwrap_or(0),
                 );
                 MatchTier::WordStartMatch {
-                    sort_perfect_score,
                     sort_mixed_case_prefix_length,
                     sort_snippet,
                     sort_kind: mat.sort_kind,

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -664,12 +664,14 @@ impl CompletionsMenu {
         #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
         enum MatchTier<'a> {
             WordStartMatch {
-                sort_prefix: Reverse<usize>,
-                sort_fuzzy_bracket: Reverse<usize>,
+                sort_perfect_score: Reverse<usize>,
+                sort_mixed_case_prefix_length: Reverse<usize>,
                 sort_snippet: Reverse<i32>,
+                sort_kind: usize,
+                sort_fuzzy_bracket: Reverse<usize>,
                 sort_text: Option<&'a str>,
                 sort_score: Reverse<OrderedFloat<f64>>,
-                sort_key: (usize, &'a str),
+                sort_label: &'a str,
             },
             OtherMatch {
                 sort_score: Reverse<OrderedFloat<f64>>,
@@ -685,7 +687,7 @@ impl CompletionsMenu {
             .iter()
             .map(|mat| mat.string_match.score)
             .fold(0.0, f64::max);
-        let second_bracket_threshold = max_score * (2.0 / 3.0);
+        let fuzzy_bracket_threshold = max_score * (2.0 / 3.0);
 
         let query_start_lower = query
             .and_then(|q| q.chars().next())
@@ -709,9 +711,8 @@ impl CompletionsMenu {
             if query_start_doesnt_match_split_words {
                 MatchTier::OtherMatch { sort_score }
             } else {
-                let sort_fuzzy_bracket = Reverse(if score == 1.0 {
-                    2
-                } else if score >= second_bracket_threshold {
+                let sort_perfect_score = Reverse(if score == 1.0 { 1 } else { 0 });
+                let sort_fuzzy_bracket = Reverse(if score >= fuzzy_bracket_threshold {
                     1
                 } else {
                     0
@@ -721,7 +722,7 @@ impl CompletionsMenu {
                     SnippetSortOrder::Bottom => Reverse(if mat.is_snippet { 0 } else { 1 }),
                     SnippetSortOrder::Inline => Reverse(0),
                 };
-                let mixed_case_prefix_length = Reverse(
+                let sort_mixed_case_prefix_length = Reverse(
                     query
                         .map(|q| {
                             q.chars()
@@ -741,12 +742,14 @@ impl CompletionsMenu {
                         .unwrap_or(0),
                 );
                 MatchTier::WordStartMatch {
-                    sort_prefix: mixed_case_prefix_length,
-                    sort_fuzzy_bracket,
+                    sort_perfect_score,
+                    sort_mixed_case_prefix_length,
                     sort_snippet,
+                    sort_kind: mat.sort_kind,
+                    sort_fuzzy_bracket,
                     sort_text: mat.sort_text,
                     sort_score,
-                    sort_key: mat.sort_key,
+                    sort_label: mat.sort_label,
                 }
             }
         });
@@ -797,13 +800,14 @@ impl CompletionsMenu {
                             None
                         };
 
-                    let sort_key = completion.sort_key();
+                    let (sort_kind, sort_label) = completion.sort_key();
 
                     SortableMatch {
                         string_match,
                         is_snippet,
                         sort_text,
-                        sort_key,
+                        sort_kind,
+                        sort_label,
                     }
                 })
                 .collect();
@@ -828,7 +832,8 @@ pub struct SortableMatch<'a> {
     pub string_match: StringMatch,
     pub is_snippet: bool,
     pub sort_text: Option<&'a str>,
-    pub sort_key: (usize, &'a str),
+    pub sort_kind: usize,
+    pub sort_label: &'a str,
 }
 
 #[derive(Clone)]

--- a/typos.toml
+++ b/typos.toml
@@ -47,7 +47,9 @@ extend-exclude = [
     # Eval examples for prompts and criteria
     "crates/eval/src/examples/",
     # typos-cli doesn't understand our `vˇariable` markup
-    "crates/editor/src/hover_links.rs"
+    "crates/editor/src/hover_links.rs",
+    # typos-cli doesn't understand `setis` is intentional test case
+    "crates/editor/src/code_completion_tests.rs"
 ]
 
 [default]


### PR DESCRIPTION
Adds 3 more test cases where local variable should be preferred over method, and local method over library methods.

Before / After:

<img height="280" alt="before-rust" src="https://github.com/user-attachments/assets/72b34ce8-89ff-4c2b-87dc-9e63f855d31e" />
<img height="280" alt="after-rust" src="https://github.com/user-attachments/assets/8e23c9ca-576c-4dc5-8946-fa37554a19e0" />

Before / After:

<img height="280" alt="before-react" src="https://github.com/user-attachments/assets/f7070413-e397-441a-a0c1-16d8ce25aa12" />
<img height="280" alt="after-react" src="https://github.com/user-attachments/assets/7a095954-7844-4a3e-bf59-5420b7ffdb03" />

Release Notes:

- N/A
