### PR TITLE
workspace: Ensure pane handle hitbox blocks mouse events

### DIFF
--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1091,7 +1091,7 @@ mod element {
             };
 
             PaneAxisHandleLayout {
-                hitbox: window.insert_hitbox(handle_bounds, HitboxBehavior::Normal),
+                hitbox: window.insert_hitbox(handle_bounds, HitboxBehavior::BlockMouse),
                 divider_bounds,
             }
         }


### PR DESCRIPTION
Follow-up to #31712

Pane handle hitboxes were opaque prior to the linked PR. This was the case because pane handles have an intentionally larger hitbox than the pane dividers size to allow for easier dragging. The cursor style is also updated for that hitbox to indicate that resizing is possible:

https://github.com/zed-industries/zed/blob/908678403871e0ef18bbe20f78a84654dfdd431d/crates/workspace/src/pane_group.rs#L1297-L1301

Not blocking the mouse events here causes mouse events to bleed through this hitbox whilst actually any clicks will only cause a pane resize to happen. Hence, this hitbox should continue to block mouse events to avoid any confusion when resizing panes.

I considered using `HitboxBehavior::BlockMouseExceptScroll` here, however, due to the reasons mentioned above, I decided against it. The cursor will not indicate that scrolling should be possible. Since all other mouse events on underlying elements (like hovers) are blocked, it felt more reasonable to just go with `HitboxBehavior::BlockMouse`. 

Release Notes:

- N/A