### PR TITLE
debugger: Fix wrong path to the downloaded delve-shim-dap

### DIFF
--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -76,7 +76,7 @@ impl GoDebugAdapter {
 
         let path = paths::debug_adapters_dir()
             .join("delve-shim-dap")
-            .join(format!("delve-shim-dap{}", asset.tag_name))
+            .join(format!("delve-shim-dap_{}", asset.tag_name))
             .join(format!("delve-shim-dap{}", std::env::consts::EXE_SUFFIX));
         self.shim_path.set(path.clone()).ok();
 


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- N/A