### PR TITLE
debugger: Use new icons for quick debug/spawn button

### DIFF
--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -147,7 +147,7 @@ impl Render for QuickActionBar {
         let run_button = if last_run_debug {
             QuickActionBarButton::new(
                 "debug",
-                IconName::Debug, // TODO: use debug + play icon
+                IconName::PlayBug,
                 false,
                 Box::new(debugger_ui::Start),
                 focus_handle.clone(),
@@ -162,7 +162,7 @@ impl Render for QuickActionBar {
             });
             QuickActionBarButton::new(
                 "run",
-                IconName::Play,
+                IconName::PlayAlt,
                 false,
                 action.boxed_clone(),
                 focus_handle.clone(),


### PR DESCRIPTION
This PR wires up the new icons that were added in #31784.

Release Notes:

- N/A