### PR TITLE
Use both language and LSP icons for LSP tasks

### DIFF
--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -181,7 +181,7 @@ pub fn lsp_tasks(
                         lsp_tasks
                             .entry(source_kind)
                             .or_insert_with(Vec::new)
-                            .extend(new_lsp_tasks.drain(..));
+                            .append(&mut new_lsp_tasks);
                     }
                 }
             }

--- a/crates/editor/src/lsp_ext.rs
+++ b/crates/editor/src/lsp_ext.rs
@@ -22,6 +22,7 @@ use smol::stream::StreamExt;
 use task::ResolvedTask;
 use task::TaskContext;
 use text::BufferId;
+use ui::SharedString;
 use util::ResultExt as _;
 
 pub(crate) fn find_specific_language_server_in_selection<F>(
@@ -133,13 +134,22 @@ pub fn lsp_tasks(
 
     cx.spawn(async move |cx| {
         cx.spawn(async move |cx| {
-            let mut lsp_tasks = Vec::new();
+            let mut lsp_tasks = HashMap::default();
             while let Some(server_to_query) = lsp_task_sources.next().await {
                 if let Some((server_id, buffers)) = server_to_query {
-                    let source_kind = TaskSourceKind::Lsp(server_id);
-                    let id_base = source_kind.to_id_base();
                     let mut new_lsp_tasks = Vec::new();
                     for buffer in buffers {
+                        let source_kind = match buffer.update(cx, |buffer, _| {
+                            buffer.language().map(|language| language.name())
+                        }) {
+                            Ok(Some(language_name)) => TaskSourceKind::Lsp {
+                                server: server_id,
+                                language_name: SharedString::from(language_name),
+                            },
+                            Ok(None) => continue,
+                            Err(_) => return Vec::new(),
+                        };
+                        let id_base = source_kind.to_id_base();
                         let lsp_buffer_context = lsp_task_context(&project, &buffer, cx)
                             .await
                             .unwrap_or_default();
@@ -168,11 +178,14 @@ pub fn lsp_tasks(
                                 );
                             }
                         }
+                        lsp_tasks
+                            .entry(source_kind)
+                            .or_insert_with(Vec::new)
+                            .extend(new_lsp_tasks.drain(..));
                     }
-                    lsp_tasks.push((source_kind, new_lsp_tasks));
                 }
             }
-            lsp_tasks
+            lsp_tasks.into_iter().collect()
         })
         .race({
             // `lsp::LSP_REQUEST_TIMEOUT` is larger than we want for the modal to open fast

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -132,7 +132,10 @@ pub enum TaskSourceKind {
     /// Languages-specific tasks coming from extensions.
     Language { name: SharedString },
     /// Language-specific tasks coming from LSP servers.
-    Lsp(LanguageServerId),
+    Lsp {
+        language_name: SharedString,
+        server: LanguageServerId,
+    },
 }
 
 /// A collection of task contexts, derived from the current state of the workspace.
@@ -211,7 +214,10 @@ impl TaskSourceKind {
                 format!("{id_base}_{id}_{}", directory_in_worktree.display())
             }
             Self::Language { name } => format!("language_{name}"),
-            Self::Lsp(server_id) => format!("lsp_{server_id}"),
+            Self::Lsp {
+                server,
+                language_name,
+            } => format!("lsp_{language_name}_{server}"),
         }
     }
 }
@@ -712,7 +718,7 @@ fn task_lru_comparator(
 
 fn task_source_kind_preference(kind: &TaskSourceKind) -> u32 {
     match kind {
-        TaskSourceKind::Lsp(..) => 0,
+        TaskSourceKind::Lsp { .. } => 0,
         TaskSourceKind::Language { .. } => 1,
         TaskSourceKind::UserInput => 2,
         TaskSourceKind::Worktree { .. } => 3,


### PR DESCRIPTION
Make more explicit which language LSP tasks are used.

Before:
![image](https://github.com/user-attachments/assets/3f2112f1-badd-4d17-9574-188f67108f8f)

After:

![image (1)](https://github.com/user-attachments/assets/5a29fb0a-2e16-4c35-9dda-ae7925eaa034)

Regular Rust language icon below (for Zed tasks):

![image](https://github.com/user-attachments/assets/d1bf518e-63d1-4ebf-af3d-3c9d464c6532)


Release Notes:

- N/A
