### PR TITLE
markdown_preview: Fix release notes title being overridden

### DIFF
--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -91,7 +91,7 @@ fn view_release_notes_locally(
 
                             let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
 
-                            let tab_content = SharedString::from(body.title.to_string());
+                            let tab_content = Some(SharedString::from(body.title.to_string()));
                             let editor = cx.new(|cx| {
                                 Editor::for_multibuffer(buffer, Some(project), window, cx)
                             });

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -496,7 +496,9 @@ impl Item for MarkdownPreviewView {
     }
 
     fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
-        self.tab_content_text.clone().unwrap_or_else(|| SharedString::from("Markdown Preview"))
+        self.tab_content_text
+            .clone()
+            .unwrap_or_else(|| SharedString::from("Markdown Preview"))
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -36,7 +36,7 @@ pub struct MarkdownPreviewView {
     contents: Option<ParsedMarkdown>,
     selected_block: usize,
     list_state: ListState,
-    tab_content_text: SharedString,
+    tab_content_text: Option<SharedString>,
     language_registry: Arc<LanguageRegistry>,
     parsing_markdown_task: Option<Task<Result<()>>>,
 }
@@ -130,7 +130,7 @@ impl MarkdownPreviewView {
             editor,
             workspace_handle,
             language_registry,
-            "".into(),
+            None,
             window,
             cx,
         )
@@ -141,7 +141,7 @@ impl MarkdownPreviewView {
         active_editor: Entity<Editor>,
         workspace: WeakEntity<Workspace>,
         language_registry: Arc<LanguageRegistry>,
-        tab_content_text: SharedString,
+        tab_content_text: Option<SharedString>,
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) -> Entity<Self> {
@@ -345,8 +345,8 @@ impl MarkdownPreviewView {
         let tab_content = editor.read(cx).tab_content_text(0, cx);
 
         // Only update the tab content if it doesn't have a default value.
-        if self.tab_content_text.is_empty() {
-            self.tab_content_text = format!("Preview {}", tab_content).into();
+        if self.tab_content_text.is_none() {
+            self.tab_content_text = Some(format!("Preview {}", tab_content).into());
         }
 
         self.active_editor = Some(EditorState {
@@ -498,7 +498,7 @@ impl Item for MarkdownPreviewView {
     }
 
     fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
-        self.tab_content_text.clone()
+        self.tab_content_text.clone().unwrap_or_else(|| SharedString::from("Markdown Preview"))
     }
 
     fn telemetry_event_text(&self) -> Option<&'static str> {

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -130,7 +130,7 @@ impl MarkdownPreviewView {
             editor,
             workspace_handle,
             language_registry,
-            "Markdown Preview".into(),
+            "".into(),
             window,
             cx,
         )
@@ -343,7 +343,11 @@ impl MarkdownPreviewView {
         );
 
         let tab_content = editor.read(cx).tab_content_text(0, cx);
-        self.tab_content_text = format!("Preview {}", tab_content).into();
+
+        // Only update the tab content if it's not have a default value.
+        if self.tab_content_text.is_empty() {
+            self.tab_content_text = format!("Preview {}", tab_content).into();
+        }
 
         self.active_editor = Some(EditorState {
             editor,

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -343,8 +343,6 @@ impl MarkdownPreviewView {
         );
 
         let tab_content = editor.read(cx).tab_content_text(0, cx);
-
-        // Only update the tab content if it doesn't have a default value.
         if self.tab_content_text.is_none() {
             self.tab_content_text = Some(format!("Preview {}", tab_content).into());
         }

--- a/crates/markdown_preview/src/markdown_preview_view.rs
+++ b/crates/markdown_preview/src/markdown_preview_view.rs
@@ -344,7 +344,7 @@ impl MarkdownPreviewView {
 
         let tab_content = editor.read(cx).tab_content_text(0, cx);
 
-        // Only update the tab content if it's not have a default value.
+        // Only update the tab content if it doesn't have a default value.
         if self.tab_content_text.is_empty() {
             self.tab_content_text = format!("Preview {}", tab_content).into();
         }


### PR DESCRIPTION
Closes: #31701

Screenshot:

<img width="383" alt="image" src="https://github.com/user-attachments/assets/7fd8ce70-2208-4aca-bc70-860d6c649765" />



Release Notes:

- Fixed in-app release notes having an incorrect title
