### PR TITLE
feat(tsgo): add support for typescript corsa

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1473,7 +1473,7 @@
       }
     },
     "JavaScript": {
-      "language_servers": ["!typescript-language-server", "vtsls", "..."],
+      "language_servers": ["!typescript-language-server", "!vtsls", "typescript", "..."],
       "prettier": {
         "allowed": true
       }
@@ -1541,7 +1541,7 @@
       }
     },
     "TSX": {
-      "language_servers": ["!typescript-language-server", "vtsls", "..."],
+      "language_servers": ["!typescript-language-server", "!vtsls", "typescript", "..."],
       "prettier": {
         "allowed": true
       }
@@ -1552,7 +1552,7 @@
       }
     },
     "TypeScript": {
-      "language_servers": ["!typescript-language-server", "vtsls", "..."],
+      "language_servers": ["!typescript-language-server", "!vtsls", "typescript", "..."],
       "prettier": {
         "allowed": true
       }

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -21,6 +21,7 @@ mod python;
 mod rust;
 mod tailwind;
 mod typescript;
+mod typescript_go;
 mod vtsls;
 mod yaml;
 
@@ -90,6 +91,8 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
     let tailwind_adapter = Arc::new(tailwind::TailwindLspAdapter::new(node.clone()));
     let typescript_context = Arc::new(typescript::typescript_task_context());
     let typescript_lsp_adapter = Arc::new(typescript::TypeScriptLspAdapter::new(node.clone()));
+    let typescript_go_lsp_adapter =
+        Arc::new(typescript_go::TypeScriptGoLspAdapter::new(node.clone()));
     let vtsls_adapter = Arc::new(vtsls::VtslsLspAdapter::new(node.clone()));
     let yaml_lsp_adapter = Arc::new(yaml::YamlLspAdapter::new(node.clone()));
 
@@ -173,25 +176,41 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
         },
         LanguageInfo {
             name: "tsx",
-            adapters: vec![typescript_lsp_adapter.clone(), vtsls_adapter.clone()],
+            adapters: vec![
+                typescript_go_lsp_adapter.clone(),
+                typescript_lsp_adapter.clone(),
+                vtsls_adapter.clone(),
+            ],
             context: Some(typescript_context.clone()),
             ..Default::default()
         },
         LanguageInfo {
             name: "typescript",
-            adapters: vec![typescript_lsp_adapter.clone(), vtsls_adapter.clone()],
+            adapters: vec![
+                typescript_go_lsp_adapter.clone(),
+                typescript_lsp_adapter.clone(),
+                vtsls_adapter.clone(),
+            ],
             context: Some(typescript_context.clone()),
             ..Default::default()
         },
         LanguageInfo {
             name: "javascript",
-            adapters: vec![typescript_lsp_adapter.clone(), vtsls_adapter.clone()],
+            adapters: vec![
+                typescript_go_lsp_adapter.clone(),
+                typescript_lsp_adapter.clone(),
+                vtsls_adapter.clone(),
+            ],
             context: Some(typescript_context.clone()),
             ..Default::default()
         },
         LanguageInfo {
             name: "jsdoc",
-            adapters: vec![typescript_lsp_adapter.clone(), vtsls_adapter.clone()],
+            adapters: vec![
+                typescript_go_lsp_adapter.clone(),
+                typescript_lsp_adapter.clone(),
+                vtsls_adapter.clone(),
+            ],
             ..Default::default()
         },
         LanguageInfo {
@@ -256,6 +275,10 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
             move || adapter.clone()
         },
     );
+    languages.register_available_lsp_adapter(LanguageServerName("typescript".into()), {
+        let adapter = typescript_go_lsp_adapter.clone();
+        move || adapter.clone()
+    });
 
     // Register Tailwind for the existing languages that should have it by default.
     //

