### PR TITLE
nix: Make zeditor symlink in package output

### DIFF
--- a/nix/build.nix
+++ b/nix/build.nix
@@ -280,7 +280,9 @@ craneLib.buildPackage (
 
           mkdir -p $out/bin $out/libexec
           cp $TARGET_DIR/zed $out/libexec/zed-editor
-          cp $TARGET_DIR/cli $out/bin/zed
+          cp $TARGET_DIR/cli  $out/bin/zed
+          ln -s $out/bin/zed $out/bin/zeditor  # home-manager expects the CLI binary to be here
+
 
           install -D "crates/zed/resources/app-icon-nightly@2x.png" \
             "$out/share/icons/hicolor/1024x1024@2x/apps/zed.png"


### PR DESCRIPTION
home-manager expects a `zeditor` binary to wrap (because the nixpkgs derivation names the CLI `zeditor` instead of `zed`)

Release Notes:

- N/A
