### PR TITLE
debugger: Fix invalid schema for `pathMappings`

### DIFF
--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -149,22 +149,8 @@ impl DebugAdapter for PhpDebugAdapter {
                     "default": false
                 },
                 "pathMappings": {
-                    "type": "array",
-                    "description": "A list of server paths mapping to the local source paths on your machine for remote host debugging",
-                    "items": {
-                        "type": "object",
-                        "properties": {
-                            "serverPath": {
-                                "type": "string",
-                                "description": "Path on the server"
-                            },
-                            "localPath": {
-                                "type": "string",
-                                "description": "Corresponding path on the local machine"
-                            }
-                        },
-                        "required": ["serverPath", "localPath"]
-                    }
+                    "type": "object",
+                    "description": "A mapping of server paths to local paths.",
                 },
                 "log": {
                     "type": "boolean",


### PR DESCRIPTION
See https://github.com/xdebug/vscode-php-debug?tab=readme-ov-file#remote-host-debugging

Release Notes:

- Debugger Beta: Fixed invalid schema for `pathMappings`
