### PR TITLE
language_models: Don't mark local subscription binding as unused

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -60,10 +60,10 @@ impl State {
 impl CopilotChatLanguageModelProvider {
     pub fn new(cx: &mut App) -> Self {
         let state = cx.new(|cx| {
-            let _copilot_chat_subscription = CopilotChat::global(cx)
+            let copilot_chat_subscription = CopilotChat::global(cx)
                 .map(|copilot_chat| cx.observe(&copilot_chat, |_, _, cx| cx.notify()));
             State {
-                _copilot_chat_subscription,
+                _copilot_chat_subscription: copilot_chat_subscription,
                 _settings_subscription: cx.observe_global::<SettingsStore>(|_, cx| {
                     cx.notify();
                 }),


### PR DESCRIPTION
This PR removes an instance of marking a local `Subscription` binding as unused.

While we `_` the field to prevent unused warnings, the locals shouldn't be marked as unused as we do use them (and want them to participate in usage tracking).

Release Notes:

- N/A
