### PR TITLE
agent: Adjust codeblock design across edit file tool call card and Markdown

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -345,17 +345,20 @@ fn render_markdown_code_block(
     _window: &Window,
     cx: &App,
 ) -> Div {
+    let label_size = rems(0.8125);
+
     let label = match kind {
         CodeBlockKind::Indented => None,
         CodeBlockKind::Fenced => Some(
             h_flex()
+                .px_1()
                 .gap_1()
                 .child(
                     Icon::new(IconName::Code)
                         .color(Color::Muted)
                         .size(IconSize::XSmall),
                 )
-                .child(Label::new("untitled").size(LabelSize::Small))
+                .child(div().text_size(label_size).child("Plain Text"))
                 .into_any_element(),
         ),
         CodeBlockKind::FencedLang(raw_language_name) => Some(render_code_language(
@@ -383,7 +386,6 @@ fn render_markdown_code_block(
                     cx,
                 )
             } else {
-                let text_size = rems(0.8125);
                 let content = if let Some(parent) = path_range.path.parent() {
                     let file_name = file_name.to_string_lossy().to_string();
                     let path = parent.to_string_lossy().to_string();
@@ -393,7 +395,7 @@ fn render_markdown_code_block(
                         .id(("code-block-header-label", ix))
                         .ml_1()
                         .gap_1()
-                        .child(div().text_size(text_size).child(file_name))
+                        .child(div().text_size(label_size).child(file_name))
                         .child(Label::new(path).color(Color::Muted).size(LabelSize::Small))
                         .tooltip(move |window, cx| {
                             Tooltip::with_meta(
@@ -408,7 +410,7 @@ fn render_markdown_code_block(
                 } else {
                     div()
                         .ml_1()
-                        .text_size(text_size)
+                        .text_size(label_size)
                         .child(path_range.path.to_string_lossy().to_string())
                         .into_any_element()
                 };
@@ -629,10 +631,13 @@ fn render_code_language(
         .map(|language| language.name().into())
         .unwrap_or(name_fallback);
 
+    let label_size = rems(0.8125);
+
     h_flex()
-        .gap_1()
-        .children(icon_path.map(|icon| icon.color(Color::Muted).size(IconSize::Small)))
-        .child(Label::new(language_label).size(LabelSize::Small))
+        .px_1()
+        .gap_1p5()
+        .children(icon_path.map(|icon| icon.color(Color::Muted).size(IconSize::XSmall)))
+        .child(div().text_size(label_size).child(language_label))
         .into_any_element()
 }
 

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -392,7 +392,7 @@ fn render_markdown_code_block(
                         .id(("code-block-header-label", ix))
                         .ml_1()
                         .gap_1()
-                        .child(Label::new(file_name).size(LabelSize::Small))
+                        .child(div().text_size(rems(0.8125)).child(file_name))
                         .child(Label::new(path).color(Color::Muted).size(LabelSize::Small))
                         .tooltip(move |window, cx| {
                             Tooltip::with_meta(
@@ -461,7 +461,7 @@ fn render_markdown_code_block(
         .theme()
         .colors()
         .element_background
-        .blend(cx.theme().colors().editor_foreground.opacity(0.01));
+        .blend(cx.theme().colors().editor_foreground.opacity(0.025));
 
     let control_buttons = h_flex()
         .visible_on_hover(CODEBLOCK_CONTAINER_GROUP)
@@ -545,15 +545,13 @@ fn render_markdown_code_block(
         .gap_1()
         .justify_between()
         .bg(codeblock_header_bg)
-        .when(is_expanded, |this| {
-            this.border_b_1()
-                .border_color(cx.theme().colors().border.opacity(0.6))
-        })
         .map(|this| {
             if !is_expanded {
                 this.rounded_md()
             } else {
                 this.rounded_t_md()
+                    .border_b_1()
+                    .border_color(cx.theme().colors().border.opacity(0.6))
             }
         })
         .children(label)
@@ -563,12 +561,12 @@ fn render_markdown_code_block(
         .group(CODEBLOCK_CONTAINER_GROUP)
         .my_2()
         .overflow_hidden()
-        .rounded_lg()
+        .rounded_md()
         .border_1()
         .border_color(cx.theme().colors().border.opacity(0.6))
         .bg(cx.theme().colors().editor_background)
         .child(codeblock_header)
-        .when(!is_expanded, |this| this.h(rems_from_px(29.)))
+        .when(!is_expanded, |this| this.h(rems_from_px(31.)))
 }
 
 fn open_path(

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -333,7 +333,6 @@ fn tool_use_markdown_style(window: &Window, cx: &mut App) -> MarkdownStyle {
 }
 
 const CODEBLOCK_CONTAINER_GROUP: &str = "codeblock_container";
-const MAX_UNCOLLAPSED_LINES_IN_CODE_BLOCK: usize = 10;
 
 fn render_markdown_code_block(
     message_id: MessageId,
@@ -2370,15 +2369,12 @@ impl ActiveThread {
                                         transform: Some(Arc::new({
                                             let active_thread = cx.entity();
 
-                                            move |element, range, metadata, _, cx| {
-                                                let can_expand = metadata.line_count
-                                                    >= MAX_UNCOLLAPSED_LINES_IN_CODE_BLOCK;
-
+                                            move |element, range, _, _, cx| {
                                                 let is_expanded = active_thread
                                                     .read(cx)
                                                     .is_codeblock_expanded(message_id, range.start);
 
-                                                if !can_expand || is_expanded {
+                                                if is_expanded {
                                                     return element;
                                                 }
 

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -456,8 +456,6 @@ fn render_markdown_code_block(
         .copied_code_block_ids
         .contains(&(message_id, ix));
 
-    // let can_expand = metadata.line_count >= MAX_UNCOLLAPSED_LINES_IN_CODE_BLOCK;
-
     let is_expanded = active_thread.read(cx).is_codeblock_expanded(message_id, ix);
 
     let codeblock_header_bg = cx

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -383,6 +383,7 @@ fn render_markdown_code_block(
                     cx,
                 )
             } else {
+                let text_size = rems(0.8125);
                 let content = if let Some(parent) = path_range.path.parent() {
                     let file_name = file_name.to_string_lossy().to_string();
                     let path = parent.to_string_lossy().to_string();
@@ -392,7 +393,7 @@ fn render_markdown_code_block(
                         .id(("code-block-header-label", ix))
                         .ml_1()
                         .gap_1()
-                        .child(div().text_size(rems(0.8125)).child(file_name))
+                        .child(div().text_size(text_size).child(file_name))
                         .child(Label::new(path).color(Color::Muted).size(LabelSize::Small))
                         .tooltip(move |window, cx| {
                             Tooltip::with_meta(
@@ -405,9 +406,10 @@ fn render_markdown_code_block(
                         })
                         .into_any_element()
                 } else {
-                    Label::new(path_range.path.to_string_lossy().to_string())
-                        .size(LabelSize::Small)
+                    div()
                         .ml_1()
+                        .text_size(text_size)
+                        .child(path_range.path.to_string_lossy().to_string())
                         .into_any_element()
                 };
 

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -400,7 +400,7 @@ impl EditFileToolCard {
             diff_task: None,
             preview_expanded: true,
             error_expanded: None,
-            full_height_expanded: false,
+            full_height_expanded: true,
             total_lines: None,
         }
     }


### PR DESCRIPTION
This PR makes the edit tool call codeblock cards expanded by default, to be consistent with https://github.com/zed-industries/zed/pull/30806. Also, I am removing the collapsing behavior of Markdown codeblocks where we'd add a gradient while capping the container's height based on an arbitrary number of lines. Figured if they're all now initially expanded, we could simplify how the design/code operates here altogether. 

Open for feedback, as I can see an argument where the previous Markdown codeblock design of "collapsed but not fully; it shows a preview" should stay as it is useful.

Release Notes:

- N/A
