### PR TITLE
Make `editor::Rewrap` respect paragraphs

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10919,7 +10919,6 @@ impl Editor {
         let mut rewrapped_row_ranges = Vec::<RangeInclusive<u32>>::new();
 
         for (language_settings, language_scope, range) in ranges {
-            dbg!(&range);
             let mut start_row = range.start.row;
             let mut end_row = range.end.row;
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5223,11 +5223,11 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             }
         "},
         indoc! {"
-            // long long long long long long long long long long long long long long long
+            //ˇ long long long long long long long long long long long long long long long
             // long long long long long long long long long long long long long
-            //
-            // long long long long long long long long long long long long long long long
-            // long long long long long long long long long long long long long short short
+            //ˇ
+            //ˇ long long long long long long long long long long long long long long long
+            //ˇ long long long long long long long long long long long long long short short
             // short
             int main(void) {
                 return 17;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5212,6 +5212,31 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
+    assert_rewrap(
+        indoc! {"
+            //ˇ long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+            //ˇ
+            //ˇ long long long long long long long long long long long long long long long long long long long long long long long long long long long long
+            //ˇ short short short
+            int main(void) {
+                return 17;
+            }
+        "},
+        indoc! {"
+            // long long long long long long long long long long long long long long long
+            // long long long long long long long long long long long long long
+            //
+            // long long long long long long long long long long long long long long long
+            // long long long long long long long long long long long long long short short
+            // short
+            int main(void) {
+                return 17;
+            }
+        "},
+        language_with_c_comments,
+        &mut cx,
+    );
+
     #[track_caller]
     fn assert_rewrap(
         unwrapped_text: &str,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5111,7 +5111,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             nisl venenatis tempus. Donec molestie blandit quam, et porta nunc laoreet in.
             Integer sit amet scelerisque nisi.
         "},
-        plaintext_language,
+        plaintext_language.clone(),
         &mut cx,
     );
 
@@ -5171,6 +5171,44 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             }
         "},
         language_with_doc_comments.clone(),
+        &mut cx,
+    );
+
+    assert_rewrap(
+        indoc! {"
+            «ˇone one one one one one one one one one one one one one one one one one one one one one one one one
+
+            two»
+
+            three
+
+            «ˇ\t
+
+            four four four four four four four four four four four four four four four four four four four four»
+
+            «ˇfive five five five five five five five five five five five five five five five five five five five
+            \t»
+            six six six six six six six six six six six six six six six six six six six six six six six six six
+        "},
+        indoc! {"
+            «ˇone one one one one one one one one one one one one one one one one one one one
+            one one one one one
+
+            two»
+
+            three
+
+            «ˇ\t
+
+            four four four four four four four four four four four four four four four four
+            four four four four»
+
+            «ˇfive five five five five five five five five five five five five five five five
+            five five five five
+            \t»
+            six six six six six six six six six six six six six six six six six six six six six six six six six
+        "},
+        plaintext_language.clone(),
         &mut cx,
     );
 


### PR DESCRIPTION
Closes #32021 

Release Notes:

- Changed the behavior of `editor::Rewrap` to not join paragraphs together.
