### PR TITLE
debugger: Improve Go debugging support, with inline hints and stdout/stderr redirect

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4032,6 +4032,8 @@ dependencies = [
  "smol",
  "task",
  "telemetry",
+ "tree-sitter",
+ "tree-sitter-go",
  "util",
  "workspace-hack",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4244,6 +4244,7 @@ dependencies = [
  "sysinfo",
  "task",
  "tasks_ui",
+ "terminal",
  "terminal_view",
  "theme",
  "ui",

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -57,4 +57,6 @@ env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 task = { workspace = true, features = ["test-support"] }
+tree-sitter.workspace = true
+tree-sitter-go.workspace = true
 util = { workspace = true, features = ["test-support"] }

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -18,7 +18,7 @@ use dap::{
         GithubRepo,
     },
     configure_tcp_connection,
-    inline_value::{PythonInlineValueProvider, RustInlineValueProvider},
+    inline_value::{GoInlineValueProvider, PythonInlineValueProvider, RustInlineValueProvider},
 };
 use gdb::GdbDebugAdapter;
 use go::GoDebugAdapter;
@@ -48,5 +48,6 @@ pub fn init(cx: &mut App) {
         registry.add_inline_value_provider("Rust".to_string(), Arc::from(RustInlineValueProvider));
         registry
             .add_inline_value_provider("Python".to_string(), Arc::from(PythonInlineValueProvider));
+        registry.add_inline_value_provider("Go".to_string(), Arc::from(GoInlineValueProvider));
     })
 }

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -56,6 +56,7 @@ shlex.workspace = true
 sysinfo.workspace = true
 task.workspace = true
 tasks_ui.workspace = true
+terminal.workspace = true
 terminal_view.workspace = true
 theme.workspace = true
 ui.workspace = true

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -49,7 +49,7 @@ use terminal_view::TerminalView;
 use ui::{
     ActiveTheme, AnyElement, App, ButtonCommon as _, Clickable as _, Context, FluentBuilder,
     IconButton, IconName, IconSize, InteractiveElement, IntoElement, Label, LabelCommon as _,
-    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, Tab, Tooltip,
+    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, StyledTypography, Tab, Tooltip,
     VisibleOnHover, VisualContext, Window, div, h_flex, v_flex,
 };
 use util::ResultExt;
@@ -58,6 +58,7 @@ use workspace::{
     ActivePaneDecorator, DraggedTab, Item, ItemHandle, Member, Pane, PaneGroup, SplitDirection,
     Workspace, item::TabContentParams, move_item, pane::Event,
 };
+
 
 pub struct RunningState {
     session: Entity<Session>,
@@ -533,12 +534,14 @@ impl gpui::Render for DebugTerminal {
                 div()
                     .p_2()
                     .text_color(cx.theme().colors().text)
+                    .text_buffer(cx)
                     .child(self.output_text.clone())
                     .into_any_element()
             } else {
                 div()
                     .p_2()
                     .text_color(cx.theme().colors().text_muted)
+                    .text_buffer(cx)
                     .child("Terminal output will appear here...")
                     .into_any_element()
             },

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -49,8 +49,8 @@ use terminal_view::TerminalView;
 use ui::{
     ActiveTheme, AnyElement, App, ButtonCommon as _, Clickable as _, Context, FluentBuilder,
     IconButton, IconName, IconSize, InteractiveElement, IntoElement, Label, LabelCommon as _,
-    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, StyledTypography, Tab, Tooltip,
-    VisibleOnHover, VisualContext, Window, div, h_flex, v_flex,
+    ParentElement, Render, SharedString, StatefulInteractiveElement, Styled, StyledTypography, Tab,
+    Tooltip, VisibleOnHover, VisualContext, Window, div, h_flex, v_flex,
 };
 use util::ResultExt;
 use variable_list::VariableList;
@@ -58,7 +58,6 @@ use workspace::{
     ActivePaneDecorator, DraggedTab, Item, ItemHandle, Member, Pane, PaneGroup, SplitDirection,
     Workspace, item::TabContentParams, move_item, pane::Event,
 };
-
 
 pub struct RunningState {
     session: Entity<Session>,

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -101,17 +101,8 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
                 .unwrap();
 
             assert_eq!(
-                "First console output line before thread stopped!\n",
-                active_debug_session_panel
-                    .read(cx)
-                    .running_state()
-                    .read(cx)
-                    .console()
-                    .read(cx)
-                    .editor()
-                    .read(cx)
-                    .text(cx)
-                    .as_str()
+                "First console output line before thread stopped!\nFirst output line before thread stopped!\n",
+                active_debug_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
             );
         })
         .unwrap();
