### PR TITLE
task: Wrap programs in ""s

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -382,10 +382,7 @@ impl ContextProvider for PythonContextProvider {
                 toolchains
                     .active_toolchain(worktree_id, Arc::from("".as_ref()), "Python".into(), cx)
                     .await
-                    .map_or_else(
-                        || "python3".to_owned(),
-                        |toolchain| format!("\"{}\"", toolchain.path),
-                    )
+                    .map_or_else(|| "python3".to_owned(), |toolchain| toolchain.path)
             } else {
                 String::from("python3")
             };

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -382,7 +382,7 @@ impl ContextProvider for PythonContextProvider {
                 toolchains
                     .active_toolchain(worktree_id, Arc::from("".as_ref()), "Python".into(), cx)
                     .await
-                    .map_or_else(|| "python3".to_owned(), |toolchain| toolchain.path)
+                    .map_or_else(|| "python3".to_owned(), |toolchain| toolchain.path.into())
             } else {
                 String::from("python3")
             };

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -384,6 +384,7 @@ impl ShellBuilder {
 
     /// Returns the program and arguments to run this task in a shell.
     pub fn build(mut self, task_command: String, task_args: &Vec<String>) -> (String, Vec<String>) {
+        let task_command = format!("\"{task_command}\"");
         let combined_command = task_args
             .into_iter()
             .fold(task_command, |mut command, arg| {


### PR DESCRIPTION
This commit effectively re-implements #21981 in task system. commands with spaces cannot be spawned currently, and we don't want to have to deal with shell variables wrapped in "" in DAP locators.

Closes #ISSUE

Release Notes:

- Fixed an issue where tasks with spaces in `command` field could not be spawned.
