### PR TITLE
agent: Allow to accept and reject all via the panel

### DIFF
--- a/assets/icons/list_todo.svg
+++ b/assets/icons/list_todo.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-todo-icon lucide-list-todo"><rect x="3" y="5" width="6" height="6" rx="1"/><path d="m3 17 2 2 4-4"/><path d="M13 6h8"/><path d="M13 12h8"/><path d="M13 18h8"/></svg>

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -278,7 +278,9 @@
       "enter": "agent::Chat",
       "ctrl-enter": "agent::ChatWithFollow",
       "ctrl-i": "agent::ToggleProfileSelector",
-      "shift-ctrl-r": "agent::OpenAgentDiff"
+      "shift-ctrl-r": "agent::OpenAgentDiff",
+      "ctrl-shift-y": "agent::KeepAll",
+      "ctrl-shift-n": "agent::RejectAll"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -315,7 +315,9 @@
       "enter": "agent::Chat",
       "cmd-enter": "agent::ChatWithFollow",
       "cmd-i": "agent::ToggleProfileSelector",
-      "shift-ctrl-r": "agent::OpenAgentDiff"
+      "shift-ctrl-r": "agent::OpenAgentDiff",
+      "cmd-shift-y": "agent::KeepAll",
+      "cmd-shift-n": "agent::RejectAll"
     }
   },
   {

--- a/crates/agent/src/context_server_tool.rs
+++ b/crates/agent/src/context_server_tool.rs
@@ -51,6 +51,10 @@ impl Tool for ContextServerTool {
         true
     }
 
+    fn may_perform_edits(&self) -> bool {
+        true
+    }
+
     fn input_schema(&self, format: LanguageModelToolSchemaFormat) -> Result<serde_json::Value> {
         let mut schema = self.tool.input_schema.clone();
         assistant_tool::adapt_schema_to_format(&mut schema, format)?;

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -6,7 +6,7 @@ use crate::agent_model_selector::{AgentModelSelector, ModelType};
 use crate::context::{AgentContextKey, ContextCreasesAddon, ContextLoadResult, load_context};
 use crate::tool_compatibility::{IncompatibleToolsState, IncompatibleToolsTooltip};
 use crate::ui::{
-    AnimatedLabel, MaxModeTooltip,
+    MaxModeTooltip,
     preview::{AgentPreview, UsageCallout},
 };
 use agent_settings::{AgentSettings, CompletionMode};
@@ -27,7 +27,7 @@ use gpui::{
     Animation, AnimationExt, App, ClipboardEntry, Entity, EventEmitter, Focusable, Subscription,
     Task, TextStyle, WeakEntity, linear_color_stop, linear_gradient, point, pulsating_between,
 };
-use language::{Buffer, Language};
+use language::{Buffer, Language, Point};
 use language_model::{
     ConfiguredModel, LanguageModelRequestMessage, MessageContent, RequestUsage,
     ZED_CLOUD_PROVIDER_ID,
@@ -51,9 +51,9 @@ use crate::profile_selector::ProfileSelector;
 use crate::thread::{MessageCrease, Thread, TokenUsageRatio};
 use crate::thread_store::{TextThreadStore, ThreadStore};
 use crate::{
-    ActiveThread, AgentDiffPane, Chat, ChatWithFollow, ExpandMessageEditor, Follow, NewThread,
-    OpenAgentDiff, RemoveAllContext, ToggleBurnMode, ToggleContextPicker, ToggleProfileSelector,
-    register_agent_preview,
+    ActiveThread, AgentDiffPane, Chat, ChatWithFollow, ExpandMessageEditor, Follow, KeepAll,
+    NewThread, OpenAgentDiff, RejectAll, RemoveAllContext, ToggleBurnMode, ToggleContextPicker,
+    ToggleProfileSelector, register_agent_preview,
 };
 
 #[derive(RegisterComponent)]
@@ -459,8 +459,17 @@ impl MessageEditor {
     }
 
     fn handle_review_click(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if !self.thread.read(cx).are_edits_ready(cx) {
+            return;
+        }
+
         self.edits_expanded = true;
         AgentDiffPane::deploy(self.thread.clone(), self.workspace.clone(), window, cx).log_err();
+        cx.notify();
+    }
+
+    fn handle_edit_bar_expand(&mut self, cx: &mut Context<Self>) {
+        self.edits_expanded = !self.edits_expanded;
         cx.notify();
     }
 
@@ -492,6 +501,40 @@ impl MessageEditor {
                 CompletionMode::Normal => CompletionMode::Burn,
             });
         });
