### PR TITLE
nix: Refactor gh-actions and re-enable nightly builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,48 +714,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   nix-build:
-    timeout-minutes: 60
-    name: Nix Build
-    continue-on-error: true
-    if: github.repository_owner == 'zed-industries' && contains(github.event.pull_request.labels.*.name, 'run-nix')
-    strategy:
-      fail-fast: false
-      matrix:
-        system:
-          - os: x86 Linux
-            runner: buildjet-16vcpu-ubuntu-2204
-            install_nix: true
-          - os: arm Mac
-            runner: [macOS, ARM64, test]
-            install_nix: false
-    runs-on: ${{ matrix.system.runner }}
-    env:
-      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
-      GIT_LFS_SKIP_SMUDGE: 1 # breaks the livekit rust sdk examples which we don't actually depend on
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          clean: false
-      - name: Set path
-        if: ${{ ! matrix.system.install_nix }}
-        run: |
-          echo "/nix/var/nix/profiles/default/bin" >> $GITHUB_PATH
-          echo "/Users/administrator/.nix-profile/bin" >> $GITHUB_PATH
-
-      - uses: cachix/install-nix-action@d1ca217b388ee87b2507a9a93bf01368bde7cec2 # v31
-        if: ${{ matrix.system.install_nix }}
-        with:
-          github_access_token: ${{ secrets.GITHUB_TOKEN }}
-
-      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
-        with:
-          name: zed-industries
-          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-          skipPush: true
-      - run: nix build .#debug
-      - name: Limit /nix/store to 50GB
-        run: "[ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d"
+    uses: ./.github/workflows/nix.yml
 
   auto-release-preview:
     name: Auto release preview

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -715,6 +715,11 @@ jobs:
 
   nix-build:
     uses: ./.github/workflows/nix.yml
+    if: github.repository_owner == 'zed-industries' && contains(github.event.pull_request.labels.*.name, 'run-nix')
+    with:
+      flake-output: debug
+      # excludes the final package to only cache dependencies
+      cachix-filter: "-zed-editor-[0-9.]*-nightly"
 
   auto-release-preview:
     name: Auto release preview

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,23 +1,20 @@
 name: "Nix build"
 
 on:
-  pull_request:
-    paths:
-      - "nix/**"
-      - "*.nix"
   workflow_call:
     inputs:
-      FLAKE_OUTPUT:
-        default: ".#debug"
+      flake-output:
         type: string
-
-    secrets:
+        default: "default"
+      cachix-filter:
+        type: string
+        default: ""
 
 jobs:
   nix-build:
     timeout-minutes: 60
     name: (${{ matrix.system.os }}) Nix Build
-    continue-on-error: true
+    continue-on-error: true # TODO: remove when we want this to start blocking CI
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +27,6 @@ jobs:
             install_nix: false
     if: github.repository_owner == 'zed-industries'
     runs-on: ${{ matrix.system.runner }}
-    needs: tests
     env:
       ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
       ZED_CLOUD_PROVIDER_ADDITIONAL_MODELS_JSON: ${{ secrets.ZED_CLOUD_PROVIDER_ADDITIONAL_MODELS_JSON }}
