### PR TITLE
Have tools respect private and excluded file settings 

### DIFF
--- a/crates/assistant_tools/src/grep_tool.rs
+++ b/crates/assistant_tools/src/grep_tool.rs
@@ -129,12 +129,12 @@ impl Tool for GrepTool {
 
         // Exclude file_scan_exclusions and private_files
         let exclude_matcher = {
-            let settings = WorktreeSettings::get_global(cx);
-            let exclude_patterns = settings
+            let global_settings = WorktreeSettings::get_global(cx);
+            let exclude_patterns = global_settings
                 .file_scan_exclusions
                 .sources()
                 .iter()
-                .chain(settings.private_files.sources().iter());
+                .chain(global_settings.private_files.sources().iter());
 
             match PathMatcher::new(exclude_patterns) {
                 Ok(matcher) => matcher,

--- a/crates/assistant_tools/src/grep_tool.rs
+++ b/crates/assistant_tools/src/grep_tool.rs
@@ -326,7 +326,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor().clone());
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             serde_json::json!({
                 "src": {
                     "main.rs": "fn main() {\n    println!(\"Hello, world!\");\n}",
@@ -414,7 +414,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor().clone());
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             serde_json::json!({
                 "case_test.txt": "This file has UPPERCASE and lowercase text.\nUPPERCASE patterns should match only with case_sensitive: true",
             }),
@@ -495,7 +495,7 @@ mod tests {
 
         // Create test file with syntax structures
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             serde_json::json!({
                 "test_syntax.rs": r#"
                     fn top_level_function() {
@@ -824,7 +824,7 @@ mod tests {
         let fs = FakeFs::new(cx.executor());
 
         fs.insert_tree(
-            "/",
+            path!("/"),
             json!({
                 "project_root": {
                     "allowed_file.rs": "fn main() { println!(\"This file is in the project\"); }",
@@ -1108,9 +1108,9 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
 
-        // Create first worktree with its own private_files setting
+        // Create first worktree with its own private files
         fs.insert_tree(
-            "/worktree1",
+            path!("/worktree1"),
             json!({
                 ".zed": {
                     "settings.json": r#"{
@@ -1131,9 +1131,9 @@ mod tests {
         )
         .await;
 
-        // Create second worktree with different private_files setting
+        // Create second worktree with different private files
         fs.insert_tree(
-            "/worktree2",
+            path!("/worktree2"),
             json!({
                 ".zed": {
                     "settings.json": r#"{

--- a/crates/assistant_tools/src/list_directory_tool.rs
+++ b/crates/assistant_tools/src/list_directory_tool.rs
@@ -253,7 +253,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/project",
+            path!("/project"),
             json!({
                 "src": {
                     "main.rs": "fn main() {}",
@@ -383,7 +383,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/project",
+            path!("/project"),
             json!({
                 "empty_dir": {}
             }),
@@ -415,7 +415,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/project",
+            path!("/project"),
             json!({
                 "file.txt": "content"
             }),
@@ -475,7 +475,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/project",
+            path!("/project"),
             json!({
                 "normal_dir": {
                     "file1.txt": "content",
@@ -546,14 +546,8 @@ mod tests {
         let content = result.content.as_str().unwrap();
 
         // Should include normal directories
-        assert!(
-            content.contains("project/normal_dir"),
-            "Should list normal_dir"
-        );
-        assert!(
-            content.contains("project/visible_dir"),
-            "Should list visible_dir"
-        );
+        assert!(content.contains("normal_dir"), "Should list normal_dir");
+        assert!(content.contains("visible_dir"), "Should list visible_dir");
 
         // Should NOT include excluded or private files
         assert!(
@@ -652,7 +646,7 @@ mod tests {
 
         // Create first worktree with its own private files
         fs.insert_tree(
-            "/worktree1",
+            path!("/worktree1"),
             json!({
                 ".zed": {
                     "settings.json": r#"{
@@ -675,7 +669,7 @@ mod tests {
 
         // Create second worktree with different private files
         fs.insert_tree(
-            "/worktree2",
+            path!("/worktree2"),
             json!({
                 ".zed": {
                     "settings.json": r#"{

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -648,7 +648,6 @@ mod test {
         )
         .await;
 
-        // Configure settings explicitly for all tests
         cx.update(|cx| {
             use gpui::UpdateGlobal;
             use project::WorktreeSettings;
@@ -767,7 +766,7 @@ mod test {
             "read_file_tool should error when attempting to read .mymetadata files (file_scan_exclusions)"
         );
 
-        // Test 4: Reading private files should fail
+        // Reading private files should fail
         let result = cx
             .update(|cx| {
                 let input = json!({

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -12,7 +12,6 @@ use language::{Anchor, Point};
 use language_model::{
     LanguageModel, LanguageModelImage, LanguageModelRequest, LanguageModelToolSchemaFormat,
 };
-use project::{AgentLocation, Project};
 use project::{AgentLocation, Project, Worktree};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -298,7 +298,7 @@ mod test {
         init_test(cx);
 
         let fs = FakeFs::new(cx.executor());
-        fs.insert_tree("/root", json!({})).await;
+        fs.insert_tree(path!("/root"), json!({})).await;
         let project = Project::test(fs.clone(), [path!("/root").as_ref()], cx).await;
         let action_log = cx.new(|_| ActionLog::new(project.clone()));
         let model = Arc::new(FakeLanguageModel::default());
@@ -332,7 +332,7 @@ mod test {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             json!({
                 "small_file.txt": "This is a small file content"
             }),
@@ -371,7 +371,7 @@ mod test {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             json!({
                 "large_file.rs": (0..1000).map(|i| format!("struct Test{} {{\n    a: u32,\n    b: usize,\n}}", i)).collect::<Vec<_>>().join("\n")
             }),
@@ -462,7 +462,7 @@ mod test {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             json!({
                 "multiline.txt": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
             }),
@@ -503,7 +503,7 @@ mod test {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/root",
+            path!("/root"),
             json!({
                 "multiline.txt": "Line 1\nLine 2\nLine 3\nLine 4\nLine 5"
             }),
@@ -642,7 +642,7 @@ mod test {
         let fs = FakeFs::new(cx.executor());
 
         fs.insert_tree(
-            "/",
+            path!("/"),
             json!({
                 "project_root": {
                     "allowed_file.txt": "This file is in the project",
@@ -908,9 +908,9 @@ mod test {
 
         let fs = FakeFs::new(cx.executor());
 
-        // Create first worktree with its own private files
+        // Create first worktree with its own private_files setting
         fs.insert_tree(
-            "/worktree1",
+            path!("/worktree1"),
             json!({
                 "src": {
                     "main.rs": "fn main() { println!(\"Hello from worktree1\"); }",
@@ -931,9 +931,9 @@ mod test {
         )
         .await;
 
-        // Create second worktree with different private files
+        // Create second worktree with different private_files setting
         fs.insert_tree(
-            "/worktree2",
+            path!("/worktree2"),
             json!({
                 "lib": {
                     "public.js": "export function greet() { return 'Hello from worktree2'; }",


### PR DESCRIPTION
Based on a Slack conversation with @notpeter - this prevents secrets in private/excluded files from being sent by the agent to third parties for tools that don't require confirmation.

Of course, the agent can still use the terminal tool or MCP to access these, but those require confirmation before they run (unlike these tools).

This change doesn't seem to cause any trouble for evals:

<img width="730" alt="Screenshot 2025-06-03 at 8 48 33 PM" src="https://github.com/user-attachments/assets/d90221be-f946-4af2-b57b-4aa047e86853" />


Release Notes:

- N/A
