### PR TITLE
collab: Reconnect to channel notes

### DIFF
--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -103,6 +103,16 @@ impl ChannelBuffer {
         }
     }
 
+    pub fn connected(&mut self, cx: &mut Context<Self>) {
+        self.connected = true;
+        if self.subscription.is_none() {
+            let Ok(subscription) = self.client.subscribe_to_entity(self.channel_id.0) else {
+                return;
+            };
+            self.subscription = Some(subscription.set_entity(&cx.entity(), &mut cx.to_async()));
+        }
+    }
+
     pub fn remote_id(&self, cx: &App) -> BufferId {
         self.buffer.read(cx).remote_id()
     }

--- a/crates/channel/src/channel_buffer.rs
+++ b/crates/channel/src/channel_buffer.rs
@@ -35,6 +35,7 @@ pub struct ChannelBuffer {
 pub enum ChannelBufferEvent {
     CollaboratorsChanged,
     Disconnected,
+    Connected,
     BufferEdited,
     ChannelChanged,
 }
@@ -110,6 +111,7 @@ impl ChannelBuffer {
                 return;
             };
             self.subscription = Some(subscription.set_entity(&cx.entity(), &mut cx.to_async()));
+            cx.emit(ChannelBufferEvent::Connected);
         }
     }
 

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -19,7 +19,7 @@ use settings::Settings;
 use std::{mem, sync::Arc, time::Duration};
 use util::{ResultExt, maybe};
 
-pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(1);
+pub const RECONNECT_TIMEOUT: Duration = Duration::from_secs(30);
 
 pub fn init(client: &Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
     let channel_store = cx.new(|cx| ChannelStore::new(client.clone(), user_store.clone(), cx));

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -354,6 +354,10 @@ impl ChannelView {
                 editor.set_read_only(true);
                 cx.notify();
             }),
+            ChannelBufferEvent::Connected => self.editor.update(cx, |editor, cx| {
+                editor.set_read_only(false);
+                cx.notify();
+            }),
             ChannelBufferEvent::ChannelChanged => {
                 self.editor.update(cx, |_, cx| {
                     cx.emit(editor::EditorEvent::TitleChanged);


### PR DESCRIPTION
Closes #31758

Release Notes:

- Fixed channel notes not getting re-connected when a connection to Zed servers is restored.
