### PR TITLE
Add LM Studio URL configuration field

### DIFF
--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -5,8 +5,6 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::{convert::TryFrom, sync::Arc, time::Duration};
 
-pub const LMSTUDIO_API_URL: &str = "http://localhost:1234/api/v0";
-
 #[derive(Clone, Copy, Serialize, Deserialize, Debug, Eq, PartialEq)]
 #[serde(rename_all = "lowercase")]
 pub enum Role {


### PR DESCRIPTION
Adds a URL input field to configure LM Studio server endpoint.

**Primary Change:**
- URL text input field for LM Studio server configuration
- Allows users to specify custom LM Studio server URL

**Additional Features:**
- Check button to validate server connectivity
- Visual feedback with status indicators
- URL validation and error handling

This enables users to connect to LM Studio servers running on different hosts/ports.