### PR TITLE
Make a test no longer `pub`

### DIFF
--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1824,7 +1824,7 @@ mod tests {
     }
 
     #[test]
-    pub fn test_resolve_language_servers() {
+    fn test_resolve_language_servers() {
         fn language_server_names(names: &[&str]) -> Vec<LanguageServerName> {
             names
                 .iter()


### PR DESCRIPTION
I spotted this while working on something else. Very quick fix!

Release Notes:

- N/A
