### PR TITLE
ｗindows: Only call `TranslateMessage` when we can't handle the event

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1229,6 +1229,7 @@ where
     match virtual_key {
         VK_PROCESSKEY => {
             // IME composition
+            // ImmGetVirtualKey(handle);
             None
         }
         VK_SHIFT | VK_CONTROL | VK_MENU | VK_LWIN | VK_RWIN => {

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -34,7 +34,14 @@ pub(crate) fn handle_msg(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> LRESULT {
+    if msg != WM_PAINT {
+        println!("==> MSG: {}", msg);
+    }
     let handled = match msg {
+        WM_IME_NOTIFY => {
+            println!("WM_IME_NOTIFY: wparam: {}", wparam.0);
+            None
+        }
         WM_ACTIVATE => handle_activate_msg(handle, wparam, state_ptr),
         WM_CREATE => handle_create_msg(handle, state_ptr),
         WM_MOVE => handle_move_msg(handle, lparam, state_ptr),

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1232,6 +1232,8 @@ fn translate_message(handle: HWND, wparam: WPARAM, lparam: LPARAM) {
         message: WM_KEYDOWN,
         wParam: wparam,
         lParam: lparam,
+        // It seems like leaving the following two parameters empty doesn't break key events, they still work as expected.
+        // But if any bugs pop up after this PR, this is probably the place to look first.
         time: 0,
         pt: POINT::default(),
     };

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -231,9 +231,6 @@ impl WindowsPlatform {
                         }
                     }
                     _ => {
-                        // todo(windows)
-                        // crate `windows 0.56` reports true as Err
-                        TranslateMessage(&msg).as_bool();
                         DispatchMessageW(&msg);
                     }
                 }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -43,7 +43,6 @@ pub struct WindowsWindowState {
     pub callbacks: Callbacks,
     pub input_handler: Option<PlatformInputHandler>,
     pub last_reported_modifiers: Option<Modifiers>,
-    pub suppress_next_char_msg: bool,
     pub system_key_handled: bool,
     pub hovered: bool,
 
@@ -103,7 +102,6 @@ impl WindowsWindowState {
         let callbacks = Callbacks::default();
         let input_handler = None;
         let last_reported_modifiers = None;
-        let suppress_next_char_msg = false;
         let system_key_handled = false;
         let hovered = false;
         let click_state = ClickState::new();
@@ -123,7 +121,6 @@ impl WindowsWindowState {
             callbacks,
             input_handler,
             last_reported_modifiers,
-            suppress_next_char_msg,
             system_key_handled,
             hovered,
             renderer,


### PR DESCRIPTION
This PR improves key handling on Windows by moving the `TranslateMessage` call from the message loop to after we handled `WM_KEYDOWN`. This brings Windows behavior more in line with macOS and gives us finer control over key events. As a result, Vim keybindings now work properly even when an IME is active. The trade-off is that it might introduce a slight delay in text input.


Release Notes:

- N/A
