### PR TITLE
Implement FIXME/TODO searching functionality

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -432,7 +432,8 @@
       "ctrl-alt-shift-r": "search::ToggleRegex",
       "ctrl-alt-shift-x": "search::ToggleRegex",
       "alt-r": "search::ToggleRegex",
-      "ctrl-k shift-enter": "pane::TogglePinTab"
+      "ctrl-k shift-enter": "pane::TogglePinTab",
+      "alt-q": "search::ToggleTodoFixme"
     }
   },
   // Bindings from VS Code

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -475,6 +475,7 @@
       "alt-cmd-w": "search::ToggleWholeWord",
       "alt-cmd-f": "project_search::ToggleFilters",
       "alt-cmd-x": "search::ToggleRegex",
+      "alt-cmd-q": "search::ToggleTodoFixme",
       "cmd-k shift-enter": "pane::TogglePinTab"
     }
   },

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -809,6 +809,7 @@ impl SearchableItem for DapLogView {
             word: true,
             regex: true,
             find_in_results: true,
+            todo_fixme: true,
             // DAP log is read-only.
             replacement: false,
             selection: false,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1495,6 +1495,7 @@ impl SearchableItem for Editor {
                 replacement: false,
                 selection: false,
                 find_in_results: true,
+                todo_fixme: true,
             }
         } else {
             SearchOptions {
@@ -1504,6 +1505,7 @@ impl SearchableItem for Editor {
                 replacement: true,
                 selection: true,
                 find_in_results: false,
+                todo_fixme: true,
             }
         }
     }

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -1163,6 +1163,7 @@ impl SearchableItem for LspLogView {
             word: true,
             regex: true,
             find_in_results: false,
+            todo_fixme: false,
             // LSP log is read-only.
             replacement: false,
             selection: false,

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -37,6 +37,7 @@ actions!(
         PreviousHistoryQuery,
         ReplaceAll,
         ReplaceNext,
+        ToggleTodoFixme,
     ]
 );
 
@@ -48,6 +49,7 @@ bitflags! {
         const CASE_SENSITIVE = 0b010;
         const INCLUDE_IGNORED = 0b100;
         const REGEX = 0b1000;
+        const TODO_FIXME = 0b1000000;
         const ONE_MATCH_PER_LINE = 0b100000;
         /// If set, reverse direction when finding the active match
         const BACKWARDS = 0b10000;
@@ -61,6 +63,7 @@ impl SearchOptions {
             SearchOptions::CASE_SENSITIVE => "Match Case Sensitively",
             SearchOptions::INCLUDE_IGNORED => "Also search files ignored by configuration",
             SearchOptions::REGEX => "Use Regular Expressions",
+            SearchOptions::TODO_FIXME => "Find TODOs/FIXMEs",
             _ => panic!("{:?} is not a named SearchOption", self),
         }
     }
@@ -71,6 +74,7 @@ impl SearchOptions {
             SearchOptions::CASE_SENSITIVE => ui::IconName::CaseSensitive,
             SearchOptions::INCLUDE_IGNORED => ui::IconName::Sliders,
             SearchOptions::REGEX => ui::IconName::Regex,
+            SearchOptions::TODO_FIXME => ui::IconName::Warning,
             _ => panic!("{:?} is not a named SearchOption", self),
         }
     }
@@ -81,6 +85,7 @@ impl SearchOptions {
             SearchOptions::CASE_SENSITIVE => Box::new(ToggleCaseSensitive),
             SearchOptions::INCLUDE_IGNORED => Box::new(ToggleIncludeIgnored),
             SearchOptions::REGEX => Box::new(ToggleRegex),
+            SearchOptions::TODO_FIXME => Box::new(ToggleTodoFixme),
             _ => panic!("{:?} is not a named SearchOption", self),
         }
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1767,6 +1767,7 @@ impl SearchableItem for TerminalView {
             replacement: false,
             selection: false,
             find_in_results: false,
+            todo_fixme: false,
         }
     }
 

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -43,6 +43,7 @@ pub struct SearchOptions {
     pub replacement: bool,
     pub selection: bool,
     pub find_in_results: bool,
+    pub todo_fixme: bool,
 }
 
 pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
@@ -56,6 +57,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
             replacement: true,
             selection: true,
             find_in_results: false,
+            todo_fixme: true,
         }
     }
 


### PR DESCRIPTION
Closes #26904

Added a new search option: TODO/FIXME, which can be toggled by a button / shortcut, both in project search and buffer search. This option finds all TODO/FIXME annotations.
Added a notification to alert the user when this option is active.

Release Notes:

- Implemented a button next to all the other search functionalities that searches for all the TODO/FIXME annotations, both in buffer search and project wide search.
