### PR TITLE
Show version info when downloading and installing updates

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -699,7 +699,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_install_version_tooltip_message() {
+    fn test_version_tooltip_message() {
         let message = ActivityIndicator::version_tooltip_message(&VersionCheckType::Semantic(
             SemanticVersion::new(1, 0, 0),
         ));

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -472,7 +472,7 @@ impl ActivityIndicator {
                     })),
                     tooltip_message: None,
                 }),
-                AutoUpdateStatus::Downloading => Some(Content {
+                AutoUpdateStatus::Downloading { version } => Some(Content {
                     icon: Some(
                         Icon::new(IconName::Download)
                             .size(IconSize::Small)
@@ -482,9 +482,9 @@ impl ActivityIndicator {
                     on_click: Some(Arc::new(|this, window, cx| {
                         this.dismiss_error_message(&DismissErrorMessage, window, cx)
                     })),
-                    tooltip_message: None,
+                    tooltip_message: Some(Self::version_tooltip_message(&version)),
                 }),
-                AutoUpdateStatus::Installing => Some(Content {
+                AutoUpdateStatus::Installing { version } => Some(Content {
                     icon: Some(
                         Icon::new(IconName::Download)
                             .size(IconSize::Small)
@@ -494,7 +494,7 @@ impl ActivityIndicator {
                     on_click: Some(Arc::new(|this, window, cx| {
                         this.dismiss_error_message(&DismissErrorMessage, window, cx)
                     })),
-                    tooltip_message: None,
+                    tooltip_message: Some(Self::version_tooltip_message(&version)),
                 }),
                 AutoUpdateStatus::Updated {
                     binary_path,
@@ -508,7 +508,7 @@ impl ActivityIndicator {
                         };
                         move |_, _, cx| workspace::reload(&reload, cx)
                     })),
-                    tooltip_message: Some(Self::install_version_tooltip_message(&version)),
+                    tooltip_message: Some(Self::version_tooltip_message(&version)),
                 }),
                 AutoUpdateStatus::Errored => Some(Content {
                     icon: Some(
@@ -548,8 +548,8 @@ impl ActivityIndicator {
         None
     }
 
-    fn install_version_tooltip_message(version: &VersionCheckType) -> String {
-        format!("Install version: {}", {
+    fn version_tooltip_message(version: &VersionCheckType) -> String {
+        format!("Version: {}", {
             match version {
                 auto_update::VersionCheckType::Sha(sha) => format!("{}…", sha.short()),
                 auto_update::VersionCheckType::Semantic(semantic_version) => {
@@ -700,13 +700,13 @@ mod tests {
 
     #[test]
     fn test_install_version_tooltip_message() {
-        let message = ActivityIndicator::install_version_tooltip_message(
-            &VersionCheckType::Semantic(SemanticVersion::new(1, 0, 0)),
-        );
+        let message = ActivityIndicator::version_tooltip_message(&VersionCheckType::Semantic(
+            SemanticVersion::new(1, 0, 0),
+        ));
 
         assert_eq!(message, "Install version: 1.0.0");
 
-        let message = ActivityIndicator::install_version_tooltip_message(&VersionCheckType::Sha(
+        let message = ActivityIndicator::version_tooltip_message(&VersionCheckType::Sha(
             AppCommitSha::new("14d9a4189f058d8736339b06ff2340101eaea5af".to_string()),
         ));
 

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -704,12 +704,12 @@ mod tests {
             SemanticVersion::new(1, 0, 0),
         ));
 
-        assert_eq!(message, "Install version: 1.0.0");
+        assert_eq!(message, "Version: 1.0.0");
 
         let message = ActivityIndicator::version_tooltip_message(&VersionCheckType::Sha(
             AppCommitSha::new("14d9a4189f058d8736339b06ff2340101eaea5af".to_string()),
         ));
 
-        assert_eq!(message, "Install version: 14d9a41…");
+        assert_eq!(message, "Version: 14d9a41…");
     }
 }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -49,8 +49,12 @@ pub enum VersionCheckType {
 pub enum AutoUpdateStatus {
     Idle,
     Checking,
-    Downloading,
-    Installing,
+    Downloading {
+        version: VersionCheckType,
+    },
+    Installing {
+        version: VersionCheckType,
+    },
     Updated {
         binary_path: PathBuf,
         version: VersionCheckType,
@@ -531,7 +535,9 @@ impl AutoUpdater {
         };
 
         this.update(&mut cx, |this, cx| {
-            this.status = AutoUpdateStatus::Downloading;
+            this.status = AutoUpdateStatus::Downloading {
+                version: newer_version.clone(),
+            };
             cx.notify();
         })?;
 
@@ -540,7 +546,9 @@ impl AutoUpdater {
         download_release(&target_path, fetched_release_data, client, &cx).await?;
 
         this.update(&mut cx, |this, cx| {
-            this.status = AutoUpdateStatus::Installing;
+            this.status = AutoUpdateStatus::Installing {
+                version: newer_version.clone(),
+            };
             cx.notify();
         })?;
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -647,8 +647,8 @@ impl TitleBar {
                 let auto_updater = auto_update::AutoUpdater::get(cx);
                 let label = match auto_updater.map(|auto_update| auto_update.read(cx).status()) {
                     Some(AutoUpdateStatus::Updated { .. }) => "Please restart Zed to Collaborate",
-                    Some(AutoUpdateStatus::Installing)
-                    | Some(AutoUpdateStatus::Downloading)
+                    Some(AutoUpdateStatus::Installing { .. })
+                    | Some(AutoUpdateStatus::Downloading { .. })
                     | Some(AutoUpdateStatus::Checking) => "Updating...",
                     Some(AutoUpdateStatus::Idle) | Some(AutoUpdateStatus::Errored) | None => {
                         "Please update Zed to Collaborate"


### PR DESCRIPTION
Follow up to #31179 

In addition to seeing the version when in the `Click to restart and update Zed` status, this PR allows us to see the version when in `Downloading Zed update…` or `Installing Zed update…` status, in a tooltip, when hovering on the activity indicator.

Will merge after tomorrow's release.

Release Notes:

- Added version information, in a tooltip, when hovering on the activity indicator for both the download and install status.
