### PR TITLE
Debounce language server file system events

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -9150,7 +9150,7 @@ impl LspStore {
             if watch.pending_events.is_empty() {
                 continue;
             }
-            let server_id = server_id.clone();
+            let server_id = *server_id;
 
             watch.flush_timer_task = Some(cx.spawn(async move |this, cx| {
                 cx.background_executor()

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::format_collect)]
 
 use crate::{
-    Event, git_store::StatusEntry, task_inventory::TaskContexts, task_store::TaskSettingsLocation,
-    *,
+    Event, git_store::StatusEntry, lsp_store::FS_WATCH_DEBOUNCE_TIMEOUT,
+    task_inventory::TaskContexts, task_store::TaskSettingsLocation, *,
 };
 use buffer_diff::{
     BufferDiffEvent, CALCULATE_DIFF_TASK, DiffHunkSecondaryStatus, DiffHunkStatus,
@@ -1190,6 +1190,9 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
 
     // The language server receives events for the FS mutations that match its watch patterns.
     cx.executor().run_until_parked();
+    cx.executor().advance_clock(FS_WATCH_DEBOUNCE_TIMEOUT);
+    cx.executor().run_until_parked();
+
     assert_eq!(
         &*file_changes.lock(),
         &[


### PR DESCRIPTION
This helps prevent a race condition where the language server would update in the middle of a `git checkout` 

Release Notes:

- N/A
