### PR TITLE
Fix Claude Sonnet 4 model ID

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -729,14 +729,14 @@
       // The provider to use.
       "provider": "zed.dev",
       // The model to use.
-      "model": "claude-4-sonnet"
+      "model": "claude-sonnet-4"
     },
     // The model to use when applying edits from the agent.
     "editor_model": {
       // The provider to use.
       "provider": "zed.dev",
       // The model to use.
-      "model": "claude-4-sonnet"
+      "model": "claude-sonnet-4"
     },
     // Additional parameters for language model requests. When making a request to a model, parameters will be taken
     // from the last entry in this list that matches the model's provider and name. In each entry, both provider
@@ -756,7 +756,7 @@
       // To set parameters for a specific provider and model:
       // {
       //   "provider": "zed.dev",
-      //   "model": "claude-4-sonnet",
+      //   "model": "claude-sonnet-4",
       //   "temperature": 1.0
       // }
     ],

--- a/crates/assistant_settings/src/assistant_settings.rs
+++ b/crates/assistant_settings/src/assistant_settings.rs
@@ -1018,7 +1018,7 @@ mod tests {
                 AssistantSettings::get_global(cx).default_model,
                 LanguageModelSelection {
                     provider: "zed.dev".into(),
-                    model: "claude-4-sonnet".into(),
+                    model: "claude-sonnet-4".into(),
                 }
             );
         });

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -152,8 +152,8 @@ You can configure a model to use [extended thinking](https://docs.anthropic.com/
 
 ```json
 {
-  "name": "claude-4-sonnet-latest",
-  "display_name": "claude-4-sonnet-thinking",
+  "name": "claude-sonnet-4-latest",
+  "display_name": "claude-sonnet-4-thinking",
   "max_tokens": 200000,
   "mode": {
     "type": "thinking",
@@ -455,7 +455,7 @@ Where `some-provider` can be any of the following values: `anthropic`, `google`,
 
 ### Default Model {#default-model}
 
-Zed's hosted LLM service sets `claude-4-sonnet-latest` as the default model.
+Zed's hosted LLM service sets `claude-sonnet-4` as the default model.
 However, you can change it either via the model dropdown in the Agent Panel's bottom-right corner or by manually editing the `default_model` object in your settings:
 
 ```json
@@ -488,7 +488,7 @@ Example configuration:
     "version": "2",
     "default_model": {
       "provider": "zed.dev",
-      "model": "claude-4-sonnet"
+      "model": "claude-sonnet-4"
     },
     "inline_assistant_model": {
       "provider": "anthropic",
@@ -520,7 +520,7 @@ One with Claude 3.7 Sonnet, and one with GPT-4o.
   "agent": {
     "default_model": {
       "provider": "zed.dev",
-      "model": "claude-4-sonnet"
+      "model": "claude-sonnet-4"
     },
     "inline_alternatives": [
       {

--- a/docs/src/ai/temperature.md
+++ b/docs/src/ai/temperature.md
@@ -16,7 +16,7 @@ Zed's settings allow you to specify a custom temperature for a provider and/or m
       // To set parameters for a specific provider and model:
       {
         "provider": "zed.dev",
-        "model": "claude-4-sonnet",
+        "model": "claude-sonnet-4",
         "temperature": 1.0
       }
     ],

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3287,11 +3287,11 @@ Run the `theme selector: toggle` action in the command palette to see a current 
   "default_view": "thread",
   "default_model": {
     "provider": "zed.dev",
-    "model": "claude-4-sonnet"
+    "model": "claude-sonnet-4"
   },
   "editor_model": {
     "provider": "zed.dev",
-    "model": "claude-4-sonnet"
+    "model": "claude-sonnet-4"
   },
   "single_file_review": true,
 }


### PR DESCRIPTION
This PR is a follow-up to https://github.com/zed-industries/zed/pull/31415 that fixes the model ID for Claude Sonnet 4.

With the release of the Claude 4 models, the model version now appears at the end.

Release Notes:

- N/A
