### PR TITLE
Restore the ability to drag and drop images into the editor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7946,6 +7946,7 @@ dependencies = [
  "editor",
  "file_icons",
  "gpui",
+ "language",
  "log",
  "project",
  "schemars",

--- a/crates/image_viewer/Cargo.toml
+++ b/crates/image_viewer/Cargo.toml
@@ -21,6 +21,7 @@ db.workspace = true
 editor.workspace = true
 file_icons.workspace = true
 gpui.workspace = true
+language.workspace = true
 log.workspace = true
 project.workspace = true
 schemars.workspace = true

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -11,6 +11,7 @@ use gpui::{
     InteractiveElement, IntoElement, ObjectFit, ParentElement, Render, Styled, Task, WeakEntity,
     Window, canvas, div, fill, img, opaque_grey, point, size,
 };
+use language::File as _;
 use persistence::IMAGE_VIEWER;
 use project::{ImageItem, Project, ProjectPath, image_store::ImageItemEvent};
 use settings::Settings;
@@ -104,7 +105,7 @@ impl Item for ImageView {
     }
 
     fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
-        let abs_path = self.image_item.read(cx).file.as_local()?.abs_path(cx);
+        let abs_path = self.image_item.read(cx).abs_path(cx)?;
         let file_path = abs_path.compact().to_string_lossy().to_string();
         Some(file_path.into())
     }
@@ -149,10 +150,10 @@ impl Item for ImageView {
     }
 
     fn tab_icon(&self, _: &Window, cx: &App) -> Option<Icon> {
-        let path = self.image_item.read(cx).path();
+        let path = self.image_item.read(cx).abs_path(cx)?;
         ItemSettings::get_global(cx)
             .file_icons
-            .then(|| FileIcons::get_icon(path, cx))
+            .then(|| FileIcons::get_icon(&path, cx))
             .flatten()
             .map(Icon::from_path)
     }
@@ -274,7 +275,7 @@ impl SerializableItem for ImageView {
         cx: &mut Context<Self>,
     ) -> Option<Task<gpui::Result<()>>> {
         let workspace_id = workspace.database_id()?;
-        let image_path = self.image_item.read(cx).file.as_local()?.abs_path(cx);
+        let image_path = self.image_item.read(cx).abs_path(cx)?;
 
         Some(cx.background_spawn({
             async move {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -107,6 +107,15 @@ pub struct LoadedBinaryFile {
     pub content: Vec<u8>,
 }
 
+impl fmt::Debug for LoadedBinaryFile {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("LoadedBinaryFile")
+            .field("file", &self.file)
+            .field("content_bytes", &self.content.len())
+            .finish()
+    }
+}
+
 pub struct LocalWorktree {
     snapshot: LocalSnapshot,
     scan_requests_tx: channel::Sender<ScanRequest>,
@@ -3293,7 +3302,7 @@ impl fmt::Debug for Snapshot {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct File {
     pub worktree: Entity<Worktree>,
     pub path: Arc<Path>,


### PR DESCRIPTION
`ImageItem`'s `file` is returning `""` as its `path` for single-filed worktrees like the ones are created for the images dropped from the OS.
`ImageItem::load_image_metadata` had used that `path` in FS operations and the other method tried to use for icon resolving.

Rework the code to use a more specific, `worktree::File` instead and always use the `abs_path` when dealing with paths from this `file`.

Release Notes:

- Fixed images not opening on drag and drop into the editor
