### PR TITLE
Add GitHub token authentication to HTTP client

### DIFF
--- a/docs/src/environment.md
+++ b/docs/src/environment.md
@@ -90,3 +90,30 @@ These language server processes always inherit Zed's process environment. But, d
 
 - If the language server was found in the project environment's `$PATH`, then the project environment's is passed along to the language server process. Where the project environment comes from depends on how the project was opened, via CLI or not. See previous point on look-up of language servers.
 - If the language servers was not found in the project environment, Zed tries to install it globally and start it globally. In that case, the process will inherit Zed's process environment, and — if the project was opened via ClI — from the CLI.
+
+### GITHUB_TOKEN
+
+The `GITHUB_TOKEN` environment variable is used to authenticate requests to GitHub's API. This is particularly useful for avoiding rate limits when downloading language servers, extensions, or other resources from GitHub. This is also necessary if you have a GitHub Enterprise account, as there are increased permissions required to access avatars and other resources related to enterprise user accounts.
+
+#### Setting up GITHUB_TOKEN
+
+1. Create a GitHub Personal Access Token:
+
+   - Go to GitHub Settings → Developer settings → Personal access tokens
+   - Create a new token (classic or fine-grained)
+   - No special scopes are required for public repository access
+
+2. Set the environment variable before starting Zed:
+   ```bash
+   export GITHUB_TOKEN=your_personal_access_token
+   zed
+   ```
+
+The token will be automatically used for requests to:
+
+- `api.github.com`
+- `github.com`
+- `avatars.githubusercontent.com`
+- `raw.githubusercontent.com`
+- `uploads.github.com`
+- `gist.github.com`


### PR DESCRIPTION
Automatically adds GitHub authentication headers when GITHUB_TOKEN
environment variable is set. Increases rate limit from 60 to 5,000
requests per hour for GitHub API calls, preventing rate limit errors
when downloading assets from GitHub.

Closes #19207

Release Notes:

- If GITHUB_TOKEN is provided as an env variable, we use that when making requests to GitHub urls by default, to increase the rate limit, as well as allow for accessing avatars from GitHub Enterprise accounts. 
