### PR TITLE
collab: Drop `monthly_usages` and `lifetime_usages` tables

### DIFF
--- a/crates/collab/migrations_llm/20250521211721_drop_monthly_and_lifetime_usages_tables.sql
+++ b/crates/collab/migrations_llm/20250521211721_drop_monthly_and_lifetime_usages_tables.sql
@@ -1,0 +1,2 @@
+drop table monthly_usages;
+drop table lifetime_usages;


### PR DESCRIPTION
This PR drops the `monthly_usages` and `lifetime_usages` tables from the LLM database, as they are no longer used.

Release Notes:

- N/A
