### PR TITLE
edit_file_tool: Fail when edit location is not unique

### DIFF
--- a/crates/assistant_tools/src/edit_agent.rs
+++ b/crates/assistant_tools/src/edit_agent.rs
@@ -440,19 +440,22 @@ impl EditAgent {
             }
 
             let matches = matcher.finish();
-            if matches.is_empty() {
-                old_range_tx.send(None)?;
-                return Ok((edit_events, Vec::new()));
-            }
 
-            let line_indent = LineIndent::from_iter(matcher.query_lines().first().unwrap().chars());
             let old_range = if matches.len() == 1 {
                 matches.first()
             } else {
+                // No matches or multiple ambiguous matches
                 None
             };
             old_range_tx.send(old_range.cloned())?;
 
+            let line_indent = LineIndent::from_iter(
+                matcher
+                    .query_lines()
+                    .first()
+                    .unwrap_or(&String::new())
+                    .chars(),
+            );
             let resolved_old_texts = matches
                 .into_iter()
                 .map(|range| ResolvedOldText {

--- a/crates/assistant_tools/src/edit_agent.rs
+++ b/crates/assistant_tools/src/edit_agent.rs
@@ -1410,9 +1410,9 @@ mod tests {
 
         // And AmbiguousEditRange even should be emitted
         let events = drain_events(&mut events);
-        let ambigous_ranges = vec![17..31, 52..66, 87..101];
+        let ambiguous_ranges = vec![17..31, 52..66, 87..101];
         assert!(
-            events.contains(&EditAgentOutputEvent::AmbiguousEditRange(ambigous_ranges)),
+            events.contains(&EditAgentOutputEvent::AmbiguousEditRange(ambiguous_ranges)),
             "Should emit AmbiguousEditRange for non-unique text"
         );
     }

--- a/crates/assistant_tools/src/edit_agent.rs
+++ b/crates/assistant_tools/src/edit_agent.rs
@@ -449,7 +449,7 @@ impl EditAgent {
             };
             old_range_tx.send(old_range.cloned())?;
 
-            let line_indent = LineIndent::from_iter(
+            let indent = LineIndent::from_iter(
                 matcher
                     .query_lines()
                     .first()
@@ -458,10 +458,7 @@ impl EditAgent {
             );
             let resolved_old_texts = matches
                 .into_iter()
-                .map(|range| ResolvedOldText {
-                    range,
-                    indent: line_indent.clone(),
-                })
+                .map(|range| ResolvedOldText { range, indent })
                 .collect::<Vec<_>>();
 
             Ok((edit_events, resolved_old_texts))


### PR DESCRIPTION
When `<old_text>` points to more than one location in a file, we used to edit the first match, confusing the agent along the way. Now we will return an error, asking to expand `<old_text>` selection.

Closes #ISSUE

Release Notes:

- agent: Fixed incorrect file edits when edit locations are ambiguous