### PR TITLE
Add excluded_files to pane::DeploySearch

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1028,6 +1028,12 @@ impl ProjectSearchView {
                     .update(cx, |editor, cx| editor.set_text(included_files, window, cx));
                 search.filters_enabled = true;
             }
+            if let Some(excluded_files) = action.excluded_files.as_deref() {
+                search
+                    .excluded_files_editor
+                    .update(cx, |editor, cx| editor.set_text(excluded_files, window, cx));
+                search.filters_enabled = true;
+            }
             search.focus_query_editor(window, cx)
         });
     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -156,6 +156,8 @@ pub struct DeploySearch {
     pub replace_enabled: bool,
     #[serde(default)]
     pub included_files: Option<String>,
+    #[serde(default)]
+    pub excluded_files: Option<String>,
 }
 
 impl_actions!(
@@ -203,6 +205,7 @@ impl DeploySearch {
         Self {
             replace_enabled: false,
             included_files: None,
+            excluded_files: None,
         }
     }
 }
@@ -3116,6 +3119,7 @@ fn default_render_tab_bar_buttons(
                                 DeploySearch {
                                     replace_enabled: false,
                                     included_files: None,
+                                    excluded_files: None,
                                 }
                                 .boxed_clone(),
                             )


### PR DESCRIPTION
In accordance with #30327, I saw no reason for included files to get special treatment, and I actually get use out of prefilling excluded files because I like not to search symlinked files which, in my workflow, use a naming convention.

This is simply implementing the same exact changes, but for excluded. It was tested with `"space /": ["pane::DeploySearch", { "excluded_files": "**/_*.tf" }]` and works just fine.

Closes #ISSUE

Release Notes:

- Added `excluded_files` to `pane::DeploySearch`.
