### PR TITLE
google_ai: Parse thought parts in Gemini responses

### DIFF
--- a/crates/google_ai/src/google_ai.rs
+++ b/crates/google_ai/src/google_ai.rs
@@ -202,6 +202,7 @@ pub enum Part {
     InlineDataPart(InlineDataPart),
     FunctionCallPart(FunctionCallPart),
     FunctionResponsePart(FunctionResponsePart),
+    ThoughtPart(ThoughtPart),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -233,6 +234,13 @@ pub struct FunctionCallPart {
 #[serde(rename_all = "camelCase")]
 pub struct FunctionResponsePart {
     pub function_response: FunctionResponse,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ThoughtPart {
+    pub thought: bool,
+    pub thought_signature: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -620,6 +620,7 @@ impl GoogleEventMapper {
                             )));
                         }
                         Part::FunctionResponsePart(_) => {}
+                        Part::ThoughtPart(_) => {}
                     });
             }
         }


### PR DESCRIPTION
Closes #31902. Though I'm not sure how completely. I noticed that function parts are being ignored so I did the same. Not sure if this impacts the ability to show thinking in the agent window, as I'm rather unfamiliar with what's happening behind the scenes. This small fix enables me to use Gemini 2.5 Pro Preview again.

Release Notes:

- Fixed thought parsing issue with Google Gemini 2.5 Pro Preview
