### PR TITLE
keymap: Fix subword navigation and selection on Sublime Text keymap

### DIFF
--- a/assets/keymaps/linux/sublime_text.json
+++ b/assets/keymaps/linux/sublime_text.json
@@ -52,10 +52,10 @@
       "shift-alt-m": "markdown::OpenPreviewToTheSide",
       "ctrl-backspace": "editor::DeleteToPreviousWordStart",
       "ctrl-delete": "editor::DeleteToNextWordEnd",
-      "ctrl-right": "editor::MoveToNextSubwordEnd",
-      "ctrl-left": "editor::MoveToPreviousSubwordStart",
-      "ctrl-shift-right": "editor::SelectToNextSubwordEnd",
-      "ctrl-shift-left": "editor::SelectToPreviousSubwordStart"
+      "alt-right": "editor::MoveToNextSubwordEnd",
+      "alt-left": "editor::MoveToPreviousSubwordStart",
+      "alt-shift-right": "editor::SelectToNextSubwordEnd",
+      "alt-shift-left": "editor::SelectToPreviousSubwordStart"
     }
   },
   {


### PR DESCRIPTION
On Linux, the correct modifier key for this action is `alt`, not `ctrl`. I mistakenly set it to `ctrl` on #30268.

From Sublime's keymap: 
```json
{ "keys": ["ctrl+left"], "command": "move", "args": {"by": "words", "forward": false} },
{ "keys": ["ctrl+right"], "command": "move", "args": {"by": "word_ends", "forward": true} },
{ "keys": ["ctrl+shift+left"], "command": "move", "args": {"by": "words", "forward": false, "extend": true} },
{ "keys": ["ctrl+shift+right"], "command": "move", "args": {"by": "word_ends", "forward": true, "extend": true} },

{ "keys": ["alt+left"], "command": "move", "args": {"by": "subwords", "forward": false} },
{ "keys": ["alt+right"], "command": "move", "args": {"by": "subword_ends", "forward": true} },
{ "keys": ["alt+shift+left"], "command": "move", "args": {"by": "subwords", "forward": false, "extend": true} },
{ "keys": ["alt+shift+right"], "command": "move", "args": {"by": "subword_ends", "forward": true, "extend": true} },
```

Release Notes:

- N/A
