### PR TITLE
Format streamed edits on save

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,7 @@ dependencies = [
  "language_model",
  "language_models",
  "log",
+ "lsp",
  "markdown",
  "open",
  "paths",

--- a/crates/assistant_tools/Cargo.toml
+++ b/crates/assistant_tools/Cargo.toml
@@ -36,6 +36,7 @@ itertools.workspace = true
 language.workspace = true
 language_model.workspace = true
 log.workspace = true
+lsp.workspace = true
 markdown.workspace = true
 open.workspace = true
 paths.workspace = true
@@ -64,6 +65,7 @@ workspace.workspace = true
 zed_llm_client.workspace = true
 
 [dev-dependencies]
+lsp = { workspace = true, features = ["test-support"] }
 client = { workspace = true, features = ["test-support"] }
 clock = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -41,7 +41,6 @@ use std::{
 use theme::ThemeSettings;
 use ui::{Disclosure, Tooltip, prelude::*};
 use util::ResultExt;
-
 use workspace::Workspace;
 
 pub struct EditFileTool;

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -252,7 +252,7 @@ impl Tool for EditFileTool {
             }
             let agent_output = output.await?;
 
-            // Check if format_on_save is enabled
+            // If format_on_save is enabled, format the buffer
             let format_on_save_enabled = buffer
                 .read_with(cx, |buffer, cx| {
                     let settings = language_settings::language_settings(
@@ -264,7 +264,6 @@ impl Tool for EditFileTool {
                 })
                 .unwrap_or(false);
 
-            // If format_on_save is enabled, format the buffer before saving
             if format_on_save_enabled {
                 let format_task = project.update(cx, |project, cx| {
                     project.format(
@@ -282,20 +281,24 @@ impl Tool for EditFileTool {
                 .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))?
                 .await?;
 
-            // Notify the action log that we've edited the buffer AFTER save completes
-            // This ensures the tracked version matches the saved version
+            // Notify the action log that we've edited the buffer (*after* formatting has completed).
             action_log.update(cx, |log, cx| {
                 log.buffer_edited(buffer.clone(), cx);
             })?;
 
             let new_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
-            let new_text = cx
+            let (new_text, diff) = cx
                 .background_spawn({
                     let new_snapshot = new_snapshot.clone();
-                    async move { new_snapshot.text() }
+                    let old_text = old_text.clone();
+                    async move {
+                        let new_text = new_snapshot.text();
+                        let diff = language::unified_diff(&old_text, &new_text);
+
+                        (new_text, diff)
+                    }
                 })
                 .await;
-            let diff = language::unified_diff(&old_text, &new_text);
 
             let output = EditFileToolOutput {
                 original_path: project_path.path.to_path_buf(),
@@ -1484,6 +1487,15 @@ mod tests {
             "Code should be formatted when format_on_save is enabled"
         );
 
+        let stale_buffer_count = action_log.read_with(cx, |log, cx| log.stale_buffers(cx).count());
+
+        assert_eq!(
+            stale_buffer_count, 0,
+            "BUG: Buffer is incorrectly marked as stale after format-on-save. Found {} stale buffers. \
+             This causes the agent to think the file was modified externally when it was just formatted.",
+            stale_buffer_count
+        );
+
         // Next, test with format_on_save disabled
         cx.update(|cx| {
             SettingsStore::update_global(cx, |store, cx| {
@@ -1674,158 +1686,6 @@ mod tests {
             final_content.replace("\r\n", "\n"),
             CONTENT_WITH_TRAILING_WHITESPACE,
             "Trailing whitespace should remain when remove_trailing_whitespace_on_save is disabled"
-        );
-    }
-
-    #[gpui::test]
-    async fn test_format_on_save_marks_buffer_as_conflicted(cx: &mut TestAppContext) {
-        // This test demonstrates a bug where format-on-save causes the buffer to be
-        // incorrectly marked as stale, leading the agent to think the file has been
-        // modified externally when it was actually just formatted as part of the save.
-        init_test(cx);
-
-        let fs = FakeFs::new(cx.executor());
-        fs.insert_tree(path!("/root"), json!({"src": {}})).await;
-
-        let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
-
-        // Set up a Rust language with LSP formatting support
-        let rust_language = Arc::new(language::Language::new(
-            language::LanguageConfig {
-                name: "Rust".into(),
-                matcher: language::LanguageMatcher {
-                    path_suffixes: vec!["rs".to_string()],
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-            None,
-        ));
-
-        // Register the language and fake LSP
-        let language_registry = project.read_with(cx, |project, _| project.languages().clone());
-        language_registry.add(rust_language);
-
-        let mut fake_language_servers = language_registry.register_fake_lsp(
-            "Rust",
-            language::FakeLspAdapter {
-                capabilities: lsp::ServerCapabilities {
-                    document_formatting_provider: Some(lsp::OneOf::Left(true)),
-                    ..Default::default()
-                },
-                ..Default::default()
-            },
-        );
-
-        // Create the file with some initial content
-        fs.save(
-            path!("/root/src/main.rs").as_ref(),
-            &"fn main() { }\n".into(),
-            language::LineEnding::Unix,
-        )
-        .await
-        .unwrap();
-
-        // Open the buffer to trigger LSP initialization
-        let buffer = project
-            .update(cx, |project, cx| {
-                project.open_local_buffer(path!("/root/src/main.rs"), cx)
-            })
-            .await
-            .unwrap();
-
-        // Register the buffer with language servers
-        let _handle = project.update(cx, |project, cx| {
-            project.register_buffer_with_language_servers(&buffer, cx)
-        });
-
-        const UNFORMATTED_CONTENT: &str = "fn main() {println!(\"Hello!\");}\n";
-        const FORMATTED_CONTENT: &str = "fn main() {\n    println!(\"Hello!\");\n}\n";
-
-        // Get the fake language server and set up formatting handler
-        let fake_language_server = fake_language_servers.next().await.unwrap();
-        fake_language_server.set_request_handler::<lsp::request::Formatting, _, _>({
-            move |_, _| async move {
-                Ok(Some(vec![lsp::TextEdit {
-                    range: lsp::Range::new(lsp::Position::new(0, 0), lsp::Position::new(1, 0)),
-                    new_text: FORMATTED_CONTENT.to_string(),
-                }]))
-            }
-        });
-
-        let action_log = cx.new(|_| ActionLog::new(project.clone()));
-        let model = Arc::new(FakeLanguageModel::default());
-
-        // Enable format_on_save
-        cx.update(|cx| {
-            SettingsStore::update_global(cx, |store, cx| {
-                store.update_user_settings::<language::language_settings::AllLanguageSettings>(
-                    cx,
-                    |settings| {
-                        settings.defaults.format_on_save = Some(FormatOnSave::On);
-                        settings.defaults.formatter =
-                            Some(language::language_settings::SelectedFormatter::Auto);
-                    },
-                );
-            });
-        });
-
-        // Have the agent edit the file (this should trigger format on save)
-        let edit_result = {
-            let edit_task = cx.update(|cx| {
-                let input = serde_json::to_value(EditFileToolInput {
-                    display_description: "Update main function".into(),
-                    path: "root/src/main.rs".into(),
-                    mode: EditFileMode::Overwrite,
-                })
-                .unwrap();
-                Arc::new(EditFileTool)
-                    .run(
-                        input,
-                        Arc::default(),
-                        project.clone(),
-                        action_log.clone(),
-                        model.clone(),
-                        None,
-                        cx,
-                    )
-                    .output
-            });
-
-            // Stream the unformatted content
-            cx.executor().run_until_parked();
-            model.stream_last_completion_response(UNFORMATTED_CONTENT.to_string());
-            model.end_last_completion_stream();
-
-            edit_task.await
-        };
-        assert!(edit_result.is_ok());
-
-        // Wait for any async operations (e.g. formatting) to complete
-        cx.executor().run_until_parked();
-
-        // Read the file to verify it was formatted automatically
-        let new_content = fs.load(path!("/root/src/main.rs").as_ref()).await.unwrap();
-        assert_eq!(
-            new_content.replace("\r\n", "\n"),
-            FORMATTED_CONTENT,
-            "Code should be formatted when format_on_save is enabled"
-        );
-
-        // Now simulate what would happen if the agent re-reads the buffer
-        // (e.g., because it thinks the file changed externally)
-        let stale_buffer_count = action_log.read_with(cx, |log, cx| log.stale_buffers(cx).count());
-
-        // This assertion demonstrates the bug: the buffer should NOT be considered stale
-        // after format-on-save, but it is incorrectly marked as stale because the
-        // formatting process causes the file's mtime to change, making it appear as if
-        // the file was modified externally. This causes the agent to unnecessarily
-        // re-read the file, thinking it has changed outside of the agent's control.
-        assert_eq!(
-            stale_buffer_count, 0,
-            "BUG: Buffer is incorrectly marked as stale after format-on-save. Found {} stale buffers. \
-             This causes the agent to think the file was modified externally when it was just formatted.",
-            stale_buffer_count
         );
     }
 }


### PR DESCRIPTION
Re-enables format on save for agent changes (when the user has that enabled in settings), except differently from before:
- Now we do the format-on-save in the separate buffer the edit tool uses, *before* the diff
- This means it never triggers separate staleness
- It has the downside that edits are now blocked on the formatter completing, but that's true of saving in general.

Release Notes:

- N/A
