### PR TITLE
bedrock: Fix Claude 4 output token bug

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -245,7 +245,9 @@ impl Model {
             | Self::Claude3_5Haiku
             | Self::Claude3_7Sonnet
             | Self::ClaudeSonnet4
-            | Self::ClaudeOpus4 => 200_000,
+            | Self::ClaudeOpus4
+            | Self::ClaudeSonnet4Thinking
+            | Self::ClaudeOpus4Thinking => 200_000,
             Self::AmazonNovaPremier => 1_000_000,
             Self::PalmyraWriterX5 => 1_000_000,
             Self::PalmyraWriterX4 => 128_000,


### PR DESCRIPTION
Release Notes:

- Fixed unable to use Claude 4 Thinking models with Bedrock
