### PR TITLE
Validate actions in docs

### DIFF
--- a/.github/actions/build_docs/action.yml
+++ b/.github/actions/build_docs/action.yml
@@ -1,0 +1,36 @@
+name: "Build docs"
+description: "Build the docs"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Setup mdBook
+      uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
+      with:
+        mdbook-version: "0.4.37"
+
+    - name: Cache dependencies
+      uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+      with:
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+        cache-provider: "buildjet"
+
+    - name: Install Linux dependencies
+      shell: bash -euxo pipefail {0}
+      run: ./script/linux
+
+    - name: Install system dependencies
+      shell: bash -euxo pipefail {0}
+      run: |
+        sudo apt-get update
+        sudo apt-get install libxkbcommon-dev libxkbcommon-x11-dev
+
+    - name: Limit target directory size
+      shell: bash -euxo pipefail {0}
+      run: script/clear-target-dir-if-larger-than 100
+
+    - name: Build book
+      shell: bash -euxo pipefail {0}
+      run: |
+        mkdir -p target/deploy
+        mdbook build ./docs --dest-dir=../target/deploy/docs/

--- a/.github/actions/build_docs/action.yml
+++ b/.github/actions/build_docs/action.yml
@@ -19,16 +19,6 @@ runs:
       shell: bash -euxo pipefail {0}
       run: ./script/linux
 
-    - name: Install system dependencies
-      shell: bash -euxo pipefail {0}
-      run: |
-        sudo apt-get update
-        sudo apt-get install libxkbcommon-dev libxkbcommon-x11-dev
-
-    - name: Limit target directory size
-      shell: bash -euxo pipefail {0}
-      run: script/clear-target-dir-if-larger-than 100
-
     - name: Build book
       shell: bash -euxo pipefail {0}
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,29 @@ jobs:
         with:
           config: ./typos.toml
 
+  check_docs:
+    timeout-minutes: 60
+    name: Check docs
+    needs: [job_spec]
+    if: github.repository_owner == 'zed-industries'
+    runs-on:
+      - buildjet-8vcpu-ubuntu-2204
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          clean: false
+
+      - name: Configure CI
+        run: |
+          mkdir -p ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+
+      - name: Build docs
+        uses: ./.github/actions/build_docs
+        with:
+          working-directory: ${{ env.ZED_WORKSPACE }}
+
   macos_tests:
     timeout-minutes: 60
     name: (macOS) Run Clippy and tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,6 @@ jobs:
 
       - name: Build docs
         uses: ./.github/actions/build_docs
-        with:
-          working-directory: ${{ env.ZED_WORKSPACE }}
 
   macos_tests:
     timeout-minutes: 60

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -17,24 +17,13 @@ jobs:
         with:
           clean: false
 
-      - name: Setup mdBook
-        uses: peaceiris/actions-mdbook@ee69d230fe19748b7abf22df32acaa93833fad08 # v2
-        with:
-          mdbook-version: "0.4.37"
-
       - name: Set up default .cargo/config.toml
         run: cp ./.cargo/collab-config.toml ./.cargo/config.toml
 
-      - name: Install system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install libxkbcommon-dev libxkbcommon-x11-dev
-
-      - name: Build book
-        run: |
-          set -euo pipefail
-          mkdir -p target/deploy
-          mdbook build ./docs --dest-dir=../target/deploy/docs/
+      - name: Build Docs
+        uses: ./.github/actions/build_docs
+        with:
+          working-directory: ${{ env.ZED_WORKSPACE }}
 
       - name: Deploy Docs
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -9,7 +9,7 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     if: github.repository_owner == 'zed-industries'
-    runs-on: ubuntu-latest
+    runs-on: buildjet-8vcpu-ubuntu-2204
 
     steps:
       - name: Checkout repo
@@ -20,10 +20,8 @@ jobs:
       - name: Set up default .cargo/config.toml
         run: cp ./.cargo/collab-config.toml ./.cargo/config.toml
 
-      - name: Build Docs
+      - name: Build docs
         uses: ./.github/actions/build_docs
-        with:
-          working-directory: ${{ env.ZED_WORKSPACE }}
 
       - name: Deploy Docs
         uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -3,8 +3,7 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - "*"
-      # - main
+      - main
 
 jobs:
   deploy-docs:
