### PR TITLE
agent: Scroll to the bottom after sending a new message

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -3410,6 +3410,7 @@ impl ActiveThread {
             .or_insert(true);
         *is_expanded = !*is_expanded;
     }
+
     pub fn scroll_to_bottom(&mut self, cx: &mut Context<Self>) {
         self.list_state.reset(self.messages.len());
         cx.notify();

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1014,6 +1014,7 @@ impl ActiveThread {
                     self.push_message(message_id, &message_segments, window, cx);
                 }
 
+                self.scroll_to_bottom(cx);
                 self.save_thread(cx);
                 cx.notify();
             }
@@ -1027,6 +1028,7 @@ impl ActiveThread {
                     self.edited_message(message_id, &message_segments, window, cx);
                 }
 
+                self.scroll_to_bottom(cx);
                 self.save_thread(cx);
                 cx.notify();
             }
@@ -3407,6 +3409,10 @@ impl ActiveThread {
             .entry((message_id, ix))
             .or_insert(true);
         *is_expanded = !*is_expanded;
+    }
+    pub fn scroll_to_bottom(&mut self, cx: &mut Context<Self>) {
+        self.list_state.reset(self.messages.len());
+        cx.notify();
     }
 }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/30572

Release Notes:

- agent: Improved UX by scrolling to the bottom of the thread after submitting a new message or editing a previous one.
