### PR TITLE
Change default diagnostics_max_severity to 'hint'

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -230,11 +230,11 @@
   // Possible values:
   //  - "off" — no diagnostics are allowed
   //  - "error"
-  //  - "warning" (default)
+  //  - "warning"
   //  - "info"
   //  - "hint"
-  //  - null — allow all diagnostics
-  "diagnostics_max_severity": "hint",
+  //  - null — allow all diagnostics (default)
+  "diagnostics_max_severity": null,
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
   // if 'soft_wrap' is set to 'preferred_line_length', and will show any

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -234,7 +234,7 @@
   //  - "info"
   //  - "hint"
   //  - null — allow all diagnostics
-  "diagnostics_max_severity": "warning",
+  "diagnostics_max_severity": "hint",
   // Whether to show wrap guides (vertical rulers) in the editor.
   // Setting this to true will show a guide at the 'preferred_line_length' value
   // if 'soft_wrap' is set to 'preferred_line_length', and will show any


### PR DESCRIPTION
Closes https://github.com/blopker/codebook/issues/79

Recently, the setting `diagnostics_max_severity` was changed from `null` to `warning`in this PR: https://github.com/zed-industries/zed/pull/30316 This change has caused the various spell checking extensions to not work as expected by default, most of which use the `hint` diagnostic. This goes against user expectations when installing one of these extensions.

Without `hint` as the default, extension authors will either need to change the diagnostic levels, or instruct users to add `diagnostics_max_severity` to their settings as an additional step, neither of which is a great user experience.

This PR sets the default `hint`, which is closer to the original behavior before the aforementioned PR.

Release Notes:

- Changed `diagnostics_max_severity` to `hint` instead of `warning` by default
