### PR TITLE
Have `edit_file_tool` respect `format_on_save`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "language_model",
  "language_models",
  "log",
+ "lsp",
  "markdown",
  "open",
  "paths",

--- a/crates/assistant_tools/Cargo.toml
+++ b/crates/assistant_tools/Cargo.toml
@@ -59,11 +59,12 @@ ui.workspace = true
 util.workspace = true
 web_search.workspace = true
 which.workspace = true
-workspace-hack.workspace = true
 workspace.workspace = true
+workspace-hack.workspace = true
 zed_llm_client.workspace = true
 
 [dev-dependencies]
+lsp = { workspace = true, features = ["test-support"] }
 client = { workspace = true, features = ["test-support"] }
 clock = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -1183,7 +1183,7 @@ mod tests {
         fs.save(
             path!("/root/src/main.rs").as_ref(),
             &"initial content".into(),
-            Default::default(),
+            LineEnding::Unix,
         )
         .await
         .unwrap();
@@ -1337,7 +1337,7 @@ mod tests {
         fs.save(
             path!("/root/src/main.rs").as_ref(),
             &"initial content".into(),
-            Default::default(),
+            LineEnding::Unix,
         )
         .await
         .unwrap();

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -1239,9 +1239,13 @@ mod tests {
         cx.executor().run_until_parked();
 
         // Read the file to verify trailing whitespace was removed automatically
-        let updated_content = fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap();
         assert_eq!(
-            updated_content, "fn main() {\n    println!(\"Hello!\");\n}\n",
+            // Ignore carriage returns on Windows
+            fs.load(path!("/root/src/main.rs").as_ref())
+                .await
+                .unwrap()
+                .replace("\r\n", "\n"),
+            "fn main() {\n    println!(\"Hello!\");\n}\n",
             "Trailing whitespace should be removed when remove_trailing_whitespace_on_save is enabled"
         );
 
@@ -1289,8 +1293,11 @@ mod tests {
         cx.executor().run_until_parked();
 
         // Verify the file still has trailing whitespace
+        // Read the file again - it should still have trailing whitespace
+        let final_content = fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap();
         assert_eq!(
-            fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap(),
+            // Ignore carriage returns on Windows
+            final_content.replace("\r\n", "\n"),
             CONTENT_WITH_TRAILING_WHITESPACE,
             "Trailing whitespace should remain when remove_trailing_whitespace_on_save is disabled"
         );
@@ -1420,7 +1427,9 @@ mod tests {
         // Read the file to verify it was formatted automatically
         let new_content = fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap();
         assert_eq!(
-            new_content, FORMATTED_CONTENT,
+            // Ignore carriage returns on Windows
+            new_content.replace("\r\n", "\n"),
+            FORMATTED_CONTENT,
             "Code should be formatted when format_on_save is enabled"
         );
 
@@ -1469,7 +1478,11 @@ mod tests {
 
         // Verify the file is still unformatted
         assert_eq!(
-            fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap(),
+            // Ignore carriage returns on Windows
+            fs.load(path!("/root/src/main.rs").as_ref())
+                .await
+                .unwrap()
+                .replace("\r\n", "\n"),
             UNFORMATTED_CONTENT,
             "Code should remain unformatted when format_on_save is disabled"
         );
@@ -1520,9 +1533,13 @@ mod tests {
         cx.executor().run_until_parked();
 
         // Read the file to verify it was formatted with the specified formatter
-        let new_content = fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap();
         assert_eq!(
-            new_content, FORMATTED_CONTENT,
+            // Ignore carriage returns on Windows
+            fs.load(path!("/root/src/main.rs").as_ref())
+                .await
+                .unwrap()
+                .replace("\r\n", "\n"),
+            FORMATTED_CONTENT,
             "Code should be formatted when format_on_save is set to a list"
         );
     }

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -1345,7 +1345,7 @@ mod tests {
         // Open the buffer to trigger LSP initialization
         let buffer = project
             .update(cx, |project, cx| {
-                project.open_local_buffer("/root/src/main.rs", cx)
+                project.open_local_buffer(path!("/root/src/main.rs"), cx)
             })
             .await
             .unwrap();

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -958,9 +958,13 @@ mod tests {
     use client::TelemetrySettings;
     use fs::{FakeFs, Fs};
     use gpui::{TestAppContext, UpdateGlobal};
+    use language::{FakeLspAdapter, Language, LanguageConfig, LanguageMatcher};
     use language_model::fake_provider::FakeLanguageModel;
+    use language_settings::{AllLanguageSettings, SelectedFormatter};
+    use lsp;
     use serde_json::json;
     use settings::SettingsStore;
+    use std::sync::Arc;
     use util::path;
 
     #[gpui::test]
@@ -1289,6 +1293,185 @@ mod tests {
             fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap(),
             CONTENT_WITH_TRAILING_WHITESPACE,
             "Trailing whitespace should remain when remove_trailing_whitespace_on_save is disabled"
+        );
+    }
+
+    #[gpui::test]
+    async fn test_format_on_save(cx: &mut TestAppContext) {
+        init_test(cx);
+
+        let fs = FakeFs::new(cx.executor());
+        fs.insert_tree("/root", json!({"src": {}})).await;
+
+        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
+
+        // Set up a Rust language with LSP formatting support
+        let rust_language = Arc::new(Language::new(
+            LanguageConfig {
+                name: "Rust".into(),
+                matcher: LanguageMatcher {
+                    path_suffixes: vec!["rs".to_string()],
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            None,
+        ));
+
+        // Register the language and fake LSP
+        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
+        language_registry.add(rust_language);
+
+        let mut fake_language_servers = language_registry.register_fake_lsp(
+            "Rust",
+            FakeLspAdapter {
+                capabilities: lsp::ServerCapabilities {
+                    document_formatting_provider: Some(lsp::OneOf::Left(true)),
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+        );
+
+        // Create the file
+        fs.save(
+            path!("/root/src/main.rs").as_ref(),
+            &"initial content".into(),
+            Default::default(),
+        )
+        .await
+        .unwrap();
+
+        // Open the buffer to trigger LSP initialization
+        let buffer = project
+            .update(cx, |project, cx| {
+                project.open_local_buffer("/root/src/main.rs", cx)
+            })
+            .await
+            .unwrap();
+
+        // Register the buffer with language servers
+        let _handle = project.update(cx, |project, cx| {
+            project.register_buffer_with_language_servers(&buffer, cx)
+        });
+
+        const UNFORMATTED_CONTENT: &str = "fn main() {println!(\"Hello!\");}\n";
+        const FORMATTED_CONTENT: &str =
+            "This file was formatted by the fake formatter in the test.\n";
+
+        // Get the fake language server and set up formatting handler
+        let fake_language_server = fake_language_servers.next().await.unwrap();
+        fake_language_server.set_request_handler::<lsp::request::Formatting, _, _>({
+            |_, _| async move {
+                Ok(Some(vec![lsp::TextEdit {
+                    range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(1, 0)),
+                    new_text: FORMATTED_CONTENT.to_string(),
+                }]))
+            }
+        });
+
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let model = Arc::new(FakeLanguageModel::default());
+
+        // First, test with format_on_save enabled
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
+                    settings.defaults.format_on_save = Some(FormatOnSave::On);
+                    settings.defaults.formatter = Some(SelectedFormatter::Auto);
+                });
+            });
+        });
+
+        // Have the model stream unformatted content
+        let edit_result = {
+            let edit_task = cx.update(|cx| {
+                let input = serde_json::to_value(EditFileToolInput {
+                    display_description: "Create main function".into(),
+                    path: "root/src/main.rs".into(),
+                    mode: EditFileMode::Overwrite,
+                })
+                .unwrap();
+                Arc::new(EditFileTool)
+                    .run(
+                        input,
+                        Arc::default(),
+                        project.clone(),
+                        action_log.clone(),
+                        model.clone(),
+                        None,
+                        cx,
+                    )
+                    .output
+            });
+
+            // Stream the unformatted content
+            cx.executor().run_until_parked();
+            model.stream_last_completion_response(UNFORMATTED_CONTENT.to_string());
+            model.end_last_completion_stream();
+
+            edit_task.await
+        };
+        assert!(edit_result.is_ok());
+
+        // Wait for any async operations (e.g. formatting) to complete
+        cx.executor().run_until_parked();
+
+        // Read the file to verify it was formatted automatically
+        let new_content = fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap();
+        assert_eq!(
+            new_content, FORMATTED_CONTENT,
+            "Code should be formatted when format_on_save is enabled"
+        );
+
+        // Next, test with format_on_save disabled
+        cx.update(|cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings::<AllLanguageSettings>(cx, |settings| {
+                    settings.defaults.format_on_save = Some(FormatOnSave::Off);
+                });
+            });
+        });
+
+        // Stream unformatted edits again
+        let edit_result = {
+            let edit_task = cx.update(|cx| {
+                let input = serde_json::to_value(EditFileToolInput {
+                    display_description: "Update main function".into(),
+                    path: "root/src/main.rs".into(),
+                    mode: EditFileMode::Overwrite,
+                })
+                .unwrap();
+                Arc::new(EditFileTool)
+                    .run(
+                        input,
+                        Arc::default(),
+                        project.clone(),
+                        action_log.clone(),
+                        model.clone(),
+                        None,
+                        cx,
+                    )
+                    .output
+            });
+
+            // Stream the unformatted content
+            cx.executor().run_until_parked();
+            model.stream_last_completion_response(UNFORMATTED_CONTENT.to_string());
+            model.end_last_completion_stream();
+
+            edit_task.await
+        };
+        assert!(edit_result.is_ok());
+
+        // Wait for any async operations (e.g. formatting) to complete
+        cx.executor().run_until_parked();
+
+        // Verify the file is still unformatted
+        assert_eq!(
+            fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap(),
+            UNFORMATTED_CONTENT,
+            "Code should remain unformatted when format_on_save is disabled"
         );
     }
 }


### PR DESCRIPTION
Release Notes:

- Agents now automatically format after edits if `format_on_save` is enabled.
