### PR TITLE
debugger: Make the new session modal more keyboard-friendly

### DIFF
--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -47,7 +47,6 @@ actions!(
         ShowStackTrace,
         ToggleThreadPicker,
         ToggleSessionPicker,
-        NewCustomSession,
     ]
 );
 

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -47,6 +47,7 @@ actions!(
         ShowStackTrace,
         ToggleThreadPicker,
         ToggleSessionPicker,
+        NewCustomSession,
     ]
 );
 


### PR DESCRIPTION
WIP

- [ ] figure out what to do with the adapter dropdown
- [ ] tab and shift-tab to move between modes (on top of existing pane bindings)

Release Notes:

- TODO