### PR TITLE
gpui: Correct the image id in the example image_loading

### DIFF
--- a/crates/gpui/examples/image_loading.rs
+++ b/crates/gpui/examples/image_loading.rs
@@ -177,7 +177,7 @@ impl Render for ImageLoadingExample {
                         )
                         .to_path_buf();
                         img(image_source.clone())
-                            .id("image-1")
+                            .id("image-4")
                             .border_1()
                             .size_12()
                             .with_fallback(|| Self::fallback_element().into_any_element())


### PR DESCRIPTION

The image id "image-1" already exists so the id should be "image-4"

Release Notes:

- N/A
