### PR TITLE
ruby: Add `sorbet` and `steep` to the list of available language servers

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1528,7 +1528,7 @@
       "allow_rewrap": "anywhere"
     },
     "Ruby": {
-      "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "..."]
+      "language_servers": ["solargraph", "!ruby-lsp", "!rubocop", "!sorbet", "!steep", "..."]
     },
     "SCSS": {
       "prettier": {


### PR DESCRIPTION
Hi, this pull request adds `sorbet` and `steep` to the list of available language servers for the Ruby language in order to prepare default Ruby language settings for these LS. Both language servers are disabled by default. We plan to add both in #104  and #102. Thanks!

Release Notes:

- ruby: Added `sorbet` and `steep` to the list of available language servers.
