### PR TITLE
debugger beta: Fix dap_schema for DAP extensions

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -386,7 +386,7 @@ pub trait DebugAdapter: 'static + Send + Sync {
         }
     }
 
-    fn dap_schema(&self) -> serde_json::Value;
+    async fn dap_schema(&self) -> serde_json::Value;
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -434,7 +434,7 @@ impl DebugAdapter for FakeAdapter {
         DebugAdapterName(Self::ADAPTER_NAME.into())
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         serde_json::Value::Null
     }
 

--- a/crates/dap/src/registry.rs
+++ b/crates/dap/src/registry.rs
@@ -67,9 +67,12 @@ impl DapRegistry {
     pub async fn adapters_schema(&self) -> task::AdapterSchemas {
         let mut schemas = AdapterSchemas(vec![]);
 
-        for (name, adapter) in self.0.read().adapters.iter() {
+        // Clone to avoid holding lock over await points
+        let adapters = self.0.read().adapters.clone();
+
+        for (name, adapter) in adapters.into_iter() {
             schemas.0.push(AdapterSchema {
-                adapter: name.clone().into(),
+                adapter: name.into(),
                 schema: adapter.dap_schema().await,
             });
         }

--- a/crates/dap/src/registry.rs
+++ b/crates/dap/src/registry.rs
@@ -64,13 +64,13 @@ impl DapRegistry {
         );
     }
 
-    pub fn adapters_schema(&self) -> task::AdapterSchemas {
+    pub async fn adapters_schema(&self) -> task::AdapterSchemas {
         let mut schemas = AdapterSchemas(vec![]);
 
         for (name, adapter) in self.0.read().adapters.iter() {
             schemas.0.push(AdapterSchema {
                 adapter: name.clone().into(),
-                schema: adapter.dap_schema(),
+                schema: adapter.dap_schema().await,
             });
         }
 

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -175,7 +175,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
         })
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         json!({
             "properties": {
                 "request": {

--- a/crates/dap_adapters/src/gdb.rs
+++ b/crates/dap_adapters/src/gdb.rs
@@ -61,7 +61,7 @@ impl DebugAdapter for GdbDebugAdapter {
         })
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         json!({
             "oneOf": [
                 {

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -27,7 +27,7 @@ impl DebugAdapter for GoDebugAdapter {
         Some(SharedString::new_static("Go").into())
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         // Create common properties shared between launch and attach
         let common_properties = json!({
             "debugAdapter": {

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -170,7 +170,7 @@ impl DebugAdapter for JsDebugAdapter {
         })
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         json!({
             "oneOf": [
                 {

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -101,7 +101,7 @@ impl PhpDebugAdapter {
 
 #[async_trait(?Send)]
 impl DebugAdapter for PhpDebugAdapter {
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         json!({
             "properties": {
                 "request": {

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -210,7 +210,7 @@ impl DebugAdapter for PythonDebugAdapter {
         }
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         json!({
             "properties": {
                 "request": {

--- a/crates/dap_adapters/src/ruby.rs
+++ b/crates/dap_adapters/src/ruby.rs
@@ -31,7 +31,7 @@ impl DebugAdapter for RubyDebugAdapter {
         Some(SharedString::new_static("Ruby").into())
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
+    async fn dap_schema(&self) -> serde_json::Value {
         json!({
             "oneOf": [
                 {

--- a/crates/debug_adapter_extension/src/extension_dap_adapter.rs
+++ b/crates/debug_adapter_extension/src/extension_dap_adapter.rs
@@ -61,8 +61,8 @@ impl DebugAdapter for ExtensionDapAdapter {
         self.debug_adapter_name.as_ref().into()
     }
 
-    fn dap_schema(&self) -> serde_json::Value {
-        serde_json::Value::Null
+    async fn dap_schema(&self) -> serde_json::Value {
+        self.extension.get_dap_schema().await.unwrap_or_default()
     }
 
     async fn get_binary(

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -144,7 +144,7 @@ pub trait Extension: Send + Sync + 'static {
         worktree: Arc<dyn WorktreeDelegate>,
     ) -> Result<DebugAdapterBinary>;
 
-    async fn dap_schema(&self) -> Result<serde_json::Value>;
+    async fn get_dap_schema(&self) -> Result<serde_json::Value>;
 }
 
 pub fn parse_wasm_extension_version(

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -399,7 +399,7 @@ impl extension::Extension for WasmExtension {
         .await
     }
 
-    async fn dap_schema(&self) -> Result<serde_json::Value> {
+    async fn get_dap_schema(&self) -> Result<serde_json::Value> {
         self.call(|extension, store| {
             async move {
                 extension


### PR DESCRIPTION
We now actually call dap_schema provided by extensions instead of defaulting to a null `serde_json::Value`. We still need to update the Json LSP whenever a new dap is installed. 

Release Notes:

- N/A
