### PR TITLE
extension: Update wasi preview adapter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5065,6 +5065,7 @@ dependencies = [
  "task",
  "toml 0.8.20",
  "util",
+ "wasi-preview1-component-adapter-provider",
  "wasm-encoder 0.221.3",
  "wasmparser 0.221.3",
  "wit-component 0.221.3",
@@ -16210,6 +16211,12 @@ checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt 0.39.0",
 ]
+
+[[package]]
+name = "wasi-preview1-component-adapter-provider"
+version = "29.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcd9f21bbde82ba59e415a8725e6ad0d0d7e9e460b1a3ccbca5bdee952c1a324"
 
 [[package]]
 name = "wasite"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -594,6 +594,7 @@ url = "2.2"
 urlencoding = "2.1.2"
 uuid = { version = "1.1.2", features = ["v4", "v5", "v7", "serde"] }
 walkdir = "2.3"
+wasi-preview1-component-adapter-provider = "29"
 wasm-encoder = "0.221"
 wasmparser = "0.221"
 wasmtime = { version = "29", default-features = false, features = [

--- a/crates/extension/Cargo.toml
+++ b/crates/extension/Cargo.toml
@@ -33,6 +33,7 @@ serde_json.workspace = true
 task.workspace = true
 toml.workspace = true
 util.workspace = true
+wasi-preview1-component-adapter-provider.workspace = true
 wasm-encoder.workspace = true
 wasmparser.workspace = true
 wit-component.workspace = true


### PR DESCRIPTION
Replace dynamic downloading of WASI adapter with the provided crate.

More importantly, this makes sure we are using the same adapter version
as our version of wasmtime, which includes several fixes.

Arguably we could also at this point update to wasm32-wasip2 target and
remove this dependency as well if we want, but that might need further
testing.

Release Notes:

- N/A
