### PR TITLE
Revert "gpui: Fix `shape_text` split to support \r\n"

### DIFF
--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -474,7 +474,7 @@ impl WindowTextSystem {
             font_runs.clear();
         };
 
-        let mut split_lines = text.lines();
+        let mut split_lines = text.split('\n');
         let mut processed = false;
 
         if let Some(first_line) = split_lines.next() {


### PR DESCRIPTION
Release Notes:

- N/A

----

Reverts zed-industries/zed#31022

Sorry @mikayla-maki, I found that things are more complicated than I thought.

The lines returned by shape_text must maintain the same length as all the original characters, otherwise the subsequent offset needs to always consider the difference of `\r\n` or `\n` to do the offset.

> I used this for multi-line input in GPUI Component, after #31022 change is actually fixed some position issue, but coming with too much offset incorrect issues.

Before, we only needed to add +1 after each offset after the line, but now we need to consider +1 or +2, which is much more complicated.