### PR TITLE
collab: Fully move `StripeBilling` over to using `StripeClient`

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -1182,10 +1182,8 @@ async fn sync_subscription(
                 .has_active_billing_subscription(billing_customer.user_id)
                 .await?;
             if !already_has_active_billing_subscription {
-                let stripe_customer_id = billing_customer
-                    .stripe_customer_id
-                    .parse::<stripe::CustomerId>()
-                    .context("failed to parse Stripe customer ID from database")?;
+                let stripe_customer_id =
+                    StripeCustomerId(billing_customer.stripe_customer_id.clone().into());
 
                 stripe_billing
                     .subscribe_to_zed_free(stripe_customer_id)

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -5,6 +5,7 @@ use crate::api::{CloudflareIpCountryHeader, SystemIdHeader};
 use crate::db::billing_subscription::SubscriptionKind;
 use crate::llm::db::LlmDatabase;
 use crate::llm::{AGENT_EXTENDED_TRIAL_FEATURE_FLAG, LlmTokenClaims};
+use crate::stripe_client::StripeCustomerId;
 use crate::{
     AppState, Error, Result, auth,
     db::{
@@ -4055,10 +4056,8 @@ async fn get_llm_api_token(
         if let Some(billing_subscription) = db.get_active_billing_subscription(user.id).await? {
             billing_subscription
         } else {
-            let stripe_customer_id = billing_customer
-                .stripe_customer_id
-                .parse::<stripe::CustomerId>()
-                .context("failed to parse Stripe customer ID from database")?;
+            let stripe_customer_id =
+                StripeCustomerId(billing_customer.stripe_customer_id.clone().into());
 
             let stripe_subscription = stripe_billing
                 .subscribe_to_zed_free(stripe_customer_id)

--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -24,7 +24,6 @@ use crate::stripe_client::{
 
 pub struct StripeBilling {
     state: RwLock<StripeBillingState>,
-    real_client: Arc<stripe::Client>,
     client: Arc<dyn StripeClient>,
 }
 
@@ -39,7 +38,6 @@ impl StripeBilling {
     pub fn new(client: Arc<stripe::Client>) -> Self {
         Self {
             client: Arc::new(RealStripeClient::new(client.clone())),
-            real_client: client,
             state: RwLock::default(),
         }
     }
@@ -47,8 +45,6 @@ impl StripeBilling {
     #[cfg(test)]
     pub fn test(client: Arc<crate::stripe_client::FakeStripeClient>) -> Self {
         Self {
-            // This is just temporary until we can remove all usages of the real Stripe client.
-            real_client: Arc::new(stripe::Client::new("sk_test")),
             client,
             state: RwLock::default(),
         }

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -30,7 +30,7 @@ pub struct CreateCustomerParams<'a> {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
 pub struct StripeSubscriptionId(pub Arc<str>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StripeSubscription {
     pub id: StripeSubscriptionId,
     // TODO: Create our own version of this enum.
@@ -43,7 +43,7 @@ pub struct StripeSubscription {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
 pub struct StripeSubscriptionItemId(pub Arc<str>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StripeSubscriptionItem {
     pub id: StripeSubscriptionItemId,
     pub price: Option<StripePrice>,
@@ -92,7 +92,7 @@ pub enum StripeSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod {
 #[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
 pub struct StripePriceId(pub Arc<str>);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StripePrice {
     pub id: StripePriceId,
     pub unit_amount: Option<i64>,
@@ -100,7 +100,7 @@ pub struct StripePrice {
     pub recurring: Option<StripePriceRecurring>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, PartialEq, Clone)]
 pub struct StripePriceRecurring {
     pub meter: Option<String>,
 }

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -33,6 +33,7 @@ pub struct StripeSubscriptionId(pub Arc<str>);
 #[derive(Debug, PartialEq, Clone)]
 pub struct StripeSubscription {
     pub id: StripeSubscriptionId,
+    pub customer: StripeCustomerId,
     // TODO: Create our own version of this enum.
     pub status: stripe::SubscriptionStatus,
     pub current_period_end: i64,

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -33,6 +33,10 @@ pub struct StripeSubscriptionId(pub Arc<str>);
 #[derive(Debug, Clone)]
 pub struct StripeSubscription {
     pub id: StripeSubscriptionId,
+    // TODO: Create our own version of this enum.
+    pub status: stripe::SubscriptionStatus,
+    pub current_period_end: i64,
+    pub current_period_start: i64,
     pub items: Vec<StripeSubscriptionItem>,
 }
 
@@ -43,6 +47,18 @@ pub struct StripeSubscriptionItemId(pub Arc<str>);
 pub struct StripeSubscriptionItem {
     pub id: StripeSubscriptionItemId,
     pub price: Option<StripePrice>,
+}
+
+#[derive(Debug)]
+pub struct StripeCreateSubscriptionParams {
+    pub customer: StripeCustomerId,
+    pub items: Vec<StripeCreateSubscriptionItems>,
+}
+
+#[derive(Debug)]
+pub struct StripeCreateSubscriptionItems {
+    pub price: Option<StripePriceId>,
+    pub quantity: Option<u64>,
 }
 
 #[derive(Debug, Clone)]
@@ -160,9 +176,19 @@ pub trait StripeClient: Send + Sync {
 
     async fn create_customer(&self, params: CreateCustomerParams<'_>) -> Result<StripeCustomer>;
 
+    async fn list_subscriptions_for_customer(
+        &self,
+        customer_id: &StripeCustomerId,
+    ) -> Result<Vec<StripeSubscription>>;
+
     async fn get_subscription(
         &self,
         subscription_id: &StripeSubscriptionId,
+    ) -> Result<StripeSubscription>;
+
+    async fn create_subscription(
+        &self,
+        params: StripeCreateSubscriptionParams,
     ) -> Result<StripeSubscription>;
 
     async fn update_subscription(

--- a/crates/collab/src/stripe_client/real_stripe_client.rs
+++ b/crates/collab/src/stripe_client/real_stripe_client.rs
@@ -268,6 +268,7 @@ impl From<Subscription> for StripeSubscription {
     fn from(value: Subscription) -> Self {
         Self {
             id: value.id.into(),
+            customer: value.customer.id().into(),
             status: value.status,
             current_period_start: value.current_period_start,
             current_period_end: value.current_period_end,

--- a/crates/collab/src/stripe_client/real_stripe_client.rs
+++ b/crates/collab/src/stripe_client/real_stripe_client.rs
@@ -20,10 +20,11 @@ use crate::stripe_client::{
     CreateCustomerParams, StripeCheckoutSession, StripeCheckoutSessionMode,
     StripeCheckoutSessionPaymentMethodCollection, StripeClient,
     StripeCreateCheckoutSessionLineItems, StripeCreateCheckoutSessionParams,
-    StripeCreateCheckoutSessionSubscriptionData, StripeCreateMeterEventParams, StripeCustomer,
-    StripeCustomerId, StripeMeter, StripePrice, StripePriceId, StripePriceRecurring,
-    StripeSubscription, StripeSubscriptionId, StripeSubscriptionItem, StripeSubscriptionItemId,
-    StripeSubscriptionTrialSettings, StripeSubscriptionTrialSettingsEndBehavior,
+    StripeCreateCheckoutSessionSubscriptionData, StripeCreateMeterEventParams,
+    StripeCreateSubscriptionParams, StripeCustomer, StripeCustomerId, StripeMeter, StripePrice,
+    StripePriceId, StripePriceRecurring, StripeSubscription, StripeSubscriptionId,
+    StripeSubscriptionItem, StripeSubscriptionItemId, StripeSubscriptionTrialSettings,
+    StripeSubscriptionTrialSettingsEndBehavior,
     StripeSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod, UpdateSubscriptionParams,
 };
 
@@ -69,6 +70,29 @@ impl StripeClient for RealStripeClient {
         Ok(StripeCustomer::from(customer))
     }
 
+    async fn list_subscriptions_for_customer(
+        &self,
+        customer_id: &StripeCustomerId,
+    ) -> Result<Vec<StripeSubscription>> {
+        let customer_id = customer_id.try_into()?;
+
+        let subscriptions = stripe::Subscription::list(
+            &self.client,
+            &stripe::ListSubscriptions {
+                customer: Some(customer_id),
+                status: None,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        Ok(subscriptions
+            .data
+            .into_iter()
+            .map(StripeSubscription::from)
+            .collect())
+    }
+
     async fn get_subscription(
         &self,
         subscription_id: &StripeSubscriptionId,
@@ -76,6 +100,30 @@ impl StripeClient for RealStripeClient {
         let subscription_id = subscription_id.try_into()?;
 
         let subscription = Subscription::retrieve(&self.client, &subscription_id, &[]).await?;
+
+        Ok(StripeSubscription::from(subscription))
+    }
+
+    async fn create_subscription(
+        &self,
+        params: StripeCreateSubscriptionParams,
+    ) -> Result<StripeSubscription> {
+        let customer_id = params.customer.try_into()?;
+
+        let mut create_subscription = stripe::CreateSubscription::new(customer_id);
+        create_subscription.items = Some(
+            params
+                .items
+                .into_iter()
+                .map(|item| stripe::CreateSubscriptionItems {
+                    price: item.price.map(|price| price.to_string()),
+                    quantity: item.quantity,
+                    ..Default::default()
+                })
+                .collect(),
+        );
+
+        let subscription = Subscription::create(&self.client, create_subscription).await?;
 
         Ok(StripeSubscription::from(subscription))
     }
@@ -220,6 +268,9 @@ impl From<Subscription> for StripeSubscription {
     fn from(value: Subscription) -> Self {
         Self {
             id: value.id.into(),
+            status: value.status,
+            current_period_start: value.current_period_start,
+            current_period_end: value.current_period_end,
             items: value.items.data.into_iter().map(Into::into).collect(),
         }
     }

--- a/crates/collab/src/tests/stripe_billing_tests.rs
+++ b/crates/collab/src/tests/stripe_billing_tests.rs
@@ -167,6 +167,7 @@ async fn test_subscribe_to_price() {
     let now = Utc::now();
     let subscription = StripeSubscription {
         id: StripeSubscriptionId("sub_test".into()),
+        customer: StripeCustomerId("cus_test".into()),
         status: stripe::SubscriptionStatus::Active,
         current_period_start: now.timestamp(),
         current_period_end: (now + Duration::days(30)).timestamp(),
@@ -202,6 +203,7 @@ async fn test_subscribe_to_price() {
         let now = Utc::now();
         let subscription = StripeSubscription {
             id: StripeSubscriptionId("sub_test".into()),
+            customer: StripeCustomerId("cus_test".into()),
             status: stripe::SubscriptionStatus::Active,
             current_period_start: now.timestamp(),
             current_period_end: (now + Duration::days(30)).timestamp(),
@@ -270,6 +272,7 @@ async fn test_subscribe_to_zed_free() {
         let now = Utc::now();
         let existing_subscription = StripeSubscription {
             id: StripeSubscriptionId("sub_existing_active".into()),
+            customer: customer_id.clone(),
             status: stripe::SubscriptionStatus::Active,
             current_period_start: now.timestamp(),
             current_period_end: (now + Duration::days(30)).timestamp(),
@@ -298,6 +301,7 @@ async fn test_subscribe_to_zed_free() {
         let now = Utc::now();
         let existing_subscription = StripeSubscription {
             id: StripeSubscriptionId("sub_existing_trial".into()),
+            customer: customer_id.clone(),
             status: stripe::SubscriptionStatus::Trialing,
             current_period_start: now.timestamp(),
             current_period_end: (now + Duration::days(14)).timestamp(),

--- a/crates/collab/src/tests/stripe_billing_tests.rs
+++ b/crates/collab/src/tests/stripe_billing_tests.rs
@@ -225,6 +225,102 @@ async fn test_subscribe_to_price() {
 }
 
 #[gpui::test]
+async fn test_subscribe_to_zed_free() {
+    let (stripe_billing, stripe_client) = make_stripe_billing();
+
+    let zed_pro_price = StripePrice {
+        id: StripePriceId("price_1".into()),
+        unit_amount: Some(0),
+        lookup_key: Some("zed-pro".to_string()),
+        recurring: None,
+    };
+    stripe_client
+        .prices
+        .lock()
+        .insert(zed_pro_price.id.clone(), zed_pro_price.clone());
+    let zed_free_price = StripePrice {
+        id: StripePriceId("price_2".into()),
+        unit_amount: Some(0),
+        lookup_key: Some("zed-free".to_string()),
+        recurring: None,
+    };
+    stripe_client
+        .prices
+        .lock()
+        .insert(zed_free_price.id.clone(), zed_free_price.clone());
+
+    stripe_billing.initialize().await.unwrap();
+
+    // Customer is subscribed to Zed Free when not already subscribed to a plan.
+    {
+        let customer_id = StripeCustomerId("cus_no_plan".into());
+
+        let subscription = stripe_billing
+            .subscribe_to_zed_free(customer_id)
+            .await
+            .unwrap();
+
+        assert_eq!(subscription.items[0].price.as_ref(), Some(&zed_free_price));
+    }
+
+    // Customer is not subscribed to Zed Free when they already have an active subscription.
+    {
+        let customer_id = StripeCustomerId("cus_active_subscription".into());
+
+        let now = Utc::now();
+        let existing_subscription = StripeSubscription {
+            id: StripeSubscriptionId("sub_existing_active".into()),
+            status: stripe::SubscriptionStatus::Active,
+            current_period_start: now.timestamp(),
+            current_period_end: (now + Duration::days(30)).timestamp(),
+            items: vec![StripeSubscriptionItem {
+                id: StripeSubscriptionItemId("si_test".into()),
+                price: Some(zed_pro_price.clone()),
+            }],
+        };
+        stripe_client.subscriptions.lock().insert(
+            existing_subscription.id.clone(),
+            existing_subscription.clone(),
+        );
+
+        let subscription = stripe_billing
+            .subscribe_to_zed_free(customer_id)
+            .await
+            .unwrap();
+
+        assert_eq!(subscription, existing_subscription);
+    }
+
+    // Customer is not subscribed to Zed Free when they already have a trial subscription.
+    {
+        let customer_id = StripeCustomerId("cus_trial_subscription".into());
+
+        let now = Utc::now();
+        let existing_subscription = StripeSubscription {
+            id: StripeSubscriptionId("sub_existing_trial".into()),
+            status: stripe::SubscriptionStatus::Trialing,
+            current_period_start: now.timestamp(),
+            current_period_end: (now + Duration::days(14)).timestamp(),
+            items: vec![StripeSubscriptionItem {
+                id: StripeSubscriptionItemId("si_test".into()),
+                price: Some(zed_pro_price.clone()),
+            }],
+        };
+        stripe_client.subscriptions.lock().insert(
+            existing_subscription.id.clone(),
+            existing_subscription.clone(),
+        );
+
+        let subscription = stripe_billing
+            .subscribe_to_zed_free(customer_id)
+            .await
+            .unwrap();
+
+        assert_eq!(subscription, existing_subscription);
+    }
+}
+
+#[gpui::test]
 async fn test_bill_model_request_usage() {
     let (stripe_billing, stripe_client) = make_stripe_billing();
 

--- a/crates/collab/src/tests/stripe_billing_tests.rs
+++ b/crates/collab/src/tests/stripe_billing_tests.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use chrono::{Duration, Utc};
 use pretty_assertions::assert_eq;
 
 use crate::llm::AGENT_EXTENDED_TRIAL_FEATURE_FLAG;
@@ -163,8 +164,12 @@ async fn test_subscribe_to_price() {
         .lock()
         .insert(price.id.clone(), price.clone());
 
+    let now = Utc::now();
     let subscription = StripeSubscription {
         id: StripeSubscriptionId("sub_test".into()),
+        status: stripe::SubscriptionStatus::Active,
+        current_period_start: now.timestamp(),
+        current_period_end: (now + Duration::days(30)).timestamp(),
         items: vec![],
     };
     stripe_client
@@ -194,8 +199,12 @@ async fn test_subscribe_to_price() {
 
     // Subscribing to a price that is already on the subscription is a no-op.
     {
+        let now = Utc::now();
         let subscription = StripeSubscription {
             id: StripeSubscriptionId("sub_test".into()),
+            status: stripe::SubscriptionStatus::Active,
+            current_period_start: now.timestamp(),
+            current_period_end: (now + Duration::days(30)).timestamp(),
             items: vec![StripeSubscriptionItem {
                 id: StripeSubscriptionItemId("si_test".into()),
                 price: Some(price.clone()),


### PR DESCRIPTION
This PR moves over the last method on `StripeBilling` to use the `StripeClient` trait, allowing us to fully mock out Stripe behaviors for `StripeBilling` in tests.

Release Notes:

- N/A
