### PR TITLE
Fix project search panic

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1055,16 +1055,17 @@ impl ProjectSearchView {
 
         let is_dirty = self.is_dirty(cx);
 
-        let skip_save_on_close = self
-            .workspace
-            .read_with(cx, |workspace, cx| {
-                workspace::Pane::skip_save_on_close(&self.results_editor, workspace, cx)
-            })
-            .unwrap_or(false);
-
-        let should_prompt_to_save = !skip_save_on_close && !will_autosave && is_dirty;
-
         cx.spawn_in(window, async move |this, cx| {
+            let skip_save_on_close = this
+                .read_with(cx, |this, cx| {
+                    this.workspace.read_with(cx, |workspace, cx| {
+                        workspace::Pane::skip_save_on_close(&this.results_editor, workspace, cx)
+                    })
+                })?
+                .unwrap_or(false);
+
+            let should_prompt_to_save = !skip_save_on_close && !will_autosave && is_dirty;
+
             let should_search = if should_prompt_to_save {
                 let options = &["Save", "Don't Save", "Cancel"];
                 let result_channel = this.update_in(cx, |_, window, cx| {


### PR DESCRIPTION
The panic occurred when querying a second search in the project search multibuffer while there were dirty buffers.

The panic only happened in Nightly so there's no release notes 

Release Notes:

- N/A
