### PR TITLE
Add setting for minimap on active editor only

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -402,11 +402,11 @@
     "show": "never",
     // Where to show the minimap in the editor.
     // This setting can take two values:
-    // 1. Show the minimap on the focused pane only:
+    // 1. Show the minimap on the focused editor only:
     //    "active_editor"
-    // 2. Show the minimap on all open panes:
+    // 2. Show the minimap on all open editors:
     //    "all_editors" (default)
-    "display_scope": "all_editors",
+    "display_in": "all_editors",
     // When to show the minimap thumb.
     // This setting can take two values:
     // 1. Show the minimap thumb if the mouse is over the minimap:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -403,10 +403,10 @@
     // Where to show the minimap in the editor.
     // This setting can take two values:
     // 1. Show the minimap on the focused pane only:
-    //    "focused_pane"
+    //    "active_editor"
     // 2. Show the minimap on all open panes:
-    //    "all_panes" (default)
-    "display_scope": "all_panes",
+    //    "all_editors" (default)
+    "display_scope": "all_editors",
     // When to show the minimap thumb.
     // This setting can take two values:
     // 1. Show the minimap thumb if the mouse is over the minimap:

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -400,6 +400,13 @@
     // 3. Never show the minimap:
     //    "never" (default)
     "show": "never",
