### PR TITLE
Better log canonicalization errors

### DIFF
--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -597,7 +597,9 @@ impl Fs for RealFs {
     }
 
     async fn canonicalize(&self, path: &Path) -> Result<PathBuf> {
-        Ok(smol::fs::canonicalize(path).await?)
+        Ok(smol::fs::canonicalize(path)
+            .await
+            .with_context(|| format!("canonicalizing {path:?}"))?)
     }
 
     async fn is_file(&self, path: &Path) -> bool {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3948,7 +3948,7 @@ impl BackgroundScanner {
         let root_canonical_path = match self.fs.canonicalize(root_path.as_path()).await {
             Ok(path) => SanitizedPath::from(path),
             Err(err) => {
-                log::error!("failed to canonicalize root path: {}", err);
+                log::error!("failed to canonicalize root path {root_path:?}: {err}");
                 return true;
             }
         };


### PR DESCRIPTION
Based on https://github.com/zed-industries/zed/issues/18673#issuecomment-2933025951

Adds an anyhow error context with the path used for canonicalization (also, explicitly mention path at the place from the comment).

Release Notes:

- N/A
