### PR TITLE
debugger beta: Add error handling when gdb doesn't send thread names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "dap-types"
 version = "0.0.1"
-source = "git+https://github.com/zed-industries/dap-types?rev=be69a016ba710191b9fdded28c8b042af4b617f7#be69a016ba710191b9fdded28c8b042af4b617f7"
+source = "git+https://github.com/zed-industries/dap-types?rev=68516de327fa1be15214133a0a2e52a12982ce75#68516de327fa1be15214133a0a2e52a12982ce75"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -430,7 +430,7 @@ core-foundation-sys = "0.8.6"
 core-video = { version = "0.4.3", features = ["metal"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 ctor = "0.4.0"
-dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "be69a016ba710191b9fdded28c8b042af4b617f7" }
+dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "68516de327fa1be15214133a0a2e52a12982ce75" }
 dashmap = "6.0"
 derive_more = "0.99.17"
 dirs = "4.0"

--- a/crates/debugger_ui/src/dropdown_menus.rs
+++ b/crates/debugger_ui/src/dropdown_menus.rs
@@ -156,7 +156,13 @@ impl DebugPanel {
         let selected_thread_name = threads
             .iter()
             .find(|(thread, _)| thread_id.map(|id| id.0) == Some(thread.id))
-            .map(|(thread, _)| thread.name.clone());
+            .map(|(thread, _)| {
+                thread
+                    .name
+                    .is_empty()
+                    .then(|| format!("Tid: {}", thread.id))
+                    .unwrap_or_else(|| thread.name.clone())
+            });
 
         if let Some(selected_thread_name) = selected_thread_name {
             let trigger = DebugPanel::dropdown_label(selected_thread_name).into_any_element();
@@ -168,7 +174,13 @@ impl DebugPanel {
                         for (thread, _) in threads {
                             let running_state = running_state.clone();
                             let thread_id = thread.id;
-                            this = this.entry(thread.name, None, move |window, cx| {
+                            let entry_name = thread
+                                .name
+                                .is_empty()
+                                .then(|| format!("Tid: {}", thread.id))
+                                .unwrap_or_else(|| thread.name);
+
+                            this = this.entry(entry_name, None, move |window, cx| {
                                 running_state.update(cx, |running_state, cx| {
                                     running_state.select_thread(ThreadId(thread_id), window, cx);
                                 });


### PR DESCRIPTION
If gdb doesn't send a thread name we display the thread's process id in the thread drop down menu instead now.

Co-authored-by: Remco Smits \<djsmits12@gmail.com\>

Release Notes:

- debugger beta: Handle bug where DAPs don't send thread names
