### PR TITLE
nix: Add job names and garnix substitutor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -714,6 +714,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   nix-build:
+    name: Build with Nix
     uses: ./.github/workflows/nix.yml
     if: github.repository_owner == 'zed-industries' && contains(github.event.pull_request.labels.*.name, 'run-nix')
     with:

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -56,6 +56,7 @@ jobs:
           name: zed
           authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
           pushFilter: "${{ inputs.cachix-filter }}"
+          cachixArgs: '-v'
 
       - run: nix build .#${{ inputs.flake-output }} -L --accept-flake-config
 

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -168,6 +168,7 @@ jobs:
         run: script/upload-nightly linux-targz
 
   bundle-nix:
+    name: Build and cache Nix package
     needs: tests
     uses: ./.github/workflows/nix.yml
 

--- a/flake.nix
+++ b/flake.nix
@@ -54,9 +54,13 @@
     };
 
   nixConfig = {
-    extra-substituters = [ "https://zed.cachix.org" ];
+    extra-substituters = [
+      "https://zed.cachix.org"
+      "https://cache.garnix.io"
+    ];
     extra-trusted-public-keys = [
       "zed.cachix.org-1:/pHQ6dpMsAZk2DiP4WCL0p9YDNKWj2Q5FL20bNmw1cU="
+      "cache.garnix.io:CTFPyKSLcx5RMJKfLo5EEPUObbA78b0YQ2DTCJXqr9g="
     ];
   };
 }


### PR DESCRIPTION
This should result in some additional cache hits as I personally use garnix.

Also added `-v` cachix arg to try to figure out why CI jobs aren't pushing any paths. Right now they just show ["Pushing is disabled."](https://github.com/zed-industries/zed/actions/runs/15293723678/job/43018512167#step:13:3) but I'm not sure if that's due to the `pushFilter` or misconfigured secrets.

Release Notes:

- N/A