### PR TITLE
docs: Update mentions to GitHub to use correct capitalization

### DIFF
--- a/crates/collab/README.md
+++ b/crates/collab/README.md
@@ -57,7 +57,7 @@ We run two instances of collab:
 
 Both of these run on the Kubernetes cluster hosted in Digital Ocean.
 
-Deployment is triggered by pushing to the `collab-staging` (or `collab-production`) tag in Github. The best way to do this is:
+Deployment is triggered by pushing to the `collab-staging` (or `collab-production`) tag in GitHub. The best way to do this is:
 
 - `./script/deploy-collab staging`
 - `./script/deploy-collab production`

--- a/docs/src/accounts.md
+++ b/docs/src/accounts.md
@@ -27,6 +27,6 @@ To sign out of Zed, you can use either of these methods:
 
 ## Email
 
-Note that Zed associates your Github _profile email_ with your Zed account, not your _primary email_. We're unable to change the email associated with your Zed account without you changing your profile email.
+Note that Zed associates your GitHub _profile email_ with your Zed account, not your _primary email_. We're unable to change the email associated with your Zed account without you changing your profile email.
 
 We _are_ able to update the billing email on your account, if you're a Zed Pro user. See [Updating Billing Information](./ai/billing.md#updating-billing-info) for more

--- a/docs/src/development/local-collaboration.md
+++ b/docs/src/development/local-collaboration.md
@@ -26,7 +26,7 @@ The script will seed the database with various content defined by:
 cat crates/collab/seed.default.json
 ```
 
-To use a different set of admin users, you can create your own version of that json file and export the `SEED_PATH` environment variable. Note that the usernames listed in the admins list currently must correspond to valid Github users.
+To use a different set of admin users, you can create your own version of that json file and export the `SEED_PATH` environment variable. Note that the usernames listed in the admins list currently must correspond to valid GitHub users.
 
 ```json
 {

--- a/docs/src/remote-development.md
+++ b/docs/src/remote-development.md
@@ -170,7 +170,7 @@ Once the master connection is established, Zed will check to see if the remote s
 
 If it is not there or the version mismatches, Zed will try to download the latest version. By default, it will download from `https://zed.dev` directly, but if you set: `{"upload_binary_over_ssh":true}` in your settings for that server, it will download the binary to your local machine and then upload it to the remote server.
 
-If you'd like to maintain the server binary yourself you can. You can either download our prebuilt versions from [Github](https://github.com/zed-industries/zed/releases), or [build your own](https://zed.dev/docs/development) with `cargo build -p remote_server --release`. If you do this, you must upload it to `~/.zed_server/zed-remote-server-{RELEASE_CHANNEL}-{VERSION}` on the server, for example `~/.zed_server/zed-remote-server-stable-0.181.6`. The version must exactly match the version of Zed itself you are using.
+If you'd like to maintain the server binary yourself you can. You can either download our prebuilt versions from [GitHub](https://github.com/zed-industries/zed/releases), or [build your own](https://zed.dev/docs/development) with `cargo build -p remote_server --release`. If you do this, you must upload it to `~/.zed_server/zed-remote-server-{RELEASE_CHANNEL}-{VERSION}` on the server, for example `~/.zed_server/zed-remote-server-stable-0.181.6`. The version must exactly match the version of Zed itself you are using.
 
 ## Maintaining the SSH connection
 


### PR DESCRIPTION
That type of thing... 😅 "Github" is the incorrect formatting; "GitHub" is the correct.

Release Notes:

- N/A
