### PR TITLE
picker: Improve input padding

### DIFF
--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -189,7 +189,7 @@ pub trait PickerDelegate: Sized + 'static {
                     .overflow_hidden()
                     .flex_none()
                     .h_9()
-                    .px_1p5()
+                    .px_2p5()
                     .child(editor.clone()),
             )
             .when(

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -189,7 +189,7 @@ pub trait PickerDelegate: Sized + 'static {
                     .overflow_hidden()
                     .flex_none()
                     .h_9()
-                    .px_3()
+                    .px_1p5()
                     .child(editor.clone()),
             )
             .when(


### PR DESCRIPTION
This is a tiny PR to make the picker input padding match the list item results horizontal spacing. They were previously misaligned and it was getting to me. 😬 

| Before | After |
|--------|--------|
| ![CleanShot 2025-05-26 at 8  03 59@2x](https://github.com/user-attachments/assets/e3d8c10a-7ded-4e40-bc69-dc9d35038785) | ![CleanShot 2025-05-26 at 8  04 09@2x](https://github.com/user-attachments/assets/a8273174-edcb-45a8-809b-622ea18af37a) | 

Release Notes:

- N/A
