### PR TITLE
editor: Ensure minimap top offset is never `NaN`

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9154,9 +9154,13 @@ impl MinimapLayout {
         visible_minimap_lines: f32,
         scroll_position: f32,
     ) -> f32 {
-        let scroll_percentage =
-            (scroll_position / (document_lines - visible_editor_lines)).clamp(0., 1.);
-        scroll_percentage * (document_lines - visible_minimap_lines).max(0.)
+        let non_visible_document_lines = (document_lines - visible_editor_lines).max(0.);
+        if non_visible_document_lines == 0. {
+            0.
+        } else {
+            let scroll_percentage = (scroll_position / non_visible_document_lines).clamp(0., 1.);
+            scroll_percentage * (document_lines - visible_minimap_lines).max(0.)
+        }
     }
 }
 


### PR DESCRIPTION
(Late) Follow-up to https://github.com/zed-industries/zed/pull/26893#discussion_r2073427393

The mentioned issue of needed zero-division for scrollbars is now fixed via #30189. 
However, whilst the linked PR fixed the issue for the layouting of the scrollbar thumb, I sadly did not address the (somewhat rare) case of `document_lines == visible_editor_lines` within the calculation of the minimap top offset.

This PR adds coverage for that case and ensures that the `minimap_top_offset` never ends up being `NaN`.

Release Notes:

- N/A