### PR TITLE
debugger: Add missing StepOut handler

### DIFF
--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -119,6 +119,17 @@ pub fn init(cx: &mut App) {
                         }
                     }
                 })
+                .register_action(|workspace, _: &StepOut, _, cx| {
+                    if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
+                        if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {
+                            panel
+                                .active_session()
+                                .map(|session| session.read(cx).running_state().clone())
+                        }) {
+                            active_item.update(cx, |item, cx| item.step_out(cx))
+                        }
+                    }
+                })
                 .register_action(|workspace, _: &StepBack, _, cx| {
                     if let Some(debug_panel) = workspace.panel::<DebugPanel>(cx) {
                         if let Some(active_item) = debug_panel.read_with(cx, |panel, cx| {


### PR DESCRIPTION
Closes #31317

Release Notes:

- Debugger Beta: Fixed a bug that prevented keybindings for the `StepOut` action from working.