### PR TITLE
Fix lag when interacting with `MarkdownElement`

### DIFF
--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -1209,6 +1209,7 @@ impl Element for MarkdownElement {
     ) -> Self::PrepaintState {
         let focus_handle = self.markdown.read(cx).focus_handle.clone();
         window.set_focus_handle(&focus_handle, cx);
+        window.set_view_id(self.markdown.entity_id());
 
         let hitbox = window.insert_hitbox(bounds, false);
         rendered_markdown.element.prepaint(window, cx);


### PR DESCRIPTION
Previously, we forgot to associate the `Markdown` entity to `MarkdownElement` during `prepaint`. This caused calls to `Context<Markdown>::notify` to not invalidate the view cache, which meant we would have to wait for some other invalidation before seeing the results of that initial notify.

Release Notes:

- Improved responsiveness of mouse interactions with the agent panel.