@@ -24,37 +23,37 @@ jobs:
       - name: Build docs
         uses: ./.github/actions/build_docs
 
-      # - name: Deploy Docs
-      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-      #   with:
-      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      #     command: pages deploy target/deploy --project-name=docs
+      - name: Deploy Docs
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy target/deploy --project-name=docs
 
-      # - name: Deploy Install
-      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-      #   with:
-      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      #     command: r2 object put -f script/install.sh zed-open-source-website-assets/install.sh
+      - name: Deploy Install
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: r2 object put -f script/install.sh zed-open-source-website-assets/install.sh
 
-      # - name: Deploy Docs Workers
-      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-      #   with:
-      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      #     command: deploy .cloudflare/docs-proxy/src/worker.js
+      - name: Deploy Docs Workers
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy .cloudflare/docs-proxy/src/worker.js
 
-      # - name: Deploy Install Workers
-      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-      #   with:
-      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-      #     command: deploy .cloudflare/docs-proxy/src/worker.js
+      - name: Deploy Install Workers
+        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: deploy .cloudflare/docs-proxy/src/worker.js
 
-      # - name: Preserve Wrangler logs
-      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-      #   if: always()
-      #   with:
-      #     name: wrangler_logs
-      #     path: /home/runner/.config/.wrangler/logs/
+      - name: Preserve Wrangler logs
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        if: always()
+        with:
+          name: wrangler_logs
+          path: /home/runner/.config/.wrangler/logs/

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -3,7 +3,8 @@ name: Deploy Docs
 on:
   push:
     branches:
-      - main
+      - "*"
+      # - main
 
 jobs:
   deploy-docs:
@@ -23,37 +24,37 @@ jobs:
       - name: Build docs
         uses: ./.github/actions/build_docs
 
-      - name: Deploy Docs
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy target/deploy --project-name=docs
+      # - name: Deploy Docs
+      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+      #   with:
+      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      #     command: pages deploy target/deploy --project-name=docs
 
-      - name: Deploy Install
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: r2 object put -f script/install.sh zed-open-source-website-assets/install.sh
+      # - name: Deploy Install
+      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+      #   with:
+      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      #     command: r2 object put -f script/install.sh zed-open-source-website-assets/install.sh
 
-      - name: Deploy Docs Workers
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy .cloudflare/docs-proxy/src/worker.js
+      # - name: Deploy Docs Workers
+      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+      #   with:
+      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      #     command: deploy .cloudflare/docs-proxy/src/worker.js
 
-      - name: Deploy Install Workers
-        uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: deploy .cloudflare/docs-proxy/src/worker.js
+      # - name: Deploy Install Workers
+      #   uses: cloudflare/wrangler-action@da0e0dfe58b7a431659754fdf3f186c529afbe65 # v3
+      #   with:
+      #     apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      #     accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      #     command: deploy .cloudflare/docs-proxy/src/worker.js
 
-      - name: Preserve Wrangler logs
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: always()
-        with:
-          name: wrangler_logs
-          path: /home/runner/.config/.wrangler/logs/
+      # - name: Preserve Wrangler logs
+      #   uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+      #   if: always()
+      #   with:
+      #     name: wrangler_logs
+      #     path: /home/runner/.config/.wrangler/logs/

--- a/.github/workflows/deploy_cloudflare.yml
+++ b/.github/workflows/deploy_cloudflare.yml
@@ -10,7 +10,7 @@ jobs:
   deploy-docs:
     name: Deploy Docs
     if: github.repository_owner == 'zed-industries'
-    runs-on: buildjet-8vcpu-ubuntu-2204
+    runs-on: buildjet-16vcpu-ubuntu-2204
 
     steps:
       - name: Checkout repo

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4543,6 +4543,8 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "command_palette",
+ "gpui",
  "mdbook",
  "regex",
  "serde",
@@ -4550,6 +4552,7 @@ dependencies = [
  "settings",
  "util",
  "workspace-hack",
+ "zed",
 ]
 
 [[package]]

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -120,7 +120,7 @@
       "ctrl-'": "editor::ToggleSelectedDiffHunks",
       "ctrl-\"": "editor::ExpandAllDiffHunks",
       "ctrl-i": "editor::ShowSignatureHelp",
