### PR TITLE
Upgrade `tempfile` to v3.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14482,9 +14482,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand 2.3.0",
  "getrandom 0.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -548,7 +548,7 @@ syn = { version = "1.0.72", features = ["full", "extra-traits"] }
 sys-locale = "0.3.1"
 sysinfo = "0.31.0"
 take-until = "0.2.0"
-tempfile = "3.9.0"
+tempfile = "3.20.0"
 thiserror = "2.0.12"
 tiktoken-rs = "0.6.0"
 time = { version = "0.3", features = [


### PR DESCRIPTION
This PR upgrades our `tempfile` dependency to v3.20.0.

Pulling out of https://github.com/zed-industries/zed/pull/30883.

Release Notes:

- N/A
