### PR TITLE
editor: Add astrick on new line in multiline comment for Go, Rust, C, and C++

### DIFF
--- a/crates/languages/src/c/config.toml
+++ b/crates/languages/src/c/config.toml
@@ -12,3 +12,4 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
 debuggers = ["CodeLLDB", "GDB"]
+documentation = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }

--- a/crates/languages/src/cpp/config.toml
+++ b/crates/languages/src/cpp/config.toml
@@ -12,3 +12,4 @@ brackets = [
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
 debuggers = ["CodeLLDB", "GDB"]
+documentation = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }

--- a/crates/languages/src/go/config.toml
+++ b/crates/languages/src/go/config.toml
@@ -15,3 +15,4 @@ brackets = [
 tab_size = 4
 hard_tabs = true
 debuggers = ["Delve"]
+documentation = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }

--- a/crates/languages/src/rust/config.toml
+++ b/crates/languages/src/rust/config.toml
@@ -16,3 +16,4 @@ brackets = [
 ]
 collapsed_placeholder = " /* ... */ "
 debuggers = ["CodeLLDB", "GDB"]
+documentation = { start = "/*", end = "*/", prefix = "* ", tab_size = 1 }


### PR DESCRIPTION
Add asterisk on new line in multiline comments for Go, Rust, C, and C++. While `*` is entirely for style. There's no actual need for it. It can be disabled from setting. More: https://doc.rust-lang.org/rust-by-example/hello/comment.html

<img width="491" alt="image" src="https://github.com/user-attachments/assets/385b1eb5-be81-446c-b7cf-34165d6b384a" />

Release Notes:

- Added automatic asterisk insertion for new lines in multiline comments for Go, Rust, C, and C++. This can be disable by setting `extend_comment_on_newline` to `false`. 
