### PR TITLE
debugger: Add ability to specify go tags when debugging go tests

### DIFF
--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -12,6 +12,24 @@ use uuid::Uuid;
 
 pub(crate) struct GoLocator;
 
+impl GoLocator {
+    fn get_build_tags(&self, build_config: &TaskTemplate) -> Vec<String> {
+        let mut tags = Vec::new();
+        let mut i = 0;
+        let args = &build_config.args;
+        while i < args.len() {
+            if args[i] == "-tags" && i + 1 < args.len() {
+                tags.push("-tags".to_string());
+                tags.push(args[i + 1].clone());
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+        tags
+    }
+}
+
 #[async_trait]
 impl DapLocator for GoLocator {
     fn name(&self) -> SharedString {
@@ -33,17 +51,20 @@ impl DapLocator for GoLocator {
         match go_action.as_str() {
             "test" => {
                 let binary_path = format!("__debug_{}", Uuid::new_v4().simple());
+                let build_tags = self.get_build_tags(build_config);
+
+                let mut args = vec!["test".into(), "-c".into()];
+                args.extend(build_tags);
+                args.extend(vec![
+                    "-gcflags \"all=-N -l\"".into(),
+                    "-o".into(),
+                    binary_path,
+                ]);
 
                 let build_task = TaskTemplate {
                     label: "go test debug".into(),
                     command: "go".into(),
-                    args: vec![
-                        "test".into(),
-                        "-c".into(),
-                        "-gcflags \"all=-N -l\"".into(),
-                        "-o".into(),
-                        binary_path,
-                    ],
+                    args,
                     env: build_config.env.clone(),
                     cwd: build_config.cwd.clone(),
                     use_new_terminal: false,
@@ -74,15 +95,16 @@ impl DapLocator for GoLocator {
                     .get(1)
                     .cloned()
                     .unwrap_or_else(|| ".".to_string());
+                let build_tags = self.get_build_tags(build_config);
+
+                let mut args = vec!["build".into()];
+                args.extend(build_tags);
+                args.extend(vec!["-gcflags \"all=-N -l\"".into(), program.clone()]);
 
                 let build_task = TaskTemplate {
                     label: "go build debug".into(),
                     command: "go".into(),
-                    args: vec![
-                        "build".into(),
-                        "-gcflags \"all=-N -l\"".into(),
-                        program.clone(),
-                    ],
+                    args,
                     env: build_config.env.clone(),
                     cwd: build_config.cwd.clone(),
                     use_new_terminal: false,
@@ -130,9 +152,12 @@ impl DapLocator for GoLocator {
 
         match go_action.as_str() {
             "test" => {
+                // Find the binary path after the -o flag
                 let binary_arg = build_config
                     .args
-                    .get(4)
+                    .windows(2)
+                    .find(|window| window[0] == "-o")
+                    .map(|window| &window[1])
                     .ok_or_else(|| anyhow::anyhow!("can't locate debug binary"))?;
 
                 let program = PathBuf::from(&cwd)
@@ -333,6 +358,138 @@ mod tests {
     }
 
     #[test]
+    fn test_create_scenario_for_go_test_with_tags() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "go test with tags".into(),
+            command: "go".into(),
+            args: vec![
+                "test".into(),
+                "-tags".into(),
+                "integration,e2e".into(),
+                ".".into(),
+            ],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+
+        assert!(scenario.is_some());
+        let scenario = scenario.unwrap();
+
+        if let Some(BuildTaskDefinition::Template { task_template, .. }) = &scenario.build {
+            assert!(task_template.args.contains(&"test".into()));
+            assert!(task_template.args.contains(&"-c".into()));
+            assert!(task_template.args.contains(&"-tags".into()));
+            assert!(task_template.args.contains(&"integration,e2e".into()));
+            assert!(
+                task_template
+                    .args
+                    .contains(&"-gcflags \"all=-N -l\"".into())
+            );
+        } else {
+            panic!("Expected BuildTaskDefinition::Template");
+        }
+    }
+
+    #[test]
+    fn test_get_build_tags() {
+        let locator = GoLocator;
+
+        // Test with tags
+        let task_with_tags = TaskTemplate {
+            label: "test".into(),
+            command: "go".into(),
+            args: vec![
+                "test".to_string(),
+                "-tags".to_string(),
+                "integration,unit".to_string(),
+                ".".to_string(),
+            ],
+            env: FxHashMap::default(),
+            cwd: None,
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+        let tags = locator.get_build_tags(&task_with_tags);
+        assert_eq!(
+            tags,
+            vec!["-tags".to_string(), "integration,unit".to_string()]
+        );
+
+        // Test without tags
+        let task_without_tags = TaskTemplate {
+            label: "test".into(),
+            command: "go".into(),
+            args: vec!["test".to_string(), ".".to_string()],
+            env: FxHashMap::default(),
+            cwd: None,
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+        let tags = locator.get_build_tags(&task_without_tags);
+        assert!(tags.is_empty());
+
+        let task_multiple_tags = TaskTemplate {
+            label: "test".into(),
+            command: "go".into(),
+            args: vec![
+                "test".to_string(),
+                "-tags".to_string(),
+                "unit".to_string(),
+                "-tags".to_string(),
+                "integration".to_string(),
+            ],
+            env: FxHashMap::default(),
+            cwd: None,
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+        let tags = locator.get_build_tags(&task_multiple_tags);
+        assert_eq!(
+            tags,
+            vec![
+                "-tags".to_string(),
+                "unit".to_string(),
+                "-tags".to_string(),
+                "integration".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn test_create_scenario_for_go_test_with_cwd_binary() {
         let locator = GoLocator;
 
@@ -409,7 +566,7 @@ mod tests {
                 "-c".into(),
                 "-gcflags \"all=-N -l\"".into(),
                 "-o".into(),
-            ], // Missing the binary path (arg 4)
+            ], // Missing the binary path after -o
             command_label: "go test -c -gcflags \"all=-N -l\" -o".to_string(),
             env: Default::default(),
             cwd: Some(PathBuf::from("/test/path")),
@@ -432,5 +589,51 @@ mod tests {
                 .to_string()
                 .contains("can't locate debug binary")
         );
+    }
+
+    #[test]
+    fn test_run_go_test_with_tags() {
+        let locator = GoLocator;
+        let build_config = SpawnInTerminal {
+            id: TaskId("test_task".to_string()),
+            full_label: "go test".to_string(),
+            label: "go test".to_string(),
+            command: "go".into(),
+            args: vec![
+                "test".into(),
+                "-c".into(),
+                "-tags".into(),
+                "integration".into(),
+                "-gcflags \"all=-N -l\"".into(),
+                "-o".into(),
+                "__debug_binary".into(),
+            ],
+            command_label: "go test -c -tags integration -gcflags \"all=-N -l\" -o __debug_binary"
+                .to_string(),
+            env: Default::default(),
+            cwd: Some(PathBuf::from("/test/path")),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            show_summary: true,
+            show_command: true,
+            show_rerun: true,
+        };
+
+        let result = futures::executor::block_on(locator.run(build_config));
+        assert!(result.is_ok());
+
+        if let Ok(DebugRequest::Launch(launch_request)) = result {
+            assert!(launch_request.program.ends_with("__debug_binary"));
+            assert_eq!(
+                launch_request.args,
+                vec!["-test.v".to_string(), "-test.run=${ZED_SYMBOL}".to_string()]
+            );
+        } else {
+            panic!("Expected LaunchRequest");
+        }
     }
 }

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -261,6 +261,93 @@ Given an externally-ran web server (e.g. with `npx serve` or `npx live-server`) 
 ]
 ```
 
+#### Go
+
+##### Debug Go Tests with Build Tags
+
+Go build tags (build constraints) allow conditional compilation of code. When debugging Go applications or tests that require specific build tags, you can configure them in your debug scenarios:
+
+```json
+[
+  {
+    "label": "Debug Go Test with Integration Tags",
+    "adapter": "Delve",
+    "build": {
+      "label": "Build Go Test with Tags",
+      "command": "go",
+      "args": [
+        "test",
+        "-c",
+        "-tags",
+        "integration",
+        "-gcflags=\"all=-N -l\"",
+        "-o",
+        "__debug_test",
+        "./pkg/..."
+      ]
+    },
+    "program": "${ZED_WORKTREE_ROOT}/__debug_test",
+    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"],
+    "cwd": "${ZED_WORKTREE_ROOT}"
+  }
+]
+```
+
+##### Multiple Tag Configurations
+
+You can create different debug configurations for different tag combinations:
+
+```json
+[
+  {
+    "label": "Debug Unit Tests",
+    "adapter": "Delve",
+    "build": {
+      "command": "go",
+      "args": [
+        "test",
+        "-c",
+        "-tags",
+        "unit",
+        "-gcflags\"all=-N -l\"",
+        "-o",
+        "__debug_unit",
+        "./pkg/..."
+      ]
+    },
+    "program": "${ZED_WORKTREE_ROOT}/__debug_unit",
+    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
+  },
+  {
+    "label": "Debug Integration Tests",
+    "adapter": "Delve",
+    "build": {
+      "command": "go",
+      "args": [
+        "test",
+        "-c",
+        "-tags",
+        "integration",
+        "-gcflags",
+        "all=-N -l",
+        "-o",
+        "__debug_integration",
+        "./pkg/..."
+      ]
+    },
+    "program": "${ZED_WORKTREE_ROOT}/__debug_integration",
+    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
+  }
+]
+```
+
+**Important Build Arguments for Go:**
+
+- `-c`: Compile the test binary but don't run it
+- `-gcflags "all=-N -l"`: Disable optimizations for better debugging experience
+- `-o <filename>`: Specify output binary name (use different names for different tag configurations)
+- `-tags <taglist>`: Comma-separated list of build tags
+
 ## Breakpoints
 
 To set a breakpoint, simply click next to the line number in the editor gutter.


### PR DESCRIPTION
Add support and document the way to debug tests with go tags.
![Kapture 2025-06-05 at 23 33 41](https://github.com/user-attachments/assets/ee69544d-edec-4237-a0bd-b1644d848e99)


Release Notes:

- Support go tags when debugging go tests 


PS. To be honest what causes tests to fail. They seem to be unrelated to my change.