### PR TITLE
gpui: Optimize SharedString deserialization

### DIFF
--- a/crates/gpui/src/shared_string.rs
+++ b/crates/gpui/src/shared_string.rs
@@ -127,7 +127,7 @@ impl<'de> Deserialize<'de> for SharedString {
     where
         D: serde::Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        Ok(SharedString::from(s))
+        let owned: Arc<str> = Arc::deserialize(deserializer)?;
+        Ok(SharedString(ArcCow::Owned(owned)))
     }
 }


### PR DESCRIPTION
Motivation: Avoids one allocation of the entire `String` during deserialization

Deserializing a `SharedString` is currently implemented by deserializing into a `String` first as an intermediate step, followed by a conversion from `String` to `SharedString`.  However it is important to note that `SharedString` uses `Arc<str>` internally as the owned variant. Converting a `String` to `Arc<str>` reallocates the entire string. Since `serde` supports deserializing directly into a `Arc<str>` (using the `rc` crate feature which is enabled) we can simply replace the intermediate `String` deserialization with this instead.

Release Notes:

- N/A
