### PR TITLE
git_ui: Fix commit message text being obscured when too long

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3043,7 +3043,7 @@ impl GitPanel {
                     )
                     .child(
                         div()
-                            .pr_2p5()
+                            .pr_6()
                             .on_action(|&editor::actions::MoveUp, _, cx| {
                                 cx.stop_propagation();
                             })


### PR DESCRIPTION
| Before | After |
| - | - |
| <img width="699" alt="Before" src="https://github.com/user-attachments/assets/67dd0405-ac0b-4ce0-8809-a25eb2f836da" /> | <img width="697" alt="After" src="https://github.com/user-attachments/assets/7f030cfc-dec8-4b06-8b2a-6101b1f6534f" /> |

Release Notes:

- Fix commit message text being obscured when too long.
