### PR TITLE
Project Search: Don't prompt to save edited buffers in project search results if buffers open elsewhere

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1055,10 +1055,17 @@ impl ProjectSearchView {
 
         let is_dirty = self.is_dirty(cx);
 
-        let should_confirm_save = !will_autosave && is_dirty;
+        let skip_save_on_close = self
+            .workspace
+            .read_with(cx, |workspace, cx| {
+                workspace::Pane::skip_save_on_close(&self.results_editor, workspace, cx)
+            })
+            .unwrap_or(false);
+
+        let should_prompt_to_save = !skip_save_on_close && !will_autosave && is_dirty;
 
         cx.spawn_in(window, async move |this, cx| {
-            let should_search = if should_confirm_save {
+            let should_search = if should_prompt_to_save {
                 let options = &["Save", "Don't Save", "Cancel"];
                 let result_channel = this.update_in(cx, |_, window, cx| {
                     window.prompt(

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1449,10 +1449,7 @@ impl Pane {
             }
         });
         if dirty_project_item_ids.is_empty() {
-            if item.is_singleton(cx) && item.is_dirty(cx) {
-                return false;
-            }
-            return true;
+            return !(item.is_singleton(cx) && item.is_dirty(cx));
         }
 
         for open_item in workspace.items(cx) {
@@ -1465,11 +1462,7 @@ impl Pane {
             let other_project_item_ids = open_item.project_item_model_ids(cx);
             dirty_project_item_ids.retain(|id| !other_project_item_ids.contains(id));
         }
-        if dirty_project_item_ids.is_empty() {
-            return true;
-        }
-
-        false
+        return dirty_project_item_ids.is_empty();
     }
 
     pub(super) fn file_names_for_prompt(


### PR DESCRIPTION
Closes #ISSUE

Follow up for: #30864, making it so that you aren't prompted to save edits for buffers you have elsewhere, as if they are open elsewhere there is no need to prompt to save as the edits won't be thrown away

Release Notes:

- N/A *or* Added/Fixed/Improved ...
