### PR TITLE
zlog: Replace usages of `env_logger` in tests with `zlog`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -593,7 +593,6 @@ dependencies = [
  "collections",
  "context_server",
  "editor",
- "env_logger 0.11.8",
  "feature_flags",
  "fs",
  "futures 0.3.31",
@@ -619,6 +618,7 @@ dependencies = [
  "workspace",
  "workspace-hack",
  "worktree",
+ "zlog",
 ]
 
 [[package]]
@@ -631,7 +631,6 @@ dependencies = [
  "collections",
  "ctor",
  "derive_more",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "gpui",
  "icons",
@@ -650,6 +649,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -2220,9 +2220,9 @@ name = "buffer_diff"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "buffer_diff",
  "clock",
  "ctor",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "git2",
  "gpui",
@@ -2237,6 +2237,7 @@ dependencies = [
  "unindent",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -3007,7 +3008,6 @@ dependencies = [
  "debugger_ui",
  "derive_more",
  "editor",
- "env_logger 0.11.8",
  "envy",
  "extension",
  "file_finder",
@@ -3082,6 +3082,7 @@ dependencies = [
  "workspace-hack",
  "worktree",
  "zed_llm_client",
+ "zlog",
 ]
 
 [[package]]
@@ -3336,7 +3337,6 @@ dependencies = [
  "command_palette_hooks",
  "ctor",
  "editor",
- "env_logger 0.11.8",
  "fs",
  "futures 0.3.31",
  "gpui",
@@ -3362,6 +3362,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -4012,7 +4013,6 @@ dependencies = [
  "client",
  "collections",
  "dap-types",
- "env_logger 0.11.8",
  "fs",
  "futures 0.3.31",
  "gpui",
@@ -4033,6 +4033,7 @@ dependencies = [
  "telemetry",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -4219,7 +4220,6 @@ dependencies = [
  "db",
  "debugger_tools",
  "editor",
- "env_logger 0.11.8",
  "feature_flags",
  "file_icons",
  "futures 0.3.31",
@@ -4248,6 +4248,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -4364,7 +4365,6 @@ dependencies = [
  "component",
  "ctor",
  "editor",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "gpui",
  "indoc",
@@ -4385,6 +4385,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -4683,7 +4684,6 @@ dependencies = [
  "dap",
  "db",
  "emojis",
- "env_logger 0.11.8",
  "feature_flags",
  "file_icons",
  "fs",
@@ -4738,6 +4738,7 @@ dependencies = [
  "workspace",
  "workspace-hack",
  "zed_actions",
+ "zlog",
 ]
 
 [[package]]
@@ -5165,7 +5166,6 @@ dependencies = [
  "criterion",
  "ctor",
  "dap",
- "env_logger 0.11.8",
  "extension",
  "fs",
  "futures 0.3.31",
@@ -5202,6 +5202,7 @@ dependencies = [
  "wasmtime",
  "wasmtime-wasi",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -5375,7 +5376,6 @@ dependencies = [
  "collections",
  "ctor",
  "editor",
- "env_logger 0.11.8",
  "file_icons",
  "futures 0.3.31",
  "fuzzy",
@@ -5395,6 +5395,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -6109,7 +6110,6 @@ dependencies = [
  "ctor",
  "db",
  "editor",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "fuzzy",
  "git",
@@ -6145,6 +6145,7 @@ dependencies = [
  "workspace",
  "workspace-hack",
  "zed_actions",
+ "zlog",
 ]
 
 [[package]]
@@ -8726,7 +8727,6 @@ dependencies = [
  "ctor",
  "diffy",
  "ec4rs",
- "env_logger 0.11.8",
  "fs",
  "futures 0.3.31",
  "fuzzy",
@@ -8771,6 +8771,7 @@ dependencies = [
  "unindent",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -8897,7 +8898,6 @@ dependencies = [
  "collections",
  "copilot",
  "editor",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "gpui",
  "itertools 0.14.0",
@@ -8914,6 +8914,7 @@ dependencies = [
  "workspace",
  "workspace-hack",
  "zed_actions",
+ "zlog",
 ]
 
 [[package]]
@@ -9436,7 +9437,6 @@ dependencies = [
  "async-pipe",
  "collections",
  "ctor",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "gpui",
  "log",
@@ -9450,6 +9450,7 @@ dependencies = [
  "smol",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -9946,7 +9947,6 @@ dependencies = [
  "clock",
  "collections",
  "ctor",
- "env_logger 0.11.8",
  "gpui",
  "indoc",
  "itertools 0.14.0",
@@ -9967,6 +9967,7 @@ dependencies = [
  "tree-sitter",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -12033,7 +12034,6 @@ dependencies = [
  "context_server",
  "dap",
  "dap_adapters",
- "env_logger 0.11.8",
  "extension",
  "fancy-regex 0.14.0",
  "fs",
@@ -13018,6 +13018,7 @@ dependencies = [
  "unindent",
  "util",
  "worktree",
+ "zlog",
 ]
 
 [[package]]
@@ -13359,7 +13360,6 @@ dependencies = [
  "arrayvec",
  "criterion",
  "ctor",
- "env_logger 0.11.8",
  "gpui",
  "log",
  "rand 0.8.5",
@@ -13369,6 +13369,7 @@ dependencies = [
  "unicode-segmentation",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -13386,7 +13387,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "collections",
- "env_logger 0.11.8",
  "futures 0.3.31",
  "gpui",
  "parking_lot",
@@ -13400,6 +13400,7 @@ dependencies = [
  "tracing",
  "util",
  "workspace-hack",
+ "zlog",
  "zstd",
 ]
 
@@ -14115,7 +14116,6 @@ dependencies = [
  "client",
  "clock",
  "collections",
- "env_logger 0.11.8",
  "feature_flags",
  "fs",
  "futures 0.3.31",
@@ -14146,6 +14146,7 @@ dependencies = [
  "workspace",
  "workspace-hack",
  "worktree",
+ "zlog",
 ]
 
 [[package]]
@@ -15175,11 +15176,11 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "ctor",
- "env_logger 0.11.8",
  "log",
  "rand 0.8.5",
  "rayon",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -15490,7 +15491,6 @@ dependencies = [
  "collections",
  "ctor",
  "editor",
- "env_logger 0.11.8",
  "fuzzy",
  "gpui",
  "language",
@@ -15507,6 +15507,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -15752,7 +15753,6 @@ dependencies = [
  "clock",
  "collections",
  "ctor",
- "env_logger 0.11.8",
  "gpui",
  "http_client",
  "log",
@@ -15765,6 +15765,7 @@ dependencies = [
  "sum_tree",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -19152,7 +19153,6 @@ dependencies = [
  "component",
  "dap",
  "db",
- "env_logger 0.11.8",
  "fs",
  "futures 0.3.31",
  "gpui",
@@ -19184,6 +19184,7 @@ dependencies = [
  "windows 0.61.1",
  "workspace-hack",
  "zed_actions",
+ "zlog",
 ]
 
 [[package]]
@@ -19381,7 +19382,6 @@ dependencies = [
  "anyhow",
  "clock",
  "collections",
- "env_logger 0.11.8",
  "fs",
  "futures 0.3.31",
  "fuzzy",
@@ -19408,6 +19408,7 @@ dependencies = [
  "text",
  "util",
  "workspace-hack",
+ "zlog",
 ]
 
 [[package]]
@@ -20101,7 +20102,6 @@ dependencies = [
  "ctor",
  "db",
  "editor",
- "env_logger 0.11.8",
  "feature_flags",
  "fs",
  "futures 0.3.31",
@@ -20140,6 +20140,7 @@ dependencies = [
  "worktree",
  "zed_actions",
  "zed_llm_client",
+ "zlog",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2220,7 +2220,6 @@ name = "buffer_diff"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "buffer_diff",
  "clock",
  "ctor",
  "futures 0.3.31",

--- a/crates/assistant_slash_commands/Cargo.toml
+++ b/crates/assistant_slash_commands/Cargo.toml
@@ -44,6 +44,6 @@ worktree.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-env_logger.workspace = true
 pretty_assertions.workspace = true
 settings.workspace = true
+zlog.workspace = true

--- a/crates/assistant_slash_commands/src/file_command.rs
+++ b/crates/assistant_slash_commands/src/file_command.rs
@@ -587,9 +587,7 @@ mod test {
     use super::collect_files;
 
     pub fn init_test(cx: &mut gpui::TestAppContext) {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
 
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);

--- a/crates/assistant_tool/Cargo.toml
+++ b/crates/assistant_tool/Cargo.toml
@@ -37,7 +37,6 @@ buffer_diff = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }
 clock = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
@@ -48,3 +47,4 @@ rand.workspace = true
 settings = { workspace = true, features = ["test-support"] }
 text = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/assistant_tool/src/action_log.rs
+++ b/crates/assistant_tool/src/action_log.rs
@@ -717,9 +717,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/assistant_tools/src/edit_agent/evals/fixtures/add_overwrite_test/before.rs
+++ b/crates/assistant_tools/src/edit_agent/evals/fixtures/add_overwrite_test/before.rs
@@ -676,9 +676,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/assistant_tools/src/terminal_tool.rs
+++ b/crates/assistant_tools/src/terminal_tool.rs
@@ -673,8 +673,7 @@ mod tests {
     use super::*;
 
     fn init_test(executor: &BackgroundExecutor, cx: &mut TestAppContext) {
-        zlog::init();
-        zlog::init_output_stdout();
+        zlog::init_test();
 
         executor.allow_parking();
         cx.update(|cx| {

--- a/crates/buffer_diff/Cargo.toml
+++ b/crates/buffer_diff/Cargo.toml
@@ -30,10 +30,11 @@ util.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
+buffer_diff = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 rand.workspace = true
 serde_json.workspace = true
 text = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
+zlog.workspace = true

--- a/crates/buffer_diff/Cargo.toml
+++ b/crates/buffer_diff/Cargo.toml
@@ -30,7 +30,6 @@ util.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-buffer_diff = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 rand.workspace = true

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -1346,9 +1346,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     #[gpui::test]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -95,7 +95,6 @@ dap = { workspace = true, features = ["test-support"] }
 dap_adapters = { workspace = true, features = ["test-support"] }
 debugger_ui = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 extension.workspace = true
 file_finder.workspace = true
 fs = { workspace = true, features = ["test-support"] }
@@ -133,6 +132,7 @@ unindent.workspace = true
 util.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 worktree = { workspace = true, features = ["test-support"] }
+zlog.workspace = true
 
 [package.metadata.cargo-machete]
 ignored = ["async-stripe"]

--- a/crates/collab/src/tests/debug_panel_tests.rs
+++ b/crates/collab/src/tests/debug_panel_tests.rs
@@ -18,9 +18,7 @@ use workspace::{Workspace, dock::Panel};
 use super::{TestClient, TestServer};
 
 pub fn init_test(cx: &mut gpui::TestAppContext) {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::try_init().ok();
-    }
+    zlog::init_test();
 
     cx.update(|cx| {
         theme::init(theme::LoadThemes::JustBase, cx);

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -56,9 +56,7 @@ use workspace::Pane;
 
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[gpui::test(iterations = 10)]

--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -589,9 +589,7 @@ async fn test_remote_server_debugger(
     cx_a.update(|cx| {
         release_channel::init(SemanticVersion::default(), cx);
         command_palette_hooks::init(cx);
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
         dap_adapters::init(cx);
     });
     server_cx.update(|cx| {

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -61,7 +61,6 @@ clock = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 editor = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
@@ -76,3 +75,4 @@ settings = { workspace = true, features = ["test-support"] }
 theme = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -1329,7 +1329,5 @@ mod tests {
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }

--- a/crates/dap/Cargo.toml
+++ b/crates/dap/Cargo.toml
@@ -53,8 +53,8 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 async-pipe.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 task = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -281,9 +281,7 @@ mod tests {
     };
 
     pub fn init_test(cx: &mut gpui::TestAppContext) {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
 
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -21,7 +21,6 @@ test-support = [
     "project/test-support",
     "util/test-support",
     "workspace/test-support",
-    "env_logger",
     "unindent",
     "debugger_tools"
 ]
@@ -62,7 +61,6 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 workspace-hack.workspace = true
-env_logger = { workspace = true, optional = true }
 debugger_tools = { workspace = true, optional = true }
 unindent = { workspace = true, optional = true }
 
@@ -71,9 +69,9 @@ dap = { workspace = true, features = ["test-support"] }
 dap_adapters = { workspace = true, features = ["test-support"] }
 debugger_tools = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -35,9 +35,8 @@ mod stack_frame_list;
 mod variable_list;
 
 pub fn init_test(cx: &mut gpui::TestAppContext) {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::try_init().ok();
-    }
+    #[cfg(test)]
+    zlog::init_test();
 
     cx.update(|cx| {
         let settings = SettingsStore::test(cx);

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -18,7 +18,6 @@ collections.workspace = true
 component.workspace = true
 ctor.workspace = true
 editor.workspace = true
-env_logger.workspace = true
 futures.workspace = true
 gpui.workspace = true
 indoc.workspace = true
@@ -44,9 +43,10 @@ editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 markdown = { workspace = true, features = ["test-support"] }
-lsp = { workspace = true, features = ["test-support"] }
+lsp = { workspace = true, features=["test-support"] }
 serde_json.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
+zlog.workspace = true

--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -27,9 +27,7 @@ use util::{RandomCharIter, path, post_inc};
 
 #[ctor::ctor]
 fn init_logger() {
-    if env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[gpui::test]
@@ -1413,7 +1411,7 @@ async fn test_diagnostics_with_code(cx: &mut TestAppContext) {
 
 fn init_test(cx: &mut TestAppContext) {
     cx.update(|cx| {
-        env_logger::try_init().ok();
+        zlog::init_test();
         let settings = SettingsStore::test(cx);
         cx.set_global(settings);
         theme::init(theme::LoadThemes::JustBase, cx);

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -94,7 +94,6 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 languages = {workspace = true, features = ["test-support"] }
@@ -114,3 +113,4 @@ unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -25,9 +25,7 @@ use util::test::{marked_text_offsets, marked_text_ranges};
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 pub fn test_font() -> Font {

--- a/crates/extension_host/Cargo.toml
+++ b/crates/extension_host/Cargo.toml
@@ -57,7 +57,6 @@ workspace-hack.workspace = true
 [dev-dependencies]
 criterion.workspace = true
 ctor.workspace = true
-env_logger.workspace = true
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
@@ -68,6 +67,7 @@ rand.workspace = true
 reqwest_client.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 theme_extension.workspace = true
+zlog.workspace = true
 
 [[bench]]
 name = "extension_compilation_benchmark"

--- a/crates/extension_host/src/extension_store_test.rs
+++ b/crates/extension_host/src/extension_store_test.rs
@@ -30,9 +30,7 @@ use util::test::TempTree;
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[gpui::test]

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -37,10 +37,10 @@ workspace-hack.workspace = true
 [dev-dependencies]
 ctor.workspace = true
 editor = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 picker = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -11,9 +11,7 @@ use workspace::{AppState, OpenOptions, ToggleFileFinder, Workspace};
 
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[test]

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -65,7 +65,6 @@ windows.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-env_logger.workspace = true
 editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
@@ -73,3 +72,4 @@ project = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4765,9 +4765,7 @@ mod tests {
     use super::*;
 
     fn init_test(cx: &mut gpui::TestAppContext) {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
 
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -1347,7 +1347,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        env_logger::init();
+        zlog::init_test();
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/language/Cargo.toml
+++ b/crates/language/Cargo.toml
@@ -71,7 +71,6 @@ diffy = "0.4.2"
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
 lsp = { workspace = true, features = ["test-support"] }
@@ -92,3 +91,4 @@ tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -39,9 +39,7 @@ pub static TRAILING_WHITESPACE_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| 
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[gpui::test]

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -36,6 +36,6 @@ workspace-hack.workspace = true
 client = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/language_tools/src/lsp_log_tests.rs
+++ b/crates/language_tools/src/lsp_log_tests.rs
@@ -15,9 +15,7 @@ use util::path;
 
 #[gpui::test]
 async fn test_lsp_logs(cx: &mut TestAppContext) {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 
     init_test(cx);
 

--- a/crates/lsp/Cargo.toml
+++ b/crates/lsp/Cargo.toml
@@ -36,6 +36,6 @@ workspace-hack.workspace = true
 [dev-dependencies]
 async-pipe.workspace = true
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1668,9 +1668,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     #[gpui::test]

--- a/crates/multi_buffer/Cargo.toml
+++ b/crates/multi_buffer/Cargo.toml
@@ -27,7 +27,6 @@ clock.workspace = true
 collections.workspace = true
 ctor.workspace = true
 buffer_diff.workspace = true
-env_logger.workspace = true
 gpui.workspace = true
 itertools.workspace = true
 language.workspace = true
@@ -57,3 +56,4 @@ rand.workspace = true
 settings = { workspace = true, features = ["test-support"] }
 text = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -11,9 +11,7 @@ use util::test::sample_text;
 
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[gpui::test]

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -93,7 +93,6 @@ collections = { workspace = true, features = ["test-support"] }
 buffer_diff = { workspace = true, features = ["test-support"] }
 dap = { workspace = true, features = ["test-support"] }
 dap_adapters = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 fs = { workspace = true, features = ["test-support"] }
 git2.workspace = true
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/project/src/git_store/conflict_set.rs
+++ b/crates/project/src/git_store/conflict_set.rs
@@ -463,7 +463,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_conflict_updates(executor: BackgroundExecutor, cx: &mut TestAppContext) {
-        env_logger::try_init().ok();
+        zlog::init_test();
         cx.update(|cx| {
             settings::init(cx);
             WorktreeSettings::register(cx);

--- a/crates/project/src/git_store/git_traversal.rs
+++ b/crates/project/src/git_store/git_traversal.rs
@@ -674,9 +674,7 @@ mod tests {
     }
 
     fn init_test(cx: &mut gpui::TestAppContext) {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
 
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);

--- a/crates/project/src/image_store.rs
+++ b/crates/project/src/image_store.rs
@@ -739,9 +739,7 @@ mod tests {
     use std::path::PathBuf;
 
     pub fn init_test(cx: &mut TestAppContext) {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
 
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -8528,9 +8528,7 @@ async fn search(
 }
 
 pub fn init_test(cx: &mut gpui::TestAppContext) {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::try_init().ok();
-    }
+    zlog::init_test();
 
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -1191,9 +1191,7 @@ mod tests {
     }
 
     fn init_test(_cx: &mut TestAppContext) {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::try_init().ok();
-        }
+        zlog::init_test();
         TaskStore::init(None);
     }
 

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -86,6 +86,7 @@ language_model = { workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features=["test-support"] }
 unindent.workspace = true
 serde_json.workspace = true
+zlog.workspace = true
 
 [build-dependencies]
 cargo_toml.workspace = true

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -1663,9 +1663,7 @@ pub async fn init_test(
 }
 
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::try_init().ok();
-    }
+    zlog::init_test();
 }
 
 fn build_project(ssh: Entity<SshRemoteClient>, cx: &mut TestAppContext) -> Entity<Project> {

--- a/crates/rope/Cargo.toml
+++ b/crates/rope/Cargo.toml
@@ -23,11 +23,11 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 rand.workspace = true
 util = { workspace = true, features = ["test-support"] }
 criterion.workspace = true
+zlog.workspace = true
 
 [[bench]]
 name = "rope_benchmark"

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -1435,9 +1435,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     #[test]

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -40,6 +40,6 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 proto = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/rpc/src/peer.rs
+++ b/crates/rpc/src/peer.rs
@@ -684,9 +684,7 @@ mod tests {
     use gpui::TestAppContext;
 
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     #[gpui::test(iterations = 50)]

--- a/crates/semantic_index/Cargo.toml
+++ b/crates/semantic_index/Cargo.toml
@@ -54,7 +54,6 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 fs = { workspace = true, features = ["test-support"] }
 futures.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
@@ -67,3 +66,4 @@ reqwest_client.workspace = true
 util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
 worktree = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/semantic_index/examples/index.rs
+++ b/crates/semantic_index/examples/index.rs
@@ -12,7 +12,7 @@ use std::{
 };
 
 fn main() {
-    env_logger::init();
+    zlog::init();
 
     use clock::FakeSystemClock;
 

--- a/crates/semantic_index/src/semantic_index.rs
+++ b/crates/semantic_index/src/semantic_index.rs
@@ -280,7 +280,7 @@ mod tests {
     use util::separator;
 
     fn init_test(cx: &mut TestAppContext) {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         cx.update(|cx| {
             let store = SettingsStore::test(cx);

--- a/crates/sum_tree/Cargo.toml
+++ b/crates/sum_tree/Cargo.toml
@@ -20,5 +20,5 @@ workspace-hack.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true
-env_logger.workspace = true
 rand.workspace = true
+zlog.workspace = true

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -998,9 +998,7 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 
     #[test]

--- a/crates/tab_switcher/Cargo.toml
+++ b/crates/tab_switcher/Cargo.toml
@@ -32,9 +32,9 @@ workspace-hack.workspace = true
 [dev-dependencies]
 anyhow.workspace = true
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/tab_switcher/src/tab_switcher_tests.rs
+++ b/crates/tab_switcher/src/tab_switcher_tests.rs
@@ -10,9 +10,7 @@ use workspace::{AppState, Workspace};
 
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[gpui::test]

--- a/crates/text/Cargo.toml
+++ b/crates/text/Cargo.toml
@@ -33,8 +33,8 @@ workspace-hack.workspace = true
 [dev-dependencies]
 collections = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 rand.workspace = true
 util = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/text/src/tests.rs
+++ b/crates/text/src/tests.rs
@@ -11,9 +11,7 @@ use std::{
 #[cfg(test)]
 #[ctor::ctor]
 fn init_logger() {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::init();
-    }
+    zlog::init_test();
 }
 
 #[test]

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -74,7 +74,6 @@ call = { workspace = true, features = ["test-support"] }
 client = { workspace = true, features = ["test-support"] }
 dap = { workspace = true, features = ["test-support"] }
 db = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
@@ -82,3 +81,4 @@ session = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true
+zlog.workspace = true

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1466,7 +1466,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_breakpoints() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_breakpoints").await;
         let id = db.next_id().await.unwrap();
@@ -1651,7 +1651,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_remove_last_breakpoint() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_remove_last_breakpoint").await;
         let id = db.next_id().await.unwrap();
@@ -1738,7 +1738,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_next_id_stability() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_next_id_stability").await;
 
@@ -1786,7 +1786,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_workspace_id_stability() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_workspace_id_stability").await;
 
@@ -1880,7 +1880,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_full_workspace_serialization() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_full_workspace_serialization").await;
 
@@ -1955,7 +1955,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_workspace_assignment() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_basic_functionality").await;
 
@@ -2051,7 +2051,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_session_workspaces() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_serializing_workspaces_session_id").await;
 
@@ -2488,7 +2488,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_simple_split() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("simple_split").await;
 
@@ -2543,7 +2543,7 @@ mod tests {
 
     #[gpui::test]
     async fn test_cleanup_panes() {
-        env_logger::try_init().ok();
+        zlog::init_test();
 
         let db = WorkspaceDb::open_test_db("test_cleanup_panes").await;
 

--- a/crates/worktree/Cargo.toml
+++ b/crates/worktree/Cargo.toml
@@ -52,7 +52,6 @@ workspace-hack.workspace = true
 [dev-dependencies]
 clock = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 git2.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 http_client.workspace = true
@@ -61,3 +60,4 @@ rand.workspace = true
 rpc = { workspace = true, features = ["test-support"] }
 settings = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -2091,9 +2091,7 @@ fn check_worktree_entries(
 }
 
 fn init_test(cx: &mut gpui::TestAppContext) {
-    if std::env::var("RUST_LOG").is_ok() {
-        env_logger::try_init().ok();
-    }
+    zlog::init_test();
 
     cx.update(|cx| {
         let settings_store = SettingsStore::test(cx);

--- a/crates/zeta/Cargo.toml
+++ b/crates/zeta/Cargo.toml
@@ -64,7 +64,6 @@ client = { workspace = true, features = ["test-support"] }
 clock = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 editor = { workspace = true, features = ["test-support"] }
-env_logger.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 indoc.workspace = true
@@ -79,3 +78,4 @@ unindent.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 worktree = { workspace = true, features = ["test-support"] }
 call = { workspace = true, features = ["test-support"] }
+zlog.workspace = true

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -2140,8 +2140,6 @@ mod tests {
 
     #[ctor::ctor]
     fn init_logger() {
-        if std::env::var("RUST_LOG").is_ok() {
-            env_logger::init();
-        }
+        zlog::init_test();
     }
 }

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -22,13 +22,21 @@ pub fn try_init() -> anyhow::Result<()> {
 }
 
 pub fn init_test() {
-    if try_init().is_ok() {
-        init_output_stdout();
+    if get_env_config().is_some() {
+        if try_init().is_ok() {
+            init_output_stdout();
+        }
     }
 }
 
+fn get_env_config() -> Option<String> {
+    std::env::var("ZED_LOG")
+        .or_else(|_| std::env::var("RUST_LOG"))
+        .ok()
+}
+
 pub fn process_env() {
-    let Ok(env_config) = std::env::var("ZED_LOG").or_else(|_| std::env::var("RUST_LOG")) else {
+    let Some(env_config) = get_env_config() else {
         return;
     };
     match env_config::parse(&env_config) {

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -5,14 +5,26 @@ mod env_config;
 pub mod filter;
 pub mod sink;
 
+use anyhow::Context;
 pub use sink::{flush, init_output_file, init_output_stdout};
 
 pub const SCOPE_DEPTH_MAX: usize = 4;
 
 pub fn init() {
-    process_env();
-    log::set_logger(&ZLOG).expect("Logger should not be initialized twice");
+    try_init().expect("Failed to initialize logger");
+}
+
+pub fn try_init() -> anyhow::Result<()> {
+    log::set_logger(&ZLOG).context("cannot be initialized twice")?;
     log::set_max_level(log::LevelFilter::max());
+    process_env();
+    Ok(())
+}
+
+pub fn init_test() {
+    if try_init().is_ok() {
+        init_output_stdout();
+    }
 }
 
 pub fn process_env() {


### PR DESCRIPTION
Also fixes: https://github.com/zed-industries/zed/pull/31400#issuecomment-2908165249

Release Notes:

- N/A *or* Added/Fixed/Improved ...
