### PR TITLE
lsp: Fix signature help parameter highlighting

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9939,7 +9939,7 @@ async fn test_handle_input_for_show_signature_help_auto_signature_help_true(
         let signature_help_state = editor.signature_help_state.popover().cloned();
         assert_eq!(
             signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            "fn sample(param1: u8, param2: u8)"
         );
     });
 }
@@ -10110,7 +10110,7 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut TestA
         assert!(signature_help_state.is_some());
         assert_eq!(
             signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            "fn sample(param1: u8, param2: u8)"
         );
         editor.signature_help_state = SignatureHelpState::default();
     });
@@ -10151,7 +10151,7 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut TestA
         assert!(signature_help_state.is_some());
         assert_eq!(
             signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            "fn sample(param1: u8, param2: u8)"
         );
     });
 }
@@ -10212,7 +10212,7 @@ async fn test_signature_help(cx: &mut TestAppContext) {
         assert!(signature_help_state.is_some());
         assert_eq!(
             signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            "fn sample(param1: u8, param2: u8)"
         );
     });
 


### PR DESCRIPTION
This update enhances the parameter highlighting logic in the SignatureHelp. Previously, SignatureHelp displayed parameters separated by commas, which was incorrect for languages like Scheme. This commit resolves the issue by displaying the full signature, aligning the behavior with editors such as VS Code.

Closes: #22128

Release Notes:

- Improved parameter highlighting in signature help.