### PR TITLE
Store profile per thread

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,7 @@ dependencies = [
  "assistant_slash_command",
  "assistant_slash_commands",
  "assistant_tool",
+ "assistant_tools",
  "async-watch",
  "audio",
  "buffer_diff",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -148,7 +148,6 @@ dependencies = [
  "deepseek",
  "fs",
  "gpui",
- "indexmap",
  "language_model",
  "lmstudio",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2987,7 +2987,6 @@ dependencies = [
  "anyhow",
  "assistant_context_editor",
  "assistant_slash_command",
- "assistant_tool",
  "async-stripe",
  "async-trait",
  "async-tungstenite",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -771,7 +771,6 @@
         "tools": {
           "copy_path": true,
           "create_directory": true,
-          "create_file": true,
           "delete_path": true,
           "diagnostics": true,
           "edit_file": true,

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -102,6 +102,7 @@ zed_llm_client.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]
+assistant_tools.workspace = true
 buffer_diff = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, "features" = ["test-support"] }

--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1144,6 +1144,10 @@ impl ActiveThread {
                     cx,
                 );
             }
+            ThreadEvent::ProfileChanged => {
+                self.save_thread(cx);
+                cx.notify();
+            }
         }
     }
 

--- a/crates/agent/src/agent.rs
+++ b/crates/agent/src/agent.rs
@@ -3,6 +3,7 @@ mod agent_configuration;
 mod agent_diff;
 mod agent_model_selector;
 mod agent_panel;
+mod agent_profile;
 mod buffer_codegen;
 mod context;
 mod context_picker;

--- a/crates/agent/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent/src/agent_configuration/manage_profiles_modal.rs
@@ -2,7 +2,7 @@ mod profile_modal_header;
 
 use std::sync::Arc;
 
-use agent_settings::{AgentProfile, AgentProfileId, AgentSettings, builtin_profiles};
+use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings, builtin_profiles};
 use assistant_tool::ToolWorkingSet;
 use convert_case::{Case, Casing as _};
 use editor::Editor;
