### PR TITLE
Fix slowness in Terminal when vi-mode is enabled

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -653,7 +653,12 @@ impl TerminalView {
         if let Some(keystroke) = Keystroke::parse(&text.0).log_err() {
             self.clear_bell(cx);
             self.terminal.update(cx, |term, cx| {
-                term.try_keystroke(&keystroke, TerminalSettings::get_global(cx).option_as_meta);
+                let processed =
+                    term.try_keystroke(&keystroke, TerminalSettings::get_global(cx).option_as_meta);
+                if processed && term.vi_mode_enabled() {
+                    cx.notify();
+                }
+                processed
             });
         }
     }


### PR DESCRIPTION
It seems alacritty handles vi-mode motions in a special way and it is up to the client to decide when redraw is necessary. With this change, `TerminalView` notifies the context if a keystroke is processed and vi mode is enabled.

Fixes #31447

Before:

https://github.com/user-attachments/assets/a78d4ba0-23a3-4660-a834-2f92948f586c

After:

https://github.com/user-attachments/assets/cabbb0f4-a1f9-4f1c-87d8-a56a10e35cc8

Release Notes:

- Fixed sluggish cursor motions in Terminal when Vi Mode is enabled [#31447]
