### PR TITLE
Use `read()` over `read_with()` to improve readability in simple cases

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -1185,9 +1185,10 @@ impl MessageEditor {
     fn reload_context(&mut self, cx: &mut Context<Self>) -> Task<Option<ContextLoadResult>> {
         let load_task = cx.spawn(async move |this, cx| {
             let Ok(load_task) = this.update(cx, |this, cx| {
-                let new_context = this.context_store.read_with(cx, |context_store, cx| {
-                    context_store.new_context_for_thread(this.thread.read(cx), None)
-                });
+                let new_context = this
+                    .context_store
+                    .read(cx)
+                    .new_context_for_thread(this.thread.read(cx), None);
                 load_context(new_context, &this.project, &this.prompt_store, cx)
             }) else {
                 return;

--- a/crates/assistant_context_editor/src/context.rs
+++ b/crates/assistant_context_editor/src/context.rs
@@ -1730,9 +1730,8 @@ impl AssistantContext {
                                 merge_same_roles,
                             } => {
                                 if !merge_same_roles && Some(role) != last_role {
-                                    let offset = this.buffer.read_with(cx, |buffer, _cx| {
-                                        insert_position.to_offset(buffer)
-                                    });
+                                    let buffer = this.buffer.read(cx);
+                                    let offset = insert_position.to_offset(buffer);
                                     this.insert_message_at_offset(
                                         offset,
                                         role,

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -66,77 +66,77 @@ pub fn init(cx: &mut App) {
                 })
                 .register_action(|workspace, _: &Pause, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.pause_thread(cx))
                         }
                     }
                 })
                 .register_action(|workspace, _: &Restart, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.restart_session(cx))
                         }
                     }
                 })
                 .register_action(|workspace, _: &Continue, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.continue_thread(cx))
                         }
                     }
                 })
                 .register_action(|workspace, _: &StepInto, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.step_in(cx))
                         }
                     }
                 })
                 .register_action(|workspace, _: &StepOver, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.step_over(cx))
                         }
                     }
                 })
                 .register_action(|workspace, _: &StepBack, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.step_back(cx))
                         }
                     }
                 })
                 .register_action(|workspace, _: &Stop, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             cx.defer(move |cx| {
                                 active_item.update(cx, |item, cx| item.stop_thread(cx))
                             })
@@ -145,11 +145,11 @@ pub fn init(cx: &mut App) {
                 })
                 .register_action(|workspace, _: &ToggleIgnoreBreakpoints, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
-                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
-                            panel
-                                .active_session()
-                                .map(|session| session.read(cx).running_state().clone())
-                        }) {
+                        if let Some(active_item) = debug_panel
+                            .read(cx)
+                            .active_session()
+                            .map(|session| session.read(cx).running_state().clone())
+                        {
                             active_item.update(cx, |item, cx| item.toggle_ignore_breakpoints(cx))
                         }
                     }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6601,8 +6601,7 @@ impl Editor {
                 }
 
                 // Store the transaction ID and selections before applying the edit
-                let transaction_id_prev =
-                    self.buffer.read_with(cx, |b, cx| b.last_transaction_id(cx));
+                let transaction_id_prev = self.buffer.read(cx).last_transaction_id(cx);
 
                 let snapshot = self.buffer.read(cx).snapshot(cx);
                 let last_edit_end = edits.last().unwrap().0.end.bias_right(&snapshot);
@@ -6616,9 +6615,7 @@ impl Editor {
                 });
 
                 let selections = self.selections.disjoint_anchors();
