### PR TITLE
askpass: Workaround rust lang 69343

### DIFF
--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -163,8 +163,10 @@ impl AskPassSession {
 #[cfg(unix)]
 fn get_shell_safe_zed_path() -> anyhow::Result<String> {
     let zed_path = std::env::current_exe()
-        .context("Failed to figure out current executable path for use in askpass")?
+        .context("Failed to determine current executable path for use in askpass")?
         .to_string_lossy()
+        // see https://github.com/rust-lang/rust/issues/69343
+        .trim_end_matches(" (deleted)")
         .to_string();
 
     // NOTE: this was previously enabled, however, it caused errors when it shouldn't have

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -426,8 +426,8 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn app_path(&self) -> Result<PathBuf> {
         // get the path of the executable of the current process
-        let exe_path = env::current_exe()?;
-        Ok(exe_path)
+        let app_path = env::current_exe()?;
+        return Ok(app_path);
     }
 
     fn set_menus(&self, menus: Vec<Menu>, _keymap: &Keymap) {


### PR DESCRIPTION
Closes #ISSUE

Work around https://github.com/rust-lang/rust/issues/69343 in askpass

Release Notes:

- Fixed an issue with askpass on Linux after an auto-update is installed but not yet applied
