### PR TITLE
docs: Document how to load extension grammars from the local FS during development

### DIFF
--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -54,7 +54,7 @@ repository = "https://github.com/gleam-lang/tree-sitter-gleam"
 rev = "58b7cac8fc14c92b0677c542610d8738c373fa81"
 ```
 
-The `repository` field must specify a repository where the Tree-sitter grammar should be loaded from, and the `rev` field must contain a Git revision to use, such as the SHA of a Git commit. An extension can provide multiple grammars by referencing multiple tree-sitter repositories.
+The `repository` field must specify a repository where the Tree-sitter grammar should be loaded from, and the `rev` field must contain a Git revision to use, such as the SHA of a Git commit. If you're developing an extension locally and want to load a grammar from the local filesystem, you can use a `file://` URL for `repository`. An extension can provide multiple grammars by referencing multiple tree-sitter repositories.
 
 ## Tree-sitter Queries
 


### PR DESCRIPTION
Loading a local grammar could be useful if you're developing the extension and the grammar in tandem, and a user pointed out that our docs don't make it obvious that it's possible at all.

Release Notes:

- N/A