-                if let Some(transaction_id_now) =
-                    self.buffer.read_with(cx, |b, cx| b.last_transaction_id(cx))
-                {
+                if let Some(transaction_id_now) = self.buffer.read(cx).last_transaction_id(cx) {
                     let has_new_transaction = transaction_id_prev != Some(transaction_id_now);
                     if has_new_transaction {
                         self.selection_history
@@ -7114,9 +7111,10 @@ impl Editor {
         for (buffer_snapshot, range, excerpt_id) in
             multi_buffer_snapshot.range_to_buffer_ranges(range)
         {
-            let Some(buffer) = project.read_with(cx, |this, cx| {
-                this.buffer_for_id(buffer_snapshot.remote_id(), cx)
-            }) else {
+            let Some(buffer) = project
+                .read(cx)
+                .buffer_for_id(buffer_snapshot.remote_id(), cx)
+            else {
                 continue;
             };
             let breakpoints = breakpoint_store.read(cx).breakpoints(
@@ -9724,7 +9722,7 @@ impl Editor {
         })?;
 
         let enclosing_excerpt = breakpoint_position.excerpt_id;
-        let buffer = project.read_with(cx, |project, cx| project.buffer_for_id(buffer_id, cx))?;
+        let buffer = project.read(cx).buffer_for_id(buffer_id, cx)?;
         let buffer_snapshot = buffer.read(cx).snapshot();
 
         let row = buffer_snapshot
@@ -15153,7 +15151,7 @@ impl Editor {
             }
         };
 
-        let transaction_id_prev = buffer.read_with(cx, |b, cx| b.last_transaction_id(cx));
+        let transaction_id_prev = buffer.read(cx).last_transaction_id(cx);
         let selections_prev = transaction_id_prev
             .and_then(|transaction_id_prev| {
                 // default to selections as they were after the last edit, if we have them,
@@ -19516,9 +19514,7 @@ impl CollaborationHub for Entity<Project> {
     fn user_names(&self, cx: &App) -> HashMap<u64, SharedString> {
         let this = self.read(cx);
         let user_ids = this.collaborators().values().map(|c| c.user_id);
-        this.user_store().read_with(cx, |user_store, cx| {
-            user_store.participant_names(user_ids, cx)
-        })
+        this.user_store().read(cx).participant_names(user_ids, cx)
     }
 }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1533,9 +1533,7 @@ impl EditorElement {
         window: &mut Window,
         cx: &mut App,
     ) -> Option<MinimapLayout> {
-        let minimap_editor = self
-            .editor
-            .read_with(cx, |editor, _| editor.minimap().cloned())?;
+        let minimap_editor = self.editor.read(cx).minimap().cloned()?;
 
         let minimap_settings = EditorSettings::get_global(cx).minimap;
 
@@ -1581,12 +1579,10 @@ impl EditorElement {
         );
         let minimap_line_height = self.get_minimap_line_height(
             minimap_editor
-                .read_with(cx, |editor, _| {
-                    editor
-                        .text_style_refinement
-                        .as_ref()
-                        .and_then(|refinement| refinement.font_size)
-                })
+                .read(cx)
+                .text_style_refinement
+                .as_ref()
+                .and_then(|refinement| refinement.font_size)
                 .unwrap_or(MINIMAP_FONT_SIZE),
             window,
             cx,
@@ -7548,14 +7544,14 @@ impl Element for EditorElement {
                     let scrollbars_shown = settings.scrollbar.show != ShowScrollbar::Never;
                     let vertical_scrollbar_width = (scrollbars_shown
                         && settings.scrollbar.axes.vertical
-                        && self
-                            .editor
-                            .read_with(cx, |editor, _| editor.show_scrollbars))
-                    .then_some(style.scrollbar_width)
-                    .unwrap_or_default();
+                        && self.editor.read(cx).show_scrollbars)
+                        .then_some(style.scrollbar_width)
+                        .unwrap_or_default();
                     let minimap_width = self
                         .editor
-                        .read_with(cx, |editor, _| editor.minimap().is_some())
+                        .read(cx)
+                        .minimap()
+                        .is_some()
                         .then(|| match settings.minimap.show {
                             ShowMinimap::Auto => {
                                 scrollbars_shown.then_some(MinimapLayout::MINIMAP_WIDTH)

--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -458,13 +458,12 @@ pub(crate) fn handle_from(
             let ensure_no_edits_since_start = || -> Option<()> {
                 let has_edits_since_start = this
                     .read_with(cx, |this, cx| {
-                        this.buffer.read_with(cx, |buffer, cx| {
-                            buffer.buffer(buffer_id).map_or(true, |buffer| {
-                                buffer.read_with(cx, |buffer, _| {
-                                    buffer.has_edits_since(&buffer_version_initial)
-                                })
+                        this.buffer
+                            .read(cx)
+                            .buffer(buffer_id)
+                            .map_or(true, |buffer| {
+                                buffer.read(cx).has_edits_since(&buffer_version_initial)
                             })
-                        })
                     })
                     .ok()?;
 
@@ -507,9 +506,7 @@ pub(crate) fn handle_from(
             ensure_no_edits_since_start()?;
 
             let multi_buffer_snapshot = this
-                .read_with(cx, |this, cx| {
-                    this.buffer.read_with(cx, |buffer, cx| buffer.snapshot(cx))
-                })
+                .read_with(cx, |this, cx| this.buffer.read(cx).snapshot(cx))
                 .ok()?;
 
             let mut base_selections = Vec::new();

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -842,9 +842,10 @@ impl LspLogView {
     ) {
         let typ = self
             .log_store
-            .read_with(cx, |v, _| {
-                v.language_servers.get(&server_id).map(|v| v.log_level)
-            })
+            .read(cx)
+            .language_servers
+            .get(&server_id)
+            .map(|v| v.log_level)
             .unwrap_or(MessageType::LOG);
         let log_contents = self
             .log_store

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -222,9 +222,8 @@ impl LocalMode {
     ) -> Task<()> {
         let breakpoints =
             breakpoint_store
-                .read_with(cx, |store, cx| {
-                    store.source_breakpoints_from_path(&abs_path, cx)
-                })
+                .read(cx)
+                .source_breakpoints_from_path(&abs_path, cx)
                 .into_iter()
                 .filter(|bp| bp.state.is_enabled())
                 .chain(self.tmp_breakpoint.iter().filter_map(|breakpoint| {
@@ -303,8 +302,7 @@ impl LocalMode {
         cx: &App,
     ) -> Task<HashMap<Arc<Path>, anyhow::Error>> {
         let mut breakpoint_tasks = Vec::new();
-        let breakpoints =
-            breakpoint_store.read_with(cx, |store, cx| store.all_source_breakpoints(cx));
+        let breakpoints = breakpoint_store.read(cx).all_source_breakpoints(cx);
         let mut raw_breakpoints = breakpoint_store.read_with(cx, |this, _| this.all_breakpoints());
         debug_assert_eq!(raw_breakpoints.len(), breakpoints.len());
         let session_id = self.client.id();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3870,9 +3870,7 @@ impl Project {
     }
 
     pub fn find_worktree(&self, abs_path: &Path, cx: &App) -> Option<(Entity<Worktree>, PathBuf)> {
-        self.worktree_store.read_with(cx, |worktree_store, cx| {
-            worktree_store.find_worktree(abs_path, cx)
-        })
+        self.worktree_store.read(cx).find_worktree(abs_path, cx)
     }
 
     pub fn is_shared(&self) -> bool {


### PR DESCRIPTION
Follow up to: #31263 

Release Notes:

- N/A
