### PR TITLE
gpui: Fix `shape_text` split to support \r\n

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -474,7 +474,7 @@ impl WindowTextSystem {
             font_runs.clear();
         };
 
-        let mut split_lines = text.split('\n');
+        let mut split_lines = text.lines();
         let mut processed = false;
 
         if let Some(first_line) = split_lines.next() {


### PR DESCRIPTION
Release Notes:

- N/A

---

Today I check the shape_text result on Windows, I get:

<img width="409" alt="屏幕截图 2025-05-20 222908" src="https://github.com/user-attachments/assets/3ee93911-3de1-4e01-9433-00c626fc2369" />

Here the `shape_text` split logic I think it should use `lines` method, not `split('\n')`, the newline on Windows is `\r\n`.