### PR TITLE
gpui: Add API for read and write active drag cursor style

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1559,10 +1559,30 @@ impl App {
         self.active_drag.is_some()
     }
 
+    /// Gets the cursor style of the currently active drag operation.
+    pub fn active_drag_cursor_style(&self) -> Option<CursorStyle> {
+        self.active_drag.as_ref().and_then(|drag| drag.cursor_style)
+    }
+
     /// Stops active drag and clears any related effects.
     pub fn stop_active_drag(&mut self, window: &mut Window) -> bool {
         if self.active_drag.is_some() {
             self.active_drag = None;
+            window.refresh();
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Sets the cursor style for the currently active drag operation.
+    pub fn set_active_drag_cursor_style(
+        &mut self,
+        cursor_style: CursorStyle,
+        window: &mut Window,
+    ) -> bool {
+        if let Some(ref mut drag) = self.active_drag {
+            drag.cursor_style = Some(cursor_style);
             window.refresh();
             true
         } else {


### PR DESCRIPTION
Prep for https://github.com/zed-industries/zed/pull/32040

Currently, there’s no way to modify the cursor style of the active drag state after dragging begins. However, there are scenarios where we might want to change the cursor style, such as pressing a modifier key while dragging. This PR introduces an API to update and read the current active drag state cursor.

Release Notes:

- N/A
