### PR TITLE
collab: Cancel trials when they end with a missing payment method

### DIFF
--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -278,7 +278,7 @@ impl StripeBilling {
             trial_period_days: Some(trial_period_days),
             trial_settings: Some(stripe::CreateCheckoutSessionSubscriptionDataTrialSettings {
                 end_behavior: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior {
-                    missing_payment_method: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::Pause,
+                    missing_payment_method: stripe::CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod::Cancel,
                 }
             }),
             metadata: if !subscription_metadata.is_empty() {


### PR DESCRIPTION
This PR makes it so we cancel trials instead of pausing them when they end with a missing payment method.

Release Notes:

- N/A
