### PR TITLE
recent_projects: Fix remote projects not regaining focus after SSH server connect

### DIFF
--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -474,14 +474,15 @@ impl RemoteServerProjects {
         .prompt_err("Failed to connect", window, cx, |_, _, _| None);
 
         let address_editor = editor.clone();
-        let creating = cx.spawn(async move |this, cx| {
+        let creating = cx.spawn_in(window, async move |this, cx| {
             match connection.await {
                 Some(Some(client)) => this
-                    .update(cx, |this, cx| {
+                    .update_in(cx, |this, window, cx| {
                         telemetry::event!("SSH Server Created");
                         this.retained_connections.push(client);
                         this.add_ssh_server(connection_options, cx);
                         this.mode = Mode::default_mode(cx);
+                        this.focus_handle(cx).focus(window);
                         cx.notify()
                     })
                     .log_err(),


### PR DESCRIPTION
Closes #28071

Release Notes:

- Fixed issue preventing remote projects modal from regaining focus after a successful SSH server connection.