### PR TITLE
title_bar: Fix config merging to respect priority

### DIFF
--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -3,52 +3,48 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
 
-#[derive(Copy, Clone, Serialize, Deserialize, JsonSchema, Debug)]
-#[serde(default)]
+#[derive(Copy, Clone, Deserialize, Debug)]
 pub struct TitleBarSettings {
-    /// Whether to show the branch icon beside branch switcher in the title bar.
-    ///
-    /// Default: false
     pub show_branch_icon: bool,
-    /// Whether to show onboarding banners in the title bar.
-    ///
-    /// Default: true
     pub show_onboarding_banner: bool,
-    /// Whether to show user avatar in the title bar.
-    ///
-    /// Default: true
     pub show_user_picture: bool,
-    /// Whether to show the branch name button in the titlebar.
-    ///
-    /// Default: true
     pub show_branch_name: bool,
-    /// Whether to show the project host and name in the titlebar.
-    ///
-    /// Default: true
     pub show_project_items: bool,
-    /// Whether to show the sign in button in the title bar.
-    ///
-    /// Default: true
     pub show_sign_in: bool,
 }
 
-impl Default for TitleBarSettings {
-    fn default() -> Self {
-        Self {
-            show_branch_icon: false,
-            show_onboarding_banner: true,
-            show_user_picture: true,
-            show_branch_name: true,
-            show_project_items: true,
-            show_sign_in: true,
-        }
-    }
+#[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
+pub struct TitleBarSettingsContent {
+    /// Whether to show the branch icon beside branch switcher in the title bar.
+    ///
+    /// Default: false
+    pub show_branch_icon: Option<bool>,
+    /// Whether to show onboarding banners in the title bar.
+    ///
+    /// Default: true
+    pub show_onboarding_banner: Option<bool>,
+    /// Whether to show user avatar in the title bar.
+    ///
+    /// Default: true
+    pub show_user_picture: Option<bool>,
+    /// Whether to show the branch name button in the titlebar.
+    ///
+    /// Default: true
+    pub show_branch_name: Option<bool>,
+    /// Whether to show the project host and name in the titlebar.
+    ///
+    /// Default: true
+    pub show_project_items: Option<bool>,
+    /// Whether to show the sign in button in the title bar.
+    ///
+    /// Default: true
+    pub show_sign_in: Option<bool>,
 }
 
 impl Settings for TitleBarSettings {
     const KEY: Option<&'static str> = Some("title_bar");
 
-    type FileContent = Self;
+    type FileContent = TitleBarSettingsContent;
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut gpui::App) -> anyhow::Result<Self>
     where


### PR DESCRIPTION
This is a follow-up to #30450 so that _global_ `title_bar` configs
shadow _defaults_. The way `SettingsSources::json_merge` works is by
considering non-json-nulls as values to propagate. So it's important
that configs be `Option<T>` so any intent in overriding values is
captured.

This PR follows the same `*Settings<FileContent = *SettingsContent>`
pattern used throughout to keep the `Option`s in the "settings content"
type with the finalized values in the "settings" type.

Release Notes:

- N/A
