### PR TITLE
recent_projects: Move SSH server entry to initialize once instead of every render

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -289,7 +289,6 @@ struct DefaultState {
     scrollbar: ScrollbarState,
     add_new_server: NavigableEntry,
     servers: Vec<RemoteEntry>,
-    handle: ScrollHandle,
 }
 
 impl DefaultState {
@@ -339,7 +338,6 @@ impl DefaultState {
             scrollbar,
             add_new_server,
             servers,
-            handle,
         }
     }
 }


### PR DESCRIPTION
Currently, `RemoteEntry::SshConfig` for `ssh_config_servers` initializes on every render. This leads to side effects like a new focus handle being created on every render, which leads to breaking navigating up/down for `ssh_config_servers` items.

This PR fixes it by moving the logic of remote entry for`ssh_config_servers` into `default_mode`, and only rebuilding it when `ssh_config_servers` actually changes. 

Before:

https://github.com/user-attachments/assets/8c7187d3-16b5-4f96-aa73-fe4f8227b7d0

After:

https://github.com/user-attachments/assets/21588628-8b1c-43fb-bcb8-0b93c70a1e2b

Release Notes:

- Fixed issue navigating SSH config servers in Remote Projects with keyboard.