### PR TITLE
extension/dap: Add resolve_tcp_template function

### DIFF
--- a/crates/dap/src/dap.rs
+++ b/crates/dap/src/dap.rs
@@ -6,6 +6,8 @@ pub mod proto_conversions;
 mod registry;
 pub mod transport;
 
+use std::net::Ipv4Addr;
+
 pub use dap_types::*;
 pub use registry::{DapLocator, DapRegistry};
 pub use task::DebugRequest;
@@ -16,3 +18,19 @@ pub type StackFrameId = u64;
 
 #[cfg(any(test, feature = "test-support"))]
 pub use adapters::FakeAdapter;
+use task::TcpArgumentsTemplate;
+
+pub async fn configure_tcp_connection(
+    tcp_connection: TcpArgumentsTemplate,
+) -> anyhow::Result<(Ipv4Addr, u16, Option<u64>)> {
+    let host = tcp_connection.host();
+    let timeout = tcp_connection.timeout;
+
+    let port = if let Some(port) = tcp_connection.port {
+        port
+    } else {
+        transport::TcpTransport::port(&tcp_connection).await?
+    };
+
+    Ok((host, port, timeout))
+}

--- a/crates/dap/src/registry.rs
+++ b/crates/dap/src/registry.rs
@@ -54,10 +54,6 @@ impl DapRegistry {
     pub fn add_adapter(&self, adapter: Arc<dyn DebugAdapter>) {
         let name = adapter.name();
         let _previous_value = self.0.write().adapters.insert(name, adapter);
-        debug_assert!(
-            _previous_value.is_none(),
-            "Attempted to insert a new debug adapter when one is already registered"
-        );
     }
 
     pub fn adapter_language(&self, adapter_name: &str) -> Option<LanguageName> {

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -6,7 +6,7 @@ mod php;
 mod python;
 mod ruby;
 
-use std::{net::Ipv4Addr, sync::Arc};
+use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
 use async_trait::async_trait;
@@ -28,7 +28,6 @@ use php::PhpDebugAdapter;
 use python::PythonDebugAdapter;
 use ruby::RubyDebugAdapter;
 use serde_json::{Value, json};
-use task::TcpArgumentsTemplate;
 
 pub fn init(cx: &mut App) {
     cx.update_default_global(|registry: &mut DapRegistry, _cx| {

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -17,6 +17,7 @@ use dap::{
         self, AdapterVersion, DapDelegate, DebugAdapter, DebugAdapterBinary, DebugAdapterName,
         GithubRepo,
     },
+    configure_tcp_connection,
     inline_value::{PythonInlineValueProvider, RustInlineValueProvider},
 };
 use gdb::GdbDebugAdapter;
@@ -43,21 +44,6 @@ pub fn init(cx: &mut App) {
         registry
             .add_inline_value_provider("Python".to_string(), Arc::from(PythonInlineValueProvider));
     })
-}
-
-pub(crate) async fn configure_tcp_connection(
-    tcp_connection: TcpArgumentsTemplate,
-) -> Result<(Ipv4Addr, u16, Option<u64>)> {
-    let host = tcp_connection.host();
-    let timeout = tcp_connection.timeout;
-
-    let port = if let Some(port) = tcp_connection.port {
-        port
-    } else {
-        dap::transport::TcpTransport::port(&tcp_connection).await?
-    };
-
-    Ok((host, port, timeout))
 }
 
 trait ToDap {

--- a/crates/extension_api/src/extension_api.rs
+++ b/crates/extension_api/src/extension_api.rs
@@ -22,6 +22,7 @@ pub use wit::{
     zed::extension::dap::{
         DebugAdapterBinary, DebugRequest, DebugTaskDefinition, StartDebuggingRequestArguments,
         StartDebuggingRequestArgumentsRequest, TcpArguments, TcpArgumentsTemplate,
+        resolve_tcp_template,
     },
     zed::extension::github::{
         GithubRelease, GithubReleaseAsset, GithubReleaseOptions, github_release_by_tag_name,

--- a/crates/extension_api/wit/since_v0.6.0/dap.wit
+++ b/crates/extension_api/wit/since_v0.6.0/dap.wit
@@ -1,6 +1,9 @@
 interface dap {
     use common.{env-vars};
 
+    /// Resolves a specified TcpArgumentsTemplate into TcpArguments
+    resolve-tcp-template: func(template: tcp-arguments-template) -> result<tcp-arguments, string>;
+
     record launch-request {
         program: string,
         cwd: option<string>,


### PR DESCRIPTION
Extensions cannot look up available port themselves, hence the new API. With this I'm able to port our Ruby implementation into an extension.

Release Notes:

- N/A