### PR TITLE
x11: Remove logs for mac-os specific `set_edited` and `show_character_palette`

### DIFF
--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -1322,19 +1322,11 @@ impl PlatformWindow for X11Window {
         Ok(())
     }
 
-    fn set_edited(&mut self, _edited: bool) {
-        log::info!("ignoring macOS specific set_edited");
-    }
-
     fn set_background_appearance(&self, background_appearance: WindowBackgroundAppearance) {
         let mut state = self.0.state.borrow_mut();
         state.background_appearance = background_appearance;
         let transparent = state.is_transparent();
         state.renderer.update_transparency(transparent);
-    }
-
-    fn show_character_palette(&self) {
-        log::info!("ignoring macOS specific show_character_palette");
     }
 
     fn minimize(&self) {


### PR DESCRIPTION
Release Notes:

- N/A