### PR TITLE
docs: Fix Claude Sonnet 4 model name

### DIFF
--- a/docs/src/ai/models.md
+++ b/docs/src/ai/models.md
@@ -7,8 +7,8 @@ Zed’s plans offer hosted versions of major LLM’s, generally with higher rate
 | Claude 3.5 Sonnet | Anthropic | ❌       | 60k            | $0.04            | N/A               |
 | Claude 3.7 Sonnet | Anthropic | ❌       | 120k           | $0.04            | N/A               |
 | Claude 3.7 Sonnet | Anthropic | ✅       | 200k           | N/A              | $0.05             |
-| Claude 4 Sonnet   | Anthropic | ❌       | 120k           | $0.04            | N/A               |
-| Claude 4 Sonnet   | Anthropic | ✅       | 200k           | N/A              | $0.05             |
+| Claude Sonnet 4   | Anthropic | ❌       | 120k           | $0.04            | N/A               |
+| Claude Sonnet 4   | Anthropic | ✅       | 200k           | N/A              | $0.05             |
 
 ## Usage {#usage}
 


### PR DESCRIPTION
This PR fixes the model name for Claude Sonnet 4 to match Anthropic's new ordering.

Release Notes:

- N/A
