### PR TITLE
collab: Increase number of returned extensions to 1,000

### DIFF
--- a/crates/collab/src/api/extensions.rs
+++ b/crates/collab/src/api/extensions.rs
@@ -66,7 +66,7 @@ async fn get_extensions(
             params.filter.as_deref(),
             provides_filter.as_ref(),
             params.max_schema_version,
-            500,
+            1_000,
         )
         .await?;
 


### PR DESCRIPTION
This PR increases the number of returned extensions from the extension API to 1,000 (up from 500).

We'll need a better solution at some point, but for now we can keep bumping this number.

Closes https://github.com/zed-industries/zed/issues/31067.

Release Notes:

- N/A
