### PR TITLE
debugger: Use  UUID for Go debug binary names, do not rely on OUT_DIR

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12113,6 +12113,7 @@ dependencies = [
  "unindent",
  "url",
  "util",
+ "uuid",
  "which 6.0.3",
  "workspace-hack",
  "worktree",

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -82,6 +82,7 @@ text.workspace = true
 toml.workspace = true
 url.workspace = true
 util.workspace = true
+uuid.workspace = true
 which.workspace = true
 worktree.workspace = true
 zlog.workspace = true

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -132,7 +132,7 @@ impl DapLocator for GoLocator {
                 let program = PathBuf::from(&cwd)
                     .join(format!("__debug_{}", std::process::id()))
                     .to_string_lossy()
-                    .to_string();
+                    .into_owned();
 
                 Ok(DebugRequest::Launch(task::LaunchRequest {
                     program,


### PR DESCRIPTION
It seems that there was a regression. `build_config` no longer has an `OUT_DIR` in it.
On way to mitigate it is to stop relying on it and just use `cwd` as dir for the test binary to be placed in.

Release Notes:
- N/A