### PR TITLE
collab: Drop `billing_events` table

### DIFF
--- a/crates/collab/migrations_llm/20250521222416_drop_billing_events_table.sql
+++ b/crates/collab/migrations_llm/20250521222416_drop_billing_events_table.sql
@@ -1,0 +1,1 @@
+drop table billing_events;


### PR DESCRIPTION
This PR drops the `billing_events` table, as we're no longer using it.

Release Notes:

- N/A