### PR TITLE
debugger: Fix wrong port used for SSH debugging

### DIFF
--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -240,13 +240,13 @@ impl DapStore {
 
                     let mut connection = None;
                     if let Some(c) = binary.connection {
-                        let local_bind_addr = Ipv4Addr::new(127, 0, 0, 1);
+                        let local_bind_addr = Ipv4Addr::LOCALHOST;
                         let port =
                             dap::transport::TcpTransport::unused_port(local_bind_addr).await?;
 
                         ssh_command.add_port_forwarding(port, c.host.to_string(), c.port);
                         connection = Some(TcpArguments {
-                            port: c.port,
+                            port,
                             host: local_bind_addr,
                             timeout: c.timeout,
                         })


### PR DESCRIPTION
We were trying to connect on the user's machine to the port number used by the debugger on the remote machine, instead of the randomly-assigned local available port.

Release Notes:

- Debugger Beta: Fixed a bug that caused connecting to a debug adapter over SSH to hang.