### PR TITLE
gpui: Replace Mutex with RefCell for SubscriberSet

### DIFF
--- a/crates/gpui/src/subscription.rs
+++ b/crates/gpui/src/subscription.rs
@@ -1,5 +1,10 @@
 use collections::{BTreeMap, BTreeSet};
-use std::{cell::{Cell, RefCell}, fmt::Debug, mem, rc::Rc};
+use std::{
+    cell::{Cell, RefCell},
+    fmt::Debug,
+    mem,
+    rc::Rc,
+};
 use util::post_inc;
 
 pub(crate) struct SubscriberSet<EmitterKey, Callback>(


### PR DESCRIPTION
 `SubscriberSet` is `!Send` and `!Sync` because the `active` field of `Subscriber`  is `Rc`.

Release Notes:

- N/A

