### PR TITLE
collab: Use `StripeClient` in `sync_subscription`

### DIFF
--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -429,7 +429,7 @@ async fn manage_billing_subscription(
         .await?
         .context("user not found")?;
 
-    let Some(stripe_client) = app.stripe_client.clone() else {
+    let Some(stripe_client) = app.real_stripe_client.clone() else {
         log::error!("failed to retrieve Stripe client");
         Err(Error::http(
             StatusCode::NOT_IMPLEMENTED,
@@ -647,7 +647,7 @@ async fn migrate_to_new_billing(
     Extension(app): Extension<Arc<AppState>>,
     extract::Json(body): extract::Json<MigrateToNewBillingBody>,
 ) -> Result<Json<MigrateToNewBillingResponse>> {
-    let Some(stripe_client) = app.stripe_client.clone() else {
+    let Some(stripe_client) = app.real_stripe_client.clone() else {
         log::error!("failed to retrieve Stripe client");
         Err(Error::http(
             StatusCode::NOT_IMPLEMENTED,
@@ -726,7 +726,7 @@ async fn sync_billing_subscription(
     Extension(app): Extension<Arc<AppState>>,
     extract::Json(body): extract::Json<SyncBillingSubscriptionBody>,
 ) -> Result<Json<SyncBillingSubscriptionResponse>> {
-    let Some(stripe_client) = app.stripe_client.clone() else {
+    let Some(stripe_client) = app.real_stripe_client.clone() else {
         log::error!("failed to retrieve Stripe client");
         Err(Error::http(
             StatusCode::NOT_IMPLEMENTED,
@@ -811,7 +811,7 @@ const NUMBER_OF_ALREADY_PROCESSED_PAGES_BEFORE_WE_STOP: usize = 4;
 /// Polls the Stripe events API periodically to reconcile the records in our
 /// database with the data in Stripe.
 pub fn poll_stripe_events_periodically(app: Arc<AppState>, rpc_server: Arc<Server>) {
-    let Some(stripe_client) = app.stripe_client.clone() else {
+    let Some(stripe_client) = app.real_stripe_client.clone() else {
         log::warn!("failed to retrieve Stripe client");
         return;
     };

--- a/crates/collab/src/db/tables/billing_subscription.rs
+++ b/crates/collab/src/db/tables/billing_subscription.rs
@@ -1,4 +1,5 @@
 use crate::db::{BillingCustomerId, BillingSubscriptionId};
+use crate::stripe_client;
 use chrono::{Datelike as _, NaiveDate, Utc};
 use sea_orm::entity::prelude::*;
 use serde::Serialize;
@@ -158,4 +159,18 @@ pub enum StripeCancellationReason {
     PaymentDisputed,
     #[sea_orm(string_value = "payment_failed")]
     PaymentFailed,
+}
+
+impl From<stripe_client::StripeCancellationDetailsReason> for StripeCancellationReason {
+    fn from(value: stripe_client::StripeCancellationDetailsReason) -> Self {
+        match value {
+            stripe_client::StripeCancellationDetailsReason::CancellationRequested => {
+                Self::CancellationRequested
+            }
+            stripe_client::StripeCancellationDetailsReason::PaymentDisputed => {
+                Self::PaymentDisputed
+            }
+            stripe_client::StripeCancellationDetailsReason::PaymentFailed => Self::PaymentFailed,
+        }
+    }
 }

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -270,7 +270,9 @@ pub struct AppState {
     pub llm_db: Option<Arc<LlmDatabase>>,
     pub livekit_client: Option<Arc<dyn livekit_api::Client>>,
     pub blob_store_client: Option<aws_sdk_s3::Client>,
-    pub stripe_client: Option<Arc<stripe::Client>>,
+    /// This is a real instance of the Stripe client; we're working to replace references to this with the
+    /// [`StripeClient`] trait.
+    pub real_stripe_client: Option<Arc<stripe::Client>>,
     pub stripe_billing: Option<Arc<StripeBilling>>,
     pub executor: Executor,
     pub kinesis_client: Option<::aws_sdk_kinesis::Client>,
@@ -323,7 +325,7 @@ impl AppState {
             stripe_billing: stripe_client
                 .clone()
                 .map(|stripe_client| Arc::new(StripeBilling::new(stripe_client))),
-            stripe_client,
+            real_stripe_client: stripe_client,
             executor,
             kinesis_client: if config.kinesis_access_key.is_some() {
                 build_kinesis_client(&config).await.log_err()

--- a/crates/collab/src/lib.rs
+++ b/crates/collab/src/lib.rs
@@ -30,6 +30,7 @@ use std::{path::PathBuf, sync::Arc};
 use util::ResultExt;
 
 use crate::stripe_billing::StripeBilling;
+use crate::stripe_client::{RealStripeClient, StripeClient};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 
@@ -273,6 +274,7 @@ pub struct AppState {
     /// This is a real instance of the Stripe client; we're working to replace references to this with the
     /// [`StripeClient`] trait.
     pub real_stripe_client: Option<Arc<stripe::Client>>,
+    pub stripe_client: Option<Arc<dyn StripeClient>>,
     pub stripe_billing: Option<Arc<StripeBilling>>,
     pub executor: Executor,
     pub kinesis_client: Option<::aws_sdk_kinesis::Client>,
@@ -325,7 +327,9 @@ impl AppState {
             stripe_billing: stripe_client
                 .clone()
                 .map(|stripe_client| Arc::new(StripeBilling::new(stripe_client))),
-            real_stripe_client: stripe_client,
+            real_stripe_client: stripe_client.clone(),
+            stripe_client: stripe_client
+                .map(|stripe_client| Arc::new(RealStripeClient::new(stripe_client)) as _),
             executor,
             kinesis_client: if config.kinesis_access_key.is_some() {
                 build_kinesis_client(&config).await.log_err()

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -5,7 +5,7 @@ use crate::api::{CloudflareIpCountryHeader, SystemIdHeader};
 use crate::db::billing_subscription::SubscriptionKind;
 use crate::llm::db::LlmDatabase;
 use crate::llm::{AGENT_EXTENDED_TRIAL_FEATURE_FLAG, LlmTokenClaims};
-use crate::stripe_client::{RealStripeClient, StripeCustomerId};
+use crate::stripe_client::StripeCustomerId;
 use crate::{
     AppState, Error, Result, auth,
     db::{
@@ -4024,7 +4024,7 @@ async fn get_llm_api_token(
 
     let stripe_client = session
         .app_state
-        .real_stripe_client
+        .stripe_client
         .as_ref()
         .context("failed to retrieve Stripe client")?;
 
@@ -4043,7 +4043,6 @@ async fn get_llm_api_token(
             .find_or_create_customer_by_email(user.email_address.as_deref())
             .await?;
 
-        let stripe_client = Arc::new(RealStripeClient::new(stripe_client.clone()));
         find_or_create_billing_customer(&session.app_state, stripe_client.as_ref(), &customer_id)
             .await?
             .context("billing customer not found")?

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -4024,7 +4024,7 @@ async fn get_llm_api_token(
 
     let stripe_client = session
         .app_state
-        .stripe_client
+        .real_stripe_client
         .as_ref()
         .context("failed to retrieve Stripe client")?;
 

--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -111,14 +111,12 @@ impl StripeBilling {
 
     pub async fn determine_subscription_kind(
         &self,
-        subscription: &stripe::Subscription,
+        subscription: &StripeSubscription,
     ) -> Option<SubscriptionKind> {
-        let zed_pro_price_id: stripe::PriceId =
-            self.zed_pro_price_id().await.ok()?.try_into().ok()?;
-        let zed_free_price_id: stripe::PriceId =
-            self.zed_free_price_id().await.ok()?.try_into().ok()?;
+        let zed_pro_price_id = self.zed_pro_price_id().await.ok()?;
+        let zed_free_price_id = self.zed_free_price_id().await.ok()?;
 
-        subscription.items.data.iter().find_map(|item| {
+        subscription.items.iter().find_map(|item| {
             let price = item.price.as_ref()?;
 
             if price.id == zed_pro_price_id {

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -39,6 +39,8 @@ pub struct StripeSubscription {
     pub current_period_end: i64,
     pub current_period_start: i64,
     pub items: Vec<StripeSubscriptionItem>,
+    pub cancel_at: Option<i64>,
+    pub cancellation_details: Option<StripeCancellationDetails>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone, derive_more::Display)]
@@ -48,6 +50,18 @@ pub struct StripeSubscriptionItemId(pub Arc<str>);
 pub struct StripeSubscriptionItem {
     pub id: StripeSubscriptionItemId,
     pub price: Option<StripePrice>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct StripeCancellationDetails {
+    pub reason: Option<StripeCancellationDetailsReason>,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum StripeCancellationDetailsReason {
+    CancellationRequested,
+    PaymentDisputed,
+    PaymentFailed,
 }
 
 #[derive(Debug)]
@@ -175,6 +189,8 @@ pub struct StripeCheckoutSession {
 pub trait StripeClient: Send + Sync {
     async fn list_customers_by_email(&self, email: &str) -> Result<Vec<StripeCustomer>>;
 
+    async fn get_customer(&self, customer_id: &StripeCustomerId) -> Result<StripeCustomer>;
+
     async fn create_customer(&self, params: CreateCustomerParams<'_>) -> Result<StripeCustomer>;
 
     async fn list_subscriptions_for_customer(
@@ -197,6 +213,8 @@ pub trait StripeClient: Send + Sync {
         subscription_id: &StripeSubscriptionId,
         params: UpdateSubscriptionParams,
     ) -> Result<()>;
+
+    async fn cancel_subscription(&self, subscription_id: &StripeSubscriptionId) -> Result<()>;
 
     async fn list_prices(&self) -> Result<Vec<StripePrice>>;
 

--- a/crates/collab/src/stripe_client/fake_stripe_client.rs
+++ b/crates/collab/src/stripe_client/fake_stripe_client.rs
@@ -169,6 +169,9 @@ impl StripeClient for FakeStripeClient {
     }
 
     async fn cancel_subscription(&self, subscription_id: &StripeSubscriptionId) -> Result<()> {
+        // TODO: Implement fake subscription cancellation.
+        let _ = subscription_id;
+
         Ok(())
     }
 

--- a/crates/collab/src/stripe_client/fake_stripe_client.rs
+++ b/crates/collab/src/stripe_client/fake_stripe_client.rs
@@ -74,6 +74,14 @@ impl StripeClient for FakeStripeClient {
             .collect())
     }
 
+    async fn get_customer(&self, customer_id: &StripeCustomerId) -> Result<StripeCustomer> {
+        self.customers
+            .lock()
+            .get(customer_id)
+            .cloned()
+            .ok_or_else(|| anyhow!("no customer found for {customer_id:?}"))
+    }
+
     async fn create_customer(&self, params: CreateCustomerParams<'_>) -> Result<StripeCustomer> {
         let customer = StripeCustomer {
             id: StripeCustomerId(format!("cus_{}", Uuid::new_v4()).into()),
@@ -135,6 +143,8 @@ impl StripeClient for FakeStripeClient {
                         .and_then(|price_id| self.prices.lock().get(&price_id).cloned()),
                 })
                 .collect(),
+            cancel_at: None,
+            cancellation_details: None,
         };
 
         self.subscriptions
@@ -155,6 +165,10 @@ impl StripeClient for FakeStripeClient {
             .lock()
             .push((subscription.id, params));
 
+        Ok(())
+    }
+
+    async fn cancel_subscription(&self, subscription_id: &StripeSubscriptionId) -> Result<()> {
         Ok(())
     }
 

--- a/crates/collab/src/stripe_client/real_stripe_client.rs
+++ b/crates/collab/src/stripe_client/real_stripe_client.rs
@@ -5,9 +5,9 @@ use anyhow::{Context as _, Result, anyhow};
 use async_trait::async_trait;
 use serde::Serialize;
 use stripe::{
-    CheckoutSession, CheckoutSessionMode, CheckoutSessionPaymentMethodCollection,
-    CreateCheckoutSession, CreateCheckoutSessionLineItems, CreateCheckoutSessionSubscriptionData,
-    CreateCheckoutSessionSubscriptionDataTrialSettings,
+    CancellationDetails, CancellationDetailsReason, CheckoutSession, CheckoutSessionMode,
+    CheckoutSessionPaymentMethodCollection, CreateCheckoutSession, CreateCheckoutSessionLineItems,
+    CreateCheckoutSessionSubscriptionData, CreateCheckoutSessionSubscriptionDataTrialSettings,
     CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehavior,
     CreateCheckoutSessionSubscriptionDataTrialSettingsEndBehaviorMissingPaymentMethod,
     CreateCustomer, Customer, CustomerId, ListCustomers, Price, PriceId, Recurring, Subscription,
@@ -17,9 +17,9 @@ use stripe::{
 };
 
 use crate::stripe_client::{
-    CreateCustomerParams, StripeCheckoutSession, StripeCheckoutSessionMode,
-    StripeCheckoutSessionPaymentMethodCollection, StripeClient,
-    StripeCreateCheckoutSessionLineItems, StripeCreateCheckoutSessionParams,
+    CreateCustomerParams, StripeCancellationDetails, StripeCancellationDetailsReason,
+    StripeCheckoutSession, StripeCheckoutSessionMode, StripeCheckoutSessionPaymentMethodCollection,
+    StripeClient, StripeCreateCheckoutSessionLineItems, StripeCreateCheckoutSessionParams,
     StripeCreateCheckoutSessionSubscriptionData, StripeCreateMeterEventParams,
     StripeCreateSubscriptionParams, StripeCustomer, StripeCustomerId, StripeMeter, StripePrice,
     StripePriceId, StripePriceRecurring, StripeSubscription, StripeSubscriptionId,
@@ -55,6 +55,14 @@ impl StripeClient for RealStripeClient {
             .into_iter()
             .map(StripeCustomer::from)
             .collect())
+    }
+
+    async fn get_customer(&self, customer_id: &StripeCustomerId) -> Result<StripeCustomer> {
+        let customer_id = customer_id.try_into()?;
+
+        let customer = Customer::retrieve(&self.client, &customer_id, &[]).await?;
+
+        Ok(StripeCustomer::from(customer))
     }
 
     async fn create_customer(&self, params: CreateCustomerParams<'_>) -> Result<StripeCustomer> {
@@ -149,6 +157,22 @@ impl StripeClient for RealStripeClient {
                         .collect()
                 }),
                 trial_settings: params.trial_settings.map(Into::into),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        Ok(())
+    }
+
+    async fn cancel_subscription(&self, subscription_id: &StripeSubscriptionId) -> Result<()> {
+        let subscription_id = subscription_id.try_into()?;
+
+        Subscription::cancel(
+            &self.client,
+            &subscription_id,
+            stripe::CancelSubscription {
+                invoice_now: None,
                 ..Default::default()
             },
         )
@@ -273,6 +297,26 @@ impl From<Subscription> for StripeSubscription {
             current_period_start: value.current_period_start,
             current_period_end: value.current_period_end,
             items: value.items.data.into_iter().map(Into::into).collect(),
+            cancel_at: value.cancel_at,
+            cancellation_details: value.cancellation_details.map(Into::into),
+        }
+    }
+}
+
+impl From<CancellationDetails> for StripeCancellationDetails {
+    fn from(value: CancellationDetails) -> Self {
+        Self {
+            reason: value.reason.map(Into::into),
+        }
+    }
+}
+
+impl From<CancellationDetailsReason> for StripeCancellationDetailsReason {
+    fn from(value: CancellationDetailsReason) -> Self {
+        match value {
+            CancellationDetailsReason::CancellationRequested => Self::CancellationRequested,
+            CancellationDetailsReason::PaymentDisputed => Self::PaymentDisputed,
+            CancellationDetailsReason::PaymentFailed => Self::PaymentFailed,
         }
     }
 }

--- a/crates/collab/src/tests/stripe_billing_tests.rs
+++ b/crates/collab/src/tests/stripe_billing_tests.rs
@@ -172,6 +172,8 @@ async fn test_subscribe_to_price() {
         current_period_start: now.timestamp(),
         current_period_end: (now + Duration::days(30)).timestamp(),
         items: vec![],
+        cancel_at: None,
+        cancellation_details: None,
     };
     stripe_client
         .subscriptions
@@ -211,6 +213,8 @@ async fn test_subscribe_to_price() {
                 id: StripeSubscriptionItemId("si_test".into()),
                 price: Some(price.clone()),
             }],
+            cancel_at: None,
+            cancellation_details: None,
         };
         stripe_client
             .subscriptions
@@ -280,6 +284,8 @@ async fn test_subscribe_to_zed_free() {
                 id: StripeSubscriptionItemId("si_test".into()),
                 price: Some(zed_pro_price.clone()),
             }],
+            cancel_at: None,
+            cancellation_details: None,
         };
         stripe_client.subscriptions.lock().insert(
             existing_subscription.id.clone(),
@@ -309,6 +315,8 @@ async fn test_subscribe_to_zed_free() {
                 id: StripeSubscriptionItemId("si_test".into()),
                 price: Some(zed_pro_price.clone()),
             }],
+            cancel_at: None,
+            cancellation_details: None,
         };
         stripe_client.subscriptions.lock().insert(
             existing_subscription.id.clone(),

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -1,3 +1,4 @@
+use crate::stripe_client::FakeStripeClient;
 use crate::{
     AppState, Config,
     db::{NewUserParams, UserId, tests::TestDb},
@@ -523,6 +524,7 @@ impl TestServer {
             livekit_client: Some(Arc::new(livekit_test_server.create_api_client())),
             blob_store_client: None,
             real_stripe_client: None,
+            stripe_client: Some(Arc::new(FakeStripeClient::new())),
             stripe_billing: None,
             executor,
             kinesis_client: None,

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -522,7 +522,7 @@ impl TestServer {
             llm_db: None,
             livekit_client: Some(Arc::new(livekit_test_server.create_api_client())),
             blob_store_client: None,
-            stripe_client: None,
+            real_stripe_client: None,
             stripe_billing: None,
             executor,
             kinesis_client: None,


### PR DESCRIPTION
This PR updates the `sync_subscription` function to use the `StripeClient` trait instead of using `stripe::Client` directly.

Release Notes:

- N/A
