### PR TITLE
git: Allow users to customise commit prompt

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -689,6 +689,11 @@
     //
     // Default: false
     "sort_by_path": false,
+    // Custom prompt for generating commit messages with AI.
+    // When not set, uses the built-in prompt from commit_message_prompt.txt
+    //
+    // Default: null (uses built-in prompt)
+    // "commit_message_prompt": "You are an expert at writing Git commits...",
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -70,6 +70,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub sort_by_path: Option<bool>,
+
+    /// Custom prompt for generating commit messages with AI.
+    ///
+    /// Default: built-in prompt
+    pub commit_message_prompt: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -81,6 +86,15 @@ pub struct GitPanelSettings {
     pub scrollbar: ScrollbarSettings,
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
+    pub commit_message_prompt: Option<String>,
+}
+
+impl GitPanelSettings {
+    pub fn commit_message_prompt(&self) -> &str {
+        self.commit_message_prompt
+            .as_deref()
+            .unwrap_or(include_str!("commit_message_prompt.txt"))
+    }
 }
 
 impl Settings for GitPanelSettings {


### PR DESCRIPTION
Introduces a new setting:
```json
{
  "git_panel": {
    "commit_message_prompt": "..."
  },
```
That lets a user to customise the commit message prompt.

I had a strong temptation to pull `commit_message_prompt.txt` into `defaults.json` however noticed, that there are additional checks on prompt changes. So decided not to do that.

![Kapture 2025-06-01 at 19 10 32](https://github.com/user-attachments/assets/03d46d2d-874a-4b2f-aa0f-c7cd0a8868f6)

Release Notes:

- Introduces `commit_message_prompt` parameter to `git_panel` section that allows users to customise the commit message generation prompt.
