### PR TITLE
collab: Use `StripeClient` in `StripeBilling::subscribe_to_price`

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -1578,7 +1578,7 @@ async fn sync_model_request_usage_with_stripe(
             };
 
             stripe_billing
-                .subscribe_to_price(&stripe_subscription_id, price)
+                .subscribe_to_price(&stripe_subscription_id.into(), price)
                 .await?;
             stripe_billing
                 .bill_model_request_usage(

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -44,23 +44,23 @@ pub struct StripeSubscriptionItem {
     pub price: Option<StripePrice>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UpdateSubscriptionParams {
     pub items: Option<Vec<UpdateSubscriptionItems>>,
     pub trial_settings: Option<UpdateSubscriptionTrialSettings>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct UpdateSubscriptionItems {
     pub price: Option<StripePriceId>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UpdateSubscriptionTrialSettings {
     pub end_behavior: UpdateSubscriptionTrialSettingsEndBehavior,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct UpdateSubscriptionTrialSettingsEndBehavior {
     pub missing_payment_method: UpdateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod,
 }

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -27,6 +27,52 @@ pub struct CreateCustomerParams<'a> {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
+pub struct StripeSubscriptionId(pub Arc<str>);
+
+#[derive(Debug, Clone)]
+pub struct StripeSubscription {
+    pub id: StripeSubscriptionId,
+    pub items: Vec<StripeSubscriptionItem>,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
+pub struct StripeSubscriptionItemId(pub Arc<str>);
+
+#[derive(Debug, Clone)]
+pub struct StripeSubscriptionItem {
+    pub id: StripeSubscriptionItemId,
+    pub price: Option<StripePrice>,
+}
+
+#[derive(Debug)]
+pub struct UpdateSubscriptionParams {
+    pub items: Option<Vec<UpdateSubscriptionItems>>,
+    pub trial_settings: Option<UpdateSubscriptionTrialSettings>,
+}
+
+#[derive(Debug)]
+pub struct UpdateSubscriptionItems {
+    pub price: Option<StripePriceId>,
+}
+
+#[derive(Debug)]
+pub struct UpdateSubscriptionTrialSettings {
+    pub end_behavior: UpdateSubscriptionTrialSettingsEndBehavior,
+}
+
+#[derive(Debug)]
+pub struct UpdateSubscriptionTrialSettingsEndBehavior {
+    pub missing_payment_method: UpdateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum UpdateSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod {
+    Cancel,
+    CreateInvoice,
+    Pause,
+}
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
 pub struct StripePriceId(pub Arc<str>);
 
 #[derive(Debug, Clone)]
@@ -56,6 +102,17 @@ pub trait StripeClient: Send + Sync {
     async fn list_customers_by_email(&self, email: &str) -> Result<Vec<StripeCustomer>>;
 
     async fn create_customer(&self, params: CreateCustomerParams<'_>) -> Result<StripeCustomer>;
+
+    async fn get_subscription(
+        &self,
+        subscription_id: &StripeSubscriptionId,
+    ) -> Result<StripeSubscription>;
+
+    async fn update_subscription(
+        &self,
+        subscription_id: &StripeSubscriptionId,
+        params: UpdateSubscriptionParams,
+    ) -> Result<()>;
 
     async fn list_prices(&self) -> Result<Vec<StripePrice>>;
 

--- a/crates/collab/src/stripe_client/fake_stripe_client.rs
+++ b/crates/collab/src/stripe_client/fake_stripe_client.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use collections::HashMap;
 use parking_lot::Mutex;
@@ -8,11 +8,13 @@ use uuid::Uuid;
 
 use crate::stripe_client::{
     CreateCustomerParams, StripeClient, StripeCustomer, StripeCustomerId, StripeMeter,
-    StripeMeterId, StripePrice, StripePriceId,
+    StripeMeterId, StripePrice, StripePriceId, StripeSubscription, StripeSubscriptionId,
+    UpdateSubscriptionParams,
 };
 
 pub struct FakeStripeClient {
     pub customers: Arc<Mutex<HashMap<StripeCustomerId, StripeCustomer>>>,
+    pub subscriptions: Arc<Mutex<HashMap<StripeSubscriptionId, StripeSubscription>>>,
     pub prices: Arc<Mutex<HashMap<StripePriceId, StripePrice>>>,
     pub meters: Arc<Mutex<HashMap<StripeMeterId, StripeMeter>>>,
 }
@@ -21,6 +23,7 @@ impl FakeStripeClient {
     pub fn new() -> Self {
         Self {
             customers: Arc::new(Mutex::new(HashMap::default())),
+            subscriptions: Arc::new(Mutex::new(HashMap::default())),
             prices: Arc::new(Mutex::new(HashMap::default())),
             meters: Arc::new(Mutex::new(HashMap::default())),
         }
@@ -50,6 +53,27 @@ impl StripeClient for FakeStripeClient {
             .insert(customer.id.clone(), customer.clone());
 
         Ok(customer)
+    }
+
+    async fn get_subscription(
+        &self,
+        subscription_id: &StripeSubscriptionId,
+    ) -> Result<StripeSubscription> {
+        self.subscriptions
+            .lock()
+            .get(subscription_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("no subscription found for {subscription_id:?}"))
+    }
+
+    async fn update_subscription(
+        &self,
+        subscription_id: &StripeSubscriptionId,
+        _params: UpdateSubscriptionParams,
+    ) -> Result<()> {
+        let _subscription = self.get_subscription(subscription_id).await?;
+
+        Ok(())
     }
 
     async fn list_prices(&self) -> Result<Vec<StripePrice>> {


### PR DESCRIPTION
This PR updates the `StripeBilling::subscribe_to_price` method to use the `StripeClient` trait.

Release Notes:

- N/A
