### PR TITLE
Improve handling of `injection.combined` injections in `SyntaxSnapshot::layers_for_range`

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1384,12 +1384,16 @@ impl Buffer {
                     is_first = false;
                     return true;
                 }
-                let any_sub_ranges_contain_range =
-                    layer.included_sub_ranges.iter().any(|sub_range| {
-                        let is_before_start = sub_range.end.cmp(&start_anchor, self).is_lt();
-                        let is_after_end = sub_range.start.cmp(&end_anchor, self).is_gt();
-                        !is_before_start && !is_after_end
-                    });
+                let any_sub_ranges_contain_range = layer
+                    .included_sub_ranges
+                    .map(|sub_ranges| {
+                        sub_ranges.iter().any(|sub_range| {
+                            let is_before_start = sub_range.end.cmp(&start_anchor, self).is_lt();
+                            let is_after_end = sub_range.start.cmp(&end_anchor, self).is_gt();
+                            !is_before_start && !is_after_end
+                        })
+                    })
+                    .unwrap_or(true);
                 let result = any_sub_ranges_contain_range;
                 return result;
             })

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -722,8 +722,8 @@ impl SyntaxSnapshot {
                     let included_sub_ranges = included_ranges
                         .into_iter()
                         .map(|r| {
-                            text.anchor_before(Point::from_ts_point(r.start_point))
-                                ..text.anchor_after(Point::from_ts_point(r.end_point))
+                            text.anchor_before(r.start_byte + step_start_byte)
+                                ..text.anchor_after(r.end_byte + step_start_byte)
                         })
                         .collect();
                     SyntaxLayerContent::Parsed {
@@ -889,7 +889,7 @@ impl SyntaxSnapshot {
                 {
                     let layer_start_offset = layer.range.start.to_offset(buffer);
                     let layer_start_point = layer.range.start.to_point(buffer).to_ts_point();
-                    if (include_hidden || !language.config.hidden) {
+                    if include_hidden || !language.config.hidden {
                         info = Some(SyntaxLayer {
                             tree,
                             language,


### PR DESCRIPTION
Closes #27596

The problem in this case was incorrect identification of which language (layer) contains the selection.

Language layer selection incorrectly assumed that the deepest `SyntaxLayer` containing a range was the most specific. This worked for Markdown (base document + injected subtrees) but failed for PHP, where `injection.combined` injections are used to make HTML logically function as the base layer, despite being at a greater depth in the layer stack. This caused HTML to be incorrectly identified as the most specific language for PHP ranges.

The solution is to track included sub-ranges for syntax layers and filter out layers that don't contain a sub-range covering the desired range. The top-level layer is never filtered to ensure gaps between sibling nodes always have a fallback language, as the top-level layer is likely more correct than the default language settings.

Release Notes:

- Fixed an issue in PHP where PHP language settings would be occasionally overridden by HTML language settings