+    // Where to show the minimap in the editor.
+    // This setting can take two values:
+    // 1. Show the minimap on the focused pane only:
+    //    "focused_pane"
+    // 2. Show the minimap on all open panes:
+    //    "all_panes" (default)
+    "display_scope": "all_panes",
     // When to show the minimap thumb.
     // This setting can take two values:
     // 1. Show the minimap thumb if the mouse is over the minimap:

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -130,6 +130,7 @@ pub struct Scrollbar {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Minimap {
     pub show: ShowMinimap,
+    pub display_scope: MinimapDisplayScope,
     pub thumb: MinimapThumb,
     pub thumb_border: MinimapThumbBorder,
     pub current_line_highlight: Option<CurrentLineHighlight>,
@@ -140,8 +141,8 @@ impl Minimap {
         self.show != ShowMinimap::Never
     }
 
-    pub fn on_active_buffer(&self) -> bool {
-        self.show == ShowMinimap::OnActiveBuffer
+    pub fn on_active_pane(&self) -> bool {
+        self.display_scope == MinimapDisplayScope::FocusedPane
     }
 
     pub fn with_show_override(self) -> Self {
@@ -191,8 +192,19 @@ pub enum ShowMinimap {
     /// Never show the minimap.
     #[default]
     Never,
-    // On active buffer.
-    OnActiveBuffer,
+}
+
+/// Where to show the minimap in the editor.
+///
+/// Default: all
+#[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum MinimapDisplayScope {
+    /// Show on all open panes.
+    #[default]
+    AllPanes,
+    /// Show the minimap on the focused pane only.
+    FocusedPane,
 }
 
 /// When to show the minimap thumb.
@@ -578,6 +590,11 @@ pub struct MinimapContent {
     ///
     /// Default: never
     pub show: Option<ShowMinimap>,
+
+    /// Where to show the minimap in the editor.
+    ///
+    /// Default: all
+    pub display_scope: Option<MinimapDisplayScope>,
 
     /// When to show the minimap thumb.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -140,6 +140,10 @@ impl Minimap {
         self.show != ShowMinimap::Never
     }
 
+    pub fn on_active_buffer(&self) -> bool {
+        self.show == ShowMinimap::OnActiveBuffer
+    }
+
     pub fn with_show_override(self) -> Self {
         Self {
             show: ShowMinimap::Always,
@@ -187,6 +191,8 @@ pub enum ShowMinimap {
     /// Never show the minimap.
     #[default]
     Never,
+    // On active buffer.
+    OnActiveBuffer,
 }
 
 /// When to show the minimap thumb.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -142,7 +142,7 @@ impl Minimap {
     }
 
     #[inline]
-    pub fn on_active_pane(&self) -> bool {
+    pub fn on_active_editor(&self) -> bool {
         self.display_in == DisplayIn::ActiveEditor
     }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -130,7 +130,7 @@ pub struct Scrollbar {
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
 pub struct Minimap {
     pub show: ShowMinimap,
-    pub display_scope: MinimapDisplayScope,
+    pub display_in: DisplayIn,
     pub thumb: MinimapThumb,
     pub thumb_border: MinimapThumbBorder,
     pub current_line_highlight: Option<CurrentLineHighlight>,
@@ -141,8 +141,9 @@ impl Minimap {
         self.show != ShowMinimap::Never
     }
 
+    #[inline]
     pub fn on_active_pane(&self) -> bool {
-        self.display_scope == MinimapDisplayScope::FocusedPane
+        self.display_in == DisplayIn::ActiveEditor
     }
 
     pub fn with_show_override(self) -> Self {
@@ -196,15 +197,15 @@ pub enum ShowMinimap {
 
 /// Where to show the minimap in the editor.
 ///
-/// Default: all
+/// Default: all_panes
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
-pub enum MinimapDisplayScope {
+pub enum DisplayIn {
     /// Show on all open panes.
     #[default]
-    AllPanes,
+    AllEditors,
     /// Show the minimap on the focused pane only.
-    FocusedPane,
+    ActiveEditor,
 }
 
 /// When to show the minimap thumb.
@@ -593,8 +594,8 @@ pub struct MinimapContent {
 
     /// Where to show the minimap in the editor.
     ///
-    /// Default: all
-    pub display_scope: Option<MinimapDisplayScope>,
+    /// Default: all_editors
+    pub display_in: Option<DisplayIn>,
 
     /// When to show the minimap thumb.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -197,14 +197,14 @@ pub enum ShowMinimap {
 
 /// Where to show the minimap in the editor.
 ///
-/// Default: all_panes
+/// Default: all_editors
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum DisplayIn {
-    /// Show on all open panes.
+    /// Show on all open editors.
     #[default]
     AllEditors,
-    /// Show the minimap on the focused pane only.
+    /// Show the minimap on the active editor only.
     ActiveEditor,
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1773,7 +1773,7 @@ impl EditorElement {
 
         let minimap_settings = EditorSettings::get_global(cx).minimap;
 
-        if minimap_settings.on_active_pane() && !snapshot.is_focused {
+        if minimap_settings.on_active_editor() && !snapshot.is_focused {
             let editor = self.editor.read(cx);
             let focus_handle = &editor.focus_handle;
             if let Some(workspace) = editor.workspace() {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1772,8 +1772,19 @@ impl EditorElement {
         let minimap_editor = self.editor.read(cx).minimap().cloned()?;
 
         let minimap_settings = EditorSettings::get_global(cx).minimap;
-        if minimap_settings.on_active_buffer() && !self.editor.focus_handle(cx).is_focused(window) {
-            return None;
+
+        if minimap_settings.on_active_pane() && !snapshot.is_focused {
+            let editor = self.editor.read(cx);
+            let focus_handle = &editor.focus_handle;
+            if let Some(workspace) = editor.workspace() {
+                let focus = workspace
+                    .read(cx)
+                    .focus_handle(cx)
+                    .contains(focus_handle, window);
+                if !focus {
+                    return None;
+                }
+            }
         }
 
         if !snapshot.mode.is_full()

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1773,17 +1773,16 @@ impl EditorElement {
 
         let minimap_settings = EditorSettings::get_global(cx).minimap;
 
-        if minimap_settings.on_active_editor() && !snapshot.is_focused {
-            let editor = self.editor.read(cx);
-            let focus_handle = &editor.focus_handle;
-            if let Some(workspace) = editor.workspace() {
-                let focus = workspace
+        if minimap_settings.on_active_editor() {
+            let active_editor = self.editor.read(cx).workspace().and_then(|ws| {
+                ws.read(cx)
+                    .active_pane()
                     .read(cx)
-                    .focus_handle(cx)
-                    .contains(focus_handle, window);
-                if !focus {
-                    return None;
-                }
+                    .active_item()
+                    .and_then(|i| i.act_as::<Editor>(cx))
+            });
+            if active_editor.is_some_and(|e| e != self.editor) {
+                return None;
             }
         }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1772,6 +1772,9 @@ impl EditorElement {
         let minimap_editor = self.editor.read(cx).minimap().cloned()?;
 
         let minimap_settings = EditorSettings::get_global(cx).minimap;
+        if minimap_settings.on_active_buffer() && !self.editor.focus_handle(cx).is_focused(window) {
+            return None;
+        }
 
         if !snapshot.mode.is_full()
             || minimap_width.is_zero()


### PR DESCRIPTION
Release Notes:

- Add a setting to show the minimap only on the current active editor (file)
- This can be configured on `settings.json`: 
```json
{
  "minimap": {
    "display_in": "active_editor", //  defaults to "all_editors"
  }
}

```

- The minimap won't hide if you go from an editor pane to the terminal, the project panel, the search bar, etc. It will only hide if you go from one editor pane to another. 

Preview:

![image](https://github.com/user-attachments/assets/87b476a2-148b-497e-9e97-ea390c545c87)

Only the active editor (left) displays the minimap. 
