### PR TITLE
Add View Release Notes to Help menu

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -214,8 +214,8 @@ pub fn app_menus() -> Vec<Menu> {
             name: "Help".into(),
             items: vec![
                 MenuItem::action(
-                    "View Release Notes", 
-                    auto_update_ui::ViewReleaseNotesLocally
+                    "View Release Notes",
+                    auto_update_ui::ViewReleaseNotesLocally,
                 ),
                 MenuItem::action("View Telemetry", zed_actions::OpenTelemetryLog),
                 MenuItem::action("View Dependency Licenses", zed_actions::OpenLicenses),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -213,7 +213,10 @@ pub fn app_menus() -> Vec<Menu> {
         Menu {
             name: "Help".into(),
             items: vec![
-                MenuItem::action("View Release Notes", auto_update_ui::ViewReleaseNotesLocally),
+                MenuItem::action(
+                    "View Release Notes", 
+                    auto_update_ui::ViewReleaseNotesLocally
+                ),
                 MenuItem::action("View Telemetry", zed_actions::OpenTelemetryLog),
                 MenuItem::action("View Dependency Licenses", zed_actions::OpenLicenses),
                 MenuItem::action("Show Welcome", workspace::Welcome),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -213,6 +213,7 @@ pub fn app_menus() -> Vec<Menu> {
         Menu {
             name: "Help".into(),
             items: vec![
+                MenuItem::action("View Release Notes", auto_update_ui::ViewReleaseNotesLocally),
                 MenuItem::action("View Telemetry", zed_actions::OpenTelemetryLog),
                 MenuItem::action("View Dependency Licenses", zed_actions::OpenLicenses),
                 MenuItem::action("Show Welcome", workspace::Welcome),


### PR DESCRIPTION

<img width="891" alt="image" src="https://github.com/user-attachments/assets/59e98fdb-c1b5-4948-8d69-661561d838f1" />



Release Notes:

- Added `View Release Notes` to `Help` menu
