### PR TITLE
gpui: Remove unnecessary String

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -648,8 +648,8 @@ pub(super) unsafe fn read_fd(mut fd: filedescriptor::FileDescriptor) -> Result<V
 }
 
 impl CursorStyle {
-    #[allow(unused)]
-    pub(super) fn to_icon_name(&self) -> String {
+    #[cfg(any(feature = "wayland", feature = "x11"))]
+    pub(super) fn to_icon_name(&self) -> &'static str {
         // Based on cursor names from https://gitlab.gnome.org/GNOME/adwaita-icon-theme (GNOME)
         // and https://github.com/KDE/breeze (KDE). Both of them seem to be also derived from
         // Web CSS cursor names: https://developer.mozilla.org/en-US/docs/Web/CSS/cursor#values
@@ -682,7 +682,6 @@ impl CursorStyle {
                 "default"
             }
         }
-        .to_string()
     }
 }
 

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -704,7 +704,7 @@ impl LinuxClient for WaylandClient {
                 let scale = focused_window.primary_output_scale();
                 state
                     .cursor
-                    .set_icon(&wl_pointer, serial, &style.to_icon_name(), scale);
+                    .set_icon(&wl_pointer, serial, style.to_icon_name(), scale);
             }
         }
     }
@@ -1511,12 +1511,9 @@ impl Dispatch<wl_pointer::WlPointer, ()> for WaylandClientStatePtr {
                             cursor_shape_device.set_shape(serial, style.to_shape());
                         } else {
                             let scale = window.primary_output_scale();
-                            state.cursor.set_icon(
-                                &wl_pointer,
-                                serial,
-                                &style.to_icon_name(),
-                                scale,
-                            );
+                            state
+                                .cursor
+                                .set_icon(&wl_pointer, serial, style.to_icon_name(), scale);
                         }
                     }
                     drop(state);

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -1463,7 +1463,7 @@ impl LinuxClient for X11Client {
                     CursorStyle::None => create_invisible_cursor(&state.xcb_connection).log_err(),
                     _ => state
                         .cursor_handle
-                        .load_cursor(&state.xcb_connection, &style.to_icon_name())
+                        .load_cursor(&state.xcb_connection, style.to_icon_name())
                         .log_err(),
                 }) else {
                     return;


### PR DESCRIPTION
Replaces a `String` with `&'static str`

Release Notes:

- N/A
