### PR TITLE
editor: Add Python auto-indent test for same row bracket pair

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20836,6 +20836,19 @@ async fn test_outdent_after_input_for_python(cx: &mut TestAppContext) {
                     break
             else:ˇ
     "});
+
+    // test does not outdent on typing after line with square brackets
+    cx.set_state(indoc! {"
+        def f() -> list[str]:
+            ˇ
+    "});
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input("a", window, cx);
+    });
+    cx.assert_editor_state(indoc! {"
+        def f() -> list[str]:
+            aˇ
+    "});
 }
 
 #[gpui::test]


### PR DESCRIPTION
We [recently](https://github.com/zed-industries/zed/pull/31260) added a condition which fixes certain edge cases detecting indent ranges when a bracket pair is on the same row for suggested indent languages. This PR adds a test for that so we don't regress in the future. Ref: https://github.com/zed-industries/zed/issues/31362

https://github.com/zed-industries/zed/blob/f9592c6b9273738808210c3a2ab7a366258c7f71/crates/language/src/buffer.rs#L2910 

Release Notes:

- N/A
