### PR TITLE
sublime: Don't map editor::FindNextMatch by default

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -51,14 +51,14 @@
       "ctrl-k ctrl-l": "editor::ConvertToLowerCase",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd",
-      "f3": "editor::FindNextMatch",
-      "shift-f3": "editor::FindPreviousMatch"
+      "ctrl-delete": "editor::DeleteToNextWordEnd"
     }
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
+      "f3": "editor::FindNextMatch",
+      "shift-f3": "editor::FindPreviousMatch",
       "ctrl-r": "outline::Toggle"
     }
   },

--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -57,8 +57,6 @@
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "f3": "editor::FindNextMatch",
-      "shift-f3": "editor::FindPreviousMatch",
       "ctrl-r": "outline::Toggle"
     }
   },

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -59,8 +59,6 @@
   {
     "context": "Editor && mode == full",
     "bindings": {
-      "cmd-g": "editor::FindNextMatch",
-      "cmd-shift-g": "editor::FindPreviousMatch",
       "cmd-r": "outline::Toggle"
     }
   },

--- a/assets/keymaps/macos/sublime_text.json
+++ b/assets/keymaps/macos/sublime_text.json
@@ -53,14 +53,14 @@
       "cmd-shift-j": "editor::JoinLines",
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
-      "ctrl-delete": "editor::DeleteToNextWordEnd",
-      "cmd-g": "editor::FindNextMatch",
-      "cmd-shift-g": "editor::FindPreviousMatch"
+      "ctrl-delete": "editor::DeleteToNextWordEnd"
     }
   },
   {
     "context": "Editor && mode == full",
     "bindings": {
+      "cmd-g": "editor::FindNextMatch",
+      "cmd-shift-g": "editor::FindPreviousMatch",
       "cmd-r": "outline::Toggle"
     }
   },


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/29535

Broken in: https://github.com/zed-industries/zed/pull/28559/files

Removes `editor::FindNextMatch` and `editor::FindPreviousMatch` from the default sublime mappings.  If you would like to use this, you will have to add them to your user keymap.  Reverts the previous behavior where cmd-g / cmd-shift-g relies on the base keymap.  

Linux:
```json
  {
    "context": "Editor && mode == full",
    "bindings": {
      "f3": "editor::FindNextMatch",
      "shift-f3": "editor::FindPreviousMatch"
    }
  }
```

MacOS:
```json
  {
    "context": "Editor && mode == full",
    "bindings": {
      "cmd-g": "editor::FindNextMatch",
      "cmd-shift-g": "editor::FindPreviousMatch"
    }
  },
```


Release Notes:

- Fixed a regression in Sublime Text keymap for find next/previous in the search bar
