### PR TITLE
editor: Fix horizontal scrollbar alignment if indent guides are disabled

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1512,6 +1512,9 @@ impl EditorElement {
             ShowScrollbar::Never => return None,
         };
 
+        // The horizontal scrollbar is usually slightly offset to align nicely with
+        // indent guides. However, this offset is not needed if indent guides are
+        // disabled for the current editor.
         let content_offset = self
             .editor
             .read(cx)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1512,6 +1512,14 @@ impl EditorElement {
             ShowScrollbar::Never => return None,
         };
 
+        let content_offset = self
+            .editor
+            .read(cx)
+            .show_indent_guides
+            .is_none_or(|should_show| should_show)
+            .then_some(content_offset)
+            .unwrap_or_default();
+
         Some(EditorScrollbars::from_scrollbar_axes(
             ScrollbarAxes {
                 horizontal: scrollbar_settings.axes.horizontal


### PR DESCRIPTION
Follow-up to #24887
Follow-up to #31510

This PR ensures that [this misalignment of the horizontal scrollbar](https://github.com/zed-industries/zed/pull/31510#issuecomment-2912842457) does not occur. See the entire discussion in the first linked PR as to why this gap is there in the first place.

I am also aware of the general stance towards comments. Yet, I felt for this case it is better to just straight up explain how these two things are connected, as I do believe this is not intuitively clear after all.

Might also be a good time to bring https://github.com/zed-industries/zed/issues/25519 up again. The horizontal scrollbar seems huge for the edit file tool card. Furthermore, since we do not reserve space for the horizontal scrollbar (yet), this will lead to the last line being not clickable.

Release Notes:

- N/A