### PR TITLE
Try to store the real version in DigitalOcean

### DIFF
--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -220,7 +220,7 @@ function prepare_binaries() {
         "zed-debug-symbols" \
         target/${architecture}/${target_dir}/Zed.dwarf.gz \
         "by-uuid/${uuid}.dwarf.gz" \
-        "X-Zed-Version: ${version_tag}"
+        "x-amz-meta-zed-version: ${version_tag}"
 
     cp target/${architecture}/${target_dir}/zed "${app_path}/Contents/MacOS/zed"
     cp target/${architecture}/${target_dir}/cli "${app_path}/Contents/MacOS/cli"

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -203,17 +203,24 @@ function prepare_binaries() {
         version="$version-$(git rev-parse --short HEAD)"
     fi
 
+    # Create version tag based on channel
+    version_tag="v${version}"
+    if [ "$channel" == "preview" ]; then
+        version_tag="v${version}-pre"
+    fi
+
     echo "Removing existing gzipped dSYMs for $architecture"
     rm -f target/${architecture}/${target_dir}/Zed.dwarf.gz
 
     echo "Gzipping dSYMs for $architecture"
     gzip -f target/${architecture}/${target_dir}/Zed.dwarf
 
-    echo "Uploading dSYMs${architecture} for $architecture to by-uuid/${uuid}.dwarf.gz"
+    echo "Uploading dSYMs${architecture} for $architecture to by-uuid/${uuid}.dwarf.gz with version tag ${version_tag}"
     upload_to_blob_store_public \
         "zed-debug-symbols" \
         target/${architecture}/${target_dir}/Zed.dwarf.gz \
-        "by-uuid/${uuid}.dwarf.gz"
+        "by-uuid/${uuid}.dwarf.gz" \
+        "X-Zed-Version: ${version_tag}"
 
     cp target/${architecture}/${target_dir}/zed "${app_path}/Contents/MacOS/zed"
     cp target/${architecture}/${target_dir}/cli "${app_path}/Contents/MacOS/cli"

--- a/script/lib/blob-store.sh
+++ b/script/lib/blob-store.sh
@@ -4,6 +4,7 @@ function upload_to_blob_store_with_acl
     file_to_upload="$2"
     blob_store_key="$3"
     acl="$4"
+    custom_headers="${5:-}"
 
     date=$(date +"%a, %d %b %Y %T %z")
     content_type="application/octet-stream"
@@ -11,22 +12,29 @@ function upload_to_blob_store_with_acl
     string="PUT\n\n${content_type}\n${date}\n${acl}\n${storage_type}\n/${bucket_name}/${blob_store_key}"
     signature=$(echo -en "${string}" | openssl sha1 -hmac "${DIGITALOCEAN_SPACES_SECRET_KEY}" -binary | base64)
 
-    curl --fail -vv -s -X PUT -T "$file_to_upload" \
-        -H "Host: ${bucket_name}.nyc3.digitaloceanspaces.com" \
-        -H "Date: $date" \
-        -H "Content-Type: $content_type" \
-        -H "$storage_type" \
-        -H "$acl" \
-        -H "Authorization: AWS ${DIGITALOCEAN_SPACES_ACCESS_KEY}:$signature" \
-        "https://${bucket_name}.nyc3.digitaloceanspaces.com/${blob_store_key}"
+    curl_cmd="curl --fail -vv -s -X PUT -T \"$file_to_upload\" \
+        -H \"Host: ${bucket_name}.nyc3.digitaloceanspaces.com\" \
+        -H \"Date: $date\" \
+        -H \"Content-Type: $content_type\" \
+        -H \"$storage_type\" \
+        -H \"$acl\" \
+        -H \"Authorization: AWS ${DIGITALOCEAN_SPACES_ACCESS_KEY}:$signature\""
+
+    if [ -n "$custom_headers" ]; then
+        curl_cmd="$curl_cmd -H \"$custom_headers\""
+    fi
+
+    curl_cmd="$curl_cmd \"https://${bucket_name}.nyc3.digitaloceanspaces.com/${blob_store_key}\""
+
+    eval $curl_cmd
 }
 
 function upload_to_blob_store_public
 {
-    upload_to_blob_store_with_acl "$1" "$2" "$3" "x-amz-acl:public-read"
+    upload_to_blob_store_with_acl "$1" "$2" "$3" "x-amz-acl:public-read" "${4:-}"
 }
 
 function upload_to_blob_store
 {
-    upload_to_blob_store_with_acl "$1" "$2" "$3" "x-amz-acl:private"
+    upload_to_blob_store_with_acl "$1" "$2" "$3" "x-amz-acl:private" "${4:-}"
 }


### PR DESCRIPTION
On macOS crash reports contain the version from the on-disk version of Zed.
This may differ from the running version when an auto-update is pending, which
makes tracking down crashes trickier.

It might make sense to store this information in a better place

Release Notes:

- N/A *or* Added/Fixed/Improved ...
