### PR TITLE
assistant_context_editor: Fix copy paste regression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,7 @@ dependencies = [
  "fuzzy",
  "gpui",
  "indexed_docs",
+ "indoc",
  "language",
  "language_model",
  "languages",

--- a/crates/assistant_context_editor/Cargo.toml
+++ b/crates/assistant_context_editor/Cargo.toml
@@ -60,6 +60,7 @@ zed_actions.workspace = true
 zed_llm_client.workspace = true
 
 [dev-dependencies]
+indoc.workspace = true
 language_model = { workspace = true, features = ["test-support"] }
 languages = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true


### PR DESCRIPTION
Closes #31166

Release Notes:

- Fixed an issue where copying and pasting an assistant response in text threads would result in duplicate text
