### PR TITLE
go_to_line: Show position relative to current excerpt in a multi-buffer

### DIFF
--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -39,15 +39,32 @@ pub struct UserCaretPosition {
 }
 
 impl UserCaretPosition {
-    pub fn at_selection_end(selection: &Selection<Point>, snapshot: &MultiBufferSnapshot) -> Self {
+    pub(crate) fn at_selection_end(
+        selection: &Selection<Point>,
+        snapshot: &MultiBufferSnapshot,
+    ) -> Self {
         let selection_end = selection.head();
-        let line_start = Point::new(selection_end.row, 0);
-        let chars_to_last_position = snapshot
-            .text_summary_for_range::<text::TextSummary, _>(line_start..selection_end)
-            .chars as u32;
+        let (line, character) = if let Some((buffer_snapshot, point, _)) =
+            snapshot.point_to_buffer_point(selection_end)
+        {
+            let line_start = Point::new(point.row, 0);
+
+            let chars_to_last_position = buffer_snapshot
+                .text_summary_for_range::<text::TextSummary, _>(line_start..point)
+                .chars as u32;
+            (line_start.row, chars_to_last_position)
+        } else {
+            let line_start = Point::new(selection_end.row, 0);
+
+            let chars_to_last_position = snapshot
+                .text_summary_for_range::<text::TextSummary, _>(line_start..selection_end)
+                .chars as u32;
+            (selection_end.row, chars_to_last_position)
+        };
+
         Self {
-            line: NonZeroU32::new(selection_end.row + 1).expect("added 1"),
-            character: NonZeroU32::new(chars_to_last_position + 1).expect("added 1"),
+            line: NonZeroU32::new(line + 1).expect("added 1"),
+            character: NonZeroU32::new(character + 1).expect("added 1"),
         }
     }
 }


### PR DESCRIPTION
Closes #31515

This PR explicitly leaves the behavior of go to line unspecified with multi-buffer.

Release Notes:

- Fixed wrong line number being shown in the status bar when in multi-buffer.
