### PR TITLE
Restore scroll after undo edit prediction

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6523,12 +6523,24 @@ impl Editor {
                     provider.accept(cx);
                 }
 
+                // Store the transaction ID and selections before applying the edit
+                let transaction_id_prev = self.buffer.read_with(cx, |b, cx| b.last_transaction_id(cx));
+                let selections_prev = self.selections.disjoint_anchors();
+
                 let snapshot = self.buffer.read(cx).snapshot(cx);
                 let last_edit_end = edits.last().unwrap().0.end.bias_right(&snapshot);
 
                 self.buffer.update(cx, |buffer, cx| {
                     buffer.edit(edits.iter().cloned(), None, cx)
                 });
+
+                // Check if there's a new transaction and store the previous selections
+                if let Some(transaction_id_now) = self.buffer.read_with(cx, |b, cx| b.last_transaction_id(cx)) {
+                    let has_new_transaction = transaction_id_prev != Some(transaction_id_now);
+                    if has_new_transaction {
+                        self.selection_history.insert_transaction(transaction_id_now, selections_prev);
+                    }
+                }
 
                 self.change_selections(None, window, cx, |s| {
                     s.select_anchor_ranges([last_edit_end..last_edit_end])

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6471,7 +6471,7 @@ async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext
     cx.assert_editor_state(indoc! {"
         line 1
         line 2
-        linˇe 3
+        lineˇ 3
         line 4
         line 5
         line 6

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6387,13 +6387,11 @@ async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext
 
     let mut cx = EditorTestContext::new(cx).await;
 
-    // Create and assign a fake edit prediction provider
     let provider = cx.new(|_| FakeInlineCompletionProvider::default());
     cx.update_editor(|editor, window, cx| {
         editor.set_edit_prediction_provider(Some(provider.clone()), window, cx);
     });
 
-    // Set initial state with a long document
     cx.set_state(indoc! {"
         line 1
         line 2
@@ -6407,7 +6405,6 @@ async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext
         line 10
     "});
 
-    // Set up the proposed edit
     let snapshot = cx.buffer_snapshot();
     let edit_position = snapshot.anchor_after(Point::new(2, 4));
 
@@ -6421,13 +6418,11 @@ async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext
         })
     });
 
-    // Update and accept the completion
     cx.update_editor(|editor, window, cx| editor.update_visible_inline_completion(window, cx));
     cx.update_editor(|editor, window, cx| {
         editor.accept_edit_prediction(&crate::AcceptEditPrediction, window, cx)
     });
 
-    // Verify the edit was applied
     cx.assert_editor_state(indoc! {"
         line 1
         line 2
@@ -6441,14 +6436,12 @@ async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext
         line 10
     "});
 
-    // Move cursor to a different position
     cx.update_editor(|editor, window, cx| {
         editor.change_selections(None, window, cx, |s| {
             s.select_ranges([Point::new(9, 2)..Point::new(9, 2)]);
         });
     });
 
-    // Verify cursor moved
     cx.assert_editor_state(indoc! {"
         line 1
         line 2
@@ -6462,12 +6455,10 @@ async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext
         liˇne 10
     "});
 
-    // Undo the edit
     cx.update_editor(|editor, window, cx| {
         editor.undo(&Default::default(), window, cx);
     });
 
-    // Verify cursor moved back to the position of the edit
     cx.assert_editor_state(indoc! {"
         line 1
         line 2

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::{
     JoinLines,
+    inline_completion_tests::FakeInlineCompletionProvider,
     linked_editing_ranges::LinkedEditingRanges,
     scroll::scroll_amount::ScrollAmount,
     test::{
@@ -6377,6 +6378,107 @@ async fn test_undo_format_scrolls_to_last_edit_pos(cx: &mut TestAppContext) {
         linXˇe 3
         line 4
         line 5
+    "});
+}
+
+#[gpui::test]
+async fn test_undo_inline_completion_scrolls_to_edit_pos(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // Create and assign a fake edit prediction provider
+    let provider = cx.new(|_| FakeInlineCompletionProvider::default());
+    cx.update_editor(|editor, window, cx| {
+        editor.set_edit_prediction_provider(Some(provider.clone()), window, cx);
+    });
+
+    // Set initial state with a long document
+    cx.set_state(indoc! {"
+        line 1
+        line 2
+        linˇe 3
+        line 4
+        line 5
+        line 6
+        line 7
+        line 8
+        line 9
+        line 10
+    "});
+
+    // Set up the proposed edit
+    let snapshot = cx.buffer_snapshot();
+    let edit_position = snapshot.anchor_after(Point::new(2, 4));
+
+    cx.update(|_, cx| {
+        provider.update(cx, |provider, _| {
+            provider.set_inline_completion(Some(inline_completion::InlineCompletion {
+                id: None,
+                edits: vec![(edit_position..edit_position, "X".into())],
+                edit_preview: None,
+            }))
+        })
+    });
+
+    // Update and accept the completion
+    cx.update_editor(|editor, window, cx| editor.update_visible_inline_completion(window, cx));
+    cx.update_editor(|editor, window, cx| {
+        editor.accept_edit_prediction(&crate::AcceptEditPrediction, window, cx)
+    });
+
+    // Verify the edit was applied
+    cx.assert_editor_state(indoc! {"
+        line 1
+        line 2
+        lineXˇ 3
+        line 4
+        line 5
+        line 6
+        line 7
+        line 8
+        line 9
+        line 10
+    "});
+
+    // Move cursor to a different position
+    cx.update_editor(|editor, window, cx| {
+        editor.change_selections(None, window, cx, |s| {
+            s.select_ranges([Point::new(9, 2)..Point::new(9, 2)]);
+        });
+    });
+
+    // Verify cursor moved
+    cx.assert_editor_state(indoc! {"
+        line 1
+        line 2
+        lineX 3
+        line 4
+        line 5
+        line 6
+        line 7
+        line 8
+        line 9
+        liˇne 10
+    "});
+
+    // Undo the edit
+    cx.update_editor(|editor, window, cx| {
+        editor.undo(&Default::default(), window, cx);
+    });
+
+    // Verify cursor moved back to the position of the edit
+    cx.assert_editor_state(indoc! {"
+        line 1
+        line 2
+        linˇe 3
+        line 4
+        line 5
+        line 6
+        line 7
+        line 8
+        line 9
+        line 10
     "});
 }
 

--- a/crates/editor/src/inline_completion_tests.rs
+++ b/crates/editor/src/inline_completion_tests.rs
@@ -302,8 +302,8 @@ fn assign_editor_completion_provider(
 }
 
 #[derive(Default, Clone)]
-struct FakeInlineCompletionProvider {
-    completion: Option<inline_completion::InlineCompletion>,
+pub struct FakeInlineCompletionProvider {
+    pub completion: Option<inline_completion::InlineCompletion>,
 }
 
 impl FakeInlineCompletionProvider {


### PR DESCRIPTION
Closes #29652

Release Notes:

- Fixed an issue where the scroll and cursor position would not be restored after undoing an inline completion 
