### PR TITLE
editor: Inline Code Actions Indicator

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -326,7 +326,7 @@
     // Whether to show agent review buttons in the editor toolbar.
     "agent_review": true,
     // Whether to show code action buttons in the editor toolbar.
-    "code_actions": true
+    "code_actions": false
   },
   // Titlebar related settings
   "title_bar": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -213,6 +213,8 @@
   // Whether to show the signature help after completion or a bracket pair inserted.
   // If `auto_signature_help` is enabled, this setting will be treated as enabled also.
   "show_signature_help_after_edits": false,
+  // Whether to show code action button at start of buffer line.
+  "inline_code_actions": true,
   // What to do when go to definition yields no results.
   //
   // 1. Do nothing: `none`

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5779,8 +5779,9 @@ impl Editor {
         let show_tooltip = !self.context_menu_visible();
         Some(
             IconButton::new("inline_code_actions", ui::IconName::BoltFilled)
-                .icon_size(icon_size.clone())
+                .icon_size(icon_size)
                 .shape(ui::IconButtonShape::Square)
+                .style(ButtonStyle::Transparent)
                 .icon_color(ui::Color::Hidden)
                 .toggle_state(is_active)
                 .when(show_tooltip, |this| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5772,50 +5772,45 @@ impl Editor {
         display_row: DisplayRow,
         is_active: bool,
         cx: &mut Context<Self>,
-    ) -> Option<AnyElement> {
-        if self.available_code_actions.is_none() {
-            return None;
-        }
+    ) -> AnyElement {
         let show_tooltip = !self.context_menu_visible();
-        Some(
-            IconButton::new("inline_code_actions", ui::IconName::BoltFilled)
-                .icon_size(icon_size)
-                .shape(ui::IconButtonShape::Square)
-                .style(ButtonStyle::Transparent)
-                .icon_color(ui::Color::Hidden)
-                .toggle_state(is_active)
-                .when(show_tooltip, |this| {
-                    this.tooltip({
-                        let focus_handle = self.focus_handle.clone();
-                        move |window, cx| {
-                            Tooltip::for_action_in(
-                                "Toggle Code Actions",
-                                &ToggleCodeActions {
-                                    deployed_from: None,
-                                    quick_launch: false,
-                                },
-                                &focus_handle,
-                                window,
-                                cx,
-                            )
-                        }
-                    })
+        IconButton::new("inline_code_actions", ui::IconName::BoltFilled)
+            .icon_size(icon_size)
+            .shape(ui::IconButtonShape::Square)
+            .style(ButtonStyle::Transparent)
+            .icon_color(ui::Color::Hidden)
+            .toggle_state(is_active)
+            .when(show_tooltip, |this| {
+                this.tooltip({
+                    let focus_handle = self.focus_handle.clone();
+                    move |window, cx| {
+                        Tooltip::for_action_in(
+                            "Toggle Code Actions",
+                            &ToggleCodeActions {
+                                deployed_from: None,
+                                quick_launch: false,
+                            },
+                            &focus_handle,
+                            window,
+                            cx,
+                        )
+                    }
                 })
-                .on_click(cx.listener(move |editor, _: &ClickEvent, window, cx| {
-                    window.focus(&editor.focus_handle(cx));
-                    editor.toggle_code_actions(
-                        &crate::actions::ToggleCodeActions {
-                            deployed_from: Some(crate::actions::CodeActionSource::Indicator(
-                                display_row,
-                            )),
-                            quick_launch: false,
-                        },
-                        window,
-                        cx,
-                    );
-                }))
-                .into_any_element(),
-        )
+            })
+            .on_click(cx.listener(move |editor, _: &ClickEvent, window, cx| {
+                window.focus(&editor.focus_handle(cx));
+                editor.toggle_code_actions(
+                    &crate::actions::ToggleCodeActions {
+                        deployed_from: Some(crate::actions::CodeActionSource::Indicator(
+                            display_row,
+                        )),
+                        quick_launch: false,
+                    },
+                    window,
+                    cx,
+                );
+            }))
+            .into_any_element()
     }
 
     pub fn context_menu(&self) -> &RefCell<Option<CodeContextMenu>> {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -47,6 +47,7 @@ pub struct EditorSettings {
     pub snippet_sort_order: SnippetSortOrder,
     #[serde(default)]
     pub diagnostics_max_severity: Option<DiagnosticSeverity>,
+    pub inline_code_actions: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -482,6 +483,11 @@ pub struct EditorSettingsContent {
     /// Default: warning
     #[serde(default)]
     pub diagnostics_max_severity: Option<DiagnosticSeverity>,
+
+    /// Whether to show code action button at start of buffer line.
+    ///
+    /// Default: true
+    pub inline_code_actions: Option<bool>,
 }
 
 // Toolbar related settings
@@ -504,9 +510,9 @@ pub struct ToolbarContent {
     ///
     /// Default: true
     pub agent_review: Option<bool>,
-    /// Whether to display code action buttons in the editor toolbar.
+    /// Whether to show code action button at start of buffer line.
     ///
-    /// Default: true
+    /// Default: false
     pub code_actions: Option<bool>,
 }
 

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -510,7 +510,7 @@ pub struct ToolbarContent {
     ///
     /// Default: true
     pub agent_review: Option<bool>,
-    /// Whether to show code action button at start of buffer line.
+    /// Whether to display code action buttons in the editor toolbar.
     ///
     /// Default: false
     pub code_actions: Option<bool>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1956,6 +1956,7 @@ impl EditorElement {
 
         let icon_size = ui::IconSize::XSmall;
         let mut button = self.editor.update(cx, |editor, cx| {
+            editor.available_code_actions.as_ref()?;
             let active = editor
                 .context_menu
                 .borrow()
@@ -1974,7 +1975,7 @@ impl EditorElement {
                 .map_or(false, |source| {
                     matches!(source, CodeActionSource::Indicator(..))
                 });
-            editor.render_inline_code_actions(icon_size.clone(), display_point.row(), active, cx)
+            Some(editor.render_inline_code_actions(icon_size, display_point.row(), active, cx))
         })?;
 
         let buffer_point = display_point.to_point(&snapshot.display_snapshot);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2023,7 +2023,7 @@ impl EditorElement {
                     .buffer_snapshot
                     .excerpt_containing(candidate_point..candidate_point)
                     .map(|excerpt| excerpt.id());
-                // move to other row if diffrent excerpt
+                // move to other row if different excerpt
                 if excerpt_id != candidate_excerpt_id {
                     return false;
                 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1973,7 +1973,7 @@ impl EditorElement {
         });
         let mut button = button?;
 
-        const OVERLFOW_CHAR_LIMIT: u32 = 3;
+        const OVERLFOW_CHAR_LIMIT: u32 = 2;
         const MAX_ALTERNATE_DISTANCE: u32 = 8;
 
         let buffer_point = snapshot
@@ -2069,8 +2069,8 @@ impl EditorElement {
         let start_y = content_origin.y
             + ((new_display_row.as_f32() - (scroll_pixel_position.y / line_height)) * line_height)
             + (line_height / 2.0)
-            - (icon_size.square(window, cx) / 2.0);
-        let start_x = content_origin.x - scroll_pixel_position.x + (window.rem_size() * 0.2);
+            - (icon_size.square(window, cx) / 2.);
+        let start_x = content_origin.x - scroll_pixel_position.x + (window.rem_size() * 0.1);
 
         let absolute_offset = gpui::point(start_x, start_y);
         button.layout_as_root(gpui::AvailableSpace::min_size(), window, cx);

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1203,6 +1203,16 @@ or
 }
 ```
 
+### Show Inline Code Actions
+
+- Description: Whether to show code action button at start of buffer line.
+- Setting: `inline_code_actions`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
 ## Editor Toolbar
 
 - Description: Whether or not to show various elements in the editor toolbar.
@@ -1215,7 +1225,7 @@ or
   "quick_actions": true,
   "selections_menu": true,
   "agent_review": true,
-  "code_actions": true
+  "code_actions": false
 },
 ```
 


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/30140 and https://github.com/zed-industries/zed/pull/31236

This PR introduces an inline code action indicator that shows up at the start of a buffer line when there's enough space. If space is tight, it adjusts to lines above or below instead. It also adjusts when cursor is near indicator.

The indicator won't appear if there's no space within about 8 rows in either direction, and it also stays hidden for folded ranges. It also won't show up in case there is not space in multi buffer excerpt. These cases account for very little because practically all languages do have indents.

https://github.com/user-attachments/assets/1363ee8a-3178-4665-89a7-c86c733f2885

This PR also sets the existing `toolbar.code_actions` setting to `false` in favor of this.

Release Notes:

- Added code action indicator which shows up inline at the start of the row. This can be disabled by setting `inline_code_actions` to `false`.
