### PR TITLE
Continue processing Stripe events after seeing one that's > 1 day old

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -971,7 +971,7 @@ async fn poll_stripe_events(
                 .create_processed_stripe_event(&processed_event_params)
                 .await?;
 
-            return Ok(());
+            continue;
         }
 
         let process_result = match event.type_ {


### PR DESCRIPTION
This mostly affects local development. It fixes a bug where we would only process one Stripe event per polling period (5 seconds) when hitting old events.

Release Notes:

- N/A
