### PR TITLE
Allow to reuse PickerPopoverMenu outside of the model selector

### DIFF
--- a/crates/agent/src/agent_model_selector.rs
+++ b/crates/agent/src/agent_model_selector.rs
@@ -1,10 +1,11 @@
 use agent_settings::AgentSettings;
 use fs::Fs;
 use gpui::{Entity, FocusHandle, SharedString};
+use picker::popover_menu::PickerPopoverMenu;
 
 use crate::Thread;
 use assistant_context_editor::language_model_selector::{
-    LanguageModelSelector, LanguageModelSelectorPopoverMenu, ToggleModelSelector,
+    LanguageModelSelector, ToggleModelSelector, language_model_selector,
 };
 use language_model::{ConfiguredModel, LanguageModelRegistry};
 use settings::update_settings_file;
@@ -35,7 +36,7 @@ impl AgentModelSelector {
         Self {
             selector: cx.new(move |cx| {
                 let fs = fs.clone();
-                LanguageModelSelector::new(
+                language_model_selector(
                     {
                         let model_type = model_type.clone();
                         move |cx| match &model_type {
@@ -100,15 +101,14 @@ impl AgentModelSelector {
 }
 
 impl Render for AgentModelSelector {
-    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let focus_handle = self.focus_handle.clone();
 
-        let model = self.selector.read(cx).active_model(cx);
+        let model = self.selector.read(cx).delegate.active_model(cx);
         let model_name = model
             .map(|model| model.model.name().0)
             .unwrap_or_else(|| SharedString::from("No model selected"));
-
-        LanguageModelSelectorPopoverMenu::new(
+        PickerPopoverMenu::new(
             self.selector.clone(),
             Button::new("active-model", model_name)
                 .label_size(LabelSize::Small)
@@ -127,7 +127,9 @@ impl Render for AgentModelSelector {
                 )
             },
             gpui::Corner::BottomRight,
+            cx,
         )
         .with_handle(self.menu_handle.clone())
+        .render(window, cx)
     }
 }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -1,3 +1,7 @@
+mod head;
+pub mod highlighted_match_with_paths;
+pub mod popover_menu;
+
 use anyhow::Result;
 use editor::{
     Editor,
@@ -19,9 +23,6 @@ use ui::{
 };
 use util::ResultExt;
 use workspace::ModalView;
-
-mod head;
-pub mod highlighted_match_with_paths;
 
 enum ElementContainer {
     List(ListState),

--- a/crates/picker/src/popover_menu.rs
+++ b/crates/picker/src/popover_menu.rs
@@ -1,0 +1,93 @@
+use gpui::{
+    AnyView, Corner, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription,
+};
+use ui::{
+    App, ButtonCommon, FluentBuilder as _, IntoElement, PopoverMenu, PopoverMenuHandle,
+    PopoverTrigger, RenderOnce, Window, px,
+};
+
+use crate::{Picker, PickerDelegate};
+
+pub struct PickerPopoverMenu<T, TT, P>
+where
+    T: PopoverTrigger + ButtonCommon,
+    TT: Fn(&mut Window, &mut App) -> AnyView + 'static,
+    P: PickerDelegate,
+{
+    picker: Entity<Picker<P>>,
+    trigger: T,
+    tooltip: TT,
+    handle: Option<PopoverMenuHandle<Picker<P>>>,
+    anchor: Corner,
+    _subscriptions: Vec<Subscription>,
+}
+
+impl<T, TT, P> PickerPopoverMenu<T, TT, P>
+where
+    T: PopoverTrigger + ButtonCommon,
+    TT: Fn(&mut Window, &mut App) -> AnyView + 'static,
+    P: PickerDelegate,
+{
+    pub fn new(
+        picker: Entity<Picker<P>>,
+        trigger: T,
+        tooltip: TT,
+        anchor: Corner,
+        cx: &mut App,
+    ) -> Self {
+        Self {
+            _subscriptions: vec![cx.subscribe(&picker, |picker, &DismissEvent, cx| {
+                picker.update(cx, |_, cx| cx.emit(DismissEvent));
+            })],
+            picker,
+            trigger,
+            tooltip,
+            handle: None,
+            anchor,
+        }
+    }
+
+    pub fn with_handle(mut self, handle: PopoverMenuHandle<Picker<P>>) -> Self {
+        self.handle = Some(handle);
+        self
+    }
+}
+
+impl<T, TT, P> EventEmitter<DismissEvent> for PickerPopoverMenu<T, TT, P>
+where
+    T: PopoverTrigger + ButtonCommon,
+    TT: Fn(&mut Window, &mut App) -> AnyView + 'static,
+    P: PickerDelegate,
+{
+}
+
+impl<T, TT, P> Focusable for PickerPopoverMenu<T, TT, P>
+where
+    T: PopoverTrigger + ButtonCommon,
+    TT: Fn(&mut Window, &mut App) -> AnyView + 'static,
+    P: PickerDelegate,
+{
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl<T, TT, P> RenderOnce for PickerPopoverMenu<T, TT, P>
+where
+    T: PopoverTrigger + ButtonCommon,
+    TT: Fn(&mut Window, &mut App) -> AnyView + 'static,
+    P: PickerDelegate,
+{
+    fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
+        let picker = self.picker.clone();
+        PopoverMenu::new("popover-menu")
+            .menu(move |_window, _cx| Some(picker.clone()))
+            .trigger_with_tooltip(self.trigger, self.tooltip)
+            .anchor(self.anchor)
+            .when_some(self.handle.clone(), |menu, handle| menu.with_handle(handle))
+            .offset(gpui::Point {
+                x: px(0.0),
+                y: px(-2.0),
+            })
+    }
+}


### PR DESCRIPTION
LSP button preparation step: move out the component that will be used to build the button's context menu.

Release Notes:

- N/A
