### PR TITLE
agent: Refine naming for the panel `default_view` setting

### DIFF
--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -524,8 +524,8 @@ impl AgentPanel {
 
         let panel_type = AssistantSettings::get_global(cx).default_view;
         let active_view = match panel_type {
-            DefaultView::Agent => ActiveView::thread(thread.clone(), window, cx),
-            DefaultView::Thread => {
+            DefaultView::Thread => ActiveView::thread(thread.clone(), window, cx),
+            DefaultView::TextThread => {
                 let context =
                     context_store.update(cx, |context_store, cx| context_store.create(cx));
                 let lsp_adapter_delegate = make_lsp_adapter_delegate(&project.clone(), cx).unwrap();

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -35,8 +35,8 @@ pub enum AssistantDockPosition {
 #[serde(rename_all = "snake_case")]
 pub enum DefaultView {
     #[default]
-    Agent,
     Thread,
+    TextThread,
 }
 
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -644,9 +644,9 @@ pub struct AssistantSettingsContentV2 {
     ///
     /// Default: write
     default_profile: Option<AgentProfileId>,
-    /// The default assistant panel type.
+    /// Which view type to show by default in the Agent Panel.
     ///
-    /// Default: agentic
+    /// Default: "thread"
     default_view: Option<DefaultView>,
     /// The available agent profiles.
     pub profiles: Option<IndexMap<AgentProfileId, AgentProfileContent>>,

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -614,19 +614,19 @@ pub struct AssistantSettingsContentV2 {
     ///
     /// Default: true
     enabled: Option<bool>,
-    /// Whether to show the assistant panel button in the status bar.
+    /// Whether to show the agent panel button in the status bar.
     ///
     /// Default: true
     button: Option<bool>,
-    /// Where to dock the assistant.
+    /// Where to dock the agent panel.
     ///
     /// Default: right
     dock: Option<AssistantDockPosition>,
-    /// Default width in pixels when the assistant is docked to the left or right.
+    /// Default width in pixels when the agent panel is docked to the left or right.
     ///
     /// Default: 640
     default_width: Option<f32>,
-    /// Default height in pixels when the assistant is docked to the bottom.
+    /// Default height in pixels when the agent panel is docked to the bottom.
     ///
     /// Default: 320
     default_height: Option<f32>,
@@ -644,7 +644,7 @@ pub struct AssistantSettingsContentV2 {
     ///
     /// Default: write
     default_profile: Option<AgentProfileId>,
-    /// Which view type to show by default in the Agent Panel.
+    /// Which view type to show by default in the agent panel.
     ///
     /// Default: "thread"
     default_view: Option<DefaultView>,
@@ -676,7 +676,6 @@ pub struct AssistantSettingsContentV2 {
     /// Default: []
     #[serde(default)]
     model_parameters: Vec<LanguageModelParameters>,
-
     /// What completion mode to enable for new threads
     ///
     /// Default: normal

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -460,7 +460,7 @@ However, you can change it either via the model dropdown in the Agent Panel's bo
 
 ```json
 {
-  "assistant": {
+  "agent": {
     "version": "2",
     "default_model": {
       "provider": "zed.dev",
@@ -484,7 +484,7 @@ Example configuration:
 
 ```json
 {
-  "assistant": {
+  "agent": {
     "version": "2",
     "default_model": {
       "provider": "zed.dev",
@@ -517,7 +517,7 @@ One with Claude 3.7 Sonnet, and one with GPT-4o.
 
 ```json
 {
-  "assistant": {
+  "agent": {
     "default_model": {
       "provider": "zed.dev",
       "model": "claude-3-7-sonnet"
@@ -529,6 +529,19 @@ One with Claude 3.7 Sonnet, and one with GPT-4o.
       }
     ],
     "version": "2"
+  }
+}
+```
+
+## Default View
+
+Use the `default_view` setting to set change the default view of the Agent Panel.
+You can choose between `thread` (the default) and `text_thread`:
+
+```json
+{
+  "agent": {
+    "default_view": "text_thread".
   }
 }
 ```

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3284,6 +3284,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "dock": "right",
   "default_width": 640,
   "default_height": 320,
+  "default_view": "thread",
   "default_model": {
     "provider": "zed.dev",
     "model": "claude-3-7-sonnet-latest"


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/31353. Just ensuring we're walking toward a more consistent use of the multiple terms we have floating around in the AI realm. In this case, `thread` is the term for the now default view, the one that has agentic features; `text_thread` is the term for the original view, the one where it's just text. The settings now reflect this. Also took advantage of the opportunity to add some docs, too.

Release Notes:

- N/A
