### PR TITLE
Fix bedrock name in assistant settings schema

### DIFF
--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -692,7 +692,7 @@ impl JsonSchema for LanguageModelProviderSetting {
         schemars::schema::SchemaObject {
             enum_values: Some(vec![
                 "anthropic".into(),
-                "bedrock".into(),
+                "amazon-bedrock".into(),
                 "google".into(),
                 "lmstudio".into(),
                 "ollama".into(),


### PR DESCRIPTION
Closes #30778 

Release Notes:

- Fixed an issue with the assistant settings where `amazon-bedrock` was incorrectly called `bedrock` in the settings schema
