### PR TITLE
ui: Remove usage of `DerivePathStr` macro

### DIFF
--- a/crates/ui/src/components/icon/icon_decoration.rs
+++ b/crates/ui/src/components/icon/icon_decoration.rs
@@ -1,6 +1,7 @@
+use std::sync::Arc;
+
 use gpui::{Hsla, IntoElement, Point, svg};
 use strum::{EnumIter, EnumString, IntoStaticStr};
-use ui_macros::DerivePathStr;
 
 use crate::prelude::*;
 
@@ -8,9 +9,8 @@ const ICON_DECORATION_SIZE: Pixels = px(11.);
 
 /// An icon silhouette used to knockout the background of an element for an icon
 /// to sit on top of it, emulating a stroke/border.
-#[derive(Debug, PartialEq, Eq, Copy, Clone, EnumIter, EnumString, IntoStaticStr, DerivePathStr)]
+#[derive(Debug, PartialEq, Eq, Copy, Clone, EnumIter, EnumString, IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
-#[path_str(prefix = "icons/knockouts", suffix = ".svg")]
 pub enum KnockoutIconName {
     XFg,
     XBg,
@@ -18,6 +18,14 @@ pub enum KnockoutIconName {
     DotBg,
     TriangleFg,
     TriangleBg,
+}
+
+impl KnockoutIconName {
+    /// Returns the path to this icon.
+    pub fn path(&self) -> Arc<str> {
+        let file_stem: &'static str = self.into();
+        format!("icons/knockouts/{file_stem}.svg").into()
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, EnumIter, EnumString)]

--- a/crates/ui/src/components/image.rs
+++ b/crates/ui/src/components/image.rs
@@ -1,31 +1,29 @@
+use std::sync::Arc;
+
 use gpui::{App, IntoElement, Rems, RenderOnce, Size, Styled, Window, svg};
 use serde::{Deserialize, Serialize};
 use strum::{EnumIter, EnumString, IntoStaticStr};
-use ui_macros::{DerivePathStr, path_str};
 
 use crate::Color;
 use crate::prelude::*;
 
 #[derive(
-    Debug,
-    PartialEq,
-    Eq,
-    Copy,
-    Clone,
-    EnumIter,
-    EnumString,
-    IntoStaticStr,
-    Serialize,
-    Deserialize,
-    DerivePathStr,
+    Debug, PartialEq, Eq, Copy, Clone, EnumIter, EnumString, IntoStaticStr, Serialize, Deserialize,
 )]
 #[strum(serialize_all = "snake_case")]
-#[path_str(prefix = "images", suffix = ".svg")]
 pub enum VectorName {
     ZedLogo,
     ZedXCopilot,
     Grid,
     AiGrid,
+}
+
+impl VectorName {
+    /// Returns the path to this vector image.
+    pub fn path(&self) -> Arc<str> {
+        let file_stem: &'static str = self.into();
+        format!("images/{file_stem}.svg").into()
+    }
 }
 
 /// A vector image, such as an SVG.
@@ -35,7 +33,7 @@ pub enum VectorName {
 /// than conforming to the standard size of an icon.
 #[derive(IntoElement, RegisterComponent)]
 pub struct Vector {
-    path: &'static str,
+    path: Arc<str>,
     color: Color,
     size: Size<Rems>,
 }
@@ -160,6 +158,6 @@ mod tests {
 
     #[test]
     fn vector_path() {
-        assert_eq!(VectorName::ZedLogo.path(), "images/zed_logo.svg");
+        assert_eq!(VectorName::ZedLogo.path().as_ref(), "images/zed_logo.svg");
     }
 }


### PR DESCRIPTION
This PR updates the `KnockoutIconName` and `VectorName` enums to manually implement the `path` method instead of using the `DerivePathStr` macro.

Release Notes:

- N/A
