### PR TITLE
Revert "Highlight file finder entries according to their git status"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -959,9 +959,7 @@
     //    "skip_focus_for_active_in_search": false
     //
     // Default: true
-    "skip_focus_for_active_in_search": true,
-    // Whether to show the git status in the file finder.
-    "git_status": true
+    "skip_focus_for_active_in_search": true
   },
   // Whether or not to remove any trailing whitespace from lines of a buffer
   // before saving it.

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -11,7 +11,7 @@ use futures::future::join_all;
 pub use open_path_prompt::OpenPathDelegate;
 
 use collections::HashMap;
-use editor::{Editor, items::entry_git_aware_label_color};
+use editor::Editor;
 use file_finder_settings::{FileFinderSettings, FileFinderWidth};
 use file_icons::FileIcons;
 use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
@@ -1418,58 +1418,23 @@ impl PickerDelegate for FileFinderDelegate {
         cx: &mut Context<Picker<Self>>,
     ) -> Option<Self::ListItem> {
         let settings = FileFinderSettings::get_global(cx);
-        let path_match = self.matches.get(ix)?;
 
-        let git_status_color = if settings.git_status {
-            let (entry, project_path) = match path_match {
-                Match::History { path, .. } => {
-                    let project = self.project.read(cx);
-                    let project_path = path.project.clone();
-                    let entry = project.entry_for_path(&project_path, cx)?;
-                    Some((entry, project_path))
-                }
-                Match::Search(mat) => {
-                    let project = self.project.read(cx);
-                    let project_path = ProjectPath {
-                        worktree_id: WorktreeId::from_usize(mat.0.worktree_id),
-                        path: mat.0.path.clone(),
-                    };
-                    let entry = project.entry_for_path(&project_path, cx)?;
-                    Some((entry, project_path))
-                }
-            }?;
+        let path_match = self
+            .matches
+            .get(ix)
+            .expect("Invalid matches state: no element for index {ix}");
 
-            let git_status = self
-                .project
-                .read(cx)
-                .project_path_git_status(&project_path, cx)
-                .map(|status| status.summary())
-                .unwrap_or_default();
-            Some(entry_git_aware_label_color(
-                git_status,
-                entry.is_ignored,
-                selected,
-            ))
-        } else {
-            None
-        };
-
-        let history_icon = match path_match {
+        let history_icon = match &path_match {
             Match::History { .. } => Icon::new(IconName::HistoryRerun)
-                .size(IconSize::Small)
                 .color(Color::Muted)
+                .size(IconSize::Small)
                 .into_any_element(),
             Match::Search(_) => v_flex()
                 .flex_none()
                 .size(IconSize::Small.rems())
                 .into_any_element(),
         };
-
         let (file_name_label, full_path_label) = self.labels_for_match(path_match, window, cx, ix);
-        let file_name_label = match git_status_color {
-            Some(git_status_color) => file_name_label.color(git_status_color),
-            None => file_name_label,
-        };
 
         let file_icon = maybe!({
             if !settings.file_icons {
@@ -1477,7 +1442,7 @@ impl PickerDelegate for FileFinderDelegate {
             }
             let file_name = path_match.path().file_name()?;
             let icon = FileIcons::get_icon(file_name.as_ref(), cx)?;
-            Some(Icon::from_path(icon).color(git_status_color.unwrap_or(Color::Muted)))
+            Some(Icon::from_path(icon).color(Color::Muted))
         });
 
         Some(

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -8,7 +8,6 @@ pub struct FileFinderSettings {
     pub file_icons: bool,
     pub modal_max_width: Option<FileFinderWidth>,
     pub skip_focus_for_active_in_search: bool,
-    pub git_status: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -25,10 +24,6 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: true
     pub skip_focus_for_active_in_search: Option<bool>,
-    /// Determines whether to show the git status in the file finder
-    ///
-    /// Default: true
-    pub git_status: Option<bool>,
 }
 
 impl Settings for FileFinderSettings {
@@ -40,9 +35,7 @@ impl Settings for FileFinderSettings {
         sources.json_merge()
     }
 
-    fn import_from_vscode(vscode: &settings::VsCodeSettings, current: &mut Self::FileContent) {
-        vscode.bool_setting("git.decorations.enabled", &mut current.git_status);
-    }
+    fn import_from_vscode(_vscode: &settings::VsCodeSettings, _current: &mut Self::FileContent) {}
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy, Default, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Reverts zed-industries/zed#31469

This isn't looking great, so reverting for now.

/cc @SomeoneToIgnore 