### PR TITLE
Re-enable format on save

### DIFF
--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -2513,10 +2513,6 @@ mod tests {
 
     #[gpui::test]
     async fn test_format_on_save_after_agent_finishes(cx: &mut TestAppContext) {
-        // This test verifies that the format_changed_buffers method works correctly
-        // when given the proper setup. The integration with ThreadEvent is tested manually
-        // as the test infrastructure doesn't fully support the deferred workspace registration.
-
         cx.update(|cx| {
             let settings_store = SettingsStore::test(cx);
             cx.set_global(settings_store);


### PR DESCRIPTION
Re-enables format on save for agent changes (when the user has that enabled in settings), except differently from before:
- Now we only format after the agent has completely finished the conversation (or the user cancels it), rather than after each edit
- When the only change was a formatting change, we tell the model as much, and furthermore explicitly tell the model not to mention anything about reformatting, or to reread the file, unless it needs to know about line number changes

Release Notes:

- N/A

> Note: I made this using Claude 4 Opus, plus one slight edit to delete an unnecessary comment + revise a string literal (which Claude could have done too, but seemed like a waste of time and tokens).
> 
> [thread1.md](https://github.com/user-attachments/files/20466588/part1.md)
> [thread2.md](https://github.com/user-attachments/files/20466587/part2.md)
