### PR TITLE
Add `block_comment` to JS, TSX, and TS

### DIFF
--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2282,7 +2282,10 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
 
         let config = snapshot.language_scope_at(0).unwrap();
         assert_eq!(config.line_comment_prefixes(), &[Arc::from("// ")]);
-        assert_eq!(config.block_comment_delimiters(), Some((&"/*".into(), &"*/".into())));
+        assert_eq!(
+            config.block_comment_delimiters(),
+            Some((&"/*".into(), &"*/".into()))
+        );
         // Both bracket pairs are enabled
         assert_eq!(
             config.brackets().map(|e| e.1).collect::<Vec<_>>(),
@@ -2301,7 +2304,10 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
             .language_scope_at(text.find("b\"").unwrap())
             .unwrap();
         assert_eq!(string_config.line_comment_prefixes(), &[Arc::from("// ")]);
-        assert_eq!(string_config.block_comment_delimiters(), Some((&"/*".into(), &"*/".into())));
+        assert_eq!(
+            string_config.block_comment_delimiters(),
+            Some((&"/*".into(), &"*/".into()))
+        );
         // Second bracket pair is disabled
         assert_eq!(
             string_config.brackets().map(|e| e.1).collect::<Vec<_>>(),
@@ -2329,7 +2335,10 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
             .language_scope_at(text.find(" d=").unwrap() + 1)
             .unwrap();
         assert_eq!(tag_config.line_comment_prefixes(), &[Arc::from("// ")]);
-        assert_eq!(tag_config.block_comment_delimiters(), Some((&"/*".into(), &"*/".into())));
+        assert_eq!(
+            tag_config.block_comment_delimiters(),
+            Some((&"/*".into(), &"*/".into()))
+        );
         assert_eq!(
             tag_config.brackets().map(|e| e.1).collect::<Vec<_>>(),
             &[true, true]

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -2218,6 +2218,7 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
             LanguageConfig {
                 name: "JavaScript".into(),
                 line_comments: vec!["// ".into()],
+                block_comment: Some(("/*".into(), "*/".into())),
                 brackets: BracketPairConfig {
                     pairs: vec![
                         BracketPair {
@@ -2281,6 +2282,7 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
 
         let config = snapshot.language_scope_at(0).unwrap();
         assert_eq!(config.line_comment_prefixes(), &[Arc::from("// ")]);
+        assert_eq!(config.block_comment_delimiters(), Some((&"/*".into(), &"*/".into())));
         // Both bracket pairs are enabled
         assert_eq!(
             config.brackets().map(|e| e.1).collect::<Vec<_>>(),
@@ -2299,6 +2301,7 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
             .language_scope_at(text.find("b\"").unwrap())
             .unwrap();
         assert_eq!(string_config.line_comment_prefixes(), &[Arc::from("// ")]);
+        assert_eq!(string_config.block_comment_delimiters(), Some((&"/*".into(), &"*/".into())));
         // Second bracket pair is disabled
         assert_eq!(
             string_config.brackets().map(|e| e.1).collect::<Vec<_>>(),
@@ -2326,6 +2329,7 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
             .language_scope_at(text.find(" d=").unwrap() + 1)
             .unwrap();
         assert_eq!(tag_config.line_comment_prefixes(), &[Arc::from("// ")]);
+        assert_eq!(tag_config.block_comment_delimiters(), Some((&"/*".into(), &"*/".into())));
         assert_eq!(
             tag_config.brackets().map(|e| e.1).collect::<Vec<_>>(),
             &[true, true]
@@ -2338,6 +2342,10 @@ fn test_language_scope_at_with_javascript(cx: &mut App) {
         assert_eq!(
             expression_in_element_config.line_comment_prefixes(),
             &[Arc::from("// ")]
+        );
+        assert_eq!(
+            expression_in_element_config.block_comment_delimiters(),
+            Some((&"/*".into(), &"*/".into()))
         );
         assert_eq!(
             expression_in_element_config

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -4,6 +4,7 @@ path_suffixes = ["js", "jsx", "mjs", "cjs"]
 # [/ ] is so we match "env node" or "/node" but not "ts-node"
 first_line_pattern = '^#!.*\b(?:[/ ]node|deno run.*--ext[= ]js)\b'
 line_comments = ["// "]
+block_comment = ["/*", "*/"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -2,6 +2,7 @@ name = "TSX"
 grammar = "tsx"
 path_suffixes = ["tsx"]
 line_comments = ["// "]
+block_comment = ["/*", "*/"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -3,6 +3,7 @@ grammar = "typescript"
 path_suffixes = ["ts", "cts", "d.cts", "d.mts", "mts"]
 first_line_pattern = '^#!.*\b(?:deno run|ts-node|bun|tsx)\b'
 line_comments = ["// "]
+block_comment = ["/*", "*/"]
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },


### PR DESCRIPTION
This is the first step of ["Solution proposal for folding multiline comments with no indentation"](https://github.com/zed-industries/zed/discussions/31395):

> 1. Add block_comment in the config.toml for the languages javascript, typescript, tsx. These are simple languages for this feature, and I am already familiar with them.

The next step will be:

> 2. Modify the function `crease_for_buffer_row` in `DisplaySnapshot` to handle multiline comments. `editor::fold` and `editor::fold_all` will handle multiline comments after this change. To my knowledge, `editor::unfold`, `editor::unfold_all`, and the **unfold** indicator in the gutter will already work after folding, but there will be no **fold** indicator.

Release Notes:

- Added `block_comment` to JavaScript, TSX, and Typescript.