@@ -59,7 +55,11 @@ jobs:
         with:
           name: zed
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build ${{ inputs.FLAKE_OUTPUT }} -L --accept-flake-config
-      - name: Limit /nix/store to 50GB
+          pushFilter: "${{ inputs.cachix-filter }}"
+
+      - run: nix build .#${{ inputs.flake-output }} -L --accept-flake-config
+
+      - name: Limit /nix/store to 50GB on macs
+        if: ${{ ! matrix.system.install_nix }}
         run: |
           [ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d || :

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -7,8 +7,9 @@ on:
       - "*.nix"
   workflow_call:
     inputs:
-      flake-output:
-        default: ""
+      FLAKE_OUTPUT:
+        default: ".#debug"
+        type: string
 
     secrets:
 
@@ -58,6 +59,7 @@ jobs:
         with:
           name: zed
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
-      - run: nix build
+      - run: nix build ${{ inputs.FLAKE_OUTPUT }} -L --accept-flake-config
       - name: Limit /nix/store to 50GB
-        run: "[ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d"
+        run: |
+          [ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d || :

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,63 @@
+name: "Nix build"
+
+on:
+  pull_request:
+    paths:
+      - "nix/**"
+      - "*.nix"
+  workflow_call:
+    inputs:
+      flake-output:
+        default: ""
+
+    secrets:
+
+jobs:
+  nix-build:
+    timeout-minutes: 60
+    name: (${{ matrix.system.os }}) Nix Build
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        system:
+          - os: x86 Linux
+            runner: buildjet-16vcpu-ubuntu-2204
+            install_nix: true
+          - os: arm Mac
+            runner: [macOS, ARM64, test]
+            install_nix: false
+    if: github.repository_owner == 'zed-industries'
+    runs-on: ${{ matrix.system.runner }}
+    needs: tests
+    env:
+      ZED_CLIENT_CHECKSUM_SEED: ${{ secrets.ZED_CLIENT_CHECKSUM_SEED }}
+      ZED_CLOUD_PROVIDER_ADDITIONAL_MODELS_JSON: ${{ secrets.ZED_CLOUD_PROVIDER_ADDITIONAL_MODELS_JSON }}
+      GIT_LFS_SKIP_SMUDGE: 1 # breaks the livekit rust sdk examples which we don't actually depend on
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          clean: false
+
+      # on our macs we manually install nix. for some reason the cachix action is running
+      # under a non-login /bin/bash shell which doesn't source the proper script to add the
+      # nix profile to PATH, so we manually add them here
+      - name: Set path
+        if: ${{ ! matrix.system.install_nix }}
+        run: |
+          echo "/nix/var/nix/profiles/default/bin" >> $GITHUB_PATH
+          echo "/Users/administrator/.nix-profile/bin" >> $GITHUB_PATH
+
+      - uses: cachix/install-nix-action@02a151ada4993995686f9ed4f1be7cfbb229e56f # v31
+        if: ${{ matrix.system.install_nix }}
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: cachix/cachix-action@0fc020193b5a1fa3ac4575aa3a7d3aa6a35435ad # v16
+        with:
+          name: zed
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+      - run: nix build
+      - name: Limit /nix/store to 50GB
+        run: "[ $(du -sm /nix/store | cut -f1) -gt 50000 ] && nix-collect-garbage -d"

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -167,6 +167,10 @@ jobs:
       - name: Upload Zed Nightly
         run: script/upload-nightly linux-targz
 
+  bundle-nix:
+    needs: tests
+    uses: ./.github/workflows/nix.yml
+
   update-nightly-tag:
     name: Update nightly tag
     if: github.repository_owner == 'zed-industries'

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1742394900,
-        "narHash": "sha256-vVOAp9ahvnU+fQoKd4SEXB2JG2wbENkpqcwlkIXgUC0=",
+        "lastModified": 1748047550,
+        "narHash": "sha256-t0qLLqb4C1rdtiY8IFRH5KIapTY/n3Lqt57AmxEv9mk=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "70947c1908108c0c551ddfd73d4f750ff2ea67cd",
+        "rev": "b718a78696060df6280196a6f992d04c87a16aef",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "flake-compat": {
       "locked": {
-        "lastModified": 1733328505,
-        "narHash": "sha256-NeCCThCEP3eCl2l/+27kNNK7QrwZB1IJCrXfrbv5oqU=",
+        "lastModified": 1747046372,
+        "narHash": "sha256-CIVLLkVgvHYbgI2UpXvIIBJ12HWgX+fjA8Xf8PUmqCY=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "ff81ac966bb2cae68946d5ed5fc4994f96d0ffec",
+        "rev": "9100a0f413b0c601e0533d1d94ffd501ce2e7885",
         "type": "github"
       },
       "original": {
@@ -33,10 +33,10 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 315532800,
-        "narHash": "sha256-kgy4FnRFGj62QO3kI6a6glFl8XUtKMylWGybnVCvycM=",
-        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "narHash": "sha256-3c6Axl3SGIXCixGtpSJaMXLkkSRihHDlLaGewDEgha0=",
+        "rev": "3108eaa516ae22c2360928589731a4f1581526ef",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.05pre796313.b3582c75c7f2/nixexprs.tar.xz?rev=b3582c75c7f21ce0b429898980eddbbf05c68e55"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre806109.3108eaa516ae/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1747363019,
-        "narHash": "sha256-N4dwkRBmpOosa4gfFkFf/LTD8oOcNkAyvZ07JvRDEf0=",
+        "lastModified": 1748227081,
+        "narHash": "sha256-RLnN7LBxhEdCJ6+rIL9sbhjBVDaR6jG377M/CLP/fmE=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0e624f2b1972a34be1a9b35290ed18ea4b419b6f",
+        "rev": "1cbe817fd8c64a9f77ba4d7861a4839b0b15983e",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -54,11 +54,9 @@
     };
 
   nixConfig = {
-    extra-substituters = [
-      "https://zed-industries.cachix.org"
-    ];
+    extra-substituters = [ "https://zed.cachix.org" ];
     extra-trusted-public-keys = [
-      "zed-industries.cachix.org-1:QW3RoXK0Lm4ycmU5/3bmYRd3MLf4RbTGPqRulGlX5W0="
+      "zed.cachix.org-1:/pHQ6dpMsAZk2DiP4WCL0p9YDNKWj2Q5FL20bNmw1cU="
     ];
   };
 }


### PR DESCRIPTION
Now that the nix build is working again, re-enable nightly builds and refactor the workflow for re-use between nightly releases and CI jobs.

Release Notes:

- N/A
