### PR TITLE
context_server: Fix casing of `mimeType` in tool responses

### DIFF
--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -604,7 +604,7 @@ pub struct CallToolResponse {
 pub enum ToolResponseContent {
     #[serde(rename = "text")]
     Text { text: String },
-    #[serde(rename = "image")]
+    #[serde(rename = "image", rename_all = "camelCase")]
     Image { data: String, mime_type: String },
     #[serde(rename = "resource")]
     Resource { resource: ResourceContents },


### PR DESCRIPTION
Closes #30243

Release Notes:

- Fixed wrong casing for the `mimeType` field when parsing MCP server image responses.
