### PR TITLE
collab: Use `StripeClient` to retrieve prices and meters from Stripe

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -499,8 +499,10 @@ async fn manage_billing_subscription(
     let flow = match body.intent {
         ManageSubscriptionIntent::ManageSubscription => None,
         ManageSubscriptionIntent::UpgradeToPro => {
-            let zed_pro_price_id = stripe_billing.zed_pro_price_id().await?;
-            let zed_free_price_id = stripe_billing.zed_free_price_id().await?;
+            let zed_pro_price_id: stripe::PriceId =
+                stripe_billing.zed_pro_price_id().await?.try_into()?;
+            let zed_free_price_id: stripe::PriceId =
+                stripe_billing.zed_free_price_id().await?.try_into()?;
 
             let stripe_subscription =
                 Subscription::retrieve(&stripe_client, &subscription_id, &[]).await?;

--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -53,7 +53,7 @@ impl StripeBilling {
         let mut state = self.state.write().await;
 
         let (meters, prices) =
-            futures::try_join!(self.client.list_meters(), self.client.list_prices(),)?;
+            futures::try_join!(self.client.list_meters(), self.client.list_prices())?;
 
         for meter in meters {
             state

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -10,8 +10,9 @@ use async_trait::async_trait;
 #[cfg(test)]
 pub use fake_stripe_client::*;
 pub use real_stripe_client::*;
+use serde::Deserialize;
 
-#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+#[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
 pub struct StripeCustomerId(pub Arc<str>);
 
 #[derive(Debug, Clone)]
@@ -25,9 +26,38 @@ pub struct CreateCustomerParams<'a> {
     pub email: Option<&'a str>,
 }
 
+#[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
+pub struct StripePriceId(pub Arc<str>);
+
+#[derive(Debug, Clone)]
+pub struct StripePrice {
+    pub id: StripePriceId,
+    pub unit_amount: Option<i64>,
+    pub lookup_key: Option<String>,
+    pub recurring: Option<StripePriceRecurring>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StripePriceRecurring {
+    pub meter: Option<String>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display, Deserialize)]
+pub struct StripeMeterId(pub Arc<str>);
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct StripeMeter {
+    pub id: StripeMeterId,
+    pub event_name: String,
+}
+
 #[async_trait]
 pub trait StripeClient: Send + Sync {
     async fn list_customers_by_email(&self, email: &str) -> Result<Vec<StripeCustomer>>;
 
     async fn create_customer(&self, params: CreateCustomerParams<'_>) -> Result<StripeCustomer>;
+
+    async fn list_prices(&self) -> Result<Vec<StripePrice>>;
+
+    async fn list_meters(&self) -> Result<Vec<StripeMeter>>;
 }

--- a/crates/collab/src/stripe_client/fake_stripe_client.rs
+++ b/crates/collab/src/stripe_client/fake_stripe_client.rs
@@ -6,16 +6,23 @@ use collections::HashMap;
 use parking_lot::Mutex;
 use uuid::Uuid;
 
-use crate::stripe_client::{CreateCustomerParams, StripeClient, StripeCustomer, StripeCustomerId};
+use crate::stripe_client::{
+    CreateCustomerParams, StripeClient, StripeCustomer, StripeCustomerId, StripeMeter,
+    StripeMeterId, StripePrice, StripePriceId,
+};
 
 pub struct FakeStripeClient {
     pub customers: Arc<Mutex<HashMap<StripeCustomerId, StripeCustomer>>>,
+    pub prices: Arc<Mutex<HashMap<StripePriceId, StripePrice>>>,
+    pub meters: Arc<Mutex<HashMap<StripeMeterId, StripeMeter>>>,
 }
 
 impl FakeStripeClient {
     pub fn new() -> Self {
         Self {
             customers: Arc::new(Mutex::new(HashMap::default())),
+            prices: Arc::new(Mutex::new(HashMap::default())),
+            meters: Arc::new(Mutex::new(HashMap::default())),
         }
     }
 }
@@ -43,5 +50,17 @@ impl StripeClient for FakeStripeClient {
             .insert(customer.id.clone(), customer.clone());
 
         Ok(customer)
+    }
+
+    async fn list_prices(&self) -> Result<Vec<StripePrice>> {
+        let prices = self.prices.lock().values().cloned().collect();
+
+        Ok(prices)
+    }
+
+    async fn list_meters(&self) -> Result<Vec<StripeMeter>> {
+        let meters = self.meters.lock().values().cloned().collect();
+
+        Ok(meters)
     }
 }

--- a/crates/collab/src/stripe_client/real_stripe_client.rs
+++ b/crates/collab/src/stripe_client/real_stripe_client.rs
@@ -81,7 +81,7 @@ impl StripeClient for RealStripeClient {
             )
             .await?;
 
-        Ok(response.data.into_iter().map(StripeMeter::from).collect())
+        Ok(response.data)
     }
 }
 

--- a/crates/collab/src/stripe_client/real_stripe_client.rs
+++ b/crates/collab/src/stripe_client/real_stripe_client.rs
@@ -3,9 +3,13 @@ use std::sync::Arc;
 
 use anyhow::{Context as _, Result};
 use async_trait::async_trait;
-use stripe::{CreateCustomer, Customer, CustomerId, ListCustomers};
+use serde::Serialize;
+use stripe::{CreateCustomer, Customer, CustomerId, ListCustomers, Price, PriceId, Recurring};
 
-use crate::stripe_client::{CreateCustomerParams, StripeClient, StripeCustomer, StripeCustomerId};
+use crate::stripe_client::{
+    CreateCustomerParams, StripeClient, StripeCustomer, StripeCustomerId, StripeMeter, StripePrice,
+    StripePriceId, StripePriceRecurring,
+};
 
 pub struct RealStripeClient {
     client: Arc<stripe::Client>,
@@ -48,6 +52,37 @@ impl StripeClient for RealStripeClient {
 
         Ok(StripeCustomer::from(customer))
     }
+
+    async fn list_prices(&self) -> Result<Vec<StripePrice>> {
+        let response = stripe::Price::list(
+            &self.client,
+            &stripe::ListPrices {
+                limit: Some(100),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        Ok(response.data.into_iter().map(StripePrice::from).collect())
+    }
+
+    async fn list_meters(&self) -> Result<Vec<StripeMeter>> {
+        #[derive(Serialize)]
+        struct Params {
+            #[serde(skip_serializing_if = "Option::is_none")]
+            limit: Option<u64>,
+        }
+
+        let response = self
+            .client
+            .get_query::<stripe::List<StripeMeter>, _>(
+                "/billing/meters",
+                Params { limit: Some(100) },
+            )
+            .await?;
+
+        Ok(response.data.into_iter().map(StripeMeter::from).collect())
+    }
 }
 
 impl From<CustomerId> for StripeCustomerId {
@@ -70,5 +105,36 @@ impl From<Customer> for StripeCustomer {
             id: value.id.into(),
             email: value.email,
         }
+    }
+}
+
+impl From<PriceId> for StripePriceId {
+    fn from(value: PriceId) -> Self {
+        Self(value.as_str().into())
+    }
+}
+
+impl TryFrom<StripePriceId> for PriceId {
+    type Error = anyhow::Error;
+
+    fn try_from(value: StripePriceId) -> Result<Self, Self::Error> {
+        Self::from_str(value.0.as_ref()).context("failed to parse Stripe price ID")
+    }
+}
+
+impl From<Price> for StripePrice {
+    fn from(value: Price) -> Self {
+        Self {
+            id: value.id.into(),
+            unit_amount: value.unit_amount,
+            lookup_key: value.lookup_key,
+            recurring: value.recurring.map(StripePriceRecurring::from),
+        }
+    }
+}
+
+impl From<Recurring> for StripePriceRecurring {
+    fn from(value: Recurring) -> Self {
+        Self { meter: value.meter }
     }
 }

--- a/crates/collab/src/tests/stripe_billing_tests.rs
+++ b/crates/collab/src/tests/stripe_billing_tests.rs
@@ -3,13 +3,96 @@ use std::sync::Arc;
 use pretty_assertions::assert_eq;
 
 use crate::stripe_billing::StripeBilling;
-use crate::stripe_client::FakeStripeClient;
+use crate::stripe_client::{
+    FakeStripeClient, StripeMeter, StripeMeterId, StripePrice, StripePriceId, StripePriceRecurring,
+};
 
 fn make_stripe_billing() -> (StripeBilling, Arc<FakeStripeClient>) {
     let stripe_client = Arc::new(FakeStripeClient::new());
     let stripe_billing = StripeBilling::test(stripe_client.clone());
 
     (stripe_billing, stripe_client)
+}
+
+#[gpui::test]
+async fn test_initialize() {
+    let (stripe_billing, stripe_client) = make_stripe_billing();
+
+    // Add test meters
+    let meter1 = StripeMeter {
+        id: StripeMeterId(Arc::from("meter_1")),
+        event_name: "event_1".to_string(),
+    };
+    let meter2 = StripeMeter {
+        id: StripeMeterId(Arc::from("meter_2")),
+        event_name: "event_2".to_string(),
+    };
+    stripe_client
+        .meters
+        .lock()
+        .insert(meter1.id.clone(), meter1);
+    stripe_client
+        .meters
+        .lock()
+        .insert(meter2.id.clone(), meter2);
+
+    // Add test prices
+    let price1 = StripePrice {
+        id: StripePriceId(Arc::from("price_1")),
+        unit_amount: Some(1_000),
+        lookup_key: Some("zed-pro".to_string()),
+        recurring: None,
+    };
+    let price2 = StripePrice {
+        id: StripePriceId(Arc::from("price_2")),
+        unit_amount: Some(0),
+        lookup_key: Some("zed-free".to_string()),
+        recurring: None,
+    };
+    let price3 = StripePrice {
+        id: StripePriceId(Arc::from("price_3")),
+        unit_amount: Some(500),
+        lookup_key: None,
+        recurring: Some(StripePriceRecurring {
+            meter: Some("meter_1".to_string()),
+        }),
+    };
+    stripe_client
+        .prices
+        .lock()
+        .insert(price1.id.clone(), price1);
+    stripe_client
+        .prices
+        .lock()
+        .insert(price2.id.clone(), price2);
+    stripe_client
+        .prices
+        .lock()
+        .insert(price3.id.clone(), price3);
+
+    // Initialize the billing system
+    stripe_billing.initialize().await.unwrap();
+
+    // Verify that prices can be found by lookup key
+    let zed_pro_price_id = stripe_billing.zed_pro_price_id().await.unwrap();
+    assert_eq!(zed_pro_price_id.to_string(), "price_1");
+
+    let zed_free_price_id = stripe_billing.zed_free_price_id().await.unwrap();
+    assert_eq!(zed_free_price_id.to_string(), "price_2");
+
+    // Verify that a price can be found by lookup key
+    let zed_pro_price = stripe_billing
+        .find_price_by_lookup_key("zed-pro")
+        .await
+        .unwrap();
+    assert_eq!(zed_pro_price.id.to_string(), "price_1");
+    assert_eq!(zed_pro_price.unit_amount, Some(1_000));
+
+    // Verify that finding a non-existent lookup key returns an error
+    let result = stripe_billing
+        .find_price_by_lookup_key("non-existent")
+        .await;
+    assert!(result.is_err());
 }
 
 #[gpui::test]

--- a/crates/collab/src/tests/stripe_billing_tests.rs
+++ b/crates/collab/src/tests/stripe_billing_tests.rs
@@ -20,11 +20,11 @@ async fn test_initialize() {
 
     // Add test meters
     let meter1 = StripeMeter {
-        id: StripeMeterId(Arc::from("meter_1")),
+        id: StripeMeterId("meter_1".into()),
         event_name: "event_1".to_string(),
     };
     let meter2 = StripeMeter {
-        id: StripeMeterId(Arc::from("meter_2")),
+        id: StripeMeterId("meter_2".into()),
         event_name: "event_2".to_string(),
     };
     stripe_client
@@ -38,19 +38,19 @@ async fn test_initialize() {
 
     // Add test prices
     let price1 = StripePrice {
-        id: StripePriceId(Arc::from("price_1")),
+        id: StripePriceId("price_1".into()),
         unit_amount: Some(1_000),
         lookup_key: Some("zed-pro".to_string()),
         recurring: None,
     };
     let price2 = StripePrice {
-        id: StripePriceId(Arc::from("price_2")),
+        id: StripePriceId("price_2".into()),
         unit_amount: Some(0),
         lookup_key: Some("zed-free".to_string()),
         recurring: None,
     };
     let price3 = StripePrice {
-        id: StripePriceId(Arc::from("price_3")),
+        id: StripePriceId("price_3".into()),
         unit_amount: Some(500),
         lookup_key: None,
         recurring: Some(StripePriceRecurring {


### PR DESCRIPTION
This PR updates `StripeBilling` to use the `StripeClient` trait to retrieve prices and meters from Stripe instead of using the `stripe::Client` directly.

Release Notes:

- N/A
