### PR TITLE
assistant_tools: Disallow extra tool parameters by default

### DIFF
--- a/crates/assistant_tools/src/assistant_tools.rs
+++ b/crates/assistant_tools/src/assistant_tools.rs
@@ -126,6 +126,7 @@ mod tests {
                     }
                 },
                 "required": ["location"],
+                "additionalProperties": false
             })
         );
     }


### PR DESCRIPTION
This prevents models from hallucinating tool parameters.


Release Notes:

- Prevent models from hallucinating tool parameters
