### PR TITLE
windows:  Using `ctrl+drag` to copy in windows platform

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3104,7 +3104,8 @@ impl ProjectPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let should_copy = window.modifiers().alt;
+        let should_copy = cfg!(target_os = "macos") && window.modifiers().alt
+            || cfg!(not(target_os = "macos")) && window.modifiers().control;
         if should_copy {
             let _ = maybe!({
                 let project = self.project.read(cx);


### PR DESCRIPTION
Closes #31328 

> There should be other places in Zed that were supposed to handle mouse modifiers differently based on the platform, might worth checking for them.
reference [comments](https://github.com/zed-industries/zed/pull/29921#issuecomment-2908922764)

Release Notes:

- N/A 
