### PR TITLE
editor: Add `toggle diagnostics` to command palette

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15446,8 +15446,7 @@ impl Editor {
             .max_severity
             .unwrap_or(self.diagnostics_max_severity);
 
-        if self.mode.is_minimap()
-            || !self.inline_diagnostics_enabled()
+        if !self.inline_diagnostics_enabled()
             || !self.show_inline_diagnostics
             || max_severity == DiagnosticSeverity::Off
         {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -426,6 +426,7 @@ impl EditorElement {
         register_action(editor, window, Editor::toggle_indent_guides);
         register_action(editor, window, Editor::toggle_inlay_hints);
         register_action(editor, window, Editor::toggle_edit_predictions);
+        register_action(editor, window, Editor::toggle_diagnostics);
         register_action(editor, window, Editor::toggle_inline_diagnostics);
         register_action(editor, window, Editor::toggle_minimap);
         register_action(editor, window, hover_popover::hover);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -426,9 +426,15 @@ impl EditorElement {
         register_action(editor, window, Editor::toggle_indent_guides);
         register_action(editor, window, Editor::toggle_inlay_hints);
         register_action(editor, window, Editor::toggle_edit_predictions);
-        register_action(editor, window, Editor::toggle_diagnostics);
-        register_action(editor, window, Editor::toggle_inline_diagnostics);
-        register_action(editor, window, Editor::toggle_minimap);
+        if editor.read(cx).diagnostics_enabled() {
+            register_action(editor, window, Editor::toggle_diagnostics);
+        }
+        if editor.read(cx).inline_diagnostics_enabled() {
+            register_action(editor, window, Editor::toggle_inline_diagnostics);
+        }
+        if editor.read(cx).supports_minimap(cx) {
+            register_action(editor, window, Editor::toggle_minimap);
+        }
         register_action(editor, window, hover_popover::hover);
         register_action(editor, window, Editor::reveal_in_finder);
         register_action(editor, window, Editor::copy_path);


### PR DESCRIPTION
Follow-up to #30316

This PR adds the `editor: toggle diagnostics` action to the comand palette so that it can also be invoked that way.

I also ensures this, the `toggle inline diagnostics` and `toggle minimap` actions are only registered if these are supported by the current editor instance. 

Release Notes:

- N/A 