### PR TITLE
vim: Add vim counts and vim shortcuts to project_panel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17480,6 +17480,7 @@ dependencies = [
  "language",
  "log",
  "lsp",
+ "menu",
  "multi_buffer",
  "nvim-rs",
  "parking_lot",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -728,6 +728,21 @@
     }
   },
   {
+    "context": "(GitPanel || ProjectPanel || CollabPanel || OutlinePanel || ChatPanel || EmptyPane || SharedScreen || MarkdownPreview || KeyContextView || DebugPanel) && not_editing",
+    "bindings": {
+      "0": ["vim::Number", 0],
+      "1": ["vim::Number", 1],
+      "2": ["vim::Number", 2],
+      "3": ["vim::Number", 3],
+      "4": ["vim::Number", 4],
+      "5": ["vim::Number", 5],
+      "6": ["vim::Number", 6],
+      "7": ["vim::Number", 7],
+      "8": ["vim::Number", 8],
+      "9": ["vim::Number", 9]
+    }
+  },
+  {
     "context": "AgentPanel || GitPanel || ProjectPanel || CollabPanel || OutlinePanel || ChatPanel || VimControl || EmptyPane || SharedScreen || MarkdownPreview || KeyContextView || DebugPanel",
     "bindings": {
       // window related commands (ctrl-w X)
@@ -803,8 +818,8 @@
       "enter": "project_panel::OpenPermanent",
       "escape": "project_panel::ToggleFocus",
       "h": "project_panel::CollapseSelectedEntry",
-      "j": "menu::SelectNext",
-      "k": "menu::SelectPrevious",
+      "j": "vim::MenuSelectNext",
+      "k": "vim::MenuSelectPrevious",
       "l": "project_panel::ExpandSelectedEntry",
       "o": "project_panel::OpenPermanent",
       "shift-d": "project_panel::Delete",
@@ -822,7 +837,12 @@
       "{": "project_panel::SelectPrevDirectory",
       "shift-g": "menu::SelectLast",
       "g g": "menu::SelectFirst",
-      "-": "project_panel::SelectParent"
+      "-": "project_panel::SelectParent",
+      "ctrl-u": "project_panel::ScrollUp",
+      "ctrl-d": "project_panel::ScrollDown",
+      "z t": "project_panel::ScrollCursorTop",
+      "z z": "project_panel::ScrollCursorCenter",
+      "z b": "project_panel::ScrollCursorBottom"
     }
   },
   {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -79,6 +79,7 @@ pub struct ProjectPanel {
     // An update loop that keeps incrementing/decrementing scroll offset while there is a dragged entry that's
     // hovered over the start/end of a list.
     hover_scroll_task: Option<Task<()>>,
+    rendered_entries_len: usize,
     visible_entries: Vec<(WorktreeId, Vec<GitEntry>, OnceCell<HashSet<Arc<Path>>>)>,
     /// Maps from leaf project entry ID to the currently selected ancestor.
     /// Relevant only for auto-fold dirs, where a single project panel entry may actually consist of several
@@ -220,6 +221,11 @@ actions!(
         NewSearchInDirectory,
         UnfoldDirectory,
         FoldDirectory,
+        ScrollUp,
+        ScrollDown,
+        ScrollCursorCenter,
+        ScrollCursorTop,
+        ScrollCursorBottom,
         SelectParent,
         SelectNextGitEntry,
         SelectPrevGitEntry,
@@ -488,6 +494,7 @@ impl ProjectPanel {
                 hover_scroll_task: None,
                 fs: workspace.app_state().fs.clone(),
                 focus_handle,
+                rendered_entries_len: 0,
                 visible_entries: Default::default(),
                 ancestors: Default::default(),
                 folded_directory_drag_target: None,
@@ -1866,6 +1873,52 @@ impl ProjectPanel {
 
             self.update_visible_entries(None, cx);
             self.autoscroll(cx);
+            cx.notify();
+        }
+    }
+
+    fn scroll_up(&mut self, _: &ScrollUp, window: &mut Window, cx: &mut Context<Self>) {
+        for _ in 0..self.rendered_entries_len / 2 {
+            window.dispatch_action(SelectPrevious.boxed_clone(), cx);
+        }
+    }
+
+    fn scroll_down(&mut self, _: &ScrollDown, window: &mut Window, cx: &mut Context<Self>) {
+        for _ in 0..self.rendered_entries_len / 2 {
+            window.dispatch_action(SelectNext.boxed_clone(), cx);
+        }
+    }
+
+    fn scroll_cursor_center(
+        &mut self,
+        _: &ScrollCursorCenter,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
+            self.scroll_handle
+                .scroll_to_item_strict(index, ScrollStrategy::Center);
+            cx.notify();
+        }
+    }
+
+    fn scroll_cursor_top(&mut self, _: &ScrollCursorTop, _: &mut Window, cx: &mut Context<Self>) {
+        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
+            self.scroll_handle
+                .scroll_to_item_strict(index, ScrollStrategy::Top);
+            cx.notify();
+        }
+    }
+
+    fn scroll_cursor_bottom(
+        &mut self,
+        _: &ScrollCursorBottom,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some((_, _, index)) = self.selection.and_then(|s| self.index_for_selection(s)) {
+            self.scroll_handle
+                .scroll_to_item_strict(index, ScrollStrategy::Bottom);
             cx.notify();
         }
     }
@@ -4844,6 +4897,11 @@ impl Render for ProjectPanel {
                     this.marked_entries.clear();
                 }))
                 .key_context(self.dispatch_context(window, cx))
+                .on_action(cx.listener(Self::scroll_up))
+                .on_action(cx.listener(Self::scroll_down))
+                .on_action(cx.listener(Self::scroll_cursor_center))
+                .on_action(cx.listener(Self::scroll_cursor_top))
+                .on_action(cx.listener(Self::scroll_cursor_bottom))
                 .on_action(cx.listener(Self::select_next))
                 .on_action(cx.listener(Self::select_previous))
                 .on_action(cx.listener(Self::select_first))
@@ -4923,7 +4981,8 @@ impl Render for ProjectPanel {
                 .child(
                     uniform_list("entries", item_count, {
                         cx.processor(|this, range: Range<usize>, window, cx| {
-                            let mut items = Vec::with_capacity(range.end - range.start);
+                            this.rendered_entries_len = range.end - range.start;
+                            let mut items = Vec::with_capacity(this.rendered_entries_len);
                             this.for_each_visible_entry(
                                 range,
                                 window,

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -43,6 +43,7 @@ settings.workspace = true
 task.workspace = true
 text.workspace = true
 theme.workspace = true
+menu.workspace = true
 tokio = { version = "1.15", features = ["full"], optional = true }
 ui.workspace = true
 util.workspace = true


### PR DESCRIPTION
Closes #10930 
Closes #11353

Release Notes:

- Adds commands to project_panel
  - `ctrl-u` scrolls the project_panel up half of the visible entries
  - `ctrl-d` scrolls the project_panel down half of the visible entries
  - `z z` scrolls current selection to center of window
  - `z t`  scrolls current selection to top of window
  - `z b` scrolls current selection to bottom of window
  - `{num} j` and `{num} k` now move up and  down with a count
