### PR TITLE
markdown: fix for delayed selection

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -583,6 +583,7 @@ impl MarkdownElement {
                     if phase.bubble() {
                         if let Some(link) = rendered_text.link_for_position(event.position) {
                             markdown.pressed_link = Some(link.clone());
+                            window.prevent_default();
                         } else {
                             let source_index =
                                 match rendered_text.source_index_for_position(event.position) {
@@ -601,10 +602,10 @@ impl MarkdownElement {
                                 reversed: false,
                                 pending: true,
                             };
+                            window.prevent_default();
                             window.focus(&markdown.focus_handle);
                         }
 
-                        window.prevent_default();
                         cx.notify();
                     }
                 } else if phase.capture() {


### PR DESCRIPTION
Previously, if you double/triple-clicked in a markdown renderer, it took
a long time for the selection to appear. Now the selection should render
right away while still maintaining focus.

Release Notes:

- N/A
