### PR TITLE
debugger: Fix environment variables not being substituted in debug tasks

### DIFF
--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -886,6 +886,7 @@ impl RunningState {
                     .ok_or_else(|| anyhow!("{}: is not a valid adapter name", &adapter))
                     .map(|adapter| adapter.config_from_zed_format(zed_config))??;
                 config = scenario.config;
+                Self::substitute_variables_in_config(&mut config, &task_context);
             } else {
                 anyhow::bail!("No request or build provided");
             };


### PR DESCRIPTION
Release Notes:

- Debugger Beta: Fixed a bug where environment variables were not substituted in debug tasks in some cases.