### PR TITLE
Option to auto-close deleted files with no unsaved edits

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -128,6 +128,8 @@
   //
   // Default: true
   "restore_on_file_reopen": true,
+  // Whether to automatically close files that have been deleted on disk.
+  "close_on_file_delete": false,
   // Size of the drop target in the editor.
   "drop_target_size": 0.2,
   // Whether the window should be closed when using 'close active item' on a window with no tabs.
@@ -865,8 +867,6 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
-  // Whether to automatically close files that have been deleted on disk.
-  "close_on_file_delete": false,
   // Maximum number of tabs per pane. Unset for unlimited.
   "max_tabs": null,
   // Settings related to the editor's tab bar.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -865,6 +865,8 @@
   // 4. Save when idle for a certain amount of time:
   //     "autosave": { "after_delay": {"milliseconds": 500} },
   "autosave": "off",
+  // Whether to automatically close files that have been deleted on disk.
+  "close_on_file_delete": false,
   // Maximum number of tabs per pane. Unset for unlimited.
   "max_tabs": null,
   // Settings related to the editor's tab bar.

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -11,7 +11,7 @@ use gpui::{
     InteractiveElement, IntoElement, ObjectFit, ParentElement, Render, Styled, Task, WeakEntity,
     Window, canvas, div, fill, img, opaque_grey, point, size,
 };
-use language::File as _;
+use language::{DiskState, File as _};
 use persistence::IMAGE_VIEWER;
 use project::{ImageItem, Project, ProjectPath, image_store::ImageItemEvent};
 use settings::Settings;
@@ -190,6 +190,10 @@ impl Item for ImageView {
             project: self.project.clone(),
             focus_handle: cx.focus_handle(),
         }))
+    }
+
+    fn has_deleted_file(&self, cx: &App) -> bool {
+        self.image_item.read(cx).file.disk_state() == DiskState::Deleted
     }
 }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1319,6 +1319,7 @@ pub mod test {
         pub is_dirty: bool,
         pub is_singleton: bool,
         pub has_conflict: bool,
+        pub has_deleted_file: bool,
         pub project_items: Vec<Entity<TestProjectItem>>,
         pub nav_history: Option<ItemNavHistory>,
         pub tab_descriptions: Option<Vec<&'static str>>,
@@ -1398,6 +1399,7 @@ pub mod test {
                 reload_count: 0,
                 is_dirty: false,
                 has_conflict: false,
+                has_deleted_file: false,
                 project_items: Vec::new(),
                 is_singleton: true,
                 nav_history: None,
@@ -1423,6 +1425,10 @@ pub mod test {
         pub fn with_singleton(mut self, singleton: bool) -> Self {
             self.is_singleton = singleton;
             self
+        }
+
+        pub fn set_has_deleted_file(&mut self, deleted: bool) {
+            self.has_deleted_file = deleted;
         }
 
         pub fn with_dirty(mut self, dirty: bool) -> Self {
@@ -1562,6 +1568,7 @@ pub mod test {
                 is_dirty: self.is_dirty,
                 is_singleton: self.is_singleton,
                 has_conflict: self.has_conflict,
+                has_deleted_file: self.has_deleted_file,
                 project_items: self.project_items.clone(),
                 nav_history: None,
                 tab_descriptions: None,
@@ -1578,6 +1585,10 @@ pub mod test {
 
         fn has_conflict(&self, _: &App) -> bool {
             self.has_conflict
+        }
+
+        fn has_deleted_file(&self, _: &App) -> bool {
+            self.has_deleted_file
         }
 
         fn can_save(&self, cx: &App) -> bool {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -861,13 +861,29 @@ impl<T: Item> ItemHandle for Entity<T> {
                                 && !item.is_dirty(cx)
                                 && item.workspace_settings(cx).close_on_file_delete
                             {
-                                pane.update(cx, |pane, cx| {
-                                    pane.close_item_by_id(
-                                        item.item_id(),
-                                        crate::SaveIntent::Close,
-                                        window,
-                                        cx,
-                                    )
+                                let item_id = item.item_id();
+                                let pane = pane.clone();
+                                cx.spawn_in(window, async move |_workspace, cx| {
+                                    // Close the item first
+                                    let result = pane
+                                        .update_in(cx, |pane, window, cx| {
+                                            pane.close_item_by_id(
+                                                item_id,
+                                                crate::SaveIntent::Close,
+                                                window,
+                                                cx,
+                                            )
+                                        })?
+                                        .await;
+
+                                    // Then remove from navigation history after close completes
+                                    if result.is_ok() {
+                                        pane.update_in(cx, |pane, _window, _cx| {
+                                            pane.nav_history_mut().remove_item(item_id);
+                                        })?;
+                                    }
+
+                                    result
                                 })
                                 .detach_and_log_err(cx);
                             } else {

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -26,6 +26,7 @@ pub struct WorkspaceSettings {
     pub max_tabs: Option<NonZeroUsize>,
     pub when_closing_with_no_tabs: CloseWindowWhenNoItems,
     pub on_last_window_closed: OnLastWindowClosed,
+    pub close_on_file_delete: bool,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -197,6 +198,10 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: auto (nothing on macOS, "app quit" otherwise)
     pub on_last_window_closed: Option<OnLastWindowClosed>,
+    /// Whether to automatically close files that have been deleted on disk.
+    ///
+    /// Default: false
+    pub close_on_file_delete: Option<bool>,
 }
 
 #[derive(Deserialize)]

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -389,6 +389,20 @@ For example, to use `Nerd Font` as a fallback, add the following to your setting
 
 `"standard"`, `"comfortable"` or `{ "custom": float }` (`1` is compact, `2` is loose)
 
+## Close on File Delete
+
+- Description: Whether to automatically close editor tabs when their corresponding files are deleted from disk.
+- Setting: `close_on_file_delete`
+- Default: `false`
+
+**Options**
+
+`boolean` values
+
+When enabled, this setting will automatically close tabs for files that have been deleted from the file system. This is particularly useful for workflows involving temporary or scratch files that are frequently created and deleted. When disabled (default), deleted files remain open with a strikethrough through their tab title.
+
+Note: Dirty files (files with unsaved changes) will not be automatically closed even when this setting is enabled, ensuring you don't lose unsaved work.
+
 ## Confirm Quit
 
 - Description: Whether or not to prompt the user to confirm before closing the application.


### PR DESCRIPTION
Closes #27982

Release Notes:

- Added `close_on_file_delete` setting (off by default) to allow closing open files after they have been deleted on disk
