### PR TITLE
project_panel: When initiating a drag the highlight selection should jump to the item you've picked up

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3755,18 +3755,18 @@ impl ProjectPanel {
         &self,
         target_entry: &Entry,
         target_worktree: &Worktree,
-        dragged_selection: &DraggedSelection,
+        drag_state: &DraggedSelection,
         cx: &Context<Self>,
     ) -> Option<ProjectEntryId> {
         let target_parent_path = target_entry.path.parent();
 
         // In case of single item drag, we do not highlight existing
         // directory which item belongs too
-        if dragged_selection.items().count() == 1 {
+        if drag_state.items().count() == 1 {
             let active_entry_path = self
                 .project
                 .read(cx)
-                .path_for_entry(dragged_selection.active_selection.entry_id, cx)?;
+                .path_for_entry(drag_state.active_selection.entry_id, cx)?;
 
             if let Some(active_parent_path) = active_entry_path.path.parent() {
                 // Do not highlight active entry parent
@@ -3986,11 +3986,11 @@ impl ProjectPanel {
                         return;
                     }
 
+                    let drag_state = event.drag(cx);
                     let Some((entry_id, highlight_entry_id)) = maybe!({
                         let target_worktree = this.project.read(cx).worktree_for_id(selection.worktree_id, cx)?.read(cx);
                         let target_entry = target_worktree.entry_for_path(&path_for_dragged_selection)?;
-                        let dragged_selection = event.drag(cx);
-                        let highlight_entry_id = this.highlight_entry_for_selection_drag(target_entry, target_worktree, dragged_selection, cx);
+                        let highlight_entry_id = this.highlight_entry_for_selection_drag(target_entry, target_worktree, drag_state, cx);
                         Some((target_entry.id, highlight_entry_id))
                     }) else {
                         return;
@@ -4000,7 +4000,10 @@ impl ProjectPanel {
                         entry_id,
                         highlight_entry_id,
                     });
-                    this.marked_entries.clear();
+                    if drag_state.items().count() == 1 {
+                        this.marked_entries.clear();
+                        this.marked_entries.insert(drag_state.active_selection);
+                    }
                     this.hover_expand_task.take();
 
                     if !kind.is_dir()


### PR DESCRIPTION
Closes #14496.

In https://github.com/zed-industries/zed/pull/31976, we modified the highlighting behavior for entries when certain entries or paths are being dragged over them. Instead of relying on marked entries for highlighting, we introduced the `highlight_entry_id` parameter, which determines which entry and its children should be highlighted when an item is being dragged over it.

The rationale behind that is that we can now utilize marked entries for various other functions, such as:

1. When dragging multiple items, we use marked entried to show which items are being dragged. (This is already covered because to drag multiple items, you need to use marked entries.)
2. When dragging a single item, set that item to marked entries. (This PR)

https://github.com/user-attachments/assets/8a03bdd4-b5db-467d-b70f-53d9766fec52

Release Notes:

- Added highlighting to entries being dragged in the Project Panel, indicating which items are being moved. 
