### PR TITLE
editor: Do not start scroll when hovering the scroll thumb during dragging events

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5342,7 +5342,9 @@ impl EditorElement {
 
                         editor.scroll_manager.show_scrollbars(window, cx);
                         cx.stop_propagation();
-                    } else if let Some((layout, axis)) = scrollbars_layout.get_hovered_axis(window)
+                    } else if let Some((layout, axis)) = scrollbars_layout
+                        .get_hovered_axis(window)
+                        .filter(|_| !event.dragging())
                     {
                         if layout
                             .thumb_bounds

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -374,6 +374,7 @@ impl ScrollManager {
     pub fn dragging_scrollbar_axis(&self) -> Option<Axis> {
         self.active_scrollbar
             .as_ref()
+            .filter(|scrollbar| scrollbar.thumb_state == ScrollbarThumbState::Dragging)
             .map(|scrollbar| scrollbar.axis)
     }
 


### PR DESCRIPTION
Closes #30756
Closes #30729
Follow-up to #28064

The issue arose because GPUI does still propagate mouse events to all event handlers during dragging actions even if the dragging action does not belong to the current handler. I forgot about this in the other PR.

This resulted in an incorrect hover being registered for the thumb, which was sufficient to trigger scrolling in the next frame, since `dragging_scrollbar_axis` did not consider the actual thumb state (this was generally sufficient, but not with this incorrectly registered hover).

Theoretically, either of the both commits would suffice for fixing the issue. However, I think it is better to fix both issues at hand instead of just one. Now, we will only start the scroll on actual scrollbar clicks and not show a hover on the thumb if any other drag is currently going on.

https://github.com/user-attachments/assets/6634ffa0-78fc-428f-99b2-7bc23a320676

Release Notes:

- Fixed an issue where editor scrollbars would start scrolling when hovering over the thumb whilst already dragging something else.