### PR TITLE
Remove Repology badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,6 @@ Welcome to Zed, a high-performance, multiplayer code editor from the creators of
 
 ### Installation
 
-<a href="https://repology.org/project/zed-editor/versions">
-    <img src="https://repology.org/badge/vertical-allrepos/zed-editor.svg?minversion=0.143.5" alt="Packaging status" align="right">
-</a>
-
 On macOS and Linux you can [download Zed directly](https://zed.dev/download) or [install Zed via your local package manager](https://zed.dev/docs/linux#installing-via-a-package-manager).
 
 Other platforms are not yet available:

--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -49,7 +49,8 @@ There are several third-party Zed packages for various Linux distributions and p
 - ALT Linux (Sisyphus): [`zed`](https://packages.altlinux.org/en/sisyphus/srpms/zed/)
 - AOSC OS: [`zed`](https://packages.aosc.io/packages/zed)
 - openSUSE Tumbleweed: [`zed`](https://en.opensuse.org/Zed)
-- Please add others to this list!
+
+See [Repology](https://repology.org/project/zed-editor/versions) for a list of Zed packages in various repositories.
 
 When installing a third-party package please be aware that it may not be completely up to date and may be slightly different from the Zed we package (a common change is to rename the binary to `zedit` or `zeditor` to avoid conflicting with other packages).
 


### PR DESCRIPTION
This PR removes the Repology badge from the README.

At time of writing, the majority of the packages listed here are woefully out of date:

<img width="299" alt="Screenshot 2025-05-17 at 8 44 16 AM" src="https://github.com/user-attachments/assets/c45afba3-72ac-488d-a067-1fb0e237c7c0" />

This isn't a good look for someone coming to the Zed repository for the first time.

I've added a link to the Repology list in the "Linux" section of the docs for people who are interested in checking the packaging status in various repos.

Release Notes:

- N/A
