### PR TITLE
editor: Improve JSDoc extend comment on newline to follow convention

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4037,20 +4037,20 @@ impl Editor {
                                 };
 
                                 let cursor_is_before_end_tag_if_exists = {
-                                    let num_of_whitspaces_from_back = snapshot
+                                    let num_of_whitespaces_rev = snapshot
                                         .reversed_chars_for_range(range.clone())
                                         .take_while(|c| c.is_whitespace())
                                         .count();
                                     let mut line_iter = snapshot
                                         .reversed_chars_for_range(range)
-                                        .skip(num_of_whitspaces_from_back);
+                                        .skip(num_of_whitespaces_rev);
                                     let end_tag_exists = end_tag
                                         .chars()
                                         .rev()
                                         .all(|char| line_iter.next() == Some(char));
                                     if end_tag_exists {
                                         let max_point = snapshot.line_len(start_point.row) as usize;
-                                        let ordering = (num_of_whitspaces_from_back
+                                        let ordering = (num_of_whitespaces_rev
                                             + end_tag.len()
                                             + start_point.column as usize)
                                             .cmp(&max_point);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3912,7 +3912,7 @@ impl Editor {
     pub fn newline(&mut self, _: &Newline, window: &mut Window, cx: &mut Context<Self>) {
         self.hide_mouse_cursor(&HideMouseCursorOrigin::TypingAction);
         self.transact(window, cx, |this, window, cx| {
-            let (edits, selection_fixup_info): (Vec<_>, Vec<_>) = {
+            let (edits_with_flags, selection_info): (Vec<_>, Vec<_>) = {
                 let selections = this.selections.all::<usize>(cx);
                 let multi_buffer = this.buffer.read(cx);
                 let buffer = multi_buffer.snapshot(cx);
@@ -3927,56 +3927,14 @@ impl Editor {
                         let end = selection.end;
                         let selection_is_empty = start == end;
                         let language_scope = buffer.language_scope_at(start);
-                        let (delimiter, insert_extra_newline) = if let Some(language) =
-                            &language_scope
-                        {
-                            let mut insert_extra_newline =
-                                insert_extra_newline_brackets(&buffer, start..end, language)
-                                    || insert_extra_newline_tree_sitter(&buffer, start..end);
+                        let (delimiter, insert_extra_newline, prevent_auto_indent) =
+                            if let Some(language) = &language_scope {
+                                let mut insert_extra_newline =
+                                    insert_extra_newline_brackets(&buffer, start..end, language)
+                                        || insert_extra_newline_tree_sitter(&buffer, start..end);
 
-                            // Comment extension on newline is allowed only for cursor selections
-                            let mut delimiter = maybe!({
-                                if !selection_is_empty {
-                                    return None;
-                                }
-
-                                if !multi_buffer.language_settings(cx).extend_comment_on_newline {
-                                    return None;
-                                }
-
-                                let delimiters = language.line_comment_prefixes();
-                                let max_len_of_delimiter =
-                                    delimiters.iter().map(|delimiter| delimiter.len()).max()?;
-                                let (snapshot, range) =
-                                    buffer.buffer_line_for_row(MultiBufferRow(start_point.row))?;
-
-                                let mut index_of_first_non_whitespace = 0;
-                                let comment_candidate = snapshot
-                                    .chars_for_range(range)
-                                    .skip_while(|c| {
-                                        let should_skip = c.is_whitespace();
-                                        if should_skip {
-                                            index_of_first_non_whitespace += 1;
-                                        }
-                                        should_skip
-                                    })
-                                    .take(max_len_of_delimiter)
-                                    .collect::<String>();
-                                let comment_prefix = delimiters.iter().find(|comment_prefix| {
-                                    comment_candidate.starts_with(comment_prefix.as_ref())
-                                })?;
-                                let cursor_is_placed_after_comment_marker =
-                                    index_of_first_non_whitespace + comment_prefix.len()
-                                        <= start_point.column as usize;
-                                if cursor_is_placed_after_comment_marker {
-                                    Some(comment_prefix.clone())
-                                } else {
-                                    None
-                                }
-                            });
-
-                            if delimiter.is_none() {
-                                delimiter = maybe!({
+                                // Comment extension on newline is allowed only for cursor selections
+                                let mut delimiter = maybe!({
                                     if !selection_is_empty {
                                         return None;
                                     }
@@ -3986,88 +3944,136 @@ impl Editor {
                                         return None;
                                     }
 
-                                    let block = language.documentation_block();
-                                    let block_start = block.first()?;
-                                    let block_end = block.last()?;
-
-                                    let delimiter = language.documentation_comment_prefix()?;
-
+                                    let delimiters = language.line_comment_prefixes();
+                                    let max_len_of_delimiter =
+                                        delimiters.iter().map(|delimiter| delimiter.len()).max()?;
                                     let (snapshot, range) = buffer
                                         .buffer_line_for_row(MultiBufferRow(start_point.row))?;
 
-                                    let cursor_is_after_block_start = {
-                                        let block_start_len = block_start.len();
-                                        let num_of_whitespaces = snapshot
-                                            .chars_for_range(range.clone())
-                                            .take_while(|c| c.is_whitespace())
-                                            .count();
-                                        let block_start_line = snapshot
-                                            .chars_for_range(range.clone())
-                                            .skip(num_of_whitespaces)
-                                            .take(block_start_len)
-                                            .collect::<String>();
-                                        if block_start_line.starts_with(block_start.as_ref()) {
-                                            num_of_whitespaces + block_start_len
-                                                <= start_point.column as usize
-                                        } else {
-                                            let delimiter_trimmed = delimiter.trim();
-                                            let start_line = snapshot
-                                                .chars_for_range(range.clone())
-                                                .skip(num_of_whitespaces)
-                                                .take(delimiter_trimmed.len())
-                                                .collect::<String>();
-                                            if start_line.starts_with(delimiter_trimmed) {
-                                                num_of_whitespaces + delimiter_trimmed.len()
-                                                    <= start_point.column as usize
-                                            } else {
-                                                false
+                                    let mut index_of_first_non_whitespace = 0;
+                                    let comment_candidate = snapshot
+                                        .chars_for_range(range)
+                                        .skip_while(|c| {
+                                            let should_skip = c.is_whitespace();
+                                            if should_skip {
+                                                index_of_first_non_whitespace += 1;
                                             }
-                                        }
-                                    };
-
-                                    let cursor_is_before_end_if_exists = {
-                                        let num_of_whitspaces = snapshot
-                                            .reversed_chars_for_range(range.clone())
-                                            .take_while(|c| c.is_whitespace())
-                                            .count();
-                                        let mut line_iter = snapshot
-                                            .reversed_chars_for_range(range)
-                                            .skip(num_of_whitspaces);
-                                        let block_end_exists = block_end
-                                            .chars()
-                                            .rev()
-                                            .all(|char| line_iter.next() == Some(char));
-                                        if block_end_exists {
-                                            let max_point =
-                                                snapshot.line_len(start_point.row) as usize;
-                                            let cursor_is_before_block_end = num_of_whitspaces
-                                                + block_end.len()
-                                                + start_point.column as usize
-                                                <= max_point;
-                                            if cursor_is_before_block_end
-                                                && cursor_is_after_block_start
-                                            {
-                                                insert_extra_newline = true;
-                                            }
-                                            cursor_is_before_block_end
-                                        } else {
-                                            true
-                                        }
-                                    };
-
-                                    if cursor_is_after_block_start && cursor_is_before_end_if_exists
-                                    {
-                                        Some(delimiter.clone())
+                                            should_skip
+                                        })
+                                        .take(max_len_of_delimiter)
+                                        .collect::<String>();
+                                    let comment_prefix =
+                                        delimiters.iter().find(|comment_prefix| {
+                                            comment_candidate.starts_with(comment_prefix.as_ref())
+                                        })?;
+                                    let cursor_is_placed_after_comment_marker =
+                                        index_of_first_non_whitespace + comment_prefix.len()
+                                            <= start_point.column as usize;
+                                    if cursor_is_placed_after_comment_marker {
+                                        Some(comment_prefix.clone())
                                     } else {
                                         None
                                     }
                                 });
-                            }
 
-                            (delimiter, insert_extra_newline)
-                        } else {
-                            (None, false)
-                        };
+                                let mut prevent_auto_indent = false;
+                                if delimiter.is_none() {
+                                    delimiter = maybe!({
+                                        if !selection_is_empty {
+                                            return None;
+                                        }
+
+                                        if !multi_buffer
+                                            .language_settings(cx)
+                                            .extend_comment_on_newline
+                                        {
+                                            return None;
+                                        }
+
+                                        let block = language.documentation_block();
+                                        let block_start = block.first()?;
+                                        let block_end = block.last()?;
+
+                                        let delimiter = language.documentation_comment_prefix()?;
+
+                                        let (snapshot, range) = buffer
+                                            .buffer_line_for_row(MultiBufferRow(start_point.row))?;
+
+                                        let cursor_is_after_block_start = {
+                                            let block_start_len = block_start.len();
+                                            let num_of_whitespaces = snapshot
+                                                .chars_for_range(range.clone())
+                                                .take_while(|c| c.is_whitespace())
+                                                .count();
+                                            let block_start_line = snapshot
+                                                .chars_for_range(range.clone())
+                                                .skip(num_of_whitespaces)
+                                                .take(block_start_len)
+                                                .collect::<String>();
+                                            if block_start_line.starts_with(block_start.as_ref()) {
+                                                num_of_whitespaces + block_start_len
+                                                    <= start_point.column as usize
+                                            } else {
+                                                let delimiter_trimmed = delimiter.trim();
+                                                let start_line = snapshot
+                                                    .chars_for_range(range.clone())
+                                                    .skip(num_of_whitespaces)
+                                                    .take(delimiter_trimmed.len())
+                                                    .collect::<String>();
+                                                if start_line.starts_with(delimiter_trimmed) {
+                                                    num_of_whitespaces + delimiter_trimmed.len()
+                                                        <= start_point.column as usize
+                                                } else {
+                                                    false
+                                                }
+                                            }
+                                        };
+
+                                        let cursor_is_before_end_if_exists = {
+                                            let num_of_whitspaces = snapshot
+                                                .reversed_chars_for_range(range.clone())
+                                                .take_while(|c| c.is_whitespace())
+                                                .count();
+                                            let mut line_iter = snapshot
+                                                .reversed_chars_for_range(range)
+                                                .skip(num_of_whitspaces);
+                                            let block_end_exists = block_end
+                                                .chars()
+                                                .rev()
+                                                .all(|char| line_iter.next() == Some(char));
+                                            if block_end_exists {
+                                                let max_point =
+                                                    snapshot.line_len(start_point.row) as usize;
+                                                let cursor_is_before_block_end = num_of_whitspaces
+                                                    + block_end.len()
+                                                    + start_point.column as usize
+                                                    <= max_point;
+                                                if cursor_is_before_block_end
+                                                    && cursor_is_after_block_start
+                                                {
+                                                    insert_extra_newline = true;
+                                                }
+                                                cursor_is_before_block_end
+                                            } else {
+                                                true
+                                            }
+                                        };
+
+                                        if cursor_is_after_block_start
+                                            && cursor_is_before_end_if_exists
+                                        {
+                                            prevent_auto_indent = true;
+                                            Some(delimiter.clone())
+                                        } else {
+                                            None
+                                        }
+                                    });
+                                }
+
+                                (delimiter, insert_extra_newline, prevent_auto_indent)
+                            } else {
+                                (None, false, false)
+                            };
 
                         let capacity_for_delimiter =
                             delimiter.as_deref().map(str::len).unwrap_or_default();
@@ -4088,16 +4094,31 @@ impl Editor {
                         let anchor = buffer.anchor_after(end);
                         let new_selection = selection.map(|_| anchor);
                         (
-                            (start..end, new_text),
+                            ((start..end, new_text), prevent_auto_indent),
                             (insert_extra_newline, new_selection),
                         )
                     })
                     .unzip()
             };
 
-            this.edit_with_autoindent(edits, cx);
+            let mut auto_indent_edits = Vec::new();
+            let mut edits = Vec::new();
+            for (edit, prevent_auto_indent) in edits_with_flags {
+                if prevent_auto_indent {
+                    edits.push(edit);
+                } else {
+                    auto_indent_edits.push(edit);
+                }
+            }
+            if !edits.is_empty() {
+                this.edit(edits, cx);
+            }
+            if !auto_indent_edits.is_empty() {
+                this.edit_with_autoindent(auto_indent_edits, cx);
+            }
+
             let buffer = this.buffer.read(cx).snapshot(cx);
-            let new_selections = selection_fixup_info
+            let new_selections = selection_info
                 .into_iter()
                 .map(|(extra_newline_inserted, new_selection)| {
                     let mut cursor = new_selection.end.to_point(&buffer);

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4044,7 +4044,9 @@ impl Editor {
                                                 + block_end.len()
                                                 + start_point.column as usize
                                                 <= max_point;
-                                            if cursor_is_before_block_end {
+                                            if cursor_is_before_block_end
+                                                && cursor_is_after_block_start
+                                            {
                                                 insert_extra_newline = true;
                                             }
                                             cursor_is_before_block_end

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3927,14 +3927,56 @@ impl Editor {
                         let end = selection.end;
                         let selection_is_empty = start == end;
                         let language_scope = buffer.language_scope_at(start);
-                        let (delimiter, insert_extra_newline, prevent_auto_indent) =
-                            if let Some(language) = &language_scope {
-                                let mut insert_extra_newline =
-                                    insert_extra_newline_brackets(&buffer, start..end, language)
-                                        || insert_extra_newline_tree_sitter(&buffer, start..end);
+                        let (delimiter, insert_extra_newline) = if let Some(language) =
+                            &language_scope
+                        {
+                            let mut insert_extra_newline =
+                                insert_extra_newline_brackets(&buffer, start..end, language)
+                                    || insert_extra_newline_tree_sitter(&buffer, start..end);
 
-                                // Comment extension on newline is allowed only for cursor selections
-                                let mut delimiter = maybe!({
+                            // Comment extension on newline is allowed only for cursor selections
+                            let mut delimiter = maybe!({
+                                if !selection_is_empty {
+                                    return None;
+                                }
+
+                                if !multi_buffer.language_settings(cx).extend_comment_on_newline {
+                                    return None;
+                                }
+
+                                let delimiters = language.line_comment_prefixes();
+                                let max_len_of_delimiter =
+                                    delimiters.iter().map(|delimiter| delimiter.len()).max()?;
+                                let (snapshot, range) =
+                                    buffer.buffer_line_for_row(MultiBufferRow(start_point.row))?;
+
+                                let mut index_of_first_non_whitespace = 0;
+                                let comment_candidate = snapshot
+                                    .chars_for_range(range)
+                                    .skip_while(|c| {
+                                        let should_skip = c.is_whitespace();
+                                        if should_skip {
+                                            index_of_first_non_whitespace += 1;
+                                        }
+                                        should_skip
+                                    })
+                                    .take(max_len_of_delimiter)
+                                    .collect::<String>();
+                                let comment_prefix = delimiters.iter().find(|comment_prefix| {
+                                    comment_candidate.starts_with(comment_prefix.as_ref())
+                                })?;
+                                let cursor_is_placed_after_comment_marker =
+                                    index_of_first_non_whitespace + comment_prefix.len()
+                                        <= start_point.column as usize;
+                                if cursor_is_placed_after_comment_marker {
+                                    Some(comment_prefix.clone())
+                                } else {
+                                    None
+                                }
+                            });
+
+                            if delimiter.is_none() {
+                                delimiter = maybe!({
                                     if !selection_is_empty {
                                         return None;
                                     }
@@ -3944,137 +3986,88 @@ impl Editor {
                                         return None;
                                     }
 
-                                    let delimiters = language.line_comment_prefixes();
-                                    let max_len_of_delimiter =
-                                        delimiters.iter().map(|delimiter| delimiter.len()).max()?;
+                                    let block = language.documentation_block();
+                                    let block_start = block.first()?;
+                                    let block_end = block.last()?;
+
+                                    let delimiter = language.documentation_comment_prefix()?;
+
                                     let (snapshot, range) = buffer
                                         .buffer_line_for_row(MultiBufferRow(start_point.row))?;
 
-                                    let mut index_of_first_non_whitespace = 0;
-                                    let comment_candidate = snapshot
-                                        .chars_for_range(range)
-                                        .skip_while(|c| {
-                                            let should_skip = c.is_whitespace();
-                                            if should_skip {
-                                                index_of_first_non_whitespace += 1;
+                                    let cursor_is_after_block_start = {
+                                        let block_start_len = block_start.len();
+                                        let num_of_whitespaces = snapshot
+                                            .chars_for_range(range.clone())
+                                            .take_while(|c| c.is_whitespace())
+                                            .count();
+                                        let block_start_line = snapshot
+                                            .chars_for_range(range.clone())
+                                            .skip(num_of_whitespaces)
+                                            .take(block_start_len)
+                                            .collect::<String>();
+                                        if block_start_line.starts_with(block_start.as_ref()) {
+                                            num_of_whitespaces + block_start_len
+                                                <= start_point.column as usize
+                                        } else {
+                                            let delimiter_trimmed = delimiter.trim();
+                                            let start_line = snapshot
+                                                .chars_for_range(range.clone())
+                                                .skip(num_of_whitespaces)
+                                                .take(delimiter_trimmed.len())
+                                                .collect::<String>();
+                                            if start_line.starts_with(delimiter_trimmed) {
+                                                num_of_whitespaces + delimiter_trimmed.len()
+                                                    <= start_point.column as usize
+                                            } else {
+                                                false
                                             }
-                                            should_skip
-                                        })
-                                        .take(max_len_of_delimiter)
-                                        .collect::<String>();
-                                    let comment_prefix =
-                                        delimiters.iter().find(|comment_prefix| {
-                                            comment_candidate.starts_with(comment_prefix.as_ref())
-                                        })?;
-                                    let cursor_is_placed_after_comment_marker =
-                                        index_of_first_non_whitespace + comment_prefix.len()
-                                            <= start_point.column as usize;
-                                    if cursor_is_placed_after_comment_marker {
-                                        Some(comment_prefix.clone())
+                                        }
+                                    };
+
+                                    let cursor_is_before_end_if_exists = {
+                                        let num_of_whitspaces = snapshot
+                                            .reversed_chars_for_range(range.clone())
+                                            .take_while(|c| c.is_whitespace())
+                                            .count();
+                                        let mut line_iter = snapshot
+                                            .reversed_chars_for_range(range)
+                                            .skip(num_of_whitspaces);
+                                        let block_end_exists = block_end
+                                            .chars()
+                                            .rev()
+                                            .all(|char| line_iter.next() == Some(char));
+                                        if block_end_exists {
+                                            let max_point =
+                                                snapshot.line_len(start_point.row) as usize;
+                                            let cursor_is_before_block_end = num_of_whitspaces
+                                                + block_end.len()
+                                                + start_point.column as usize
+                                                <= max_point;
+                                            if cursor_is_before_block_end
+                                                && cursor_is_after_block_start
+                                            {
+                                                insert_extra_newline = true;
+                                            }
+                                            cursor_is_before_block_end
+                                        } else {
+                                            true
+                                        }
+                                    };
+
+                                    if cursor_is_after_block_start && cursor_is_before_end_if_exists
+                                    {
+                                        Some(delimiter.clone())
                                     } else {
                                         None
                                     }
                                 });
+                            }
 
-                                let mut prevent_auto_indent = false;
-
-                                if delimiter.is_none() {
-                                    delimiter = maybe!({
-                                        if !selection_is_empty {
-                                            return None;
-                                        }
-
-                                        if !multi_buffer
-                                            .language_settings(cx)
-                                            .extend_comment_on_newline
-                                        {
-                                            return None;
-                                        }
-
-                                        let block = language.documentation_block();
-                                        let block_start = block.first()?;
-                                        let block_end = block.last()?;
-
-                                        let delimiter = language.documentation_comment_prefix()?;
-
-                                        let (snapshot, range) = buffer
-                                            .buffer_line_for_row(MultiBufferRow(start_point.row))?;
-
-                                        let cursor_is_after_block_start = {
-                                            let block_start_len = block_start.len();
-                                            let num_of_whitespaces = snapshot
-                                                .chars_for_range(range.clone())
-                                                .take_while(|c| c.is_whitespace())
-                                                .count();
-                                            let block_start_line = snapshot
-                                                .chars_for_range(range.clone())
-                                                .skip(num_of_whitespaces)
-                                                .take(block_start_len)
-                                                .collect::<String>();
-                                            if block_start_line.starts_with(block_start.as_ref()) {
-                                                num_of_whitespaces + block_start_len
-                                                    <= start_point.column as usize
-                                            } else {
-                                                let delimiter_trimmed = delimiter.trim();
-                                                let start_line = snapshot
-                                                    .chars_for_range(range.clone())
-                                                    .skip(num_of_whitespaces)
-                                                    .take(delimiter_trimmed.len())
-                                                    .collect::<String>();
-                                                if start_line.starts_with(delimiter_trimmed) {
-                                                    num_of_whitespaces + delimiter_trimmed.len()
-                                                        <= start_point.column as usize
-                                                } else {
-                                                    false
-                                                }
-                                            }
-                                        };
-
-                                        let cursor_is_before_end_if_exists = {
-                                            let num_of_whitspaces = snapshot
-                                                .reversed_chars_for_range(range.clone())
-                                                .take_while(|c| c.is_whitespace())
-                                                .count();
-                                            let mut line_iter = snapshot
-                                                .reversed_chars_for_range(range)
-                                                .skip(num_of_whitspaces);
-                                            let block_end_exists = block_end
-                                                .chars()
-                                                .rev()
-                                                .all(|char| line_iter.next() == Some(char));
-                                            if block_end_exists {
-                                                let max_point =
-                                                    snapshot.line_len(start_point.row) as usize;
-                                                let cursor_is_before_block_end = num_of_whitspaces
-                                                    + block_end.len()
-                                                    + start_point.column as usize
-                                                    <= max_point;
-                                                if cursor_is_before_block_end
-                                                    && cursor_is_after_block_start
-                                                {
-                                                    insert_extra_newline = true;
-                                                }
-                                                cursor_is_before_block_end
-                                            } else {
-                                                true
-                                            }
-                                        };
-
-                                        if cursor_is_after_block_start
-                                            && cursor_is_before_end_if_exists
-                                        {
-                                            prevent_auto_indent = true;
-                                            Some(delimiter.clone())
-                                        } else {
-                                            None
-                                        }
-                                    });
-                                }
-
-                                (delimiter, insert_extra_newline, prevent_auto_indent)
-                            } else {
-                                (None, false, false)
-                            };
+                            (delimiter, insert_extra_newline)
+                        } else {
+                            (None, false)
+                        };
 
                         let capacity_for_delimiter =
                             delimiter.as_deref().map(str::len).unwrap_or_default();

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2806,7 +2806,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
     let language = Arc::new(Language::new(
         LanguageConfig {
             documentation_block: Some(vec!["/**".into(), "*/".into()]),
-            documentation_comment_prefix: Some(" * ".into()),
+            documentation_comment_prefix: Some("* ".into()),
             ..LanguageConfig::default()
         },
         None,
@@ -2821,7 +2821,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-         * ˇ
+        * ˇ
     "});
         // Ensure that if cursor is before the comment start,
         // we do not actually insert a comment prefix.
@@ -2849,8 +2849,22 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-         * ˇ
-         */
+        * ˇ
+        */
+    "});
+        // Ensure that delimiter space is preserved when space is not
+        // on existing delimiter.
+        cx.set_state(indoc! {"
+        /**
+        *ˇ
+        */
+    "});
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state(indoc! {"
+        /**
+        *
+        * ˇ
+        */
     "});
         // Ensure that if suffix exists on same line after cursor it
         // doesn't add extra new line if prefix is not on same line.
@@ -2895,7 +2909,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /**
          *
          */
-        ˇ
+         ˇ
     "});
     }
     // Ensure that comment continuations can be disabled.

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2806,7 +2806,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
     let language = Arc::new(Language::new(
         LanguageConfig {
             documentation_block: Some(vec!["/**".into(), "*/".into()]),
-            documentation_comment_prefix: Some("*".into()),
+            documentation_comment_prefix: Some("* ".into()),
             ..LanguageConfig::default()
         },
         None,
@@ -2821,7 +2821,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-        *ˇ
+         * ˇ
     "});
         // Ensure that if cursor is before the comment start, we do not actually insert a comment prefix.
         cx.set_state(indoc! {"
@@ -2848,8 +2848,8 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-        *ˇ
-        */
+         * ˇ
+         */
     "});
         // Ensure that it detects suffix after existing prefix.
         cx.set_state(indoc! {"
@@ -2872,14 +2872,14 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         // Ensure that if suffix exists on same line before cursor it does not add comment prefix.
         cx.set_state(indoc! {"
         /**
-        *
-        */ˇ
+         *
+         */ˇ
     "});
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-        *
-        */
+         *
+         */
         ˇ
     "});
     }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2805,8 +2805,12 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
 
     let language = Arc::new(Language::new(
         LanguageConfig {
-            documentation_block: Some(vec!["/**".into(), "*/".into()]),
-            documentation_comment_prefix: Some("* ".into()),
+            documentation: Some(language::DocumentationConfig {
+                start: "/**".into(),
+                end: "*/".into(),
+                prefix: "* ".into(),
+                tab_size: NonZeroU32::new(1).unwrap(),
+            }),
             ..LanguageConfig::default()
         },
         None,
@@ -2821,7 +2825,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-        * ˇ
+         * ˇ
     "});
         // Ensure that if cursor is before the comment start,
         // we do not actually insert a comment prefix.
@@ -2849,8 +2853,8 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-        * ˇ
-        */
+         * ˇ
+         */
     "});
         // Ensure that delimiter space is preserved when newline on already
         // spaced delimiter.
@@ -2858,9 +2862,9 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         cx.assert_editor_state(
             indoc! {"
         /**
-        *s
-        * ˇ
-        */
+         *s
+         * ˇ
+         */
     "}
             .replace("s", " ") // s is used as space placeholder to prevent format on save
             .as_str(),
@@ -2869,15 +2873,15 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         // on existing delimiter.
         cx.set_state(indoc! {"
         /**
-        *ˇ
-        */
+         *ˇ
+         */
     "});
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(indoc! {"
         /**
-        *
-        * ˇ
-        */
+         *
+         * ˇ
+         */
     "});
         // Ensure that if suffix exists on same line after cursor it
         // doesn't add extra new line if prefix is not on same line.

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2856,12 +2856,36 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
          * ˇ
          */
     "});
+        // Ensure that if suffix exists on same line after cursor with space it adds new line.
+        cx.set_state(indoc! {"
+        /**ˇ */
+    "});
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state(indoc! {"
+        /**
+         * ˇ
+         */
+    "});
+        // Ensure that if suffix exists on same line after cursor with space it adds new line.
+        cx.set_state(indoc! {"
+        /** ˇ*/
+    "});
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state(
+            indoc! {"
+        /**s
+         * ˇ
+         */
+    "}
+            .replace("s", " ") // s is used as space placeholder to prevent format on save
+            .as_str(),
+        );
         // Ensure that delimiter space is preserved when newline on already
         // spaced delimiter.
         cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
         cx.assert_editor_state(
             indoc! {"
-        /**
+        /**s
          *s
          * ˇ
          */

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2806,7 +2806,7 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
     let language = Arc::new(Language::new(
         LanguageConfig {
             documentation_block: Some(vec!["/**".into(), "*/".into()]),
-            documentation_comment_prefix: Some("* ".into()),
+            documentation_comment_prefix: Some(" * ".into()),
             ..LanguageConfig::default()
         },
         None,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2823,7 +2823,8 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /**
          * ˇ
     "});
-        // Ensure that if cursor is before the comment start, we do not actually insert a comment prefix.
+        // Ensure that if cursor is before the comment start,
+        // we do not actually insert a comment prefix.
         cx.set_state(indoc! {"
         ˇ/**
     "});
@@ -2851,6 +2852,18 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
          * ˇ
          */
     "});
+        // Ensure that if suffix exists on same line after cursor it
+        // doesn't add extra new line if prefix is not on same line.
+        cx.set_state(indoc! {"
+        /**
+        ˇ*/
+    "});
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state(indoc! {"
+        /**
+
+        ˇ*/
+    "});
         // Ensure that it detects suffix after existing prefix.
         cx.set_state(indoc! {"
         /**ˇ/
@@ -2860,7 +2873,8 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /**
         ˇ/
     "});
-        // Ensure that if suffix exists on same line before cursor it does not add comment prefix.
+        // Ensure that if suffix exists on same line before
+        // cursor it does not add comment prefix.
         cx.set_state(indoc! {"
         /** */ˇ
     "});
@@ -2869,7 +2883,8 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         /** */
         ˇ
     "});
-        // Ensure that if suffix exists on same line before cursor it does not add comment prefix.
+        // Ensure that if suffix exists on same line before
+        // cursor it does not add comment prefix.
         cx.set_state(indoc! {"
         /**
          *

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2852,6 +2852,19 @@ async fn test_newline_documentation_comments(cx: &mut TestAppContext) {
         * ˇ
         */
     "});
+        // Ensure that delimiter space is preserved when newline on already
+        // spaced delimiter.
+        cx.update_editor(|e, window, cx| e.newline(&Newline, window, cx));
+        cx.assert_editor_state(
+            indoc! {"
+        /**
+        *s
+        * ˇ
+        */
+    "}
+            .replace("s", " ") // s is used as space placeholder to prevent format on save
+            .as_str(),
+        );
         // Ensure that delimiter space is preserved when space is not
         // on existing delimiter.
         cx.set_state(indoc! {"

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -755,12 +755,10 @@ pub struct LanguageConfig {
     /// A list of preferred debuggers for this language.
     #[serde(default)]
     pub debuggers: IndexSet<SharedString>,
-    /// A character to add as a prefix when a new line is added to a documentation block.
+    /// Whether to treat documentation comment of this language differently by
+    /// auto adding prefix on new line, adjusting the indenting , etc.
     #[serde(default)]
-    pub documentation_comment_prefix: Option<Arc<str>>,
-    /// Returns string documentation block of this language should start with.
-    #[serde(default)]
-    pub documentation_block: Option<Vec<Arc<str>>>,
+    pub documentation: Option<DocumentationConfig>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Default, JsonSchema)]
@@ -809,6 +807,19 @@ pub struct JsxTagAutoCloseConfig {
     /// normal tag name node name
     #[serde(default)]
     pub erroneous_close_tag_name_node_name: Option<String>,
+}
+
+/// The configuration for documentation block for this language.
+#[derive(Clone, Deserialize, JsonSchema)]
+pub struct DocumentationConfig {
+    /// A start tag of documentation block.
+    pub start: Arc<str>,
+    /// A end tag of documentation block.
+    pub end: Arc<str>,
+    /// A character to add as a prefix when a new line is added to a documentation block.
+    pub prefix: Arc<str>,
+    /// A indent to add for prefix and end line upon new line.
+    pub tab_size: NonZeroU32,
 }
 
 /// Represents a language for the given range. Some languages (e.g. HTML)
@@ -889,8 +900,7 @@ impl Default for LanguageConfig {
             completion_query_characters: Default::default(),
             debuggers: Default::default(),
             significant_indentation: Default::default(),
-            documentation_comment_prefix: None,
-            documentation_block: None,
+            documentation: None,
         }
     }
 }
@@ -1810,21 +1820,12 @@ impl LanguageScope {
             .unwrap_or(false)
     }
 
-    /// A character to add as a prefix when a new line is added to a documentation block.
+    /// Returns config to documentation block for this language.
     ///
     /// Used for documentation styles that require a leading character on each line,
     /// such as the asterisk in JSDoc, Javadoc, etc.
-    pub fn documentation_comment_prefix(&self) -> Option<&Arc<str>> {
-        self.language.config.documentation_comment_prefix.as_ref()
-    }
-
-    /// Returns prefix and suffix for documentation block of this language.
-    pub fn documentation_block(&self) -> &[Arc<str>] {
-        self.language
-            .config
-            .documentation_block
-            .as_ref()
-            .map_or([].as_slice(), |e| e.as_slice())
+    pub fn documentation(&self) -> Option<&DocumentationConfig> {
+        self.language.config.documentation.as_ref()
     }
 
     /// Returns a list of bracket pairs for a given language with an additional

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -20,8 +20,7 @@ tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 prettier_parser_name = "babel"
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "* "
-documentation_block = ["/**", "*/"]
+documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 
 [jsx_tag_auto_close]
 open_tag_node_name = "jsx_opening_element"

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -20,7 +20,7 @@ tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 prettier_parser_name = "babel"
 debuggers = ["JavaScript"]
-documentation_comment_prefix = " * "
+documentation_comment_prefix = "* "
 documentation_block = ["/**", "*/"]
 
 [jsx_tag_auto_close]

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -20,7 +20,7 @@ tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 prettier_parser_name = "babel"
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "* "
+documentation_comment_prefix = " * "
 documentation_block = ["/**", "*/"]
 
 [jsx_tag_auto_close]

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -20,7 +20,7 @@ tab_size = 2
 scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-server"]
 prettier_parser_name = "babel"
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "*"
+documentation_comment_prefix = "* "
 documentation_block = ["/**", "*/"]
 
 [jsx_tag_auto_close]

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -18,7 +18,7 @@ scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = " * "
+documentation_comment_prefix = "* "
 documentation_block = ["/**", "*/"]
 
 [jsx_tag_auto_close]

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -18,7 +18,7 @@ scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "* "
+documentation_comment_prefix = " * "
 documentation_block = ["/**", "*/"]
 
 [jsx_tag_auto_close]

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -18,8 +18,7 @@ scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "* "
-documentation_block = ["/**", "*/"]
+documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 
 [jsx_tag_auto_close]
 open_tag_node_name = "jsx_opening_element"

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -18,7 +18,7 @@ scope_opt_in_language_servers = ["tailwindcss-language-server", "emmet-language-
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "*"
+documentation_comment_prefix = "* "
 documentation_block = ["/**", "*/"]
 
 [jsx_tag_auto_close]

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -18,7 +18,7 @@ word_characters = ["#", "$"]
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = " * "
+documentation_comment_prefix = "* "
 documentation_block = ["/**", "*/"]
 
 [overrides.string]

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -18,8 +18,7 @@ word_characters = ["#", "$"]
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "* "
-documentation_block = ["/**", "*/"]
+documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 
 [overrides.string]
 completion_query_characters = ["."]

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -18,7 +18,7 @@ word_characters = ["#", "$"]
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "*"
+documentation_comment_prefix = "* "
 documentation_block = ["/**", "*/"]
 
 [overrides.string]

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -18,7 +18,7 @@ word_characters = ["#", "$"]
 prettier_parser_name = "typescript"
 tab_size = 2
 debuggers = ["JavaScript"]
-documentation_comment_prefix = "* "
+documentation_comment_prefix = " * "
 documentation_block = ["/**", "*/"]
 
 [overrides.string]


### PR DESCRIPTION
Follow up for https://github.com/zed-industries/zed/pull/30768

This PR makes JSDoc auto comment on new line lot better by:

- Inserting delimiters regardless of whether previous delimiters have trailing spaces or not
- When on start tag, auto-indenting both prefix and end tag upon new line

This makes it correct as per convention out of the box. No need to manually adjust spaces on every new line.

https://github.com/user-attachments/assets/81b8e05a-fe8a-4459-9e90-c8a3d70a51a2

Release Notes:

- Improved JSDoc auto-commenting on newline which now correctly indents as per convention.
