### PR TITLE
Initialize zlog default filters on init rather than waiting for settings load

### DIFF
--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -90,10 +90,6 @@ pub fn is_scope_enabled(scope: &Scope, module_path: Option<&str>, level: log::Le
     };
 }
 
-pub(crate) fn refresh() {
-    refresh_from_settings(&HashMap::default());
-}
-
 pub fn refresh_from_settings(settings: &HashMap<String, String>) {
     let env_config = ENV_FILTER.get();
     let map_new = ScopeMap::new_from_settings_and_env(settings, env_config, DEFAULT_FILTERS);

--- a/crates/zlog/src/filter.rs
+++ b/crates/zlog/src/filter.rs
@@ -38,11 +38,11 @@ pub static LEVEL_ENABLED_MAX_CONFIG: AtomicU8 = AtomicU8::new(LEVEL_ENABLED_MAX_
 
 const DEFAULT_FILTERS: &[(&str, log::LevelFilter)] = &[
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
-    ("zbus", log::LevelFilter::Off),
+    ("zbus", log::LevelFilter::Warn),
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
-    ("blade_graphics", log::LevelFilter::Off),
+    ("blade_graphics", log::LevelFilter::Warn),
     #[cfg(any(target_os = "linux", target_os = "freebsd", target_os = "windows"))]
-    ("naga::back::spv::writer", log::LevelFilter::Off),
+    ("naga::back::spv::writer", log::LevelFilter::Warn),
 ];
 
 pub fn init_env_filter(filter: env_config::EnvFilter) {


### PR DESCRIPTION
Now immediately initializes the zlog filter even when there isn't an env config.  Before this change the default filters were applied after settings load - I was seeing some `zbus` logs on init.

Also defaults to allowing warnings and errors from the suppressed log sources.  If these turn out to be chatty (they don't seem to be so far), can bring back more suppression.

Release Notes:

- N/A