-      "alt-g b": "editor::ToggleGitBlame",
+      "alt-g b": "git::Blame",
       "menu": "editor::OpenContextMenu",
       "shift-f10": "editor::OpenContextMenu",
       "ctrl-shift-e": "editor::ToggleEditPrediction",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -138,7 +138,7 @@
       "cmd-;": "editor::ToggleLineNumbers",
       "cmd-'": "editor::ToggleSelectedDiffHunks",
       "cmd-\"": "editor::ExpandAllDiffHunks",
-      "cmd-alt-g b": "editor::ToggleGitBlame",
+      "cmd-alt-g b": "git::Blame",
       "cmd-i": "editor::ShowSignatureHelp",
       "f9": "editor::ToggleBreakpoint",
       "shift-f9": "editor::EditLogBreakpoint",

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -448,7 +448,7 @@ impl PickerDelegate for CommandPaletteDelegate {
     }
 }
 
-fn humanize_action_name(name: &str) -> String {
+pub fn humanize_action_name(name: &str) -> String {
     let capacity = name.len() + name.chars().filter(|c| c.is_uppercase()).count();
     let mut result = String::with_capacity(capacity);
     for char in name.chars() {

--- a/crates/docs_preprocessor/Cargo.toml
+++ b/crates/docs_preprocessor/Cargo.toml
@@ -15,6 +15,9 @@ settings.workspace = true
 regex.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
+zed.workspace = true
+gpui.workspace = true
+command_palette.workspace = true
 
 [lints]
 workspace = true

--- a/crates/docs_preprocessor/src/main.rs
+++ b/crates/docs_preprocessor/src/main.rs
@@ -17,7 +17,7 @@ static KEYMAP_LINUX: LazyLock<KeymapFile> = LazyLock::new(|| {
     load_keymap("keymaps/default-linux.json").expect("Failed to load Linux keymap")
 });
 
-static ALL_ACTIONS: LazyLock<Vec<ActionDef>> = LazyLock::new(|| dump_all_gpui_actions());
+static ALL_ACTIONS: LazyLock<Vec<ActionDef>> = LazyLock::new(dump_all_gpui_actions);
 
 pub fn make_app() -> Command {
     Command::new("zed-docs-preprocessor")
@@ -85,7 +85,7 @@ fn template_and_validate_keybindings(book: &mut Book) -> bool {
         chapter.content = regex
             .replace_all(&chapter.content, |caps: &regex::Captures| {
                 let action = caps[1].trim();
-                if !find_action_by_name(action).is_some() {
+                if find_action_by_name(action).is_none() {
                     eprintln!("Action not found: {}", action);
                     ok = false;
                     return String::new();

--- a/crates/docs_preprocessor/src/main.rs
+++ b/crates/docs_preprocessor/src/main.rs
@@ -215,16 +215,5 @@ fn dump_all_gpui_actions() -> Vec<ActionDef> {
 
     actions.sort_by_key(|a| a.name);
 
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create(true)
-        .truncate(true)
-        .open("/Users/neb/Zed/actions-gen.json")
-        .unwrap();
-    io::Write::write(
-        &mut file,
-        serde_json::to_string_pretty(&actions).unwrap().as_bytes(),
-    )
-    .unwrap();
     return actions;
 }

--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -288,6 +288,18 @@ impl ActionRegistry {
     }
 }
 
+/// Generate a list of all the registered actions.
+/// Useful for transforming the list of available actions into a
+/// format suited for static analysis such as in validating keymaps, or
+/// generating documentation.
+pub fn generate_list_of_all_registered_actions() -> Vec<MacroActionData> {
+    let mut actions = Vec::new();
+    for builder in inventory::iter::<MacroActionBuilder> {
+        actions.push(builder.0());
+    }
+    actions
+}
+
 /// Defines and registers unit structs that can be used as actions.
 ///
 /// To use more complex data types as actions, use `impl_actions!`
@@ -333,7 +345,6 @@ macro_rules! action_as {
             ::std::clone::Clone, ::std::default::Default, ::std::fmt::Debug, ::std::cmp::PartialEq,
         )]
         pub struct $name;
-
         gpui::__impl_action!(
             $namespace,
             $name,

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -12,6 +12,10 @@ workspace = true
 
 [[bin]]
 name = "zed"
+path = "src/zed-main.rs"
+
+[lib]
+name = "zed"
 path = "src/main.rs"
 
 [dependencies]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -163,6 +163,8 @@ fn fail_to_open_window(e: anyhow::Error, _cx: &mut App) {
     }
 }
 
+<<<<<<< Conflict 1 of 1
++++++++ Contents of side #1
 fn main() {
     #[cfg(unix)]
     {
@@ -182,6 +184,7 @@ Error: Running Zed as root or via sudo is unsupported.
         }
     }
 
+pub fn main() {
     // Check if there is a pending installer
     // If there is, run the installer and exit
     // And we don't want to run the installer if we are not the first instance
@@ -217,9 +220,6 @@ Error: Running Zed as root or via sudo is unsupported.
             let _ = AttachConsole(ATTACH_PARENT_PROCESS);
         }
     }
-
-    menu::init();
-    zed_actions::init();
 
     let file_errors = init_paths();
     if !file_errors.is_empty() {
@@ -361,6 +361,9 @@ Error: Running Zed as root or via sudo is unsupported.
     });
 
     app.run(move |cx| {
+        menu::init();
+        zed_actions::init();
+
         release_channel::init(app_version, cx);
         gpui_tokio::init(cx);
         if let Some(app_commit_sha) = app_commit_sha {
@@ -1023,7 +1026,7 @@ fn init_paths() -> HashMap<io::ErrorKind, Vec<&'static Path>> {
     })
 }
 
-fn stdout_is_a_pty() -> bool {
+pub fn stdout_is_a_pty() -> bool {
     std::env::var(FORCE_CLI_MODE_ENV_VAR_NAME).ok().is_none() && io::stdout().is_terminal()
 }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -163,9 +163,7 @@ fn fail_to_open_window(e: anyhow::Error, _cx: &mut App) {
     }
 }
 
-<<<<<<< Conflict 1 of 1
-+++++++ Contents of side #1
-fn main() {
+pub fn main() {
     #[cfg(unix)]
     {
         let is_root = nix::unistd::geteuid().is_root();
@@ -184,7 +182,6 @@ Error: Running Zed as root or via sudo is unsupported.
         }
     }
 
-pub fn main() {
     // Check if there is a pending installer
     // If there is, run the installer and exit
     // And we don't want to run the installer if we are not the first instance

--- a/crates/zed/src/zed-main.rs
+++ b/crates/zed/src/zed-main.rs
@@ -1,0 +1,5 @@
+pub fn main() {
+    // separated out so that the file containing the main function can be imported by other crates,
+    // while having all gpui resources that are registered in main (primarily actions) initialized
+    zed::main();
+}

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -120,7 +120,7 @@ or by simply right clicking and selecting `Copy Permalink` with line(s) selected
 | {#action git::Branch}                  | {#kb git::Branch}                  |
 | {#action git::Switch}                  | {#kb git::Switch}                  |
 | {#action git::CheckoutBranch}          | {#kb git::CheckoutBranch}          |
-| {#action editor::ToggleGitBlame}       | {#kb editor::ToggleGitBlame}       |
+| {#action git::Blame}                   | {#kb git::Blame}                   |
 | {#action editor::ToggleGitBlameInline} | {#kb editor::ToggleGitBlameInline} |
 
 > Not all actions have default keybindings, but can be bound by [customizing your keymap](./key-bindings.md#user-keymaps).


### PR DESCRIPTION
Adds a validation step to docs preprocessing so that actions referenced in docs are checked against the list of all registered actions in GPUI.

In order for this to work properly, all of the crates that register actions had to be importable by the `docs_preprocessor` crate and actually used (see [this comment](https://github.com/zed-industries/zed/commit/ec16e70336552255adf99671ca4d3c4e3d1b5c5d#diff-2674caf14ae6d70752ea60c7061232393d84e7f61a52915ace089c30a797a1c3) for why this is challenging). 

In order to accomplish this I have moved the entry point of zed into a separate stub file named `zed_main.rs` so that `main.rs` is importable by the `docs_preprocessor` crate, this is kind of gross, but ensures that all actions that are registered in the application are registered when checking them in `docs_preprocessor`. An alternative solution suggested by @mikayla-maki was to separate out all our `::init()` functions into a lib entry point in the `zed` crate that can be imported instead, however, this turned out to be a far bigger refactor and is in my opinion better to do in a follow up PR with significant testing to ensure no regressions in behavior occur.

Release Notes:

- N/A
