### PR TITLE
debugger beta: Move path resolution to resolve scenario instead of just in new session modal

### DIFF
--- a/crates/debugger_ui/src/new_session_modal.rs
+++ b/crates/debugger_ui/src/new_session_modal.rs
@@ -803,8 +803,6 @@ impl CustomMode {
 
         let args = args.collect::<Vec<_>>();
 
-        let (program, path) = resolve_paths(program, path);
-
         task::LaunchRequest {
             program,
             cwd: path.is_empty().not().then(|| PathBuf::from(path)),
@@ -1141,36 +1139,4 @@ impl PickerDelegate for DebugScenarioDelegate {
                 .child(highlighted_location.render(window, cx)),
         )
     }
-}
-
-fn resolve_paths(program: String, path: String) -> (String, String) {
-    let program = if let Some(program) = program.strip_prefix('~') {
-        format!(
-            "$ZED_WORKTREE_ROOT{}{}",
-            std::path::MAIN_SEPARATOR,
-            &program
-        )
-    } else if !program.starts_with(std::path::MAIN_SEPARATOR) {
-        format!(
-            "$ZED_WORKTREE_ROOT{}{}",
-            std::path::MAIN_SEPARATOR,
-            &program
-        )
-    } else {
-        program
-    };
-
-    let path = if path.starts_with('~') && !path.is_empty() {
-        format!(
-            "$ZED_WORKTREE_ROOT{}{}",
-            std::path::MAIN_SEPARATOR,
-            &path[1..]
-        )
-    } else if !path.starts_with(std::path::MAIN_SEPARATOR) && !path.is_empty() {
-        format!("$ZED_WORKTREE_ROOT{}{}", std::path::MAIN_SEPARATOR, &path)
-    } else {
-        path
-    };
-
-    (program, path)
 }

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -25,6 +25,7 @@ mod inline_values;
 #[cfg(test)]
 mod module_list;
 #[cfg(test)]
+#[cfg(not(windows))]
 mod new_session_modal;
 #[cfg(test)]
 mod persistence;

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -25,6 +25,8 @@ mod inline_values;
 #[cfg(test)]
 mod module_list;
 #[cfg(test)]
+mod new_session_modal;
+#[cfg(test)]
 mod persistence;
 #[cfg(test)]
 mod stack_frame_list;

