### PR TITLE
Add `#[track_caller]` to test utilities that involve marked text

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -21227,6 +21227,7 @@ fn empty_range(row: usize, column: usize) -> Range<DisplayPoint> {
     point..point
 }
 
+#[track_caller]
 fn assert_selection_ranges(marked_text: &str, editor: &mut Editor, cx: &mut Context<Editor>) {
     let (text, ranges) = marked_text_ranges(marked_text, true);
     assert_eq!(editor.text(cx), text);

--- a/crates/editor/src/test.rs
+++ b/crates/editor/src/test.rs
@@ -45,6 +45,7 @@ pub fn test_font() -> Font {
 }
 
 // Returns a snapshot from text containing '|' character markers with the markers removed, and DisplayPoints for each one.
+#[track_caller]
 pub fn marked_display_snapshot(
     text: &str,
     cx: &mut gpui::App,
@@ -83,6 +84,7 @@ pub fn marked_display_snapshot(
     (snapshot, markers)
 }
 
+#[track_caller]
 pub fn select_ranges(
     editor: &mut Editor,
     marked_text: &str,

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -109,6 +109,7 @@ impl EditorTestContext {
         }
     }
 
+    #[track_caller]
     pub fn new_multibuffer<const COUNT: usize>(
         cx: &mut gpui::TestAppContext,
         excerpts: [&str; COUNT],
@@ -351,6 +352,7 @@ impl EditorTestContext {
     /// editor state was needed to cause the failure.
     ///
     /// See the `util::test::marked_text_ranges` function for more information.
+    #[track_caller]
     pub fn set_state(&mut self, marked_text: &str) -> ContextHandle {
         let state_context = self.add_assertion_context(format!(
             "Initial Editor State: \"{}\"",
@@ -367,6 +369,7 @@ impl EditorTestContext {
     }
 
     /// Only change the editor's selections
+    #[track_caller]
     pub fn set_selections_state(&mut self, marked_text: &str) -> ContextHandle {
         let state_context = self.add_assertion_context(format!(
             "Initial Editor State: \"{}\"",

--- a/crates/language/src/buffer_tests.rs
+++ b/crates/language/src/buffer_tests.rs
@@ -3701,6 +3701,7 @@ fn get_tree_sexp(buffer: &Entity<Buffer>, cx: &mut gpui::TestAppContext) -> Stri
 }
 
 // Assert that the enclosing bracket ranges around the selection match the pairs indicated by the marked text in `range_markers`
+#[track_caller]
 fn assert_bracket_pairs(
     selection_text: &'static str,
     bracket_pair_texts: Vec<&'static str>,

--- a/crates/language/src/syntax_map/syntax_map_tests.rs
+++ b/crates/language/src/syntax_map/syntax_map_tests.rs
@@ -1317,6 +1317,7 @@ fn assert_layers_for_range(
     }
 }
 
+#[track_caller]
 fn assert_capture_ranges(
     syntax_map: &SyntaxMap,
     buffer: &BufferSnapshot,

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1662,11 +1662,13 @@ impl Buffer {
 
 #[cfg(any(test, feature = "test-support"))]
 impl Buffer {
+    #[track_caller]
     pub fn edit_via_marked_text(&mut self, marked_string: &str) {
         let edits = self.edits_for_marked_text(marked_string);
         self.edit(edits);
     }
 
+    #[track_caller]
     pub fn edits_for_marked_text(&self, marked_string: &str) -> Vec<(Range<usize>, String)> {
         let old_text = self.text();
         let (new_text, mut ranges) = util::test::marked_text_ranges(marked_string, false);

--- a/crates/util/src/test/marked_text.rs
+++ b/crates/util/src/test/marked_text.rs
@@ -109,6 +109,7 @@ pub fn marked_text_ranges_by(
 /// Any • characters in the input string will be replaced with spaces. This makes
 /// it easier to test cases with trailing spaces, which tend to get trimmed from the
 /// source code.
+#[track_caller]
 pub fn marked_text_ranges(
     marked_text: &str,
     ranges_are_directed: bool,
@@ -176,6 +177,7 @@ pub fn marked_text_ranges(
     (unmarked_text, ranges)
 }
 
+#[track_caller]
 pub fn marked_text_offsets(marked_text: &str) -> (String, Vec<usize>) {
     let (text, ranges) = marked_text_ranges(marked_text, false);
     (


### PR DESCRIPTION
Release Notes:

- N/A