### PR TITLE
editor: Prevent overlapping of signature/hover popovers and context menus

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4245,19 +4245,24 @@ impl EditorElement {
 
         let mut overall_height = Pixels::ZERO;
         let mut measured_hover_popovers = Vec::new();
-        for mut hover_popover in hover_popovers {
+        for (position, mut hover_popover) in hover_popovers.into_iter().with_position() {
             let size = hover_popover.layout_as_root(AvailableSpace::min_size(), window, cx);
             let horizontal_offset =
                 (hitbox.top_right().x - POPOVER_RIGHT_OFFSET - (hovered_point.x + size.width))
                     .min(Pixels::ZERO);
-            overall_height += HOVER_POPOVER_GAP + size.height;
+            match position {
+                itertools::Position::Middle | itertools::Position::Last => {
+                    overall_height += HOVER_POPOVER_GAP
+                }
+                _ => {}
+            }
+            overall_height += size.height;
             measured_hover_popovers.push(MeasuredHoverPopover {
                 element: hover_popover,
                 size,
                 horizontal_offset,
             });
         }
-        overall_height += HOVER_POPOVER_GAP;
 
         fn draw_occluder(
             width: Pixels,

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -1388,6 +1388,44 @@ where
             && point.y <= self.origin.y.clone() + self.size.height.clone()
     }
 
+    /// Checks if this bounds is completely contained within another bounds.
+    ///
+    /// This method determines whether the current bounds is entirely enclosed by the given bounds.
+    /// A bounds is considered to be contained within another if its origin (top-left corner) and
+    /// its bottom-right corner are both contained within the other bounds.
+    ///
+    /// # Arguments
+    ///
+    /// * `other` - A reference to another `Bounds` that might contain this bounds.
+    ///
+    /// # Returns
+    ///
+    /// Returns `true` if this bounds is completely inside the other bounds, `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// # use gpui::{Bounds, Point, Size};
+    /// let outer_bounds = Bounds {
+    ///     origin: Point { x: 0, y: 0 },
+    ///     size: Size { width: 20, height: 20 },
+    /// };
+    /// let inner_bounds = Bounds {
+    ///     origin: Point { x: 5, y: 5 },
+    ///     size: Size { width: 10, height: 10 },
+    /// };
+    /// let overlapping_bounds = Bounds {
+    ///     origin: Point { x: 15, y: 15 },
+    ///     size: Size { width: 10, height: 10 },
+    /// };
+    ///
+    /// assert!(inner_bounds.is_contained_within(&outer_bounds));
+    /// assert!(!overlapping_bounds.is_contained_within(&outer_bounds));
+    /// ```
+    pub fn is_contained_within(&self, other: &Self) -> bool {
+        other.contains(&self.origin) && other.contains(&self.bottom_right())
+    }
+
     /// Applies a function to the origin and size of the bounds, producing a new `Bounds<U>`.
     ///
     /// This method allows for converting a `Bounds<T>` to a `Bounds<U>` by specifying a closure


### PR DESCRIPTION
Closes #29358

If hover popovers or signature popovers ever clash with the context menu (like code completion or code actions), they find the best spot by trying different directions around the context menu to show the popover. If they can’t find a good spot, they just overlap with the context menu.

Not overlapping state:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/2f1bdc4c-eb01-405c-b5fb-eb28eadc9957" />

Overlapping case, moves popover to bottom of context menu:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/3ce4be23-7701-4711-b604-5e29682360e1" />

Overlapping case, moves popover to right of context menu:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/60d47518-e412-4d64-9d17-a69a17248bdf" /> <img width="350" alt="image" src="https://github.com/user-attachments/assets/2a3de176-7443-46d8-99d1-b2973a0ffaa6" />

Overlapping case, moves popover to left of context menu:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/015b799b-8c6e-4405-aee6-e205d4caebec" />

Overlapping case, moves popover to top of context menu:
<img width="350" alt="image" src="https://github.com/user-attachments/assets/fbd03d84-9a49-44eb-846b-a9852d2ff43e" />

Release Notes:

- Fixed an issue where hover popovers or signature popovers would overlap with existing opened completion or code actions context menus.
