### PR TITLE
ci: Prevent "Tests Pass" job from running on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -482,7 +482,9 @@ jobs:
       - macos_tests
       - windows_clippy
       - windows_tests
-    if: always()
+    if: |
+      github.repository_owner == 'zed-industries' &&
+      always()
     steps:
       - name: Check all tests passed
         run: |


### PR DESCRIPTION
Example fork [actions run](https://github.com/alphaArgon/zed/actions/runs/15349715488/job/43194591563) which would be supressed in the future. 

(Sorry @alphaArgon)

Release Notes:

- N/A