### PR TITLE
vim: Update keybindings for CJK users on macOS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1890,6 +1890,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a8241f3ebb85c056b509d4327ad0358fbbba6ffb340bf388f26350aeda225b1"
 
 [[package]]
+name = "better-refcell"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f13ce2fd9a2758838f3768b0b7df016c532353ad5328e7117b448c5922375208"
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7038,6 +7044,7 @@ dependencies = [
  "ashpd",
  "async-task",
  "backtrace",
+ "better-refcell",
  "bindgen 0.71.1",
  "blade-graphics",
  "blade-macros",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -79,6 +79,7 @@ doctest = false
 anyhow.workspace = true
 async-task = "4.7"
 backtrace = { version = "0.3", optional = true }
+better-refcell = "0.1.0"
 blade-graphics = { workspace = true, optional = true }
 blade-macros = { workspace = true, optional = true }
 blade-util = { workspace = true, optional = true }

--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -442,7 +442,8 @@ impl TestAppContext {
             .unwrap()
             .as_mut()
             .unwrap()
-            .platform_window
+            .borrow_mut()
+            .platform_window_mut()
             .as_test()
             .unwrap()
             .clone()
@@ -833,7 +834,7 @@ impl VisualTestContext {
             .cx
             .update_window(self.window, |_, window, _| {
                 window
-                    .platform_window
+                    .platform_window_mut()
                     .as_test()
                     .unwrap()
                     .0

--- a/crates/gpui/src/keymap/binding.rs
+++ b/crates/gpui/src/keymap/binding.rs
@@ -10,6 +10,7 @@ pub struct KeyBinding {
     pub(crate) action: Box<dyn Action>,
     pub(crate) keystrokes: SmallVec<[Keystroke; 2]>,
     pub(crate) context_predicate: Option<Rc<KeyBindingContextPredicate>>,
+    pub(crate) override_ime: bool,
 }
 
 impl Clone for KeyBinding {
@@ -18,6 +19,7 @@ impl Clone for KeyBinding {
             action: self.action.boxed_clone(),
             keystrokes: self.keystrokes.clone(),
             context_predicate: self.context_predicate.clone(),
+            override_ime: self.override_ime,
         }
     }
 }
@@ -30,7 +32,7 @@ impl KeyBinding {
         } else {
             None
         };
-        Self::load(keystrokes, Box::new(action), context_predicate, None).unwrap()
+        Self::load(keystrokes, Box::new(action), context_predicate, None, false).unwrap()
     }
 
     /// Load a keybinding from the given raw data.
@@ -39,6 +41,7 @@ impl KeyBinding {
         action: Box<dyn Action>,
         context_predicate: Option<Rc<KeyBindingContextPredicate>>,
         key_equivalents: Option<&HashMap<char, char>>,
+        override_ime: bool,
     ) -> std::result::Result<Self, InvalidKeystrokeError> {
         let mut keystrokes: SmallVec<[Keystroke; 2]> = keystrokes
             .split_whitespace()
@@ -59,12 +62,17 @@ impl KeyBinding {
             keystrokes,
             action,
             context_predicate,
+            override_ime,
         })
     }
 
     /// Check if the given keystrokes match this binding.
     pub fn match_keystrokes(&self, typed: &[Keystroke]) -> Option<bool> {
         if self.keystrokes.len() < typed.len() {
+            return None;
+        }
+
+        if !self.override_ime && typed.iter().any(|key| key.is_composing == Some(true)) {
             return None;
         }
 
@@ -98,6 +106,7 @@ impl std::fmt::Debug for KeyBinding {
         f.debug_struct("KeyBinding")
             .field("keystrokes", &self.keystrokes)
             .field("context_predicate", &self.context_predicate)
+            .field("override_ime", &self.override_ime)
             .field("action", &self.action.name())
             .finish()
     }

--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -19,6 +19,16 @@ pub struct Keystroke {
     /// this binding was pressed.
     /// e.g. for s this is "s", for option-s "ß", and cmd-s None
     pub key_char: Option<String>,
+
+    /// - `Some(true)` if the keystroke was generated during a composition session.
+    /// - `Some(false)` if the keystroke was generated during a non-composition session.
+    /// - `None` if it was unknown or not applicable.
+    #[serde(default)]
+    pub is_composing: Option<bool>,
+
+    /// platform native event that triggered this keystroke.
+    #[serde(skip)]
+    pub native_event: Option<crate::NativeEvent>,
 }
 
 /// Error type for `Keystroke::parse`. This is used instead of `anyhow::Error` so that Zed can use
@@ -192,6 +202,8 @@ impl Keystroke {
             modifiers,
             key,
             key_char,
+            is_composing: None,
+            native_event: None,
         })
     }
 

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -775,6 +775,7 @@ impl crate::Keystroke {
             modifiers,
             key,
             key_char,
+            ..Default::default()
         }
     }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -1410,6 +1410,7 @@ impl Dispatch<zwp_text_input_v3::ZwpTextInputV3, ()> for WaylandClientStatePtr {
                                 modifiers: Modifiers::default(),
                                 key: commit_text.clone(),
                                 key_char: Some(commit_text),
+                                ..Default::default()
                             },
                             is_held: false,
                         }));

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -43,6 +43,8 @@ use std::{
     ops::Range,
 };
 
+pub(crate) use events::MacNativeEvent;
+
 pub(crate) use dispatcher::*;
 pub(crate) use display::*;
 pub(crate) use display_link::*;

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1314,6 +1314,7 @@ fn parse_normal_key(
         modifiers,
         key,
         key_char,
+        ..Default::default()
     })
 }
 

--- a/crates/terminal/src/mappings/keys.rs
+++ b/crates/terminal/src/mappings/keys.rs
@@ -347,6 +347,7 @@ mod test {
             },
             key: "🖖🏻".to_string(), //2 char string
             key_char: None,
+            ..Default::default()
         };
         assert_eq!(to_esc_str(&ks, &TermMode::NONE, false), None);
     }


### PR DESCRIPTION
Closes #21136
Closes #28174
Closes #30393 

```json
{
  "context": "vim_mode == insert",
  "override_ime": true,
  "bindings": {
    "j j": "vim::NormalBefore"
  }
}
```

https://github.com/user-attachments/assets/91812f50-cab8-479e-aaf2-d1f382676643

The IME popup currently remains open briefly after the event matches. I'm working on resolving this issue.

To minimize changes to GPUI while working around structural constraints, I used unsafe code. This part has been isolated into a separate crate called [better-refcell](https://crates.io/crates/better-refcell), and I am confident that the implementation is sound.

Release Notes:

- Fixed an issue where keybindings conflicted with the default IME behavior.
- Added an option allowing keybindings to override the default IME behavior.