+    }
+
+    fn handle_accept_all(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if !self.thread.read(cx).are_edits_ready(cx) {
+            return;
+        }
+
+        self.thread.update(cx, |thread, cx| {
+            thread.keep_all_edits(cx);
+        });
+        cx.notify();
+    }
+
+    fn handle_reject_all(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+        if !self.thread.read(cx).are_edits_ready(cx) {
+            return;
+        }
+
+        // Since there's no reject_all_edits method in the thread API,
+        // we need to iterate through all buffers and reject their edits
+        let action_log = self.thread.read(cx).action_log().clone();
+        let changed_buffers = action_log.read(cx).changed_buffers(cx);
+
+        for (buffer, _) in changed_buffers {
+            self.thread.update(cx, |thread, cx| {
+                let buffer_snapshot = buffer.read(cx);
+                let start = buffer_snapshot.anchor_before(Point::new(0, 0));
+                let end = buffer_snapshot.anchor_after(buffer_snapshot.max_point());
+                thread
+                    .reject_edits_in_ranges(buffer, vec![start..end], cx)
+                    .detach();
+            });
+        }
+        cx.notify();
     }
 
     fn render_max_mode_toggle(&self, cx: &mut Context<Self>) -> Option<AnyElement> {
@@ -615,6 +658,12 @@ impl MessageEditor {
             .on_action(cx.listener(Self::move_up))
             .on_action(cx.listener(Self::expand_message_editor))
             .on_action(cx.listener(Self::toggle_burn_mode))
+            .on_action(
+                cx.listener(|this, _: &KeepAll, window, cx| this.handle_accept_all(window, cx)),
+            )
+            .on_action(
+                cx.listener(|this, _: &RejectAll, window, cx| this.handle_reject_all(window, cx)),
+            )
             .capture_action(cx.listener(Self::paste))
             .gap_2()
             .p_2()
@@ -870,7 +919,10 @@ impl MessageEditor {
         let bg_edit_files_disclosure = editor_bg_color.blend(active_color.opacity(0.3));
 
         let is_edit_changes_expanded = self.edits_expanded;
-        let is_generating = self.thread.read(cx).is_generating();
+        let thread = self.thread.read(cx);
+        let edits_ready = thread.are_edits_ready(cx);
+
+        const EDIT_NOT_READY_TOOLTIP_LABEL: &str = "Wait until file edits are complete.";
 
         v_flex()
             .mt_1()
@@ -888,31 +940,28 @@ impl MessageEditor {
             }])
             .child(
                 h_flex()
-                    .id("edits-container")
-                    .cursor_pointer()
-                    .p_1p5()
+                    .p_1()
                     .justify_between()
                     .when(is_edit_changes_expanded, |this| {
                         this.border_b_1().border_color(border_color)
                     })
-                    .on_click(
-                        cx.listener(|this, _, window, cx| this.handle_review_click(window, cx)),
-                    )
                     .child(
                         h_flex()
+                            .id("edits-container")
+                            .cursor_pointer()
+                            .w_full()
                             .gap_1()
                             .child(
                                 Disclosure::new("edits-disclosure", is_edit_changes_expanded)
-                                    .on_click(cx.listener(|this, _ev, _window, cx| {
-                                        this.edits_expanded = !this.edits_expanded;
-                                        cx.notify();
+                                    .on_click(cx.listener(|this, _, _, cx| {
+                                        this.handle_edit_bar_expand(cx)
                                     })),
                             )
                             .map(|this| {
-                                if is_generating {
+                                if !edits_ready {
                                     this.child(
-                                        AnimatedLabel::new(format!(
-                                            "Editing {} {}",
+                                        Label::new(format!(
+                                            "Editing {} {}…",
                                             changed_buffers.len(),
                                             if changed_buffers.len() == 1 {
                                                 "file"
@@ -920,7 +969,15 @@ impl MessageEditor {
                                                 "files"
                                             }
                                         ))
-                                        .size(LabelSize::Small),
+                                        .color(Color::Muted)
+                                        .size(LabelSize::Small)
+                                        .with_animation(
+                                            "edit-label",
+                                            Animation::new(Duration::from_secs(2))
+                                                .repeat()
+                                                .with_easing(pulsating_between(0.3, 0.7)),
+                                            |label, delta| label.alpha(delta),
+                                        ),
                                     )
                                 } else {
                                     this.child(
@@ -945,23 +1002,74 @@ impl MessageEditor {
                                         .color(Color::Muted),
                                     )
                                 }
-                            }),
+                            })
+                            .on_click(
+                                cx.listener(|this, _, _, cx| this.handle_edit_bar_expand(cx)),
+                            ),
                     )
                     .child(
-                        Button::new("review", "Review Changes")
-                            .label_size(LabelSize::Small)
-                            .key_binding(
-                                KeyBinding::for_action_in(
-                                    &OpenAgentDiff,
-                                    &focus_handle,
-                                    window,
-                                    cx,
-                                )
-                                .map(|kb| kb.size(rems_from_px(12.))),
+                        h_flex()
+                            .gap_1()
+                            .child(
+                                IconButton::new("review-changes", IconName::ListTodo)
+                                    .icon_size(IconSize::Small)
+                                    .tooltip({
+                                        let focus_handle = focus_handle.clone();
+                                        move |window, cx| {
+                                            Tooltip::for_action_in(
+                                                "Review Changes",
+                                                &OpenAgentDiff,
+                                                &focus_handle,
+                                                window,
+                                                cx,
+                                            )
+                                        }
+                                    })
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.handle_review_click(window, cx)
+                                    })),
                             )
-                            .on_click(cx.listener(|this, _, window, cx| {
-                                this.handle_review_click(window, cx)
-                            })),
+                            .child(ui::Divider::vertical().color(ui::DividerColor::Border))
+                            .child(
+                                Button::new("reject-all-changes", "Reject All")
+                                    .label_size(LabelSize::Small)
+                                    .disabled(!edits_ready)
+                                    .when(!edits_ready, |this| {
+                                        this.tooltip(Tooltip::text(EDIT_NOT_READY_TOOLTIP_LABEL))
+                                    })
+                                    .key_binding(
+                                        KeyBinding::for_action_in(
+                                            &RejectAll,
+                                            &focus_handle.clone(),
+                                            window,
+                                            cx,
+                                        )
+                                        .map(|kb| kb.size(rems_from_px(10.))),
+                                    )
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.handle_reject_all(window, cx)
+                                    })),
+                            )
+                            .child(
+                                Button::new("accept-all-changes", "Accept All")
+                                    .label_size(LabelSize::Small)
+                                    .disabled(!edits_ready)
+                                    .when(!edits_ready, |this| {
+                                        this.tooltip(Tooltip::text(EDIT_NOT_READY_TOOLTIP_LABEL))
+                                    })
+                                    .key_binding(
+                                        KeyBinding::for_action_in(
+                                            &KeepAll,
+                                            &focus_handle,
+                                            window,
+                                            cx,
+                                        )
+                                        .map(|kb| kb.size(rems_from_px(10.))),
+                                    )
+                                    .on_click(cx.listener(|this, _, window, cx| {
+                                        this.handle_accept_all(window, cx)
+                                    })),
+                            ),
                     ),
             )
             .when(is_edit_changes_expanded, |parent| {

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -459,7 +459,7 @@ impl MessageEditor {
     }
 
     fn handle_review_click(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if !self.thread.read(cx).are_edits_ready(cx) {
+        if self.thread.read(cx).has_pending_edit_tool_uses() {
             return;
         }
 
@@ -504,7 +504,7 @@ impl MessageEditor {
     }
 
     fn handle_accept_all(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        if !self.thread.read(cx).are_edits_ready(cx) {
+        if self.thread.read(cx).has_pending_edit_tool_uses() {
             return;
         }
 
@@ -515,7 +515,7 @@ impl MessageEditor {
     }
 
     fn handle_reject_all(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        if !self.thread.read(cx).are_edits_ready(cx) {
+        if self.thread.read(cx).has_pending_edit_tool_uses() {
             return;
         }
 
@@ -920,7 +920,7 @@ impl MessageEditor {
 
         let is_edit_changes_expanded = self.edits_expanded;
         let thread = self.thread.read(cx);
-        let edits_ready = thread.are_edits_ready(cx);
+        let pending_edits = thread.has_pending_edit_tool_uses();
 
         const EDIT_NOT_READY_TOOLTIP_LABEL: &str = "Wait until file edits are complete.";
 
@@ -958,7 +958,7 @@ impl MessageEditor {
                                     })),
                             )
                             .map(|this| {
-                                if !edits_ready {
+                                if pending_edits {
                                     this.child(
                                         Label::new(format!(
                                             "Editing {} {}…",
@@ -1033,8 +1033,8 @@ impl MessageEditor {
                             .child(
                                 Button::new("reject-all-changes", "Reject All")
                                     .label_size(LabelSize::Small)
-                                    .disabled(!edits_ready)
-                                    .when(!edits_ready, |this| {
+                                    .disabled(pending_edits)
+                                    .when(pending_edits, |this| {
                                         this.tooltip(Tooltip::text(EDIT_NOT_READY_TOOLTIP_LABEL))
                                     })
                                     .key_binding(
@@ -1053,8 +1053,8 @@ impl MessageEditor {
                             .child(
                                 Button::new("accept-all-changes", "Accept All")
                                     .label_size(LabelSize::Small)
-                                    .disabled(!edits_ready)
-                                    .when(!edits_ready, |this| {
+                                    .disabled(pending_edits)
+                                    .when(pending_edits, |this| {
                                         this.tooltip(Tooltip::text(EDIT_NOT_READY_TOOLTIP_LABEL))
                                     })
                                     .key_binding(

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -871,7 +871,15 @@ impl Thread {
         self.tool_use
             .pending_tool_uses()
             .iter()
-            .all(|tool_use| tool_use.status.is_error())
+            .all(|pending_tool_use| pending_tool_use.status.is_error())
+    }
+
+    /// Returns whether agent edits are ready for review.
+    pub fn are_edits_ready(&self, cx: &App) -> bool {
+        let has_changes = !self.action_log.read(cx).changed_buffers(cx).is_empty();
+        let tools_finished = self.all_tools_finished();
+
+        has_changes && tools_finished
     }
 
     pub fn tool_uses_for_message(&self, id: MessageId, cx: &App) -> Vec<ToolUse> {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -874,12 +874,13 @@ impl Thread {
             .all(|pending_tool_use| pending_tool_use.status.is_error())
     }
 
-    /// Returns whether agent edits are ready for review.
-    pub fn are_edits_ready(&self, cx: &App) -> bool {
-        let has_changes = !self.action_log.read(cx).changed_buffers(cx).is_empty();
-        let tools_finished = self.all_tools_finished();
-
-        has_changes && tools_finished
+    /// Returns whether any pending tool uses may perform edits
+    pub fn has_pending_edit_tool_uses(&self) -> bool {
+        self.tool_use
+            .pending_tool_uses()
+            .iter()
+            .filter(|pending_tool_use| !pending_tool_use.status.is_error())
+            .any(|pending_tool_use| pending_tool_use.may_perform_edits)
     }
 
     pub fn tool_uses_for_message(&self, id: MessageId, cx: &App) -> Vec<ToolUse> {

--- a/crates/agent/src/tool_use.rs
+++ b/crates/agent/src/tool_use.rs
@@ -337,7 +337,7 @@ impl ToolUseState {
             )
             .into();
 
-        let may_perform_edits =self
+        let may_perform_edits = self
             .tools
             .read(cx)
             .tool(&tool_use.name, cx)

--- a/crates/agent/src/tool_use.rs
+++ b/crates/agent/src/tool_use.rs
@@ -337,6 +337,12 @@ impl ToolUseState {
             )
             .into();
 
+        let may_perform_edits =self
+            .tools
+            .read(cx)
+            .tool(&tool_use.name, cx)
+            .is_some_and(|tool| tool.may_perform_edits());
+
         self.pending_tool_uses_by_id.insert(
             tool_use.id.clone(),
             PendingToolUse {
@@ -345,6 +351,7 @@ impl ToolUseState {
                 name: tool_use.name.clone(),
                 ui_text: ui_text.clone(),
                 input: tool_use.input,
+                may_perform_edits,
                 status,
             },
         );
@@ -518,6 +525,7 @@ pub struct PendingToolUse {
     pub ui_text: Arc<str>,
     pub input: serde_json::Value,
     pub status: PendingToolUseStatus,
+    pub may_perform_edits: bool,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -218,6 +218,9 @@ pub trait Tool: 'static + Send + Sync {
     /// before having permission to run.
     fn needs_confirmation(&self, input: &serde_json::Value, cx: &App) -> bool;
 
+    /// Returns true if the tool may perform edits.
+    fn may_perform_edits(&self) -> bool;
+
     /// Returns the JSON schema that describes the tool's input.
     fn input_schema(&self, _: LanguageModelToolSchemaFormat) -> Result<serde_json::Value> {
         Ok(serde_json::Value::Object(serde_json::Map::default()))

--- a/crates/assistant_tools/src/copy_path_tool.rs
+++ b/crates/assistant_tools/src/copy_path_tool.rs
@@ -48,6 +48,10 @@ impl Tool for CopyPathTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        true
+    }
+
     fn description(&self) -> String {
         include_str!("./copy_path_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/create_directory_tool.rs
+++ b/crates/assistant_tools/src/create_directory_tool.rs
@@ -33,12 +33,16 @@ impl Tool for CreateDirectoryTool {
         "create_directory".into()
     }
 
+    fn description(&self) -> String {
+        include_str!("./create_directory_tool/description.md").into()
+    }
+
     fn needs_confirmation(&self, _: &serde_json::Value, _: &App) -> bool {
         false
     }
 
-    fn description(&self) -> String {
-        include_str!("./create_directory_tool/description.md").into()
+    fn may_perform_edits(&self) -> bool {
+        false
     }
 
     fn icon(&self) -> IconName {

--- a/crates/assistant_tools/src/delete_path_tool.rs
+++ b/crates/assistant_tools/src/delete_path_tool.rs
@@ -37,6 +37,10 @@ impl Tool for DeletePathTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        true
+    }
+
     fn description(&self) -> String {
         include_str!("./delete_path_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/diagnostics_tool.rs
+++ b/crates/assistant_tools/src/diagnostics_tool.rs
@@ -50,6 +50,10 @@ impl Tool for DiagnosticsTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./diagnostics_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -128,6 +128,10 @@ impl Tool for EditFileTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        true
+    }
+
     fn description(&self) -> String {
         include_str!("edit_file_tool/description.md").to_string()
     }

--- a/crates/assistant_tools/src/fetch_tool.rs
+++ b/crates/assistant_tools/src/fetch_tool.rs
@@ -118,7 +118,11 @@ impl Tool for FetchTool {
     }
 
     fn needs_confirmation(&self, _: &serde_json::Value, _: &App) -> bool {
-        true
+        false
+    }
+
+    fn may_perform_edits(&self) -> bool {
+        false
     }
 
     fn description(&self) -> String {

--- a/crates/assistant_tools/src/find_path_tool.rs
+++ b/crates/assistant_tools/src/find_path_tool.rs
@@ -59,6 +59,10 @@ impl Tool for FindPathTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./find_path_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/grep_tool.rs
+++ b/crates/assistant_tools/src/grep_tool.rs
@@ -60,6 +60,10 @@ impl Tool for GrepTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./grep_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/list_directory_tool.rs
+++ b/crates/assistant_tools/src/list_directory_tool.rs
@@ -48,6 +48,10 @@ impl Tool for ListDirectoryTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./list_directory_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/move_path_tool.rs
+++ b/crates/assistant_tools/src/move_path_tool.rs
@@ -46,6 +46,10 @@ impl Tool for MovePathTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        true
+    }
+
     fn description(&self) -> String {
         include_str!("./move_path_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/now_tool.rs
+++ b/crates/assistant_tools/src/now_tool.rs
@@ -37,6 +37,10 @@ impl Tool for NowTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         "Returns the current datetime in RFC 3339 format. Only use this tool when the user specifically asks for it or the current task would benefit from knowing the current datetime.".into()
     }

--- a/crates/assistant_tools/src/open_tool.rs
+++ b/crates/assistant_tools/src/open_tool.rs
@@ -26,7 +26,9 @@ impl Tool for OpenTool {
     fn needs_confirmation(&self, _: &serde_json::Value, _: &App) -> bool {
         true
     }
-
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
     fn description(&self) -> String {
         include_str!("./open_tool/description.md").to_string()
     }

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -58,6 +58,10 @@ impl Tool for ReadFileTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./read_file_tool/description.md").into()
     }

--- a/crates/assistant_tools/src/terminal_tool.rs
+++ b/crates/assistant_tools/src/terminal_tool.rs
@@ -77,6 +77,10 @@ impl Tool for TerminalTool {
         true
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./terminal_tool/description.md").to_string()
     }

--- a/crates/assistant_tools/src/thinking_tool.rs
+++ b/crates/assistant_tools/src/thinking_tool.rs
@@ -28,6 +28,10 @@ impl Tool for ThinkingTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         include_str!("./thinking_tool/description.md").to_string()
     }

--- a/crates/assistant_tools/src/web_search_tool.rs
+++ b/crates/assistant_tools/src/web_search_tool.rs
@@ -36,6 +36,10 @@ impl Tool for WebSearchTool {
         false
     }
 
+    fn may_perform_edits(&self) -> bool {
+        false
+    }
+
     fn description(&self) -> String {
         "Search the web for information using your query. Use this when you need real-time information, facts, or data that might not be in your training. Results will include snippets and links from relevant web pages.".into()
     }

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -154,6 +154,7 @@ pub enum IconName {
     LineHeight,
     Link,
     ListCollapse,
+    ListTodo,
     ListTree,
     ListX,
     LoadCircle,


### PR DESCRIPTION
This PR introduces the "Reject All" and "Accept All" buttons in the panel's edit bar, which appears as soon as the agent starts editing a file. I'm also adding here a new method to the thread called `has_pending_edit_tool_uses`, which is a more specific way of knowing, in comparison to the `is_generating` method, whether or not the reject/accept all actions can be triggered. 

Previously, without this new method, you'd be waiting for the whole generation to end (e.g., the agent would be generating markdown with things like change summary) to be able to click those buttons, when the edit was already there, ready for you. It always felt like waiting for the whole thing was unnecessary when you really wanted to just wait for the _edits_ to be done, as so to avoid any potential conflicting state.

<img src="https://github.com/user-attachments/assets/0927f3a6-c9ee-46ae-8f7b-97157d39a7b5" width="500"/>

---

Release Notes:

- agent: Added ability to reject and accept all changes from the agent panel.
