### PR TITLE
Only accept outlines with len > 0 for AI summaries

### DIFF
--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -208,21 +208,23 @@ impl FileContextHandle {
 
                     if let Ok(snapshot) = buffer.read_with(cx, |buffer, _| buffer.snapshot()) {
                         if let Some(outline) = snapshot.outline(None) {
-                            let items = outline
-                                .items
-                                .into_iter()
-                                .map(|item| item.to_point(&snapshot));
+                            if outline.items.len() > 0 {
+                                let items = outline
+                                    .items
+                                    .into_iter()
+                                    .map(|item| item.to_point(&snapshot));
 
-                            if let Ok(outline_text) =
-                                outline::render_outline(items, None, 0, usize::MAX).await
-                            {
-                                let context = AgentContext::File(FileContext {
-                                    handle: self,
-                                    full_path,
-                                    text: outline_text.into(),
-                                    is_outline: true,
-                                });
-                                return Some((context, vec![buffer]));
+                                if let Ok(outline_text) =
+                                    outline::render_outline(items, None, 0, usize::MAX).await
+                                {
+                                    let context = AgentContext::File(FileContext {
+                                        handle: self,
+                                        full_path,
+                                        text: outline_text.into(),
+                                        is_outline: true,
+                                    });
+                                    return Some((context, vec![buffer]));
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Fixes #32098 by having the context generation code choose not to use empty outlines.

There's probably more than one way to fix this. E.g. we could say that generating an empty outline is an error higher in the stack. That feels mildly wrong to me, since there are cases where a large file really does semantically have an empty outline (e.g. a source code which is just a single, large, comment). Rather it's the context generation code which seems to me to consider that to be a semantically useless outline even when it is correct. Thus this seemed like the right place to fix this.

PS. Once let chains land on stable this if chain can be collapsed into a single if, so I'm not that worried about the stylistic issue of this code being heavily tabbed in.

Release Notes:

- Fixed a bug where large files with empty outlines are sent to agents as an empty outline.