### PR TITLE
Update default models to newer versions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -723,14 +723,14 @@
       // The provider to use.
       "provider": "zed.dev",
       // The model to use.
-      "model": "claude-3-7-sonnet-latest"
+      "model": "claude-4-sonnet"
     },
     // The model to use when applying edits from the agent.
     "editor_model": {
       // The provider to use.
       "provider": "zed.dev",
       // The model to use.
-      "model": "claude-3-7-sonnet-latest"
+      "model": "claude-4-sonnet"
     },
     // Additional parameters for language model requests. When making a request to a model, parameters will be taken
     // from the last entry in this list that matches the model's provider and name. In each entry, both provider
@@ -750,7 +750,7 @@
       // To set parameters for a specific provider and model:
       // {
       //   "provider": "zed.dev",
-      //   "model": "claude-3-7-sonnet-latest",
+      //   "model": "claude-4-sonnet",
       //   "temperature": 1.0
       // }
     ],

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -980,7 +980,7 @@ mod tests {
                 AssistantSettings::get_global(cx).default_model,
                 LanguageModelSelection {
                     provider: "zed.dev".into(),
-                    model: "claude-3-7-sonnet-latest".into(),
+                    model: "claude-4-sonnet".into(),
                 }
             );
         });

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -15,6 +15,7 @@ pub enum BedrockModelMode {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, PartialEq, EnumIter)]
 pub enum Model {
     // Anthropic models (already included)
+    #[default]
     #[serde(rename = "claude-sonnet-4", alias = "claude-sonnet-4-latest")]
     ClaudeSonnet4,
     #[serde(
@@ -29,7 +30,6 @@ pub enum Model {
         alias = "claude-opus-4-thinking-latest"
     )]
     ClaudeOpus4Thinking,
-    #[default]
     #[serde(rename = "claude-3-5-sonnet-v2", alias = "claude-3-5-sonnet-latest")]
     Claude3_5SonnetV2,
     #[serde(rename = "claude-3-7-sonnet", alias = "claude-3-7-sonnet-latest")]

--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -493,7 +493,7 @@ pub enum Model {
 
 impl Model {
     pub fn default_fast() -> Model {
-        Model::Gemini15Flash
+        Model::Gemini20Flash
     }
 
     pub fn id(&self) -> &str {

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -77,8 +77,8 @@ by changing the mode in of your models configuration to `thinking`, for example:
 
 ```json
 {
-  "name": "claude-3-7-sonnet-latest",
-  "display_name": "claude-3-7-sonnet-thinking",
+  "name": "claude-4-sonnet-latest",
+  "display_name": "claude-4-sonnet-thinking",
   "max_tokens": 200000,
   "mode": {
     "type": "thinking",
@@ -375,7 +375,7 @@ Where `some-provider` can be any of the following values: `anthropic`, `google`,
 
 ### Default Model {#default-model}
 
-Zed's hosted LLM service sets `claude-3-7-sonnet-latest` as the default model.
+Zed's hosted LLM service sets `claude-4-sonnet-latest` as the default model.
 However, you can change it either via the model dropdown in the Agent Panel's bottom-right corner or by manually editing the `default_model` object in your settings:
 
 ```json
@@ -404,11 +404,11 @@ Example configuration:
 
 ```json
 {
-  "assistant": {
+  "agent": {
     "version": "2",
     "default_model": {
       "provider": "zed.dev",
-      "model": "claude-3-7-sonnet"
+      "model": "claude-4-sonnet"
     },
     "inline_assistant_model": {
       "provider": "anthropic",
@@ -437,10 +437,10 @@ One with Claude 3.7 Sonnet, and one with GPT-4o.
 
 ```json
 {
-  "assistant": {
+  "agent": {
     "default_model": {
       "provider": "zed.dev",
-      "model": "claude-3-7-sonnet"
+      "model": "claude-4-sonnet"
     },
     "inline_alternatives": [
       {

--- a/docs/src/ai/temperature.md
+++ b/docs/src/ai/temperature.md
@@ -16,7 +16,7 @@ Zed's settings allow you to specify a custom temperature for a provider and/or m
       // To set parameters for a specific provider and model:
       {
         "provider": "zed.dev",
-        "model": "claude-3-7-sonnet-latest",
+        "model": "claude-4-sonnet",
         "temperature": 1.0
       }
     ],

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3276,11 +3276,11 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "default_height": 320,
   "default_model": {
     "provider": "zed.dev",
-    "model": "claude-3-7-sonnet-latest"
+    "model": "claude-4-sonnet"
   },
   "editor_model": {
     "provider": "zed.dev",
-    "model": "claude-3-7-sonnet-latest"
+    "model": "claude-4-sonnet"
   },
   "single_file_review": true,
 }


### PR DESCRIPTION
Follow up to: https://github.com/zed-industries/zed/pull/31209
Changes default models across multiple providers:
- Zed.dev Default Models in settings: claude-3-7-sonnet-latest → claude-4-sonnet-latest
- Bedrock Default Model: Claude 3.5 Sonnet v2 → Claude Sonnet 4
- Google AI Default Fast Model: Gemini 1.5 Flash → Gemini 2.0 Flash

Release Notes:

- N/A
