### PR TITLE
Make `alt-left` and `alt-right` skip punctuation like VSCode

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -1912,19 +1912,19 @@ fn test_prev_next_word_boundary(cx: &mut TestAppContext) {
         assert_selection_ranges("use std::ˇstr::{foo, bar}\n\n  {ˇbaz.qux()}", editor, cx);
 
         editor.move_to_previous_word_start(&MoveToPreviousWordStart, window, cx);
-        assert_selection_ranges("use stdˇ::str::{foo, bar}\n\n  ˇ{baz.qux()}", editor, cx);
+        assert_selection_ranges("use stdˇ::str::{foo, bar}\n\nˇ  {baz.qux()}", editor, cx);
 
         editor.move_to_previous_word_start(&MoveToPreviousWordStart, window, cx);
-        assert_selection_ranges("use ˇstd::str::{foo, bar}\n\nˇ  {baz.qux()}", editor, cx);
-
-        editor.move_to_previous_word_start(&MoveToPreviousWordStart, window, cx);
-        assert_selection_ranges("ˇuse std::str::{foo, bar}\nˇ\n  {baz.qux()}", editor, cx);
+        assert_selection_ranges("use ˇstd::str::{foo, bar}\nˇ\n  {baz.qux()}", editor, cx);
 
         editor.move_to_previous_word_start(&MoveToPreviousWordStart, window, cx);
         assert_selection_ranges("ˇuse std::str::{foo, barˇ}\n\n  {baz.qux()}", editor, cx);
 
+        editor.move_to_previous_word_start(&MoveToPreviousWordStart, window, cx);
+        assert_selection_ranges("ˇuse std::str::{foo, ˇbar}\n\n  {baz.qux()}", editor, cx);
+
         editor.move_to_next_word_end(&MoveToNextWordEnd, window, cx);
-        assert_selection_ranges("useˇ std::str::{foo, bar}ˇ\n\n  {baz.qux()}", editor, cx);
+        assert_selection_ranges("useˇ std::str::{foo, barˇ}\n\n  {baz.qux()}", editor, cx);
 
         editor.move_to_next_word_end(&MoveToNextWordEnd, window, cx);
         assert_selection_ranges("use stdˇ::str::{foo, bar}\nˇ\n  {baz.qux()}", editor, cx);
@@ -1942,7 +1942,7 @@ fn test_prev_next_word_boundary(cx: &mut TestAppContext) {
 
         editor.select_to_previous_word_start(&SelectToPreviousWordStart, window, cx);
         assert_selection_ranges(
-            "use std«ˇ::s»tr::{foo, bar}\n\n  «ˇ{b»az.qux()}",
+            "use std«ˇ::s»tr::{foo, bar}\n\n«ˇ  {b»az.qux()}",
             editor,
             cx,
         );

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -997,7 +997,7 @@ mod tests {
         assert("loremˇ    ipsumˇ   ", cx);
         assert("loremˇ-ipsumˇ", cx);
         assert("loremˇ#$@-ˇipsum", cx);
-        assert("ˇlorem_ipsumˇ", cx);
+        assert("loremˇ_ipsumˇ", cx);
         assert(" ˇbcΔˇ", cx);
         assert(" abˇ——ˇcd", cx);
         // Test punctuation skipping behavior
@@ -1037,10 +1037,10 @@ mod tests {
         assert("\nˇ\nˇ\n\n", cx);
         assert("loremˇ    ipsumˇ   ", cx);
         assert("loremˇ-ˇipsum", cx);
-        assert("loremˇ#$@-ipsumˇ", cx);
+        assert("loremˇ#$@-ˇipsum", cx);
         assert("loremˇ_ipsumˇ", cx);
         assert(" ˇbcˇΔ", cx);
-        assert(" abˇ——cdˇ", cx);
+        assert(" abˇ——ˇcd", cx);
     }
 
     #[gpui::test]

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -268,9 +268,10 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
     find_preceding_boundary_display_point(map, point, FindRange::MultiLine, |left, right| {
         // Make alt-left skip punctuation on Mac OS to respect the Mac behaviour. For example: hello.| goes to |hello.
         if cfg!(target_os = "macos") && !no_longer_punctuation && classifier.is_punctuation(right) {
+            no_longer_punctuation = classifier.is_punctuation(left);
             return false;
         }
-        no_longer_punctuation = true;
+
 
         (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(right))
             || left == '\n'
@@ -316,13 +317,16 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
     find_boundary(map, point, FindRange::MultiLine, |left, right| {
         // Make alt-right skip punctuation on Mac OS to respect the Mac behaviour. For example: |.hello goes to .hello|
         if cfg!(target_os = "macos") && !no_longer_punctuation && classifier.is_punctuation(left) {
+            no_longer_punctuation = classifier.is_punctuation(right);
             return false;
         }
-        no_longer_punctuation = true;
+
         (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(left))
             || right == '\n'
     })
 }
+
+
 
 /// Returns a position of the next word boundary, where a word character is defined as either
 /// uppercase letter, lowercase letter, '_' character, language-specific word character (like '-' in CSS) or newline.

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -272,7 +272,6 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
             return false;
         }
 
-
         (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(right))
             || left == '\n'
     })
@@ -325,8 +324,6 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
             || right == '\n'
     })
 }
