### PR TITLE
Handle differently named zed remote in scripts

### DIFF
--- a/script/bump-extension-cli
+++ b/script/bump-extension-cli
@@ -2,7 +2,7 @@
 
 set -e
 
-remote=$("$(dirname "$0")"/lib/get-zed-remote)
+remote=$(script/lib/get-zed-remote)
 git pull --ff-only "$remote" main
 git tag -f extension-cli
 git push -f "$remote" extension-cli

--- a/script/bump-extension-cli
+++ b/script/bump-extension-cli
@@ -2,6 +2,7 @@
 
 set -e
 
-git pull --ff-only origin main
+remote=$("$(dirname "$0")"/lib/get-zed-remote)
+git pull --ff-only "$remote" main
 git tag -f extension-cli
-git push -f origin extension-cli
+git push -f "$remote" extension-cli

--- a/script/bump-nightly
+++ b/script/bump-nightly
@@ -2,7 +2,7 @@
 
 set -e
 
-remote=$("$(dirname "$0")"/lib/get-zed-remote)
+remote=$(script/lib/get-zed-remote)
 git fetch "$remote" main:tags/nightly -f
 git log --oneline -1 nightly
 git push -f "$remote" nightly

--- a/script/bump-nightly
+++ b/script/bump-nightly
@@ -2,6 +2,7 @@
 
 set -e
 
-git fetch origin main:tags/nightly -f
+remote=$("$(dirname "$0")"/lib/get-zed-remote)
+git fetch "$remote" main:tags/nightly -f
 git log --oneline -1 nightly
-git push -f origin nightly
+git push -f "$remote" nightly

--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -15,7 +15,7 @@ if [[ $(git rev-parse --abbrev-ref HEAD) != "main" ]]; then
   exit 1
 fi
 
-remote=$("$(dirname "$0")"/lib/get-zed-remote)
+remote=$(script/lib/get-zed-remote)
 git pull -q --ff-only "$remote" main
 
 # Parse the current version

--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -14,7 +14,9 @@ if [[ $(git rev-parse --abbrev-ref HEAD) != "main" ]]; then
   echo "this command must be run on main"
   exit 1
 fi
-git pull -q --ff-only origin main
+
+remote=$("$(dirname "$0")"/lib/get-zed-remote)
+git pull -q --ff-only "$remote" main
 
 # Parse the current version
 version=$(script/get-crate-version zed)
@@ -30,8 +32,8 @@ next_minor_branch_name="v${major}.${next_minor}.x"
 preview_tag_name="v${major}.${minor}.${patch}-pre"
 bump_main_branch_name="set-minor-version-to-${major}.${next_minor}"
 
