### PR TITLE
Activate ViMode in the Terminal on search

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1294,7 +1294,10 @@
       // 5. Never show the scrollbar:
       //    "never"
       "show": null
-    }
+    },
+    // Whether to activate ViMode on search
+    // Default: false
+    "activate_vimode_on_search": false
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
     // "font_size": 15,

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -48,6 +48,7 @@ pub struct TerminalSettings {
     pub max_scroll_history_lines: Option<usize>,
     pub toolbar: Toolbar,
     pub scrollbar: ScrollbarSettings,
+    pub activate_vimode_on_search: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -223,6 +224,10 @@ pub struct TerminalSettingsContent {
     pub toolbar: Option<ToolbarContent>,
     /// Scrollbar-related settings
     pub scrollbar: Option<ScrollbarSettingsContent>,
+    /// Whether to activate Vimode on search
+    ///
+    /// Default: false
+    pub activate_vimode_on_search: bool,
 }
 
 impl settings::Settings for TerminalSettings {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1777,7 +1777,7 @@ impl SearchableItem for TerminalView {
 
     /// Clear stored matches
     fn clear_matches(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        self.terminal().update(cx, |term, _| term.matches.clear())
+        self.terminal().update(cx, |term, _| term.clear_matches())
     }
 
     /// Store matches returned from find_matches somewhere for rendering
@@ -1810,7 +1810,7 @@ impl SearchableItem for TerminalView {
         cx: &mut Context<Self>,
     ) {
         self.terminal()
-            .update(cx, |term, _| term.activate_match(index));
+            .update(cx, |term, cx| term.activate_match(index, cx));
         cx.notify();
     }
 


### PR DESCRIPTION
Currently, when you activate search in the terminal view, Zed highlights the matches and scrolls the active match into view, which is fine, but it's not great for keyboard-focused usage. It would be better to activate ViMode in the terminal and move the cursor to the active match, so a user can dismiss the search and continue to navigate through the scrollback using ViMode.


https://github.com/user-attachments/assets/58fa2696-391a-4c9d-9199-53653c381645


Release Notes:

- Added `terminal.activate_vimode_on_search` setting, which integrates the search in Terminal with Alacritty's ViMode