@@ -159,7 +150,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
                 .unwrap();
 
             assert_eq!(
-                "First console output line before thread stopped!\nSecond console output line after thread stopped!\n",
+                "First console output line before thread stopped!\nFirst output line before thread stopped!\nSecond output line after thread stopped!\nSecond console output line after thread stopped!\n",
                 active_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
             );
         })

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -101,8 +101,17 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
                 .unwrap();
 
             assert_eq!(
-                "First console output line before thread stopped!\nFirst output line before thread stopped!\n",
-                active_debug_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
+                "First console output line before thread stopped!\n",
+                active_debug_session_panel
+                    .read(cx)
+                    .running_state()
+                    .read(cx)
+                    .console()
+                    .read(cx)
+                    .editor()
+                    .read(cx)
+                    .text(cx)
+                    .as_str()
             );
         })
         .unwrap();
@@ -150,7 +159,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
                 .unwrap();
 
             assert_eq!(
-                "First console output line before thread stopped!\nFirst output line before thread stopped!\nSecond output line after thread stopped!\nSecond console output line after thread stopped!\n",
+                "First console output line before thread stopped!\nSecond console output line after thread stopped!\n",
                 active_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
             );
         })

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -101,7 +101,8 @@ impl DapStore {
     pub fn init(client: &AnyProtoClient, cx: &mut App) {
         static ADD_LOCATORS: Once = Once::new();
         ADD_LOCATORS.call_once(|| {
-            DapRegistry::global(cx).add_locator(Arc::new(locators::cargo::CargoLocator {}))
+            DapRegistry::global(cx).add_locator(Arc::new(locators::cargo::CargoLocator {}));
+            DapRegistry::global(cx).add_locator(Arc::new(locators::go::GoLocator {}));
         });
         client.add_entity_request_handler(Self::handle_run_debug_locator);
         client.add_entity_request_handler(Self::handle_get_debug_adapter_binary);

--- a/crates/project/src/debugger/locators.rs
+++ b/crates/project/src/debugger/locators.rs
@@ -1,1 +1,2 @@
 pub(crate) mod cargo;
+pub(crate) mod go;

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -1,0 +1,322 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use collections::FxHashMap;
+use dap::{DapLocator, DebugRequest, adapters::DebugAdapterName};
+use gpui::SharedString;
+use std::path::PathBuf;
+use task::{DebugScenario, SpawnInTerminal, TaskTemplate};
+
+pub(crate) struct GoLocator;
+
+#[async_trait]
+impl DapLocator for GoLocator {
+    fn name(&self) -> SharedString {
+        SharedString::new_static("go-debug-locator")
+    }
+
+    fn create_scenario(
+        &self,
+        build_config: &TaskTemplate,
+        resolved_label: &str,
+        adapter: DebugAdapterName,
+    ) -> Option<DebugScenario> {
+        if build_config.command != "go" {
+            return None;
+        }
+
+        let go_action = build_config.args.first()?;
+
+        match go_action.as_ref() {
+            "run" => {
+                let program = build_config
+                    .args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| ".".to_string());
+                let args = build_config.args.get(2..).unwrap_or(&[]).to_vec();
+
+                let config = serde_json::json!({
+                    "request": "launch",
+                    "mode": "debug",
+                    "program": program,
+                    "args": args,
+                    "cwd": build_config.cwd.as_deref().unwrap_or("${ZED_WORKTREE_ROOT}"),
+                    "env": build_config.env,
+                    "console": "integratedTerminal",
+                    "outputMode": "remote"
+                });
+
+                Some(DebugScenario {
+                    label: resolved_label.to_string().into(),
+                    adapter: adapter.0,
+                    build: None, // No build task - Delve handles everything
+                    config,
+                    tcp_connection: None,
+                })
+            }
+            "test" => {
+                let package = build_config
+                    .args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| ".".to_string());
+                let args = build_config.args.get(2..).unwrap_or(&[]).to_vec();
+
+                let config = serde_json::json!({
+                    "request": "launch",
+                    "mode": "test",
+                    "program": package,
+                    "args": args,
+                    "cwd": build_config.cwd.as_deref().unwrap_or("${ZED_WORKTREE_ROOT}"),
+                    "env": build_config.env,
+                    "console": "integratedTerminal",
+                    "outputMode": "remote"
+                });
+
+                Some(DebugScenario {
+                    label: resolved_label.to_string().into(),
+                    adapter: adapter.0,
+                    build: None, // No build task - Delve handles everything
+                    config,
+                    tcp_connection: None,
+                })
+            }
+            "build" => {
+                let package = build_config
+                    .args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| ".".to_string());
+
+                let config = serde_json::json!({
+                    "request": "launch",
+                    "mode": "debug",
+                    "program": package,
+                    "cwd": build_config.cwd.as_deref().unwrap_or("${ZED_WORKTREE_ROOT}"),
+                    "env": build_config.env,
+                    "console": "integratedTerminal",
+                    "outputMode": "remote"
+                });
+
+                Some(DebugScenario {
+                    label: resolved_label.to_string().into(),
+                    adapter: adapter.0,
+                    build: None, // No build task - Delve handles everything
+                    config,
+                    tcp_connection: None,
+                })
+            }
+            _ => None, // Unsupported Go commands
+        }
+    }
+
+    async fn run(&self, build_config: SpawnInTerminal) -> Result<DebugRequest> {
+        if build_config.args.is_empty() {
+            return Err(anyhow::anyhow!("Invalid Go command"));
+        }
+
+        let go_action = &build_config.args[0];
+        let cwd = build_config
+            .cwd
+            .as_ref()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|| ".".to_string());
+
+        let mut env = FxHashMap::default();
+        for (key, value) in &build_config.env {
+            env.insert(key.clone(), value.clone());
+        }
+
+        match go_action.as_str() {
+            "run" => {
+                let program = build_config
+                    .args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| ".".to_string());
+
+                Ok(DebugRequest::Launch(task::LaunchRequest {
+                    program,
+                    cwd: Some(PathBuf::from(&cwd)),
+                    args: build_config.args.get(2..).unwrap_or(&[]).to_vec(),
+                    env,
+                }))
+            }
+            "test" => {
+                let package = build_config
+                    .args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| ".".to_string());
+
+                Ok(DebugRequest::Launch(task::LaunchRequest {
+                    program: package,
+                    cwd: Some(PathBuf::from(&cwd)),
+                    args: build_config.args.get(2..).unwrap_or(&[]).to_vec(),
+                    env,
+                }))
+            }
+            "build" => {
+                let package = build_config
+                    .args
+                    .get(1)
+                    .cloned()
+                    .unwrap_or_else(|| ".".to_string());
+
+                Ok(DebugRequest::Launch(task::LaunchRequest {
+                    program: package,
+                    cwd: Some(PathBuf::from(&cwd)),
+                    args: vec![],
+                    env,
+                }))
+            }
+            _ => Err(anyhow::anyhow!("Unsupported Go command: {}", go_action)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use task::{HideStrategy, RevealStrategy, RevealTarget, Shell, TaskTemplate};
+
+    #[test]
+    fn test_create_scenario_for_go_run() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "go run main.go".into(),
+            command: "go".into(),
+            args: vec!["run".into(), "main.go".into()],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+
+        assert!(scenario.is_some());
+        let scenario = scenario.unwrap();
+        assert_eq!(scenario.adapter, "Delve");
+        assert_eq!(scenario.label, "test label");
+        assert!(scenario.build.is_none());
+    }
+
+    #[test]
+    fn test_create_scenario_for_go_test() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "go test".into(),
+            command: "go".into(),
+            args: vec!["test".into(), "./...".into()],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+
+        assert!(scenario.is_some());
+        let scenario = scenario.unwrap();
+        assert_eq!(scenario.adapter, "Delve");
+        assert_eq!(scenario.label, "test label");
+        assert!(scenario.build.is_none());
+    }
+
+    #[test]
+    fn test_create_scenario_for_go_build() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "go build".into(),
+            command: "go".into(),
+            args: vec!["build".into(), ".".into()],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+
+        assert!(scenario.is_some());
+        let scenario = scenario.unwrap();
+        assert_eq!(scenario.adapter, "Delve");
+        assert_eq!(scenario.label, "test label");
+        assert!(scenario.build.is_none());
+    }
+
+    #[test]
+    fn test_skip_non_go_commands() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "cargo build".into(),
+            command: "cargo".into(),
+            args: vec!["build".into()],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+        assert!(scenario.is_none());
+    }
+
+    #[test]
+    fn test_skip_unsupported_go_commands() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "go clean".into(),
+            command: "go".into(),
+            args: vec!["clean".into()],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+        assert!(scenario.is_none());
+    }
+}

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -900,7 +900,6 @@ impl Session {
                         location_reference: None,
                     };
                     this.push_output(event, cx);
