### PR TITLE
Remove support for changing magnification of active pane

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -73,9 +73,6 @@
   "unnecessary_code_fade": 0.3,
   // Active pane styling settings.
   "active_pane_modifiers": {
-    // The factor to grow the active pane by. Defaults to 1.0
-    // which gives the same size as all other panes.
-    "magnification": 1.0,
     // Inset border size of the active pane, in pixels.
     "border_size": 0.0,
     // Opacity of the inactive panes. 0 means transparent, 1 means opaque.

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1197,7 +1197,7 @@ mod element {
             }
 
             for (ix, child_layout) in layout.children.iter_mut().enumerate() {
-                if active_pane_magnification.is_none() && ix < len - 1 {
+                if ix < len - 1 {
                     child_layout.handle = Some(Self::layout_handle(
                         self.axis,
                         child_layout.bounds,

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -1155,16 +1155,7 @@ mod element {
             debug_assert!(flexes.len() == len);
             debug_assert!(flex_values_in_bounds(flexes.as_slice()));
 
-            let active_pane_magnification = WorkspaceSettings::get(None, cx)
-                .active_pane_modifiers
-                .magnification
-                .and_then(|val| if val == 1.0 { None } else { Some(val) });
-
-            let total_flex = if let Some(flex) = active_pane_magnification {
-                self.children.len() as f32 - 1. + flex
-            } else {
-                len as f32
-            };
+            let total_flex = len as f32;
 
             let mut origin = bounds.origin;
             let space_per_flex = bounds.size.along(self.axis) / total_flex;
@@ -1177,15 +1168,7 @@ mod element {
                 children: Vec::new(),
             };
             for (ix, mut child) in mem::take(&mut self.children).into_iter().enumerate() {
-                let child_flex = active_pane_magnification
-                    .map(|magnification| {
-                        if self.active_pane_ix == Some(ix) {
-                            magnification
-                        } else {
-                            1.
-                        }
-                    })
-                    .unwrap_or_else(|| flexes[ix]);
+                let child_flex = flexes[ix];
 
                 let child_size = bounds
                     .size

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -51,12 +51,6 @@ impl OnLastWindowClosed {
 #[derive(Copy, Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub struct ActivePanelModifiers {
-    /// Scale by which to zoom the active pane.
-    /// When set to 1.0, the active pane has the same size as others,
-    /// but when set to a larger value, the active pane takes up more space.
-    ///
-    /// Default: `1.0`
-    pub magnification: Option<f32>,
     /// Size of the border surrounding the active pane.
     /// When set to 0, the active pane doesn't have any border.
     /// The border is drawn inset.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -38,22 +38,11 @@ Extensions that provide language servers may also provide default settings for t
 ```json
 {
   "active_pane_modifiers": {
-    "magnification": 1.0,
     "border_size": 0.0,
     "inactive_opacity": 1.0
   }
 }
 ```
-
-### Magnification
-
-- Description: Scale by which to zoom the active pane. When set to `1.0`, the active pane has the same size as others, but when set to a larger value, the active pane takes up more space.
-- Setting: `magnification`
-- Default: `1.0`
-
-**Options**
-
-`float` values
 
 ### Border size
 

--- a/docs/src/fonts.md
+++ b/docs/src/fonts.md
@@ -31,8 +31,6 @@ TBD: Explain various font settings in Zed.
   - `terminal.font-size`
   - `terminal.font-family`
   - `terminal.font-features`
-- Other settings:
-  - `active-pane-magnification`
 
 ## Old Zed Fonts
 


### PR DESCRIPTION
Closes #4265
Closes #24600

This setting causes many visual defects, and introduces unnecessary (maintenance) complexity. as seen by #4265 and #24600


CC: @iamnbutler - How do you feel about this? I recommend looking at https://github.com/zed-industries/zed/pull/24150#issuecomment-2866706506 for more context

Release Notes:

- Deprecated support for `active_pane_modifiers`.`magnification` setting as it caused many visual defects.