### PR TITLE
ui: Fix content shift when selecting last tab

### DIFF
--- a/crates/ui/src/components/tab.rs
+++ b/crates/ui/src/components/tab.rs
@@ -154,7 +154,7 @@ impl RenderOnce for Tab {
                     if self.selected {
                         this.border_l_1().border_r_1().pb_px()
                     } else {
-                        this.pr_px().border_b_1().border_r_1()
+                        this.pl_px().border_b_1().border_r_1()
                     }
                 }
                 TabPosition::Middle(Ordering::Equal) => this.border_l_1().border_r_1().pb_px(),


### PR DESCRIPTION
Follow-up to #29061

This PR ensures that the last tab does not flicker when either selecting. It also fixes an issue where the layout would shift in the new last tab when closing the last tab.

https://github.com/user-attachments/assets/529a2a92-f25c-4ced-a992-fb6b2d3b5f61

This happened because in #29061, the left padding was removed due to issues with borders. However, the padding is relevant for the content to not shift (we are basically doing border-box sizing manually here). 
Instead, we need to remove the padding on the right side, as there is already a border present on the right side and this padding would make the last tab slightly larger than all other tabs.

https://github.com/user-attachments/assets/c3a10b3c-4a1d-4160-9b68-7538207bb46e


Release Notes:

- Removed a small flicker when selecting or closing the last tab in a pane.
