### PR TITLE
Add channel reordering functionality

### DIFF
--- a/.rules
+++ b/.rules
@@ -5,6 +5,12 @@
 * Prefer implementing functionality in existing files unless it is a new logical component. Avoid creating many small files.
 * Avoid using functions that panic like `unwrap()`, instead use mechanisms like `?` to propagate errors.
 * Be careful with operations like indexing which may panic if the indexes are out of bounds.
+* Never silently discard errors with `let _ =` on fallible operations. Always handle errors appropriately:
+  - Propagate errors with `?` when the calling function should handle them
+  - Use `.log_err()` or similar when you need to ignore errors but want visibility
+  - Use explicit error handling with `match` or `if let Err(...)` when you need custom logic
+  - Example: avoid `let _ = client.request(...).await?;` - use `client.request(...).await?;` instead
+* When implementing async operations that may fail, ensure errors propagate to the UI layer so users get meaningful feedback.
 * Never create files with `mod.rs` paths - prefer `src/some_module.rs` instead of `src/some_module/mod.rs`.
 
 # GPUI

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -897,7 +897,9 @@
     "context": "CollabPanel && not_editing",
     "bindings": {
       "ctrl-backspace": "collab_panel::Remove",
-      "space": "menu::Confirm"
+      "space": "menu::Confirm",
+      "ctrl-up": "collab_panel::MoveChannelUp",
+      "ctrl-down": "collab_panel::MoveChannelDown"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -951,7 +951,9 @@
     "use_key_equivalents": true,
     "bindings": {
       "ctrl-backspace": "collab_panel::Remove",
-      "space": "menu::Confirm"
+      "space": "menu::Confirm",
+      "cmd-up": "collab_panel::MoveChannelUp",
+      "cmd-down": "collab_panel::MoveChannelDown"
     }
   },
   {

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -1044,6 +1044,18 @@ impl ChannelStore {
         });
     }
 
+    #[cfg(any(test, feature = "test-support"))]
+    pub fn reset(&mut self) {
+        self.channel_invitations.clear();
+        self.channel_index.clear();
+        self.channel_participants.clear();
+        self.outgoing_invites.clear();
+        self.opened_buffers.clear();
+        self.opened_chats.clear();
+        self.disconnect_channel_buffers_task = None;
+        self.channel_states.clear();
+    }
+
     pub(crate) fn update_channels(
         &mut self,
         payload: proto::UpdateChannels,

--- a/crates/channel/src/channel_store_tests.rs
+++ b/crates/channel/src/channel_store_tests.rs
@@ -21,12 +21,14 @@ fn test_update_channels(cx: &mut App) {
                     name: "b".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: Vec::new(),
+                    channel_order: 1,
                 },
                 proto::Channel {
                     id: 2,
                     name: "a".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: Vec::new(),
+                    channel_order: 2,
                 },
             ],
             ..Default::default()
@@ -37,8 +39,8 @@ fn test_update_channels(cx: &mut App) {
         &channel_store,
         &[
             //
-            (0, "a".to_string()),
             (0, "b".to_string()),
+            (0, "a".to_string()),
         ],
         cx,
     );
@@ -52,12 +54,14 @@ fn test_update_channels(cx: &mut App) {
                     name: "x".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: vec![1],
+                    channel_order: 1,
                 },
                 proto::Channel {
                     id: 4,
                     name: "y".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: vec![2],
+                    channel_order: 1,
                 },
             ],
             ..Default::default()
@@ -67,10 +71,10 @@ fn test_update_channels(cx: &mut App) {
     assert_channels(
         &channel_store,
         &[
-            (0, "a".to_string()),
-            (1, "y".to_string()),
             (0, "b".to_string()),
             (1, "x".to_string()),
+            (0, "a".to_string()),
+            (1, "y".to_string()),
         ],
         cx,
     );
@@ -89,18 +93,21 @@ fn test_dangling_channel_paths(cx: &mut App) {
                     name: "a".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: vec![],
+                    channel_order: 1,
                 },
                 proto::Channel {
                     id: 1,
                     name: "b".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: vec![0],
+                    channel_order: 1,
                 },
                 proto::Channel {
                     id: 2,
                     name: "c".to_string(),
                     visibility: proto::ChannelVisibility::Members as i32,
                     parent_path: vec![0, 1],
+                    channel_order: 1,
                 },
             ],
             ..Default::default()
