### PR TITLE
Fix `script/build-linux` with newer GCC

### DIFF
--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -87,7 +87,11 @@ fi
 
 # Ensure that remote_server does not depend on libssl nor libcrypto, as we got rid of these deps.
 if ldd "${target_dir}/${remote_server_triple}/release/remote_server" | grep -q 'libcrypto\|libssl'; then
-    echo "Error: remote_server still depends on libssl or libcrypto" && exit 1
+    if [[ "$remote_server_triple" == *-musl ]]; then
+        echo "Error: remote_server still depends on libssl or libcrypto" && exit 1
+    else
+        echo "Info: Using non-musl remote-server build."
+    fi
 fi
 
 suffix=""


### PR DESCRIPTION
If you follow the [workaround advice in the Docs](https://zed.dev/docs/development/linux#installing-a-development-build) for building with a newer GCC, it will error:

https://github.com/zed-industries/zed/blob/79b1dd7db8baede7e5dbaa2ad077bca61d9bad49/script/bundle-linux#L88-L91

[Reported on Discord](https://discord.com/channels/869392257814519848/1379093394105696288)

Release Notes:

- Fixed `script/build-linux` for non-musl builds.