### PR TITLE
python: Fix highlighting of built-in types for `isinstance` and `issubclass`

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -52,6 +52,20 @@
 (function_definition
   name: (identifier) @function.definition)
 
+((call
+  function: (identifier) @_isinstance
+  arguments: (argument_list
+    (_)
+    (identifier) @type))
+  (#eq? @_isinstance "isinstance"))
+
+((call
+  function: (identifier) @_issubclass
+  arguments: (argument_list
+    (identifier) @type
+    (identifier) @type))
+  (#eq? @_issubclass "issubclass"))
+
 ; Function arguments
 (function_definition
   parameters: (parameters


### PR DESCRIPTION
    
When built-in types such as `list` is specified in calls like `isinstance()`, the parameter is highlighted as a type.
    
The issue is caused by a change which removed `list` and others in bf9e5b4f761b507310d744553e29ba6fdeb3c89a.
    
This commit makes two special cases for `isinstance` and `issubclass` ensuring tree sitter to highlight the parameters correctly.

Fixes #30331

Release Notes:

- python: Fixed syntax highlighting for `isinstance()` and `issubclass()` calls
