### PR TITLE
Rename 'Quit' to 'Quit Zed' in macOS menu

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -45,7 +45,7 @@ pub fn app_menus() -> Vec<Menu> {
                 #[cfg(target_os = "macos")]
                 MenuItem::action("Show All", super::ShowAll),
                 MenuItem::separator(),
-                MenuItem::action("Quit", Quit),
+                MenuItem::action("Quit Zed", Quit),
             ],
         },
         Menu {


### PR DESCRIPTION
This is standard for Mac apps.

I should have included this with [my other PR](https://github.com/zed-industries/zed/pull/30697), but didn’t catch it. 🤦🏻‍♂️

Release Notes:

- N/A