### PR TITLE
Display the correct git push flag when force-pushing

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3552,7 +3552,7 @@ impl Repository {
         let args = options
             .map(|option| match option {
                 PushOptions::SetUpstream => " --set-upstream",
-                PushOptions::Force => " --force",
+                PushOptions::Force => " --force-with-lease",
             })
             .unwrap_or("");
 


### PR DESCRIPTION
When I force pushed via the Git panel and noticed that `git push --force` command got logged at the bottom. I wanted to add an option to use `--force-with-lease` instead. However, upon investigation, it seems `--force-with-lease` is already being used for the executed command:

https://github.com/zed-industries/zed/blob/5112fcebeb365fab385b90b0954fe0bcb338ce63/crates/git/src/repository.rs#L1100

And there is a mismatch with the displayed message:

https://github.com/zed-industries/zed/blob/5112fcebeb365fab385b90b0954fe0bcb338ce63/crates/project/src/git_store.rs#L3555

Release Notes:

- Fixed the displayed flag name when force pushing
