### PR TITLE
Fix a panic in merge conflict parsing

### DIFF
--- a/crates/project/src/git_store/conflict_set.rs
+++ b/crates/project/src/git_store/conflict_set.rs
@@ -391,7 +391,7 @@ mod tests {
         assert_eq!(their_text, "This is their version in a nested conflict\n");
     }
 
-    #[gpui::test]
+    #[test]
     fn test_conflict_markers_at_eof() {
         let test_content = r#"
             <<<<<<< ours


### PR DESCRIPTION
Release Notes:

- Fixed a panic that could occur when editing files containing merge conflicts.