### PR TITLE
windows: Fix Japanese IME

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -680,6 +680,7 @@ fn handle_ime_composition_inner(
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
     let mut ime_input = None;
+    println!("IME composition lparam: {lparam:?}");
     if lparam.0 as u32 & GCS_COMPSTR.0 > 0 {
         let comp_string = parse_ime_compostion_string(ctx)?;
         with_input_handler(&state_ptr, |input_handler| {
@@ -1320,6 +1321,7 @@ fn parse_normal_key(
 fn parse_ime_compostion_string(ctx: HIMC) -> Option<String> {
     unsafe {
         let string_len = ImmGetCompositionStringW(ctx, GCS_COMPSTR, None, 0);
+        println!("Comp str len: {}", string_len);
         if string_len >= 0 {
             let mut buffer = vec![0u8; string_len as usize + 2];
             ImmGetCompositionStringW(
@@ -1347,6 +1349,7 @@ fn retrieve_composition_cursor_position(ctx: HIMC) -> usize {
 fn parse_ime_compostion_result(ctx: HIMC) -> Option<String> {
     unsafe {
         let string_len = ImmGetCompositionStringW(ctx, GCS_RESULTSTR, None, 0);
+        println!("Comp str res len: {}", string_len);
         if string_len >= 0 {
             let mut buffer = vec![0u8; string_len as usize + 2];
             ImmGetCompositionStringW(

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -679,6 +679,14 @@ fn handle_ime_composition_inner(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
+    if lparam.0 == 0 {
+        // Japanese IME may send this message with lparam = 0, which indicates that
+        // there is no composition string.
+        with_input_handler(&state_ptr, |input_handler| {
+            input_handler.replace_text_in_range(None, "");
+        })?;
+        return Some(0);
+    }
     let mut ime_input = None;
     println!("IME composition lparam: {lparam:?}");
     if lparam.0 as u32 & GCS_COMPSTR.0 > 0 {

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -688,7 +688,6 @@ fn handle_ime_composition_inner(
         return Some(0);
     }
     let mut ime_input = None;
-    println!("IME composition lparam: {lparam:?}");
     if lparam.0 as u32 & GCS_COMPSTR.0 > 0 {
         let comp_string = parse_ime_compostion_string(ctx)?;
         with_input_handler(&state_ptr, |input_handler| {
@@ -1329,7 +1328,6 @@ fn parse_normal_key(
 fn parse_ime_compostion_string(ctx: HIMC) -> Option<String> {
     unsafe {
         let string_len = ImmGetCompositionStringW(ctx, GCS_COMPSTR, None, 0);
-        println!("Comp str len: {}", string_len);
         if string_len >= 0 {
             let mut buffer = vec![0u8; string_len as usize + 2];
             ImmGetCompositionStringW(
@@ -1357,7 +1355,6 @@ fn retrieve_composition_cursor_position(ctx: HIMC) -> usize {
 fn parse_ime_compostion_result(ctx: HIMC) -> Option<String> {
     unsafe {
         let string_len = ImmGetCompositionStringW(ctx, GCS_RESULTSTR, None, 0);
-        println!("Comp str res len: {}", string_len);
         if string_len >= 0 {
             let mut buffer = vec![0u8; string_len as usize + 2];
             ImmGetCompositionStringW(


### PR DESCRIPTION
Fixed an issue where pressing `Escape` wouldn’t clear all pre-edit text when using Japanese IME.


Release Notes:

- N/A