### PR TITLE
Search tweaks

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1563,6 +1563,12 @@ impl ProjectSearchBar {
                 window.refresh();
                 cx.notify();
             });
+            this.filter_enabled = !this.filter_enabled;
+            let editor_to_focus = if this.filter_enabled {
+                this.filter_editor.focus_handle(cx)
+            } else {
+                this.query_editor.focus_handle(cx)
+            };
             cx.notify();
             true
         } else {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -155,17 +155,19 @@ pub struct DeploySearch {
     #[serde(default)]
     pub replace_enabled: bool,
     #[serde(default)]
+    pub whole_word_enabled: Option<bool>,
+    #[serde(default)]
+    pub match_case_enabled: Option<bool>,
+    #[serde(default)]
+    pub regex_enabled: Option<bool>,
+
+    // only for project search
+    #[serde(default)]
     pub filter_enabled: bool,
     #[serde(default)]
-    pub whole_word_enabled: bool,
+    pub only_open_enabled: Option<bool>,
     #[serde(default)]
-    pub match_case_enabled: bool,
-    #[serde(default)]
-    pub regex_enabled: bool,
-    #[serde(default)]
-    pub only_open_enabled: bool,
-    #[serde(default)]
-    pub include_ignored_enabled: bool,
+    pub include_ignored_enabled: Option<bool>,
 }
 
 impl_actions!(
@@ -212,6 +214,7 @@ impl DeploySearch {
     pub fn find() -> Self {
         Self {
             replace_enabled: false,
+            ..Default::default()
         }
     }
 }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -154,6 +154,18 @@ pub struct RevealInProjectPanel {
 pub struct DeploySearch {
     #[serde(default)]
     pub replace_enabled: bool,
+    #[serde(default)]
+    pub filter_enabled: bool,
+    #[serde(default)]
+    pub whole_word_enabled: bool,
+    #[serde(default)]
+    pub match_case_enabled: bool,
+    #[serde(default)]
+    pub regex_enabled: bool,
+    #[serde(default)]
+    pub only_open_enabled: bool,
+    #[serde(default)]
+    pub include_ignored_enabled: bool,
 }
 
 impl_actions!(
@@ -3112,6 +3124,7 @@ fn default_render_tab_bar_buttons(
                                 "Search Project",
                                 DeploySearch {
                                     replace_enabled: false,
+                                    ..Default::default()
                                 }
                                 .boxed_clone(),
                             )


### PR DESCRIPTION
By default search settings (whole word/match case/regex) for _project_ search are "sticky", if you set them during a session they'll stay that way for future searches until re-opening the editor.

This change allows you to choose an explicit value for each setting when you make a search binding, so you can have a binding to do local buffer search with regex disabled and whole-word match enabled for example, and it'll always open with those regardless of what your last search settings were.

Release Notes:

- Made search settings configurable per-binding