### PR TITLE
Increase terminal inline assistant block height

### DIFF
--- a/crates/agent/src/terminal_inline_assistant.rs
+++ b/crates/agent/src/terminal_inline_assistant.rs
@@ -106,7 +106,7 @@ impl TerminalInlineAssistant {
         });
         let prompt_editor_render = prompt_editor.clone();
         let block = terminal_view::BlockProperties {
-            height: 2,
+            height: 4,
             render: Box::new(move |_| prompt_editor_render.clone().into_any_element()),
         };
         terminal_view.update(cx, |terminal_view, cx| {


### PR DESCRIPTION
Closes #31806
Closes #28969

Not sure if a static value is best. Maybe it is better to somehow use `count_lines` function here too.

### Before
<img width="871" alt="449463234-ab1a33a0-2331-4605-aaee-cae60ddd0f9d" src="https://github.com/user-attachments/assets/1e3bec86-4cad-426c-9f59-5ad3d14fc9d7" />


### After
<img width="861" alt="Screenshot 2025-05-31 at 1 12 33 AM" src="https://github.com/user-attachments/assets/0c8219a9-0812-45af-8125-1f4294fe2142" />

Release Notes:

- Fixed terminal inline assistant clipping when cursor is at bottom of terminal.
