### PR TITLE
Add `crates/assistant_tools/src/evals/fixtures` to file_scan_exclusions

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -47,6 +47,7 @@
   "remove_trailing_whitespace_on_save": true,
   "ensure_final_newline_on_save": true,
   "file_scan_exclusions": [
+    "crates/assistant_tools/src/evals/fixtures",
     "crates/eval/worktrees/",
     "crates/eval/repos/",
     "**/.git",


### PR DESCRIPTION
Particularly got tired of `disable_cursor_blinking/before.rs` (an old copy of `editor.rs`) showing up in tons of searches

Release Notes:

- N/A