@@ -147,6 +154,7 @@ async fn test_channel_messages(cx: &mut TestAppContext) {
             name: "the-channel".to_string(),
             visibility: proto::ChannelVisibility::Members as i32,
             parent_path: vec![],
+            channel_order: 1,
         }],
         ..Default::default()
     });

--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -266,10 +266,13 @@ CREATE TABLE "channels" (
     "created_at" TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "visibility" VARCHAR NOT NULL,
     "parent_path" TEXT NOT NULL,
-    "requires_zed_cla" BOOLEAN NOT NULL DEFAULT FALSE
+    "requires_zed_cla" BOOLEAN NOT NULL DEFAULT FALSE,
+    "channel_order" INTEGER NOT NULL DEFAULT 1
 );
 
 CREATE INDEX "index_channels_on_parent_path" ON "channels" ("parent_path");
+
+CREATE INDEX "index_channels_on_parent_path_and_order" ON "channels" ("parent_path", "channel_order");
 
 CREATE TABLE IF NOT EXISTS "channel_chat_participants" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/crates/collab/migrations/20250530175450_add_channel_order.sql
+++ b/crates/collab/migrations/20250530175450_add_channel_order.sql
@@ -1,0 +1,16 @@
+-- Add channel_order column to channels table with default value
+ALTER TABLE channels ADD COLUMN channel_order INTEGER NOT NULL DEFAULT 1;
+
+-- Update channel_order for existing channels using ROW_NUMBER for deterministic ordering
+UPDATE channels
+SET channel_order = (
+    SELECT ROW_NUMBER() OVER (
+        PARTITION BY parent_path
+        ORDER BY name, id
+    )
+    FROM channels c2
+    WHERE c2.id = channels.id
+);
+
+-- Create index for efficient ordering queries
+CREATE INDEX "index_channels_on_parent_path_and_order" ON "channels" ("parent_path", "channel_order");

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -582,6 +582,7 @@ pub struct Channel {
     pub visibility: ChannelVisibility,
     /// parent_path is the channel ids from the root to this one (not including this one)
     pub parent_path: Vec<ChannelId>,
+    pub channel_order: i32,
 }
 
 impl Channel {
@@ -591,6 +592,7 @@ impl Channel {
             visibility: value.visibility,
             name: value.clone().name,
             parent_path: value.ancestors().collect(),
+            channel_order: value.channel_order,
         }
     }
 
@@ -600,7 +602,12 @@ impl Channel {
             name: self.name.clone(),
             visibility: self.visibility.into(),
             parent_path: self.parent_path.iter().map(|c| c.to_proto()).collect(),
+            channel_order: self.channel_order,
         }
+    }
+
+    pub fn root_id(&self) -> ChannelId {
+        self.parent_path.first().copied().unwrap_or(self.id)
     }
 }
 

--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -1073,7 +1073,6 @@ impl Database {
                 }
             };
 
-            // Swap the channel_order values atomically using a temporary value to avoid conflicts
             let current_order = channel.channel_order;
             let sibling_order = sibling_channel.channel_order;
 

