### PR TITLE
client: Remove excess intermediate buffer

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -13,7 +13,7 @@ use settings::{Settings, SettingsStore};
 use sha2::{Digest, Sha256};
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
-use std::io::Write;
+use std::io::{BufWriter, Write};
 use std::sync::LazyLock;
 use std::time::Instant;
 use std::{env, mem, path::PathBuf, sync::Arc, time::Duration};
@@ -508,9 +508,10 @@ impl Telemetry {
         self.executor.spawn(
             async move {
                 if let Some(file) = &mut this.state.lock().log_file {
+                    let mut writer = BufWriter::new(file);
                     for event in &mut events {
-                        serde_json::to_writer(&mut *file, event)?;
-                        file.write_all(b"\n")?;
+                        serde_json::to_writer(&mut writer, event)?;
+                        writer.write_all(b"\n")?;
                     }
                 }
 


### PR DESCRIPTION
`serde_json::to_writer` can write directly into a `File` instead of using an intermediate buffer. We can then make the call to `build_request` significantly cheaper by 1. removing the excess Vec, 2. avoid passing the `EventRequestBody` by value, since it's rather large, and we only require a reference for serialization anyway.

I also removed an extra clone in the `report_event` function, since the background executor is contained within `self` we don't need to clone it separately.

note: `serde_json::to_writer` doesn't necessarily use `write_all`, but we write a newline into it afterwards anyway, which ensures the buffer gets flushed and previous behavior is maintained.

edit: I added a `BufWriter` around the `File`, since `serde_json` often writes in small chunks and it better matches the performance characteristics  of the `Vec` implementation. This unfortunately kind of defeats the purpose of getting rid of the `Vec`. So I'll close the PR and open a new one with only the beneficial changes

Release Notes:

- N/A
