### PR TITLE
pane: Call close_inactive_items for Close Others

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2398,10 +2398,16 @@ impl Pane {
                                     }))
                                     .disabled(total_items == 1)
                                     .handler(window.handler_for(&pane, move |pane, window, cx| {
-                                        pane.close_items(window, cx, SaveIntent::Close, |id| {
-                                            id != item_id
-                                        })
-                                        .detach_and_log_err(cx);
+                                        if let Some(task) = pane.close_inactive_items(
+                                            &CloseInactiveItems {
+                                                save_intent: None,
+                                                close_pinned: false,
+                                            },
+                                            window,
+                                            cx,
+                                        ) {
+                                            task.detach_and_log_err(cx);
+                                        }
                                     })),
                             ))
                             .separator()


### PR DESCRIPTION
Fixes the issue where pinned panes are closed when using Close Others. 

Use `close_inactive_items()` instead of `close_items()` for Close Others to make sure that pinned tabs are not closed.

Closes https://github.com/zed-industries/zed/issues/28166

Release Notes:

- Leaves pinned tabs open when using Close Others on a tab.
