### PR TITLE
Make sure GoPlsAdapter produces output that can be rendered as Markdown

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -375,6 +375,12 @@ impl super::LspAdapter for GoLspAdapter {
             filter_range,
         })
     }
+
+    fn diagnostic_message_to_markdown(&self, message: &str) -> Option<String> {
+        static REGEX: LazyLock<Regex> =
+            LazyLock::new(|| Regex::new(r"(?m)\n\s*").expect("Failed to create REGEX"));
+        Some(REGEX.replace_all(message, "\n\n").to_string())
+    }
 }
 
 fn parse_version_output(output: &Output) -> Result<&str> {


### PR DESCRIPTION
Closes [#30695](https://github.com/zed-industries/zed/issues/30695)

Adds `diagnostic_message_to_markdown()` to GoLspAdapter to ensure that Go diagnostic messages are considered Markdown formatted and leading whitespace is removed to get the Markdown to display properly.

Before:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/8a09276a-1f45-42de-9744-d7e620d5ebb6" />


After:
<img width="805" alt="image" src="https://github.com/user-attachments/assets/bbe4aeaf-a3c6-4e85-bb10-89b3f4e27965" />

Release Notes:

- Fixed display of Go diagnostics, it should be displayed as Markdown not as escaped string.
