### PR TITLE
Fixes escape not switching mode

### DIFF
--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -36,7 +36,7 @@ impl Vim {
                     });
                 });
             });
-            self.switch_mode(self.default_mode(cx), false, window, cx);
+            self.switch_mode(Mode::Normal, true, window, cx);
             return;
         }
 

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -439,7 +439,7 @@ impl Vim {
 
         vim.update(cx, |_, cx| {
             Vim::action(editor, cx, |vim, _: &SwitchToNormalMode, window, cx| {
-                vim.switch_mode(vim.default_mode(cx), false, window, cx)
+                vim.switch_mode(Mode::Normal, false, window, cx)
             });
 
             Vim::action(editor, cx, |vim, _: &SwitchToInsertMode, window, cx| {


### PR DESCRIPTION
Closes #31728

When `"default_mode: "insert"`, hitting escape was not switching to normal mode. Recently, changes to `SwitchToNormalMode` action was modified to change mode into `default_mode` instead or actually switching to Normal mode. Same with the `NormalBefore`


Release Notes:

Fixed escape key not switching to normal mode when default_mode is insert
