### PR TITLE
Notify when pinning a tab even if the tab isn't moved

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2063,7 +2063,9 @@ impl Pane {
                 self.set_preview_item_id(None, cx);
             }
 
-            if ix != destination_index {
+            if ix == destination_index {
+                cx.notify();
+            } else {
                 self.workspace
                     .update(cx, |_, cx| {
                         cx.defer_in(window, move |_, window, cx| {


### PR DESCRIPTION
The optimization to not move a tab being pinned (when the destination index is the same as its index) in https://github.com/zed-industries/zed/pull/31871 caused a regression, as we were no longer calling `cx.notify()` indirectly through `move_item()`. Thanks for catching this, @smitbarmase.

Release Notes:

- N/A