### PR TITLE
file_finder: Reduce vertical padding in footer

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -1527,7 +1527,6 @@ impl PickerDelegate for FileFinderDelegate {
                 )
                 .child(
                     h_flex()
-                        .p_2()
                         .gap_2()
                         .child(
                             Button::new("open-selection", "Open").on_click(|_, window, cx| {


### PR DESCRIPTION
Follow-up to #31542

This PR reduces the vertical padding in the file finders footer. We can remove this padding as we already apply it just above

https://github.com/zed-industries/zed/blob/a5a116439e711772190b7fb8e5507eb5dbd95237/crates/file_finder/src/file_finder.rs#L1500

This also ensures that the items on the right side have the same padding to the border as the icon on the left side. Currently, due to the padding being applied twice, the items on the right side have `pr_4` as well as `py_4` in practice, which seems a little excessive.

| `main` | This PR |
| --- | --- |
| ![file_finder_main](https://github.com/user-attachments/assets/352d2ac9-04a9-487d-96ca-b009b797809b) | ![file_finder_pr](https://github.com/user-attachments/assets/c0b44beb-ff2c-4e93-a5b1-2393652a2a58) |


Release Notes:

- N/A
