### PR TITLE
editor: Hide hover popover when code actions or completion context menu is triggered

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5081,6 +5081,7 @@ impl Editor {
                     if editor.focus_handle.is_focused(window) && menu.is_some() {
                         let mut menu = menu.unwrap();
                         menu.resolve_visible_completions(editor.completion_provider.as_deref(), cx);
+
                         *editor.context_menu.borrow_mut() =
                             Some(CodeContextMenu::Completions(menu));
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5081,7 +5081,7 @@ impl Editor {
                     if editor.focus_handle.is_focused(window) && menu.is_some() {
                         let mut menu = menu.unwrap();
                         menu.resolve_visible_completions(editor.completion_provider.as_deref(), cx);
-
+                        crate::hover_popover::hide_hover(editor, cx);
                         *editor.context_menu.borrow_mut() =
                             Some(CodeContextMenu::Completions(menu));
 
@@ -5512,6 +5512,7 @@ impl Editor {
                                 .map_or(true, |actions| actions.is_empty())
                             && debug_scenarios.is_empty();
                         if let Ok(task) = editor.update_in(cx, |editor, window, cx| {
+                            crate::hover_popover::hide_hover(editor, cx);
                             *editor.context_menu.borrow_mut() =
                                 Some(CodeContextMenu::CodeActions(CodeActionsMenu {
                                     buffer,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5081,7 +5081,6 @@ impl Editor {
                     if editor.focus_handle.is_focused(window) && menu.is_some() {
                         let mut menu = menu.unwrap();
                         menu.resolve_visible_completions(editor.completion_provider.as_deref(), cx);
-                        crate::hover_popover::hide_hover(editor, cx);
                         *editor.context_menu.borrow_mut() =
                             Some(CodeContextMenu::Completions(menu));
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5081,7 +5081,7 @@ impl Editor {
                     if editor.focus_handle.is_focused(window) && menu.is_some() {
                         let mut menu = menu.unwrap();
                         menu.resolve_visible_completions(editor.completion_provider.as_deref(), cx);
-
+                        crate::hover_popover::hide_hover(editor, cx);
                         *editor.context_menu.borrow_mut() =
                             Some(CodeContextMenu::Completions(menu));
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -394,9 +394,6 @@ fn show_hover(
             };
 
             this.update(cx, |this, _| {
-                if diagnostic_popover.is_some() {
-                    this.context_menu.take();
-                }
                 this.hover_state.diagnostic_popover = diagnostic_popover;
             })?;
 
@@ -527,9 +524,6 @@ fn show_hover(
                     );
                 }
 
-                if !info_popovers.is_empty() {
-                    editor.context_menu.take();
-                }
                 editor.hover_state.info_popovers = info_popovers;
                 cx.notify();
                 window.refresh();

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -394,6 +394,9 @@ fn show_hover(
             };
 
             this.update(cx, |this, _| {
+                if diagnostic_popover.is_some() {
+                    this.context_menu.take();
+                }
                 this.hover_state.diagnostic_popover = diagnostic_popover;
             })?;
 
@@ -524,6 +527,9 @@ fn show_hover(
                     );
                 }
 
+                if !info_popovers.is_empty() {
+                    editor.context_menu.take();
+                }
                 editor.hover_state.info_popovers = info_popovers;
                 cx.notify();
                 window.refresh();


### PR DESCRIPTION
This PR hides hover info/diagnostic popovers when code action menu is shown. We already hide hover info/diagnostic popover on code completion menu trigger (handled on input).

Note: It is still possible to see hover popover if code completion or code action menu is already open. This is intended behavior.

- [x] Test hover popover hides when code action is triggered

Release Notes:

- Fixed issue where info and diagnostic hover popovers were still visible when code action menu is triggered.