-
-
 
 /// Returns a position of the next word boundary, where a word character is defined as either
 /// uppercase letter, lowercase letter, '_' character, language-specific word character (like '-' in CSS) or newline.
@@ -818,13 +815,12 @@ mod tests {
         assert(" ˇdefγˇ", cx);
         assert(" ˇbcΔˇ", cx);
         assert(" abˇ——ˇcd", cx);
-         // Test punctuation skipping behavior
-         assert("ˇhello.ˇ", cx);
-         assert("helloˇ...ˇ", cx);
-         assert("helloˇ.---..ˇtest", cx);
-         assert("test  ˇ.--ˇtest", cx);
-         assert("oneˇ,;:!?ˇtwo", cx);
-       
+        // Test punctuation skipping behavior
+        assert("ˇhello.ˇ", cx);
+        assert("helloˇ...ˇ", cx);
+        assert("helloˇ.---..ˇtest", cx);
+        assert("test  ˇ.--ˇtest", cx);
+        assert("oneˇ,;:!?ˇtwo", cx);
     }
 
     #[gpui::test]
@@ -995,14 +991,13 @@ mod tests {
         assert("loremˇ_ipsumˇ", cx);
         assert(" ˇbcΔˇ", cx);
         assert(" abˇ——ˇcd", cx);
-        
-         // Test punctuation skipping behavior
-         assert("ˇ.helloˇ", cx);
-         assert("ˇ...ˇhello", cx);
-         assert("helloˇ.---..ˇtest", cx);
-         assert("testˇ.--ˇ test", cx);
-         assert("oneˇ,;:!?ˇtwo", cx);
-        
+
+        // Test punctuation skipping behavior
+        assert("ˇ.helloˇ", cx);
+        assert("ˇ...ˇhello", cx);
+        assert("helloˇ.---..ˇtest", cx);
+        assert("testˇ.--ˇ test", cx);
+        assert("oneˇ,;:!?ˇtwo", cx);
     }
 
     #[gpui::test]

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -267,7 +267,7 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
     let mut no_longer_punctuation = false;
     find_preceding_boundary_display_point(map, point, FindRange::MultiLine, |left, right| {
         // Make alt-left skip punctuation on Mac OS to respect the Mac behaviour. For example: hello.| goes to |hello.
-        if cfg!(target_os = "macos") && !no_longer_punctuation && classifier.is_punctuation(right) {
+        if !no_longer_punctuation && classifier.is_punctuation(right) {
             no_longer_punctuation = classifier.is_punctuation(left);
             return false;
         }
@@ -316,7 +316,7 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
     let mut no_longer_punctuation = false;
     find_boundary(map, point, FindRange::MultiLine, |left, right| {
         // Make alt-right skip punctuation on Mac OS to respect the Mac behaviour. For example: |.hello goes to .hello|
-        if cfg!(target_os = "macos") && !no_longer_punctuation && classifier.is_punctuation(left) {
+        if !no_longer_punctuation && classifier.is_punctuation(left) {
             no_longer_punctuation = classifier.is_punctuation(right);
             return false;
         }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -268,9 +268,9 @@ pub fn previous_word_start(map: &DisplaySnapshot, point: DisplayPoint) -> Displa
     find_preceding_boundary_display_point(map, point, FindRange::MultiLine, |left, right| {
         // Make alt-left skip punctuation on Mac OS to respect the Mac behaviour. For example: hello.| goes to |hello.
         if !no_longer_punctuation && classifier.is_punctuation(right) {
+            no_longer_punctuation = true;
             return false;
         }
-        no_longer_punctuation = true;
 
         (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(right))
             || left == '\n'
@@ -316,9 +316,9 @@ pub fn next_word_end(map: &DisplaySnapshot, point: DisplayPoint) -> DisplayPoint
     find_boundary(map, point, FindRange::MultiLine, |left, right| {
         // Make alt-right skip punctuation on Mac OS to respect the Mac behaviour. For example: |.hello goes to .hello|
         if !no_longer_punctuation && classifier.is_punctuation(left) {
+            no_longer_punctuation = true;
             return false;
         }
-        no_longer_punctuation = true;
 
         (classifier.kind(left) != classifier.kind(right) && !classifier.is_whitespace(left))
             || right == '\n'
@@ -815,16 +815,16 @@ mod tests {
         assert("\n\nˇ\nˇ", cx);
         assert("    ˇlorem  ˇipsum", cx);
         assert("ˇlorem-ˇipsum", cx);
-        assert("ˇlorem-#$@ˇipsum", cx);
+        assert("loremˇ-#$@ˇipsum", cx);
         assert("ˇlorem_ˇipsum", cx);
         assert(" ˇdefγˇ", cx);
         assert(" ˇbcΔˇ", cx);
         // Test punctuation skipping behavior
         assert("ˇhello.ˇ", cx);
-        assert("ˇhello...ˇ", cx);
-        assert("ˇhello.---..ˇtest", cx);
-        assert("ˇtest  .--ˇtest", cx);
-        assert("ˇone,;:!?ˇtwo", cx);
+        assert("helloˇ...ˇ", cx);
+        assert("helloˇ.---..ˇtest", cx);
+        assert("test  ˇ.--ˇtest", cx);
+        assert("oneˇ,;:!?ˇtwo", cx);
     }
 
     #[gpui::test]
@@ -996,17 +996,17 @@ mod tests {
         assert("\nˇ\nˇ\n\n", cx);
         assert("loremˇ    ipsumˇ   ", cx);
         assert("loremˇ-ipsumˇ", cx);
-        assert("loremˇ#$@-ipsumˇ", cx);
+        assert("loremˇ#$@-ˇipsum", cx);
         assert("ˇlorem_ipsumˇ", cx);
         assert(" ˇbcΔˇ", cx);
-        assert(" abˇ——cdˇ", cx);
+        assert(" abˇ——ˇcd", cx);
         // Test punctuation skipping behavior
         assert("ˇ.helloˇ", cx);
         assert("display_pointsˇ[0ˇ]", cx);
-        assert("ˇ...helloˇ", cx);
-        assert("helloˇ.---..testˇ", cx);
-        assert("testˇ.-- testˇ", cx);
-        assert("oneˇ,;:!?twoˇ", cx);
+        assert("ˇ...ˇhello", cx);
+        assert("helloˇ.---..ˇtest", cx);
+        assert("testˇ.--ˇ test", cx);
+        assert("oneˇ,;:!?ˇtwo", cx);
     }
 
     #[gpui::test]

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -809,12 +809,12 @@ mod tests {
         assert("\nlorem\nˇ   ˇipsum", cx);
         assert("\n\nˇ\nˇ", cx);
         assert("    ˇlorem  ˇipsum", cx);
-        assert("loremˇ-ˇipsum", cx);
+        assert("ˇlorem-ˇipsum", cx);
         assert("loremˇ-#$@ˇipsum", cx);
         assert("ˇlorem_ˇipsum", cx);
         assert(" ˇdefγˇ", cx);
         assert(" ˇbcΔˇ", cx);
-        assert(" abˇ——ˇcd", cx);
+        
         // Test punctuation skipping behavior
         assert("ˇhello.ˇ", cx);
         assert("helloˇ...ˇ", cx);

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -818,6 +818,13 @@ mod tests {
         assert(" ˇdefγˇ", cx);
         assert(" ˇbcΔˇ", cx);
         assert(" abˇ——ˇcd", cx);
+         // Test punctuation skipping behavior
+         assert("ˇhello.ˇ", cx);
+         assert("helloˇ...ˇ", cx);
+         assert("helloˇ.---..ˇtest", cx);
+         assert("test  ˇ.--ˇtest", cx);
+         assert("oneˇ,;:!?ˇtwo", cx);
+       
     }
 
     #[gpui::test]
@@ -988,6 +995,14 @@ mod tests {
         assert("loremˇ_ipsumˇ", cx);
         assert(" ˇbcΔˇ", cx);
         assert(" abˇ——ˇcd", cx);
+        
+         // Test punctuation skipping behavior
+         assert("ˇ.helloˇ", cx);
+         assert("ˇ...ˇhello", cx);
+         assert("helloˇ.---..ˇtest", cx);
+         assert("testˇ.--ˇ test", cx);
+         assert("oneˇ,;:!?ˇtwo", cx);
+        
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/25526
Follow up of #29872

Release Notes:

- Make `alt-left` and `alt-right` skip punctuation on Mac OS to respect the Mac default behaviour. When pressing alt-left and the first character is a punctuation character like a dot, this character should be skipped. For example: `hello.|` goes to `|hello.`

This change makes the editor feels much snappier, it now follows the same behaviour as VSCode and any other Mac OS native application.


@ConradIrwin
