### PR TITLE
terminal: Fix file paths links with URL escapes not being clickable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15725,6 +15725,7 @@ dependencies = [
  "theme",
  "thiserror 2.0.12",
  "url",
+ "urlencoding",
  "util",
  "windows 0.61.1",
  "workspace-hack",

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -32,6 +32,7 @@ theme.workspace = true
 thiserror.workspace = true
 util.workspace = true
 regex.workspace = true
+urlencoding.workspace = true
 workspace-hack.workspace = true
 
 [target.'cfg(windows)'.dependencies]


### PR DESCRIPTION
For #31827

# URL Decoding Fix for Terminal File Path Clicking


## Discussion

This change does not allow for paths that literally have `%XX` inside of them.  If any such paths exist, they will fail to ctrl+click.  A larger change would be needed to handle that.

## Problem

In the terminal, you could ctrl+click file paths to open them in the editor, but this didn't work when the paths contained URL-encoded characters (percent-encoded sequences like `%CE%BB` for Greek letter λ).

### Example Issue
- This worked: `dashboardλ.mts:3:8`
- This didn't work: `dashboard%CE%BB.mts:3:8`

The URL-encoded form `%CE%BB` represents the Greek letter λ (lambda), but the terminal wasn't decoding these sequences before trying to open the files.

## Solution

Added URL decoding functionality to the terminal path detection system:

1. **Added urlencoding dependency** to `crates/terminal/Cargo.toml`
2. **Created decode_file_path function** in `crates/terminal/src/terminal.rs` that:
   - Attempts to decode URL-encoded paths using `urlencoding::decode()`
   - Falls back to the original string if decoding fails
   - Handles malformed encodings gracefully
3. **Applied decoding to PathLikeTarget creation** for both:
   - Regular file paths detected by word regex
   - File:// URLs that are treated as paths


## Code Changes

### New Function
```rust
/// Decodes URL-encoded file paths to handle cases where terminal output contains
/// percent-encoded characters (e.g., %CE%BB for λ).
/// Falls back to the original string if decoding fails.
fn decode_file_path(path: &str) -> String {
    urlencoding::decode(path)
        .map(|decoded| decoded.into_owned())
        .unwrap_or_else(|_| path.to_string())
}
```

### Modified PathLikeTarget Creation
The function is now called when creating `PathLikeTarget` instances:
- For file:// URLs: `decode_file_path(path)`
- For regular paths: `decode_file_path(&maybe_url_or_path)`

## Testing

Added comprehensive test coverage in `test_decode_file_path()` that verifies:
- Normal paths remain unchanged
- URL-encoded characters are properly decoded (λ, spaces, slashes)
- Paths with line numbers work correctly
- Invalid encodings fall back gracefully
- Mixed encoding scenarios work

## Impact

This fix enables ctrl+click functionality for file paths containing non-ASCII characters that appear URL-encoded in terminal output, making the feature work consistently with tools that output percent-encoded file paths.

The change is backward compatible - all existing functionality continues to work unchanged, and the fix only activates when URL-encoded sequences are detected.


Release Notes:

* File paths printed in the terminal that have `%XX` escape sequences will now be properly decoded so that ctrl+click will open them