### PR TITLE
gpui: Activate the window example along with the Quit action

### DIFF
--- a/crates/gpui/examples/input.rs
+++ b/crates/gpui/examples/input.rs
@@ -26,6 +26,7 @@ actions!(
         Paste,
         Cut,
         Copy,
+        Quit,
     ]
 );
 
@@ -736,5 +737,7 @@ fn main() {
                 cx.activate(true);
             })
             .unwrap();
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
     });
 }

--- a/crates/gpui/examples/window.rs
+++ b/crates/gpui/examples/window.rs
@@ -1,6 +1,6 @@
 use gpui::{
-    App, Application, Bounds, Context, SharedString, Timer, Window, WindowBounds, WindowKind,
-    WindowOptions, div, prelude::*, px, rgb, size,
+    App, Application, Bounds, Context, KeyBinding, SharedString, Timer, Window, WindowBounds,
+    WindowKind, WindowOptions, actions, div, prelude::*, px, rgb, size,
 };
 
 struct SubWindow {
@@ -172,6 +172,8 @@ impl Render for WindowDemo {
     }
 }
 
+actions!(window, [Quit]);
+
 fn main() {
     Application::new().run(|cx: &mut App| {
         let bounds = Bounds::centered(None, size(px(800.0), px(600.0)), cx);
@@ -193,5 +195,8 @@ fn main() {
             },
         )
         .unwrap();
+        cx.activate(true);
+        cx.on_action(|_: &Quit, cx| cx.quit());
+        cx.bind_keys([KeyBinding::new("cmd-q", Quit, None)]);
     });
 }


### PR DESCRIPTION
Make the gpui examples more consistent by activating the window upon startup.
Most of the examples have 

```rust
activate(true) 
```

so this one should as well.

Make it easier to exit the example with the `cmd-q` KeyBinding

Release Notes:

- N/A