### PR TITLE
Prevent editor focus after find and replace operations

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1460,7 +1460,6 @@ impl BufferSearchBar {
                             self.select_next_match(&SelectNextMatch, window, cx);
                         }
                         should_propagate = false;
-                        self.focus_editor(&FocusEditor, window, cx);
                     }
                 }
             }


### PR DESCRIPTION
Release Notes:

- Fixed an inconsistent behavior in the buffer "find and replace" UI where focus would be given to the editor after a replacement is made.
