### PR TITLE
Fix taplo artifact naming

### DIFF
--- a/extensions/toml/src/toml.rs
+++ b/extensions/toml/src/toml.rs
@@ -62,7 +62,7 @@ impl TomlExtension {
 
         let (platform, arch) = zed::current_platform();
         let asset_name = format!(
-            "taplo-full-{os}-{arch}.gz",
+            "taplo-{os}-{arch}.gz",
             arch = match arch {
                 zed::Architecture::Aarch64 => "aarch64",
                 zed::Architecture::X86 => "x86",


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/31261

https://github.com/tamasfe/taplo/pull/598#issuecomment-2292984164 renamed all artifacts almost a year ago, and now had released it finally.
Have to abide to that YOLO move.

Release Notes:

- N/A
