### PR TITLE
Improve LSP tasks ergonomics

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1315,7 +1315,13 @@
   "tasks": {
     "variables": {},
     "enabled": true,
-    // Use LSP tasks over Zed ones, if non-empty LSP task set is returned.
+    // Use LSP tasks over Zed language extension ones.
+    // If no LSP tasks are returned due to error/timeout or regular execution,
+    // Zed language extension tasks will be used instead.
+    //
+    // Other Zed tasks will still be shown:
+    // * Zed task from either of the task config file
+    // * Zed task from history (e.g. one-off task was spawned before)
     //
     // May take values:
     // 1. "nowhere"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1323,18 +1323,8 @@
     // * Zed task from either of the task config file
     // * Zed task from history (e.g. one-off task was spawned before)
     //
-    // May take values:
-    // 1. "nowhere"
-    //   LSP tasks are mixed with Zed tasks.
-    // 2. "modal"
-    //   Only LSP tasks are shown, if found when opening the tasks modal.
-    // 3. "fallback"
-    //   Only LSP tasks are shown in gutter icon lists, if found when refreshing.
-    // 4. "everywhere"
-    //   Both modal and gutter show only LSP tasks, if non-zero amount of them is found.
-    //
-    // Default: everywhere
-    "prefer_lsp": "everywhere"
+    // Default: true
+    "prefer_lsp": true
   },
   // An object whose keys are language names, and whose values
   // are arrays of filenames or extensions of files that should

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1314,7 +1314,21 @@
   // Settings related to running tasks.
   "tasks": {
     "variables": {},
-    "enabled": true
+    "enabled": true,
+    // Use LSP tasks over Zed ones, if non-empty LSP task set is returned.
+    //
+    // May take values:
+    // 1. "nowhere"
+    //   LSP tasks are mixed with Zed tasks.
+    // 2. "modal"
+    //   Only LSP tasks are shown, if found when opening the tasks modal.
+    // 3. "fallback"
+    //   Only LSP tasks are shown in gutter icon lists, if found when refreshing.
+    // 4. "everywhere"
+    //   Both modal and gutter show only LSP tasks, if non-zero amount of them is found.
+    //
+    // Default: everywhere
+    "prefer_lsp": "everywhere"
   },
   // An object whose keys are language names, and whose values
   // are arrays of filenames or extensions of files that should

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -97,6 +97,7 @@ gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 languages = {workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features = ["test-support"] }
+markdown = { workspace = true, features = ["test-support"] }
 multi_buffer = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 release_channel.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1672,7 +1672,10 @@ impl Editor {
                         }
                         project::Event::LanguageServerAdded(..)
                         | project::Event::LanguageServerRemoved(..) => {
-                            editor.tasks_update_task = Some(editor.refresh_runnables(window, cx));
+                            if editor.tasks_update_task.is_none() {
+                                editor.tasks_update_task =
+                                    Some(editor.refresh_runnables(window, cx));
+                            }
                         }
                         project::Event::SnippetEdit(id, snippet_edits) => {
                             if let Some(buffer) = editor.buffer.read(cx).buffer(*id) {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -112,7 +112,7 @@ use language::{
     EditPreview, HighlightedText, IndentKind, IndentSize, Language, OffsetRangeExt, Point,
     Selection, SelectionGoal, TextObject, TransactionId, TreeSitterOptions, WordsQuery,
     language_settings::{
-        self, InlayHintSettings, LspInsertMode, PreferLspMode, RewrapBehavior, WordsCompletionMode,
+        self, InlayHintSettings, LspInsertMode, RewrapBehavior, WordsCompletionMode,
         all_language_settings, language_settings,
     },
     point_from_lsp, text_diff_with_options,
@@ -13608,10 +13608,7 @@ impl Editor {
             };
 
             let Ok(prefer_lsp) = multi_buffer.update(cx, |buffer, cx| {
-                matches!(
-                    buffer.language_settings(cx).tasks.prefer_lsp,
-                    PreferLspMode::Gutter | PreferLspMode::Everywhere
-                )
+                buffer.language_settings(cx).tasks.prefer_lsp
             }) else {
                 return;
             };

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -9111,11 +9111,10 @@ async fn test_range_format_during_save(cx: &mut TestAppContext) {
                 lsp::Url::from_file_path(path!("/file.rs")).unwrap()
             );
             assert_eq!(params.options.tab_size, 8);
-            Ok(Some(vec![]))
+            Ok(Some(Vec::new()))
         })
         .next()
         .await;
-    cx.executor().start_waiting();
     save.await;
 }
 

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -1057,7 +1057,9 @@ mod tests {
 
                 for (range, event) in slice.iter() {
                     match event {
-                        MarkdownEvent::SubstitutedText(parsed) => rendered_text.push_str(parsed),
+                        MarkdownEvent::SubstitutedText(parsed) => {
+                            rendered_text.push_str(parsed.as_str())
+                        }
                         MarkdownEvent::Text | MarkdownEvent::Code => {
                             rendered_text.push_str(&text[range.clone()])
                         }

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -17,7 +17,7 @@ use project::LocationLink;
 use project::Project;
 use project::TaskSourceKind;
 use project::lsp_store::lsp_ext_command::GetLspRunnables;
-use smol::future::FutureExt;
+use smol::future::FutureExt as _;
 use smol::stream::StreamExt;
 use task::ResolvedTask;
 use task::TaskContext;
@@ -179,6 +179,7 @@ pub fn lsp_tasks(
             let timer = cx.background_executor().timer(Duration::from_millis(200));
             async move {
                 timer.await;
+                log::info!("Timed out waiting for LSP tasks");
                 Vec::new()
             }
         })

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -1,4 +1,5 @@
 use std::sync::Arc;
+use std::time::Duration;
 
 use crate::Editor;
 use collections::HashMap;
@@ -16,6 +17,7 @@ use project::LocationLink;
 use project::Project;
 use project::TaskSourceKind;
 use project::lsp_store::lsp_ext_command::GetLspRunnables;
+use smol::future::FutureExt;
 use smol::stream::StreamExt;
 use task::ResolvedTask;
 use task::TaskContext;
@@ -130,44 +132,57 @@ pub fn lsp_tasks(
         .collect::<FuturesUnordered<_>>();
 
     cx.spawn(async move |cx| {
-        let mut lsp_tasks = Vec::new();
-        while let Some(server_to_query) = lsp_task_sources.next().await {
-            if let Some((server_id, buffers)) = server_to_query {
-                let source_kind = TaskSourceKind::Lsp(server_id);
-                let id_base = source_kind.to_id_base();
-                let mut new_lsp_tasks = Vec::new();
-                for buffer in buffers {
-                    let lsp_buffer_context = lsp_task_context(&project, &buffer, cx)
-                        .await
-                        .unwrap_or_default();
+        cx.spawn(async move |cx| {
+            let mut lsp_tasks = Vec::new();
+            while let Some(server_to_query) = lsp_task_sources.next().await {
+                if let Some((server_id, buffers)) = server_to_query {
+                    let source_kind = TaskSourceKind::Lsp(server_id);
+                    let id_base = source_kind.to_id_base();
+                    let mut new_lsp_tasks = Vec::new();
+                    for buffer in buffers {
+                        let lsp_buffer_context = lsp_task_context(&project, &buffer, cx)
+                            .await
+                            .unwrap_or_default();
 
-                    if let Ok(runnables_task) = project.update(cx, |project, cx| {
-                        let buffer_id = buffer.read(cx).remote_id();
-                        project.request_lsp(
-                            buffer,
-                            LanguageServerToQuery::Other(server_id),
-                            GetLspRunnables {
-                                buffer_id,
-                                position: for_position,
-                            },
-                            cx,
-                        )
-                    }) {
-                        if let Some(new_runnables) = runnables_task.await.log_err() {
-                            new_lsp_tasks.extend(new_runnables.runnables.into_iter().filter_map(
-                                |(location, runnable)| {
-                                    let resolved_task =
-                                        runnable.resolve_task(&id_base, &lsp_buffer_context)?;
-                                    Some((location, resolved_task))
+                        if let Ok(runnables_task) = project.update(cx, |project, cx| {
+                            let buffer_id = buffer.read(cx).remote_id();
+                            project.request_lsp(
+                                buffer,
+                                LanguageServerToQuery::Other(server_id),
+                                GetLspRunnables {
+                                    buffer_id,
+                                    position: for_position,
                                 },
-                            ));
+                                cx,
+                            )
+                        }) {
+                            if let Some(new_runnables) = runnables_task.await.log_err() {
+                                new_lsp_tasks.extend(
+                                    new_runnables.runnables.into_iter().filter_map(
+                                        |(location, runnable)| {
+                                            let resolved_task = runnable
+                                                .resolve_task(&id_base, &lsp_buffer_context)?;
+                                            Some((location, resolved_task))
+                                        },
+                                    ),
+                                );
+                            }
                         }
                     }
+                    lsp_tasks.push((source_kind, new_lsp_tasks));
                 }
-                lsp_tasks.push((source_kind, new_lsp_tasks));
             }
-        }
-        lsp_tasks
+            lsp_tasks
+        })
+        .race({
+            // `lsp::LSP_REQUEST_TIMEOUT` is larger than we want for the modal to open fast
+            let timer = cx.background_executor().timer(Duration::from_millis(200));
+            async move {
+                timer.await;
+                Vec::new()
+            }
+        })
+        .await
     })
 }
 

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1045,7 +1045,13 @@ pub struct LanguageTaskConfig {
     pub variables: HashMap<String, String>,
     #[serde(default = "default_true")]
     pub enabled: bool,
-    /// Use LSP tasks over Zed ones, if non-empty LSP task set is returned.
+    /// Use LSP tasks over Zed language extension ones.
+    /// If no LSP tasks are returned due to error/timeout or regular execution,
+    /// Zed language extension tasks will be used instead.
+    ///
+    /// Other Zed tasks will still be shown:
+    /// * Zed task from either of the task config file
+    /// * Zed task from history (e.g. one-off task was spawned before)
     #[serde(default = "default_prefer_lsp_mode")]
     pub prefer_lsp: PreferLspMode,
 }

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1045,6 +1045,28 @@ pub struct LanguageTaskConfig {
     pub variables: HashMap<String, String>,
     #[serde(default = "default_true")]
     pub enabled: bool,
+    /// Use LSP tasks over Zed ones, if non-empty LSP task set is returned.
+    #[serde(default = "default_prefer_lsp_mode")]
+    pub prefer_lsp: PreferLspMode,
+}
+
+/// Cases where LSP tasks are preferred over Zed tasks.
+#[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq, Serialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PreferLspMode {
+    /// LSP tasks are mixed with Zed tasks.
+    Nowhere,
+    /// Only LSP tasks are shown, if found when opening the tasks modal.
+    Modal,
+    /// Only LSP tasks are shown in gutter icon lists, if found when refreshing.
+    Gutter,
+    /// Both modal and gutter show only LSP tasks, if non-zero amount of them is found.
+    #[default]
+    Everywhere,
+}
+
+fn default_prefer_lsp_mode() -> PreferLspMode {
+    PreferLspMode::default()
 }
 
 impl InlayHintSettings {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1052,27 +1052,8 @@ pub struct LanguageTaskConfig {
     /// Other Zed tasks will still be shown:
     /// * Zed task from either of the task config file
     /// * Zed task from history (e.g. one-off task was spawned before)
-    #[serde(default = "default_prefer_lsp_mode")]
-    pub prefer_lsp: PreferLspMode,
-}
-
-/// Cases where LSP tasks are preferred over Zed tasks.
-#[derive(Debug, Default, Clone, Deserialize, PartialEq, Eq, Serialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub enum PreferLspMode {
-    /// LSP tasks are mixed with Zed tasks.
-    Nowhere,
-    /// Only LSP tasks are shown, if found when opening the tasks modal.
-    Modal,
-    /// Only LSP tasks are shown in gutter icon lists, if found when refreshing.
-    Gutter,
-    /// Both modal and gutter show only LSP tasks, if non-zero amount of them is found.
-    #[default]
-    Everywhere,
-}
-
-fn default_prefer_lsp_mode() -> PreferLspMode {
-    PreferLspMode::default()
+    #[serde(default = "default_true")]
+    pub prefer_lsp: bool,
 }
 
 impl InlayHintSettings {

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -223,7 +223,7 @@ impl Markdown {
         self.parse(cx);
     }
 
-    #[cfg(feature = "test-support")]
+    #[cfg(any(test, feature = "test-support"))]
     pub fn parsed_markdown(&self) -> &ParsedMarkdown {
         &self.parsed_markdown
     }

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -9,7 +9,6 @@ use gpui::{
     WeakEntity, Window, rems,
 };
 use itertools::Itertools;
-use language::language_settings::PreferLspMode;
 use picker::{Picker, PickerDelegate, highlighted_match_with_paths::HighlightedMatch};
 use project::{TaskSourceKind, task_store::TaskStore};
 use task::{DebugScenario, ResolvedTask, RevealTarget, TaskContext, TaskTemplate};
@@ -244,12 +243,13 @@ impl PickerDelegate for TasksModalDelegate {
                                 .active_item(cx)
                                 .and_then(|item| item.downcast::<Editor>())
                                 .map(|editor| {
-                                    let language_settings =
-                                        editor.read(cx).buffer().read(cx).language_settings(cx);
-                                    matches!(
-                                        language_settings.tasks.prefer_lsp,
-                                        PreferLspMode::Modal | PreferLspMode::Everywhere
-                                    )
+                                    editor
+                                        .read(cx)
+                                        .buffer()
+                                        .read(cx)
+                                        .language_settings(cx)
+                                        .tasks
+                                        .prefer_lsp
                                 })
                                 .unwrap_or(false);
                             (lsp_tasks, prefer_lsp)

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -267,7 +267,8 @@ impl PickerDelegate for TasksModalDelegate {
                                 };
 
                                 let mut new_candidates = used;
-                                let add_current_tasks = !prefer_lsp || lsp_tasks.is_empty();
+                                let add_current_language_tasks =
+                                    !prefer_lsp || lsp_tasks.is_empty();
                                 new_candidates.extend(lsp_tasks.into_iter().flat_map(
                                     |(kind, tasks_with_locations)| {
                                         tasks_with_locations
@@ -278,9 +279,12 @@ impl PickerDelegate for TasksModalDelegate {
                                             .map(move |(_, task)| (kind.clone(), task))
                                     },
                                 ));
-                                if add_current_tasks {
-                                    new_candidates.extend(current);
-                                }
+                                new_candidates.extend(current.into_iter().filter(
+                                    |(task_kind, _)| {
+                                        add_current_language_tasks
+                                            || !matches!(task_kind, TaskSourceKind::Language { .. })
+                                    },
+                                ));
                                 let match_candidates = string_match_candidates(&new_candidates);
                                 let _ = picker.delegate.candidates.insert(new_candidates);
                                 match_candidates


### PR DESCRIPTION
* stopped fetching LSP tasks for too long (but still use the hardcoded value for the time being — the LSP tasks settings part is a simple bool key and it's not very simple to fit in another value there)

* introduced `prefer_lsp` language task settings value, to control whether in the gutter/modal/both/none LSP tasks are shown exclusively, if possible

Release Notes:

- Added a way to prefer LSP tasks over Zed tasks
