### PR TITLE
evals: Add system prompt to edit agent evals + fix edit agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -688,6 +688,7 @@ dependencies = [
  "portable-pty",
  "pretty_assertions",
  "project",
+ "prompt_store",
  "rand 0.8.5",
  "regex",
  "reqwest_client",

--- a/crates/assistant_tools/Cargo.toml
+++ b/crates/assistant_tools/Cargo.toml
@@ -41,6 +41,7 @@ open.workspace = true
 paths.workspace = true
 portable-pty.workspace = true
 project.workspace = true
+prompt_store.workspace = true
 regex.workspace = true
 rust-embed.workspace = true
 schemars.workspace = true

--- a/crates/assistant_tools/src/edit_agent/evals.rs
+++ b/crates/assistant_tools/src/edit_agent/evals.rs
@@ -896,59 +896,24 @@ fn eval_add_overwrite_test() {
 }
 
 #[test]
-#[ignore] // until we figure out the mystery described in the comments
-// #[cfg_attr(not(feature = "eval"), ignore)]
+#[cfg_attr(not(feature = "eval"), ignore)]
 fn eval_create_empty_file() {
     // Check that Edit Agent can create a file without writing its
     // thoughts into it. This issue is not specific to empty files, but
     // it's easier to reproduce with them.
-    //
-    // NOTE: For some mysterious reason, I could easily reproduce this
-    // issue roughly 90% of the time in actual Zed. However, once I
-    // extract the exact LLM request before the failure point and
-    // generate from that, the reproduction rate drops to 2%!
-    //
-    // Things I've tried to make sure it's not a fluke: disabling prompt
-    // caching, capturing the LLM request via a proxy server, running the
-    // prompt on Claude separately from evals. Every time it was mostly
-    // giving good outcomes, which doesn't match my actual experience in
-    // Zed.
-    //
-    // At some point I discovered that simply adding one insignificant
-    // space or a newline to the prompt suddenly results in an outcome I
-    // tried to reproduce almost perfectly.
-    //
-    // This weirdness happens even outside of the Zed code base and even
-    // when using a different subscription. The result is the same: an
-    // extra newline or space changes the model behavior significantly
-    // enough, so that the pass rate drops from 99% to 0-3%
-    //
-    // I have no explanation to this.
     //
     //
     //  Model                          | Pass rate
     // ============================================
     //
     // --------------------------------------------
-    //           Prompt version: 2025-05-19
+    //           Prompt version: 2025-05-21
     // --------------------------------------------
     //
-    //  claude-3.7-sonnet              |  0.98
-    //    + one extra space in prompt  |  0.00
-    //    + original prompt again      |  0.99
-    //    + extra newline              |  0.03
+    //  claude-3.7-sonnet              |  1.00
     //  gemini-2.5-pro-preview-03-25   |  1.00
     //  gemini-2.5-flash-preview-04-17 |  1.00
-    //    + one extra space            |  1.00
     //  gpt-4.1                        |  1.00
-    //    + one extra space            |  1.00
-    //
-    // --------------------------------------------
-    //  Prompt version: 2025-05-19 + system prompt
-    // --------------------------------------------
-    //  claude-3.7-sonnet              |  1.00
-    //    + one extra space in prompt  |  0.75
-    //    + extra newline              |  0.96
     //
     //
     // TODO: gpt-4.1-mini errored 38 times:
@@ -957,8 +922,8 @@ fn eval_create_empty_file() {
     let input_file_content = None;
     let expected_output_content = String::new();
     eval(
-        100,
-        1.0,
+        500,
+        0.99,
         EvalInput::from_conversation(
             vec![
                 message(User, [text("Create a second empty todo file ")]),

--- a/crates/assistant_tools/src/edit_agent/evals.rs
+++ b/crates/assistant_tools/src/edit_agent/evals.rs
@@ -922,7 +922,7 @@ fn eval_create_empty_file() {
     let input_file_content = None;
     let expected_output_content = String::new();
     eval(
-        500,
+        100,
         0.99,
         EvalInput::from_conversation(
             vec![

--- a/crates/assistant_tools/src/templates/create_file_prompt.hbs
+++ b/crates/assistant_tools/src/templates/create_file_prompt.hbs
@@ -1,12 +1,13 @@
 You are an expert engineer and your task is to write a new file from scratch.
 
-<file_to_edit>
+You MUST respond directly with the file's content, without explanations, additional text or triple backticks.
+The text you output will be saved verbatim as the content of the file.
+Tool calls have been disabled. You MUST start your response directly with the file's new content.
+
+<file_path>
 {{path}}
-</file_to_edit>
+</file_path>
 
 <edit_description>
 {{edit_description}}
 </edit_description>
-
-You MUST respond directly with the file's content, without explanations, additional text or triple backticks.
-The text you output will be saved verbatim as the content of the file.


### PR DESCRIPTION
1. Add a system prompt to edit agent evals to match how we call the agent from threads.

2. Fix an issue with the agent writing its thought into a newly created empty file.

Release Notes:

- N/A
