### PR TITLE
Remove unused editor_model configuration option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -733,13 +733,6 @@
       // The model to use.
       "model": "claude-sonnet-4"
     },
-    // The model to use when applying edits from the agent.
-    "editor_model": {
-      // The provider to use.
-      "provider": "zed.dev",
-      // The model to use.
-      "model": "claude-sonnet-4"
-    },
     // Additional parameters for language model requests. When making a request to a model, parameters will be taken
     // from the last entry in this list that matches the model's provider and name. In each entry, both provider
     // and model are optional, so that you can specify parameters for either one.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3303,10 +3303,6 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "provider": "zed.dev",
     "model": "claude-sonnet-4"
   },
-  "editor_model": {
-    "provider": "zed.dev",
-    "model": "claude-sonnet-4"
-  },
   "single_file_review": true,
 }
 ```


### PR DESCRIPTION
It seems that this configuration option is no longer used and can be removed.


Release Notes:

- Removed unused `agent.editor_model` setting