--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -1013,7 +1013,6 @@ impl Database {
 
             if channel.is_root() {
                 log::info!("Skipping reorder of root channel {}", channel.id,);
-
                 return Ok(vec![]);
             }
 

--- a/crates/collab/src/db/tables/channel.rs
+++ b/crates/collab/src/db/tables/channel.rs
@@ -10,6 +10,9 @@ pub struct Model {
     pub visibility: ChannelVisibility,
     pub parent_path: String,
     pub requires_zed_cla: bool,
+    /// The order of this channel relative to its siblings within the same parent.
+    /// Lower values appear first. Channels are sorted by parent_path first, then by channel_order.
+    pub channel_order: i32,
 }
 
 impl Model {

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -172,6 +172,12 @@ impl Drop for TestDb {
     }
 }
 
+fn assert_channel_tree_matches(actual: Vec<Channel>, expected: Vec<Channel>) {
+    let expected_channels = expected.into_iter().collect::<HashSet<_>>();
+    let actual_channels = actual.into_iter().collect::<HashSet<_>>();
+    pretty_assertions::assert_eq!(expected_channels, actual_channels);
+}
+
 fn channel_tree(channels: &[(ChannelId, &[ChannelId], &'static str)]) -> Vec<Channel> {
     use std::collections::HashMap;
 

--- a/crates/collab/src/db/tests.rs
+++ b/crates/collab/src/db/tests.rs
@@ -172,6 +172,7 @@ impl Drop for TestDb {
     }
 }
 
+#[track_caller]
 fn assert_channel_tree_matches(actual: Vec<Channel>, expected: Vec<Channel>) {
     let expected_channels = expected.into_iter().collect::<HashSet<_>>();
     let actual_channels = actual.into_iter().collect::<HashSet<_>>();
@@ -186,10 +187,14 @@ fn channel_tree(channels: &[(ChannelId, &[ChannelId], &'static str)]) -> Vec<Cha
 
     for (id, parent_path, name) in channels {
         let parent_key = parent_path.to_vec();
-        let order = *order_by_parent
-            .entry(parent_key.clone())
-            .and_modify(|e| *e += 1)
-            .or_insert(1);
+        let order = if parent_key.is_empty() {
+            1
+        } else {
+            *order_by_parent
+                .entry(parent_key.clone())
+                .and_modify(|e| *e += 1)
+                .or_insert(1)
+        };
 
         result.push(Channel {
             id: *id,

--- a/crates/collab/src/db/tests/channel_tests.rs
+++ b/crates/collab/src/db/tests/channel_tests.rs
@@ -502,9 +502,8 @@ async fn test_channel_reordering(db: &Arc<Database>) {
         .await
         .unwrap();
 
-    // Should return just gamma (no change)
-    assert_eq!(updated_channels.len(), 1);
-    assert_eq!(updated_channels[0].id, gamma_id);
+    // Should return just nothing
+    assert_eq!(updated_channels.len(), 0);
 
     // Test moving alpha down (should swap with gamma)
     let updated_channels = db
@@ -542,9 +541,8 @@ async fn test_channel_reordering(db: &Arc<Database>) {
         .await
         .unwrap();
 
-    // Should return just beta (no change)
-    assert_eq!(updated_channels.len(), 1);
-    assert_eq!(updated_channels[0].id, beta_id);
+    // Should return nothing
+    assert_eq!(updated_channels.len(), 0);
 
     // Adding a channel to an existing ordering should add it to the end
     let delta_id = db

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -384,6 +384,7 @@ impl Server {
             .add_request_handler(get_notifications)
             .add_request_handler(mark_notification_as_read)
             .add_request_handler(move_channel)
+            .add_request_handler(reorder_channel)
             .add_request_handler(follow)
             .add_message_handler(unfollow)
             .add_message_handler(update_followers)
@@ -3179,6 +3180,55 @@ async fn move_channel(
                 }
             })
             .collect::<Vec<_>>();
+        if channels.is_empty() {
+            continue;
+        }
+
+        let update = proto::UpdateChannels {
+            channels,
+            ..Default::default()
+        };
+
+        session.peer.send(connection_id, update.clone())?;
+    }
+
+    response.send(Ack {})?;
+    Ok(())
+}
+
+async fn reorder_channel(
+    request: proto::ReorderChannel,
+    response: Response<proto::ReorderChannel>,
+    session: Session,
+) -> Result<()> {
+    let channel_id = ChannelId::from_proto(request.channel_id);
+    let direction = request.direction();
+
+    let updated_channels = session
+        .db()
+        .await
+        .reorder_channel(channel_id, direction, session.user_id())
+        .await?;
+
+    // Get the root channel to find all connections that need updates
+    let root_id = updated_channels
+        .first()
+        .map(|channel| channel.root_id())
+        .unwrap_or(channel_id);
+
+    let connection_pool = session.connection_pool().await;
+    for (connection_id, role) in connection_pool.channel_connection_ids(root_id) {
+        let channels = updated_channels
+            .iter()
+            .filter_map(|channel| {
+                if role.can_see_channel(channel.visibility) {
+                    Some(channel.to_proto())
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+
         if channels.is_empty() {
             continue;
         }

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -52,6 +52,8 @@ actions!(
         StartMoveChannel,
         MoveSelected,
         InsertSpace,
+        MoveChannelUp,
+        MoveChannelDown,
     ]
 );
 
@@ -1961,6 +1963,33 @@ impl CollabPanel {
             })
     }
 
+    fn move_channel_up(&mut self, _: &MoveChannelUp, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(channel) = self.selected_channel() {
+            self.channel_store.update(cx, |store, cx| {
+                store
+                    .reorder_channel(channel.id, proto::reorder_channel::Direction::Up, cx)
+                    .detach_and_prompt_err("Failed to move channel up", window, cx, |_, _, _| None)
+            });
+        }
+    }
+
+    fn move_channel_down(
+        &mut self,
+        _: &MoveChannelDown,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(channel) = self.selected_channel() {
+            self.channel_store.update(cx, |store, cx| {
+                store
+                    .reorder_channel(channel.id, proto::reorder_channel::Direction::Down, cx)
+                    .detach_and_prompt_err("Failed to move channel down", window, cx, |_, _, _| {
+                        None
+                    })
+            });
+        }
+    }
+
     fn open_channel_notes(
         &mut self,
         channel_id: ChannelId,
@@ -2977,6 +3006,8 @@ impl Render for CollabPanel {
             .on_action(cx.listener(CollabPanel::collapse_selected_channel))
             .on_action(cx.listener(CollabPanel::expand_selected_channel))
             .on_action(cx.listener(CollabPanel::start_move_selected_channel))
+            .on_action(cx.listener(CollabPanel::move_channel_up))
+            .on_action(cx.listener(CollabPanel::move_channel_down))
             .track_focus(&self.focus_handle(cx))
             .size_full()
             .child(if self.user_store.read(cx).current_user().is_none() {

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -14,9 +14,9 @@ use fuzzy::{StringMatchCandidate, match_strings};
 use gpui::{
     AnyElement, App, AsyncWindowContext, Bounds, ClickEvent, ClipboardItem, Context, DismissEvent,
     Div, Entity, EventEmitter, FocusHandle, Focusable, FontStyle, InteractiveElement, IntoElement,
-    ListOffset, ListState, MouseDownEvent, ParentElement, Pixels, Point, PromptLevel, Render,
-    SharedString, Styled, Subscription, Task, TextStyle, WeakEntity, Window, actions, anchored,
-    canvas, deferred, div, fill, list, point, prelude::*, px,
+    KeyContext, ListOffset, ListState, MouseDownEvent, ParentElement, Pixels, Point, PromptLevel,
+    Render, SharedString, Styled, Subscription, Task, TextStyle, WeakEntity, Window, actions,
+    anchored, canvas, deferred, div, fill, list, point, prelude::*, px,
 };
 use menu::{Cancel, Confirm, SecondaryConfirm, SelectNext, SelectPrevious};
 use project::{Fs, Project};
@@ -2003,7 +2003,7 @@ impl CollabPanel {
 
     fn show_inline_context_menu(
         &mut self,
-        _: &menu::SecondaryConfirm,
+        _: &Secondary,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -2030,6 +2030,21 @@ impl CollabPanel {
             self.deploy_contact_context_menu(bounds.center(), contact, window, cx);
             cx.stop_propagation();
         }
+    }
+
+    fn dispatch_context(&self, window: &Window, cx: &Context<Self>) -> KeyContext {
+        let mut dispatch_context = KeyContext::new_with_defaults();
+        dispatch_context.add("CollabPanel");
+        dispatch_context.add("menu");
+
+        let identifier = if self.channel_name_editor.focus_handle(cx).is_focused(window) {
+            "editing"
+        } else {
+            "not_editing"
+        };
+
+        dispatch_context.add(identifier);
+        dispatch_context
     }
 
     fn selected_channel(&self) -> Option<&Arc<Channel>> {
@@ -2994,7 +3009,7 @@ fn render_tree_branch(
 impl Render for CollabPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
-            .key_context("CollabPanel")
+            .key_context(self.dispatch_context(window, cx))
             .on_action(cx.listener(CollabPanel::cancel))
             .on_action(cx.listener(CollabPanel::select_next))
             .on_action(cx.listener(CollabPanel::select_previous))

--- a/crates/proto/proto/channel.proto
+++ b/crates/proto/proto/channel.proto
@@ -8,6 +8,7 @@ message Channel {
     uint64 id = 1;
     string name = 2;
     ChannelVisibility visibility = 3;
+    int32 channel_order = 4;
     repeated uint64 parent_path = 5;
 }
 
@@ -205,6 +206,15 @@ message GetChannelMessagesById {
 message MoveChannel {
     uint64 channel_id = 1;
     uint64 to = 2;
+}
+
+message ReorderChannel {
+    uint64 channel_id = 1;
+    enum Direction {
+        Up = 0;
+        Down = 1;
+    }
+    Direction direction = 2;
 }
 
 message JoinChannelBuffer {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -190,6 +190,7 @@ message Envelope {
         GetChannelMessagesById get_channel_messages_by_id = 144;
 
         MoveChannel move_channel = 147;
+        ReorderChannel reorder_channel = 349;
         SetChannelVisibility set_channel_visibility = 148;
 
         AddNotification add_notification = 149;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -176,6 +176,7 @@ messages!(
     (LspExtClearFlycheck, Background),
     (MarkNotificationRead, Foreground),
     (MoveChannel, Foreground),
+    (ReorderChannel, Foreground),
     (MultiLspQuery, Background),
     (MultiLspQueryResponse, Background),
     (OnTypeFormatting, Background),
@@ -389,6 +390,7 @@ request_messages!(
     (RemoveContact, Ack),
     (RenameChannel, RenameChannelResponse),
     (RenameProjectEntry, ProjectEntryResponse),
+    (ReorderChannel, Ack),
     (RequestContact, Ack),
     (
         ResolveCompletionDocumentation,


### PR DESCRIPTION
Release Notes:

- Added channel reordering for administrators (use `cmd-up` and `cmd-down`  on macOS or `ctrl-up` `ctrl-down` on Linux to move channels up or down within their parent)

## Summary

This PR introduces the ability for channel administrators to reorder channels within their parent context, providing better organizational control over channel hierarchies. Users can now move channels up or down relative to their siblings using keyboard shortcuts.

## Problem

Previously, channels were displayed in alphabetical order with no way to customize their arrangement. This made it difficult for teams to organize channels in a logical order that reflected their workflow or importance, forcing users to prefix channel names with numbers or special characters as a workaround.

## Solution

The implementation adds a persistent `channel_order` field to channels that determines their display order within their parent. Channels with the same parent are sorted by this field rather than alphabetically.

## Implementation Details

### Database Schema

Added a new column and index to support efficient ordering:

```sql
-- crates/collab/migrations/20250530175450_add_channel_order.sql
ALTER TABLE channels ADD COLUMN channel_order INTEGER NOT NULL DEFAULT 1;

CREATE INDEX CONCURRENTLY "index_channels_on_parent_path_and_order" ON "channels" ("parent_path", "channel_order");
```

### RPC Protocol

Extended the channel proto with ordering support:

```proto
// crates/proto/proto/channel.proto
message Channel {
    uint64 id = 1;
    string name = 2;
    ChannelVisibility visibility = 3;
    int32 channel_order = 4;
    repeated uint64 parent_path = 5;
}

message ReorderChannel {
    uint64 channel_id = 1;
    enum Direction {
        Up = 0;
        Down = 1;
    }
    Direction direction = 2;
}
```

### Server-side Logic

The reordering is handled by swapping `channel_order` values between adjacent channels:

```rust
// crates/collab/src/db/queries/channels.rs
pub async fn reorder_channel(
    &self,
    channel_id: ChannelId,
    direction: proto::reorder_channel::Direction,
    user_id: UserId,
) -> Result<Vec<Channel>> {
    // Find the sibling channel to swap with
    let sibling_channel = match direction {
        proto::reorder_channel::Direction::Up => {
            // Find channel with highest order less than current
            channel::Entity::find()
                .filter(
                    channel::Column::ParentPath
                        .eq(&channel.parent_path)
                        .and(channel::Column::ChannelOrder.lt(channel.channel_order)),
                )
                .order_by_desc(channel::Column::ChannelOrder)
                .one(&*tx)
                .await?
        }
        // Similar logic for Down...
    };
    
    // Swap the channel_order values
    let temp_order = channel.channel_order;
    channel.channel_order = sibling_channel.channel_order;
    sibling_channel.channel_order = temp_order;
}
```

### Client-side Sorting

Optimized the sorting algorithm to avoid O(n²) complexity:

```rust
// crates/collab/src/db/queries/channels.rs
// Pre-compute sort keys for efficient O(n log n) sorting
let mut channels_with_keys: Vec<(Vec<i32>, Channel)> = channels
    .into_iter()
    .map(|channel| {
        let mut sort_key = Vec::with_capacity(channel.parent_path.len() + 1);
        
        // Build sort key from parent path orders
        for parent_id in &channel.parent_path {
            sort_key.push(channel_order_map.get(parent_id).copied().unwrap_or(i32::MAX));
        }
        sort_key.push(channel.channel_order);
        
        (sort_key, channel)
    })
    .collect();

channels_with_keys.sort_by(|a, b| a.0.cmp(&b.0));
```

### User Interface

Added keyboard shortcuts and proper context handling:

```json
// assets/keymaps/default-macos.json
{
  "context": "CollabPanel && not_editing",
  "bindings": {
    "cmd-up": "collab_panel::MoveChannelUp",
    "cmd-down": "collab_panel::MoveChannelDown"
  }
}
```

The CollabPanel now properly sets context to distinguish between editing and navigation modes:

```rust
// crates/collab_ui/src/collab_panel.rs
fn dispatch_context(&self, window: &Window, cx: &Context<Self>) -> KeyContext {
    let mut dispatch_context = KeyContext::new_with_defaults();
    dispatch_context.add("CollabPanel");
    dispatch_context.add("menu");
    
    let identifier = if self.channel_name_editor.focus_handle(cx).is_focused(window) {
        "editing"
    } else {
        "not_editing"
    };
    
    dispatch_context.add(identifier);
    dispatch_context
}
```

## Testing

Comprehensive tests were added to verify:
- Basic reordering functionality (up/down movement)
- Boundary conditions (first/last channels)
- Permission checks (non-admins cannot reorder)
- Ordering persistence across server restarts
- Correct broadcasting of changes to channel members

## Migration Strategy

Existing channels are assigned initial `channel_order` values based on their current alphabetical sorting to maintain the familiar order users expect:

```sql
UPDATE channels
SET channel_order = (
    SELECT ROW_NUMBER() OVER (
        PARTITION BY parent_path
        ORDER BY name, id
    )
    FROM channels c2
    WHERE c2.id = channels.id
);
```

## Future Enhancements

While this PR provides basic reordering functionality, potential future improvements could include:
- Drag-and-drop reordering in the UI
- Bulk reordering operations
- Custom sorting strategies (by activity, creation date, etc.)

## Checklist

- [x] Database migration included
- [x] Tests added for new functionality
- [x] Keybindings work on macOS and Linux
- [x] Permissions properly enforced
- [x] Error handling implemented throughout
- [x] Manual testing completed
- [x] Documentation updated
