### PR TITLE
Add a JS/TS debug locator

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -298,6 +298,7 @@ pub async fn download_adapter_from_github(
         response.status().to_string()
     );
 
+    delegate.output_to_console("Download complete".to_owned());
     match file_type {
         DownloadedFileType::GzipTar => {
             let decompressed_bytes = GzipDecoder::new(BufReader::new(response.body_mut()));

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -173,6 +173,7 @@ impl DebugAdapterClient {
             command,
             sequence_id
         );
+        dbg!(&response);
         match response.success {
             true => {
                 if let Some(json) = response.body {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -173,7 +173,6 @@ impl DebugAdapterClient {
             command,
             sequence_id
         );
-        dbg!(&response);
         match response.success {
             true => {
                 if let Some(json) = response.body {

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -434,7 +434,7 @@ impl TransportDelegate {
                 .with_context(|| "reading a message from server")?
                 == 0
             {
-                anyhow::bail!("debugger reader stream closed");
+                anyhow::bail!("debugger reader stream closed, last string output: '{buffer}'");
             };
 
             if buffer == "\r\n" {

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -71,7 +71,7 @@ impl JsDebugAdapter {
         let tcp_connection = task_definition.tcp_connection.clone().unwrap_or_default();
         let (host, port, timeout) = crate::configure_tcp_connection(tcp_connection).await?;
 
-        Ok(DebugAdapterBinary {
+        let ret = DebugAdapterBinary {
             command: delegate
                 .node_runtime()
                 .binary_path()
@@ -97,7 +97,8 @@ impl JsDebugAdapter {
                 configuration: task_definition.config.clone(),
                 request: self.validate_config(&task_definition.config)?,
             },
-        })
+        };
+        Ok(dbg!(ret))
     }
 }
 
@@ -449,6 +450,8 @@ impl DebugAdapter for JsDebugAdapter {
                     delegate.as_ref(),
                 )
                 .await?;
+            } else {
+                delegate.output_to_console(format!("{} debug adapter is up to date", self.name()));
             }
         }
 

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -26,7 +26,7 @@ impl JsDebugAdapter {
         delegate: &Arc<dyn DapDelegate>,
     ) -> Result<AdapterVersion> {
         let release = latest_github_release(
-            &format!("{}/{}", "microsoft", Self::ADAPTER_NPM_NAME),
+            &format!("microsoft/{}", Self::ADAPTER_NPM_NAME),
             true,
             false,
             delegate.http_client(),
@@ -71,7 +71,7 @@ impl JsDebugAdapter {
         let tcp_connection = task_definition.tcp_connection.clone().unwrap_or_default();
         let (host, port, timeout) = crate::configure_tcp_connection(tcp_connection).await?;
 
-        let ret = DebugAdapterBinary {
+        Ok(DebugAdapterBinary {
             command: delegate
                 .node_runtime()
                 .binary_path()
@@ -97,8 +97,7 @@ impl JsDebugAdapter {
                 configuration: task_definition.config.clone(),
                 request: self.validate_config(&task_definition.config)?,
             },
-        };
-        Ok(dbg!(ret))
+        })
     }
 }
 

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -168,7 +168,7 @@ impl ContextProvider for TypeScriptContextProvider {
             command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
             args: vec![
                 TYPESCRIPT_JEST_TASK_VARIABLE.template_value(),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             ..TaskTemplate::default()
         });
@@ -183,7 +183,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 TYPESCRIPT_JEST_TASK_VARIABLE.template_value(),
                 "--testNamePattern".to_owned(),
                 format!("\"{}\"", VariableName::Symbol.template_value()),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             tags: vec![
                 "ts-test".to_owned(),
@@ -203,7 +203,7 @@ impl ContextProvider for TypeScriptContextProvider {
             args: vec![
                 TYPESCRIPT_VITEST_TASK_VARIABLE.template_value(),
                 "run".to_owned(),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             ..TaskTemplate::default()
         });
@@ -219,7 +219,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 "run".to_owned(),
                 "--testNamePattern".to_owned(),
                 format!("\"{}\"", VariableName::Symbol.template_value()),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             tags: vec![
                 "ts-test".to_owned(),
@@ -238,7 +238,7 @@ impl ContextProvider for TypeScriptContextProvider {
             command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
             args: vec![
                 TYPESCRIPT_MOCHA_TASK_VARIABLE.template_value(),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             ..TaskTemplate::default()
         });
@@ -253,7 +253,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 TYPESCRIPT_MOCHA_TASK_VARIABLE.template_value(),
                 "--grep".to_owned(),
                 format!("\"{}\"", VariableName::Symbol.template_value()),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             tags: vec![
                 "ts-test".to_owned(),
@@ -272,7 +272,7 @@ impl ContextProvider for TypeScriptContextProvider {
             command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
             args: vec![
                 TYPESCRIPT_JASMINE_TASK_VARIABLE.template_value(),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             ..TaskTemplate::default()
         });
@@ -286,13 +286,14 @@ impl ContextProvider for TypeScriptContextProvider {
             args: vec![
                 TYPESCRIPT_JASMINE_TASK_VARIABLE.template_value(),
                 format!("--filter={}", VariableName::Symbol.template_value()),
-                VariableName::File.template_value(),
+                VariableName::RelativeFile.template_value(),
             ],
             tags: vec![
                 "ts-test".to_owned(),
                 "js-test".to_owned(),
                 "tsx-test".to_owned(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
 

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -170,6 +170,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 TYPESCRIPT_JEST_TASK_VARIABLE.template_value(),
                 VariableName::RelativeFile.template_value(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
         task_templates.0.push(TaskTemplate {
@@ -190,6 +191,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 "js-test".to_owned(),
                 "tsx-test".to_owned(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
 
@@ -205,6 +207,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 "run".to_owned(),
                 VariableName::RelativeFile.template_value(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
         task_templates.0.push(TaskTemplate {
@@ -226,6 +229,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 "js-test".to_owned(),
                 "tsx-test".to_owned(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
 
@@ -240,6 +244,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 TYPESCRIPT_MOCHA_TASK_VARIABLE.template_value(),
                 VariableName::RelativeFile.template_value(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
         task_templates.0.push(TaskTemplate {
@@ -260,6 +265,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 "js-test".to_owned(),
                 "tsx-test".to_owned(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
 
@@ -274,6 +280,7 @@ impl ContextProvider for TypeScriptContextProvider {
                 TYPESCRIPT_JASMINE_TASK_VARIABLE.template_value(),
                 VariableName::RelativeFile.template_value(),
             ],
+            cwd: Some(VariableName::WorktreeRoot.template_value()),
             ..TaskTemplate::default()
         });
         task_templates.0.push(TaskTemplate {
@@ -314,6 +321,7 @@ impl ContextProvider for TypeScriptContextProvider {
                     package_json_script.template_value(),
                 ],
                 tags: vec!["package-script".into()],
+                cwd: Some(VariableName::WorktreeRoot.template_value()),
                 ..TaskTemplate::default()
             });
         }

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -103,8 +103,9 @@ impl DapStore {
         ADD_LOCATORS.call_once(|| {
             let registry = DapRegistry::global(cx);
             registry.add_locator(Arc::new(locators::cargo::CargoLocator {}));
-            registry.add_locator(Arc::new(locators::python::PythonLocator));
             registry.add_locator(Arc::new(locators::go::GoLocator {}));
+            registry.add_locator(Arc::new(locators::node::NodeLocator));
+            registry.add_locator(Arc::new(locators::python::PythonLocator));
         });
         client.add_entity_request_handler(Self::handle_run_debug_locator);
         client.add_entity_request_handler(Self::handle_get_debug_adapter_binary);

--- a/crates/project/src/debugger/locators.rs
+++ b/crates/project/src/debugger/locators.rs
@@ -1,3 +1,4 @@
 pub(crate) mod cargo;
 pub(crate) mod go;
+pub(crate) mod node;
 pub(crate) mod python;

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -1,0 +1,67 @@
+use std::path::Path;
+
+use anyhow::{Result, bail};
+use async_trait::async_trait;
+use dap::{DapLocator, DebugRequest, adapters::DebugAdapterName};
+use gpui::SharedString;
+
+use task::{DebugScenario, SpawnInTerminal, TaskTemplate};
+
+pub(crate) struct NodeLocator;
+
+#[async_trait]
+impl DapLocator for NodeLocator {
+    fn name(&self) -> SharedString {
+        SharedString::new_static("Node")
+    }
+
+    /// Determines whether this locator can generate debug target for given task.
+    fn create_scenario(
+        &self,
+        build_config: &TaskTemplate,
+        resolved_label: &str,
+        adapter: DebugAdapterName,
+    ) -> Option<DebugScenario> {
+        if adapter.as_ref() != "JavaScript" {
+            return None;
+        }
+        //  ./node_modules/.bin/jest
+        //
+        //
+        // TODO this should be npm/deno/yarn/etc. + mocha/jake/jasmine/etc.
+        let valid_program = build_config.command == "npx"
+            && build_config
+                .args
+                .first()
+                .is_some_and(|s| s.as_str() == "jest");
+        if !valid_program {
+            return None;
+        }
+        let args = Some("--runInBand".to_owned())
+            .into_iter()
+            .chain(build_config.args[1..].iter().cloned())
+            .collect::<Vec<_>>();
+
+        // npx --node-options="--inspect-brk" jest --testNamePattern foobar folder/file.ts
+        let program_path = "$ZED_WORKTREE_ROOT/node_modules/.bin/jest";
+        let mut config = serde_json::json!({
+            "request": "launch",
+            "program": program_path,
+            "args": args,
+            "cwd": build_config.cwd.clone(),
+            "runtimeArgs": ["--inspect-brk"]
+        });
+
+        Some(DebugScenario {
+            adapter: adapter.0,
+            label: resolved_label.to_string().into(),
+            build: None,
+            config,
+            tcp_connection: None,
+        })
+    }
+
+    async fn run(&self, _: SpawnInTerminal) -> Result<DebugRequest> {
+        bail!("Python locator should not require DapLocator::run to be ran");
+    }
+}

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -1,5 +1,3 @@
-use std::path::Path;
-
 use anyhow::{Result, bail};
 use async_trait::async_trait;
 use dap::{DapLocator, DebugRequest, adapters::DebugAdapterName};
@@ -44,12 +42,13 @@ impl DapLocator for NodeLocator {
 
         // npx --node-options="--inspect-brk" jest --testNamePattern foobar folder/file.ts
         let program_path = "$ZED_WORKTREE_ROOT/node_modules/.bin/jest";
-        let mut config = serde_json::json!({
+        let config = serde_json::json!({
             "request": "launch",
             "program": program_path,
             "args": args,
             "cwd": build_config.cwd.clone(),
-            "runtimeArgs": ["--inspect-brk"]
+            "runtimeArgs": ["--inspect-brk"],
+            "console": "integratedTerminal",
         });
 
         Some(DebugScenario {

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1421,7 +1421,7 @@ impl Session {
             ));
             return cx.spawn(async move |this, cx| {
                 this.update(cx, |this, cx| process_result(this, error, cx))
-                    .log_err()
+                    .ok()
                     .flatten()
             });
         }
@@ -1430,7 +1430,7 @@ impl Session {
         cx.spawn(async move |this, cx| {
             let result = request.await;
             this.update(cx, |this, cx| process_result(this, result, cx))
-                .log_err()
+                .ok()
                 .flatten()
         })
     }


### PR DESCRIPTION
With this, a semi-working debug session is possible from the JS/TS gutter tasks:

https://github.com/user-attachments/assets/8db6ed29-b44a-4314-ae8b-a8213291bffc

For now, available in debug builds only as a base to improve on later on the DAP front.

Release Notes:

- N/A
