### PR TITLE
eval: Don't read the model from the user settings

### DIFF
--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -117,6 +117,7 @@ pub fn init(
     client: Arc<Client>,
     prompt_builder: Arc<PromptBuilder>,
     language_registry: Arc<LanguageRegistry>,
+    is_eval: bool,
     cx: &mut App,
 ) {
     AssistantSettings::register(cx);
@@ -124,7 +125,11 @@ pub fn init(
 
     assistant_context_editor::init(client.clone(), cx);
     rules_library::init(cx);
-    init_language_model_settings(cx);
+    if !is_eval {
+        // Initializing the language model from the user settings messes with the eval, so we only initialize them when
+        // we're not running inside of the eval.
+        init_language_model_settings(cx);
+    }
     assistant_slash_command::init(cx);
     thread_store::init(cx);
     agent_panel::init(cx);

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -432,6 +432,7 @@ pub fn init(cx: &mut App) -> Arc<AgentAppState> {
         client.clone(),
         prompt_builder.clone(),
         languages.clone(),
+        true,
         cx,
     );
     assistant_tools::init(client.http_client(), cx);

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -519,6 +519,7 @@ fn main() {
             app_state.client.clone(),
             prompt_builder.clone(),
             app_state.languages.clone(),
+            false,
             cx,
         );
         assistant_tools::init(app_state.client.http_client(), cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4295,6 +4295,7 @@ mod tests {
                 app_state.client.clone(),
                 prompt_builder.clone(),
                 app_state.languages.clone(),
+                false,
                 cx,
             );
             repl::init(app_state.fs.clone(), cx);


### PR DESCRIPTION
This PR fixes an issue where the eval was incorrectly pulling the provider/model from the user settings, which could cause problems when running certain evals.

Was introduced in #30168 due to the restructuring after the removal of the `assistant` crate.

Release Notes:

- N/A
