### PR TITLE
git: Rewrap commit messages just before committing instead of interactively

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1457,7 +1457,9 @@
       "language_servers": ["erlang-ls", "!elp", "..."]
     },
     "Git Commit": {
-      "allow_rewrap": "anywhere"
+      "allow_rewrap": "anywhere",
+      "soft_wrap": "editor_width",
+      "preferred_line_length": 72
     },
     "Go": {
       "code_actions_on_format": {


### PR DESCRIPTION
Closes #27508 

Release Notes:

- Fixed unintuitive wrapping behavior when editing Git commit messages.