### PR TITLE
debugger beta: Fix regression where we sent launch args twice to any dap

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -400,32 +400,6 @@ impl FakeAdapter {
     pub fn new() -> Self {
         Self {}
     }
-
-    fn request_args(
-        &self,
-        task_definition: &DebugTaskDefinition,
-    ) -> StartDebuggingRequestArguments {
-        use serde_json::json;
-
-        let obj = task_definition.config.as_object().unwrap();
-
-        let request_variant = obj["request"].as_str().unwrap();
-
-        let value = json!({
-            "request": request_variant,
-            "process_id": obj.get("process_id"),
-            "raw_request": serde_json::to_value(task_definition).unwrap()
-        });
-
-        StartDebuggingRequestArguments {
-            configuration: value,
-            request: match request_variant {
-                "launch" => dap_types::StartDebuggingRequestArgumentsRequest::Launch,
-                "attach" => dap_types::StartDebuggingRequestArgumentsRequest::Attach,
-                _ => unreachable!("Wrong fake adapter input for request field"),
-            },
-        }
-    }
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -473,7 +447,7 @@ impl DebugAdapter for FakeAdapter {
     async fn get_binary(
         &self,
         _: &Arc<dyn DapDelegate>,
-        config: &DebugTaskDefinition,
+        task_definition: &DebugTaskDefinition,
         _: Option<PathBuf>,
         _: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
@@ -483,7 +457,10 @@ impl DebugAdapter for FakeAdapter {
             connection: None,
             envs: HashMap::default(),
             cwd: None,
-            request_args: self.request_args(&config),
+            request_args: StartDebuggingRequestArguments {
+                request: self.validate_config(&task_definition.config)?,
+                configuration: task_definition.config.clone(),
+            },
         })
     }
 }

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -1439,13 +1439,7 @@ async fn test_we_send_arguments_from_user_config(
             client.on_request::<dap::requests::Launch, _>(move |_, args| {
                 launch_handler_called.store(true, Ordering::SeqCst);
 
-                let obj = args.raw.as_object().unwrap();
-                let sent_definition = serde_json::from_value::<DebugTaskDefinition>(
-                    obj.get(&"raw_request".to_owned()).unwrap().clone(),
-                )
-                .unwrap();
-
-                assert_eq!(sent_definition, debug_definition);
+                assert_eq!(args.raw, debug_definition.config);
 
                 Ok(())
             });

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -50,7 +50,7 @@ use std::{
     sync::{Arc, Once},
 };
 use task::{DebugScenario, SpawnInTerminal, TaskTemplate};
-use util::{ResultExt as _, merge_json_value_into};
+use util::ResultExt as _;
 use worktree::Worktree;
 
 #[derive(Debug)]
@@ -407,13 +407,11 @@ impl DapStore {
         cx.spawn({
             let session = session.clone();
             async move |this, cx| {
-                let mut binary = this
+                let binary = this
                     .update(cx, |this, cx| {
                         this.get_debug_adapter_binary(definition.clone(), session_id, console, cx)
                     })?
                     .await?;
-
-                merge_json_value_into(definition.config, &mut binary.request_args.configuration);
 
                 session
                     .update(cx, |session, cx| {


### PR DESCRIPTION
This regression happens because our tests weren't properly catching this edge case anymore. I updated the tests to only send the raw config to the Fake Adapter Client.

Release Notes:

- debugger beta: Fix bug where launch args were sent twice
