### PR TITLE
Fix `bindings_for_action` handling of shadowed key bindings

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2261,24 +2261,13 @@ impl Editor {
             window.bindings_for_action_in_context(&AcceptEditPrediction, key_context)
         };
 
-        AcceptEditPredictionBinding(
-            bindings
-                .into_iter()
-                .filter(|binding| {
-                    !in_conflict
-                        || binding
-                            .keystrokes()
-                            .first()
-                            .map_or(false, |keystroke| keystroke.modifiers.modified())
-                })
-                .rev()
-                .min_by_key(|binding| {
-                    binding
-                        .keystrokes()
-                        .first()
-                        .map_or(u8::MAX, |k| k.modifiers.number_of_modifiers())
-                }),
-        )
+        AcceptEditPredictionBinding(bindings.into_iter().rev().find(|binding| {
+            !in_conflict
+                || binding
+                    .keystrokes()
+                    .first()
+                    .map_or(false, |keystroke| keystroke.modifiers.modified())
+        }))
     }
 
     pub fn new_file(

--- a/crates/gpui/src/key_dispatch.rs
+++ b/crates/gpui/src/key_dispatch.rs
@@ -50,8 +50,8 @@
 ///  KeyBinding::new("cmd-k left", pane::SplitLeft, Some("Pane"))
 ///
 use crate::{
-    Action, ActionRegistry, App, DispatchPhase, EntityId, FocusId, KeyBinding, KeyContext, Keymap,
-    Keystroke, ModifiersChangedEvent, Window,
+    Action, ActionRegistry, App, BindingIndex, DispatchPhase, EntityId, FocusId, KeyBinding,
+    KeyContext, Keymap, Keystroke, ModifiersChangedEvent, Window,
 };
 use collections::FxHashMap;
 use smallvec::SmallVec;
@@ -392,20 +392,65 @@ impl DispatchTree {
 
     /// Returns key bindings that invoke an action on the currently focused element. Bindings are
     /// returned in the order they were added. For display, the last binding should take precedence.
+    ///
+    /// Bindings are only included if they are the highest precedence match for their keystrokes, so
+    /// shadowed bindings are not included.
     pub fn bindings_for_action(
         &self,
         action: &dyn Action,
         context_stack: &[KeyContext],
     ) -> Vec<KeyBinding> {
+        // Ideally this would return a `DoubleEndedIterator` to avoid `highest_precedence_*`
+        // methods, but this can't be done very cleanly since keymap must be borrowed.
         let keymap = self.keymap.borrow();
         keymap
-            .bindings_for_action(action)
-            .filter(|binding| {
-                let (bindings, _) = keymap.bindings_for_input(&binding.keystrokes, context_stack);
-                bindings.iter().any(|b| b.action.partial_eq(action))
+            .bindings_for_action_with_indices(action)
+            .filter(|(binding_index, binding)| {
+                Self::binding_matches_predicate_and_not_shadowed(
+                    &keymap,
+                    *binding_index,
+                    &binding.keystrokes,
+                    context_stack,
+                )
             })
-            .cloned()
+            .map(|(_, binding)| binding.clone())
             .collect()
+    }
+
+    /// Returns the highest precedence binding for the given action and context stack. This is the
+    /// same as the last result of `bindings_for_action`, but more efficient than getting all bindings.
+    pub fn highest_precedence_binding_for_action(
+        &self,
+        action: &dyn Action,
+        context_stack: &[KeyContext],
+    ) -> Option<KeyBinding> {
+        let keymap = self.keymap.borrow();
+        keymap
+            .bindings_for_action_with_indices(action)
+            .rev()
+            .find_map(|(binding_index, binding)| {
+                let found = Self::binding_matches_predicate_and_not_shadowed(
+                    &keymap,
+                    binding_index,
+                    &binding.keystrokes,
+                    context_stack,
+                );
+                if found { Some(binding.clone()) } else { None }
+            })
+    }
+
+    fn binding_matches_predicate_and_not_shadowed(
+        keymap: &Keymap,
+        binding_index: BindingIndex,
+        keystrokes: &[Keystroke],
+        context_stack: &[KeyContext],
+    ) -> bool {
+        let (bindings, _) = keymap.bindings_for_input_with_indices(&keystrokes, context_stack);
+        if let Some((highest_precedence_index, _)) = bindings.iter().next() {
+            binding_index == *highest_precedence_index
+        } else {
+            false
+        }
     }
 
     fn bindings_for_input(

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -315,6 +315,9 @@ impl MacPlatform {
                     action,
                     os_action,
                 } => {
+                    // Note that this is intentionally using earlier bindings, whereas typically
+                    // later ones take display precedence. See the discussion on
+                    // https://github.com/zed-industries/zed/issues/23621
                     let keystrokes = keymap
                         .bindings_for_action(action.as_ref())
                         .find_or_first(|binding| {

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -35,8 +35,7 @@ impl KeyBinding {
         if let Some(focused) = window.focused(cx) {
             return Self::for_action_in(action, &focused, window, cx);
         }
-        let key_binding =
-            gpui::Keymap::binding_to_display_from_bindings(window.bindings_for_action(action))?;
+        let key_binding = window.highest_precedence_binding_for_action(action)?;
         Some(Self::new(key_binding, cx))
     }
 
@@ -47,9 +46,7 @@ impl KeyBinding {
         window: &mut Window,
         cx: &App,
     ) -> Option<Self> {
-        let key_binding = gpui::Keymap::binding_to_display_from_bindings(
-            window.bindings_for_action_in(action, focus),
-        )?;
+        let key_binding = window.highest_precedence_binding_for_action_in(action, focus)?;
         Some(Self::new(key_binding, cx))
     }
 
@@ -355,8 +352,7 @@ impl KeyIcon {
 
 /// Returns a textual representation of the key binding for the given [`Action`].
 pub fn text_for_action(action: &dyn Action, window: &Window, cx: &App) -> Option<String> {
-    let bindings = window.bindings_for_action(action);
-    let key_binding = bindings.last()?;
+    let key_binding = window.highest_precedence_binding_for_action(action)?;
     Some(text_for_keystrokes(key_binding.keystrokes(), cx))
 }
 


### PR DESCRIPTION
Fixes two things:

* ~3 months ago [in PR #26420](https://github.com/zed-industries/zed/pull/26420/files#diff-33b58aa2da03d791c2c4761af6012851b7400e348922d64babe5fd48ac2a8e60) `bindings_for_action` was changed to return bindings even when they are shadowed (when the keystrokes would actually do something else).

* For edit prediction keybindings there was some odd behavior where bindings for `edit_prediction_conflict` were taking precedence over bindings for `edit_prediction` even when the `edit_prediction_conflict` predicate didn't match. The workaround for this was #24812. The way it worked was:

    - List all bindings for the action

    - For each binding, get the highest precedence binding with the same input sequence

    - If the highest precedence binding has the same action, include this binding. This was the bug - this meant that if a binding in the keymap has the same keystrokes and action it can incorrectly take display precedence even if its context predicate does not pass.

    - Fix is to check that the highest precedence binding is a full match.  To do this efficiently, it's based on an index within the keymap bindings.

Also adds `highest_precedence_binding_*` variants which avoid the inefficiency of building lists of bindings just to use the last.

Release Notes:

- Fixed display of keybindings to skip bindings that are shadowed by a binding that uses the same keystrokes.
- Fixed display of `editor::AcceptEditPrediction` bindings to use the normal precedence that prioritizes user bindings.