### PR TITLE
Fix Unexpected Console Window When Running Zed Release Build

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1,6 +1,3 @@
-// Disable command line from opening on release mode
-#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
-
 mod reliability;
 mod zed;
 

--- a/crates/zed/src/zed-main.rs
+++ b/crates/zed/src/zed-main.rs
@@ -1,3 +1,6 @@
+// Disable command line from opening on release mode
+#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
+
 pub fn main() {
     // separated out so that the file containing the main function can be imported by other crates,
     // while having all gpui resources that are registered in main (primarily actions) initialized


### PR DESCRIPTION
The commit #31073 had introduced `zed-main.rs`, which replaced the previous `main.rs` to be the "true" entry of the whole program. But as the macro `#![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]` only works in the "true" entry, the release build will also arise the console window if this macro doesn't move to the new entry (the `zed-main.rs` here).


Release Notes:

- N/A

