### PR TITLE
markdown: Support custom header color

### DIFF
--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -11,6 +11,32 @@
   (list_marker_parenthesis)
 ] @punctuation.list_marker
 
+(setext_heading
+  (paragraph) @markup.heading.1
+  (setext_h1_underline) @markup.heading.1)
+
+(setext_heading
+  (paragraph) @markup.heading.2
+  (setext_h2_underline) @markup.heading.2)
+
+(atx_heading
+  (atx_h1_marker)) @markup.heading.1
+
+(atx_heading
+  (atx_h2_marker)) @markup.heading.2
+
+(atx_heading
+  (atx_h3_marker)) @markup.heading.3
+
+(atx_heading
+  (atx_h4_marker)) @markup.heading.4
+
+(atx_heading
+  (atx_h5_marker)) @markup.heading.5
+
+(atx_heading
+  (atx_h6_marker)) @markup.heading.6
+
 (fenced_code_block
   (info_string
     (language) @text.literal))


### PR DESCRIPTION
closes #14115

This PR added two types of headers in markdown

[**ATX Headers(most commonly used)**](https://github.com/chrisalley/markdown-garden/blob/master/source/guides/headers/atx-headers.md):

```markdown
# This is a first level header

## This is a second level header

### This is a third level header

#### This is a fourth level header

##### This is a fifth level header

###### This is a sixth level header
```

[**Setext Headers**](https://github.com/chrisalley/markdown-garden/blob/master/source/guides/headers/setext-headers.md):
```md
This is a first level heading
=============================

This is a second level heading
------------------------------
```

> Refer to [neovim](https://github.com/neovim/neovim/blob/c4e52d604c9ac2fd47ab176ef0d1e4d72015485b/runtime/queries/markdown/highlights.scm#L2C1-L26)

Color theme configuration reference:

```jsonc
{
  "experimental.theme_overrides": {
    "syntax": {
      // =========
      "markup.heading.1": {
        "font_weight": 700,
        "color": "#d73837ff"
      },
      "markup.heading.2": {
        "font_weight": 700,
        "color": "#74ade8ff"
      },
      "markup.heading.3": {
        "font_weight": 700,
        "color": "#576cdbff"
      },
      "markup.heading.4": {
        "font_weight": 700,
        "color": "#36a165ff"
      },
      "markup.heading.5": {
        "font_weight": 700,
        "color": "#ae9414ff"
      },
      "markup.heading.6": {
        "font_weight": 700,
        "color": "#332f38ff"
      },
      // =========
    }
  }
}
```

Before:

<img width="1044" alt="image" src="https://github.com/user-attachments/assets/14dced68-e4ac-4cc3-80bd-5f7f002dc6db" />

After:

<img width="847" alt="image" src="https://github.com/user-attachments/assets/b0a60f4c-27f4-457e-ad2e-e4c762cb0e03" />


Release Notes:

- markdown: Support custom header color
