### PR TITLE
Default to fast model first for commit messages

### DIFF
--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -311,6 +311,7 @@ impl LanguageModelRegistry {
 
         self.commit_message_model
             .clone()
+            .or_else(|| self.default_fast_model.clone())
             .or_else(|| self.default_model.clone())
     }
 


### PR DESCRIPTION
I was surprised to see this being done for thread summaries, but not commit messages.

I believe it's a better default as most people would want a faster commit message generation without spending premium requests.

Considering how the default fast model for copilot is set to the base one, this is ideal for me (and likely many others), as opposed to tweaking the configuration every time the base model changes.

Release Notes:

- git: Default to fast model first if not configured for generating commit messages