--- a/crates/languages/src/typescript_go.rs
+++ b/crates/languages/src/typescript_go.rs
@@ -1,0 +1,200 @@
+use anyhow::Result;
+use async_trait::async_trait;
+use collections::HashMap;
+use gpui::AsyncApp;
+use language::{LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
+use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
+use node_runtime::NodeRuntime;
+use project::Fs;
+use serde_json::{Value, json};
+use std::{
+    any::Any,
+    ffi::OsString,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use util::{ResultExt, maybe};
+
+fn typescript_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
+    vec![server_path.into(), "--lsp".into(), "--stdio".into()]
+}
+
+pub struct TypeScriptGoLspAdapter {
+    node: NodeRuntime,
+}
+
+impl TypeScriptGoLspAdapter {
+    const PACKAGE_NAME: &'static str = "@typescript/native-preview";
+    const SERVER_PATH: &'static str = "node_modules/@typescript/native-preview/bin/tsgo.js";
+
+    pub fn new(node: NodeRuntime) -> Self {
+        Self { node }
+    }
+}
+
+struct TypeScriptVersions {
+    server_version: String,
+}
+
+const SERVER_NAME: LanguageServerName = LanguageServerName::new_static("typescript");
+
+#[async_trait(?Send)]
+impl LspAdapter for TypeScriptGoLspAdapter {
+    fn name(&self) -> LanguageServerName {
+        SERVER_NAME.clone()
+    }
+
+    async fn fetch_latest_server_version(
+        &self,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<Box<dyn 'static + Send + Any>> {
+        Ok(Box::new(TypeScriptVersions {
+            server_version: self
+                .node
+                .npm_package_latest_version(Self::PACKAGE_NAME)
+                .await?,
+        }) as Box<_>)
+    }
+
+    async fn check_if_user_installed(
+        &self,
+        delegate: &dyn LspAdapterDelegate,
+        _: Arc<dyn LanguageToolchainStore>,
+        _: &AsyncApp,
+    ) -> Option<LanguageServerBinary> {
+        let env = delegate.shell_env().await;
+        let path = delegate.which(SERVER_NAME.as_ref()).await?;
+        Some(LanguageServerBinary {
+            path: path.clone(),
+            arguments: typescript_server_binary_arguments(&path),
+            env: Some(env),
+        })
+    }
+
+    async fn fetch_server_binary(
+        &self,
+        latest_version: Box<dyn 'static + Send + Any>,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Result<LanguageServerBinary> {
+        let latest_version = latest_version.downcast::<TypeScriptVersions>().unwrap();
+        let server_path = container_dir.join(Self::SERVER_PATH);
+
+        let mut packages_to_install = Vec::new();
+
+        if self
+            .node
+            .should_install_npm_package(
+                Self::PACKAGE_NAME,
+                &server_path,
+                &container_dir,
+                &latest_version.server_version,
+            )
+            .await
+        {
+            packages_to_install.push((Self::PACKAGE_NAME, latest_version.server_version.as_str()));
+        }
+
+        self.node
+            .npm_install_packages(&container_dir, &packages_to_install)
+            .await?;
+
+        Ok(LanguageServerBinary {
+            path: self.node.binary_path().await?,
+            env: None,
+            arguments: typescript_server_binary_arguments(&server_path),
+        })
+    }
+
+    async fn cached_server_binary(
+        &self,
+        container_dir: PathBuf,
+        _: &dyn LspAdapterDelegate,
+    ) -> Option<LanguageServerBinary> {
+        get_cached_ts_server_binary(container_dir, &self.node).await
+    }
+
+    fn code_action_kinds(&self) -> Option<Vec<CodeActionKind>> {
+        Some(vec![
+            CodeActionKind::QUICKFIX,
+            CodeActionKind::REFACTOR,
+            CodeActionKind::REFACTOR_EXTRACT,
+            CodeActionKind::SOURCE,
+        ])
+    }
+
+    async fn label_for_completion(
+        &self,
+        item: &lsp::CompletionItem,
+        language: &Arc<language::Language>,
+    ) -> Option<language::CodeLabel> {
+        use lsp::CompletionItemKind as Kind;
+        let len = item.label.len();
+        let grammar = language.grammar()?;
+        let highlight_id = match item.kind? {
+            Kind::CLASS | Kind::INTERFACE | Kind::ENUM => grammar.highlight_id_for_name("type"),
+            Kind::CONSTRUCTOR => grammar.highlight_id_for_name("type"),
+            Kind::CONSTANT => grammar.highlight_id_for_name("constant"),
+            Kind::FUNCTION | Kind::METHOD => grammar.highlight_id_for_name("function"),
+            Kind::PROPERTY | Kind::FIELD => grammar.highlight_id_for_name("property"),
+            Kind::VARIABLE => grammar.highlight_id_for_name("variable"),
+            _ => None,
+        }?;
+
+        let text = if let Some(description) = item
+            .label_details
+            .as_ref()
+            .and_then(|label_details| label_details.description.as_ref())
+        {
+            format!("{} {}", item.label, description)
+        } else if let Some(detail) = &item.detail {
+            format!("{} {}", item.label, detail)
+        } else {
+            item.label.clone()
+        };
+
+        Some(language::CodeLabel {
+            text,
+            runs: vec![(0..len, highlight_id)],
+            filter_range: 0..len,
+        })
+    }
+
+    async fn workspace_configuration(
+        self: Arc<Self>,
+        fs: &dyn Fs,
+        delegate: &Arc<dyn LspAdapterDelegate>,
+        _: Arc<dyn LanguageToolchainStore>,
+        cx: &mut AsyncApp,
+    ) -> Result<Value> {
+        Ok(json!({}))
+    }
+
+    fn language_ids(&self) -> HashMap<String, String> {
+        HashMap::from_iter([
+            ("TypeScript".into(), "typescript".into()),
+            ("JavaScript".into(), "javascript".into()),
+            ("TSX".into(), "typescriptreact".into()),
+        ])
+    }
+}
+
+async fn get_cached_ts_server_binary(
+    container_dir: PathBuf,
+    node: &NodeRuntime,
+) -> Option<LanguageServerBinary> {
+    maybe!(async {
+        let server_path = container_dir.join(TypeScriptGoLspAdapter::SERVER_PATH);
+        anyhow::ensure!(
+            server_path.exists(),
+            "missing executable in directory {container_dir:?}"
+        );
+        Ok(LanguageServerBinary {
+            path: node.binary_path().await?,
+            env: None,
+            arguments: typescript_server_binary_arguments(&server_path),
+        })
+    })
+    .await
+    .log_err()
+}


### PR DESCRIPTION
Microsoft recently announced the [`@typescript/native-preview`](https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/) package which includes [a very rudimentary LSP-based language server](https://devblogs.microsoft.com/typescript/announcing-typescript-native-previews/#:~:text=a%20very%20rudimentary%20LSP%2Dbased%20language%20server).

I had initially intended to experiment with writing a Zed Extension, as I believe that is a more appropiate avenue for an experimental change. I however, did not immediately spot the best approach for adding a new TypeScript LSP via an extension. For now I've opted to use the `vtsls` implementation for reference. I'll likely attempt to explore implementing this via a Zed Extension at some point (any pointers would be appreciated). For now I thought it would be valuable to open this PR as a draft for discoverability. Feel free to close if not appropriate.