### PR TITLE
Use better fallback for empty rerun action

### DIFF
--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -80,7 +80,14 @@ pub fn init(cx: &mut App) {
                             );
                         }
                     } else {
-                        toggle_modal(workspace, None, window, cx).detach();
+                        spawn_task_or_modal(
+                            workspace,
+                            &Spawn::ViaModal {
+                                reveal_target: None,
+                            },
+                            window,
+                            cx,
+                        );
                     };
                 });
         },


### PR DESCRIPTION
When invoking the task rerun action before any task had been run, it falls back to task selection modal.
Adjust this fall back to use the debugger view, if available:

Before:
![before](https://github.com/user-attachments/assets/737d2dc1-15a4-4eea-a5f9-4aff6c7600cc)


After:
![after](https://github.com/user-attachments/assets/43381b85-5167-44e7-a8b0-865a64eaa6ea)


Release Notes:

- N/A 
