### PR TITLE
terminal: Persist pinned tabs in terminal

### DIFF
--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -102,7 +102,6 @@ pub(crate) fn deserialize_terminal_panel(
         })?;
         match &serialized_panel.items {
             SerializedItems::NoSplits(item_ids) => {
-                dbg!("ayy");
                 let items = deserialize_terminal_views(
                     database_id,
                     project,
@@ -119,7 +118,6 @@ pub(crate) fn deserialize_terminal_panel(
                 })?;
             }
             SerializedItems::WithSplits(serialized_pane_group) => {
-                dbg!("lmao");
                 let center_pane = deserialize_pane_group(
                     workspace,
                     project,
@@ -234,7 +232,6 @@ async fn deserialize_pane_group(
                 .log_err()?;
             let active_item = serialized_pane.active_item;
             let pinned_count = serialized_pane.pinned_count;
-            dbg!(pinned_count);
             let terminal = pane
                 .update_in(cx, |pane, window, cx| {
                     populate_pane_items(pane, new_items, active_item, window, cx);

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -325,7 +325,6 @@ impl TerminalPanel {
                     .ok();
             }
         }
-
         Ok(terminal_panel)
     }
 
@@ -392,6 +391,9 @@ impl TerminalPanel {
             }
             pane::Event::Focus => {
                 self.active_pane = pane.clone();
+            }
+            pane::Event::ItemPinned | pane::Event::ItemUnpinned => {
+                self.serialize(cx);
             }
 
             _ => {}

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -230,6 +230,8 @@ pub enum Event {
         item: Box<dyn ItemHandle>,
     },
     Split(SplitDirection),
+    ItemPinned,
+    ItemUnpinned,
     JoinAll,
     JoinIntoNext,
     ChangeItemTitle,
@@ -274,6 +276,8 @@ impl fmt::Debug for Event {
                 .field("item", &item.id())
                 .field("save_intent", save_intent)
                 .finish(),
+            Event::ItemPinned => f.write_str("ItemPinned"),
+            Event::ItemUnpinned => f.write_str("ItemUnpinned"),
         }
     }
 }
@@ -780,11 +784,13 @@ impl Pane {
         }
     }
 
-    pub(crate) fn set_pinned_count(&mut self, count: usize) {
+    /// Should only be used when deserializing a pane.
+    pub fn set_pinned_count(&mut self, count: usize) {
+        dbg!(count);
         self.pinned_tab_count = count;
     }
 
-    pub(crate) fn pinned_count(&self) -> usize {
+    pub fn pinned_count(&self) -> usize {
         self.pinned_tab_count
     }
 
@@ -2074,6 +2080,7 @@ impl Pane {
                     })
                     .ok()?;
             }
+            cx.emit(Event::ItemPinned);
 
             Some(())
         });
@@ -2098,6 +2105,7 @@ impl Pane {
                     })
                     .ok()?;
             }
+            cx.emit(Event::ItemUnpinned);
 
             Some(())
         });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -786,7 +786,6 @@ impl Pane {
 
     /// Should only be used when deserializing a pane.
     pub fn set_pinned_count(&mut self, count: usize) {
-        dbg!(count);
         self.pinned_tab_count = count;
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3761,6 +3761,7 @@ impl Workspace {
                 }
                 cx.notify();
             }
+            pane::Event::ItemPinned | pane::Event::ItemUnpinned => {}
         }
 
         if serialize_workspace {


### PR DESCRIPTION
Closes #31098

Release Notes:

- Fixed terminal pinned tab state not persisting across restarts.
