### PR TITLE
Revert to calling .update in eval fixture

### DIFF
--- a/crates/assistant_tools/src/edit_agent/evals/fixtures/disable_cursor_blinking/before.rs
+++ b/crates/assistant_tools/src/edit_agent/evals/fixtures/disable_cursor_blinking/before.rs
@@ -19812,7 +19812,7 @@ impl SemanticsProvider for Entity<Project> {
                     PrepareRenameResponse::InvalidPosition => None,
                     PrepareRenameResponse::OnlyUnpreparedRenameSupported => {
                         // Fallback on using TreeSitter info to determine identifier range
-                        buffer.read_with(cx, |buffer, _| {
+                        buffer.update(cx, |buffer, _| {
                             let snapshot = buffer.snapshot();
                             let (range, kind) = snapshot.surrounding_word(position);
                             if kind != Some(CharKind::Word) {


### PR DESCRIPTION
Looks like I accidentally touched a line of code in eval-fixture land in #31479, despite trying to avoid that area. Thanks @cole-miller!

Release Notes:

- N/A
