### PR TITLE
editor: Fix completion accept for optional chaining in Typescript

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19599,7 +19599,7 @@ fn process_completion_for_edit(
                             if replace_range
                                 .end
                                 .cmp(&cursor_position, &buffer_snapshot)
-                                .is_ge()
+                                .is_gt()
                             {
                                 let range_after_cursor = *cursor_position..replace_range.end;
                                 let text_after_cursor = buffer

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19586,9 +19586,7 @@ fn process_completion_for_edit(
                             let mut current_needle = text_to_replace.next();
                             for haystack_ch in completion.label.text.chars() {
                                 if let Some(needle_ch) = current_needle {
-                                    if haystack_ch.to_ascii_lowercase()
-                                        == needle_ch.to_ascii_lowercase()
-                                    {
+                                    if haystack_ch.eq_ignore_ascii_case(&needle_ch) {
                                         current_needle = text_to_replace.next();
                                     }
                                 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10479,6 +10479,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
         run_description: &'static str,
         initial_state: String,
         buffer_marked_text: String,
+        completion_label: &'static str,
         completion_text: &'static str,
         expected_with_insert_mode: String,
         expected_with_replace_mode: String,
@@ -10491,6 +10492,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Start of word matches completion text",
             initial_state: "before ediˇ after".into(),
             buffer_marked_text: "before <edi|> after".into(),
+            completion_label: "editor",
             completion_text: "editor",
             expected_with_insert_mode: "before editorˇ after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
@@ -10501,6 +10503,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Accept same text at the middle of the word",
             initial_state: "before ediˇtor after".into(),
             buffer_marked_text: "before <edi|tor> after".into(),
+            completion_label: "editor",
             completion_text: "editor",
             expected_with_insert_mode: "before editorˇtor after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
@@ -10511,6 +10514,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "End of word matches completion text -- cursor at end",
             initial_state: "before torˇ after".into(),
             buffer_marked_text: "before <tor|> after".into(),
+            completion_label: "editor",
             completion_text: "editor",
             expected_with_insert_mode: "before editorˇ after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
@@ -10521,6 +10525,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "End of word matches completion text -- cursor at start",
             initial_state: "before ˇtor after".into(),
             buffer_marked_text: "before <|tor> after".into(),
+            completion_label: "editor",
             completion_text: "editor",
             expected_with_insert_mode: "before editorˇtor after".into(),
             expected_with_replace_mode: "before editorˇ after".into(),
@@ -10531,6 +10536,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Prepend text containing whitespace",
             initial_state: "pˇfield: bool".into(),
             buffer_marked_text: "<p|field>: bool".into(),
+            completion_label: "pub ",
             completion_text: "pub ",
             expected_with_insert_mode: "pub ˇfield: bool".into(),
             expected_with_replace_mode: "pub ˇ: bool".into(),
@@ -10541,6 +10547,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Add element to start of list",
             initial_state: "[element_ˇelement_2]".into(),
             buffer_marked_text: "[<element_|element_2>]".into(),
+            completion_label: "element_1",
             completion_text: "element_1",
             expected_with_insert_mode: "[element_1ˇelement_2]".into(),
             expected_with_replace_mode: "[element_1ˇ]".into(),
@@ -10551,6 +10558,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Add element to start of list -- first and second elements are equal",
             initial_state: "[elˇelement]".into(),
             buffer_marked_text: "[<el|element>]".into(),
+            completion_label: "element",
             completion_text: "element",
             expected_with_insert_mode: "[elementˇelement]".into(),
             expected_with_replace_mode: "[elementˇ]".into(),
@@ -10561,6 +10569,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Ends with matching suffix",
             initial_state: "SubˇError".into(),
             buffer_marked_text: "<Sub|Error>".into(),
+            completion_label: "SubscriptionError",
             completion_text: "SubscriptionError",
             expected_with_insert_mode: "SubscriptionErrorˇError".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
@@ -10571,6 +10580,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Suffix is a subsequence -- contiguous",
             initial_state: "SubˇErr".into(),
             buffer_marked_text: "<Sub|Err>".into(),
+            completion_label: "SubscriptionError",
             completion_text: "SubscriptionError",
             expected_with_insert_mode: "SubscriptionErrorˇErr".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
@@ -10581,6 +10591,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Suffix is a subsequence -- non-contiguous -- replace intended",
             initial_state: "Suˇscrirr".into(),
             buffer_marked_text: "<Su|scrirr>".into(),
+            completion_label: "SubscriptionError",
             completion_text: "SubscriptionError",
             expected_with_insert_mode: "SubscriptionErrorˇscrirr".into(),
             expected_with_replace_mode: "SubscriptionErrorˇ".into(),
@@ -10591,6 +10602,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             run_description: "Suffix is a subsequence -- non-contiguous -- replace unintended",
             initial_state: "foo(indˇix)".into(),
             buffer_marked_text: "foo(<ind|ix>)".into(),
+            completion_label: "node_index",
             completion_text: "node_index",
             expected_with_insert_mode: "foo(node_indexˇix)".into(),
             expected_with_replace_mode: "foo(node_indexˇ)".into(),
@@ -10598,34 +10610,37 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             expected_with_replace_suffix_mode: "foo(node_indexˇix)".into(),
         },
         Run {
-            run_description: "Type name completion with suffix",
-            initial_state: "let z: ShaˇredString".into(),
-            buffer_marked_text: "let z: Sha<|redString>".into(),
-            completion_text: "Shared",
-            expected_with_insert_mode: "let z: ShaSharedˇredString".into(),
-            expected_with_replace_mode: "let z: ShaSharedˇ".into(),
-            expected_with_replace_subsequence_mode: "let z: ShaSharedˇredString".into(),
-            expected_with_replace_suffix_mode: "let z: ShaSharedˇredString".into(),
-        },
-        Run {
-            run_description: "Prefix expansion at start of identifier",
-            initial_state: "ˇname: 2".into(),
-            buffer_marked_text: "<|>name: 2".into(),
-            completion_text: "language_name",
-            expected_with_insert_mode: "language_nameˇname: 2".into(),
-            expected_with_replace_mode: "language_nameˇname: 2".into(),
-            expected_with_replace_subsequence_mode: "language_nameˇname: 2".into(),
-            expected_with_replace_suffix_mode: "language_nameˇname: 2".into(),
-        },
-        Run {
             run_description: "Replace range ends before cursor - should extend to cursor",
             initial_state: "before editˇo after".into(),
             buffer_marked_text: "before <{ed}>it|o after".into(),
+            completion_label: "editor",
             completion_text: "editor",
             expected_with_insert_mode: "before editorˇo after".into(),
             expected_with_replace_mode: "before editorˇo after".into(),
             expected_with_replace_subsequence_mode: "before editorˇo after".into(),
             expected_with_replace_suffix_mode: "before editorˇo after".into(),
+        },
+        Run {
+            run_description: "Uses label for suffix matching",
+            initial_state: "before ediˇtor after".into(),
+            buffer_marked_text: "before <edi|tor> after".into(),
+            completion_label: "editor",
+            completion_text: "editor()",
+            expected_with_insert_mode: "before editor()ˇtor after".into(),
+            expected_with_replace_mode: "before editor()ˇ after".into(),
+            expected_with_replace_subsequence_mode: "before editor()ˇ after".into(),
+            expected_with_replace_suffix_mode: "before editor()ˇ after".into(),
+        },
+        Run {
+            run_description: "Case insensitive subsequence and suffix matching",
+            initial_state: "before EDiˇtoR after".into(),
+            buffer_marked_text: "before <EDi|toR> after".into(),
+            completion_label: "editor",
+            completion_text: "editor",
+            expected_with_insert_mode: "before editorˇtoR after".into(),
+            expected_with_replace_mode: "before editorˇ after".into(),
+            expected_with_replace_subsequence_mode: "before editorˇ after".into(),
+            expected_with_replace_suffix_mode: "before editorˇ after".into(),
         },
     ];
 
@@ -10667,7 +10682,7 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             handle_completion_request_with_insert_and_replace(
                 &mut cx,
                 &run.buffer_marked_text,
-                vec![run.completion_text],
+                vec![(run.completion_label, run.completion_text)],
                 counter.clone(),
             )
             .await;
@@ -10727,7 +10742,7 @@ async fn test_completion_with_mode_specified_by_action(cx: &mut TestAppContext) 
     handle_completion_request_with_insert_and_replace(
         &mut cx,
         &buffer_marked_text,
-        vec![completion_text],
+        vec![(completion_text, completion_text)],
         counter.clone(),
     )
     .await;
@@ -10761,7 +10776,7 @@ async fn test_completion_with_mode_specified_by_action(cx: &mut TestAppContext) 
     handle_completion_request_with_insert_and_replace(
         &mut cx,
         &buffer_marked_text,
-        vec![completion_text],
+        vec![(completion_text, completion_text)],
         counter.clone(),
     )
     .await;
@@ -10848,7 +10863,7 @@ async fn test_completion_replacing_surrounding_text_with_multicursors(cx: &mut T
     handle_completion_request_with_insert_and_replace(
         &mut cx,
         completion_marked_buffer,
-        vec![completion_text],
+        vec![(completion_text, completion_text)],
         Arc::new(AtomicUsize::new(0)),
     )
     .await;
@@ -10902,7 +10917,7 @@ async fn test_completion_replacing_surrounding_text_with_multicursors(cx: &mut T
     handle_completion_request_with_insert_and_replace(
         &mut cx,
         completion_marked_buffer,
-        vec![completion_text],
+        vec![(completion_text, completion_text)],
         Arc::new(AtomicUsize::new(0)),
     )
     .await;
@@ -10951,7 +10966,7 @@ async fn test_completion_replacing_surrounding_text_with_multicursors(cx: &mut T
     handle_completion_request_with_insert_and_replace(
         &mut cx,
         completion_marked_buffer,
-        vec![completion_text],
+        vec![(completion_text, completion_text)],
         Arc::new(AtomicUsize::new(0)),
     )
     .await;
@@ -21105,7 +21120,7 @@ pub fn handle_completion_request(
 pub fn handle_completion_request_with_insert_and_replace(
     cx: &mut EditorLspTestContext,
     marked_string: &str,
-    completions: Vec<&'static str>,
+    completions: Vec<(&'static str, &'static str)>, // (label, new_text)
     counter: Arc<AtomicUsize>,
 ) -> impl Future<Output = ()> {
     let complete_from_marker: TextRangeMarker = '|'.into();
@@ -21147,13 +21162,13 @@ pub fn handle_completion_request_with_insert_and_replace(
                 Ok(Some(lsp::CompletionResponse::Array(
                     completions
                         .iter()
-                        .map(|completion_text| lsp::CompletionItem {
-                            label: completion_text.to_string(),
+                        .map(|(label, new_text)| lsp::CompletionItem {
+                            label: label.to_string(),
                             text_edit: Some(lsp::CompletionTextEdit::InsertAndReplace(
                                 lsp::InsertReplaceEdit {
                                     insert: insert_range,
                                     replace: replace_range,
-                                    new_text: completion_text.to_string(),
+                                    new_text: new_text.to_string(),
                                 },
                             )),
                             ..Default::default()

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10617,6 +10617,16 @@ async fn test_completion_mode(cx: &mut TestAppContext) {
             expected_with_replace_subsequence_mode: "language_nameˇname: 2".into(),
             expected_with_replace_suffix_mode: "language_nameˇname: 2".into(),
         },
+        Run {
+            run_description: "Replace range ends before cursor - should extend to cursor",
+            initial_state: "before editˇo after".into(),
+            buffer_marked_text: "before <{ed}>it|o after".into(),
+            completion_text: "editor",
+            expected_with_insert_mode: "before editorˇo after".into(),
+            expected_with_replace_mode: "before editorˇo after".into(),
+            expected_with_replace_subsequence_mode: "before editorˇo after".into(),
+            expected_with_replace_suffix_mode: "before editorˇo after".into(),
+        },
     ];
 
     for run in runs {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -20979,6 +20979,109 @@ async fn test_indent_on_newline_for_python(cx: &mut TestAppContext) {
     "});
 }
 
+#[gpui::test]
+async fn test_process_completion_for_edit(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    // test complete replace range
+    test_completion_replacement(
+        (2, 8),
+        None,
+        "toString",
+        "x.tostriˇ",
+        "x.toStringˇ",
+        &mut cx,
+    );
+
+    // test only prefix replace range
+    test_completion_replacement(
+        (1, 2),
+        None,
+        "?.toString",
+        "x.tostriˇ",
+        "x?.toStringˇ",
+        &mut cx,
+    );
+}
+
+fn test_completion_replacement(
+    replace_range: (u32, u32),
+    insert_range: Option<(u32, u32)>,
+    new_text: &str,
+    initial_state: &str,
+    expected_state: &str,
+    cx: &mut EditorTestContext,
+) {
+    cx.set_state(initial_state);
+    let result = cx.update_editor(|editor, _window, cx| {
+        let buffer = editor.buffer().read(cx).as_singleton().unwrap();
+        let source = match insert_range {
+            None => CompletionSource::Custom,
+            Some((start, end)) => CompletionSource::Lsp {
+                insert_range: Some(buffer.read_with(cx, |buffer, _| {
+                    buffer.anchor_before(Point {
+                        row: 0,
+                        column: start,
+                    })..buffer.anchor_after(Point {
+                        row: 0,
+                        column: end,
+                    })
+                })),
+                server_id: LanguageServerId(0),
+                lsp_completion: Box::new(lsp::CompletionItem::default()),
+                lsp_defaults: None,
+                resolved: false,
+            },
+        };
+        let (replace_start, replace_end) = replace_range;
+        let completion = Completion {
+            replace_range: buffer.read_with(cx, |buffer, _| {
+                buffer.anchor_before(Point {
+                    row: 0,
+                    column: replace_start,
+                })..buffer.anchor_after(Point {
+                    row: 0,
+                    column: replace_end,
+                })
+            }),
+            new_text: new_text.to_string(),
+            label: CodeLabel {
+                text: new_text.to_string(),
+                runs: Vec::new(),
+                filter_range: 0..new_text.len(),
+            },
+            documentation: None,
+            source,
+            icon_path: None,
+            insert_text_mode: None,
+            confirm: None,
+        };
+        let cursor_position = editor.selections.newest_anchor().start;
+        process_completion_for_edit(
+            &completion,
+            CompletionIntent::Complete,
+            &buffer,
+            &cursor_position,
+            cx,
+        )
+    });
+    cx.update_editor(|editor, _window, cx| {
+        let buffer = editor.buffer().read(cx).as_singleton().unwrap();
+        buffer.update(cx, |buffer, cx| {
+            let start_point = buffer.offset_to_point(result.replace_range.start);
+            let end_point = buffer.offset_to_point(result.replace_range.end);
+            buffer.edit(
+                [(start_point..end_point, result.new_text.as_str())],
+                None,
+                cx,
+            );
+        });
+    });
+    cx.assert_editor_state(expected_state);
+}
+
 fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {
     let point = DisplayPoint::new(DisplayRow(row as u32), column as u32);
     point..point


### PR DESCRIPTION
Closes #31662

Currently, we assume `insert_range` will always end at the cursor and `replace_range` will also always end after the cursor for calculating range to replace. This is a particular case for the rust-analyzer, but not widely true for other language servers.

This PR fixes this assumption, and now `insert_range` and `replace_range` both can end before cursor.

In this particular case:
```ts
let x: string | undefined;

x.tostˇ // here insert as well as replace range is just "." while new_text is "?.toString()"
```

This change makes it such that if final range to replace ends before cursor, we extend it till the cursor.

Bonus:
- Improves suffix and subsequence matching to use `label` over `new_text` as `new_text` can contain end characters like `()` or `$` which is not visible while accepting the completion.
- Make suffix and subsequence check case insensitive.
- Fixes broken subsequence matching which was not considering the order of characters while matching subsequence.

Release Notes:

- Fixed an issue where autocompleting optional chaining methods in TypeScript, such as `x.tostr`, would result in `x?.toString()tostr` instead of `x?.toString()`.
