### PR TITLE
Fix "j" key latency in vim mode with "j k" keymap

### DIFF
--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -15,7 +15,7 @@
   {
     "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
-      // "j k": "vim::SwitchToNormalMode"
+      // "j k": ["workspace::SendKeystrokes", "escape"]
     }
   }
 ]

--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -13,9 +13,9 @@
     }
   },
   {
-    "context": "Editor",
+  "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
-      // "j k": ["workspace::SendKeystrokes", "escape"]
+      "j k": "vim::SwitchToNormalMode"
     }
   }
 ]

--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -15,7 +15,7 @@
   {
   "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
-      "j k": "vim::SwitchToNormalMode"
+      // "j k": "vim::SwitchToNormalMode"
     }
   }
 ]

--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -13,7 +13,7 @@
     }
   },
   {
-  "context": "Editor && vim_mode == insert && !menu",
+    "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
       // "j k": "vim::SwitchToNormalMode"
     }

--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -15,7 +15,7 @@
   {
     "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
-      // "j k": ["workspace::SendKeystrokes", "escape"]
+      // "j k": "vim::SwitchToNormalMode"
     }
   }
 ]


### PR DESCRIPTION
Problem:
Initial keymap has "j k" keymap, which if uncommented will add +-1s delay to every "j" key press
This workaround was taken from https://github.com/zed-industries/zed/discussions/6661

Release Notes:

- N/A *or* Added/Fixed/Improved ...
