### PR TITLE
debugger: Fix wrong variant of new process modal deployed

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -342,7 +342,7 @@ impl DebugPanel {
             window.defer(cx, move |window, cx| {
                 workspace
                     .update(cx, |workspace, cx| {
-                        NewProcessModal::show(workspace, window, NewProcessMode::Launch, None, cx);
+                        NewProcessModal::show(workspace, window, NewProcessMode::Debug, None, cx);
                     })
                     .ok();
             });


### PR DESCRIPTION
I think this was added back when the `Launch` variant meant what we now call `Debug`

Release Notes:

- N/A