### PR TITLE
Add caching of parsed completion documentation markdown to reduce flicker when selecting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9565,6 +9565,7 @@ dependencies = [
  "assets",
  "base64 0.22.1",
  "env_logger 0.11.8",
+ "futures 0.3.31",
  "gpui",
  "language",
  "languages",

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -4,8 +4,8 @@ use gpui::{
     Size, StrikethroughStyle, StyledText, UniformListScrollHandle, div, px, uniform_list,
 };
 use gpui::{AsyncWindowContext, WeakEntity};
-use language::Buffer;
 use language::CodeLabel;
+use language::{Buffer, LanguageName, LanguageRegistry};
 use markdown::{Markdown, MarkdownElement};
 use multi_buffer::{Anchor, ExcerptId};
 use ordered_float::OrderedFloat;
@@ -15,6 +15,8 @@ use project::{CodeAction, Completion, TaskSourceKind};
 use task::DebugScenario;
 use task::TaskContext;
 
+use std::collections::VecDeque;
+use std::sync::Arc;
 use std::{
     cell::RefCell,
     cmp::{Reverse, min},
@@ -40,6 +42,24 @@ pub const MENU_GAP: Pixels = px(4.);
 pub const MENU_ASIDE_X_PADDING: Pixels = px(16.);
 pub const MENU_ASIDE_MIN_WIDTH: Pixels = px(260.);
 pub const MENU_ASIDE_MAX_WIDTH: Pixels = px(500.);
+
+// Constants for the markdown cache. The purpose of this cache is to reduce flickering due to
+// documentation not yet being parsed.
+//
+// The size of the cache is set to the number of items fetched around the current selection. The
+// only current benefit of a larger cache would be doing less markdown parsing when the selection
+// revisits items.
+//
+// One future benefit of a larger cache would be reducing flicker on backspace. This would require
+// not recreating the menu on every change, by not re-querying the language server when
+// `is_incomplete = false`.
+const MARKDOWN_CACHE_MAX_SIZE: usize = MARKDOWN_CACHE_BEFORE_ITEMS + MARKDOWN_CACHE_AFTER_ITEMS + 1;
+const MARKDOWN_CACHE_BEFORE_ITEMS: usize = 2;
+const MARKDOWN_CACHE_AFTER_ITEMS: usize = 2;
+
+// Number of items beyond the visible items to resolve documentation.
+const RESOLVE_BEFORE_ITEMS: usize = 4;
+const RESOLVE_AFTER_ITEMS: usize = 4;
 
 pub enum CodeContextMenu {
     Completions(CompletionsMenu),
@@ -148,13 +168,12 @@ impl CodeContextMenu {
 
     pub fn render_aside(
         &mut self,
-        editor: &Editor,
         max_size: Size<Pixels>,
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) -> Option<AnyElement> {
         match self {
-            CodeContextMenu::Completions(menu) => menu.render_aside(editor, max_size, window, cx),
+            CodeContextMenu::Completions(menu) => menu.render_aside(max_size, window, cx),
             CodeContextMenu::CodeActions(_) => None,
         }
     }
@@ -162,7 +181,7 @@ impl CodeContextMenu {
     pub fn focused(&self, window: &mut Window, cx: &mut Context<Editor>) -> bool {
         match self {
             CodeContextMenu::Completions(completions_menu) => completions_menu
-                .markdown_element
+                .get_or_create_entry_markdown(completions_menu.selected_item, cx)
                 .as_ref()
                 .is_some_and(|markdown| markdown.focus_handle(cx).contains_focused(window, cx)),
             CodeContextMenu::CodeActions(_) => false,
@@ -176,7 +195,7 @@ pub enum ContextMenuOrigin {
     QuickActionBar,
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone)]
 pub struct CompletionsMenu {
     pub id: CompletionId,
     sort_completions: bool,
@@ -191,7 +210,9 @@ pub struct CompletionsMenu {
     show_completion_documentation: bool,
     pub(super) ignore_completion_provider: bool,
     last_rendered_range: Rc<RefCell<Option<Range<usize>>>>,
-    markdown_element: Option<Entity<Markdown>>,
+    markdown_cache: Rc<RefCell<VecDeque<(usize, Entity<Markdown>)>>>,
+    language_registry: Option<Arc<LanguageRegistry>>,
+    language: Option<LanguageName>,
     snippet_sort_order: SnippetSortOrder,
 }
 
@@ -205,6 +226,9 @@ impl CompletionsMenu {
         buffer: Entity<Buffer>,
         completions: Box<[Completion]>,
         snippet_sort_order: SnippetSortOrder,
+        language_registry: Option<Arc<LanguageRegistry>>,
+        language: Option<LanguageName>,
+        cx: &mut Context<Editor>,
     ) -> Self {
         let match_candidates = completions
             .iter()
@@ -212,7 +236,7 @@ impl CompletionsMenu {
             .map(|(id, completion)| StringMatchCandidate::new(id, &completion.label.filter_text()))
             .collect();
 
-        Self {
+        let completions_menu = Self {
             id,
             sort_completions,
             initial_position,
@@ -226,9 +250,15 @@ impl CompletionsMenu {
             scroll_handle: UniformListScrollHandle::new(),
             resolve_completions: true,
             last_rendered_range: RefCell::new(None).into(),
-            markdown_element: None,
+            markdown_cache: RefCell::new(VecDeque::with_capacity(MARKDOWN_CACHE_MAX_SIZE)).into(),
+            language_registry,
+            language,
             snippet_sort_order,
-        }
+        };
+
+        completions_menu.start_markdown_parse_for_nearby_entries(cx);
+
+        completions_menu
     }
 
     pub fn new_snippet_choices(
@@ -286,7 +316,9 @@ impl CompletionsMenu {
             show_completion_documentation: false,
             ignore_completion_provider: false,
             last_rendered_range: RefCell::new(None).into(),
-            markdown_element: None,
+            markdown_cache: RefCell::new(VecDeque::new()).into(),
+            language_registry: None,
+            language: None,
             snippet_sort_order,
         }
     }
@@ -359,6 +391,7 @@ impl CompletionsMenu {
             self.scroll_handle
                 .scroll_to_item(self.selected_item, ScrollStrategy::Top);
             self.resolve_visible_completions(provider, cx);
+            self.start_markdown_parse_for_nearby_entries(cx);
             if let Some(provider) = provider {
                 self.handle_selection_changed(provider, window, cx);
             }
@@ -433,11 +466,10 @@ impl CompletionsMenu {
 
         // Expand the range to resolve more completions than are predicted to be visible, to reduce
         // jank on navigation.
-        const EXTRA_TO_RESOLVE: usize = 4;
         let entry_indices = util::iterate_expanded_and_wrapped_usize_range(
             entry_range.clone(),
-            EXTRA_TO_RESOLVE,
-            EXTRA_TO_RESOLVE,
+            RESOLVE_BEFORE_ITEMS,
+            RESOLVE_AFTER_ITEMS,
             entries.len(),
         );
 
@@ -467,12 +499,103 @@ impl CompletionsMenu {
             cx,
         );
 
+        let completion_id = self.id;
         cx.spawn(async move |editor, cx| {
             if let Some(true) = resolve_task.await.log_err() {
-                editor.update(cx, |_, cx| cx.notify()).ok();
+                editor
+                    .update(cx, |editor, cx| {
+                        // `resolve_completions` modified state affecting display.
+                        cx.notify();
+                        editor.with_completions_menu_matching_id(
+                            completion_id,
+                            || (),
+                            |this| this.start_markdown_parse_for_nearby_entries(cx),
+                        );
+                    })
+                    .ok();
             }
         })
         .detach();
+    }
+
+    fn start_markdown_parse_for_nearby_entries(&self, cx: &mut Context<Editor>) {
+        let entry_indices = util::iterate_expanded_and_wrapped_usize_range(
+            self.selected_item..self.selected_item + 1,
+            MARKDOWN_CACHE_BEFORE_ITEMS,
+            MARKDOWN_CACHE_AFTER_ITEMS,
+            self.entries.borrow().len(),
+        );
+
+        // Enqueue parse of current item first.
+        self.get_or_create_entry_markdown(self.selected_item, cx);
+
+        for index in entry_indices {
+            if index != self.selected_item {
+                self.get_or_create_entry_markdown(index, cx);
+            }
+        }
+    }
+
+    fn get_or_create_entry_markdown(
+        &self,
+        index: usize,
+        cx: &mut Context<Editor>,
+    ) -> Option<Entity<Markdown>> {
+        let entries = self.entries.borrow();
+        if index >= entries.len() {
+            return None;
+        }
+        let candidate_id = entries[index].candidate_id;
+        match &self.completions.borrow()[candidate_id].documentation {
+            Some(CompletionDocumentation::MultiLineMarkdown(source)) if !source.is_empty() => Some(
+                self.get_or_create_markdown(candidate_id, source.clone(), cx)
+                    .1,
+            ),
+            Some(_) => None,
+            _ => None,
+        }
+    }
+
+    fn get_or_create_markdown(
+        &self,
+        candidate_id: usize,
+        source: SharedString,
+        cx: &mut Context<Editor>,
+    ) -> (bool, Entity<Markdown>) {
+        let mut markdown_cache = self.markdown_cache.borrow_mut();
+        if let Some((_, markdown)) = markdown_cache.iter().find(|(id, _)| *id == candidate_id) {
+            let is_parsing = markdown.update(cx, |markdown, cx| {
+                // `reset` is called as it's possible for documentation to change due to resolve
+                // requests. It does nothing if `source` is unchanged.
+                markdown.reset(source, cx);
+                markdown.is_parsing()
+            });
+            return (is_parsing, markdown.clone());
+        }
+
+        if markdown_cache.len() < MARKDOWN_CACHE_MAX_SIZE {
+            let markdown = cx.new(|cx| {
+                Markdown::new(
+                    source,
+                    self.language_registry.clone(),
+                    self.language.clone(),
+                    cx,
+                )
+            });
+            // Handles redraw when the markdown is done parsing. The current render is for a
+            // deferred draw, and so without this did not redraw when `markdown` notified.
+            cx.observe(&markdown, |_, _, cx| cx.notify()).detach();
+            markdown_cache.push_front((candidate_id, markdown.clone()));
+            (true, markdown)
+        } else {
+            debug_assert_eq!(markdown_cache.capacity(), MARKDOWN_CACHE_MAX_SIZE);
+            // The ring buffer is full, so this does no copying and just shifts indexes.
+            markdown_cache.rotate_right(1);
+            markdown_cache[0].0 = candidate_id;
+            let markdown = &markdown_cache[0].1;
+            markdown.update(cx, |markdown, cx| markdown.reset(source, cx));
+            (true, markdown.clone())
+        }
     }
 
     pub fn visible(&self) -> bool {
@@ -625,7 +748,6 @@ impl CompletionsMenu {
 
     fn render_aside(
         &mut self,
-        editor: &Editor,
         max_size: Size<Pixels>,
         window: &mut Window,
         cx: &mut Context<Editor>,
@@ -644,33 +766,14 @@ impl CompletionsMenu {
                 plain_text: Some(text),
                 ..
             } => div().child(text.clone()),
-            CompletionDocumentation::MultiLineMarkdown(parsed) if !parsed.is_empty() => {
-                let markdown = self.markdown_element.get_or_insert_with(|| {
-                    let markdown = cx.new(|cx| {
-                        let languages = editor
-                            .workspace
-                            .as_ref()
-                            .and_then(|(workspace, _)| workspace.upgrade())
-                            .map(|workspace| workspace.read(cx).app_state().languages.clone());
-                        let language = editor
-                            .language_at(self.initial_position, cx)
-                            .map(|l| l.name().to_proto());
-                        Markdown::new(SharedString::default(), languages, language, cx)
-                    });
-                    // Handles redraw when the markdown is done parsing. The current render is for a
-                    // deferred draw and so was not getting redrawn when `markdown` notified.
-                    cx.observe(&markdown, |_, _, cx| cx.notify()).detach();
-                    markdown
-                });
-                let is_parsing = markdown.update(cx, |markdown, cx| {
-                    markdown.reset(parsed.clone(), cx);
-                    markdown.is_parsing()
-                });
+            CompletionDocumentation::MultiLineMarkdown(source) if !source.is_empty() => {
+                let (is_parsing, markdown) =
+                    self.get_or_create_markdown(mat.candidate_id, source.clone(), cx);
                 if is_parsing {
                     return None;
                 }
                 div().child(
-                    MarkdownElement::new(markdown.clone(), hover_markdown_style(window, cx))
+                    MarkdownElement::new(markdown, hover_markdown_style(window, cx))
                         .code_block_renderer(markdown::CodeBlockRenderer::Default {
                             copy_button: false,
                             copy_button_on_hover: false,
@@ -882,13 +985,7 @@ impl CompletionsMenu {
                 // another opened. `provider.selection_changed` should not be called in this case.
                 let this_menu_still_active = editor
                     .read_with(cx, |editor, _cx| {
-                        if let Some(CodeContextMenu::Completions(completions_menu)) =
-                            editor.context_menu.borrow().as_ref()
-                        {
-                            completions_menu.id == self.id
-                        } else {
-                            false
-                        }
+                        editor.with_completions_menu_matching_id(self.id, || false, |_| true)
                     })
                     .unwrap_or(false);
                 if this_menu_still_active {

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -583,13 +583,6 @@ async fn parse_blocks(
     language: Option<Arc<Language>>,
     cx: &mut AsyncWindowContext,
 ) -> Option<Entity<Markdown>> {
-    let fallback_language_name = if let Some(ref l) = language {
-        let l = Arc::clone(l);
-        Some(l.lsp_id().clone())
-    } else {
-        None
-    };
-
     let combined_text = blocks
         .iter()
         .map(|block| match &block.kind {
@@ -607,7 +600,7 @@ async fn parse_blocks(
             Markdown::new(
                 combined_text.into(),
                 Some(language_registry.clone()),
-                fallback_language_name,
+                language.map(|language| language.name()),
                 cx,
             )
         })

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -20,6 +20,7 @@ test-support = [
 
 [dependencies]
 base64.workspace = true
+futures.workspace = true
 gpui.workspace = true
 language.workspace = true
 linkify.workspace = true

--- a/crates/markdown/examples/markdown.rs
+++ b/crates/markdown/examples/markdown.rs
@@ -67,14 +67,8 @@ struct MarkdownExample {
 
 impl MarkdownExample {
     pub fn new(text: SharedString, language_registry: Arc<LanguageRegistry>, cx: &mut App) -> Self {
-        let markdown = cx.new(|cx| {
-            Markdown::new(
-                text,
-                Some(language_registry),
-                Some("TypeScript".to_string()),
-                cx,
-            )
-        });
+        let markdown = cx
+            .new(|cx| Markdown::new(text, Some(language_registry), Some("TypeScript".into()), cx));
         Self { markdown }
     }
 }

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -2,6 +2,8 @@ pub mod parser;
 mod path_range;
 
 use base64::Engine as _;
+use futures::FutureExt as _;
+use language::LanguageName;
 use log::Level;
 pub use path_range::{LineCol, PathWithRange};
 
@@ -101,7 +103,7 @@ pub struct Markdown {
     pending_parse: Option<Task<()>>,
     focus_handle: FocusHandle,
     language_registry: Option<Arc<LanguageRegistry>>,
-    fallback_code_block_language: Option<String>,
+    fallback_code_block_language: Option<LanguageName>,
     options: Options,
     copied_code_blocks: HashSet<ElementId>,
 }
@@ -144,7 +146,7 @@ impl Markdown {
     pub fn new(
         source: SharedString,
         language_registry: Option<Arc<LanguageRegistry>>,
-        fallback_code_block_language: Option<String>,
+        fallback_code_block_language: Option<LanguageName>,
         cx: &mut Context<Self>,
     ) -> Self {
         let focus_handle = cx.focus_handle();
@@ -310,9 +312,9 @@ impl Markdown {
             if let Some(registry) = language_registry.as_ref() {
                 for name in language_names {
                     let language = if !name.is_empty() {
-                        registry.language_for_name_or_extension(&name)
+                        registry.language_for_name_or_extension(&name).left_future()
                     } else if let Some(fallback) = &fallback {
-                        registry.language_for_name_or_extension(fallback)
+                        registry.language_for_name(fallback.as_ref()).right_future()
                     } else {
                         continue;
                     };


### PR DESCRIPTION
Related to #31460 and #28635.

Release Notes:

- Fixed redraw delay of documentation from language server completions and added caching to reduce flicker when using arrow keys to change selection.