### PR TITLE
agent: Move focus to the panel after dismissing a user message edit

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1533,9 +1533,22 @@ impl ActiveThread {
         });
     }
 
-    fn cancel_editing_message(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
+    fn cancel_editing_message(
+        &mut self,
+        _: &menu::Cancel,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
         self.editing_message.take();
         cx.notify();
+
+        if let Some(workspace) = self.workspace.upgrade() {
+            workspace.update(cx, |workspace, cx| {
+                if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                    panel.focus_handle(cx).focus(window);
+                }
+            });
+        }
     }
 
     fn confirm_editing_message(


### PR DESCRIPTION
Previously, when you clicked on a previous message to edit it and then dismissed it, your focus would jump to the buffer. This caught me several times as the most obvious place to return to for me was the agent panel main message editor, so I can continue prompting something else. And this is what this PR changes.

Release Notes:

- agent: Improved previous message editing UX by returning focus to the main panel's text area after dismissing it.
