### PR TITLE
Update syn crate from 1.0.109 to 2.0.101

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4351,7 +4351,7 @@ version = "0.1.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
  "workspace-hack",
 ]
 
@@ -7125,7 +7125,7 @@ dependencies = [
  "gpui",
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
  "workspace-hack",
 ]
 
@@ -14757,7 +14757,7 @@ version = "0.1.0"
 dependencies = [
  "sqlez",
  "sqlformat",
- "syn 1.0.109",
+ "syn 2.0.101",
  "workspace-hack",
 ]
 
@@ -16842,7 +16842,7 @@ name = "ui_macros"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
  "workspace-hack",
 ]
 
@@ -17099,7 +17099,7 @@ name = "util_macros"
 version = "0.1.0"
 dependencies = [
  "quote",
- "syn 1.0.109",
+ "syn 2.0.101",
  "workspace-hack",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -550,7 +550,7 @@ streaming-iterator = "0.1"
 strsim = "0.11"
 strum = { version = "0.27.0", features = ["derive"] }
 subtle = "2.5.0"
-syn = { version = "1.0.72", features = ["full", "extra-traits"] }
+syn = { version = "2.0.101", features = ["full", "extra-traits"] }
 sys-locale = "0.3.1"
 sysinfo = "0.31.0"
 take-until = "0.2.0"

--- a/crates/gpui_macros/src/gpui_macros.rs
+++ b/crates/gpui_macros/src/gpui_macros.rs
@@ -183,7 +183,7 @@ pub(crate) fn get_simple_attribute_field(ast: &DeriveInput, name: &'static str) 
         syn::Data::Struct(data_struct) => data_struct
             .fields
             .iter()
-            .find(|field| field.attrs.iter().any(|attr| attr.path.is_ident(name)))
+            .find(|field| field.attrs.iter().any(|attr| attr.path().is_ident(name)))
             .map(|field| field.ident.clone().unwrap()),
         syn::Data::Enum(_) => None,
         syn::Data::Union(_) => None,

--- a/crates/ui_macros/src/dynamic_spacing.rs
+++ b/crates/ui_macros/src/dynamic_spacing.rs
@@ -23,7 +23,7 @@ enum DynamicSpacingValue {
 impl Parse for DynamicSpacingInput {
     fn parse(input: ParseStream) -> syn::Result<Self> {
         Ok(DynamicSpacingInput {
-            values: input.parse_terminated(DynamicSpacingValue::parse)?,
+            values: input.parse_terminated(DynamicSpacingValue::parse, Token![,])?,
         })
     }
 }


### PR DESCRIPTION
Nearly all generated by Zed Agent + Claude Opus 4.  I just wrote the test `Args` struct and pointed it at the [2.0 release notes](https://github.com/dtolnay/syn/releases/tag/2.0.0).

Release Notes:

- N/A