### PR TITLE
Disable single-file review by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -765,7 +765,7 @@
     // When enabled, the agent will stream edits.
     "stream_edits": false,
     // When enabled, agent edits will be displayed in single-file editors for review
-    "single_file_review": true,
+    "single_file_review": false,
     // When enabled, show voting thumbs for feedback on agent edits.
     "enable_feedback": true,
     "default_profile": "write",

--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -1919,6 +1919,13 @@ mod tests {
             EditorSettings::register(cx);
             language_model::init_settings(cx);
             workspace::register_project_item::<Editor>(cx);
+
+            // Explicitly set single_file_review to true since it's now false by default
+            SettingsStore::update_global(cx, |store, _cx| {
+                let mut agent_settings = store.get::<AgentSettings>(None).clone();
+                agent_settings.single_file_review = true;
+                store.override_global(agent_settings);
+            });
         });
 
         let fs = FakeFs::new(cx.executor());

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -663,7 +663,7 @@ pub struct AgentSettingsContentV2 {
     stream_edits: Option<bool>,
     /// Whether to display agent edits in single-file editors in addition to the review multibuffer pane.
     ///
-    /// Default: true
+    /// Default: false
     single_file_review: Option<bool>,
     /// Additional parameters for language model requests. When making a request
     /// to a model, parameters will be taken from the last entry in this list

--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -56,8 +56,8 @@ To see which files specifically have been edited, expand the accordion bar that 
 
 You're able to reject or accept each individual change hunk, or the whole set of changes made by the agent.
 
-Edit diffs also appear in individual buffers.
-So, if your active tab had edits made by the AI, you'll see diffs with the same accept/reject controls as in the multi-buffer.
+By default, edit diffs appear only in the multi-buffer review tab.
+You can enable diffs in individual buffers by setting `single_file_review` to `true` in your settings. When enabled, if your active tab had edits made by the AI, you'll see diffs with the same accept/reject controls as in the multi-buffer.
 
 ## Adding Context {#adding-context}
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3293,7 +3293,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
     "provider": "zed.dev",
     "model": "claude-sonnet-4"
   },
-  "single_file_review": true,
+  "single_file_review": false,
 }
 ```
 


### PR DESCRIPTION
Release Notes:

- Single-file review is now disabled by default in the agent panel