### PR TITLE
Fix `Replace Next Match` command

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1460,7 +1460,6 @@ impl BufferSearchBar {
                             self.select_next_match(&SelectNextMatch, window, cx);
                         }
                         should_propagate = false;
-                        self.focus_editor(&FocusEditor, window, cx);
                     }
                 }
             }


### PR DESCRIPTION
Currently, `search::ReplaceNext` works only first time it is executed because Zed switches the focus to the editor. It seems `self.editor_focus` call is unnecessary.

Closes #17466

Release Notes:

- Fixed `Replace Next Match` command. Previously it worked once, then Zed incorrectly  switched the focus to the editor

https://github.com/user-attachments/assets/66ef61d6-1efe-43ca-8d8c-6b40540a9930


