### PR TITLE
bedrock: Fix ci failure due model enum and model name mismatch

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -71,20 +71,22 @@ pub enum Model {
     // DeepSeek
     DeepSeekR1,
     // Meta models
-    MetaLlama3_8BInstruct,
-    MetaLlama3_70BInstruct,
-    MetaLlama31_8BInstruct,
-    MetaLlama31_70BInstruct,
-    MetaLlama31_405BInstruct,
-    MetaLlama32_1BInstruct,
-    MetaLlama32_3BInstruct,
-    MetaLlama32_11BMultiModal,
-    MetaLlama32_90BMultiModal,
-    MetaLlama33_70BInstruct,
+    MetaLlama38BInstructV1,
+    MetaLlama370BInstructV1,
+    MetaLlama318BInstructV1_128k,
+    MetaLlama318BInstructV1,
+    MetaLlama3170BInstructV1_128k,
+    MetaLlama3170BInstructV1,
+    MetaLlama31405BInstructV1,
+    MetaLlama321BInstructV1,
+    MetaLlama323BInstructV1,
+    MetaLlama3211BInstructV1,
+    MetaLlama3290BInstructV1,
+    MetaLlama3370BInstructV1,
     #[allow(non_camel_case_types)]
-    MetaLlama4Scout_17BInstruct,
+    MetaLlama4Scout17BInstructV1,
     #[allow(non_camel_case_types)]
-    MetaLlama4Maverick_17BInstruct,
+    MetaLlama4Maverick17BInstructV1,
     // Mistral models
     MistralMistral7BInstructV0,
     MistralMixtral8x7BInstructV0,
@@ -167,10 +169,14 @@ impl Model {
             Model::MetaLlama318BInstructV1 => "meta-llama3-1-8b-instruct-v1",
             Model::MetaLlama3170BInstructV1_128k => "meta-llama3-1-70b-instruct-v1-128k",
             Model::MetaLlama3170BInstructV1 => "meta-llama3-1-70b-instruct-v1",
-            Model::MetaLlama3211BInstructV1 => "meta-llama3-2-11b-instruct-v1",
-            Model::MetaLlama3290BInstructV1 => "meta-llama3-2-90b-instruct-v1",
+            Model::MetaLlama31405BInstructV1 => "meta-llama3-1-405b-instruct-v1",
             Model::MetaLlama321BInstructV1 => "meta-llama3-2-1b-instruct-v1",
             Model::MetaLlama323BInstructV1 => "meta-llama3-2-3b-instruct-v1",
+            Model::MetaLlama3211BInstructV1 => "meta-llama3-2-11b-instruct-v1",
+            Model::MetaLlama3290BInstructV1 => "meta-llama3-2-90b-instruct-v1",
+            Model::MetaLlama3370BInstructV1 => "meta-llama3-3-70b-instruct-v1",
+            Model::MetaLlama4Scout17BInstructV1 => "meta-llama4-scout-17b-instruct-v1",
+            Model::MetaLlama4Maverick17BInstructV1 => "meta-llama4-maverick-17b-instruct-v1",
             Model::MistralMistral7BInstructV0 => "mistral-7b-instruct-v0",
             Model::MistralMixtral8x7BInstructV0 => "mistral-mixtral-8x7b-instruct-v0",
             Model::MistralMistralLarge2402V1 => "mistral-large-2402-v1",
@@ -218,18 +224,20 @@ impl Model {
             Model::CohereCommandRV1 => "cohere.command-r-v1:0",
             Model::CohereCommandRPlusV1 => "cohere.command-r-plus-v1:0",
             Model::CohereCommandLightTextV14_4k => "cohere.command-light-text-v14:7:4k",
-            Model::MetaLlama3_8BInstruct => "meta.llama3-8b-instruct-v1:0",
-            Model::MetaLlama3_70BInstruct => "meta.llama3-70b-instruct-v1:0",
-            Model::MetaLlama31_8BInstruct => "meta.llama3-1-8b-instruct-v1:0",
-            Model::MetaLlama31_70BInstruct => "meta.llama3-1-70b-instruct-v1:0",
-            Model::MetaLlama31_405BInstruct => "meta.llama3-1-405b-instruct-v1:0",
-            Model::MetaLlama32_11BMultiModal => "meta.llama3-2-11b-instruct-v1:0",
-            Model::MetaLlama32_90BMultiModal => "meta.llama3-2-90b-instruct-v1:0",
-            Model::MetaLlama32_1BInstruct => "meta.llama3-2-1b-instruct-v1:0",
-            Model::MetaLlama32_3BInstruct => "meta.llama3-2-3b-instruct-v1:0",
-            Model::MetaLlama33_70BInstruct => "meta.llama3-3-70b-instruct-v1:0",
-            Model::MetaLlama4Scout_17BInstruct => "meta.llama4-scout-17b-instruct-v1:0",
-            Model::MetaLlama4Maverick_17BInstruct => "meta.llama4-maverick-17b-instruct-v1:0",
+            Model::MetaLlama38BInstructV1 => "meta.llama3-8b-instruct-v1:0",
+            Model::MetaLlama370BInstructV1 => "meta.llama3-70b-instruct-v1:0",
+            Model::MetaLlama318BInstructV1_128k => "meta.llama3-1-8b-instruct-v1:0",
+            Model::MetaLlama318BInstructV1 => "meta.llama3-1-8b-instruct-v1:0",
+            Model::MetaLlama3170BInstructV1_128k => "meta.llama3-1-70b-instruct-v1:0",
+            Model::MetaLlama3170BInstructV1 => "meta.llama3-1-70b-instruct-v1:0",
+            Model::MetaLlama31405BInstructV1 => "meta.llama3-1-405b-instruct-v1:0",
+            Model::MetaLlama3211BInstructV1 => "meta.llama3-2-11b-instruct-v1:0",
+            Model::MetaLlama3290BInstructV1 => "meta.llama3-2-90b-instruct-v1:0",
+            Model::MetaLlama321BInstructV1 => "meta.llama3-2-1b-instruct-v1:0",
+            Model::MetaLlama323BInstructV1 => "meta.llama3-2-3b-instruct-v1:0",
+            Model::MetaLlama3370BInstructV1 => "meta.llama3-3-70b-instruct-v1:0",
+            Model::MetaLlama4Scout17BInstructV1 => "meta.llama4-scout-17b-instruct-v1:0",
+            Model::MetaLlama4Maverick17BInstructV1 => "meta.llama4-maverick-17b-instruct-v1:0",
             Model::MistralMistral7BInstructV0 => "mistral.mistral-7b-instruct-v0:2",
             Model::MistralMixtral8x7BInstructV0 => "mistral.mixtral-8x7b-instruct-v0:1",
             Model::MistralMistralLarge2402V1 => "mistral.mistral-large-2402-v1:0",
@@ -274,18 +282,20 @@ impl Model {
             Self::CohereCommandRV1 => "Cohere Command R V1",
             Self::CohereCommandRPlusV1 => "Cohere Command R Plus V1",
             Self::CohereCommandLightTextV14_4k => "Cohere Command Light Text V14 4K",
-            Self::MetaLlama3_8BInstruct => "Meta Llama 3 8B Instruct",
-            Self::MetaLlama3_70BInstruct => "Meta Llama 3 70B Instruct",
-            Self::MetaLlama31_8BInstruct => "Meta Llama 3.1 8B Instruct",
-            Self::MetaLlama31_70BInstruct => "Meta Llama 3.1 70B Instruct",
-            Self::MetaLlama31_405BInstruct => "Meta Llama 3.1 405B Instruct",
-            Self::MetaLlama32_11BMultiModal => "Meta Llama 3.2 11B Vision Instruct",
-            Self::MetaLlama32_90BMultiModal => "Meta Llama 3.2 90B Vision Instruct",
-            Self::MetaLlama32_1BInstruct => "Meta Llama 3.2 1B Instruct",
-            Self::MetaLlama32_3BInstruct => "Meta Llama 3.2 3B Instruct",
-            Self::MetaLlama33_70BInstruct => "Meta Llama 3.3 70B Instruct",
-            Self::MetaLlama4Scout_17BInstruct => "Meta Llama 4 Scout 17B Instruct",
-            Self::MetaLlama4Maverick_17BInstruct => "Meta Llama 4 Maverick 17B Instruct",
+            Self::MetaLlama38BInstructV1 => "Meta Llama 3 8B Instruct",
+            Self::MetaLlama370BInstructV1 => "Meta Llama 3 70B Instruct",
+            Self::MetaLlama318BInstructV1_128k => "Meta Llama 3.1 8B Instruct 128K",
+            Self::MetaLlama318BInstructV1 => "Meta Llama 3.1 8B Instruct",
+            Self::MetaLlama3170BInstructV1_128k => "Meta Llama 3.1 70B Instruct 128K",
+            Self::MetaLlama3170BInstructV1 => "Meta Llama 3.1 70B Instruct",
+            Self::MetaLlama31405BInstructV1 => "Meta Llama 3.1 405B Instruct",
+            Self::MetaLlama3211BInstructV1 => "Meta Llama 3.2 11B Instruct",
+            Self::MetaLlama3290BInstructV1 => "Meta Llama 3.2 90B Instruct",
+            Self::MetaLlama321BInstructV1 => "Meta Llama 3.2 1B Instruct",
+            Self::MetaLlama323BInstructV1 => "Meta Llama 3.2 3B Instruct",
+            Self::MetaLlama3370BInstructV1 => "Meta Llama 3.3 70B Instruct",
+            Self::MetaLlama4Scout17BInstructV1 => "Meta Llama 4 Scout 17B Instruct",
+            Self::MetaLlama4Maverick17BInstructV1 => "Meta Llama 4 Maverick 17B Instruct",
             Self::MistralMistral7BInstructV0 => "Mistral 7B Instruct V0",
             Self::MistralMixtral8x7BInstructV0 => "Mistral Mixtral 8x7B Instruct V0",
             Self::MistralMistralLarge2402V1 => "Mistral Large 2402 V1",
@@ -446,16 +456,18 @@ impl Model {
                 | Model::Claude3Opus
                 | Model::Claude3Sonnet
                 | Model::DeepSeekR1
-                | Model::MetaLlama31_405BInstruct
-                | Model::MetaLlama31_70BInstruct
-                | Model::MetaLlama31_8BInstruct
-                | Model::MetaLlama32_11BMultiModal
-                | Model::MetaLlama32_1BInstruct
-                | Model::MetaLlama32_3BInstruct
-                | Model::MetaLlama32_90BMultiModal
-                | Model::MetaLlama33_70BInstruct
-                | Model::MetaLlama4Maverick_17BInstruct
-                | Model::MetaLlama4Scout_17BInstruct
+                | Model::MetaLlama31405BInstructV1
+                | Model::MetaLlama3170BInstructV1_128k
+                | Model::MetaLlama3170BInstructV1
+                | Model::MetaLlama318BInstructV1_128k
+                | Model::MetaLlama318BInstructV1
+                | Model::MetaLlama3211BInstructV1
+                | Model::MetaLlama321BInstructV1
+                | Model::MetaLlama323BInstructV1
+                | Model::MetaLlama3290BInstructV1
+                | Model::MetaLlama3370BInstructV1
+                | Model::MetaLlama4Maverick17BInstructV1
+                | Model::MetaLlama4Scout17BInstructV1
                 | Model::MistralPixtralLarge2502V1
                 | Model::PalmyraWriterX4
                 | Model::PalmyraWriterX5,
@@ -469,8 +481,8 @@ impl Model {
                 | Model::Claude3_7SonnetThinking
                 | Model::Claude3Haiku
                 | Model::Claude3Sonnet
-                | Model::MetaLlama32_1BInstruct
-                | Model::MetaLlama32_3BInstruct
+                | Model::MetaLlama321BInstructV1
+                | Model::MetaLlama323BInstructV1
                 | Model::MistralPixtralLarge2502V1,
                 "eu",
             ) => Ok(format!("{}.{}", region_group, model_id)),
@@ -562,15 +574,15 @@ mod tests {
     fn test_meta_models_inference_ids() -> anyhow::Result<()> {
         // Test Meta models
         assert_eq!(
-            Model::MetaLlama3_70BInstruct.cross_region_inference_id("us-east-1")?,
+            Model::MetaLlama370BInstructV1.cross_region_inference_id("us-east-1")?,
             "meta.llama3-70b-instruct-v1:0"
         );
         assert_eq!(
-            Model::MetaLlama31_70BInstruct.cross_region_inference_id("us-east-1")?,
+            Model::MetaLlama3170BInstructV1.cross_region_inference_id("us-east-1")?,
             "us.meta.llama3-1-70b-instruct-v1:0"
         );
         assert_eq!(
-            Model::MetaLlama32_1BInstruct.cross_region_inference_id("eu-west-1")?,
+            Model::MetaLlama321BInstructV1.cross_region_inference_id("eu-west-1")?,
             "eu.meta.llama3-2-1b-instruct-v1:0"
         );
         Ok(())
@@ -658,7 +670,7 @@ mod tests {
             "anthropic.claude-3-5-sonnet-20241022-v2:0"
         );
         assert_eq!(Model::AmazonNovaLite.request_id(), "amazon.nova-lite-v1:0");
-        assert_eq!(Model::DeepSeekR1.request_id(), "us.deepseek.r1-v1:0");
+        assert_eq!(Model::DeepSeekR1.request_id(), "deepseek.r1-v1:0");
         assert_eq!(
             Model::MetaLlama38BInstructV1.request_id(),
             "meta.llama3-8b-instruct-v1:0"


### PR DESCRIPTION
cc @osyvokon last merge broke the CI. This fixes it.

Release Notes:

- N/A
