### PR TITLE
Don't always scroll to bottom on every new message

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1033,7 +1033,6 @@ impl ActiveThread {
                     self.push_message(message_id, &message_segments, window, cx);
                 }
 
-                self.scroll_to_bottom(cx);
                 self.save_thread(cx);
                 cx.notify();
             }


### PR DESCRIPTION
This is a partial reversion of https://github.com/zed-industries/zed/pull/30878 - having it always scroll to bottom whenever a new message is added makes it so that when you're scrolled up, you don't have time to read what you're trying to read before it autoscrolls to the end.

@danilo-leal when you're back, we can pair on addressing that in a different way!

Release Notes:

- Fixed bug where scrolling up in the agent panel didn't prevent automatic scroll-to-end whenever a new message arrived.
