### PR TITLE
Highlight file finder entries according to their git status

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -954,7 +954,9 @@
     //    "skip_focus_for_active_in_search": false
     //
     // Default: true
-    "skip_focus_for_active_in_search": true
+    "skip_focus_for_active_in_search": true,
+    // Whether to show the git status in the file finder.
+    "git_status": true
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -8,6 +8,7 @@ pub struct FileFinderSettings {
     pub file_icons: bool,
     pub modal_max_width: Option<FileFinderWidth>,
     pub skip_focus_for_active_in_search: bool,
+    pub git_status: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -24,6 +25,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: true
     pub skip_focus_for_active_in_search: Option<bool>,
+    /// Determines whether to show the git status in the file finder
+    ///
+    /// Default: true
+    pub git_status: Option<bool>,
 }
 
 impl Settings for FileFinderSettings {
@@ -35,7 +40,9 @@ impl Settings for FileFinderSettings {
         sources.json_merge()
     }
 
-    fn import_from_vscode(_vscode: &settings::VsCodeSettings, _current: &mut Self::FileContent) {}
+    fn import_from_vscode(vscode: &settings::VsCodeSettings, current: &mut Self::FileContent) {
+        vscode.bool_setting("git.decorations.enabled", &mut current.git_status);
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Configure this with the
```json5
"file_finder": {
  "git_status": true
}
```
settings value.

Before:
<img width="864" alt="before" src="https://github.com/user-attachments/assets/5943e30f-1105-445e-9398-ea6dd35877c8" />

After:
<img width="864" alt="image" src="https://github.com/user-attachments/assets/56b2fad6-8cdc-4f28-b238-920745231b1f" />

After with search matches:
<img width="577" alt="image" src="https://github.com/user-attachments/assets/8c414575-7daf-43a8-89c2-98137d52b7a0" />

Release Notes:

- Start highlighting file finder entries according to their git status
