### PR TITLE
Update `Cargo.lock`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9540,6 +9540,7 @@ dependencies = [
  "async-recursion 1.1.1",
  "collections",
  "editor",
+ "fs",
  "gpui",
  "language",
  "linkify",


### PR DESCRIPTION
This PR updates the `Cargo.lock` file, as running `cargo check` was producing a diff on `main`.

Release Notes:

- N/A
