### PR TITLE
ci: Improve Danger and ci.yml explicitness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
     timeout-minutes: 60
     runs-on:
       - self-hosted
-      - test
+      - macOS
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -200,7 +200,7 @@ jobs:
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
       - self-hosted
-      - test
+      - macOS
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
-      - test
+      - macOS
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -33,7 +33,7 @@ jobs:
     name: Run tests
     runs-on:
       - self-hosted
-      - test
+      - macOS
     needs: style
     steps:
       - name: Checkout repo

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -20,7 +20,7 @@ jobs:
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
-      - test
+      - macOS
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -40,7 +40,7 @@ jobs:
     if: github.repository_owner == 'zed-industries'
     runs-on:
       - self-hosted
-      - test
+      - macOS
     needs: style
     steps:
       - name: Checkout repo

--- a/script/danger/dangerfile.ts
+++ b/script/danger/dangerfile.ts
@@ -38,7 +38,7 @@ if (!hasReleaseNotes) {
 }
 
 const ISSUE_LINK_PATTERN =
-  /(?<!(?:Close[sd]?|Fixe[sd]|Resolve[sd]|Implement[sed]|Follow-up of|Part of)\s+)https:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/gi;
+  /(?:- )?(?<!(?:Close[sd]?|Fixe[sd]|Resolve[sd]|Implement[sed]|Follow-up of|Part of):?\s+)https:\/\/github\.com\/[\w-]+\/[\w-]+\/issues\/\d+/gi;
 
 const bodyWithoutReleaseNotes = hasReleaseNotes ? body.split(/Release Notes:/)[0] : body;
 const includesIssueUrl = ISSUE_LINK_PATTERN.test(bodyWithoutReleaseNotes);


### PR DESCRIPTION
Allow colons after issue links and for them to in ul.
Change ci references from [self-hosted, test] to more explicit [self-hosted, macOS]

Release Notes:

- N/A
