### PR TITLE
docs: Fix incorrect info in C# documentation

### DIFF
--- a/docs/src/languages/csharp.md
+++ b/docs/src/languages/csharp.md
@@ -23,17 +23,3 @@ The `OmniSharp` binary can be configured in a Zed settings file with:
   }
 }
 ```
-
-If you want to disable Zed looking for a `omnisharp` binary, you can set `ignore_system_version` to `true`:
-
-```json
-{
-  "lsp": {
-    "omnisharp": {
-      "binary": {
-        "ignore_system_version": true
-      }
-    }
-  }
-}
-```


### PR DESCRIPTION
`ignore_system_version` does not work for extensions.

Release Notes:

- N/A
