### PR TITLE
Add `editor::BlameHover` action for triggering the blame popover via keyboard

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -483,6 +483,7 @@
       "ctrl-k ctrl-d": ["editor::SelectNext", { "replace_newest": true }], // editor.action.moveSelectionToNextFindMatch  / find_under_expand_skip
       "ctrl-k ctrl-shift-d": ["editor::SelectPrevious", { "replace_newest": true }], // editor.action.moveSelectionToPreviousFindMatch
       "ctrl-k ctrl-i": "editor::Hover",
+      "ctrl-k ctrl-b": "editor::BlameHover",
       "ctrl-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "ctrl-u": "editor::UndoSelection",
       "ctrl-shift-u": "editor::RedoSelection",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -537,6 +537,7 @@
       "ctrl-cmd-d": ["editor::SelectPrevious", { "replace_newest": false }], // editor.action.addSelectionToPreviousFindMatch
       "cmd-k ctrl-cmd-d": ["editor::SelectPrevious", { "replace_newest": true }], // editor.action.moveSelectionToPreviousFindMatch
       "cmd-k cmd-i": "editor::Hover",
+      "cmd-k cmd-b": "editor::BlameHover",
       "cmd-/": ["editor::ToggleComments", { "advance_downwards": false }],
       "cmd-u": "editor::UndoSelection",
       "cmd-shift-u": "editor::RedoSelection",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -124,7 +124,7 @@
       "g r a": "editor::ToggleCodeActions",
       "g g": "vim::StartOfDocument",
       "g h": "editor::Hover",
-      "g b": "editor::BlameHover",
+      "g B": "editor::BlameHover",
       "g t": "pane::ActivateNextItem",
       "g shift-t": "pane::ActivatePreviousItem",
       "g d": "editor::GoToDefinition",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -124,6 +124,7 @@
       "g r a": "editor::ToggleCodeActions",
       "g g": "vim::StartOfDocument",
       "g h": "editor::Hover",
+      "g b": "editor::BlameHover",
       "g t": "pane::ActivateNextItem",
       "g shift-t": "pane::ActivatePreviousItem",
       "g d": "editor::GoToDefinition",

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -322,6 +322,8 @@ actions!(
         ApplyDiffHunk,
         /// Deletes the character before the cursor.
         Backspace,
+        /// Shows git blame information for the current line.
+        BlameHover,
         /// Cancels the current operation.
         Cancel,
         /// Cancels the running flycheck operation.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6517,6 +6517,10 @@ impl Editor {
         }
     }
 
