### PR TITLE
debugger: Fix go locator creating false scenarios

### DIFF
--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -23,6 +23,10 @@ impl DapLocator for GoLocator {
         resolved_label: &str,
         adapter: DebugAdapterName,
     ) -> Option<DebugScenario> {
+        if build_config.command != "go" {
+            return None;
+        }
+
         let go_action = build_config.args.first()?;
 
         match go_action.as_str() {


### PR DESCRIPTION
This caused other locators to fail because go would accept build tasks that it couldn't actually resolve

Release Notes:

- N/A
