### PR TITLE
Refactor item-closing actions

### DIFF
--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -1010,7 +1010,6 @@ async fn test_peers_following_each_other(cx_a: &mut TestAppContext, cx_b: &mut T
     workspace_b.update_in(cx_b, |workspace, window, cx| {
         workspace.active_pane().update(cx, |pane, cx| {
             pane.close_inactive_items(&Default::default(), window, cx)
-                .unwrap()
                 .detach();
         });
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20051,7 +20051,6 @@ println!("5");
         .unwrap();
     pane_2
         .update_in(cx, |pane, window, cx| {
-            // TODO
             pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
                 .unwrap()
         })

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20016,9 +20016,9 @@ println!("5");
     pane_1
         .update_in(cx, |pane, window, cx| {
             pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
-                .unwrap()
         })
-        .await;
+        .await
+        .unwrap();
     drop(editor_1);
     pane_1.update(cx, |pane, cx| {
         pane.active_item()
@@ -20052,9 +20052,9 @@ println!("5");
     pane_2
         .update_in(cx, |pane, window, cx| {
             pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
-                .unwrap()
         })
-        .await;
+        .await
+        .unwrap();
     drop(editor_2);
     pane_2.update(cx, |pane, cx| {
         let open_editor = pane.active_item().unwrap().downcast::<Editor>().unwrap();
@@ -20227,9 +20227,9 @@ println!("5");
     });
     pane.update_in(cx, |pane, window, cx| {
         pane.close_all_items(&CloseAllItems::default(), window, cx)
-            .unwrap()
     })
-    .await;
+    .await
+    .unwrap();
     pane.update(cx, |pane, _| {
         assert!(pane.active_item().is_none());
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20018,8 +20018,7 @@ println!("5");
             pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
                 .unwrap()
         })
-        .await
-        .unwrap();
+        .await;
     drop(editor_1);
     pane_1.update(cx, |pane, cx| {
         pane.active_item()
@@ -20052,11 +20051,11 @@ println!("5");
         .unwrap();
     pane_2
         .update_in(cx, |pane, window, cx| {
+            // TODO
             pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
                 .unwrap()
         })
-        .await
-        .unwrap();
+        .await;
     drop(editor_2);
     pane_2.update(cx, |pane, cx| {
         let open_editor = pane.active_item().unwrap().downcast::<Editor>().unwrap();
@@ -20231,8 +20230,7 @@ println!("5");
         pane.close_all_items(&CloseAllItems::default(), window, cx)
             .unwrap()
     })
-    .await
-    .unwrap();
+    .await;
     pane.update(cx, |pane, _| {
         assert!(pane.active_item().is_none());
     });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1498,7 +1498,7 @@ impl Pane {
     }
 
     pub fn close_items(
-        &mut self,
+        &self,
         window: &mut Window,
         cx: &mut Context<Pane>,
         mut save_intent: SaveIntent,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1298,6 +1298,10 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<Task<Result<()>>> {
+        if self.items.is_empty() {
+            return None;
+        }
+
         let clean_item_ids = self.clean_item_ids(cx);
         let pinned_item_ids = self.pinned_item_ids();
         Some(
@@ -1336,6 +1340,10 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
+        if self.items.is_empty() {
+            return Task::ready(Ok(()));
+        }
+
         let to_the_left_item_ids = self.to_the_left_item_ids(item_id);
         self.close_items(window, cx, SaveIntent::Close, move |item_id| {
             to_the_left_item_ids.contains(&item_id)
@@ -1371,6 +1379,10 @@ impl Pane {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
+        if self.items.is_empty() {
+            return Task::ready(Ok(()));
+        }
+
         let to_the_right_item_ids = self.to_the_right_item_ids(item_id);
         self.close_items(window, cx, SaveIntent::Close, move |item_id| {
             to_the_right_item_ids.contains(&item_id)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1035,6 +1035,10 @@ impl Pane {
         self.items.get(self.active_item_index).cloned()
     }
 
+    fn active_item_id(&self) -> EntityId {
+        self.items[self.active_item_index].item_id()
+    }
+
     pub fn pixel_position_of_cursor(&self, cx: &App) -> Option<Point<Pixels>> {
         self.items
             .get(self.active_item_index)?
@@ -1335,8 +1339,7 @@ impl Pane {
         let to_the_left_item_ids = self.to_the_left_item_ids(item_id);
         self.close_items(window, cx, SaveIntent::Close, move |item_id| {
             to_the_left_item_ids.contains(&item_id)
-                && !action.close_pinned
-                && !pinned_item_ids.contains(&item_id)
+                && (action.close_pinned || !pinned_item_ids.contains(&item_id))
         })
     }
 
@@ -1371,8 +1374,7 @@ impl Pane {
         let to_the_right_item_ids = self.to_the_right_item_ids(item_id);
         self.close_items(window, cx, SaveIntent::Close, move |item_id| {
             to_the_right_item_ids.contains(&item_id)
-                && !action.close_pinned
-                && !pinned_item_ids.contains(&item_id)
+                && (action.close_pinned || !pinned_item_ids.contains(&item_id))
         })
     }
 
@@ -1391,7 +1393,7 @@ impl Pane {
             window,
             cx,
             action.save_intent.unwrap_or(SaveIntent::Close),
-            |item_id| (action.close_pinned || !pinned_item_ids.contains(&item_id)),
+            |item_id| action.close_pinned || !pinned_item_ids.contains(&item_id),
         ))
     }
 
@@ -3075,10 +3077,6 @@ impl Pane {
 
     pub fn display_nav_history_buttons(&mut self, display: Option<bool>) {
         self.display_nav_history_buttons = display;
-    }
-
-    fn active_item_id(&self) -> EntityId {
-        self.items[self.active_item_index].item_id()
     }
 
     fn pinned_item_ids(&self) -> HashSet<EntityId> {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1276,12 +1276,12 @@ impl Pane {
         }
 
         let active_item_id = self.items[self.active_item_index].item_id();
-        let non_closeable_items = self.get_non_closeable_item_ids(action.close_pinned);
+        let non_closable_item_ids = self.get_non_closable_item_ids(action.close_pinned);
         Some(self.close_items(
             window,
             cx,
             action.save_intent.unwrap_or(SaveIntent::Close),
-            move |item_id| item_id != active_item_id && !non_closeable_items.contains(&item_id),
+            move |item_id| item_id != active_item_id && !non_closable_item_ids.contains(&item_id),
         ))
     }
 
@@ -1296,10 +1296,10 @@ impl Pane {
             .filter(|item| !item.is_dirty(cx))
             .map(|item| item.item_id())
             .collect();
-        let non_closeable_items = self.get_non_closeable_item_ids(action.close_pinned);
+        let non_closable_item_ids = self.get_non_closable_item_ids(action.close_pinned);
         Some(
             self.close_items(window, cx, SaveIntent::Close, move |item_id| {
-                item_ids.contains(&item_id) && !non_closeable_items.contains(&item_id)
+                item_ids.contains(&item_id) && !non_closable_item_ids.contains(&item_id)
             }),
         )
     }
@@ -1314,11 +1314,11 @@ impl Pane {
             return None;
         }
         let active_item_id = self.items[self.active_item_index].item_id();
-        let non_closeable_items = self.get_non_closeable_item_ids(action.close_pinned);
+        let non_closable_item_ids = self.get_non_closable_item_ids(action.close_pinned);
         Some(self.close_items_to_the_left_by_id(
             active_item_id,
             action,
-            non_closeable_items,
+            non_closable_item_ids,
             window,
             cx,
         ))
@@ -1328,7 +1328,7 @@ impl Pane {
         &mut self,
         item_id: EntityId,
         action: &CloseItemsToTheLeft,
-        non_closeable_items: HashSet<EntityId>,
+        non_closable_item_ids: HashSet<EntityId>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
@@ -1340,7 +1340,7 @@ impl Pane {
         self.close_items(window, cx, SaveIntent::Close, move |item_id| {
             item_ids.contains(&item_id)
                 && !action.close_pinned
-                && !non_closeable_items.contains(&item_id)
+                && !non_closable_item_ids.contains(&item_id)
         })
     }
 
@@ -1354,11 +1354,11 @@ impl Pane {
             return None;
         }
         let active_item_id = self.items[self.active_item_index].item_id();
-        let non_closeable_items = self.get_non_closeable_item_ids(action.close_pinned);
+        let non_closable_item_ids = self.get_non_closable_item_ids(action.close_pinned);
         Some(self.close_items_to_the_right_by_id(
             active_item_id,
             action,
-            non_closeable_items,
+            non_closable_item_ids,
             window,
             cx,
         ))
@@ -1368,7 +1368,7 @@ impl Pane {
         &mut self,
         item_id: EntityId,
         action: &CloseItemsToTheRight,
-        non_closeable_items: HashSet<EntityId>,
+        non_closable_item_ids: HashSet<EntityId>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
@@ -1381,7 +1381,7 @@ impl Pane {
         self.close_items(window, cx, SaveIntent::Close, move |item_id| {
             item_ids.contains(&item_id)
                 && !action.close_pinned
-                && !non_closeable_items.contains(&item_id)
+                && !non_closable_item_ids.contains(&item_id)
         })
     }
 
@@ -1395,12 +1395,12 @@ impl Pane {
             return None;
         }
 
-        let non_closeable_items = self.get_non_closeable_item_ids(action.close_pinned);
+        let non_closable_item_ids = self.get_non_closable_item_ids(action.close_pinned);
         Some(self.close_items(
             window,
             cx,
             action.save_intent.unwrap_or(SaveIntent::Close),
-            |item_id| !non_closeable_items.contains(&item_id),
+            |item_id| !non_closable_item_ids.contains(&item_id),
         ))
     }
 
@@ -2404,10 +2404,10 @@ impl Pane {
                                     }))
                                     .disabled(total_items == 1)
                                     .handler(window.handler_for(&pane, move |pane, window, cx| {
-                                        let non_closeable_ids =
-                                            pane.get_non_closeable_item_ids(false);
+                                        let non_closable_item_ids =
+                                            pane.get_non_closable_item_ids(false);
                                         pane.close_items(window, cx, SaveIntent::Close, |id| {
-                                            id != item_id && !non_closeable_ids.contains(&id)
+                                            id != item_id && !non_closable_item_ids.contains(&id)
                                         })
                                         .detach_and_log_err(cx);
                                     })),
@@ -2425,7 +2425,7 @@ impl Pane {
                                             &CloseItemsToTheLeft {
                                                 close_pinned: false,
                                             },
-                                            pane.get_non_closeable_item_ids(false),
+                                            pane.get_non_closable_item_ids(false),
                                             window,
                                             cx,
                                         )
@@ -2444,7 +2444,7 @@ impl Pane {
                                             &CloseItemsToTheRight {
                                                 close_pinned: false,
                                             },
-                                            pane.get_non_closeable_item_ids(false),
+                                            pane.get_non_closable_item_ids(false),
                                             window,
                                             cx,
                                         )
@@ -3087,9 +3087,9 @@ impl Pane {
         self.display_nav_history_buttons = display;
     }
 
-    fn get_non_closeable_item_ids(&self, close_pinned: bool) -> HashSet<EntityId> {
+    fn get_non_closable_item_ids(&self, close_pinned: bool) -> HashSet<EntityId> {
         if close_pinned {
-            return HashSet::from_iter([]);
+            return HashSet::default();
         }
 
         self.items


### PR DESCRIPTION
While working on 

- https://github.com/zed-industries/zed/pull/31783
- https://github.com/zed-industries/zed/pull/31786

... I noticed some areas that could be improved through refactoring. The bug in https://github.com/zed-industries/zed/pull/31783 came from having duplicate code. The fix had been applied to one version, but not the duplicated code.

This PR attempts to do some initial clean up, through some refactoring.

Release Notes:

- N/A