+    pub fn blame_hover(&mut self, _: &BlameHover, window: &mut Window, cx: &mut Context<Self>) {
+        println!("blame_hover todo!()");
+    }
+
     fn show_blame_popover(
         &mut self,
         blame_entry: &BlameEntry,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6544,26 +6544,28 @@ impl Editor {
         // TODO: Render at the cursor position
         let position = window.mouse_position();
 
-        // TODO: Ignore delay
         // TODO: Don't hide when mouse is not over popover
-        self.show_blame_popover(&blame_entry, position, cx);
+        self.show_blame_popover(&blame_entry, position, true, cx);
     }
 
     fn show_blame_popover(
         &mut self,
         blame_entry: &BlameEntry,
         position: gpui::Point<Pixels>,
+        ignore_timeout: bool,
         cx: &mut Context<Self>,
     ) {
         if let Some(state) = &mut self.inline_blame_popover {
             state.hide_task.take();
         } else {
-            let delay = EditorSettings::get_global(cx).hover_popover_delay;
+            let blame_popover_delay = EditorSettings::get_global(cx).hover_popover_delay;
             let blame_entry = blame_entry.clone();
             let show_task = cx.spawn(async move |editor, cx| {
-                cx.background_executor()
-                    .timer(std::time::Duration::from_millis(delay))
-                    .await;
+                if !ignore_timeout {
+                    cx.background_executor()
+                        .timer(std::time::Duration::from_millis(blame_popover_delay))
+                        .await;
+                }
                 editor
                     .update(cx, |editor, cx| {
                         editor.inline_blame_popover_show_task.take();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -950,6 +950,7 @@ struct InlineBlamePopover {
     hide_task: Option<Task<()>>,
     popover_bounds: Option<Bounds<Pixels>>,
     popover_state: InlineBlamePopoverState,
+    keyboard_grace: bool,
 }
 
 enum SelectionDragState {
@@ -6545,7 +6546,6 @@ impl Editor {
         let anchor = self.selections.newest_anchor().head();
         let position = self.to_pixel_point(anchor, &snapshot, window);
         if let Some(position) = position {
-            // TODO: Don't hide when mouse is not over popover
             self.show_blame_popover(&blame_entry, position, true, cx);
         }
     }
@@ -6596,6 +6596,7 @@ impl Editor {
                                 commit_message: details,
                                 markdown,
                             },
+                            keyboard_grace: ignore_timeout,
                         });
                         cx.notify();
                     })

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6541,11 +6541,13 @@ impl Editor {
             return;
         };
 
-        // TODO: Render at the cursor position
-        let position = window.mouse_position();
-
-        // TODO: Don't hide when mouse is not over popover
-        self.show_blame_popover(&blame_entry, position, true, cx);
+        // TODO: Place the popover in a more sensible place
+        let anchor = self.selections.newest_anchor().head();
+        let position = self.to_pixel_point(anchor, &snapshot, window);
+        if let Some(position) = position {
+            // TODO: Don't hide when mouse is not over popover
+            self.show_blame_popover(&blame_entry, position, true, cx);
+        }
     }
 
     fn show_blame_popover(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6542,12 +6542,11 @@ impl Editor {
             return;
         };
 
-        // TODO: Place the popover in a more sensible place
         let anchor = self.selections.newest_anchor().head();
         let position = self.to_pixel_point(anchor, &snapshot, window);
-        if let Some(position) = position {
-            self.show_blame_popover(&blame_entry, position, true, cx);
-        }
+        if let (Some(position), Some(last_bounds)) = (position, self.last_bounds) {
+            self.show_blame_popover(&blame_entry, position + last_bounds.origin, true, cx);
+        };
     }
 
     fn show_blame_popover(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -216,6 +216,7 @@ impl EditorElement {
         register_action(editor, window, Editor::newline_above);
         register_action(editor, window, Editor::newline_below);
         register_action(editor, window, Editor::backspace);
+        register_action(editor, window, Editor::blame_hover);
         register_action(editor, window, Editor::delete);
         register_action(editor, window, Editor::tab);
         register_action(editor, window, Editor::backtab);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1146,7 +1146,7 @@ impl EditorElement {
                 .map_or(false, |bounds| bounds.contains(&event.position));
 
             if mouse_over_inline_blame || mouse_over_popover {
-                editor.show_blame_popover(&blame_entry, event.position, cx);
+                editor.show_blame_popover(&blame_entry, event.position, false, cx);
             } else {
                 editor.hide_blame_popover(cx);
             }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1144,10 +1144,14 @@ impl EditorElement {
                 .as_ref()
                 .and_then(|state| state.popover_bounds)
                 .map_or(false, |bounds| bounds.contains(&event.position));
+            let keyboard_grace = editor
+                .inline_blame_popover
+                .as_ref()
+                .map_or(false, |state| state.keyboard_grace);
 
             if mouse_over_inline_blame || mouse_over_popover {
                 editor.show_blame_popover(&blame_entry, event.position, false, cx);
-            } else {
+            } else if !keyboard_grace {
                 editor.hide_blame_popover(cx);
             }
         } else {


### PR DESCRIPTION
Make the git blame popover available via the keymap by making it an action. The blame popover stays open after being shown via the action, similar to the `editor::Hover` action.

I added a default vim-mode key binding for `g b`, which goes in hand with `g h` for hover. I'm not sure what the keybind would be for regular layouts, if any would be set by default.

I'm opening this as a draft because I coludn't figure out a way to position the popover correctly above/under the cursor head. I saw some uses of `content_origin` in other places for calculating absolute pixel positions, but I'm not sure how to make use of it here without doing a big refactor of the blame popover code 🤔. I would appreciate some help/tips with positioning, because it seems like the last thing to implement here.

Opening as a draft for now because I think without the correct positioning this feature is not complete.

Closes https://github.com/zed-industries/zed/discussions/26447

Release Notes:

- Added `editor::BlameHover` action for showing the git blame popover under the cursor. By default bound to `ctrl-k ctrl-b` and to `g h` in vim mode.