### PR TITLE
Clean up some auto updater code

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -511,12 +511,12 @@ impl AutoUpdater {
             Self::get_latest_release(&this, "zed", OS, ARCH, release_channel, &mut cx).await?;
         let fetched_version = fetched_release_data.clone().version;
         let app_commit_sha = cx.update(|cx| AppCommitSha::try_global(cx).map(|sha| sha.full()));
-        let newer_version = Self::check_for_newer_version(
+        let newer_version = Self::check_if_fetched_version_is_newer(
             *RELEASE_CHANNEL,
             app_commit_sha,
             installed_version,
-            previous_status.clone(),
             fetched_version,
+            previous_status.clone(),
         )?;
 
         let Some(newer_version) = newer_version else {
@@ -557,12 +557,12 @@ impl AutoUpdater {
         })
     }
 
-    fn check_for_newer_version(
+    fn check_if_fetched_version_is_newer(
         release_channel: ReleaseChannel,
         app_commit_sha: Result<Option<String>>,
         installed_version: SemanticVersion,
-        status: AutoUpdateStatus,
         fetched_version: String,
+        status: AutoUpdateStatus,
     ) -> Result<Option<VersionCheckType>> {
         let parsed_fetched_version = fetched_version.parse::<SemanticVersion>();
 
@@ -575,7 +575,7 @@ impl AutoUpdater {
                     return Ok(newer_version);
                 }
                 VersionCheckType::Semantic(cached_version) => {
-                    return Self::check_for_newer_version_non_nightly(
+                    return Self::check_if_fetched_version_is_newer_non_nightly(
                         cached_version,
                         parsed_fetched_version?,
                     );
@@ -594,7 +594,7 @@ impl AutoUpdater {
                     .then(|| VersionCheckType::Sha(AppCommitSha::new(fetched_version)));
                 Ok(newer_version)
             }
-            _ => Self::check_for_newer_version_non_nightly(
+            _ => Self::check_if_fetched_version_is_newer_non_nightly(
                 installed_version,
                 parsed_fetched_version?,
             ),
@@ -631,7 +631,7 @@ impl AutoUpdater {
         }
     }
 
-    fn check_for_newer_version_non_nightly(
+    fn check_if_fetched_version_is_newer_non_nightly(
         installed_version: SemanticVersion,
         fetched_version: SemanticVersion,
     ) -> Result<Option<VersionCheckType>> {
@@ -925,12 +925,12 @@ mod tests {
         let status = AutoUpdateStatus::Idle;
         let fetched_version = SemanticVersion::new(1, 0, 0);
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_version.to_string(),
+            status,
         );
 
         assert_eq!(newer_version.unwrap(), None);
@@ -944,12 +944,12 @@ mod tests {
         let status = AutoUpdateStatus::Idle;
         let fetched_version = SemanticVersion::new(1, 0, 1);
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_version.to_string(),
+            status,
         );
 
         assert_eq!(
@@ -969,12 +969,12 @@ mod tests {
         };
         let fetched_version = SemanticVersion::new(1, 0, 1);
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_version.to_string(),
+            status,
         );
 
         assert_eq!(newer_version.unwrap(), None);
@@ -991,12 +991,12 @@ mod tests {
         };
         let fetched_version = SemanticVersion::new(1, 0, 2);
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_version.to_string(),
+            status,
         );
 
         assert_eq!(
@@ -1013,12 +1013,12 @@ mod tests {
         let status = AutoUpdateStatus::Idle;
         let fetched_sha = "a".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha,
+            status,
         );
 
         assert_eq!(newer_version.unwrap(), None);
@@ -1032,12 +1032,12 @@ mod tests {
         let status = AutoUpdateStatus::Idle;
         let fetched_sha = "b".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha.clone(),
+            status,
         );
 
         assert_eq!(
@@ -1057,12 +1057,12 @@ mod tests {
         };
         let fetched_sha = "b".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha,
+            status,
         );
 
         assert_eq!(newer_version.unwrap(), None);
@@ -1079,12 +1079,12 @@ mod tests {
         };
         let fetched_sha = "c".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha.clone(),
+            status,
         );
 
         assert_eq!(
@@ -1101,12 +1101,12 @@ mod tests {
         let status = AutoUpdateStatus::Idle;
         let fetched_sha = "a".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha.clone(),
+            status,
         );
 
         assert_eq!(
@@ -1127,12 +1127,12 @@ mod tests {
         };
         let fetched_sha = "b".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha,
+            status,
         );
 
         assert_eq!(newer_version.unwrap(), None);
@@ -1150,12 +1150,12 @@ mod tests {
         };
         let fetched_sha = "c".to_string();
 
-        let newer_version = AutoUpdater::check_for_newer_version(
+        let newer_version = AutoUpdater::check_if_fetched_version_is_newer(
             release_channel,
             app_commit_sha,
             installed_version,
-            status,
             fetched_sha.clone(),
+            status,
         );
 
         assert_eq!(


### PR DESCRIPTION
This PR simply does a tiny bit of cleanup on some code, where I wasn't quite happy with the naming and ordering of parameters of the now `check_if_fetched_version_is_newer` function. There should be no functional changes here, but I will wait until after tomorrow's release to merge.

Release Notes:

- N/A
