### PR TITLE
debugger: Don't try to open `<node_internals>` paths

### DIFF
--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -250,6 +250,9 @@ impl StackFrameList {
         let Some(abs_path) = Self::abs_path_from_stack_frame(&stack_frame) else {
             return Task::ready(Err(anyhow!("Project path not found")));
         };
+        if abs_path.starts_with("<node_internals>") {
+            return Task::ready(Ok(()));
+        }
         let row = stack_frame.line.saturating_sub(1) as u32;
         cx.emit(StackFrameListEvent::SelectedStackFrameChanged(
             stack_frame_id,


### PR DESCRIPTION
The JS DAP returns these, and they don't point to anything real on the filesystem.

Release Notes:

- N/A