### PR TITLE
python: Re-land usage of source file path in toolchain picker

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -34,7 +34,7 @@ pub use highlight_map::HighlightMap;
 use http_client::HttpClient;
 pub use language_registry::{LanguageName, LoadedLanguage};
 use lsp::{CodeActionKind, InitializeParams, LanguageServerBinary, LanguageServerBinaryOptions};
-pub use manifest::{ManifestName, ManifestProvider, ManifestQuery};
+pub use manifest::{ManifestDelegate, ManifestName, ManifestProvider, ManifestQuery};
 use parking_lot::Mutex;
 use regex::Regex;
 use schemars::{
@@ -323,7 +323,6 @@ pub trait LspAdapterDelegate: Send + Sync {
     fn http_client(&self) -> Arc<dyn HttpClient>;
     fn worktree_id(&self) -> WorktreeId;
     fn worktree_root_path(&self) -> &Path;
-    fn exists(&self, path: &Path, is_dir: Option<bool>) -> bool;
     fn update_status(&self, language: LanguageServerName, status: BinaryStatus);
     fn registered_lsp_adapters(&self) -> Vec<Arc<dyn LspAdapter>>;
     async fn language_server_download_dir(&self, name: &LanguageServerName) -> Option<Arc<Path>>;

--- a/crates/language/src/manifest.rs
+++ b/crates/language/src/manifest.rs
@@ -1,8 +1,7 @@
 use std::{borrow::Borrow, path::Path, sync::Arc};
 
 use gpui::SharedString;
-
-use crate::LspAdapterDelegate;
+use settings::WorktreeId;
 
 #[derive(Clone, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct ManifestName(SharedString);
@@ -39,10 +38,15 @@ pub struct ManifestQuery {
     /// Path to the file, relative to worktree root.
     pub path: Arc<Path>,
     pub depth: usize,
-    pub delegate: Arc<dyn LspAdapterDelegate>,
+    pub delegate: Arc<dyn ManifestDelegate>,
 }
 
 pub trait ManifestProvider {
     fn name(&self) -> ManifestName;
     fn search(&self, query: ManifestQuery) -> Option<Arc<Path>>;
+}
+
+pub trait ManifestDelegate: Send + Sync {
+    fn worktree_id(&self) -> WorktreeId;
+    fn exists(&self, path: &Path, is_dir: Option<bool>) -> bool;
 }

--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -44,6 +44,7 @@ pub trait ToolchainLister: Send + Sync {
     async fn list(
         &self,
         worktree_root: PathBuf,
+        subroot_relative_path: Option<Arc<Path>>,
         project_env: Option<HashMap<String, String>>,
     ) -> ToolchainList;
     // Returns a term which we should use in UI to refer to a toolchain.

--- a/crates/language/src/toolchain.rs
+++ b/crates/language/src/toolchain.rs
@@ -14,7 +14,7 @@ use collections::HashMap;
 use gpui::{AsyncApp, SharedString};
 use settings::WorktreeId;
 
-use crate::LanguageName;
+use crate::{LanguageName, ManifestName};
 
 /// Represents a single toolchain.
 #[derive(Clone, Debug)]
@@ -48,6 +48,8 @@ pub trait ToolchainLister: Send + Sync {
     ) -> ToolchainList;
     // Returns a term which we should use in UI to refer to a toolchain.
     fn term(&self) -> SharedString;
+    /// Returns the name of the manifest file for this toolchain.
+    fn manifest_name(&self) -> ManifestName;
 }
 
 #[async_trait(?Send)]

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -689,6 +689,9 @@ fn get_worktree_venv_declaration(worktree_root: &Path) -> Option<String> {
 
 #[async_trait]
 impl ToolchainLister for PythonToolchainProvider {
+    fn manifest_name(&self) -> language::ManifestName {
+        ManifestName::from(SharedString::new_static("pyproject.toml"))
+    }
     async fn list(
         &self,
         worktree_root: PathBuf,

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -694,7 +694,7 @@ impl ToolchainLister for PythonToolchainProvider {
     }
     async fn list(
         &self,
-        worktree_root: PathBuf,
+        root: PathBuf,
         project_env: Option<HashMap<String, String>>,
     ) -> ToolchainList {
         let env = project_env.unwrap_or_default();
@@ -705,7 +705,7 @@ impl ToolchainLister for PythonToolchainProvider {
             &environment,
         );
         let mut config = Configuration::default();
-        config.workspace_directories = Some(vec![worktree_root.clone()]);
+        config.workspace_directories = Some(vec![root.clone()]);
         for locator in locators.iter() {
             locator.configure(&config);
         }
@@ -718,7 +718,7 @@ impl ToolchainLister for PythonToolchainProvider {
             .lock()
             .map_or(Vec::new(), |mut guard| std::mem::take(&mut guard));
 
-        let wr = worktree_root;
+        let wr = root;
         let wr_venv = get_worktree_venv_declaration(&wr);
         // Sort detected environments by:
         //     environment name matching activation file (<workdir>/.venv)

--- a/crates/project/src/manifest_tree.rs
+++ b/crates/project/src/manifest_tree.rs
@@ -11,16 +11,17 @@ use std::{
     borrow::Borrow,
     collections::{BTreeMap, hash_map::Entry},
     ops::ControlFlow,
+    path::Path,
     sync::Arc,
 };
 
 use collections::HashMap;
 use gpui::{App, AppContext as _, Context, Entity, EventEmitter, Subscription};
-use language::{LspAdapterDelegate, ManifestName, ManifestQuery};
+use language::{ManifestDelegate, ManifestName, ManifestQuery};
 pub use manifest_store::ManifestProviders;
 use path_trie::{LabelPresence, RootPathTrie, TriePath};
 use settings::{SettingsStore, WorktreeId};
-use worktree::{Event as WorktreeEvent, Worktree};
+use worktree::{Event as WorktreeEvent, Snapshot, Worktree};
 
 use crate::{
     ProjectPath,
@@ -89,7 +90,7 @@ pub(crate) enum ManifestTreeEvent {
 impl EventEmitter<ManifestTreeEvent> for ManifestTree {}
 
 impl ManifestTree {
-    pub(crate) fn new(worktree_store: Entity<WorktreeStore>, cx: &mut App) -> Entity<Self> {
+    pub fn new(worktree_store: Entity<WorktreeStore>, cx: &mut App) -> Entity<Self> {
         cx.new(|cx| Self {
             root_points: Default::default(),
             _subscriptions: [
@@ -106,11 +107,11 @@ impl ManifestTree {
             worktree_store,
         })
     }
-    fn root_for_path(
+    pub(crate) fn root_for_path(
         &mut self,
         ProjectPath { worktree_id, path }: ProjectPath,
         manifests: &mut dyn Iterator<Item = ManifestName>,
-        delegate: Arc<dyn LspAdapterDelegate>,
+        delegate: Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> BTreeMap<ManifestName, ProjectPath> {
         debug_assert_eq!(delegate.worktree_id(), worktree_id);
@@ -216,5 +217,28 @@ impl ManifestTree {
             }
             _ => {}
         }
+    }
+}
+
+pub(crate) struct ManifestQueryDelegate {
+    worktree: Snapshot,
+}
+impl ManifestQueryDelegate {
+    pub fn new(worktree: Snapshot) -> Self {
+        Self { worktree }
+    }
+}
+
+impl ManifestDelegate for ManifestQueryDelegate {
+    fn exists(&self, path: &Path, is_dir: Option<bool>) -> bool {
+        self.worktree.entry_for_path(path).map_or(false, |entry| {
+            is_dir.map_or(true, |is_required_to_be_dir| {
+                is_required_to_be_dir == entry.is_dir()
+            })
+        })
+    }
+
+    fn worktree_id(&self) -> WorktreeId {
+        self.worktree.id()
     }
 }

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -16,7 +16,7 @@ use std::{
 use collections::{HashMap, IndexMap};
 use gpui::{App, AppContext as _, Entity, Subscription};
 use language::{
-    Attach, CachedLspAdapter, LanguageName, LanguageRegistry, LspAdapterDelegate,
+    Attach, CachedLspAdapter, LanguageName, LanguageRegistry, ManifestDelegate,
     language_settings::AllLanguageSettings,
 };
 use lsp::LanguageServerName;
@@ -151,7 +151,7 @@ impl LanguageServerTree {
         &'a mut self,
         path: ProjectPath,
         query: AdapterQuery<'_>,
-        delegate: Arc<dyn LspAdapterDelegate>,
+        delegate: Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
         let settings_location = SettingsLocation {
@@ -181,7 +181,7 @@ impl LanguageServerTree {
             LanguageServerName,
             (LspSettings, BTreeSet<LanguageName>, Arc<CachedLspAdapter>),
         >,
-        delegate: Arc<dyn LspAdapterDelegate>,
+        delegate: Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
         let worktree_id = path.worktree_id;
@@ -401,7 +401,7 @@ impl<'tree> ServerTreeRebase<'tree> {
         &'a mut self,
         path: ProjectPath,
         query: AdapterQuery<'_>,
-        delegate: Arc<dyn LspAdapterDelegate>,
+        delegate: Arc<dyn ManifestDelegate>,
         cx: &mut App,
     ) -> impl Iterator<Item = LanguageServerTreeNode> + 'a {
         let settings_location = SettingsLocation {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -35,6 +35,7 @@ pub use git_store::{
     ConflictRegion, ConflictSet, ConflictSetSnapshot, ConflictSetUpdate,
     git_traversal::{ChildEntriesGitIter, GitEntry, GitEntryRef, GitTraversal},
 };
+pub use manifest_tree::ManifestTree;
 
 use anyhow::{Context as _, Result, anyhow};
 use buffer_store::{BufferStore, BufferStoreEvent};
@@ -874,11 +875,13 @@ impl Project {
                 cx.new(|cx| ContextServerStore::new(worktree_store.clone(), cx));
 
             let environment = cx.new(|_| ProjectEnvironment::new(env));
+            let manifest_tree = ManifestTree::new(worktree_store.clone(), cx);
             let toolchain_store = cx.new(|cx| {
                 ToolchainStore::local(
                     languages.clone(),
                     worktree_store.clone(),
                     environment.clone(),
+                    manifest_tree.clone(),
                     cx,
                 )
             });
@@ -946,6 +949,7 @@ impl Project {
                     prettier_store.clone(),
                     toolchain_store.clone(),
                     environment.clone(),
+                    manifest_tree,
                     languages.clone(),
                     client.http_client(),
                     fs.clone(),
@@ -3085,15 +3089,12 @@ impl Project {
         language_name: LanguageName,
         cx: &App,
     ) -> Task<Option<ToolchainList>> {
-        if let Some(toolchain_store) = self.toolchain_store.clone() {
+        if let Some(toolchain_store) = self.toolchain_store.as_ref().map(Entity::downgrade) {
             cx.spawn(async move |cx| {
-                cx.update(|cx| {
-                    toolchain_store
-                        .read(cx)
-                        .list_toolchains(path, language_name, cx)
-                })
-                .ok()?
-                .await
+                toolchain_store
+                    .update(cx, |this, cx| this.list_toolchains(path, language_name, cx))
+                    .ok()?
+                    .await
             })
         } else {
             Task::ready(None)

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3088,7 +3088,7 @@ impl Project {
         path: ProjectPath,
         language_name: LanguageName,
         cx: &App,
-    ) -> Task<Option<ToolchainList>> {
+    ) -> Task<Option<(ToolchainList, Arc<Path>)>> {
         if let Some(toolchain_store) = self.toolchain_store.as_ref().map(Entity::downgrade) {
             cx.spawn(async move |cx| {
                 toolchain_store

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -348,6 +348,7 @@ impl LocalToolchainStore {
                 .ok()
                 .flatten()?;
             let worktree_id = snapshot.id();
+            let worktree_root = snapshot.abs_path().to_path_buf();
             let relative_path = manifest_tree
                 .update(cx, |this, cx| {
                     this.root_for_path(
@@ -377,7 +378,14 @@ impl LocalToolchainStore {
 
             cx.background_spawn(async move {
                 Some((
-                    toolchains.list(abs_path.to_path_buf(), project_env).await,
+                    toolchains
+                        .list(
+                            worktree_root,
+                            Some(relative_path.path.clone())
+                                .filter(|_| *relative_path.path != *Path::new("")),
+                            project_env,
+                        )
+                        .await,
                     relative_path.path,
                 ))
             })

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -318,19 +318,14 @@ impl LocalToolchainStore {
         cx: &App,
     ) -> Task<Option<ToolchainList>> {
         let registry = self.languages.clone();
-        let Some(abs_path) = self
-            .worktree_store
-            .read(cx)
-            .worktree_for_id(path.worktree_id, cx)
-            .map(|worktree| worktree.read(cx).abs_path())
-        else {
+        let Some(abs_path) = self.worktree_store.read(cx).absolutize(&path, cx) else {
             return Task::ready(None);
         };
         let environment = self.project_environment.clone();
         cx.spawn(async move |cx| {
             let project_env = environment
                 .update(cx, |environment, cx| {
-                    environment.get_directory_environment(abs_path.clone(), cx)
+                    environment.get_directory_environment(abs_path.as_path().into(), cx)
                 })
                 .ok()?
                 .await;

--- a/crates/proto/proto/toolchain.proto
+++ b/crates/proto/proto/toolchain.proto
@@ -23,6 +23,7 @@ message ListToolchainsResponse {
     repeated Toolchain toolchains = 1;
     bool has_values = 2;
     repeated ToolchainGroup groups = 3;
+    optional string relative_worktree_path = 4;
 }
 
 message ActivateToolchain {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -9,8 +9,8 @@ use http_client::HttpClient;
 use language::{Buffer, BufferEvent, LanguageRegistry, proto::serialize_operation};
 use node_runtime::NodeRuntime;
 use project::{
-    LspStore, LspStoreEvent, PrettierStore, ProjectEnvironment, ProjectPath, ToolchainStore,
-    WorktreeId,
+    LspStore, LspStoreEvent, ManifestTree, PrettierStore, ProjectEnvironment, ProjectPath,
+    ToolchainStore, WorktreeId,
     buffer_store::{BufferStore, BufferStoreEvent},
     debugger::{breakpoint_store::BreakpointStore, dap_store::DapStore},
     git_store::GitStore,
@@ -87,12 +87,13 @@ impl HeadlessProject {
         });
 
         let environment = cx.new(|_| ProjectEnvironment::new(None));
-
+        let manifest_tree = ManifestTree::new(worktree_store.clone(), cx);
         let toolchain_store = cx.new(|cx| {
             ToolchainStore::local(
                 languages.clone(),
                 worktree_store.clone(),
                 environment.clone(),
+                manifest_tree.clone(),
                 cx,
             )
         });
@@ -172,6 +173,7 @@ impl HeadlessProject {
                 prettier_store.clone(),
                 toolchain_store.clone(),
                 environment,
+                manifest_tree,
                 languages.clone(),
                 http_client.clone(),
                 fs.clone(),

--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -92,7 +92,7 @@ pub fn python_env_kernel_specifications(
     let background_executor = cx.background_executor().clone();
 
     async move {
-        let toolchains = if let Some(toolchains) = toolchains.await {
+        let toolchains = if let Some((toolchains, _)) = toolchains.await {
             toolchains
         } else {
             return Ok(Vec::new());

--- a/crates/toolchain_selector/src/active_toolchain.rs
+++ b/crates/toolchain_selector/src/active_toolchain.rs
@@ -158,7 +158,7 @@ impl ActiveToolchain {
                 let project = workspace
                     .read_with(cx, |this, _| this.project().clone())
                     .ok()?;
-                let toolchains = cx
+                let (toolchains, relative_path) = cx
                     .update(|_, cx| {
                         project.read(cx).available_toolchains(
                             ProjectPath {

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -10,7 +10,7 @@ use gpui::{
 use language::{LanguageName, Toolchain, ToolchainList};
 use picker::{Picker, PickerDelegate};
 use project::{Project, ProjectPath, WorktreeId};
-use std::{path::Path, sync::Arc};
+use std::{borrow::Cow, path::Path, sync::Arc};
 use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
 use workspace::{ModalView, Workspace};
@@ -186,13 +186,18 @@ impl ToolchainSelectorDelegate {
                     })
                     .ok()?
                     .await?;
-                let placeholder_text = format!(
-                    "Select a {} for `{}`…",
-                    term.to_lowercase(),
-                    relative_path.to_string_lossy()
-                )
-                .into();
+                let pretty_path = {
+                    let path = relative_path.to_string_lossy();
+                    if path.is_empty() {
+                        Cow::Borrowed("worktree root")
+                    } else {
+                        Cow::Owned(format!("`{}`", path))
+                    }
+                };
+                let placeholder_text =
+                    format!("Select a {} for {pretty_path}…", term.to_lowercase(),).into();
                 let _ = this.update_in(cx, move |this, window, cx| {
+                    this.delegate.relative_path = relative_path;
                     this.delegate.placeholder_text = placeholder_text;
                     this.refresh_placeholder(window, cx);
                 });

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -172,18 +172,8 @@ impl ToolchainSelectorDelegate {
                 let relative_path = this
                     .read_with(cx, |this, _| this.delegate.relative_path.clone())
                     .ok()?;
-                let placeholder_text = format!(
-                    "Select a {} for `{}`…",
-                    term.to_lowercase(),
-                    relative_path.to_string_lossy()
-                )
-                .into();
-                let _ = this.update_in(cx, move |this, window, cx| {
-                    this.delegate.placeholder_text = placeholder_text;
-                    this.refresh_placeholder(window, cx);
-                });
 
-                let available_toolchains = project
+                let (available_toolchains, relative_path) = project
                     .update(cx, |this, cx| {
                         this.available_toolchains(
                             ProjectPath {
@@ -196,6 +186,16 @@ impl ToolchainSelectorDelegate {
                     })
                     .ok()?
                     .await?;
+                let placeholder_text = format!(
+                    "Select a {} for `{}`…",
+                    term.to_lowercase(),
+                    relative_path.to_string_lossy()
+                )
+                .into();
+                let _ = this.update_in(cx, move |this, window, cx| {
+                    this.delegate.placeholder_text = placeholder_text;
+                    this.refresh_placeholder(window, cx);
+                });
 
                 let _ = this.update_in(cx, move |this, window, cx| {
                     this.delegate.candidates = available_toolchains;


### PR DESCRIPTION
This reverts commit 1e55e88c1822402566bdec8a893ec0429d8ee5e6.

Closes #21743

Release Notes:

- Python toolchain selector now uses path to the closest pyproject.toml as a basis for picking a toolchain. All files under the same pyproject.toml (in filesystem hierarchy) will share a single virtual environment. It is possible to have multiple Python virtual environments selected for disjoint parts of the same project.