### PR TITLE
editor: Add python indentation tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4675,6 +4675,7 @@ dependencies = [
  "theme",
  "time",
  "tree-sitter-html",
+ "tree-sitter-python",
  "tree-sitter-rust",
  "tree-sitter-typescript",
  "ui",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -79,6 +79,7 @@ theme.workspace = true
 tree-sitter-html = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
+tree-sitter-python = { workspace = true, optional = true }
 unicode-segmentation.workspace = true
 unicode-script.workspace = true
 unindent = { workspace = true, optional = true }

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -1,3 +1,6 @@
+(_ "[" "]" @end) @indent
+(_ "{" "}" @end) @indent
+
 (function_definition
   ":" @start
   body: (block) @indent


### PR DESCRIPTION
This PR add tests for a recent PR: [language: Fix indent suggestions for significant indented languages like Python](https://github.com/zed-industries/zed/pull/29625)

It also covers cases from past related issues so that we don't end up circling back to them on future fixes.

- [Python incorrect auto-indentation for except:](https://github.com/zed-industries/zed/issues/10832)
- [Python for/while...else indention overridden by if statement ](https://github.com/zed-industries/zed/issues/30795)
- [Python: erroneous indent on newline when comment ends in :](https://github.com/zed-industries/zed/issues/25416)
- [Newline in Python file does not indent ](https://github.com/zed-industries/zed/issues/16288)
- [Tab Indentation works incorrectly when there are multiple cursors](https://github.com/zed-industries/zed/issues/26157)

Release Notes:

- N/A
