### PR TITLE
language_model: Allow Max Mode for Claude 4 models

### DIFF
--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -248,6 +248,10 @@ pub trait LanguageModel: Send + Sync {
         }
 
         const MAX_MODE_CAPABLE_MODELS: &[CloudModel] = &[
+            CloudModel::Anthropic(anthropic::Model::ClaudeOpus4),
+            CloudModel::Anthropic(anthropic::Model::ClaudeOpus4Thinking),
+            CloudModel::Anthropic(anthropic::Model::ClaudeSonnet4),
+            CloudModel::Anthropic(anthropic::Model::ClaudeSonnet4Thinking),
             CloudModel::Anthropic(anthropic::Model::Claude3_7Sonnet),
             CloudModel::Anthropic(anthropic::Model::Claude3_7SonnetThinking),
         ];


### PR DESCRIPTION
This PR adds the Claude 4 models to the list of models that support Max Mode.

Release Notes:

- Added Max Mode support for Claude 4 models.
