### PR TITLE
Fix innermost brackets panic

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6213,7 +6213,7 @@ impl MultiBufferSnapshot {
         cursor.seek_to_start_of_current_excerpt();
         let region = cursor.region()?;
         let offset = region.range.start;
-        let buffer_offset = region.buffer_range.start;
+        let buffer_offset = start_excerpt.buffer_start_offset();
         let excerpt_offset = cursor.excerpts.start().clone();
         Some(MultiBufferExcerpt {
             diff_transforms: cursor.diff_transforms,

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -2842,8 +2842,21 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
                 .unwrap()
                 + 1
         );
+        let reference_ranges = cx.update(|cx| {
+            reference
+                .excerpts
+                .iter()
+                .map(|excerpt| {
+                    (
+                        excerpt.id,
+                        excerpt.range.to_offset(&excerpt.buffer.read(cx).snapshot()),
+                    )
+                })
+                .collect::<HashMap<_, _>>()
+        });
         for i in 0..snapshot.len() {
-            snapshot.innermost_enclosing_bracket_ranges(i..i, None);
+            let excerpt = snapshot.excerpt_containing(i..i).unwrap();
+            assert_eq!(excerpt.buffer_range(), reference_ranges[&excerpt.id()]);
         }
 
         assert_consistent_line_numbers(&snapshot);

--- a/crates/multi_buffer/src/multi_buffer_tests.rs
+++ b/crates/multi_buffer/src/multi_buffer_tests.rs
@@ -2842,6 +2842,9 @@ async fn test_random_multibuffer(cx: &mut TestAppContext, mut rng: StdRng) {
                 .unwrap()
                 + 1
         );
+        for i in 0..snapshot.len() {
+            snapshot.innermost_enclosing_bracket_ranges(i..i, None);
+        }
 
         assert_consistent_line_numbers(&snapshot);
         assert_position_translation(&snapshot);


### PR DESCRIPTION

Release Notes:

- Fixed a few rare panics that could happen when a multibuffer excerpt started with expanded deleted content.