### PR TITLE
agent: Support `AGENT.md` and `AGENTS.md` as rules file names

### DIFF
--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -70,13 +70,15 @@ impl Column for DataType {
     }
 }
 
-const RULES_FILE_NAMES: [&'static str; 6] = [
+const RULES_FILE_NAMES: [&'static str; 8] = [
     ".rules",
     ".cursorrules",
     ".windsurfrules",
     ".clinerules",
     ".github/copilot-instructions.md",
     "CLAUDE.md",
+    "AGENT.md",
+    "AGENTS.md",
 ];
 
 pub fn init(cx: &mut App) {

--- a/docs/src/ai/rules.md
+++ b/docs/src/ai/rules.md
@@ -5,8 +5,17 @@ Currently, Zed supports `.rules` files at the directory's root and the Rules Lib
 
 ## `.rules` files
 
-Zed supports including `.rules` files at the top level of worktrees, and act as project-level instructions you'd like to have included in all of your interactions with the Agent Panel.
-Other names for this file are also supported—the first file which matches in this list will be used: `.rules`, `.cursorrules`, `.windsurfrules`, `.clinerules`, `.github/copilot-instructions.md`, or `CLAUDE.md`.
+Zed supports including `.rules` files at the top level of worktrees, and act as project-level instructions that are included in all of your interactions with the Agent Panel.
+Other names for this file are also supported for compatibility with other agents, but note that the first file which matches in this list will be used:
+
+- `.rules`
+- `.cursorrules`
+- `.windsurfrules`
+- `.clinerules`
+- `.github/copilot-instructions.md`
+- `AGENT.md`
+- `AGENTS.md`
+- `CLAUDE.md`
 
 ## Rules Library {#rules-library}
 


### PR DESCRIPTION
These started to be used more recently, so we should also support them.

Release Notes:

- agent: Added support for `AGENT.md` and `AGENTS.md` as rules file names.
