### PR TITLE
agent: Make clicking on the backdrop to dismiss message editing more reliable

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1818,6 +1818,7 @@ impl ActiveThread {
 
         let colors = cx.theme().colors();
         let editor_bg_color = colors.editor_background;
+        let panel_bg = colors.panel_background;
 
         let open_as_markdown = IconButton::new(("open-as-markdown", ix), IconName::DocumentText)
             .icon_size(IconSize::XSmall)
@@ -1838,7 +1839,6 @@ impl ActiveThread {
         const RESPONSE_PADDING_X: Pixels = px(19.);
 
         let show_feedback = thread.is_turn_end(ix);
-
         let feedback_container = h_flex()
             .group("feedback_container")
             .mt_1()
@@ -2135,16 +2135,14 @@ impl ActiveThread {
                 message_id > *editing_message_id
             });
 
-        let panel_background = cx.theme().colors().panel_background;
-
         let backdrop = div()
-            .id("backdrop")
-            .stop_mouse_events_except_scroll()
+            .id(("backdrop", ix))
+            .size_full()
             .absolute()
             .inset_0()
-            .size_full()
-            .bg(panel_background)
+            .bg(panel_bg)
             .opacity(0.8)
+            .stop_mouse_events_except_scroll()
             .on_click(cx.listener(Self::handle_cancel_click));
 
         v_flex()


### PR DESCRIPTION
Previously, the click on the backdrop to dismiss the message editing was unreliable. You would click on it and sometimes it would work and others it wouldn't. This PR fixes that now.

Release Notes:

- agent: Fixes the previous message dismissal by clicking on the backdrop
