### PR TITLE
debugger: Add actions and keybindings for opening the thread and session menus

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -863,6 +863,13 @@
     }
   },
   {
+    "context": "DebugPanel",
+    "bindings": {
+      "ctrl-t": "debugger::ToggleThreadPicker",
+      "ctrl-i": "debugger::ToggleSessionPicker"
+    }
+  },
+  {
     "context": "CollabPanel && not_editing",
     "bindings": {
       "ctrl-backspace": "collab_panel::Remove",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -930,6 +930,13 @@
     }
   },
   {
+    "context": "DebugPanel",
+    "bindings": {
+      "cmd-t": "debugger::ToggleThreadPicker",
+      "cmd-i": "debugger::ToggleSessionPicker"
+    }
+  },
+  {
     "context": "CollabPanel && not_editing",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -45,6 +45,8 @@ actions!(
         FocusLoadedSources,
         FocusTerminal,
         ShowStackTrace,
+        ToggleThreadPicker,
+        ToggleSessionPicker,
     ]
 );
 

--- a/crates/debugger_ui/src/dropdown_menus.rs
+++ b/crates/debugger_ui/src/dropdown_menus.rs
@@ -132,7 +132,8 @@ impl DebugPanel {
                         this
                     }),
                 )
-                .style(DropdownStyle::Ghost),
+                .style(DropdownStyle::Ghost)
+                .handle(self.session_picker_menu_handle.clone()),
             )
         } else {
             None
@@ -163,7 +164,7 @@ impl DebugPanel {
                 DropdownMenu::new_with_element(
                     ("thread-list", session_id.0),
                     trigger,
-                    ContextMenu::build_eager(window, cx, move |mut this, _, _| {
+                    ContextMenu::build(window, cx, move |mut this, _, _| {
                         for (thread, _) in threads {
                             let running_state = running_state.clone();
                             let thread_id = thread.id;
@@ -177,7 +178,8 @@ impl DebugPanel {
                     }),
                 )
                 .disabled(session_terminated)
-                .style(DropdownStyle::Ghost),
+                .style(DropdownStyle::Ghost)
+                .handle(self.thread_picker_menu_handle.clone()),
             )
         } else {
             None

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -96,7 +96,7 @@ impl Render for RunningState {
             .find(|pane| pane.read(cx).is_zoomed());
 
         let active = self.panes.panes().into_iter().next();
-        let x = if let Some(ref zoomed_pane) = zoomed_pane {
+        let pane = if let Some(ref zoomed_pane) = zoomed_pane {
             zoomed_pane.update(cx, |pane, cx| pane.render(window, cx).into_any_element())
         } else if let Some(active) = active {
             self.panes
@@ -122,7 +122,7 @@ impl Render for RunningState {
             .size_full()
             .key_context("DebugSessionItem")
             .track_focus(&self.focus_handle(cx))
-            .child(h_flex().flex_1().child(x))
+            .child(h_flex().flex_1().child(pane))
     }
 }
 

--- a/crates/ui/src/components/dropdown_menu.rs
+++ b/crates/ui/src/components/dropdown_menu.rs
@@ -2,6 +2,8 @@ use gpui::{ClickEvent, Corner, CursorStyle, Entity, Hsla, MouseButton};
 
 use crate::{ContextMenu, PopoverMenu, prelude::*};
 
+use super::PopoverMenuHandle;
+
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum DropdownStyle {
     #[default]
@@ -22,6 +24,7 @@ pub struct DropdownMenu {
     menu: Entity<ContextMenu>,
     full_width: bool,
     disabled: bool,
+    handle: Option<PopoverMenuHandle<ContextMenu>>,
 }
 
 impl DropdownMenu {
@@ -37,6 +40,7 @@ impl DropdownMenu {
             menu,
             full_width: false,
             disabled: false,
+            handle: None,
         }
     }
 
@@ -52,6 +56,7 @@ impl DropdownMenu {
             menu,
             full_width: false,
             disabled: false,
+            handle: None,
         }
     }
 
@@ -62,6 +67,11 @@ impl DropdownMenu {
 
     pub fn full_width(mut self, full_width: bool) -> Self {
         self.full_width = full_width;
+        self
+    }
+
+    pub fn handle(mut self, handle: PopoverMenuHandle<ContextMenu>) -> Self {
+        self.handle = Some(handle);
         self
     }
 }
@@ -85,6 +95,7 @@ impl RenderOnce for DropdownMenu {
                     .style(self.style),
             )
             .attach(Corner::BottomLeft)
+            .when_some(self.handle.clone(), |el, handle| el.with_handle(handle))
     }
 }
 
@@ -159,17 +170,11 @@ pub struct DropdownTriggerStyle {
 impl DropdownTriggerStyle {
     pub fn for_style(style: DropdownStyle, cx: &App) -> Self {
         let colors = cx.theme().colors();
-
-        if style == DropdownStyle::Solid {
-            Self {
-                // why is this editor_background?
-                bg: colors.editor_background,
-            }
-        } else {
-            Self {
-                bg: colors.ghost_element_background,
-            }
-        }
+        let bg = match style {
+            DropdownStyle::Solid => colors.editor_background,
+            DropdownStyle::Ghost => colors.ghost_element_background,
+        };
+        Self { bg }
     }
 }
 


### PR DESCRIPTION
Makes it possible to open and navigate these menus from the keyboard.

I also removed the eager previewing behavior for the thread picker, which was buggy and came with a jarring layout shift.

Release Notes:

- Debugger Beta: Added the `debugger: open thread picker` and `debugger: open session picker` actions.