-git fetch origin ${prev_minor_branch_name}:${prev_minor_branch_name}
-git fetch origin --tags
+git fetch "$remote" ${prev_minor_branch_name}:${prev_minor_branch_name}
+git fetch "$remote" --tags
 cargo check -q
 
 function cleanup {
@@ -97,7 +99,7 @@ Prepared new Zed versions locally. You will need to push the branches and open a
 
 # To push and open a PR to update main:
 
-    git push origin \\
+    git push "$remote" \\
       ${preview_tag_name} \\
       ${stable_tag_name} \\
       ${minor_branch_name} \\

--- a/script/deploy-collab
+++ b/script/deploy-collab
@@ -16,7 +16,7 @@ if [ "$branch" != "main" ]; then
   exit 1
 fi
 
-remote=$("$(dirname "$0")"/lib/get-zed-remote)
+remote=$(script/lib/get-zed-remote)
 git pull --ff-only "$remote" main
 git tag -f $tag
 git push -f "$remote" $tag

--- a/script/deploy-collab
+++ b/script/deploy-collab
@@ -16,6 +16,7 @@ if [ "$branch" != "main" ]; then
   exit 1
 fi
 
-git pull --ff-only origin main
+remote=$("$(dirname "$0")"/lib/get-zed-remote)
+git pull --ff-only "$remote" main
 git tag -f $tag
-git push -f origin $tag
+git push -f "$remote" $tag

--- a/script/lib/bump-version.sh
+++ b/script/lib/bump-version.sh
@@ -21,7 +21,7 @@ new_version=$(script/get-crate-version $package)
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 old_sha=$(git rev-parse HEAD)
 tag_name=${tag_prefix}${new_version}${tag_suffix}
-remote=$("$(dirname "$0")"/get-zed-remote)
+remote=$(script/get-zed-remote)
 
 git commit --quiet --all --message "${package} ${new_version}"
 git tag ${tag_name}

--- a/script/lib/bump-version.sh
+++ b/script/lib/bump-version.sh
@@ -21,6 +21,7 @@ new_version=$(script/get-crate-version $package)
 branch_name=$(git rev-parse --abbrev-ref HEAD)
 old_sha=$(git rev-parse HEAD)
 tag_name=${tag_prefix}${new_version}${tag_suffix}
+remote=$("$(dirname "$0")"/get-zed-remote)
 
 git commit --quiet --all --message "${package} ${new_version}"
 git tag ${tag_name}
@@ -30,7 +31,7 @@ Locally committed and tagged ${package} version ${new_version}
 
 To push this:
 
-    git push origin ${tag_name} ${branch_name}
+    git push ${remote} ${tag_name} ${branch_name}
 
 To undo this:
 

--- a/script/lib/get-zed-remote
+++ b/script/lib/get-zed-remote
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+git remote -v |
+    grep 'zed-industries/zed' |
+    cut -f1 |
+    head -n1

--- a/script/squawk
+++ b/script/squawk
@@ -14,6 +14,7 @@ fi
 SQUAWK_VERSION=0.26.0
 SQUAWK_BIN="./target/squawk-$SQUAWK_VERSION"
 SQUAWK_ARGS="--assume-in-transaction --config script/lib/squawk.toml"
+remote=$("$(dirname "$0")"/lib/get-zed-remote)
 
 if  [ ! -f "$SQUAWK_BIN" ]; then
   pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto || /usr/sbin/softwareupdate --install-rosetta --agree-to-license
@@ -28,7 +29,7 @@ if [ -n "$SQUAWK_GITHUB_TOKEN" ]; then
     export SQUAWK_GITHUB_REPO_NAME=$(echo $GITHUB_REPOSITORY | awk -F/ '{print $2}')
     export SQUAWK_GITHUB_PR_NUMBER=$(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
 
-    $SQUAWK_BIN $SQUAWK_ARGS upload-to-github $(git diff --name-only origin/$GITHUB_BASE_REF...origin/$GITHUB_HEAD_REF 'crates/collab/migrations/*.sql' 'crates/collab/migrations_llm/*.sql')
+    $SQUAWK_BIN $SQUAWK_ARGS upload-to-github $(git diff --name-only $remote/$GITHUB_BASE_REF...$remote/$GITHUB_HEAD_REF 'crates/collab/migrations/*.sql' 'crates/collab/migrations_llm/*.sql')
 else
     $SQUAWK_BIN $SQUAWK_ARGS $(git ls-files --others crates/collab/migrations/*.sql crates/collab/migrations_llm/*.sql) $(git diff --name-only main crates/collab/migrations/*.sql crates/collab/migrations_llm/*.sql)
 fi

--- a/script/squawk
+++ b/script/squawk
@@ -14,7 +14,7 @@ fi
 SQUAWK_VERSION=0.26.0
 SQUAWK_BIN="./target/squawk-$SQUAWK_VERSION"
 SQUAWK_ARGS="--assume-in-transaction --config script/lib/squawk.toml"
-remote=$("$(dirname "$0")"/lib/get-zed-remote)
+remote=$(script/lib/get-zed-remote)
 
 if  [ ! -f "$SQUAWK_BIN" ]; then
   pkgutil --pkg-info com.apple.pkg.RosettaUpdateAuto || /usr/sbin/softwareupdate --install-rosetta --agree-to-license


### PR DESCRIPTION
I contribute to zed from a fork so the "main" remote which these scripts should run against is called `upstream` instead of `main`. This change should handle arbitrary remote names by checking which one points to this repository.

Release Notes:

- N/A
