### PR TITLE
debugger: Fix delve-dap-shim path on Windows

### DIFF
--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -77,7 +77,7 @@ impl GoDebugAdapter {
         let path = paths::debug_adapters_dir()
             .join("delve-shim-dap")
             .join(format!("delve-shim-dap{}", asset.tag_name))
-            .join("delve-shim-dap");
+            .join(format!("delve-shim-dap{}", std::env::consts::EXE_SUFFIX));
         self.shim_path.set(path.clone()).ok();
 
         Ok(path)

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -414,13 +414,15 @@ impl DebugAdapter for GoDebugAdapter {
         &self,
         delegate: &Arc<dyn DapDelegate>,
         task_definition: &DebugTaskDefinition,
-        _user_installed_path: Option<PathBuf>,
+        user_installed_path: Option<PathBuf>,
         _cx: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
         let adapter_path = paths::debug_adapters_dir().join(&Self::ADAPTER_NAME);
         let dlv_path = adapter_path.join("dlv");
 
-        let delve_path = if let Some(path) = delegate.which(OsStr::new("dlv")).await {
+        let delve_path = if let Some(path) = user_installed_path {
+            path.to_string_lossy().to_string()
+        } else if let Some(path) = delegate.which(OsStr::new("dlv")).await {
             path.to_string_lossy().to_string()
         } else if delegate.fs().is_file(&dlv_path).await {
             dlv_path.to_string_lossy().to_string()


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- debugger: Fixed wrong path being picked up for delve on Windows
- debugger: Fixed delve not respecting the user-provided binary path from settings.
