### PR TITLE
debugger: Use integrated terminal for Python

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4053,6 +4053,7 @@ dependencies = [
  "dap",
  "futures 0.3.31",
  "gpui",
+ "json_dotpath",
  "language",
  "paths",
  "serde",
@@ -8546,6 +8547,18 @@ checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "json_dotpath"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbdcfef3cf5591f0cef62da413ae795e3d1f5a00936ccec0b2071499a32efd1a"
+dependencies = [
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -462,6 +462,7 @@ indoc = "2"
 inventory = "0.3.19"
 itertools = "0.14.0"
 jj-lib = { git = "https://github.com/jj-vcs/jj", rev = "e18eb8e05efaa153fad5ef46576af145bba1807f" }
+json_dotpath = "1.1"
 jsonschema = "0.30.0"
 jsonwebtoken = "9.3"
 jupyter-protocol = { git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734" }

--- a/crates/dap_adapters/Cargo.toml
+++ b/crates/dap_adapters/Cargo.toml
@@ -26,6 +26,7 @@ async-trait.workspace = true
 dap.workspace = true
 futures.workspace = true
 gpui.workspace = true
+json_dotpath.workspace = true
 language.workspace = true
 paths.workspace = true
 serde.workspace = true

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -5,7 +5,9 @@ use dap::{
     adapters::DebugTaskDefinition,
 };
 use gpui::{AsyncApp, SharedString};
+use json_dotpath::DotPaths;
 use language::LanguageName;
+use serde_json::Value;
 use std::{collections::HashMap, ffi::OsStr, path::PathBuf, sync::OnceLock};
 use util::ResultExt;
 
@@ -26,8 +28,16 @@ impl PythonDebugAdapter {
     ) -> Result<StartDebuggingRequestArguments> {
         let request = self.validate_config(&task_definition.config)?;
 
+        let mut configuration = task_definition.config.clone();
+        if let Ok(console) = configuration.dot_get_mut("console") {
+            // Use built-in Zed terminal if user did not explicitly provide a setting for console.
+            if console.is_null() {
+                *console = Value::String("integratedTerminal".into());
+            }
+        }
+
         Ok(StartDebuggingRequestArguments {
-            configuration: task_definition.config.clone(),
+            configuration,
             request,
         })
     }


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- debugger: Use integrated terminal for Python, allowing one to interact with standard input/output when debugging Python projects.
