### PR TITLE
Fix some completion docs render delays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9562,7 +9562,6 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 name = "markdown"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assets",
  "base64 0.22.1",
  "env_logger 0.11.8",

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -19,7 +19,6 @@ test-support = [
 ]
 
 [dependencies]
-anyhow.workspace = true
 base64.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -30,7 +30,7 @@ use pulldown_cmark::Alignment;
 use sum_tree::TreeMap;
 use theme::SyntaxTheme;
 use ui::{Tooltip, prelude::*};
-use util::{ResultExt, TryFutureExt};
+use util::ResultExt;
 
 use crate::parser::CodeBlockKind;
 
@@ -98,7 +98,7 @@ pub struct Markdown {
     parsed_markdown: ParsedMarkdown,
     images_by_source_offset: HashMap<usize, Arc<Image>>,
     should_reparse: bool,
-    pending_parse: Option<Task<Option<()>>>,
+    pending_parse: Option<Task<()>>,
     focus_handle: FocusHandle,
     language_registry: Option<Arc<LanguageRegistry>>,
     fallback_code_block_language: Option<String>,
@@ -219,6 +219,7 @@ impl Markdown {
         self.parse(cx);
     }
 
+    #[cfg(feature = "test-support")]
     pub fn parsed_markdown(&self) -> &ParsedMarkdown {
         &self.parsed_markdown
     }
@@ -275,14 +276,19 @@ impl Markdown {
             self.should_reparse = true;
             return;
         }
+        self.should_reparse = false;
+        self.pending_parse = Some(self.run_background_parse(cx));
+    }
 
+    fn run_background_parse(&self, cx: &Context<Self>) -> Task<()> {
         let source = self.source.clone();
         let should_parse_links_only = self.options.parse_links_only;
         let language_registry = self.language_registry.clone();
         let fallback = self.fallback_code_block_language.clone();
+
         let parsed = cx.background_spawn(async move {
             if should_parse_links_only {
-                return anyhow::Ok((
+                return (
                     ParsedMarkdown {
                         events: Arc::from(parse_links_only(source.as_ref())),
                         source,
@@ -290,8 +296,9 @@ impl Markdown {
                         languages_by_path: TreeMap::default(),
                     },
                     Default::default(),
-                ));
+                );
             }
+
             let (events, language_names, paths) = parse_markdown(&source);
             let mut images_by_source_offset = HashMap::default();
             let mut languages_by_name = TreeMap::default();
@@ -343,7 +350,7 @@ impl Markdown {
                 }
             }
 
-            anyhow::Ok((
+            (
                 ParsedMarkdown {
                     source,
                     events: Arc::from(events),
@@ -351,29 +358,23 @@ impl Markdown {
                     languages_by_path,
                 },
                 images_by_source_offset,
-            ))
+            )
         });
 
-        self.should_reparse = false;
-        self.pending_parse = Some(cx.spawn(async move |this, cx| {
-            async move {
-                let (parsed, images_by_source_offset) = parsed.await?;
+        cx.spawn(async move |this, cx| {
+            let (parsed, images_by_source_offset) = parsed.await;
 
-                this.update(cx, |this, cx| {
-                    this.parsed_markdown = parsed;
-                    this.images_by_source_offset = images_by_source_offset;
-                    this.pending_parse.take();
-                    if this.should_reparse {
-                        this.parse(cx);
-                    }
-                    cx.notify();
-                })
-                .ok();
-                anyhow::Ok(())
-            }
-            .log_err()
-            .await
-        }));
+            this.update(cx, |this, cx| {
+                this.parsed_markdown = parsed;
+                this.images_by_source_offset = images_by_source_offset;
+                this.pending_parse.take();
+                if this.should_reparse {
+                    this.parse(cx);
+                }
+                cx.refresh_windows();
+            })
+            .ok();
+        })
     }
 }
 

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -192,6 +192,10 @@ impl Markdown {
         this
     }
 
+    pub fn is_parsing(&self) -> bool {
+        self.pending_parse.is_some()
+    }
+
     pub fn source(&self) -> &str {
         &self.source
     }
@@ -277,10 +281,10 @@ impl Markdown {
             return;
         }
         self.should_reparse = false;
-        self.pending_parse = Some(self.run_background_parse(cx));
+        self.pending_parse = Some(self.start_background_parse(cx));
     }
 
-    fn run_background_parse(&self, cx: &Context<Self>) -> Task<()> {
+    fn start_background_parse(&self, cx: &Context<Self>) -> Task<()> {
         let source = self.source.clone();
         let should_parse_links_only = self.options.parse_links_only;
         let language_registry = self.language_registry.clone();


### PR DESCRIPTION
Closes #31460

While this is now much better than it was, the documentation still flickers when changing selection.  Hoping to fix that, but it will be a much more involved change.  So leaving release notes as "N/A" for now, in anticipation of the full fix.

Release Notes:

- N/A