### PR TITLE
Ensure horizontal scrollbars show as needed

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4384,11 +4384,9 @@ impl OutlinePanel {
                 .bottom_0()
                 .h(px(12.))
                 .cursor_default()
-                .when(self.width.is_some(), |this| {
-                    this.children(Scrollbar::horizontal(
-                        self.horizontal_scrollbar_state.clone(),
-                    ))
-                }),
+                .children(Scrollbar::horizontal(
+                    self.horizontal_scrollbar_state.clone(),
+                )),
         )
     }
 

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4336,18 +4336,7 @@ impl OutlinePanel {
             return None;
         }
 
-        let scroll_handle = self.scroll_handle.0.borrow();
-        let longest_item_width = scroll_handle
-            .last_item_size
-            .filter(|size| size.contents.width > size.item.width)?
-            .contents
-            .width
-            .0 as f64;
-        if longest_item_width < scroll_handle.base_handle.bounds().size.width.0 as f64 {
-            return None;
-        }
-
-        Some(
+        Scrollbar::horizontal(self.horizontal_scrollbar_state.clone()).map(|scrollbar| {
             div()
                 .occlude()
                 .id("project-panel-horizontal-scroll")
@@ -4384,10 +4373,8 @@ impl OutlinePanel {
                 .bottom_0()
                 .h(px(12.))
                 .cursor_default()
-                .children(Scrollbar::horizontal(
-                    self.horizontal_scrollbar_state.clone(),
-                )),
-        )
+                .child(scrollbar)
+        })
     }
 
     fn should_show_scrollbar(cx: &App) -> bool {

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4335,7 +4335,6 @@ impl OutlinePanel {
         {
             return None;
         }
-
         Scrollbar::horizontal(self.horizontal_scrollbar_state.clone()).map(|scrollbar| {
             div()
                 .occlude()

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4346,18 +4346,7 @@ impl ProjectPanel {
             return None;
         }
 
-        let scroll_handle = self.scroll_handle.0.borrow();
-        let longest_item_width = scroll_handle
-            .last_item_size
-            .filter(|size| size.contents.width > size.item.width)?
-            .contents
-            .width
-            .0 as f64;
-        if longest_item_width < scroll_handle.base_handle.bounds().size.width.0 as f64 {
-            return None;
-        }
-
-        Some(
+        Scrollbar::horizontal(self.horizontal_scrollbar_state.clone()).map(|scrollbar| {
             div()
                 .occlude()
                 .id("project-panel-horizontal-scroll")
@@ -4394,10 +4383,8 @@ impl ProjectPanel {
                 .bottom_1()
                 .h(px(12.))
                 .cursor_default()
-                .children(Scrollbar::horizontal(
-                    self.horizontal_scrollbar_state.clone(),
-                )),
-        )
+                .child(scrollbar)
+        })
     }
 
     fn dispatch_context(&self, window: &Window, cx: &Context<Self>) -> KeyContext {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4345,7 +4345,6 @@ impl ProjectPanel {
         {
             return None;
         }
-
         Scrollbar::horizontal(self.horizontal_scrollbar_state.clone()).map(|scrollbar| {
             div()
                 .occlude()

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4394,11 +4394,9 @@ impl ProjectPanel {
                 .bottom_1()
                 .h(px(12.))
                 .cursor_default()
-                .when(self.width.is_some(), |this| {
-                    this.children(Scrollbar::horizontal(
-                        self.horizontal_scrollbar_state.clone(),
-                    ))
-                }),
+                .children(Scrollbar::horizontal(
+                    self.horizontal_scrollbar_state.clone(),
+                )),
         )
     }
 


### PR DESCRIPTION
This PR fixes an issue where the horizontal scrollbar was sometimes not rendered despite being needed for the outline and project panels. 

The issue occured since `self.width` does not neccessarily have to be set when the scrollbar is rendered (it is only set on panel resize). However, the check for a `width` is not needed at all since the scrollbar constructor determines whether a scrollbar has to be rendered or not. Hence, this does not need to be special-cased.

Furthermore, since `Scrollbar::horizontal()` returns `Some(...)` when a scrollbar needs to be rendered, we do not have to check for this seperately on the scroll handle and can just map on the option. This simplifies the code a bit.

| `main` | This PR |
| --- | --- | 
| ![main](https://github.com/user-attachments/assets/db1d4524-716e-42c1-a6f9-7cfd59c94b30) | ![PR](https://github.com/user-attachments/assets/12536d28-616e-487d-b948-653f53da36b4) |



Release Notes:

- Fixed an issue where the horizontal scrollbar would not render in the project and outline panels.
