### PR TITLE
agent: Generate a notification when reaching tool use limit

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1017,6 +1017,15 @@ impl ActiveThread {
                 self.play_notification_sound(cx);
                 self.show_notification("Waiting for tool confirmation", IconName::Info, window, cx);
             }
+            ThreadEvent::ToolUseLimitReached => {
+                self.play_notification_sound(cx);
+                self.show_notification(
+                    "Consecutive tool use limit reached.",
+                    IconName::Warning,
+                    window,
+                    cx,
+                );
+            }
             ThreadEvent::StreamedAssistantText(message_id, text) => {
                 if let Some(rendered_message) = self.rendered_messages_by_id.get_mut(&message_id) {
                     rendered_message.append_text(text, cx);

--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -1372,6 +1372,7 @@ impl AgentDiff {
             | ThreadEvent::ToolFinished { .. }
             | ThreadEvent::CheckpointChanged
             | ThreadEvent::ToolConfirmationNeeded
+            | ThreadEvent::ToolUseLimitReached
             | ThreadEvent::CancelEditing => {}
         }
     }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1673,6 +1673,7 @@ impl Thread {
                                         }
                                         CompletionRequestStatus::ToolUseLimitReached => {
                                             thread.tool_use_limit_reached = true;
+                                            cx.emit(ThreadEvent::ToolUseLimitReached);
                                         }
                                     }
                                 }
@@ -2843,6 +2844,7 @@ pub enum ThreadEvent {
     },
     CheckpointChanged,
     ToolConfirmationNeeded,
+    ToolUseLimitReached,
     CancelEditing,
     CompletionCanceled,
 }

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -246,6 +246,7 @@ impl ExampleContext {
                 | ThreadEvent::StreamedAssistantThinking(_, _)
                 | ThreadEvent::UsePendingTools { .. }
                 | ThreadEvent::CompletionCanceled => {}
+                ThreadEvent::ToolUseLimitReached => {}
                 ThreadEvent::ToolFinished {
                     tool_use_id,
                     pending_tool_use,


### PR DESCRIPTION
When reaching the consecutive tool call limit, the agent gets blocked and without a notification, you wouldn't know that. This PR adds the ability to be notified when that happens, and you can use either sound _and_ toast, or just one of them.

Release Notes:

- agent: Added support for getting notified (via toast and/or sound) when reaching the consecutive tool call limit.
