### PR TITLE
collab: Remove Zed Free as an option when initiating a checkout session

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -283,7 +283,6 @@ async fn list_billing_subscriptions(
 enum ProductCode {
     ZedPro,
     ZedProTrial,
-    ZedFree,
 }
 
 #[derive(Debug, Deserialize)]
@@ -378,11 +377,6 @@ async fn create_billing_subscription(
                     feature_flags,
                     &success_url,
                 )
-                .await?
-        }
-        ProductCode::ZedFree => {
-            stripe_billing
-                .checkout_with_zed_free(customer_id, &user.github_login, &success_url)
                 .await?
         }
     };

--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -342,31 +342,6 @@ impl StripeBilling {
 
         Ok(subscription)
     }
-
-    pub async fn checkout_with_zed_free(
-        &self,
-        customer_id: stripe::CustomerId,
-        github_login: &str,
-        success_url: &str,
-    ) -> Result<String> {
-        let zed_free_price_id = self.zed_free_price_id().await?;
-
-        let mut params = stripe::CreateCheckoutSession::new();
-        params.mode = Some(stripe::CheckoutSessionMode::Subscription);
-        params.payment_method_collection =
-            Some(stripe::CheckoutSessionPaymentMethodCollection::IfRequired);
-        params.customer = Some(customer_id);
-        params.client_reference_id = Some(github_login);
-        params.line_items = Some(vec![stripe::CreateCheckoutSessionLineItems {
-            price: Some(zed_free_price_id.to_string()),
-            quantity: Some(1),
-            ..Default::default()
-        }]);
-        params.success_url = Some(success_url);
-
-        let session = stripe::CheckoutSession::create(&self.real_client, params).await?;
-        Ok(session.url.context("no checkout session URL")?)
-    }
 }
 
 fn subscription_contains_price(


### PR DESCRIPTION
This PR removes Zed Free as an option when initiating a checkout session, as we manage this plan automatically now.

Release Notes:

- N/A
