### PR TITLE
Add `follow_after_prompt` agent setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -827,7 +827,10 @@
     // its response, or needs user input.
 
     // Default: false
-    "play_sound_when_agent_done": false
+    "play_sound_when_agent_done": false,
+    // Whether to automatically follow the agent after entering a prompt.
+    // Default: false
+    "follow_after_prompt": false
   },
   // The settings for slash commands.
   "slash_commands": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -825,10 +825,11 @@
     "notify_when_agent_waiting": "primary_screen",
     // Whether to play a sound when the agent has either completed
     // its response, or needs user input.
-
+    //
     // Default: false
     "play_sound_when_agent_done": false,
     // Whether to automatically follow the agent after entering a prompt.
+    //
     // Default: false
     "follow_after_prompt": false
   },

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -299,6 +299,16 @@ impl MessageEditor {
             return;
         }
 
+        // Check if follow_after_prompt is enabled and follow the agent if so
+        let settings = AgentSettings::get_global(cx);
+        if settings.follow_after_prompt {
+            self.workspace
+                .update(cx, |this, cx| {
+                    this.follow(CollaboratorId::Agent, window, cx)
+                })
+                .log_err();
+        }
+
         self.set_editor_is_expanded(false, cx);
         self.send_to_model(window, cx);
 

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -299,9 +299,7 @@ impl MessageEditor {
             return;
         }
 
-        // Check if follow_after_prompt is enabled and follow the agent if so
-        let settings = AgentSettings::get_global(cx);
-        if settings.follow_after_prompt {
+        if AgentSettings::get_global(cx).follow_after_prompt {
             self.workspace
                 .update(cx, |this, cx| {
                     this.follow(CollaboratorId::Agent, window, cx)

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -111,6 +111,7 @@ pub struct AgentSettings {
     pub model_parameters: Vec<LanguageModelParameters>,
     pub preferred_completion_mode: CompletionMode,
     pub enable_feedback: bool,
+    pub follow_after_prompt: bool,
 }
 
 impl AgentSettings {
@@ -279,6 +280,7 @@ impl AgentSettingsContent {
                     preferred_completion_mode: None,
                     enable_feedback: None,
                     play_sound_when_agent_done: None,
+                    follow_after_prompt: None,
                 },
                 VersionedAgentSettingsContent::V2(ref settings) => settings.clone(),
             },
@@ -312,6 +314,7 @@ impl AgentSettingsContent {
                 preferred_completion_mode: None,
                 enable_feedback: None,
                 play_sound_when_agent_done: None,
+                follow_after_prompt: None,
             },
             None => AgentSettingsContentV2::default(),
         }
@@ -597,6 +600,7 @@ impl Default for VersionedAgentSettingsContent {
             preferred_completion_mode: None,
             enable_feedback: None,
             play_sound_when_agent_done: None,
+            follow_after_prompt: None,
         })
     }
 }
@@ -682,6 +686,10 @@ pub struct AgentSettingsContentV2 {
     ///
     /// Default: true
     enable_feedback: Option<bool>,
+    /// Whether to automatically follow the agent after entering a prompt.
+    ///
+    /// Default: false
+    follow_after_prompt: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
@@ -896,6 +904,7 @@ impl Settings for AgentSettings {
                 value.preferred_completion_mode,
             );
             merge(&mut settings.enable_feedback, value.enable_feedback);
+            merge(&mut settings.follow_after_prompt, value.follow_after_prompt);
 
             settings
                 .model_parameters
@@ -1033,6 +1042,7 @@ mod tests {
                             enable_feedback: None,
                             model_parameters: Vec::new(),
                             preferred_completion_mode: None,
+                            follow_after_prompt: None,
                         })),
                     }
                 },


### PR DESCRIPTION
This pull request adds a setting that if set, will follow agent after every prompt automatically.

Release Notes:

- Add `follow_after_prompt` agent setting.
