### PR TITLE
Use `@property` highlights capture for CSS properties

### DIFF
--- a/crates/languages/src/css/highlights.scm
+++ b/crates/languages/src/css/highlights.scm
@@ -36,9 +36,8 @@
   (id_name)
   (namespace_name)
   (feature_name)
+  (property_name)
 ] @property
-
-(property_name) @constant
 
 (function_name) @function
 


### PR DESCRIPTION
See https://github.com/zed-industries/zed/pull/17324#issuecomment-2480050882. I'm not sure why this node should be marked with the `@constant` capture, which for reference is not done by Helix or Neovim:

https://github.com/helix-editor/helix/blob/f6878f62f74430cff188e7978d06c5ed143179e9/runtime/queries/css/highlights.scm#L31

(uses `@variable.other.member`)

https://github.com/nvim-treesitter/nvim-treesitter/blob/42fc28ba918343ebfd5565147a42a26580579482/queries/css/highlights.scm#L25-L28

(uses `@property`, like this PR and before #17324)

---

Related to https://github.com/zed-industries/zed/discussions/23371.

Release Notes:

- Improve highlighting for property names in CSS