@@ -280,7 +280,7 @@ impl ManageProfilesModal {
                 let name = mode.name_editor.read(cx).text(cx);
                 let profile_id = AgentProfileId(name.to_case(Case::Kebab).into());
 
-                let profile = AgentProfile {
+                let profile = AgentProfileSettings {
                     name: name.into(),
                     tools: base_profile
                         .as_ref()
@@ -329,7 +329,7 @@ impl ManageProfilesModal {
     fn create_profile(
         &self,
         profile_id: AgentProfileId,
-        profile: AgentProfile,
+        profile: AgentProfileSettings,
         cx: &mut Context<Self>,
     ) {
         update_settings_file::<AgentSettings>(self.fs.clone(), cx, {

--- a/crates/agent/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent/src/agent_configuration/manage_profiles_modal.rs
@@ -7,10 +7,7 @@ use assistant_tool::ToolWorkingSet;
 use convert_case::{Case, Casing as _};
 use editor::Editor;
 use fs::Fs;
-use gpui::{
-    DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription, WeakEntity,
-    prelude::*,
-};
+use gpui::{DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription, prelude::*};
 use settings::{Settings as _, update_settings_file};
 use ui::{
     KeyBinding, ListItem, ListItemSpacing, ListSeparator, Navigable, NavigableEntry, prelude::*,
@@ -20,7 +17,7 @@ use workspace::{ModalView, Workspace};
 
 use crate::agent_configuration::manage_profiles_modal::profile_modal_header::ProfileModalHeader;
 use crate::agent_configuration::tool_picker::{ToolPicker, ToolPickerDelegate};
-use crate::{AgentPanel, ManageProfiles, ThreadStore};
+use crate::{AgentPanel, ManageProfiles};
 
 use super::tool_picker::ToolPickerMode;
 
@@ -103,7 +100,6 @@ pub struct NewProfileMode {
 pub struct ManageProfilesModal {
     fs: Arc<dyn Fs>,
     tools: Entity<ToolWorkingSet>,
-    thread_store: WeakEntity<ThreadStore>,
     focus_handle: FocusHandle,
     mode: Mode,
 }
@@ -119,9 +115,8 @@ impl ManageProfilesModal {
                 let fs = workspace.app_state().fs.clone();
                 let thread_store = panel.read(cx).thread_store();
                 let tools = thread_store.read(cx).tools();
-                let thread_store = thread_store.downgrade();
                 workspace.toggle_modal(window, cx, |window, cx| {
-                    let mut this = Self::new(fs, tools, thread_store, window, cx);
+                    let mut this = Self::new(fs, tools, window, cx);
 
                     if let Some(profile_id) = action.customize_tools.clone() {
                         this.configure_builtin_tools(profile_id, window, cx);
@@ -136,7 +131,6 @@ impl ManageProfilesModal {
     pub fn new(
         fs: Arc<dyn Fs>,
         tools: Entity<ToolWorkingSet>,
-        thread_store: WeakEntity<ThreadStore>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -145,7 +139,6 @@ impl ManageProfilesModal {
         Self {
             fs,
             tools,
-            thread_store,
             focus_handle,
             mode: Mode::choose_profile(window, cx),
         }
@@ -206,7 +199,6 @@ impl ManageProfilesModal {
                 ToolPickerMode::McpTools,
                 self.fs.clone(),
                 self.tools.clone(),
-                self.thread_store.clone(),
                 profile_id.clone(),
                 profile,
                 cx,
@@ -244,7 +236,6 @@ impl ManageProfilesModal {
                 ToolPickerMode::BuiltinTools,
                 self.fs.clone(),
                 self.tools.clone(),
-                self.thread_store.clone(),
                 profile_id.clone(),
                 profile,
                 cx,

--- a/crates/agent/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent/src/agent_configuration/manage_profiles_modal.rs
@@ -520,14 +520,13 @@ impl ManageProfilesModal {
     ) -> impl IntoElement {
         let settings = AgentSettings::get_global(cx);
 
-        let profile_id = &settings.default_profile;
         let profile_name = settings
             .profiles
             .get(&mode.profile_id)
             .map(|profile| profile.name.clone())
             .unwrap_or_else(|| "Unknown".into());
 
-        let icon = match profile_id.as_str() {
+        let icon = match mode.profile_id.as_str() {
             "write" => IconName::Pencil,
             "ask" => IconName::MessageBubbles,
             _ => IconName::UserRoundPen,

--- a/crates/agent/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent/src/agent_configuration/manage_profiles_modal.rs
@@ -271,7 +271,7 @@ impl ManageProfilesModal {
                 let name = mode.name_editor.read(cx).text(cx);
                 let profile_id = AgentProfileId(name.to_case(Case::Kebab).into());
 
-                let profile = AgentProfileSettings {
+                let profile_settings = AgentProfileSettings {
                     name: name.into(),
                     tools: base_profile
                         .as_ref()
@@ -286,7 +286,7 @@ impl ManageProfilesModal {
                         .unwrap_or_default(),
                 };
 
-                self.create_profile(profile_id.clone(), profile, cx);
+                self.create_profile(profile_id.clone(), profile_settings, cx);
                 self.view_profile(profile_id, window, cx);
             }
             Mode::ViewProfile(_) => {}

--- a/crates/agent/src/agent_configuration/tool_picker.rs
+++ b/crates/agent/src/agent_configuration/tool_picker.rs
@@ -1,7 +1,7 @@
 use std::{collections::BTreeMap, sync::Arc};
 
 use agent_settings::{
-    AgentProfile, AgentProfileContent, AgentProfileId, AgentSettings, AgentSettingsContent,
+    AgentProfileContent, AgentProfileId, AgentProfileSettings, AgentSettings, AgentSettingsContent,
     ContextServerPresetContent,
 };
 use assistant_tool::{ToolSource, ToolWorkingSet};
@@ -75,7 +75,7 @@ pub struct ToolPickerDelegate {
     fs: Arc<dyn Fs>,
     items: Arc<Vec<PickerItem>>,
     profile_id: AgentProfileId,
-    profile: AgentProfile,
+    profile: AgentProfileSettings,
     filtered_items: Vec<PickerItem>,
     selected_index: usize,
     mode: ToolPickerMode,
@@ -88,7 +88,7 @@ impl ToolPickerDelegate {
         tool_set: Entity<ToolWorkingSet>,
         thread_store: WeakEntity<ThreadStore>,
         profile_id: AgentProfileId,
-        profile: AgentProfile,
+        profile: AgentProfileSettings,
         cx: &mut Context<ToolPicker>,
     ) -> Self {
         let items = Arc::new(Self::resolve_items(mode, &tool_set, cx));

--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -1378,7 +1378,8 @@ impl AgentDiff {
             | ThreadEvent::CheckpointChanged
             | ThreadEvent::ToolConfirmationNeeded
             | ThreadEvent::ToolUseLimitReached
-            | ThreadEvent::CancelEditing => {}
+            | ThreadEvent::CancelEditing
+            | ThreadEvent::ProfileChanged => {}
         }
     }
 

--- a/crates/agent/src/agent_profile.rs
+++ b/crates/agent/src/agent_profile.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings};
-use assistant_tool::{Tool, ToolWorkingSet};
+use assistant_tool::{Tool, ToolSource, ToolWorkingSet};
 use gpui::{App, Entity};
 use settings::Settings;
 
@@ -28,13 +28,15 @@ impl AgentProfile {
             .read(cx)
             .tools(cx)
             .into_iter()
-            .filter(|tool| {
-                *settings
-                    .tools
-                    .get(&Arc::from(tool.name()))
-                    .unwrap_or(&false)
-            })
+            .filter(|tool| Self::is_enabled(&settings, tool.source(), tool.name()))
             .collect()
+    }
+
+    pub fn is_enabled(settings: &AgentProfileSettings, source: ToolSource, name: String) -> bool {
+        match source {
+            ToolSource::Native => *settings.tools.get(&Arc::from(name)).unwrap_or(&false),
+            ToolSource::ContextServer { id } => false,
+        }
     }
 
     fn settings(&self, cx: &App) -> Option<AgentProfileSettings> {

--- a/crates/agent/src/agent_profile.rs
+++ b/crates/agent/src/agent_profile.rs
@@ -99,6 +99,8 @@ mod tests {
             // Provider dependent
             .filter(|tool| tool != "web_search")
             .collect::<Vec<_>>();
+        // Plus all registered MCP tools
+        expected_tools.extend(["enabled_mcp_tool".into(), "disabled_mcp_tool".into()]);
         expected_tools.sort();
 
         assert_eq!(enabled_tools, expected_tools);
@@ -138,10 +140,10 @@ mod tests {
     }
 
     #[gpui::test]
-    async fn test_all_tools(cx: &mut TestAppContext) {
+    async fn test_only_built_in(cx: &mut TestAppContext) {
         init_test_settings(cx);
 
-        let id = AgentProfileId("write_plus_all_mcp".into());
+        let id = AgentProfileId("write_minus_mcp".into());
         let profile_settings = cx.read(|cx| {
             AgentSettings::get_global(cx)
                 .profiles
@@ -167,8 +169,6 @@ mod tests {
             // Provider dependent
             .filter(|tool| tool != "web_search")
             .collect::<Vec<_>>();
-        // Plus all registered MCP tools
-        expected_tools.extend(["enabled_mcp_tool".into(), "disabled_mcp_tool".into()]);
         expected_tools.sort();
 
         assert_eq!(enabled_tools, expected_tools);
@@ -188,10 +188,10 @@ mod tests {
         cx.update(|cx| {
             let mut agent_settings = AgentSettings::get_global(cx).clone();
             agent_settings.profiles.insert(
-                AgentProfileId("write_plus_all_mcp".into()),
+                AgentProfileId("write_minus_mcp".into()),
                 AgentProfileSettings {
-                    name: "write_plus_all_mcp".into(),
-                    enable_all_context_servers: true,
+                    name: "write_minus_mcp".into(),
+                    enable_all_context_servers: false,
                     ..agent_settings.profiles[&AgentProfileId::default()].clone()
                 },
             );

--- a/crates/agent/src/agent_profile.rs
+++ b/crates/agent/src/agent_profile.rs
@@ -2,10 +2,12 @@ use std::sync::Arc;
 
 use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings};
 use assistant_tool::{Tool, ToolSource, ToolWorkingSet};
+use collections::IndexMap;
 use convert_case::{Case, Casing};
 use fs::Fs;
 use gpui::{App, Entity};
 use settings::{Settings, update_settings_file};
+use ui::SharedString;
 use util::ResultExt;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -13,6 +15,8 @@ pub struct AgentProfile {
     id: AgentProfileId,
     tool_set: Entity<ToolWorkingSet>,
 }
+
+pub type AvailableProfiles = IndexMap<AgentProfileId, SharedString>;
 
 impl AgentProfile {
     pub fn new(id: AgentProfileId, tool_set: Entity<ToolWorkingSet>) -> Self {
@@ -54,6 +58,15 @@ impl AgentProfile {
         });
 
         id
+    }
+
+    /// Returns a map of AgentProfileIds to their names
+    pub fn available_profiles(cx: &App) -> AvailableProfiles {
+        let mut profiles = AvailableProfiles::default();
+        for (id, profile) in AgentSettings::get_global(cx).profiles.iter() {
+            profiles.insert(id.clone(), profile.name.clone());
+        }
+        profiles
     }
 
     pub fn id(&self) -> &AgentProfileId {

--- a/crates/agent/src/agent_profile.rs
+++ b/crates/agent/src/agent_profile.rs
@@ -1,0 +1,102 @@
+use std::sync::Arc;
+
+use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings};
+use assistant_tool::{Tool, ToolWorkingSet};
+use gpui::{App, Entity};
+use settings::Settings;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct AgentProfile {
+    id: AgentProfileId,
+    tool_set: Entity<ToolWorkingSet>,
+}
+
+impl AgentProfile {
+    pub fn new(id: AgentProfileId, tool_set: Entity<ToolWorkingSet>) -> Self {
+        Self { id, tool_set }
+    }
+
+    pub fn id(&self) -> &AgentProfileId {
+        &self.id
+    }
+
+    pub fn enabled_tools(&self, cx: &App) -> Vec<Arc<dyn Tool>> {
+        let Some(settings) = self.settings(cx) else {
+            return vec![];
+        };
+        self.tool_set
+            .read(cx)
+            .tools(cx)
+            .into_iter()
+            .filter(|tool| {
+                *settings
+                    .tools
+                    .get(&Arc::from(tool.name()))
+                    .unwrap_or(&false)
+            })
+            .collect()
+    }
+
+    fn settings(&self, cx: &App) -> Option<AgentProfileSettings> {
+        AgentSettings::get_global(cx)
+            .profiles
+            .get(&self.id)
+            .cloned()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use assistant_tool::ToolRegistry;
+    use gpui::{AppContext, TestAppContext};
+    use http_client::FakeHttpClient;
+    use settings::{Settings, SettingsStore};
+
+    use super::*;
+
+    #[gpui::test]
+    async fn test_enabled_built_in_tools_for_profile(cx: &mut TestAppContext) {
+        init_test_settings(cx);
+
+        let id = AgentProfileId::default();
+        let profile_settings = cx.read(|cx| {
+            AgentSettings::get_global(cx)
+                .profiles
+                .get(&id)
+                .unwrap()
+                .clone()
+        });
+        let tool_set = cx.new(|_| ToolWorkingSet::default());
+
+        let profile = AgentProfile::new(id.clone(), tool_set);
+
+        let mut enabled_tools = cx
+            .read(|cx| profile.enabled_tools(cx))
+            .into_iter()
+            .map(|tool| tool.name())
+            .collect::<Vec<_>>();
+        enabled_tools.sort();
+
+        let mut expected_tools = profile_settings
+            .tools
+            .into_iter()
+            .filter_map(|(tool, enabled)| enabled.then_some(tool.to_string()))
+            // Provider dependent
+            .filter(|tool| tool != "web_search")
+            .collect::<Vec<_>>();
+        expected_tools.sort();
+
+        assert_eq!(enabled_tools, expected_tools);
+    }
+
+    fn init_test_settings(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let settings_store = SettingsStore::test(cx);
+            cx.set_global(settings_store);
+            AgentSettings::register(cx);
+            language_model::init_settings(cx);
+            ToolRegistry::default_global(cx);
+            assistant_tools::init(FakeHttpClient::with_404_response(), cx);
+        });
+    }
+}

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -203,15 +203,8 @@ impl MessageEditor {
             )
         });
 
-        let profile_selector = cx.new(|cx| {
-            ProfileSelector::new(
-                fs,
-                thread.clone(),
-                thread_store,
-                editor.focus_handle(cx),
-                cx,
-            )
-        });
+        let profile_selector =
+            cx.new(|cx| ProfileSelector::new(fs, thread.clone(), editor.focus_handle(cx), cx));
 
         Self {
             editor: editor.clone(),

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -175,8 +175,7 @@ impl MessageEditor {
             )
         });
 
-        let incompatible_tools =
-            cx.new(|cx| IncompatibleToolsState::new(thread.read(cx).tools().clone(), cx));
+        let incompatible_tools = cx.new(|cx| IncompatibleToolsState::new(thread.clone(), cx));
 
         let subscriptions = vec![
             cx.subscribe_in(&context_strip, window, Self::handle_context_strip_event),

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -65,6 +65,7 @@ impl ProfileSelector {
             for (profile_id, profile_name) in self.profiles.iter() {
                 if !builtin_profiles::is_builtin(profile_id) {
                     found_non_builtin = true;
+                    continue;
                 }
                 menu = menu.item(self.menu_entry_for_profile(
                     profile_id.clone(),

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -101,7 +101,7 @@ impl ProfileSelector {
         profile_id: AgentProfileId,
         profile: &AgentProfileSettings,
         settings: &AgentSettings,
-        _cx: &App,
+        cx: &App,
     ) -> ContextMenuEntry {
         let documentation = match profile.name.to_lowercase().as_str() {
             builtin_profiles::WRITE => Some("Get help to write anything."),
@@ -109,9 +109,10 @@ impl ProfileSelector {
             builtin_profiles::MINIMAL => Some("Chat about anything with no tools."),
             _ => None,
         };
+        let thread_profile_id = self.thread.read(cx).profile().id();
 
         let entry = ContextMenuEntry::new(profile.name.clone())
-            .toggleable(IconPosition::End, profile_id == settings.default_profile);
+            .toggleable(IconPosition::End, &profile_id == thread_profile_id);
 
         let entry = if let Some(doc_text) = documentation {
             entry.documentation_aside(documentation_side(settings.dock), move |_| {
@@ -146,7 +147,7 @@ impl ProfileSelector {
 impl Render for ProfileSelector {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let settings = AgentSettings::get_global(cx);
-        let profile_id = &settings.default_profile;
+        let profile_id = self.thread.read(cx).profile().id();
         let profile = settings.profiles.get(profile_id);
 
         let selected_profile = profile

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -95,11 +95,11 @@ impl ProfileSelector {
     fn menu_entry_for_profile(
         &self,
         profile_id: AgentProfileId,
-        profile: &AgentProfileSettings,
+        profile_settings: &AgentProfileSettings,
         settings: &AgentSettings,
         cx: &App,
     ) -> ContextMenuEntry {
-        let documentation = match profile.name.to_lowercase().as_str() {
+        let documentation = match profile_settings.name.to_lowercase().as_str() {
             builtin_profiles::WRITE => Some("Get help to write anything."),
             builtin_profiles::ASK => Some("Chat about your codebase."),
             builtin_profiles::MINIMAL => Some("Chat about anything with no tools."),
@@ -107,7 +107,7 @@ impl ProfileSelector {
         };
         let thread_profile_id = self.thread.read(cx).profile().id();
 
-        let entry = ContextMenuEntry::new(profile.name.clone())
+        let entry = ContextMenuEntry::new(profile_settings.name.clone())
             .toggleable(IconPosition::End, &profile_id == thread_profile_id);
 
         let entry = if let Some(doc_text) = documentation {

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -124,6 +124,7 @@ impl ProfileSelector {
 
         entry.handler({
             let fs = self.fs.clone();
+            let thread = self.thread.clone();
             let thread_store = self.thread_store.clone();
             let profile_id = profile_id.clone();
             move |_window, cx| {
@@ -132,6 +133,10 @@ impl ProfileSelector {
                     move |settings, _cx| {
                         settings.set_profile(profile_id.clone());
                     }
+                });
+
+                thread.update(cx, |this, cx| {
+                    this.set_profile(profile_id.clone(), cx);
                 });
 
                 thread_store

--- a/crates/agent/src/profile_selector.rs
+++ b/crates/agent/src/profile_selector.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use agent_settings::{
-    AgentDockPosition, AgentProfile, AgentProfileId, AgentSettings, GroupedAgentProfiles,
+    AgentDockPosition, AgentProfileId, AgentProfileSettings, AgentSettings, GroupedAgentProfiles,
     builtin_profiles,
 };
 use fs::Fs;
@@ -99,7 +99,7 @@ impl ProfileSelector {
     fn menu_entry_for_profile(
         &self,
         profile_id: AgentProfileId,
-        profile: &AgentProfile,
+        profile: &AgentProfileSettings,
         settings: &AgentSettings,
         _cx: &App,
     ) -> ContextMenuEntry {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Instant;
 
-use agent_settings::{AgentSettings, CompletionMode};
+use agent_settings::{AgentProfileId, AgentSettings, CompletionMode};
 use anyhow::{Result, anyhow};
 use assistant_tool::{ActionLog, AnyToolCard, Tool, ToolWorkingSet};
 use chrono::{DateTime, Utc};
@@ -595,6 +595,13 @@ impl Thread {
 
     pub fn profile(&self) -> &AgentProfile {
         &self.profile
+    }
+
+    pub fn set_profile(&mut self, id: AgentProfileId, cx: &mut Context<Self>) {
+        if &id != self.profile.id() {
+            self.profile = AgentProfile::new(id, self.tools.clone());
+            cx.emit(ThreadEvent::ProfileChanged);
+        }
     }
 
     pub fn is_empty(&self) -> bool {
@@ -2869,6 +2876,7 @@ pub enum ThreadEvent {
     ToolUseLimitReached,
     CancelEditing,
     CompletionCanceled,
+    ProfileChanged,
 }
 
 impl EventEmitter<ThreadEvent> for Thread {}

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2232,19 +2232,15 @@ impl Thread {
     ) -> Task<()> {
         let tool_name: Arc<str> = tool.name().into();
 
-        let tool_result = if self.tools.read(cx).is_disabled(&tool.source(), &tool_name) {
-            Task::ready(Err(anyhow!("tool is disabled: {tool_name}"))).into()
-        } else {
-            tool.run(
-                input,
-                request,
-                self.project.clone(),
-                self.action_log.clone(),
-                model,
-                window,
-                cx,
-            )
-        };
+        let tool_result = tool.run(
+            input,
+            request,
+            self.project.clone(),
+            self.action_log.clone(),
+            model,
+            window,
+            cx,
+        );
 
         // Store the card separately if it exists
         if let Some(card) = tool_result.card.clone() {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4,7 +4,7 @@ use std::ops::Range;
 use std::sync::Arc;
 use std::time::Instant;
 
-use agent_settings::{AgentProfileId, AgentSettings, CompletionMode};
+use agent_settings::{AgentSettings, CompletionMode};
 use anyhow::{Result, anyhow};
 use assistant_tool::{ActionLog, AnyToolCard, Tool, ToolWorkingSet};
 use chrono::{DateTime, Utc};
@@ -41,6 +41,7 @@ use uuid::Uuid;
 use zed_llm_client::{CompletionIntent, CompletionRequestStatus};
 
 use crate::ThreadStore;
+use crate::agent_profile::AgentProfile;
 use crate::context::{AgentContext, AgentContextHandle, ContextLoadResult, LoadedContext};
 use crate::thread_store::{
     SerializedCrease, SerializedLanguageModel, SerializedMessage, SerializedMessageSegment,
@@ -319,18 +320,6 @@ pub enum QueueState {
     Sending,
     Queued { position: usize },
     Started,
-}
-
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct AgentProfile {
-    pub id: AgentProfileId,
-    tool_set: Entity<ToolWorkingSet>,
-}
-
-impl AgentProfile {
-    pub fn new(id: AgentProfileId, tool_set: Entity<ToolWorkingSet>) -> Self {
-        Self { id, tool_set }
-    }
 }
 
 /// A thread of conversation with the LLM.
@@ -1199,7 +1188,7 @@ impl Thread {
                     }),
                 completion_mode: Some(this.completion_mode),
                 tool_use_limit_reached: this.tool_use_limit_reached,
-                profile: Some(this.profile.id.clone()),
+                profile: Some(this.profile.id().clone()),
             })
         })
     }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -593,6 +593,10 @@ impl Thread {
         &self.id
     }
 
+    pub fn profile(&self) -> &AgentProfile {
+        &self.profile
+    }
+
     pub fn is_empty(&self) -> bool {
         self.messages.is_empty()
     }
@@ -927,8 +931,7 @@ impl Thread {
         model: Arc<dyn LanguageModel>,
     ) -> Vec<LanguageModelRequestTool> {
         if model.supports_tools() {
-            self.tools()
-                .read(cx)
+            self.profile
                 .enabled_tools(cx)
                 .into_iter()
                 .filter_map(|tool| {
@@ -2130,7 +2133,7 @@ impl Thread {
         window: Option<AnyWindowHandle>,
         cx: &mut Context<Thread>,
     ) {
-        let available_tools = self.tools.read(cx).enabled_tools(cx);
+        let available_tools = self.profile.enabled_tools(cx);
 
         let tool_list = available_tools
             .iter()
@@ -2353,8 +2356,7 @@ impl Thread {
         let client = self.project.read(cx).client();
 
         let enabled_tool_names: Vec<String> = self
-            .tools()
-            .read(cx)
+            .profile
             .enabled_tools(cx)
             .iter()
             .map(|tool| tool.name())

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -531,6 +531,7 @@ impl ThreadStore {
         match event {
             project::context_server_store::Event::ServerStatusChanged { server_id, status } => {
                 match status {
+                    ContextServerStatus::Starting => {}
                     ContextServerStatus::Running => {
                         if let Some(server) =
                             context_server_store.read(cx).get_running_server(server_id)
@@ -589,7 +590,6 @@ impl ThreadStore {
                             });
                         }
                     }
-                    _ => {}
                 }
             }
         }

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings, CompletionMode};
+use agent_settings::{AgentProfileId, AgentProfileSettings, CompletionMode};
 use anyhow::{Context as _, Result, anyhow};
 use assistant_tool::{ToolId, ToolSource, ToolWorkingSet};
 use chrono::{DateTime, Utc};
@@ -25,7 +25,6 @@ use prompt_store::{
     UserRulesContext, WorktreeContext,
 };
 use serde::{Deserialize, Serialize};
-use settings::Settings as _;
 use ui::Window;
 use util::ResultExt as _;
 
@@ -512,14 +511,6 @@ impl ThreadStore {
                 cx.notify();
             })
         })
-    }
-
-    pub fn load_profile_by_id(&self, profile_id: AgentProfileId, cx: &mut Context<Self>) {
-        let assistant_settings = AgentSettings::get_global(cx);
-
-        if let Some(profile) = assistant_settings.profiles.get(&profile_id) {
-            self.load_profile(profile.clone(), cx);
-        }
     }
 
     pub fn load_profile(&self, profile: AgentProfileSettings, cx: &mut Context<Self>) {

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -714,6 +714,8 @@ pub struct SerializedThread {
     pub completion_mode: Option<CompletionMode>,
     #[serde(default)]
     pub tool_use_limit_reached: bool,
+    #[serde(default)]
+    pub profile: Option<AgentProfileId>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -856,6 +858,7 @@ impl LegacySerializedThread {
             model: None,
             completion_mode: None,
             tool_use_limit_reached: false,
+            profile: None,
         }
     }
 }

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -3,7 +3,7 @@ use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
 
-use agent_settings::{AgentProfile, AgentProfileId, AgentSettings, CompletionMode};
+use agent_settings::{AgentProfileId, AgentProfileSettings, AgentSettings, CompletionMode};
 use anyhow::{Context as _, Result, anyhow};
 use assistant_tool::{ToolId, ToolSource, ToolWorkingSet};
 use chrono::{DateTime, Utc};
@@ -534,7 +534,7 @@ impl ThreadStore {
         }
     }
 
-    pub fn load_profile(&self, profile: AgentProfile, cx: &mut Context<Self>) {
+    pub fn load_profile(&self, profile: AgentProfileSettings, cx: &mut Context<Self>) {
         self.tools.update(cx, |tools, cx| {
             tools.disable_all_tools(cx);
             tools.enable(

--- a/crates/agent_settings/Cargo.toml
+++ b/crates/agent_settings/Cargo.toml
@@ -16,7 +16,6 @@ anthropic = { workspace = true, features = ["schemars"] }
 anyhow.workspace = true
 collections.workspace = true
 gpui.workspace = true
-indexmap.workspace = true
 language_model.workspace = true
 lmstudio = { workspace = true, features = ["schemars"] }
 log.workspace = true

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -17,29 +17,6 @@ pub mod builtin_profiles {
     }
 }
 
-#[derive(Default)]
-pub struct GroupedAgentProfiles {
-    pub builtin: IndexMap<AgentProfileId, AgentProfileSettings>,
-    pub custom: IndexMap<AgentProfileId, AgentProfileSettings>,
-}
-
-impl GroupedAgentProfiles {
-    pub fn from_settings(settings: &crate::AgentSettings) -> Self {
-        let mut builtin = IndexMap::default();
-        let mut custom = IndexMap::default();
-
-        for (profile_id, profile) in settings.profiles.clone() {
-            if builtin_profiles::is_builtin(&profile_id) {
-                builtin.insert(profile_id, profile);
-            } else {
-                custom.insert(profile_id, profile);
-            }
-        }
-
-        Self { builtin, custom }
-    }
-}
-
 #[derive(Debug, PartialEq, Eq, Hash, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AgentProfileId(pub Arc<str>);
 

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -19,8 +19,8 @@ pub mod builtin_profiles {
 
 #[derive(Default)]
 pub struct GroupedAgentProfiles {
-    pub builtin: IndexMap<AgentProfileId, AgentProfile>,
-    pub custom: IndexMap<AgentProfileId, AgentProfile>,
+    pub builtin: IndexMap<AgentProfileId, AgentProfileSettings>,
+    pub custom: IndexMap<AgentProfileId, AgentProfileSettings>,
 }
 
 impl GroupedAgentProfiles {
@@ -63,7 +63,7 @@ impl Default for AgentProfileId {
 
 /// A profile for the Zed Agent that controls its behavior.
 #[derive(Debug, Clone)]
-pub struct AgentProfile {
+pub struct AgentProfileSettings {
     /// The name of the profile.
     pub name: SharedString,
     pub tools: IndexMap<Arc<str>, bool>,

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -75,14 +75,3 @@ pub struct AgentProfileSettings {
 pub struct ContextServerPreset {
     pub tools: IndexMap<Arc<str>, bool>,
 }
-
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
-pub struct AgentProfile {
-    pub id: AgentProfileId,
-}
-
-impl AgentProfile {
-    pub fn new(id: AgentProfileId) -> Self {
-        Self { id }
-    }
-}

--- a/crates/agent_settings/src/agent_profile.rs
+++ b/crates/agent_settings/src/agent_profile.rs
@@ -75,3 +75,14 @@ pub struct AgentProfileSettings {
 pub struct ContextServerPreset {
     pub tools: IndexMap<Arc<str>, bool>,
 }
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct AgentProfile {
+    pub id: AgentProfileId,
+}
+
+impl AgentProfile {
+    pub fn new(id: AgentProfileId) -> Self {
+        Self { id }
+    }
+}

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -102,7 +102,7 @@ pub struct AgentSettings {
     pub using_outdated_settings_version: bool,
     pub default_profile: AgentProfileId,
     pub default_view: DefaultView,
-    pub profiles: IndexMap<AgentProfileId, AgentProfile>,
+    pub profiles: IndexMap<AgentProfileId, AgentProfileSettings>,
     pub always_allow_tool_actions: bool,
     pub notify_when_agent_waiting: NotifyWhenAgentWaiting,
     pub play_sound_when_agent_done: bool,
@@ -531,7 +531,7 @@ impl AgentSettingsContent {
     pub fn create_profile(
         &mut self,
         profile_id: AgentProfileId,
-        profile: AgentProfile,
+        profile: AgentProfileSettings,
     ) -> Result<()> {
         self.v2_setting(|settings| {
             let profiles = settings.profiles.get_or_insert_default();
@@ -910,7 +910,7 @@ impl Settings for AgentSettings {
                     .extend(profiles.into_iter().map(|(id, profile)| {
                         (
                             id,
-                            AgentProfile {
+                            AgentProfileSettings {
                                 name: profile.name.into(),
                                 tools: profile.tools,
                                 enable_all_context_servers: profile

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -531,7 +531,7 @@ impl AgentSettingsContent {
     pub fn create_profile(
         &mut self,
         profile_id: AgentProfileId,
-        profile: AgentProfileSettings,
+        profile_settings: AgentProfileSettings,
     ) -> Result<()> {
         self.v2_setting(|settings| {
             let profiles = settings.profiles.get_or_insert_default();
@@ -542,10 +542,10 @@ impl AgentSettingsContent {
             profiles.insert(
                 profile_id,
                 AgentProfileContent {
-                    name: profile.name.into(),
-                    tools: profile.tools,
-                    enable_all_context_servers: Some(profile.enable_all_context_servers),
-                    context_servers: profile
+                    name: profile_settings.name.into(),
+                    tools: profile_settings.tools,
+                    enable_all_context_servers: Some(profile_settings.enable_all_context_servers),
+                    context_servers: profile_settings
                         .context_servers
                         .into_iter()
                         .map(|(server_id, preset)| {

--- a/crates/assistant_tool/src/tool_working_set.rs
+++ b/crates/assistant_tool/src/tool_working_set.rs
@@ -102,7 +102,7 @@ impl ToolWorkingSet {
         tool_id
     }
 
-    pub fn is_enabled(&self, source: &ToolSource, name: &Arc<str>) -> bool {
+    fn is_enabled(&self, source: &ToolSource, name: &Arc<str>) -> bool {
         self.enabled_tools_by_source
             .get(source)
             .map_or(false, |enabled_tools| enabled_tools.contains(name))

--- a/crates/assistant_tool/src/tool_working_set.rs
+++ b/crates/assistant_tool/src/tool_working_set.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
-use collections::{HashMap, HashSet, IndexMap};
-use gpui::{App, Context, EventEmitter};
+use collections::{HashMap, IndexMap};
+use gpui::App;
 
 use crate::{Tool, ToolRegistry, ToolSource};
 
@@ -13,16 +13,8 @@ pub struct ToolId(usize);
 pub struct ToolWorkingSet {
     context_server_tools_by_id: HashMap<ToolId, Arc<dyn Tool>>,
     context_server_tools_by_name: HashMap<String, Arc<dyn Tool>>,
-    enabled_sources: HashSet<ToolSource>,
-    enabled_tools_by_source: HashMap<ToolSource, HashSet<Arc<str>>>,
     next_tool_id: ToolId,
 }
-
-pub enum ToolWorkingSetEvent {
-    EnabledToolsChanged,
-}
-
-impl EventEmitter<ToolWorkingSetEvent> for ToolWorkingSet {}
 
 impl ToolWorkingSet {
     pub fn tool(&self, name: &str, cx: &App) -> Option<Arc<dyn Tool>> {
@@ -57,42 +49,6 @@ impl ToolWorkingSet {
         tools_by_source
     }
 
-    pub fn enabled_tools(&self, cx: &App) -> Vec<Arc<dyn Tool>> {
-        let all_tools = self.tools(cx);
-
-        all_tools
-            .into_iter()
-            .filter(|tool| self.is_enabled(&tool.source(), &tool.name().into()))
-            .collect()
-    }
-
-    pub fn disable_all_tools(&mut self, cx: &mut Context<Self>) {
-        self.enabled_tools_by_source.clear();
-        cx.emit(ToolWorkingSetEvent::EnabledToolsChanged);
-    }
-
-    pub fn enable_source(&mut self, source: ToolSource, cx: &mut Context<Self>) {
-        self.enabled_sources.insert(source.clone());
-
-        let tools_by_source = self.tools_by_source(cx);
-        if let Some(tools) = tools_by_source.get(&source) {
-            self.enabled_tools_by_source.insert(
-                source,
-                tools
-                    .into_iter()
-                    .map(|tool| tool.name().into())
-                    .collect::<HashSet<_>>(),
-            );
-        }
-        cx.emit(ToolWorkingSetEvent::EnabledToolsChanged);
-    }
-
-    pub fn disable_source(&mut self, source: &ToolSource, cx: &mut Context<Self>) {
-        self.enabled_sources.remove(source);
-        self.enabled_tools_by_source.remove(source);
-        cx.emit(ToolWorkingSetEvent::EnabledToolsChanged);
-    }
-
     pub fn insert(&mut self, tool: Arc<dyn Tool>) -> ToolId {
         let tool_id = self.next_tool_id;
         self.next_tool_id.0 += 1;
@@ -100,42 +56,6 @@ impl ToolWorkingSet {
             .insert(tool_id, tool.clone());
         self.tools_changed();
         tool_id
-    }
-
-    fn is_enabled(&self, source: &ToolSource, name: &Arc<str>) -> bool {
-        self.enabled_tools_by_source
-            .get(source)
-            .map_or(false, |enabled_tools| enabled_tools.contains(name))
-    }
-
-    pub fn is_disabled(&self, source: &ToolSource, name: &Arc<str>) -> bool {
-        !self.is_enabled(source, name)
-    }
-
-    pub fn enable(
-        &mut self,
-        source: ToolSource,
-        tools_to_enable: &[Arc<str>],
-        cx: &mut Context<Self>,
-    ) {
-        self.enabled_tools_by_source
-            .entry(source)
-            .or_default()
-            .extend(tools_to_enable.into_iter().cloned());
-        cx.emit(ToolWorkingSetEvent::EnabledToolsChanged);
-    }
-
-    pub fn disable(
-        &mut self,
-        source: ToolSource,
-        tools_to_disable: &[Arc<str>],
-        cx: &mut Context<Self>,
-    ) {
-        self.enabled_tools_by_source
-            .entry(source)
-            .or_default()
-            .retain(|name| !tools_to_disable.contains(name));
-        cx.emit(ToolWorkingSetEvent::EnabledToolsChanged);
     }
 
     pub fn remove(&mut self, tool_ids_to_remove: &[ToolId]) {

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -80,7 +80,6 @@ zed_llm_client.workspace = true
 agent_settings.workspace = true
 assistant_context_editor.workspace = true
 assistant_slash_command.workspace = true
-assistant_tool.workspace = true
 async-trait.workspace = true
 audio.workspace = true
 buffer_diff.workspace = true

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -294,6 +294,7 @@ impl ExampleContext {
                 | ThreadEvent::MessageDeleted(_)
                 | ThreadEvent::SummaryChanged
                 | ThreadEvent::SummaryGenerated
+                | ThreadEvent::ProfileChanged
                 | ThreadEvent::ReceivedTextChunk
                 | ThreadEvent::StreamedToolUse { .. }
                 | ThreadEvent::CheckpointChanged

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -306,17 +306,19 @@ impl ExampleInstance {
 
             let thread_store = thread_store.await?;
 
-            let profile_id = meta.profile_id.clone();
-            thread_store.update(cx, |thread_store, cx| thread_store.load_profile_by_id(profile_id, cx)).expect("Failed to load profile");
 
             let thread =
                 thread_store.update(cx, |thread_store, cx| {
-                    if let Some(json) = &meta.existing_thread_json {
+                    let thread = if let Some(json) = &meta.existing_thread_json {
                         let serialized = SerializedThread::from_json(json.as_bytes()).expect("Can't read serialized thread");
                         thread_store.create_thread_from_serialized(serialized, cx)
                     } else {
                         thread_store.create_thread(cx)
-                    }
+                    };
+                    thread.update(cx, |thread, cx| {
+                        thread.set_profile(meta.profile_id.clone(), cx);
+                    });
+                    thread
                 })?;
 
 


### PR DESCRIPTION
This allows storing the profile per thread, as well as moving the logic of which tools are enabled or not to the profile itself.

This makes it much easier to switch between profiles, means there is less global state being changed on every profile change.

Release Notes:

- agent panel: allow saving the profile per thread
