### PR TITLE
gpui: Fix a potential panic after closing a window on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -221,7 +221,7 @@ impl WindowsPlatform {
         unsafe {
             while PeekMessageW(&mut msg, None, 0, 0, PM_REMOVE).as_bool() {
                 match msg.message {
-                    WM_QUIT => return true,
+                    WM_CLOSE => return true,
                     WM_INPUTLANGCHANGE
                     | WM_GPUI_CLOSE_ONE_WINDOW
                     | WM_GPUI_TASK_DISPATCHED_ON_MAIN_THREAD


### PR DESCRIPTION
Release Notes:

- Fix a potential panic after closing window on Windows platform.

In Debug mode, Zed will cause a panic after closing window: [Panic Info](https://github.com/user-attachments/files/20459937/Panic.Info.txt)

In original code, `WM_QUIT` can be caught only after calling `PostQuitMessage()`, which should be called after catching `WM_DESTROY`. As `PostQuitMessage` doesn't be called, `WM_QUIT` will never appear in message queue, and I chose directly handling `WM_CLOSE` to resolve this issue.