### PR TITLE
Fix existing CompletionMode deserialization

### DIFF
--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -689,6 +689,7 @@ pub struct AgentSettingsContentV2 {
 pub enum CompletionMode {
     #[default]
     Normal,
+    #[serde(alias = "max")]
     Burn,
 }
 


### PR DESCRIPTION
https://github.com/zed-industries/zed/pull/31668 renamed `CompletionMode::Max` to `CompletionMode::Burn` which is a good change, but this broke the deserialization for threads whose completion mode was stored in LMDB. This adds a deserialization alias so that both values work. 

We could make a full new `SerializedThread` version which migrates this value, but that seems overkill for this single change, we can batch that with more changes later. Also, people in nightly already have some v1 threads with `burn` stored, so it wouldn't quite work for everybody.

Release Notes:

- N/A
