### PR TITLE
python: Improve docstring highlighting

### DIFF
--- a/crates/languages/src/python/highlights.scm
+++ b/crates/languages/src/python/highlights.scm
@@ -151,6 +151,12 @@
   "}" @punctuation.special) @embedded
 
 ; Docstrings.
+([
+  (expression_statement (assignment))
+  (type_alias_statement)
+]
+. (expression_statement (string) @string.doc)+)
+
 (module
   .(expression_statement (string) @string.doc)+)
 
@@ -171,13 +177,6 @@
 
 (module
   . (comment) @comment*
-  . (expression_statement (string) @string.doc)+)
-
-(module
-  [
-    (expression_statement (assignment))
-    (type_alias_statement)
-  ]
   . (expression_statement (string) @string.doc)+)
 
 (class_definition


### PR DESCRIPTION
This PR broadens the highlighting for docstrings in Python. 

Previously, only the first docstring for e.g. type aliases was highlighted in Python files. This happened as only the first occurrence in the module was considered a docstring. With this change, now all existing docstrings are actually highlighted as such.

| `main` | This PR | 
| --- | --- |
| ![main](https://github.com/user-attachments/assets/facc96a9-4e98-4063-8b93-d6e9884221ff) | ![PR](https://github.com/user-attachments/assets/9da557a1-b327-466a-be87-65d6a811e24c) |

Release Notes:

- Added more docstring highlights for Python.
