### PR TITLE
Change pane navigation to work like tmux

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19166,6 +19166,7 @@ dependencies = [
  "parking_lot",
  "postage",
  "project",
+ "rand 0.8.5",
  "remote",
  "schemars",
  "serde",

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -921,7 +921,11 @@ impl TerminalPanel {
             let workspace = self.workspace.clone();
             window.defer(cx, move |window, cx| {
                 workspace
+<<<<<<< ours
                     .update(cx, |workspace, cx| {
+=======
+                    .update_in(cx, |workspace, window, cx| {
+>>>>>>> theirs
                         workspace.activate_pane_in_direction(direction, window, cx);
                     })
                     .ok();

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -921,11 +921,7 @@ impl TerminalPanel {
             let workspace = self.workspace.clone();
             window.defer(cx, move |window, cx| {
                 workspace
-<<<<<<< ours
                     .update(cx, |workspace, cx| {
-=======
-                    .update_in(cx, |workspace, window, cx| {
->>>>>>> theirs
                         workspace.activate_pane_in_direction(direction, window, cx);
                     })
                     .ok();

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -918,11 +918,14 @@ impl TerminalPanel {
         {
             window.focus(&pane.focus_handle(cx));
         } else {
-            self.workspace
-                .update(cx, |workspace, cx| {
-                    workspace.activate_pane_in_direction(direction, window, cx)
-                })
-                .ok();
+            let workspace = self.workspace.clone();
+            window.defer(cx, move |window, cx| {
+                workspace
+                    .update(cx, |workspace, cx| {
+                        workspace.activate_pane_in_direction(direction, window, cx);
+                    })
+                    .ok();
+            });
         }
     }
 

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -65,6 +65,7 @@ util.workspace = true
 uuid.workspace = true
 zed_actions.workspace = true
 workspace-hack.workspace = true
+rand.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -5,15 +5,19 @@ use anyhow::Context as _;
 use client::proto;
 use gpui::{
     Action, AnyView, App, Axis, Context, Corner, Entity, EntityId, EventEmitter, FocusHandle,
-    Focusable, Hsla, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent,
+    Focusable, IntoElement, KeyContext, MouseButton, MouseDownEvent, MouseUpEvent,
     ParentElement, Render, SharedString, StyleRefinement, Styled, Subscription, WeakEntity, Window,
-    deferred, div, hsla, px,
+    deferred, div, px,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::SettingsStore;
-use rand::Rng;
 use std::sync::Arc;
+
+#[cfg(debug_assertions)]
+use gpui::{Hsla, hsla};
+#[cfg(debug_assertions)]
+use rand::Rng;
 use ui::{ContextMenu, Divider, DividerColor, IconButton, Tooltip, h_flex};
 use ui::{prelude::*, right_click_menu};
 
@@ -252,7 +256,7 @@ pub struct PanelButtons {
 #[cfg(debug_assertions)]
 fn random_debug_color() -> Hsla {
     let mut rng = rand::thread_rng();
-    let h: f32 = rng.gen();
+    let h: f32 = rng.r#gen();
     hsla(h, 1.0, 0.5, 1.0)
 }
 

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -195,6 +195,8 @@ pub struct Dock {
     position: DockPosition,
     panel_entries: Vec<PanelEntry>,
     workspace: WeakEntity<Workspace>,
+    /// Last time *any* panel in this dock gained focus.
+    pub(crate) last_visit_ts: usize,
     is_open: bool,
     active_panel_index: Option<usize>,
     focus_handle: FocusHandle,
@@ -273,6 +275,7 @@ impl Dock {
                 active_panel_index: None,
                 is_open: false,
                 focus_handle: focus_handle.clone(),
+                last_visit_ts: 0,
                 _subscriptions: [focus_subscription, zoom_subscription],
                 serialized_dock: None,
                 zoom_layer_open: false,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -18,14 +18,18 @@ use futures::{StreamExt, stream::FuturesUnordered};
 use gpui::{
     Action, AnyElement, App, AsyncWindowContext, ClickEvent, ClipboardItem, Context, Corner, Div,
     DragMoveEvent, Entity, EntityId, EventEmitter, ExternalPaths, FocusHandle, FocusOutEvent,
-    Focusable, Hsla, KeyContext, MouseButton, MouseDownEvent, NavigationDirection, Pixels, Point,
+    Focusable, KeyContext, MouseButton, MouseDownEvent, NavigationDirection, Pixels, Point,
     PromptLevel, Render, ScrollHandle, Subscription, Task, WeakEntity, WeakFocusHandle, Window,
-    actions, anchored, deferred, impl_actions, prelude::*, hsla,
+    actions, anchored, deferred, impl_actions, prelude::*,
 };
 use itertools::Itertools;
 use language::DiagnosticSeverity;
-use rand::Rng;
 use parking_lot::Mutex;
+
+#[cfg(debug_assertions)]
+use gpui::{Hsla, hsla};
+#[cfg(debug_assertions)]
+use rand::Rng;
 use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -354,7 +358,7 @@ pub struct ItemNavHistory {
 #[cfg(debug_assertions)]
 fn random_debug_color() -> Hsla {
     let mut rng = rand::thread_rng();
-    let h: f32 = rng.gen();
+    let h: f32 = rng.r#gen();
     hsla(h, 1.0, 0.5, 1.0)
 }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -290,6 +290,9 @@ pub struct Pane {
     focus_handle: FocusHandle,
     items: Vec<Box<dyn ItemHandle>>,
     activation_history: Vec<ActivationHistoryEntry>,
+    /// Updated each time this pane gains focus.  Used for directional
+    /// navigation tie-breaking.
+    pub(crate) last_visit_ts: usize,
     next_activation_timestamp: Arc<AtomicUsize>,
     zoomed: bool,
     was_focused: bool,
@@ -418,6 +421,7 @@ impl Pane {
             focus_handle,
             items: Vec::new(),
             activation_history: Vec::new(),
+            last_visit_ts: 0,
             next_activation_timestamp: next_timestamp.clone(),
             was_focused: false,
             zoomed: false,

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -28,8 +28,6 @@ use parking_lot::Mutex;
 
 #[cfg(debug_assertions)]
 use gpui::{Hsla, hsla};
-#[cfg(debug_assertions)]
-use rand::Rng;
 use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
 use schemars::JsonSchema;
 use serde::Deserialize;
@@ -356,9 +354,16 @@ pub struct ItemNavHistory {
 }
 
 #[cfg(debug_assertions)]
-fn random_debug_color() -> Hsla {
-    let mut rng = rand::thread_rng();
-    let h: f32 = rng.r#gen();
+fn debug_color_for_pane() -> Hsla {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    static PANE_COLOR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+    const COLOR_COUNT: usize = 12;
+    
+    // Get next color index and wrap around
+    let color_index = PANE_COLOR_COUNTER.fetch_add(1, Ordering::Relaxed) % COLOR_COUNT;
+    
+    // Convert index to hue that will map back to the same index
+    let h = color_index as f32 / COLOR_COUNT as f32;
     hsla(h, 1.0, 0.5, 1.0)
 }
 
@@ -457,7 +462,7 @@ impl Pane {
             workspace,
             project: project.downgrade(),
             #[cfg(debug_assertions)]
-            debug_color: random_debug_color(),
+            debug_color: debug_color_for_pane(),
             can_drop_predicate,
             custom_drop_handle: None,
             can_split_predicate: None,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3415,10 +3415,10 @@ impl Workspace {
                 let position = dock.read(cx).position();
                 println!("focused dock {:?}", position);
                 if let Some(bounds) = self.bounding_box_for_dock(dock, window, cx) {
-                    println!("origin bounds from dock {:?}: {:?}", position, bounds);
+                    println!("FOO origin bounds from dock {:?}: {:?}", position, bounds);
                     bounds
                 } else {
-                    println!("dock {:?} has no bounds, falling back to active pane", position);
+                    println!("FOO dock {:?} has no bounds, falling back to active pane", position);
                     match self.bounding_box_for_pane(&self.active_pane) {
                         Some(bounds) => bounds,
                         None => return,
@@ -3428,7 +3428,7 @@ impl Workspace {
                 println!("no dock focused, using active pane");
                 match self.bounding_box_for_pane(&self.active_pane) {
                     Some(bounds) => {
-                        println!("origin bounds from active pane: {:?}", bounds);
+                        println!("FOO origin bounds from active pane: {:?}", bounds);
                         bounds
                     },
                     None => return,
@@ -3483,7 +3483,7 @@ impl Workspace {
         overlap_width >= min_width * 0.25
     }
 
-    /// Helper function to check if two bounds have significant vertical overlap (for circular navigation)  
+    /// Helper function to check if two bounds have significant vertical overlap (for circular navigation)
     fn significant_vertical_overlap(bounds1: Bounds<Pixels>, bounds2: Bounds<Pixels>) -> bool {
         let overlap_start = bounds1.top().max(bounds2.top());
         let overlap_end = bounds1.bottom().min(bounds2.bottom());
@@ -3610,7 +3610,7 @@ impl Workspace {
 
         // No target found in the intended direction, try circular navigation
         println!("no direct target found, trying circular navigation");
-        
+
         let mut best: Option<FocusTarget> = None;
         let mut best_extreme_pos = match direction {
             SplitDirection::Right => f32::MAX,  // looking for leftmost (minimum x)
@@ -3715,7 +3715,7 @@ impl Workspace {
         } else {
             println!("no circular target found either - staying in place");
         }
-        
+
         best
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3428,10 +3428,11 @@ impl Workspace {
                     window.focus(&p.focus_handle(cx));
                 }
                 FocusTarget::Dock(d, _, _) => {
-                    // Read dock once and get the active panel
-                    let active_panel = d.read(cx).active_panel();
-                    if let Some(panel) = active_panel {
-                        panel.panel_focus_handle(cx).focus(window);
+                    // Get both the active panel and its focus handle in one read operation
+                    let focus_handle = d.read(cx).active_panel()
+                        .map(|panel| panel.panel_focus_handle(cx));
+                    if let Some(handle) = focus_handle {
+                        handle.focus(window);
                     }
                 }
             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3967,16 +3967,31 @@ impl Workspace {
                     height: workspace_bounds.size.height,
                 },
             }),
-            DockPosition::Bottom => Some(Bounds {
-                origin: Point {
-                    x: workspace_bounds.origin.x,
-                    y: workspace_bounds.origin.y + workspace_bounds.size.height - panel_size,
-                },
-                size: Size {
-                    width: workspace_bounds.size.width,
-                    height: panel_size,
-                },
-            }),
+            DockPosition::Bottom => {
+                // Calculate bottom dock position accounting for left and right docks
+                let left_dock_width = if self.left_dock.read(cx).is_open() {
+                    self.left_dock.read(cx).active_panel_size(_window, cx).unwrap_or(px(0.0))
+                } else {
+                    px(0.0)
+                };
+                
+                let right_dock_width = if self.right_dock.read(cx).is_open() {
+                    self.right_dock.read(cx).active_panel_size(_window, cx).unwrap_or(px(0.0))
+                } else {
+                    px(0.0)
+                };
+                
+                Some(Bounds {
+                    origin: Point {
+                        x: workspace_bounds.origin.x + left_dock_width,
+                        y: workspace_bounds.origin.y + workspace_bounds.size.height - panel_size,
+                    },
+                    size: Size {
+                        width: workspace_bounds.size.width - left_dock_width - right_dock_width,
+                        height: panel_size,
+                    },
+                })
+            },
         };
 
         log::debug!("bounds for dock {:?}: {:?}", position, bounds);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3415,10 +3415,10 @@ impl Workspace {
                 let position = dock.read(cx).position();
                 println!("focused dock {:?}", position);
                 if let Some(bounds) = self.bounding_box_for_dock(dock, window, cx) {
-                    println!("FOO origin bounds from dock {:?}: {:?}", position, bounds);
+                    println!("origin bounds from dock {:?}: {:?}", position, bounds);
                     bounds
                 } else {
-                    println!("FOO dock {:?} has no bounds, falling back to active pane", position);
+                    println!("dock {:?} has no bounds, falling back to active pane", position);
                     match self.bounding_box_for_pane(&self.active_pane) {
                         Some(bounds) => bounds,
                         None => return,
@@ -3428,7 +3428,7 @@ impl Workspace {
                 println!("no dock focused, using active pane");
                 match self.bounding_box_for_pane(&self.active_pane) {
                     Some(bounds) => {
-                        println!("FOO origin bounds from active pane: {:?}", bounds);
+                        println!("origin bounds from active pane: {:?}", bounds);
                         bounds
                     },
                     None => return,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6637,7 +6637,65 @@ impl Render for Workspace {
                                         }
                                     })
                                 }))
-                                .children(self.render_notifications(window, cx)),
+                                .children(self.render_notifications(window, cx))
+                                .child({
+                                    #[cfg(debug_assertions)]
+                                    {
+                                        use gpui::{PathBuilder, px, point};
+                                        
+                                        // Debug grid overlay to visualize position coordinates
+                                        div()
+                                            .absolute()
+                                            .top_0()
+                                            .left_0()
+                                            .size_full()
+                                            .stop_mouse_events_except_scroll()
+                                            .child({
+                                                canvas(
+                                                    move |_bounds, _window, _cx| {
+                                                        // No prepaint state needed
+                                                    },
+                                                    move |bounds, _state, window, _cx| {
+                                                        // Draw debug grid
+                                                        let grid_size = px(50.0); // 50px grid
+                                                        let line_color = gpui::rgba(0x00FF0080); // Semi-transparent green
+                                                        
+                                                        // Draw vertical lines
+                                                        let mut x = px(0.0);
+                                                        while x <= bounds.size.width {
+                                                            let mut builder = PathBuilder::stroke(px(1.0));
+                                                            builder.move_to(point(bounds.origin.x + x, bounds.origin.y));
+                                                            builder.line_to(point(bounds.origin.x + x, bounds.origin.y + bounds.size.height));
+                                                            if let Ok(path) = builder.build() {
+                                                                window.paint_path(path, line_color);
+                                                            }
+                                                            x += grid_size;
+                                                        }
+                                                        
+                                                        // Draw horizontal lines
+                                                        let mut y = px(0.0);
+                                                        while y <= bounds.size.height {
+                                                            let mut builder = PathBuilder::stroke(px(1.0));
+                                                            builder.move_to(point(bounds.origin.x, bounds.origin.y + y));
+                                                            builder.line_to(point(bounds.origin.x + bounds.size.width, bounds.origin.y + y));
+                                                            if let Ok(path) = builder.build() {
+                                                                window.paint_path(path, line_color);
+                                                            }
+                                                            y += grid_size;
+                                                        }
+                                                        
+                                                        // TODO: Add coordinate labels - needs text rendering API
+                                                        // For now just the grid lines provide spatial reference
+                                                    },
+                                                )
+                                                .size_full()
+                                            })
+                                    }
+                                    #[cfg(not(debug_assertions))]
+                                    {
+                                        div() // Empty div when not in debug mode
+                                    }
+                                }),
                         )
                         .child(self.status_bar.clone())
                         .child(self.modal_layer.clone())

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3465,6 +3465,17 @@ impl Workspace {
                 }
             }
 
+            (Origin::LeftDock, SplitDirection::Left) => {
+                if let Some(dock_target) = try_dock(&self.right_dock) {
+                    Some(dock_target)
+                } else if !self.panes.is_empty() {
+                    // Safe: we’ve established the center has at least one pane
+                    Some(Target::Pane(self.center.last_pane()))
+                } else {
+                    None
+                }
+            }
+
             (Origin::LeftDock, SplitDirection::Right) => {
                 if let Some(last_active_pane) = get_last_active_pane() {
                     Some(Target::Pane(last_active_pane))
@@ -3485,6 +3496,16 @@ impl Workspace {
                     Some(Target::Pane(last_active_pane))
                 } else {
                     try_dock(&self.bottom_dock).or_else(|| try_dock(&self.left_dock))
+                }
+            }
+
+            (Origin::RightDock, SplitDirection::Right) => {
+                if let Some(dock_target) = try_dock(&self.left_dock) {
+                    Some(dock_target)
+                } else if !self.panes.is_empty() {
+                    Some(Target::Pane(self.center.first_pane()))
+                } else {
+                    None
                 }
             }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6641,7 +6641,7 @@ impl Render for Workspace {
                                 .child({
                                     #[cfg(debug_assertions)]
                                     {
-                                        use gpui::{PathBuilder, px, point};
+                                        use gpui::{PathBuilder, px, point, SharedString};
                                         
                                         // Debug grid overlay to visualize position coordinates
                                         div()
@@ -6651,6 +6651,7 @@ impl Render for Workspace {
                                             .size_full()
                                             .stop_mouse_events_except_scroll()
                                             .child({
+                                                // Grid lines layer
                                                 canvas(
                                                     move |_bounds, _window, _cx| {
                                                         // No prepaint state needed
@@ -6658,7 +6659,7 @@ impl Render for Workspace {
                                                     move |bounds, _state, window, _cx| {
                                                         // Draw debug grid
                                                         let grid_size = px(50.0); // 50px grid
-                                                        let line_color = gpui::rgba(0x00FF0080); // Semi-transparent green
+                                                        let line_color = gpui::rgba(0x00FF0030); // More subtle green
                                                         
                                                         // Draw vertical lines
                                                         let mut x = px(0.0);
@@ -6683,12 +6684,50 @@ impl Render for Workspace {
                                                             }
                                                             y += grid_size;
                                                         }
-                                                        
-                                                        // TODO: Add coordinate labels - needs text rendering API
-                                                        // For now just the grid lines provide spatial reference
                                                     },
                                                 )
                                                 .size_full()
+                                            })
+                                            .children({
+                                                // Coordinate labels layer
+                                                let mut labels = Vec::new();
+                                                let grid_size = 50.0; // px
+                                                
+                                                // X-axis labels along top
+                                                let mut x = grid_size;
+                                                while x <= 2000.0 { // Reasonable max width
+                                                    labels.push(
+                                                        div()
+                                                            .absolute()
+                                                            .left(px(x + 2.0))
+                                                            .top(px(2.0))
+                                                            .text_xs()
+                                                            .text_color(gpui::rgba(0x00FF0060)) // More subtle green text
+                                                            .bg(gpui::rgba(0x00000040)) // More subtle black background
+                                                            .px_1()
+                                                            .child(format!("{:.0}", x))
+                                                    );
+                                                    x += grid_size;
+                                                }
+                                                
+                                                // Y-axis labels along left
+                                                let mut y = grid_size;
+                                                while y <= 2000.0 { // Reasonable max height
+                                                    labels.push(
+                                                        div()
+                                                            .absolute()
+                                                            .left(px(2.0))
+                                                            .top(px(y + 2.0))
+                                                            .text_xs()
+                                                            .text_color(gpui::rgba(0x00FF0060)) // More subtle green text
+                                                            .bg(gpui::rgba(0x00000040)) // More subtle black background
+                                                            .px_1()
+                                                            .child(format!("{:.0}", y))
+                                                    );
+                                                    y += grid_size;
+                                                }
+                                                
+                                                labels
                                             })
                                     }
                                     #[cfg(not(debug_assertions))]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3605,6 +3605,12 @@ impl Workspace {
         let docks = self.all_docks();
         let docks_iter = docks.iter().filter_map(|d| {
             // Read dock state once and extract what we need
+            #[cfg(debug_assertions)]
+            let (is_open, last_visit_ts, position, debug_color) = {
+                let dock_read = d.read(cx);
+                (dock_read.is_open(), dock_read.last_visit_ts, dock_read.position(), dock_read.debug_color)
+            };
+            #[cfg(not(debug_assertions))]
             let (is_open, last_visit_ts, position) = {
                 let dock_read = d.read(cx);
                 (dock_read.is_open(), dock_read.last_visit_ts, dock_read.position())
@@ -3612,7 +3618,7 @@ impl Workspace {
 
             if !is_open {
                 #[cfg(debug_assertions)]
-                println!("dock {:?} ({}) closed", position, debug_color_name(dock_read.debug_color));
+                println!("dock {:?} ({}) closed", position, debug_color_name(debug_color));
                 #[cfg(not(debug_assertions))]
                 println!("dock {:?} closed", position);
                 return None;
@@ -3623,7 +3629,7 @@ impl Workspace {
                 println!(
                     "candidate dock {:?} ({}) -> {:?}",
                     position,
-                    debug_color_name(dock_read.debug_color),
+                    debug_color_name(debug_color),
                     b
                 );
                 #[cfg(not(debug_assertions))]
@@ -3631,7 +3637,7 @@ impl Workspace {
                 println!(
                     "candidate dock {:?} ({}) -> {:?}",
                     position,
-                    debug_color_name(dock_read.debug_color),
+                    debug_color_name(debug_color),
                     b
                 );
                 #[cfg(not(debug_assertions))]
@@ -3742,6 +3748,12 @@ impl Workspace {
         });
 
         let docks_iter = docks.iter().filter_map(|d| {
+            #[cfg(debug_assertions)]
+            let (is_open, last_visit_ts, position, debug_color) = {
+                let dock_read = d.read(cx);
+                (dock_read.is_open(), dock_read.last_visit_ts, dock_read.position(), dock_read.debug_color)
+            };
+            #[cfg(not(debug_assertions))]
             let (is_open, last_visit_ts, position) = {
                 let dock_read = d.read(cx);
                 (dock_read.is_open(), dock_read.last_visit_ts, dock_read.position())
@@ -3756,7 +3768,7 @@ impl Workspace {
                 println!(
                     "circular candidate dock {:?} ({}) -> {:?}",
                     position,
-                    debug_color_name(dock_read.debug_color),
+                    debug_color_name(debug_color),
                     b
                 );
                 #[cfg(not(debug_assertions))]


### PR DESCRIPTION
Hey! This PR contains rough experimental code for changing the pane navigation behavior in Zed. I wanted pane navigation to behave like tmux:

https://github.com/user-attachments/assets/e2904d9a-8473-42dc-a03f-3663cbde3fca

1. If I have the layout
```
A | B
A | -
A | C
```

and go from C -> A and then go right again, I should end up back in C, not in B.

2. If I'm in the rightmost pane / dock and navigate right, I want to end up in the left-most, etc.

3. Relatedly, there's some behavior about jumping to the last active panel from a dock that feels weird to me (https://github.com/zed-industries/zed/discussions/31396)

The code in this PR changes these three things:

https://github.com/user-attachments/assets/5eb7eaea-b683-48b4-8762-772ed01c5889

There's no tests yet and a bunch of debug logs / UI artifacts that still in. Before I go and clean that up, could I get a high-level review on the behavior change?

Related issues / discussion:
- https://github.com/zed-industries/zed/discussions/31396
- https://github.com/zed-industries/zed/issues/20738
- https://github.com/zed-industries/zed/discussions/24109