### PR TITLE
linux: Fix crash when switching repository via git panel

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -125,19 +125,21 @@ impl ScrollbarState {
             return None;
         }
 
+        let visible_percentage = viewport_size / content_size;
+        let thumb_size = MINIMUM_THUMB_SIZE.max(viewport_size * visible_percentage);
+        if thumb_size > viewport_size {
+            return None;
+        }
         let max_offset = content_size - viewport_size;
+        if max_offset.is_zero() {
+            return None;
+        }
         let current_offset = self
             .scroll_handle
             .offset()
             .along(axis)
             .clamp(-max_offset, Pixels::ZERO)
             .abs();
-
-        let visible_percentage = viewport_size / content_size;
-        let thumb_size = MINIMUM_THUMB_SIZE.max(viewport_size * visible_percentage);
-        if thumb_size > viewport_size {
-            return None;
-        }
         let start_offset = (current_offset / max_offset) * (viewport_size - thumb_size);
         let thumb_percentage_start = start_offset / viewport_size;
         let thumb_percentage_end = (start_offset + thumb_size) / viewport_size;

--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -121,19 +121,15 @@ impl ScrollbarState {
         const MINIMUM_THUMB_SIZE: Pixels = px(25.);
         let content_size = self.scroll_handle.content_size().along(axis);
         let viewport_size = self.scroll_handle.viewport().size.along(axis);
-        if content_size.is_zero() || viewport_size.is_zero() || content_size < viewport_size {
+        if content_size.is_zero() || viewport_size.is_zero() || content_size <= viewport_size {
             return None;
         }
-
         let visible_percentage = viewport_size / content_size;
         let thumb_size = MINIMUM_THUMB_SIZE.max(viewport_size * visible_percentage);
         if thumb_size > viewport_size {
             return None;
         }
         let max_offset = content_size - viewport_size;
-        if max_offset.is_zero() {
-            return None;
-        }
         let current_offset = self
             .scroll_handle
             .offset()


### PR DESCRIPTION
Closes #30409

Handles edge case where `f32` turns into `Nan` and causes panic down the code.

Release Notes:

- Fixed issue where Zed crashes on switching repository via git panel on Linux.