### PR TITLE
project_panel: Fix drop highlight is not being removed when `esc` is pressed

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1383,6 +1383,8 @@ impl ProjectPanel {
 
     fn cancel(&mut self, _: &menu::Cancel, window: &mut Window, cx: &mut Context<Self>) {
         if cx.stop_active_drag(window) {
+            self.drag_target_entry.take();
+            self.hover_expand_task.take();
             return;
         }
 


### PR DESCRIPTION


Release Notes:

- Fixed the issue where pressing `esc` would cancel the drag-and-drop operation but wouldn’t clear the drop highlight on directories.
