### PR TITLE
git_panel: Add toggle for collapsing untracked files section

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -694,7 +694,11 @@
       //
       // Default: inherits editor scrollbar settings
       "show": null
-    }
+    },
+    // Whether to show the untracked files section in the git panel
+    //
+    // Default: false
+    "collapse_untracked_files_section": false
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1390,7 +1390,7 @@ impl GitPanel {
         self.collapse_untracked_files_section = !self.collapse_untracked_files_section;
         self.update_visible_entries(cx);
     }
-    
+
     fn stage_selected(&mut self, _: &git::StageFile, _window: &mut Window, cx: &mut Context<Self>) {
         let Some(selected_entry) = self.get_selected_entry() else {
             return;
@@ -3741,11 +3741,18 @@ impl GitPanel {
                 .px(rems(0.75)) // ~12px
                 .pb(rems(0.3125)) // ~ 5px
                 .cursor_pointer()
-                .on_click(cx.listener(|this: &mut GitPanel, _, _window, current_cx: &mut Context<Self>| {
-                    this.collapse_untracked_files_section = !this.collapse_untracked_files_section;
-                    this.update_visible_entries(current_cx);
-                }))
-                .child(Icon::new(icon_name).size(IconSize::Small).color(Color::Muted))
+                .on_click(cx.listener(
+                    |this: &mut GitPanel, _, _window, current_cx: &mut Context<Self>| {
+                        this.collapse_untracked_files_section =
+                            !this.collapse_untracked_files_section;
+                        this.update_visible_entries(current_cx);
+                    },
+                ))
+                .child(
+                    Icon::new(icon_name)
+                        .size(IconSize::Small)
+                        .color(Color::Muted),
+                )
                 .child(div().w(rems(0.25)))
                 .child(
                     Label::new(header.title())
@@ -5006,13 +5013,13 @@ mod tests {
         fs.insert_tree(
             "/root",
             json!({
-            "project": {
-                ".git": {},
-                "tracked.rs": "// tracked file",
-            },
-        }),
+                "project": {
+                    ".git": {},
+                    "tracked.rs": "// tracked file",
+                },
+            }),
         )
-            .await;
+        .await;
 
         let project = Project::test(fs.clone(), [Path::new("/root/project")], cx).await;
         let (workspace, cx) =
@@ -5021,11 +5028,20 @@ mod tests {
         let app_state = workspace.read_with(cx, |workspace, _| workspace.app_state().clone());
 
         let panel = cx.new_window_entity(|window, cx| {
-            GitPanel::new(workspace.clone(), project.clone(), app_state.clone(), window, cx)
+            GitPanel::new(
+                workspace.clone(),
+                project.clone(),
+                app_state.clone(),
+                window,
+                cx,
+            )
         });
 
         panel.read_with(cx, |panel, _| {
-            assert!(!panel.collapse_untracked_files_section, "Untracked section should be expanded by default");
+            assert!(
+                !panel.collapse_untracked_files_section,
+                "Untracked section should be expanded by default"
+            );
         });
 
         cx.update_window_entity(&panel, |panel, _, cx| {
@@ -5034,7 +5050,10 @@ mod tests {
         });
 
         panel.read_with(cx, |panel, _| {
-            assert!(panel.collapse_untracked_files_section, "Untracked section should be collapsed");
+            assert!(
+                panel.collapse_untracked_files_section,
+                "Untracked section should be collapsed"
+            );
         });
 
         cx.update_window_entity(&panel, |panel, window, cx| {
@@ -5042,7 +5061,10 @@ mod tests {
         });
 
         panel.read_with(cx, |panel, _| {
-            assert!(!panel.collapse_untracked_files_section, "Untracked section should be expanded after toggle");
+            assert!(
+                !panel.collapse_untracked_files_section,
+                "Untracked section should be expanded after toggle"
+            );
         });
 
         cx.update(|_, cx| {
@@ -5058,7 +5080,10 @@ mod tests {
         });
 
         panel2.read_with(cx, |panel, _| {
-            assert!(panel.collapse_untracked_files_section, "Untracked section should be collapsed when setting is true");
+            assert!(
+                panel.collapse_untracked_files_section,
+                "Untracked section should be collapsed when setting is true"
+            );
         });
     }
 }

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -70,6 +70,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub sort_by_path: Option<bool>,
+
+    /// Whether untracked entries should be collapsed by default.
+    /// 
+    /// Default: false (expanded)
+    pub collapse_untracked_files_section: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -81,6 +86,7 @@ pub struct GitPanelSettings {
     pub scrollbar: ScrollbarSettings,
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
+    pub collapse_untracked_files_section: bool,
 }
 
 impl Settings for GitPanelSettings {

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -72,7 +72,7 @@ pub struct GitPanelSettingsContent {
     pub sort_by_path: Option<bool>,
 
     /// Whether untracked entries should be collapsed by default.
-    /// 
+    ///
     /// Default: false (expanded)
     pub collapse_untracked_files_section: Option<bool>,
 }

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -23,6 +23,50 @@ In the panel you can see the state of your project at a glance—which repositor
 
 Zed monitors your repository so that changes you make on the command line are instantly reflected.
 
+### Git Panel Settings
+The Git Panel can be customized through your settings file. You can configure its appearance, behavior, and default states.
+To customize the Git Panel, add a git_panel object to your settings.json:
+```
+{
+  "git_panel": {
+    "collapse_untracked_files_section": true
+  }
+}
+```
+The `collapse_untracked_files_section` setting is particularly useful for projects with many generated or temporary files. When enabled, the untracked files section shows only a header with a chevron icon that you can click to expand and view the files.
+You can also toggle the untracked section visibility using the `git_panel::ToggleUntrackedSection` action, which can be bound to a custom keybinding in your keymap.
+
+```
+{
+  "bindings": {
+    "cmd-alt-u": "git_panel::ToggleUntrackedSection"
+  }
+}
+```
+
+Important: This action works when the Git Panel is focused! If you want to toggle the untracked section from anywhere in Zed, you can use: 
+
+```
+{
+  "bindings": {
+      "cmd-alt-shift-f": "git_panel::ToggleFocus",
+      "cmd-alt-shift-u": "git_panel::ToggleUntrackedSection"
+  }
+}
+```
+This way you can ensure the Git Panel is focused before toggling the untracked section.
+
+
+Available Git Panel settings include:
+
+ - `button`: Whether to show the Git Panel button in the status bar (default: true)
+ - `dock`: Where to dock the panel, either "left" or "right" (default: "left")
+ - `default_width`: Width of the panel in pixels (default: 360)
+ - `status_style`: How to display file status indicators, either "icon" or "label_color" (default: "icon")
+ - `fallback_branch_name`: Default branch name when Git's init.defaultBranch is not set (default: "main")
+ - `sort_by_path`: Sort entries by file path instead of by status (default: false)
+ - `collapse_untracked_files_section`: Whether untracked files should be collapsed by default (default: false)
+
 ## Project Diff
 
 You can see all of the changes captured by Git in Zed by opening the Project Diff ({#kb git::Diff}), accessible via the {#action git::Diff} action in the Command Palette or the Git Panel.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -24,8 +24,10 @@ In the panel you can see the state of your project at a glance—which repositor
 Zed monitors your repository so that changes you make on the command line are instantly reflected.
 
 ### Git Panel Settings
+
 The Git Panel can be customized through your settings file. You can configure its appearance, behavior, and default states.
 To customize the Git Panel, add a git_panel object to your settings.json:
+
 ```
 {
   "git_panel": {
@@ -33,6 +35,7 @@ To customize the Git Panel, add a git_panel object to your settings.json:
   }
 }
 ```
+
 The `collapse_untracked_files_section` setting is particularly useful for projects with many generated or temporary files. When enabled, the untracked files section shows only a header with a chevron icon that you can click to expand and view the files.
 You can also toggle the untracked section visibility using the `git_panel::ToggleUntrackedSection` action, which can be bound to a custom keybinding in your keymap.
 
@@ -44,7 +47,7 @@ You can also toggle the untracked section visibility using the `git_panel::Toggl
 }
 ```
 
-Important: This action works when the Git Panel is focused! If you want to toggle the untracked section from anywhere in Zed, you can use: 
+Important: This action works when the Git Panel is focused! If you want to toggle the untracked section from anywhere in Zed, you can use:
 
 ```
 {
@@ -54,18 +57,18 @@ Important: This action works when the Git Panel is focused! If you want to toggl
   }
 }
 ```
-This way you can ensure the Git Panel is focused before toggling the untracked section.
 
+This way you can ensure the Git Panel is focused before toggling the untracked section.
 
 Available Git Panel settings include:
 
- - `button`: Whether to show the Git Panel button in the status bar (default: true)
- - `dock`: Where to dock the panel, either "left" or "right" (default: "left")
- - `default_width`: Width of the panel in pixels (default: 360)
- - `status_style`: How to display file status indicators, either "icon" or "label_color" (default: "icon")
- - `fallback_branch_name`: Default branch name when Git's init.defaultBranch is not set (default: "main")
- - `sort_by_path`: Sort entries by file path instead of by status (default: false)
- - `collapse_untracked_files_section`: Whether untracked files should be collapsed by default (default: false)
+- `button`: Whether to show the Git Panel button in the status bar (default: true)
+- `dock`: Where to dock the panel, either "left" or "right" (default: "left")
+- `default_width`: Width of the panel in pixels (default: 360)
+- `status_style`: How to display file status indicators, either "icon" or "label_color" (default: "icon")
+- `fallback_branch_name`: Default branch name when Git's init.defaultBranch is not set (default: "main")
+- `sort_by_path`: Sort entries by file path instead of by status (default: false)
+- `collapse_untracked_files_section`: Whether untracked files should be collapsed by default (default: false)
 
 ## Project Diff
 


### PR DESCRIPTION
CLOSES https://github.com/zed-industries/zed/discussions/31856

Release Notes
 
 - Improved 
 
Git Panel: Collapsible Untracked Files Section
The Git Panel now supports collapsing the untracked files section, making it easier to manage repositories with many generated or temporary files.
What's New

Collapsible Untracked Section: Click the chevron icon next to "Untracked" header to expand/collapse untracked files
Configurable Default State: Set collapse_untracked_files_section to true in your settings to have untracked files collapsed by default
Keyboard Shortcut Support: Use the git_panel::ToggleUntrackedSection action to toggle visibility via keybinding

Configuration
Add to your settings.json:
```
{
  "git_panel": {
    "collapse_untracked_files_section": true
  }
}
```

Add to your keymap.json:
```
{
  "bindings": {
    "cmd-alt-u": "git_panel::ToggleUntrackedSection"
  }
}
```

This feature is particularly useful for projects with build artifacts, node_modules, or other generated files that clutter the Git Panel view.

