### PR TITLE
Revert "task: Wrap programs in ""s (#31537)"

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -382,7 +382,10 @@ impl ContextProvider for PythonContextProvider {
                 toolchains
                     .active_toolchain(worktree_id, Arc::from("".as_ref()), "Python".into(), cx)
                     .await
-                    .map_or_else(|| "python3".to_owned(), |toolchain| toolchain.path.into())
+                    .map_or_else(
+                        || "python3".to_owned(),
+                        |toolchain| format!("\"{}\"", toolchain.path),
+                    )
             } else {
                 String::from("python3")
             };

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -384,7 +384,6 @@ impl ShellBuilder {
 
     /// Returns the program and arguments to run this task in a shell.
     pub fn build(mut self, task_command: String, task_args: &Vec<String>) -> (String, Vec<String>) {
-        let task_command = format!("\"{task_command}\"");
         let combined_command = task_args
             .into_iter()
             .fold(task_command, |mut command, arg| {


### PR DESCRIPTION
That commit broke a lot, as our one-off tasks (alt-enter in the tasks modal), npm, jest tasks are all not real commands, but a composition of commands and arguments.

This reverts commit 5db14d315b0822c6d261c0853a3ea039877fd8a8.

Closes https://github.com/zed-industries/zed/issues/31554

Release Notes:

- N/A 