--- a/crates/debugger_ui/src/tests/new_session_modal.rs
+++ b/crates/debugger_ui/src/tests/new_session_modal.rs
@@ -1,0 +1,146 @@
+use anyhow::{Context as _, Result};
+use dap::adapters::DebugTaskDefinition;
+use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext, WindowHandle};
+use project::{FakeFs, Project, WorktreeId};
+use serde_json::json;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use task::{DebugScenario, TaskContext, VariableName};
+use util::path;
+use workspace::Workspace;
+
+use crate::debugger_panel::DebugPanel;
+use crate::session::running::RunningState;
+use crate::tests::{active_debug_session_panel, init_test, init_test_workspace};
+
+#[gpui::test]
+async fn test_debug_session_substitutes_variables_and_relativizes_paths(
+    executor: BackgroundExecutor,
+    cx: &mut TestAppContext,
+) -> Result<()> {
+    init_test(cx);
+
+    let fs = FakeFs::new(executor.clone());
+    fs.insert_tree(
+        path!("/project"),
+        json!({
+            "main.rs": "fn main() {}"
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/project").as_ref()], cx).await;
+    let workspace = init_test_workspace(&project, cx).await;
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+
+    // Set up task variables to simulate a real environment
+    let test_variables = vec![(
+        VariableName::WorktreeRoot,
+        "/test/worktree/path".to_string(),
+    )]
+    .into_iter()
+    .collect();
+
+    let task_context = TaskContext {
+        cwd: None,
+        task_variables: test_variables,
+        project_env: Default::default(),
+    };
+
+    // Test cases for different path formats
+    let test_cases = vec![
+        // Absolute path - should not be relativized
+        ("/absolute/path/to/program", "/absolute/path/to/program"),
+        // Path with $ZED_WORKTREE_ROOT - should be substituted
+        (
+            "$ZED_WORKTREE_ROOT/src/program",
+            "/test/worktree/path/src/program",
+        ),
+        // Relative path - should be prefixed with worktree root
+        ("./src/program", "/test/worktree/path/src/program"),
+        // Implicit relative path - should be prefixed with worktree root
+        ("src/program", "/test/worktree/path/src/program"),
+        // Home directory path - should be prefixed with worktree root
+        ("~/src/program", "/test/worktree/path/src/program"),
+    ];
+
+    let called_launch = Arc::new(AtomicBool::new(false));
+
+    for (input_path, expected_path) in test_cases {
+        let _subscription = project::debugger::test::intercept_debug_sessions(cx, {
+            let called_launch = called_launch.clone();
+            move |client| {
+                client.on_request::<dap::requests::Launch, _>({
+                    let called_launch = called_launch.clone();
+                    move |_, args| {
+                        let config = args.raw.as_object().unwrap();
+
+                        // Verify the program path was substituted correctly
+                        assert_eq!(
+                            config["program"].as_str().unwrap(),
+                            expected_path,
+                            "Program path was not correctly substituted for input: {}",
+                            input_path
+                        );
+
+                        // Verify the cwd path was substituted correctly
+                        assert_eq!(
+                            config["cwd"].as_str().unwrap(),
+                            expected_path,
+                            "CWD path was not correctly substituted for input: {}",
+                            input_path
+                        );
+
+                        // Verify that otherField was substituted but not relativized
+                        // It should still have $ZED_WORKTREE_ROOT substituted if present
+                        let expected_other_field = if input_path.contains("$ZED_WORKTREE_ROOT") {
+                            input_path.replace("$ZED_WORKTREE_ROOT", "/test/worktree/path")
+                        } else {
+                            input_path.to_string()
+                        };
+
+                        assert_eq!(
+                            config["otherField"].as_str().unwrap(),
+                            expected_other_field,
+                            "Other field was incorrectly modified for input: {}",
+                            input_path
+                        );
+
+                        called_launch.store(true, Ordering::SeqCst);
+
+                        Ok(())
+                    }
+                });
+            }
+        });
+
+        // Create a debug scenario with the input path
+        let scenario = DebugScenario {
+            adapter: "fake-adapter".into(),
+            label: "test-debug-session".into(),
+            build: None,
+            config: json!({
+                "request": "launch",
+                "program": input_path,
+                "cwd": input_path,
+                "otherField": input_path // This field should not be relativized
+            }),
+            tcp_connection: None,
+        };
+
+        // Start the debug session
+        workspace
+            .update(cx, |workspace, window, cx| {
+                workspace.start_debug_session(scenario, task_context.clone(), None, window, cx)
+            })
+            .unwrap();
+
+        cx.run_until_parked();
+
+        assert!(called_launch.load(Ordering::SeqCst));
+        called_launch.store(false, Ordering::SeqCst);
+    }
+
+    Ok(())
+}

--- a/crates/debugger_ui/src/tests/new_session_modal.rs
+++ b/crates/debugger_ui/src/tests/new_session_modal.rs
@@ -46,17 +46,20 @@ async fn test_debug_session_substitutes_variables_and_relativizes_paths(
 
     let sep = std::path::MAIN_SEPARATOR;
 
+    // Path with $ZED_WORKTREE_ROOT - should be substituted without double appending
+    // todo(tasks) fix this test to work properly on windows builds
+    // The problem is likely due to ZED_WORKTREE_ROOT not being replaced correctly
+    let unix_only = (
+        Arc::from(format!("$ZED_WORKTREE_ROOT{0}src{0}program", sep)),
+        Arc::from(format!("{0}test{0}worktree{0}path{0}src{0}program", sep)),
+    );
+
     // Test cases for different path formats
-    let test_cases: Vec<(Arc<String>, Arc<String>)> = vec![
+    let mut test_cases: Vec<(Arc<String>, Arc<String>)> = vec![
         // Absolute path - should not be relativized
         (
             Arc::from(format!("{0}absolute{0}path{0}to{0}program", sep)),
             Arc::from(format!("{0}absolute{0}path{0}to{0}program", sep)),
-        ),
-        // Path with $ZED_WORKTREE_ROOT - should be substituted without double appending
-        (
-            Arc::from(format!("$ZED_WORKTREE_ROOT{0}src{0}program", sep)),
-            Arc::from(format!("{0}test{0}worktree{0}path{0}src{0}program", sep)),
         ),
         // Relative path - should be prefixed with worktree root
         (
@@ -73,6 +76,10 @@ async fn test_debug_session_substitutes_variables_and_relativizes_paths(
             )),
         ),
     ];
+
+    if !cfg!(windows) {
+        test_cases.push(unix_only);
+    }
 
     let called_launch = Arc::new(AtomicBool::new(false));
 

--- a/crates/debugger_ui/src/tests/new_session_modal.rs
+++ b/crates/debugger_ui/src/tests/new_session_modal.rs
@@ -10,7 +10,6 @@ use crate::tests::{init_test, init_test_workspace};
 
 // todo(tasks) figure out why task replacement is broken on windows
 #[gpui::test]
-#[cfg(not(windows))]
 async fn test_debug_session_substitutes_variables_and_relativizes_paths(
     executor: BackgroundExecutor,
     cx: &mut TestAppContext,


### PR DESCRIPTION
This move was done so debug configs could use path resolution, and saving a configuration from the new session modal wouldn't resolve paths beforehand.

I also added an integration test to make sure path resolution happens from an arbitrary config.  The test was placed under the new session modal directory because it has to do with starting a session, and that's what the new session modal typically does, even if it's implicitly used in the test. 

In the future, I plan to add more tests to the new session modal too.

Release Notes:

- debugger beta: Allow configs from debug.json to resolve paths
