### PR TITLE
linux: Fix wrong keys are reported when using German layout

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -827,7 +827,7 @@ impl X11Client {
             }
             Event::XkbNewKeyboardNotify(_) | Event::MapNotify(_) => {
                 let mut state = self.0.borrow_mut();
-                let mut xkb_state = {
+                let xkb_state = {
                     let xkb_keymap = xkbc::x11::keymap_new_from_device(
                         &state.xkb_context,
                         &state.xcb_connection,

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -844,6 +844,11 @@ impl X11Client {
                 let latched_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_LATCHED);
                 let locked_group = xkb_state.serialize_layout(xkbc::ffi::XKB_STATE_LAYOUT_LOCKED);
                 xkb_state.update_mask(0, 0, 0, depressed_group, latched_group, locked_group);
+                state.previous_xkb_state = XKBStateNotiy {
+                    depressed_layout: depressed_group,
+                    latched_layout: latched_group,
+                    locked_layout: locked_group,
+                };
                 state.xkb = xkb_state;
             }
             Event::XkbStateNotify(event) => {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -827,7 +827,7 @@ impl X11Client {
             }
             Event::XkbNewKeyboardNotify(_) | Event::MapNotify(_) => {
                 let mut state = self.0.borrow_mut();
-                let xkb_state = {
+                let mut xkb_state = {
                     let xkb_keymap = xkbc::x11::keymap_new_from_device(
                         &state.xkb_context,
                         &state.xcb_connection,
@@ -840,6 +840,10 @@ impl X11Client {
                         state.xkb_device_id,
                     )
                 };
+                let depressed_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_DEPRESSED);
+                let latched_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_LATCHED);
+                let locked_group = xkb_state.serialize_layout(xkbc::ffi::XKB_STATE_LAYOUT_LOCKED);
+                xkb_state.update_mask(0, 0, 0, depressed_group, latched_group, locked_group);
                 state.xkb = xkb_state;
             }
             Event::XkbStateNotify(event) => {

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -843,7 +843,6 @@ impl X11Client {
                 let depressed_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_DEPRESSED);
                 let latched_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_LATCHED);
                 let locked_group = xkb_state.serialize_layout(xkbc::ffi::XKB_STATE_LAYOUT_LOCKED);
-                xkb_state.update_mask(0, 0, 0, depressed_group, latched_group, locked_group);
                 state.previous_xkb_state = XKBStateNotiy {
                     depressed_layout: depressed_group,
                     latched_layout: latched_group,

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -895,7 +895,6 @@ impl X11Client {
                 }
             }
             Event::KeyPress(event) => {
-                println!("KeyPress: {:?}", event);
                 let window = self.get_window(event.event)?;
                 let mut state = self.0.borrow_mut();
 
@@ -964,7 +963,6 @@ impl X11Client {
                 }));
             }
             Event::KeyRelease(event) => {
-                println!("KeyRelease: {:?}", event);
                 let window = self.get_window(event.event)?;
                 let mut state = self.0.borrow_mut();
 

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -890,6 +890,7 @@ impl X11Client {
                 }
             }
             Event::KeyPress(event) => {
+                println!("KeyPress: {:?}", event);
                 let window = self.get_window(event.event)?;
                 let mut state = self.0.borrow_mut();
 
@@ -958,6 +959,7 @@ impl X11Client {
                 }));
             }
             Event::KeyRelease(event) => {
+                println!("KeyRelease: {:?}", event);
                 let window = self.get_window(event.event)?;
                 let mut state = self.0.borrow_mut();
 

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -840,13 +840,13 @@ impl X11Client {
                         state.xkb_device_id,
                     )
                 };
-                let depressed_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_DEPRESSED);
-                let latched_group = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_LATCHED);
-                let locked_group = xkb_state.serialize_layout(xkbc::ffi::XKB_STATE_LAYOUT_LOCKED);
+                let depressed_layout = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_DEPRESSED);
+                let latched_layout = xkb_state.serialize_layout(xkbc::STATE_LAYOUT_LATCHED);
+                let locked_layout = xkb_state.serialize_layout(xkbc::ffi::XKB_STATE_LAYOUT_LOCKED);
                 state.previous_xkb_state = XKBStateNotiy {
-                    depressed_layout: depressed_group,
-                    latched_layout: latched_group,
-                    locked_layout: locked_group,
+                    depressed_layout,
+                    latched_layout,
+                    locked_layout,
                 };
                 state.xkb = xkb_state;
             }


### PR DESCRIPTION
Part of #31174

Because the keyboard layout parameter wasn’t set correctly, characters don’t show up properly when using the German layout at launch.

To reproduce:
Switch to the German layout, launch Zed, and press the `7` key. it should output `7`, but instead it outputs `è`.


Release Notes:

- N/A