-                    cx.emit(SessionEvent::ConsoleOutput);
                 })?;
             }
             anyhow::Ok(())
@@ -1316,21 +1315,7 @@ impl Session {
                     return;
                 }
 
-                // Route stdout/stderr to terminal, everything else to console
-                let is_terminal_output = event.category.as_ref().is_some_and(|category| {
-                    matches!(
-                        category,
-                        OutputEventCategory::Stdout | OutputEventCategory::Stderr
-                    )
-                });
-
                 self.push_output(event, cx);
-
-                if is_terminal_output {
-                    cx.emit(SessionEvent::TerminalOutput);
-                } else {
-                    cx.emit(SessionEvent::ConsoleOutput);
-                }
 
                 cx.notify();
             }
@@ -1509,9 +1494,23 @@ impl Session {
             });
     }
 
-    fn push_output(&mut self, event: OutputEvent, _cx: &mut Context<Self>) {
-        self.output.push_back(event);
+    fn push_output(&mut self, event: OutputEvent, cx: &mut Context<Self>) {
+        self.output.push_back(event.clone());
         self.output_token.0 += 1;
+
+        // Route stdout/stderr to terminal, everything else to console
+        let is_terminal_output = event.category.as_ref().is_some_and(|category| {
+            matches!(
+                category,
+                OutputEventCategory::Stdout | OutputEventCategory::Stderr
+            )
+        });
+
+        if is_terminal_output {
+            cx.emit(SessionEvent::TerminalOutput);
+        } else {
+            cx.emit(SessionEvent::ConsoleOutput);
+        }
     }
 
     pub fn any_stopped_thread(&self) -> bool {
@@ -2144,7 +2143,6 @@ impl Session {
             location_reference: None,
         };
         self.push_output(event, cx);
-        cx.emit(SessionEvent::ConsoleOutput);
         let request = self.mode.request_dap(EvaluateCommand {
             expression,
             context,
@@ -2168,7 +2166,6 @@ impl Session {
                             location_reference: None,
                         };
                         this.push_output(event, cx);
-                        cx.emit(SessionEvent::ConsoleOutput);
                     }
                     Err(e) => {
                         let event = dap::OutputEvent {
@@ -2183,7 +2180,6 @@ impl Session {
                             location_reference: None,
                         };
                         this.push_output(event, cx);
-                        cx.emit(SessionEvent::ConsoleOutput);
                     }
                 };
                 this.invalidate_command_type::<ScopesCommand>();

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1134,20 +1134,7 @@ impl Session {
             0
         };
 
-        (
-            self.output
-                .range(range_start..)
-                .filter(|event: &&dap::OutputEvent| {
-                    // Filter out stdout/stderr events - those go to terminal only
-                    !event.category.as_ref().is_some_and(|category| {
-                        matches!(
-                            category,
-                            OutputEventCategory::Stdout | OutputEventCategory::Stderr
-                        )
-                    })
-                }),
-            self.output_token,
-        )
+        (self.output.range(range_start..), self.output_token)
     }
 
     pub fn terminal_output(
@@ -1498,7 +1485,6 @@ impl Session {
         self.output.push_back(event.clone());
         self.output_token.0 += 1;
 
-        // Route stdout/stderr to terminal, everything else to console
         let is_terminal_output = event.category.as_ref().is_some_and(|category| {
             matches!(
                 category,
@@ -1508,9 +1494,9 @@ impl Session {
 
         if is_terminal_output {
             cx.emit(SessionEvent::TerminalOutput);
-        } else {
-            cx.emit(SessionEvent::ConsoleOutput);
         }
+
+        cx.emit(SessionEvent::ConsoleOutput);
     }
 
     pub fn any_stopped_thread(&self) -> bool {

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1134,7 +1134,19 @@ impl Session {
             0
         };
 
-        (self.output.range(range_start..), self.output_token)
+        (
+            self.output
+                .range(range_start..)
+                .filter(|event: &&dap::OutputEvent| {
+                    !event.category.as_ref().is_some_and(|category| {
+                        matches!(
+                            category,
+                            OutputEventCategory::Stdout | OutputEventCategory::Stderr
+                        )
+                    })
+                }),
+            self.output_token,
+        )
     }
 
     pub fn terminal_output(
@@ -1494,9 +1506,9 @@ impl Session {
 
         if is_terminal_output {
             cx.emit(SessionEvent::TerminalOutput);
+        } else {
+            cx.emit(SessionEvent::ConsoleOutput);
         }
-
-        cx.emit(SessionEvent::ConsoleOutput);
     }
 
     pub fn any_stopped_thread(&self) -> bool {


### PR DESCRIPTION
With this PR, I’m aiming to improve Go debugger support.

What I did:

- Added a Go locator for accurate language detection and toolchain resolution
- Enabled inline hints to provide contextual variable and expression information during debugging
- Implemented stdout/stderr redirection to the terminal so users can see live application output in the debug panel

Redirecting stdout/stderr to the terminal in the debug panel turned out to be less straightforward than expected, so I had to adjust some surrounding code. Hopefully, it doesn’t interfere with existing logic.

Here is an example of the a single session:
<img width="1333" alt="image" src="https://github.com/user-attachments/assets/da218c38-5969-46e0-9b65-2fa2d4b498a4" />
Locator output before:
<img width="597" alt="image" src="https://github.com/user-attachments/assets/80325e72-a6a0-4a7a-a2c8-cb5a295a8409" />
With this PR:
<img width="602" alt="image" src="https://github.com/user-attachments/assets/81102706-ce9c-4562-bb3a-c95584e971d2" />
Variables are also displayed:
<img width="534" alt="image" src="https://github.com/user-attachments/assets/67f00b5a-7f08-40a0-b41d-95b493f68752" />
Variables inside for-loops:
<img width="414" alt="image" src="https://github.com/user-attachments/assets/600dec4f-9dfa-4cd0-a416-036fc63e791b" />


Release Notes:

- Added Go locator for accurate toolchain resolution
- Enabled inline hints for Go debugging
- Implemented stdout/stderr redirection to terminal in debug panel
- Improved Delve integration for Go debugger

Happy to adjust the PR based on the feedback. It is my first contribution to the this project, so I may have missed some guidelines.