### PR TITLE
javascript/typescript/tsx: Highlight private properties

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -7,6 +7,7 @@
 (property_identifier) @property
 (shorthand_property_identifier) @property
 (shorthand_property_identifier_pattern) @property
+(private_property_identifier) @property
 
 ; Function and method calls
 
@@ -15,7 +16,7 @@
 
 (call_expression
   function: (member_expression
-    property: (property_identifier) @function.method))
+      property: [(property_identifier) (private_property_identifier)] @function.method))
 
 ; Function and method definitions
 
@@ -24,18 +25,18 @@
 (function_declaration
   name: (identifier) @function)
 (method_definition
-  name: (property_identifier) @function.method)
+  name: [(property_identifier) (private_property_identifier)] @function.method)
 (method_definition
     name: (property_identifier) @constructor
     (#eq? @constructor "constructor"))
 
 (pair
-  key: (property_identifier) @function.method
+  key: [(property_identifier) (private_property_identifier)] @function.method
   value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (member_expression
-    property: (property_identifier) @function.method)
+    property: [(property_identifier) (private_property_identifier)] @function.method)
   right: [(function_expression) (arrow_function)])
 
 (variable_declarator

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -7,6 +7,7 @@
 (property_identifier) @property
 (shorthand_property_identifier) @property
 (shorthand_property_identifier_pattern) @property
+(private_property_identifier) @property
 
 ; Function and method calls
 
@@ -15,7 +16,7 @@
 
 (call_expression
   function: (member_expression
-    property: (property_identifier) @function.method))
+    property: [(property_identifier) (private_property_identifier)] @function.method))
 
 ; Function and method definitions
 
@@ -24,18 +25,18 @@
 (function_declaration
   name: (identifier) @function)
 (method_definition
-  name: (property_identifier) @function.method)
+  name: [(property_identifier) (private_property_identifier)] @function.method)
 (method_definition
     name: (property_identifier) @constructor
     (#eq? @constructor "constructor"))
 
 (pair
-  key: (property_identifier) @function.method
+  key: [(property_identifier) (private_property_identifier)] @function.method
   value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (member_expression
-    property: (property_identifier) @function.method)
+    property: [(property_identifier) (private_property_identifier)] @function.method)
   right: [(function_expression) (arrow_function)])
 
 (variable_declarator

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -39,6 +39,7 @@
 (property_identifier) @property
 (shorthand_property_identifier) @property
 (shorthand_property_identifier_pattern) @property
+(private_property_identifier) @property
 
 ; Function and method calls
 
@@ -47,7 +48,7 @@
 
 (call_expression
   function: (member_expression
-    property: (property_identifier) @function.method))
+    property: [(property_identifier) (private_property_identifier)] @function.method))
 
 ; Function and method definitions
 
@@ -56,18 +57,18 @@
 (function_declaration
   name: (identifier) @function)
 (method_definition
-  name: (property_identifier) @function.method)
+  name: [(property_identifier) (private_property_identifier)] @function.method)
 (method_definition
     name: (property_identifier) @constructor
     (#eq? @constructor "constructor"))
 
 (pair
-  key: (property_identifier) @function.method
+  key: [(property_identifier) (private_property_identifier)] @function.method
   value: [(function_expression) (arrow_function)])
 
 (assignment_expression
   left: (member_expression
-    property: (property_identifier) @function.method)
+    property: [(property_identifier) (private_property_identifier)] @function.method)
   right: [(function_expression) (arrow_function)])
 
 (variable_declarator


### PR DESCRIPTION
Closes #28411

Release Notes:

- Fixed the lack of highlighting for private properties in classes for JavaScript/TypeScript/TSX files
