### PR TITLE
agent: Lower "no thread found" logging level to debug

### DIFF
--- a/crates/agent/src/history_store.rs
+++ b/crates/agent/src/history_store.rs
@@ -152,7 +152,7 @@ impl HistoryStore {
                     let entries = join_all(entries)
                         .await
                         .into_iter()
-                        .filter_map(|result| result.log_err())
+                        .filter_map(|result| result.log_with_level(log::Level::Debug))
                         .collect::<VecDeque<_>>();
 
                     this.update(cx, |this, _| {


### PR DESCRIPTION
This code path is not really an error, as it can happen due to normal, albeit uncommon, actions. Like, for example, this scenario:

1. Create a thread X in Zed instance A
2. Open Zed instance B
3. Delete the thread X in instance A
4. Close instance B. This will write non-existing thread id X to `agent-navigation-history.json`
5. Open Zed instance C. It won't be able to load the thread X.

Another way to get into this state is by running Zed with LMDB and SQLite thread storages side-by-side.

In any case, this is not severe enough for an error.

Closes #ISSUE

Release Notes:

- N/A
