### PR TITLE
git: Fix hunk controls blocking scrolling

### DIFF
--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -699,7 +699,7 @@ fn render_diff_hunk_controls(
         .rounded_b_md()
         .bg(cx.theme().colors().editor_background)
         .gap_1()
-        .occlude()
+        .stop_mouse_events_except_scroll()
         .shadow_md()
         .children(vec![
             Button::new(("reject", row as u64), "Reject")

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -21445,7 +21445,7 @@ fn render_diff_hunk_controls(
         .rounded_b_lg()
         .bg(cx.theme().colors().editor_background)
         .gap_1()
-        .occlude()
+        .stop_mouse_events_except_scroll()
         .shadow_md()
         .child(if status.has_secondary_hunk() {
             Button::new(("stage", row as u64), "Stage")


### PR DESCRIPTION
Closes #29488

Thanks @mgsloan for introducing `stop_mouse_events_except_scroll` which is exactly what we want here!

Release Notes:

- Fixed being unable to scroll editors when the cursor is positioned on diff hunk controls.