### PR TITLE
docs: Add a missing comma in AI configuration docs

### DIFF
--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -167,7 +167,7 @@ Depending on your hardware or use-case you may wish to limit or increase the con
         {
           "name": "qwen2.5-coder",
           "display_name": "qwen 2.5 coder 32K",
-          "max_tokens": 32768
+          "max_tokens": 32768,
           "supports_tools": true
         }
       ]


### PR DESCRIPTION
I was experimenting with running AI models locally and copied a code block from the documentation.
Noticed it’s not valid JSON, just a small fix to add a missing comma.

Release Notes:

- N/A