### PR TITLE
agent: Fix path checks in edit_file

### DIFF
--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -969,13 +969,13 @@ mod tests {
         let mode = &EditFileMode::Create;
 
         let result = test_resolve_path(mode, "root/new.txt", cx);
-        assert_eq!(result.await.unwrap().path.to_str(), Some("new.txt"));
+        assert_resolved_path_eq(result.await, "new.txt");
 
         let result = test_resolve_path(mode, "new.txt", cx);
-        assert_eq!(result.await.unwrap().path.to_str(), Some("new.txt"));
+        assert_resolved_path_eq(result.await, "new.txt");
 
         let result = test_resolve_path(mode, "dir/new.txt", cx);
-        assert_eq!(result.await.unwrap().path.to_str(), Some("dir/new.txt"));
+        assert_resolved_path_eq(result.await, "dir/new.txt");
 
         let result = test_resolve_path(mode, "root/dir/subdir/existing.txt", cx);
         assert_eq!(
@@ -989,6 +989,7 @@ mod tests {
             "Can't create file: parent directory doesn't exist"
         );
     }
+
     #[gpui::test]
     async fn test_resolve_path_for_editing_file(cx: &mut TestAppContext) {
         let mode = &EditFileMode::Edit;
@@ -996,10 +997,10 @@ mod tests {
         let path_with_root = "root/dir/subdir/existing.txt";
         let path_without_root = "dir/subdir/existing.txt";
         let result = test_resolve_path(mode, path_with_root, cx);
-        assert_eq!(result.await.unwrap().path.to_str(), Some(path_without_root));
+        assert_resolved_path_eq(result.await, path_without_root);
 
         let result = test_resolve_path(mode, path_without_root, cx);
-        assert_eq!(result.await.unwrap().path.to_str(), Some(path_without_root));
+        assert_resolved_path_eq(result.await, path_without_root);
 
         let result = test_resolve_path(mode, "root/nonexistent.txt", cx);
         assert_eq!(
@@ -1043,6 +1044,16 @@ mod tests {
 
         let result = cx.update(|cx| resolve_path(&input, project, cx));
         result
+    }
+
+    fn assert_resolved_path_eq(path: Result<ProjectPath, anyhow::Error>, expected: &str) {
+        let actual = path
+            .expect("Should return valid path")
+            .path
+            .to_str()
+            .unwrap()
+            .replace("\\", "/"); // Naive Windows paths normalization
+        assert_eq!(actual, expected);
     }
 
     #[test]

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4004,7 +4004,7 @@ impl Project {
         })
     }
 
-    pub fn resolve_path_in_worktree(
+    fn resolve_path_in_worktree(
         worktree: &Entity<Worktree>,
         path: &PathBuf,
         cx: &mut AsyncApp,
@@ -4026,28 +4026,6 @@ impl Project {
                 })
             })
             .ok()?
-    }
-
-    pub fn resolve_path_in_worktree_sync(
-        worktree: &Entity<Worktree>,
-        path: &PathBuf,
-        cx: &mut App,
-    ) -> Option<ResolvedPath> {
-        worktree.update(cx, |worktree, _| {
-            let root_entry_path = &worktree.root_entry()?.path;
-            let resolved = resolve_path(root_entry_path, path);
-            let stripped = resolved.strip_prefix(root_entry_path).unwrap_or(&resolved);
-            worktree.entry_for_path(stripped).map(|entry| {
-                let project_path = ProjectPath {
-                    worktree_id: worktree.id(),
-                    path: entry.path.clone(),
-                };
-                ResolvedPath::ProjectPath {
-                    project_path,
-                    is_dir: entry.is_dir(),
-                }
-            })
-        })
     }
 
     pub fn list_directory(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -4004,7 +4004,7 @@ impl Project {
         })
     }
 
-    fn resolve_path_in_worktree(
+    pub fn resolve_path_in_worktree(
         worktree: &Entity<Worktree>,
         path: &PathBuf,
         cx: &mut AsyncApp,
@@ -4026,6 +4026,28 @@ impl Project {
                 })
             })
             .ok()?
+    }
+
+    pub fn resolve_path_in_worktree_sync(
+        worktree: &Entity<Worktree>,
+        path: &PathBuf,
+        cx: &mut App,
+    ) -> Option<ResolvedPath> {
+        worktree.update(cx, |worktree, _| {
+            let root_entry_path = &worktree.root_entry()?.path;
+            let resolved = resolve_path(root_entry_path, path);
+            let stripped = resolved.strip_prefix(root_entry_path).unwrap_or(&resolved);
+            worktree.entry_for_path(stripped).map(|entry| {
+                let project_path = ProjectPath {
+                    worktree_id: worktree.id(),
+                    path: entry.path.clone(),
+                };
+                ResolvedPath::ProjectPath {
+                    project_path,
+                    is_dir: entry.is_dir(),
+                }
+            })
+        })
     }
 
     pub fn list_directory(


### PR DESCRIPTION
- Fixed bug where creating a file failed when the root path wasn't provided

- Many new checks for the edit_file path

Closes #30706

Release Notes:

- N/A
