### PR TITLE
collab: Downgrade non-collab queries to `READ COMMITTED` isolation level

### DIFF
--- a/crates/collab/src/db/queries/billing_customers.rs
+++ b/crates/collab/src/db/queries/billing_customers.rs
@@ -20,7 +20,7 @@ impl Database {
         &self,
         params: &CreateBillingCustomerParams,
     ) -> Result<billing_customer::Model> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let customer = billing_customer::Entity::insert(billing_customer::ActiveModel {
                 user_id: ActiveValue::set(params.user_id),
                 stripe_customer_id: ActiveValue::set(params.stripe_customer_id.clone()),
@@ -40,7 +40,7 @@ impl Database {
         id: BillingCustomerId,
         params: &UpdateBillingCustomerParams,
     ) -> Result<()> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             billing_customer::Entity::update(billing_customer::ActiveModel {
                 id: ActiveValue::set(id),
                 user_id: params.user_id.clone(),
@@ -61,7 +61,7 @@ impl Database {
         &self,
         id: BillingCustomerId,
     ) -> Result<Option<billing_customer::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_customer::Entity::find()
                 .filter(billing_customer::Column::Id.eq(id))
                 .one(&*tx)
@@ -75,7 +75,7 @@ impl Database {
         &self,
         user_id: UserId,
     ) -> Result<Option<billing_customer::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_customer::Entity::find()
                 .filter(billing_customer::Column::UserId.eq(user_id))
                 .one(&*tx)
@@ -89,7 +89,7 @@ impl Database {
         &self,
         stripe_customer_id: &str,
     ) -> Result<Option<billing_customer::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_customer::Entity::find()
                 .filter(billing_customer::Column::StripeCustomerId.eq(stripe_customer_id))
                 .one(&*tx)

--- a/crates/collab/src/db/queries/billing_preferences.rs
+++ b/crates/collab/src/db/queries/billing_preferences.rs
@@ -22,7 +22,7 @@ impl Database {
         &self,
         user_id: UserId,
     ) -> Result<Option<billing_preference::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_preference::Entity::find()
                 .filter(billing_preference::Column::UserId.eq(user_id))
                 .one(&*tx)
@@ -37,7 +37,7 @@ impl Database {
         user_id: UserId,
         params: &CreateBillingPreferencesParams,
     ) -> Result<billing_preference::Model> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let preferences = billing_preference::Entity::insert(billing_preference::ActiveModel {
                 user_id: ActiveValue::set(user_id),
                 max_monthly_llm_usage_spending_in_cents: ActiveValue::set(
@@ -65,7 +65,7 @@ impl Database {
         user_id: UserId,
         params: &UpdateBillingPreferencesParams,
     ) -> Result<billing_preference::Model> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let preferences = billing_preference::Entity::update_many()
                 .set(billing_preference::ActiveModel {
                     max_monthly_llm_usage_spending_in_cents: params

--- a/crates/collab/src/db/queries/billing_subscriptions.rs
+++ b/crates/collab/src/db/queries/billing_subscriptions.rs
@@ -35,7 +35,7 @@ impl Database {
         &self,
         params: &CreateBillingSubscriptionParams,
     ) -> Result<billing_subscription::Model> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let id = billing_subscription::Entity::insert(billing_subscription::ActiveModel {
                 billing_customer_id: ActiveValue::set(params.billing_customer_id),
                 kind: ActiveValue::set(params.kind),
@@ -64,7 +64,7 @@ impl Database {
         id: BillingSubscriptionId,
         params: &UpdateBillingSubscriptionParams,
     ) -> Result<()> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             billing_subscription::Entity::update(billing_subscription::ActiveModel {
                 id: ActiveValue::set(id),
                 billing_customer_id: params.billing_customer_id.clone(),
@@ -90,7 +90,7 @@ impl Database {
         &self,
         id: BillingSubscriptionId,
     ) -> Result<Option<billing_subscription::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_subscription::Entity::find_by_id(id)
                 .one(&*tx)
                 .await?)
@@ -103,7 +103,7 @@ impl Database {
         &self,
         stripe_subscription_id: &str,
     ) -> Result<Option<billing_subscription::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_subscription::Entity::find()
                 .filter(
                     billing_subscription::Column::StripeSubscriptionId.eq(stripe_subscription_id),
@@ -118,7 +118,7 @@ impl Database {
         &self,
         user_id: UserId,
     ) -> Result<Option<billing_subscription::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(billing_subscription::Entity::find()
                 .inner_join(billing_customer::Entity)
                 .filter(billing_customer::Column::UserId.eq(user_id))
@@ -152,7 +152,7 @@ impl Database {
         &self,
         user_id: UserId,
     ) -> Result<Vec<billing_subscription::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let subscriptions = billing_subscription::Entity::find()
                 .inner_join(billing_customer::Entity)
                 .filter(billing_customer::Column::UserId.eq(user_id))
@@ -169,7 +169,7 @@ impl Database {
         &self,
         user_ids: HashSet<UserId>,
     ) -> Result<HashMap<UserId, (billing_customer::Model, billing_subscription::Model)>> {
-        self.transaction(|tx| {
+        self.weak_transaction(|tx| {
             let user_ids = user_ids.clone();
             async move {
                 let mut rows = billing_subscription::Entity::find()
@@ -201,7 +201,7 @@ impl Database {
         &self,
         user_ids: HashSet<UserId>,
     ) -> Result<HashMap<UserId, (billing_customer::Model, billing_subscription::Model)>> {
-        self.transaction(|tx| {
+        self.weak_transaction(|tx| {
             let user_ids = user_ids.clone();
             async move {
                 let mut rows = billing_subscription::Entity::find()
@@ -236,7 +236,7 @@ impl Database {
 
     /// Returns the count of the active billing subscriptions for the user with the specified ID.
     pub async fn count_active_billing_subscriptions(&self, user_id: UserId) -> Result<usize> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let count = billing_subscription::Entity::find()
                 .inner_join(billing_customer::Entity)
                 .filter(

--- a/crates/collab/src/db/queries/contributors.rs
+++ b/crates/collab/src/db/queries/contributors.rs
@@ -9,7 +9,7 @@ pub enum ContributorSelector {
 impl Database {
     /// Retrieves the GitHub logins of all users who have signed the CLA.
     pub async fn get_contributors(&self) -> Result<Vec<String>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
             enum QueryGithubLogin {
                 GithubLogin,
@@ -32,7 +32,7 @@ impl Database {
         &self,
         selector: &ContributorSelector,
     ) -> Result<Option<DateTime>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let condition = match selector {
                 ContributorSelector::GitHubUserId { github_user_id } => {
                     user::Column::GithubUserId.eq(*github_user_id)
@@ -69,7 +69,7 @@ impl Database {
         github_user_created_at: DateTimeUtc,
         initial_channel_id: Option<ChannelId>,
     ) -> Result<()> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let user = self
                 .get_or_create_user_by_github_account_tx(
                     github_login,

--- a/crates/collab/src/db/queries/extensions.rs
+++ b/crates/collab/src/db/queries/extensions.rs
@@ -15,7 +15,7 @@ impl Database {
         max_schema_version: i32,
         limit: usize,
     ) -> Result<Vec<ExtensionMetadata>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let mut condition = Condition::all()
                 .add(
                     extension::Column::LatestVersion
@@ -43,7 +43,7 @@ impl Database {
         ids: &[&str],
         constraints: Option<&ExtensionVersionConstraints>,
     ) -> Result<Vec<ExtensionMetadata>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let extensions = extension::Entity::find()
                 .filter(extension::Column::ExternalId.is_in(ids.iter().copied()))
                 .all(&*tx)
@@ -123,7 +123,7 @@ impl Database {
         &self,
         extension_id: &str,
     ) -> Result<Vec<ExtensionMetadata>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let condition = extension::Column::ExternalId
                 .eq(extension_id)
                 .into_condition();
@@ -162,7 +162,7 @@ impl Database {
         extension_id: &str,
         constraints: Option<&ExtensionVersionConstraints>,
     ) -> Result<Option<ExtensionMetadata>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let extension = extension::Entity::find()
                 .filter(extension::Column::ExternalId.eq(extension_id))
                 .one(&*tx)
@@ -187,7 +187,7 @@ impl Database {
         extension_id: &str,
         version: &str,
     ) -> Result<Option<ExtensionMetadata>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let extension = extension::Entity::find()
                 .filter(extension::Column::ExternalId.eq(extension_id))
                 .filter(extension_version::Column::Version.eq(version))
@@ -204,7 +204,7 @@ impl Database {
     }
 
     pub async fn get_known_extension_versions(&self) -> Result<HashMap<String, Vec<String>>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             let mut extension_external_ids_by_id = HashMap::default();
 
             let mut rows = extension::Entity::find().stream(&*tx).await?;
@@ -242,7 +242,7 @@ impl Database {
         &self,
         versions_by_extension_id: &HashMap<&str, Vec<NewExtensionVersion>>,
     ) -> Result<()> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             for (external_id, versions) in versions_by_extension_id {
                 if versions.is_empty() {
                     continue;
@@ -346,7 +346,7 @@ impl Database {
     }
 
     pub async fn record_extension_download(&self, extension: &str, version: &str) -> Result<bool> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
             enum QueryId {
                 Id,

--- a/crates/collab/src/db/queries/processed_stripe_events.rs
+++ b/crates/collab/src/db/queries/processed_stripe_events.rs
@@ -13,7 +13,7 @@ impl Database {
         &self,
         params: &CreateProcessedStripeEventParams,
     ) -> Result<()> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             processed_stripe_event::Entity::insert(processed_stripe_event::ActiveModel {
                 stripe_event_id: ActiveValue::set(params.stripe_event_id.clone()),
                 stripe_event_type: ActiveValue::set(params.stripe_event_type.clone()),
@@ -35,7 +35,7 @@ impl Database {
         &self,
         event_id: &str,
     ) -> Result<Option<processed_stripe_event::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(processed_stripe_event::Entity::find_by_id(event_id)
                 .one(&*tx)
                 .await?)
@@ -48,7 +48,7 @@ impl Database {
         &self,
         event_ids: &[&str],
     ) -> Result<Vec<processed_stripe_event::Model>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             Ok(processed_stripe_event::Entity::find()
                 .filter(
                     processed_stripe_event::Column::StripeEventId.is_in(event_ids.iter().copied()),

--- a/crates/collab/src/db/queries/users.rs
+++ b/crates/collab/src/db/queries/users.rs
@@ -382,7 +382,7 @@ impl Database {
 
     /// Returns the active flags for the user.
     pub async fn get_user_flags(&self, user: UserId) -> Result<Vec<String>> {
-        self.transaction(|tx| async move {
+        self.weak_transaction(|tx| async move {
             #[derive(Copy, Clone, Debug, EnumIter, DeriveColumn)]
             enum QueryAs {
                 Flag,


### PR DESCRIPTION
This PR downgrades a number of database queries that aren't part of the actual collaboration from `SERIALIZABLE` to `READ COMMITTED`.

The serializable isolation level is overkill for these queries.

Release Notes:

- N/A
