### PR TITLE
debugger: Run locators on LSP tasks for the new process modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4233,6 +4233,7 @@ dependencies = [
  "futures 0.3.31",
  "fuzzy",
  "gpui",
+ "itertools 0.14.0",
  "language",
  "log",
  "menu",

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -39,6 +39,7 @@ file_icons.workspace = true
 futures.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+itertools.workspace = true
 language.workspace = true
 log.workspace = true
 menu.workspace = true

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -1333,12 +1333,17 @@ impl PickerDelegate for DebugDelegate {
         .map(|icon| icon.color(Color::Muted).size(IconSize::Small));
         let indicator = if matches!(task_kind, Some(TaskSourceKind::Lsp { .. })) {
             Some(Indicator::icon(
-                Icon::new(IconName::BoltFilled).color(Color::Muted),
+                Icon::new(IconName::BoltFilled)
+                    .color(Color::Muted)
+                    .size(IconSize::Small),
             ))
         } else {
             None
         };
-        let icon = icon.map(|icon| IconWithIndicator::new(icon, indicator));
+        let icon = icon.map(|icon| {
+            IconWithIndicator::new(icon, indicator)
+                .indicator_border_color(Some(cx.theme().colors().border_transparent))
+        });
 
         Some(
             ListItem::new(SharedString::from(format!("debug-scenario-selection-{ix}")))

--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -47,12 +47,16 @@ impl DapLocator for CargoLocator {
         resolved_label: &str,
         adapter: DebugAdapterName,
     ) -> Option<DebugScenario> {
+        // dbg!(&build_config);
         if build_config.command != "cargo" {
+            dbg!("not cargo");
             return None;
         }
         let mut task_template = build_config.clone();
+        // dbg!(&task_template.args.first());
         let cargo_action = task_template.args.first_mut()?;
         if cargo_action == "check" || cargo_action == "clean" {
+            // dbg!("bad subcommand", &cargo_action);
             return None;
         }
 

--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -47,16 +47,12 @@ impl DapLocator for CargoLocator {
         resolved_label: &str,
         adapter: DebugAdapterName,
     ) -> Option<DebugScenario> {
-        // dbg!(&build_config);
         if build_config.command != "cargo" {
-            dbg!("not cargo");
             return None;
         }
         let mut task_template = build_config.clone();
-        // dbg!(&task_template.args.first());
         let cargo_action = task_template.args.first_mut()?;
         if cargo_action == "check" || cargo_action == "clean" {
-            // dbg!("bad subcommand", &cargo_action);
             return None;
         }
 

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -244,6 +244,7 @@ impl Inventory {
         &self,
         task_contexts: &TaskContexts,
         lsp_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
+        current_resolved_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
         add_current_language_tasks: bool,
         cx: &mut App,
     ) -> (Vec<DebugScenario>, Vec<(TaskSourceKind, DebugScenario)>) {
@@ -260,8 +261,6 @@ impl Inventory {
         }
         scenarios.extend(self.global_debug_scenarios_from_settings());
 
-        let (_, new) = self.used_and_current_resolved_tasks(task_contexts, cx);
-
         if let Some(location) = task_contexts.location() {
             let file = location.buffer.read(cx).file();
             let language = location.buffer.read(cx).language();
@@ -277,7 +276,7 @@ impl Inventory {
                 for (kind, task) in
                     lsp_tasks
                         .into_iter()
-                        .chain(new.into_iter().filter(|(kind, _)| {
+                        .chain(current_resolved_tasks.into_iter().filter(|(kind, _)| {
                             add_current_language_tasks
                                 || !matches!(kind, TaskSourceKind::Language { .. })
                         }))

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -243,6 +243,8 @@ impl Inventory {
     pub fn list_debug_scenarios(
         &self,
         task_contexts: &TaskContexts,
+        lsp_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
+        add_current_language_tasks: bool,
         cx: &mut App,
     ) -> (Vec<DebugScenario>, Vec<(TaskSourceKind, DebugScenario)>) {
         let mut scenarios = Vec::new();
@@ -259,6 +261,19 @@ impl Inventory {
         scenarios.extend(self.global_debug_scenarios_from_settings());
 
         let (_, new) = self.used_and_current_resolved_tasks(task_contexts, cx);
+
+        let lang_tasks = new
+            .iter()
+            .filter(|(kind, _)| {
+                matches!(
+                    kind,
+                    TaskSourceKind::Lsp { .. } | TaskSourceKind::Language { .. }
+                )
+            })
+            .map(|(_, task)| task.resolved_label.clone())
+            .collect_vec();
+        dbg!(lang_tasks);
+
         if let Some(location) = task_contexts.location() {
             let file = location.buffer.read(cx).file();
             let language = location.buffer.read(cx).language();
@@ -271,7 +286,14 @@ impl Inventory {
                     language.and_then(|l| l.config().debuggers.first().map(SharedString::from))
                 });
             if let Some(adapter) = adapter {
-                for (kind, task) in new {
+                for (kind, task) in new
+                    .into_iter()
+                    .filter(|(kind, _)| {
+                        add_current_language_tasks
+                            || !matches!(kind, TaskSourceKind::Language { .. })
+                    })
+                    .chain(lsp_tasks)
+                {
                     if let Some(scenario) =
                         DapRegistry::global(cx)
                             .locators()

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -262,18 +262,6 @@ impl Inventory {
 
         let (_, new) = self.used_and_current_resolved_tasks(task_contexts, cx);
 
-        let lang_tasks = new
-            .iter()
-            .filter(|(kind, _)| {
-                matches!(
-                    kind,
-                    TaskSourceKind::Lsp { .. } | TaskSourceKind::Language { .. }
-                )
-            })
-            .map(|(_, task)| task.resolved_label.clone())
-            .collect_vec();
-        dbg!(lang_tasks);
-
         if let Some(location) = task_contexts.location() {
             let file = location.buffer.read(cx).file();
             let language = location.buffer.read(cx).language();
@@ -286,13 +274,13 @@ impl Inventory {
                     language.and_then(|l| l.config().debuggers.first().map(SharedString::from))
                 });
             if let Some(adapter) = adapter {
-                for (kind, task) in new
-                    .into_iter()
-                    .filter(|(kind, _)| {
-                        add_current_language_tasks
-                            || !matches!(kind, TaskSourceKind::Language { .. })
-                    })
-                    .chain(lsp_tasks)
+                for (kind, task) in
+                    lsp_tasks
+                        .into_iter()
+                        .chain(new.into_iter().filter(|(kind, _)| {
+                            add_current_language_tasks
+                                || !matches!(kind, TaskSourceKind::Language { .. })
+                        }))
                 {
                     if let Some(scenario) =
                         DapRegistry::global(cx)

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -165,6 +165,7 @@ impl TasksModal {
     pub fn task_contexts_loaded(
         &mut self,
         task_contexts: Arc<TaskContexts>,
+        // lsp_tasks: Vec<()>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -296,6 +297,9 @@ impl PickerDelegate for TasksModalDelegate {
                                             .map(move |(_, task)| (kind.clone(), task))
                                     },
                                 ));
+                                // todo(debugger): We're always adding lsp tasks here even if prefer_lsp is false
+                                // We should move the filter to new_candidates instead of on current
+                                // and add a test for this
                                 new_candidates.extend(current.into_iter().filter(
                                     |(task_kind, _)| {
                                         add_current_language_tasks

--- a/crates/tasks_ui/src/modal.rs
+++ b/crates/tasks_ui/src/modal.rs
@@ -162,16 +162,33 @@ impl TasksModal {
         }
     }
 
-    pub fn task_contexts_loaded(
+    pub fn tasks_loaded(
         &mut self,
         task_contexts: Arc<TaskContexts>,
-        // lsp_tasks: Vec<()>,
+        lsp_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
+        used_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
+        current_resolved_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
+        add_current_language_tasks: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let last_used_candidate_index = if used_tasks.is_empty() {
+            None
+        } else {
+            Some(used_tasks.len() - 1)
+        };
+        let mut new_candidates = used_tasks;
+        new_candidates.extend(lsp_tasks);
+        // todo(debugger): We're always adding lsp tasks here even if prefer_lsp is false
+        // We should move the filter to new_candidates instead of on current
+        // and add a test for this
+        new_candidates.extend(current_resolved_tasks.into_iter().filter(|(task_kind, _)| {
+            add_current_language_tasks || !matches!(task_kind, TaskSourceKind::Language { .. })
+        }));
         self.picker.update(cx, |picker, cx| {
             picker.delegate.task_contexts = task_contexts;
-            picker.delegate.candidates = None;
+            picker.delegate.last_used_candidate_index = last_used_candidate_index;
+            picker.delegate.candidates = Some(new_candidates);
             picker.refresh(window, cx);
             cx.notify();
         })


### PR DESCRIPTION
- [x] pass LSP tasks into list_debug_scenarios
- [x] load LSP tasks only once for both modals
- [x] align ordering
- [x] improve appearance of LSP debug task icons
- [ ] reconsider how `add_current_language_tasks` works
- [ ] add a test

Release Notes:

- Debugger Beta: Added debuggable LSP tasks to the "Debug" tab of the new process modal.