### PR TITLE
debugger: More focus tweaks

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -68,12 +68,13 @@ pub struct DebugPanel {
     pub(crate) thread_picker_menu_handle: PopoverMenuHandle<ContextMenu>,
     pub(crate) session_picker_menu_handle: PopoverMenuHandle<ContextMenu>,
     fs: Arc<dyn Fs>,
+    _subscriptions: [Subscription; 1],
 }
 
 impl DebugPanel {
     pub fn new(
         workspace: &Workspace,
-        _window: &mut Window,
+        window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> Entity<Self> {
         cx.new(|cx| {
@@ -81,6 +82,14 @@ impl DebugPanel {
             let focus_handle = cx.focus_handle();
             let thread_picker_menu_handle = PopoverMenuHandle::default();
             let session_picker_menu_handle = PopoverMenuHandle::default();
+
+            let focus_subscription = cx.on_focus(
+                &focus_handle,
+                window,
+                |this: &mut DebugPanel, window, cx| {
+                    this.focus_active_item(window, cx);
+                },
+            );
 
             Self {
                 size: px(300.),
@@ -93,6 +102,7 @@ impl DebugPanel {
                 fs: workspace.app_state().fs.clone(),
                 thread_picker_menu_handle,
                 session_picker_menu_handle,
+                _subscriptions: [focus_subscription],
             }
         })
     }

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -101,15 +101,12 @@ impl DebugPanel {
         let Some(session) = self.active_session.clone() else {
             return;
         };
-        let Some(active_pane) = session
+        let active_pane = session
             .read(cx)
             .running_state()
             .read(cx)
             .active_pane()
-            .cloned()
-        else {
-            return;
-        };
+            .clone();
         active_pane.update(cx, |pane, cx| {
             pane.focus_active_item(window, cx);
         });

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -62,16 +62,7 @@ pub fn init(cx: &mut App) {
         cx.when_flag_enabled::<DebuggerFeatureFlag>(window, |workspace, _, _| {
             workspace
                 .register_action(|workspace, _: &ToggleFocus, window, cx| {
-                    let did_focus_panel = workspace.toggle_panel_focus::<DebugPanel>(window, cx);
-                    if !did_focus_panel {
-                        return;
-                    };
-                    let Some(panel) = workspace.panel::<DebugPanel>(cx) else {
-                        return;
-                    };
-                    panel.update(cx, |panel, cx| {
-                        panel.focus_active_item(window, cx);
-                    })
+                    workspace.toggle_panel_focus::<DebugPanel>(window, cx);
                 })
                 .register_action(|workspace, _: &Pause, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -84,7 +84,7 @@ impl Console {
                     this.update_output(window, cx)
                 }
             }),
-            cx.on_focus_in(&focus_handle, window, |console, window, cx| {
+            cx.on_focus(&focus_handle, window, |console, window, cx| {
                 if console.is_running(cx) {
                     console.query_bar.focus_handle(cx).focus(window);
                 }


### PR DESCRIPTION
- Make remembering focus work with `ActivatePaneDown` as well
- Tone down the console's focus-in behavior so clicking doesn't misbehave

Release Notes:

- N/A