### PR TITLE
Make minimum width for line numbers in gutter configurable

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -446,7 +446,7 @@
     "breakpoints": true,
     // Whether to show fold buttons in the gutter.
     "folds": true,
-    // Minimum width for line numbers in characters.
+    // Minimum number of characters to reserve space for in the gutter.
     "min_line_number_digits": 4
   },
   "indent_guides": {

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -447,7 +447,7 @@
     // Whether to show fold buttons in the gutter.
     "folds": true,
     // Minimum width for line numbers in characters.
-    "line_number_base_width": 4
+    "min_line_number_digits": 4
   },
   "indent_guides": {
     // Whether to show indent guides in the editor.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -445,7 +445,9 @@
     // Whether to show breakpoints in the gutter.
     "breakpoints": true,
     // Whether to show fold buttons in the gutter.
-    "folds": true
+    "folds": true,
+    // Minimum width for line numbers in characters.
+    "line_number_base_width": 4
   },
   "indent_guides": {
     // Whether to show indent guides in the editor.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -240,7 +240,6 @@ pub(crate) const SCROLL_CENTER_TOP_BOTTOM_DEBOUNCE_TIMEOUT: Duration = Duration:
 
 pub(crate) const EDIT_PREDICTION_KEY_CONTEXT: &str = "edit_prediction";
 pub(crate) const EDIT_PREDICTION_CONFLICT_KEY_CONTEXT: &str = "edit_prediction_conflict";
-pub(crate) const MIN_LINE_NUMBER_DIGITS: u32 = 4;
 pub(crate) const MINIMAP_FONT_SIZE: AbsoluteLength = AbsoluteLength::Pixels(px(2.));
 
 pub type RenderDiffHunkControlsFn = Arc<
@@ -21558,7 +21557,8 @@ impl EditorSnapshot {
             .unwrap_or(gutter_settings.line_numbers);
         let line_gutter_width = if show_line_numbers {
             // Avoid flicker-like gutter resizes when the line number gains another digit and only resize the gutter on files with N*10^5 lines.
-            let min_width_for_number_on_gutter = em_advance * MIN_LINE_NUMBER_DIGITS as f32;
+            let min_width_for_number_on_gutter =
+                em_advance * gutter_settings.line_number_base_width as f32;
             max_line_number_width.max(min_width_for_number_on_gutter)
         } else {
             0.0.into()

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -21558,7 +21558,7 @@ impl EditorSnapshot {
         let line_gutter_width = if show_line_numbers {
             // Avoid flicker-like gutter resizes when the line number gains another digit and only resize the gutter on files with N*10^5 lines.
             let min_width_for_number_on_gutter =
-                em_advance * gutter_settings.line_number_base_width as f32;
+                em_advance * gutter_settings.min_line_number_digits as f32;
             max_line_number_width.max(min_width_for_number_on_gutter)
         } else {
             0.0.into()

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -150,7 +150,7 @@ impl Minimap {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Gutter {
-    pub line_number_base_width: usize,
+    pub min_line_number_digits: usize,
     pub line_numbers: bool,
     pub runnables: bool,
     pub breakpoints: bool,
@@ -613,7 +613,7 @@ pub struct GutterContent {
     /// Minimum width for line numbers in characters.
     ///
     /// Default: 4
-    pub line_number_base_width: Option<usize>,
+    pub min_line_number_digits: Option<usize>,
     /// Whether to show runnable buttons in the gutter.
     ///
     /// Default: true

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -610,9 +610,9 @@ pub struct GutterContent {
     ///
     /// Default: true
     pub line_numbers: Option<bool>,
-    /// Minimum width for line numbers in characters
+    /// Minimum width for line numbers in characters.
     ///
-    /// Default 4
+    /// Default: 4
     pub line_number_base_width: Option<usize>,
     /// Whether to show runnable buttons in the gutter.
     ///

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -610,7 +610,7 @@ pub struct GutterContent {
     ///
     /// Default: true
     pub line_numbers: Option<bool>,
-    /// Minimum width for line numbers in characters.
+    /// Minimum number of characters to reserve space for in the gutter.
     ///
     /// Default: 4
     pub min_line_number_digits: Option<usize>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -150,6 +150,7 @@ impl Minimap {
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct Gutter {
+    pub line_number_base_width: usize,
     pub line_numbers: bool,
     pub runnables: bool,
     pub breakpoints: bool,
@@ -609,6 +610,10 @@ pub struct GutterContent {
     ///
     /// Default: true
     pub line_numbers: Option<bool>,
+    /// Minimum width for line numbers in characters
+    ///
+    /// Default 4
+    pub line_number_base_width: Option<usize>,
     /// Whether to show runnable buttons in the gutter.
     ///
     /// Default: true

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2827,7 +2827,7 @@ impl EditorElement {
 
                 let editor = self.editor.clone();
                 let is_wide = max_line_number_length
-                    >= EditorSettings::get_global(cx).gutter.line_number_base_width as u32
+                    >= EditorSettings::get_global(cx).gutter.min_line_number_digits as u32
                     && row_info
                         .buffer_row
                         .is_some_and(|row| (row + 1).ilog10() + 1 == max_line_number_length)

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6,10 +6,10 @@ use crate::{
     Editor, EditorMode, EditorSettings, EditorSnapshot, EditorStyle, FILE_HEADER_HEIGHT,
     FocusedBlock, GutterDimensions, HalfPageDown, HalfPageUp, HandleInput, HoveredCursor,
     InlayHintRefreshReason, InlineCompletion, JumpData, LineDown, LineHighlight, LineUp,
-    MAX_LINE_LEN, MIN_LINE_NUMBER_DIGITS, MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT,
-    OpenExcerpts, PageDown, PageUp, PhantomBreakpointIndicator, Point, RowExt, RowRangeExt,
-    SelectPhase, SelectedTextHighlight, Selection, SelectionDragState, SoftWrap,
-    StickyHeaderExcerpt, ToPoint, ToggleFold,
+    MAX_LINE_LEN, MINIMAP_FONT_SIZE, MULTI_BUFFER_EXCERPT_HEADER_HEIGHT, OpenExcerpts, PageDown,
+    PageUp, PhantomBreakpointIndicator, Point, RowExt, RowRangeExt, SelectPhase,
+    SelectedTextHighlight, Selection, SelectionDragState, SoftWrap, StickyHeaderExcerpt, ToPoint,
+    ToggleFold,
     code_context_menus::{CodeActionsMenu, MENU_ASIDE_MAX_WIDTH, MENU_ASIDE_MIN_WIDTH, MENU_GAP},
     display_map::{
         Block, BlockContext, BlockStyle, DisplaySnapshot, EditorMargins, FoldId, HighlightedChunk,
@@ -2826,7 +2826,8 @@ impl EditorElement {
                 let available_width = gutter_dimensions.left_padding - git_gutter_width;
 
                 let editor = self.editor.clone();
-                let is_wide = max_line_number_length >= MIN_LINE_NUMBER_DIGITS
+                let is_wide = max_line_number_length
+                    >= EditorSettings::get_global(cx).gutter.line_number_base_width as u32
                     && row_info
                         .buffer_row
                         .is_some_and(|row| (row + 1).ilog10() + 1 == max_line_number_length)


### PR DESCRIPTION
Closes #7334

# Changes
This PR makes the minimum width allocated for line numbers in the side gutter configurable in units of character width via the `"line_number_base_width"` attribute in `gutter` settings. Set the previously hard coded value of `4` as default.

Together with other settings (`"folds"`, `"breakpoints"`,...) this gives the user control over the gutter width.

If the number of lines exceedes the base width, the number of digits in the largest line number is chosen instead. This is consistent with previous behaviour.

Screenshot for reference:
<img width="1104" alt="Screenshot 2025-06-03 at 12 15 29" src="https://github.com/user-attachments/assets/77c869ad-164b-4b74-8e39-8be43d740ad4" />


P.S.: This is my first time contributing to zed (yay!🎉). Let me know if i'm missing something. 

Release Notes:

- Make minimum line number width in gutter configurable

