### PR TITLE
Parse `./`/`a/`/`b/`-prefixed paths more leniently in the file finder

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1174,8 +1174,8 @@ impl PickerDelegate for FileFinderDelegate {
         let raw_query = raw_query.trim();
 
         let raw_query = match &raw_query.get(0..2) {
-            Some("./") => &raw_query[2..],
-            Some("a/") => {
+            Some(".\\") | Some("./") => &raw_query[2..],
+            Some("a\\") | Some("a/") => {
                 if self
                     .workspace
                     .upgrade()
@@ -1193,7 +1193,7 @@ impl PickerDelegate for FileFinderDelegate {
                     raw_query
                 }
             }
-            Some("b/") => {
+            Some("b\\") | Some("b/") => {
                 if self
                     .workspace
                     .upgrade()

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -206,6 +206,9 @@ async fn test_matching_paths(cx: &mut TestAppContext) {
 
     for bandana_query in [
         "bandana",
+        "./bandana",
+        "a/bandana",
+        "b/bandana",
         " bandana",
         "bandana ",
         " bandana ",

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -207,8 +207,10 @@ async fn test_matching_paths(cx: &mut TestAppContext) {
     for bandana_query in [
         "bandana",
         "./bandana",
-        "a/bandana",
+        ".\\bandana",
+        util::separator!("a/bandana"),
         "b/bandana",
+        "b\\bandana",
         " bandana",
         "bandana ",
         " bandana ",
@@ -227,7 +229,8 @@ async fn test_matching_paths(cx: &mut TestAppContext) {
             assert_eq!(
                 picker.delegate.matches.len(),
                 1,
-                "Wrong number of matches for bandana query '{bandana_query}'"
+                "Wrong number of matches for bandana query '{bandana_query}'. Matches: {:?}",
+                picker.delegate.matches
             );
         });
         cx.dispatch_action(SelectNext);


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/15081
Closes https://github.com/zed-industries/zed/issues/31064

Release Notes:

- Parse `./`/`a/`/`b/`-prefixed paths more leniently in the file finder
