### PR TITLE
collab: Enable tax ID collection in Stripe checkout sessions

### DIFF
--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -203,6 +203,9 @@ impl StripeBilling {
             quantity: Some(1),
             ..Default::default()
         }]);
+        // Should be based on location: https://docs.stripe.com/tax/checkout/tax-ids
+        params.tax_id_collection =
+            Some(stripe::CreateCheckoutSessionTaxIdCollection { enabled: true });
         params.success_url = Some(success_url);
 
         let session = stripe::CheckoutSession::create(&self.client, params).await?;
@@ -257,6 +260,9 @@ impl StripeBilling {
             quantity: Some(1),
             ..Default::default()
         }]);
+        // Should be based on location: https://docs.stripe.com/tax/checkout/tax-ids
+        params.tax_id_collection =
+            Some(stripe::CreateCheckoutSessionTaxIdCollection { enabled: true });
         params.success_url = Some(success_url);
 
         let session = stripe::CheckoutSession::create(&self.client, params).await?;
@@ -282,6 +288,9 @@ impl StripeBilling {
             quantity: Some(1),
             ..Default::default()
         }]);
+        // Should be based on location: https://docs.stripe.com/tax/checkout/tax-ids
+        params.tax_id_collection =
+            Some(stripe::CreateCheckoutSessionTaxIdCollection { enabled: true });
         params.success_url = Some(success_url);
 
         let session = stripe::CheckoutSession::create(&self.client, params).await?;


### PR DESCRIPTION
This should be based on locations where this is applicable. I've used
this in the past, and the user is allowed to indicate this is for a
Business and then the checkout flow shows a tax id field for them.

https://docs.stripe.com/tax/checkout/tax-ids

Release Notes:

- N/A
