### PR TITLE
Add `agent: chat with follow` action (experimental)

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -274,6 +274,7 @@
     "context": "MessageEditor > Editor",
     "bindings": {
       "enter": "agent::Chat",
+      "ctrl-enter": "agent::ChatWithFollow",
       "ctrl-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff"
     }

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -311,6 +311,7 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "agent::Chat",
+      "cmd-enter": "agent::ChatWithFollow",
       "cmd-i": "agent::ToggleProfileSelector",
       "shift-ctrl-r": "agent::OpenAgentDiff"
     }

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -69,6 +69,7 @@ actions!(
         AddContextServer,
         RemoveSelectedThread,
         Chat,
+        ChatWithFollow,
         CycleNextInlineAssist,
         CyclePreviousInlineAssist,
         FocusUp,

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -309,14 +309,12 @@ impl MessageEditor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        // Always enable following
-        if let Some(workspace) = self.workspace.upgrade() {
-            workspace.update(cx, |workspace, cx| {
-                workspace.follow(CollaboratorId::Agent, window, cx);
-            });
-        }
+        self.workspace
+            .update(cx, |this, cx| {
+                this.follow(CollaboratorId::Agent, window, cx)
+            })
+            .log_err();
 
-        // Then proceed with the normal chat action
         self.chat(&Chat, window, cx);
     }
 


### PR DESCRIPTION
This PR introduces a new `agent: chat with follow` action that automatically enables "Follow Agent" when submitting a chat message with `cmd-enter` or `ctrl-enter`. This is experimental. I'm not super thrilled with the name, but the root action to submit a chat is called `agent: chat`, so I'm following that wording. I'm also unsure if the binding feels right or not.

Release Notes:

- Added an `agent: chat with follow` action via `cmd-enter` on macOS and `ctrl-enter` on Linux
