### PR TITLE
Fix panic in git conflict parsing

### DIFF
--- a/crates/project/src/git_store/conflict_set.rs
+++ b/crates/project/src/git_store/conflict_set.rs
@@ -212,7 +212,7 @@ impl ConflictSet {
                 && theirs_start.is_some()
             {
                 let theirs_end = line_pos;
-                let conflict_end = line_end + 1;
+                let conflict_end = (line_end + 1).min(buffer.len());
 
                 let range = buffer.anchor_after(conflict_start.unwrap())
                     ..buffer.anchor_before(conflict_end);


### PR DESCRIPTION
cc @cole-miller

Release Notes:

- Fix a panic when a git conflict marker ended on the last line of a file with no trailing newline
