### PR TITLE
docs: Add more details to the agent checkpoint section

### DIFF
--- a/docs/src/ai/agent-panel.md
+++ b/docs/src/ai/agent-panel.md
@@ -23,6 +23,8 @@ You can click on the card that contains your message and re-submit it with an ad
 
 Every time the AI performs an edit, you should see a "Restore Checkpoint" button to the top of your message, allowing you to return your codebase to the state it was in prior to that message.
 
+The checkpoint button appears even if you interrupt the thread midway through an edit attempt, as this is likely a moment when you've identified that the agent is not heading in the right direction and you want to revert back.
+
 ### Navigating History {#navigating-history}
 
 To quickly navigate through recently opened threads, use the {#kb agent::ToggleNavigationMenu} binding, when focused on the panel's editor, or click the hamburger icon button at the top left of the panel to open the dropdown that shows you the six most recent threads.


### PR DESCRIPTION
Figured this was worth highlighting as part of the "Restore Checkpoint" feature behavior.

Release Notes:

- N/A
