### PR TITLE
Add a separator before Quit in the application menu

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -44,6 +44,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Hide Others", super::HideOthers),
                 #[cfg(target_os = "macos")]
                 MenuItem::action("Show All", super::ShowAll),
+                MenuItem::separator(),
                 MenuItem::action("Quit", Quit),
             ],
         },


### PR DESCRIPTION
macOS applications should have a separator between “Show All” and “Quit” in the application menu.

Release Notes:

- N/A