### PR TITLE
agent: Add a setting choose the default view

### DIFF
--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -12,7 +12,7 @@ use assistant_context_editor::{
     ContextSummary, SlashCommandCompletionProvider, humanize_token_count,
     make_lsp_adapter_delegate, render_remaining_tokens,
 };
-use assistant_settings::{AssistantDockPosition, AssistantPanelType, AssistantSettings};
+use assistant_settings::{AssistantDockPosition, AssistantSettings, DefaultView};
 use assistant_slash_command::SlashCommandWorkingSet;
 use assistant_tool::ToolWorkingSet;
 
@@ -522,10 +522,10 @@ impl AgentPanel {
 
         cx.observe(&history_store, |_, _, cx| cx.notify()).detach();
 
-        let panel_type = AssistantSettings::get_global(cx).assistant_panel_type;
+        let panel_type = AssistantSettings::get_global(cx).default_view;
         let active_view = match panel_type {
-            AssistantPanelType::Agentic => ActiveView::thread(thread.clone(), window, cx),
-            AssistantPanelType::Text => {
+            DefaultView::Agent => ActiveView::thread(thread.clone(), window, cx),
+            DefaultView::Thread => {
                 let context =
                     context_store.update(cx, |context_store, cx| context_store.create(cx));
                 let lsp_adapter_delegate = make_lsp_adapter_delegate(&project.clone(), cx).unwrap();

--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -12,7 +12,7 @@ use assistant_context_editor::{
     ContextSummary, SlashCommandCompletionProvider, humanize_token_count,
     make_lsp_adapter_delegate, render_remaining_tokens,
 };
-use assistant_settings::{AssistantDockPosition, AssistantSettings};
+use assistant_settings::{AssistantDockPosition, AssistantPanelType, AssistantSettings};
 use assistant_slash_command::SlashCommandWorkingSet;
 use assistant_tool::ToolWorkingSet;
 
@@ -522,7 +522,30 @@ impl AgentPanel {
 
         cx.observe(&history_store, |_, _, cx| cx.notify()).detach();
 
-        let active_view = ActiveView::thread(thread.clone(), window, cx);
+        let panel_type = AssistantSettings::get_global(cx).assistant_panel_type;
+        let active_view = match panel_type {
+            AssistantPanelType::Agentic => ActiveView::thread(thread.clone(), window, cx),
+            AssistantPanelType::Text => {
+                let context =
+                    context_store.update(cx, |context_store, cx| context_store.create(cx));
+                let lsp_adapter_delegate = make_lsp_adapter_delegate(&project.clone(), cx).unwrap();
+                let context_editor = cx.new(|cx| {
+                    let mut editor = ContextEditor::for_context(
+                        context,
+                        fs.clone(),
+                        workspace.clone(),
+                        project.clone(),
+                        lsp_adapter_delegate,
+                        window,
+                        cx,
+                    );
+                    editor.insert_default_prompt(window, cx);
+                    editor
+                });
+                ActiveView::prompt_editor(context_editor, language_registry.clone(), window, cx)
+            }
+        };
+
         let thread_subscription = cx.subscribe(&thread, |_, _, event, cx| {
             if let ThreadEvent::MessageAdded(_) = &event {
                 // needed to leave empty state

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -31,6 +31,14 @@ pub enum AssistantDockPosition {
     Bottom,
 }
 
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AssistantPanelType {
+    #[default]
+    Agentic,
+    Text,
+}
+
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum NotifyWhenAgentWaiting {
@@ -93,6 +101,7 @@ pub struct AssistantSettings {
     pub inline_alternatives: Vec<LanguageModelSelection>,
     pub using_outdated_settings_version: bool,
     pub default_profile: AgentProfileId,
+    pub assistant_panel_type: AssistantPanelType,
     pub profiles: IndexMap<AgentProfileId, AgentProfile>,
     pub always_allow_tool_actions: bool,
     pub notify_when_agent_waiting: NotifyWhenAgentWaiting,
@@ -267,6 +276,7 @@ impl AssistantSettingsContent {
                     thread_summary_model: None,
                     inline_alternatives: None,
                     default_profile: None,
+                    assistant_panel_type: None,
                     profiles: None,
                     always_allow_tool_actions: None,
                     notify_when_agent_waiting: None,
@@ -298,6 +308,7 @@ impl AssistantSettingsContent {
                 thread_summary_model: None,
                 inline_alternatives: None,
                 default_profile: None,
+                assistant_panel_type: None,
                 profiles: None,
                 always_allow_tool_actions: None,
                 notify_when_agent_waiting: None,
@@ -581,6 +592,7 @@ impl Default for VersionedAssistantSettingsContent {
             thread_summary_model: None,
             inline_alternatives: None,
             default_profile: None,
+            assistant_panel_type: None,
             profiles: None,
             always_allow_tool_actions: None,
             notify_when_agent_waiting: None,
@@ -630,6 +642,10 @@ pub struct AssistantSettingsContentV2 {
     ///
     /// Default: write
     default_profile: Option<AgentProfileId>,
+    /// The default assistant panel type.
+    ///
+    /// Default: agentic
+    assistant_panel_type: Option<AssistantPanelType>,
     /// The available agent profiles.
     pub profiles: Option<IndexMap<AgentProfileId, AgentProfileContent>>,
     /// Whenever a tool action would normally wait for your confirmation
@@ -871,6 +887,10 @@ impl Settings for AssistantSettings {
             merge(&mut settings.single_file_review, value.single_file_review);
             merge(&mut settings.default_profile, value.default_profile);
             merge(
+                &mut settings.assistant_panel_type,
+                value.assistant_panel_type,
+            );
+            merge(
                 &mut settings.preferred_completion_mode,
                 value.preferred_completion_mode,
             );
@@ -1006,6 +1026,7 @@ mod tests {
                                 default_width: None,
                                 default_height: None,
                                 default_profile: None,
+                                assistant_panel_type: None,
                                 profiles: None,
                                 always_allow_tool_actions: None,
                                 notify_when_agent_waiting: None,

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -33,10 +33,10 @@ pub enum AssistantDockPosition {
 
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum AssistantPanelType {
+pub enum DefaultView {
     #[default]
-    Agentic,
-    Text,
+    Agent,
+    Thread,
 }
 
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -101,7 +101,7 @@ pub struct AssistantSettings {
     pub inline_alternatives: Vec<LanguageModelSelection>,
     pub using_outdated_settings_version: bool,
     pub default_profile: AgentProfileId,
-    pub assistant_panel_type: AssistantPanelType,
+    pub default_view: DefaultView,
     pub profiles: IndexMap<AgentProfileId, AgentProfile>,
     pub always_allow_tool_actions: bool,
     pub notify_when_agent_waiting: NotifyWhenAgentWaiting,
@@ -276,7 +276,7 @@ impl AssistantSettingsContent {
                     thread_summary_model: None,
                     inline_alternatives: None,
                     default_profile: None,
-                    assistant_panel_type: None,
+                    default_view: None,
                     profiles: None,
                     always_allow_tool_actions: None,
                     notify_when_agent_waiting: None,
@@ -308,7 +308,7 @@ impl AssistantSettingsContent {
                 thread_summary_model: None,
                 inline_alternatives: None,
                 default_profile: None,
-                assistant_panel_type: None,
+                default_view: None,
                 profiles: None,
                 always_allow_tool_actions: None,
                 notify_when_agent_waiting: None,
@@ -592,7 +592,7 @@ impl Default for VersionedAssistantSettingsContent {
             thread_summary_model: None,
             inline_alternatives: None,
             default_profile: None,
-            assistant_panel_type: None,
+            default_view: None,
             profiles: None,
             always_allow_tool_actions: None,
             notify_when_agent_waiting: None,
@@ -645,7 +645,7 @@ pub struct AssistantSettingsContentV2 {
     /// The default assistant panel type.
     ///
     /// Default: agentic
-    assistant_panel_type: Option<AssistantPanelType>,
+    default_view: Option<DefaultView>,
     /// The available agent profiles.
     pub profiles: Option<IndexMap<AgentProfileId, AgentProfileContent>>,
     /// Whenever a tool action would normally wait for your confirmation
@@ -886,10 +886,7 @@ impl Settings for AssistantSettings {
             merge(&mut settings.stream_edits, value.stream_edits);
             merge(&mut settings.single_file_review, value.single_file_review);
             merge(&mut settings.default_profile, value.default_profile);
-            merge(
-                &mut settings.assistant_panel_type,
-                value.assistant_panel_type,
-            );
+            merge(&mut settings.default_view, value.default_view);
             merge(
                 &mut settings.preferred_completion_mode,
                 value.preferred_completion_mode,
@@ -1026,7 +1023,7 @@ mod tests {
                                 default_width: None,
                                 default_height: None,
                                 default_profile: None,
-                                assistant_panel_type: None,
+                                default_view: None,
                                 profiles: None,
                                 always_allow_tool_actions: None,
                                 notify_when_agent_waiting: None,


### PR DESCRIPTION
Related discussions #30240 #30596

Release Notes:

- Added an option on the settings file to choose either the `agent` panel or the `thread` panel as the default assistant panel when you first open it. On `settings.json`:
```json
{
  "agent": {
    "default_view": "thread", // default is agent
    }
}
```

