### PR TITLE
debugger: Use Delve to build Go binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12118,7 +12118,6 @@ dependencies = [
  "unindent",
  "url",
  "util",
- "uuid",
  "which 6.0.3",
  "workspace-hack",
  "worktree",

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -82,7 +82,6 @@ text.workspace = true
 toml.workspace = true
 url.workspace = true
 util.workspace = true
-uuid.workspace = true
 which.workspace = true
 worktree.workspace = true
 zlog.workspace = true

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -111,6 +111,7 @@ impl DapLocator for GoLocator {
                 let mut next_arg_is_test = false;
                 let mut next_arg_is_build = false;
                 let mut seen_pkg = false;
+                let mut seen_v = false;
 
                 for arg in build_config.args.iter().skip(1) {
                     if all_args_are_test || next_arg_is_test {
@@ -133,6 +134,9 @@ impl DapLocator for GoLocator {
                         if flag == "args" {
                             all_args_are_test = true;
                         } else if let Some(has_arg) = is_debug_flag(flag) {
+                            if flag == "v" || flag == "test.v" {
+                                seen_v = true;
+                            }
                             if flag.starts_with("test.") {
                                 args.push(arg.clone());
                             } else {
@@ -149,6 +153,9 @@ impl DapLocator for GoLocator {
                     } else {
                         args.push(arg.clone());
                     }
+                }
+                if !seen_v {
+                    args.push("-test.v".to_string());
                 }
 
                 let config: serde_json::Value = serde_json::to_value(DelveLaunchRequest {
@@ -376,7 +383,11 @@ mod tests {
                 mode: "test".to_string(),
                 program: ".".to_string(),
                 build_flags: vec!["-tags".to_string(), "integration,unit".to_string(),],
-                args: vec!["-test.run".to_string(), "Foo".to_string()],
+                args: vec![
+                    "-test.run".to_string(),
+                    "Foo".to_string(),
+                    "-test.v".to_string()
+                ],
                 env: HashMap::default(),
                 cwd: None,
             }

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -12,6 +12,24 @@ use uuid::Uuid;
 
 pub(crate) struct GoLocator;
 
+impl GoLocator {
+    fn get_build_tags(&self, build_config: &TaskTemplate) -> Vec<String> {
+        let mut tags = Vec::new();
+        let mut i = 0;
+        let args = &build_config.args;
+        while i < args.len() {
+            if args[i] == "-tags" && i + 1 < args.len() {
+                tags.push("-tags".to_string());
+                tags.push(args[i + 1].clone());
+                i += 2;
+            } else {
+                i += 1;
+            }
+        }
+        tags
+    }
+}
+
 #[async_trait]
 impl DapLocator for GoLocator {
     fn name(&self) -> SharedString {
@@ -33,17 +51,20 @@ impl DapLocator for GoLocator {
         match go_action.as_str() {
             "test" => {
                 let binary_path = format!("__debug_{}", Uuid::new_v4().simple());
+                let build_tags = self.get_build_tags(build_config);
+
+                let mut args = vec!["test".into(), "-c".into()];
+                args.extend(build_tags);
+                args.extend(vec![
+                    "-gcflags \"all=-N -l\"".into(),
+                    "-o".into(),
+                    binary_path,
+                ]);
 
                 let build_task = TaskTemplate {
                     label: "go test debug".into(),
                     command: "go".into(),
-                    args: vec![
-                        "test".into(),
-                        "-c".into(),
-                        "-gcflags \"all=-N -l\"".into(),
-                        "-o".into(),
-                        binary_path,
-                    ],
+                    args,
                     env: build_config.env.clone(),
                     cwd: build_config.cwd.clone(),
                     use_new_terminal: false,
@@ -74,15 +95,16 @@ impl DapLocator for GoLocator {
                     .get(1)
                     .cloned()
                     .unwrap_or_else(|| ".".to_string());
+                let build_tags = self.get_build_tags(build_config);
+
+                let mut args = vec!["build".into()];
+                args.extend(build_tags);
+                args.extend(vec!["-gcflags \"all=-N -l\"".into(), program.clone()]);
 
                 let build_task = TaskTemplate {
                     label: "go build debug".into(),
                     command: "go".into(),
-                    args: vec![
-                        "build".into(),
-                        "-gcflags \"all=-N -l\"".into(),
-                        program.clone(),
-                    ],
+                    args,
                     env: build_config.env.clone(),
                     cwd: build_config.cwd.clone(),
                     use_new_terminal: false,
@@ -130,9 +152,12 @@ impl DapLocator for GoLocator {
 
         match go_action.as_str() {
             "test" => {
+                // Find the binary path after the -o flag
                 let binary_arg = build_config
                     .args
-                    .get(4)
+                    .windows(2)
+                    .find(|window| window[0] == "-o")
+                    .map(|window| &window[1])
                     .ok_or_else(|| anyhow::anyhow!("can't locate debug binary"))?;
 
                 let program = PathBuf::from(&cwd)
@@ -333,6 +358,138 @@ mod tests {
     }
 
     #[test]
+    fn test_create_scenario_for_go_test_with_tags() {
+        let locator = GoLocator;
+        let task = TaskTemplate {
+            label: "go test with tags".into(),
+            command: "go".into(),
+            args: vec![
+                "test".into(),
+                "-tags".into(),
+                "integration,e2e".into(),
+                ".".into(),
+            ],
+            env: Default::default(),
+            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+
+        let scenario =
+            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+
+        assert!(scenario.is_some());
+        let scenario = scenario.unwrap();
+
+        if let Some(BuildTaskDefinition::Template { task_template, .. }) = &scenario.build {
+            assert!(task_template.args.contains(&"test".into()));
+            assert!(task_template.args.contains(&"-c".into()));
+            assert!(task_template.args.contains(&"-tags".into()));
+            assert!(task_template.args.contains(&"integration,e2e".into()));
+            assert!(
+                task_template
+                    .args
+                    .contains(&"-gcflags \"all=-N -l\"".into())
+            );
+        } else {
+            panic!("Expected BuildTaskDefinition::Template");
+        }
+    }
+
+    #[test]
+    fn test_get_build_tags() {
+        let locator = GoLocator;
+
+        // Test with tags
+        let task_with_tags = TaskTemplate {
+            label: "test".into(),
+            command: "go".into(),
+            args: vec![
+                "test".to_string(),
+                "-tags".to_string(),
+                "integration,unit".to_string(),
+                ".".to_string(),
+            ],
+            env: FxHashMap::default(),
+            cwd: None,
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+        let tags = locator.get_build_tags(&task_with_tags);
+        assert_eq!(
+            tags,
+            vec!["-tags".to_string(), "integration,unit".to_string()]
+        );
+
+        // Test without tags
+        let task_without_tags = TaskTemplate {
+            label: "test".into(),
+            command: "go".into(),
+            args: vec!["test".to_string(), ".".to_string()],
+            env: FxHashMap::default(),
+            cwd: None,
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+        let tags = locator.get_build_tags(&task_without_tags);
+        assert!(tags.is_empty());
+
+        let task_multiple_tags = TaskTemplate {
+            label: "test".into(),
+            command: "go".into(),
+            args: vec![
+                "test".to_string(),
+                "-tags".to_string(),
+                "unit".to_string(),
+                "-tags".to_string(),
+                "integration".to_string(),
+            ],
+            env: FxHashMap::default(),
+            cwd: None,
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            tags: vec![],
+            show_summary: true,
+            show_command: true,
+        };
+        let tags = locator.get_build_tags(&task_multiple_tags);
+        assert_eq!(
+            tags,
+            vec![
+                "-tags".to_string(),
+                "unit".to_string(),
+                "-tags".to_string(),
+                "integration".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn test_create_scenario_for_go_test_with_cwd_binary() {
         let locator = GoLocator;
 
@@ -409,7 +566,7 @@ mod tests {
                 "-c".into(),
                 "-gcflags \"all=-N -l\"".into(),
                 "-o".into(),
-            ], // Missing the binary path (arg 4)
+            ], // Missing the binary path after -o
             command_label: "go test -c -gcflags \"all=-N -l\" -o".to_string(),
             env: Default::default(),
             cwd: Some(PathBuf::from("/test/path")),
@@ -432,5 +589,51 @@ mod tests {
                 .to_string()
                 .contains("can't locate debug binary")
         );
+    }
+
+    #[test]
+    fn test_run_go_test_with_tags() {
+        let locator = GoLocator;
+        let build_config = SpawnInTerminal {
+            id: TaskId("test_task".to_string()),
+            full_label: "go test".to_string(),
+            label: "go test".to_string(),
+            command: "go".into(),
+            args: vec![
+                "test".into(),
+                "-c".into(),
+                "-tags".into(),
+                "integration".into(),
+                "-gcflags \"all=-N -l\"".into(),
+                "-o".into(),
+                "__debug_binary".into(),
+            ],
+            command_label: "go test -c -tags integration -gcflags \"all=-N -l\" -o __debug_binary"
+                .to_string(),
+            env: Default::default(),
+            cwd: Some(PathBuf::from("/test/path")),
+            use_new_terminal: false,
+            allow_concurrent_runs: false,
+            reveal: RevealStrategy::Always,
+            reveal_target: RevealTarget::Dock,
+            hide: HideStrategy::Never,
+            shell: Shell::System,
+            show_summary: true,
+            show_command: true,
+            show_rerun: true,
+        };
+
+        let result = futures::executor::block_on(locator.run(build_config));
+        assert!(result.is_ok());
+
+        if let Ok(DebugRequest::Launch(launch_request)) = result {
+            assert!(launch_request.program.ends_with("__debug_binary"));
+            assert_eq!(
+                launch_request.args,
+                vec!["-test.v".to_string(), "-test.run=${ZED_SYMBOL}".to_string()]
+            );
+        } else {
+            panic!("Expected LaunchRequest");
+        }
     }
 }

--- a/crates/project/src/debugger/locators/go.rs
+++ b/crates/project/src/debugger/locators/go.rs
@@ -8,7 +8,7 @@ use task::{DebugScenario, SpawnInTerminal, TaskTemplate};
 
 pub(crate) struct GoLocator;
 
-#[derive(Serialize, Deserialize, Debug)]
+#[derive(Serialize, Deserialize, Debug, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 struct DelveLaunchRequest {
     request: String,
@@ -185,10 +185,10 @@ impl DapLocator for GoLocator {
                         build_flags.push(arg.clone());
                         next_arg_is_build = false;
                     } else if arg.starts_with("-") {
-                        if let Some(has_arg) = is_build_flag(arg) {
+                        if let Some(has_arg) = is_build_flag(arg.trim_start_matches("-")) {
                             next_arg_is_build = has_arg;
                         }
-                        args.push(arg.clone())
+                        build_flags.push(arg.clone())
                     } else {
                         program = arg.to_string();
                         seen_pkg = true;
@@ -218,7 +218,7 @@ impl DapLocator for GoLocator {
         }
     }
 
-    async fn run(&self, build_config: SpawnInTerminal) -> Result<DebugRequest> {
+    async fn run(&self, _build_config: SpawnInTerminal) -> Result<DebugRequest> {
         unreachable!()
     }
 }
@@ -226,55 +226,7 @@ impl DapLocator for GoLocator {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use task::{HideStrategy, RevealStrategy, RevealTarget, Shell, TaskId, TaskTemplate};
-
-    #[test]
-    fn test_create_scenario_for_go_run() {
-        let locator = GoLocator;
-        let task = TaskTemplate {
-            label: "go run main.go".into(),
-            command: "go".into(),
-            args: vec!["run".into(), "main.go".into()],
-            env: Default::default(),
-            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
-        };
-
-        let scenario =
-            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
-
-        assert!(scenario.is_some());
-        let scenario = scenario.unwrap();
-        assert_eq!(scenario.adapter, "Delve");
-        assert_eq!(scenario.label, "test label");
-        assert!(scenario.build.is_some());
-
-        if let Some(BuildTaskDefinition::Template { task_template, .. }) = &scenario.build {
-            assert_eq!(task_template.command, "go");
-            assert!(task_template.args.contains(&"build".into()));
-            assert!(
-                task_template
-                    .args
-                    .contains(&"-gcflags \"all=-N -l\"".into())
-            );
-            assert!(task_template.args.contains(&"main.go".into()));
-        } else {
-            panic!("Expected BuildTaskDefinition::Template");
-        }
-
-        assert!(
-            scenario.config.is_null(),
-            "Initial config should be null to ensure it's invalid"
-        );
-    }
+    use task::{HideStrategy, RevealStrategy, RevealTarget, Shell, TaskTemplate};
 
     #[test]
     fn test_create_scenario_for_go_build() {
@@ -333,113 +285,71 @@ mod tests {
             locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
         assert!(scenario.is_none());
     }
-
     #[test]
-    fn test_create_scenario_for_go_test() {
+    fn test_go_locator_run() {
         let locator = GoLocator;
+        let delve = DebugAdapterName("Delve".into());
+
         let task = TaskTemplate {
-            label: "go test".into(),
+            label: "go run with flags".into(),
             command: "go".into(),
-            args: vec!["test".into(), ".".into()],
-            env: Default::default(),
-            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
+            args: vec![
+                "run".to_string(),
+                "-race".to_string(),
+                "-ldflags".to_string(),
+                "-X main.version=1.0".to_string(),
+                "./cmd/myapp".to_string(),
+                "--config".to_string(),
+                "production.yaml".to_string(),
+                "--verbose".to_string(),
+            ],
+            env: {
+                let mut env = HashMap::default();
+                env.insert("GO_ENV".to_string(), "production".to_string());
+                env
+            },
+            cwd: Some("/project/root".into()),
+            ..Default::default()
         };
 
-        let scenario =
-            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
+        let scenario = locator
+            .create_scenario(&task, "test run label", delve)
+            .unwrap();
 
-        assert!(scenario.is_some());
-        let scenario = scenario.unwrap();
-        assert_eq!(scenario.adapter, "Delve");
-        assert_eq!(scenario.label, "test label");
-        assert!(scenario.build.is_some());
+        let config: DelveLaunchRequest = serde_json::from_value(scenario.config).unwrap();
 
-        if let Some(BuildTaskDefinition::Template { task_template, .. }) = &scenario.build {
-            assert_eq!(task_template.command, "go");
-            assert!(task_template.args.contains(&"test".into()));
-            assert!(task_template.args.contains(&"-c".into()));
-            assert!(
-                task_template
-                    .args
-                    .contains(&"-gcflags \"all=-N -l\"".into())
-            );
-            assert!(task_template.args.contains(&"-o".into()));
-            assert!(
-                task_template
-                    .args
-                    .iter()
-                    .any(|arg| arg.starts_with("__debug_"))
-            );
-        } else {
-            panic!("Expected BuildTaskDefinition::Template");
-        }
-
-        assert!(
-            scenario.config.is_null(),
-            "Initial config should be null to ensure it's invalid"
+        assert_eq!(
+            config,
+            DelveLaunchRequest {
+                request: "launch".to_string(),
+                mode: "debug".to_string(),
+                program: "./cmd/myapp".to_string(),
+                build_flags: vec![
+                    "-race".to_string(),
+                    "-ldflags".to_string(),
+                    "-X main.version=1.0".to_string()
+                ],
+                args: vec![
+                    "--config".to_string(),
+                    "production.yaml".to_string(),
+                    "--verbose".to_string(),
+                ],
+                env: {
+                    let mut env = HashMap::default();
+                    env.insert("GO_ENV".to_string(), "production".to_string());
+                    env
+                },
+                cwd: Some("/project/root".to_string()),
+            }
         );
     }
 
     #[test]
-    fn test_create_scenario_for_go_test_with_tags() {
+    fn test_go_locator_test() {
         let locator = GoLocator;
-        let task = TaskTemplate {
-            label: "go test with tags".into(),
-            command: "go".into(),
-            args: vec![
-                "test".into(),
-                "-tags".into(),
-                "integration,e2e".into(),
-                ".".into(),
-            ],
-            env: Default::default(),
-            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
-        };
+        let delve = DebugAdapterName("Delve".into());
 
-        let scenario =
-            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
-
-        assert!(scenario.is_some());
-        let scenario = scenario.unwrap();
-
-        if let Some(BuildTaskDefinition::Template { task_template, .. }) = &scenario.build {
-            assert!(task_template.args.contains(&"test".into()));
-            assert!(task_template.args.contains(&"-c".into()));
-            assert!(task_template.args.contains(&"-tags".into()));
-            assert!(task_template.args.contains(&"integration,e2e".into()));
-            assert!(
-                task_template
-                    .args
-                    .contains(&"-gcflags \"all=-N -l\"".into())
-            );
-        } else {
-            panic!("Expected BuildTaskDefinition::Template");
-        }
-    }
-
-    #[test]
-    fn test_get_build_tags() {
-        let locator = GoLocator;
-
-        // Test with tags
+        // Test with tags and run flag
         let task_with_tags = TaskTemplate {
             label: "test".into(),
             command: "go".into(),
@@ -447,117 +357,30 @@ mod tests {
                 "test".to_string(),
                 "-tags".to_string(),
                 "integration,unit".to_string(),
+                "-run".to_string(),
+                "Foo".to_string(),
                 ".".to_string(),
             ],
-            env: FxHashMap::default(),
-            cwd: None,
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
+            ..Default::default()
         };
-        let tags = locator.get_build_tags(&task_with_tags);
+        let result = locator
+            .create_scenario(&task_with_tags, "", delve.clone())
+            .unwrap();
+
+        let config: DelveLaunchRequest = serde_json::from_value(result.config).unwrap();
+
         assert_eq!(
-            tags,
-            vec!["-tags".to_string(), "integration,unit".to_string()]
+            config,
+            DelveLaunchRequest {
+                request: "launch".to_string(),
+                mode: "test".to_string(),
+                program: ".".to_string(),
+                build_flags: vec!["-tags".to_string(), "integration,unit".to_string(),],
+                args: vec!["-test.run".to_string(), "Foo".to_string()],
+                env: HashMap::default(),
+                cwd: None,
+            }
         );
-
-        // Test without tags
-        let task_without_tags = TaskTemplate {
-            label: "test".into(),
-            command: "go".into(),
-            args: vec!["test".to_string(), ".".to_string()],
-            env: FxHashMap::default(),
-            cwd: None,
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
-        };
-        let tags = locator.get_build_tags(&task_without_tags);
-        assert!(tags.is_empty());
-
-        let task_multiple_tags = TaskTemplate {
-            label: "test".into(),
-            command: "go".into(),
-            args: vec![
-                "test".to_string(),
-                "-tags".to_string(),
-                "unit".to_string(),
-                "-tags".to_string(),
-                "integration".to_string(),
-            ],
-            env: FxHashMap::default(),
-            cwd: None,
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
-        };
-        let tags = locator.get_build_tags(&task_multiple_tags);
-        assert_eq!(
-            tags,
-            vec![
-                "-tags".to_string(),
-                "unit".to_string(),
-                "-tags".to_string(),
-                "integration".to_string()
-            ]
-        );
-    }
-
-    #[test]
-    fn test_create_scenario_for_go_test_with_cwd_binary() {
-        let locator = GoLocator;
-
-        let task = TaskTemplate {
-            label: "go test".into(),
-            command: "go".into(),
-            args: vec!["test".into(), ".".into()],
-            env: Default::default(),
-            cwd: Some("${ZED_WORKTREE_ROOT}".into()),
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            tags: vec![],
-            show_summary: true,
-            show_command: true,
-        };
-
-        let scenario =
-            locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
-
-        assert!(scenario.is_some());
-        let scenario = scenario.unwrap();
-
-        if let Some(BuildTaskDefinition::Template { task_template, .. }) = &scenario.build {
-            assert!(
-                task_template
-                    .args
-                    .iter()
-                    .any(|arg| arg.starts_with("__debug_"))
-            );
-        } else {
-            panic!("Expected BuildTaskDefinition::Template");
-        }
     }
 
     #[test]
@@ -583,89 +406,5 @@ mod tests {
         let scenario =
             locator.create_scenario(&task, "test label", DebugAdapterName("Delve".into()));
         assert!(scenario.is_none());
-    }
-
-    #[test]
-    fn test_run_go_test_missing_binary_path() {
-        let locator = GoLocator;
-        let build_config = SpawnInTerminal {
-            id: TaskId("test_task".to_string()),
-            full_label: "go test".to_string(),
-            label: "go test".to_string(),
-            command: "go".into(),
-            args: vec![
-                "test".into(),
-                "-c".into(),
-                "-gcflags \"all=-N -l\"".into(),
-                "-o".into(),
-            ], // Missing the binary path after -o
-            command_label: "go test -c -gcflags \"all=-N -l\" -o".to_string(),
-            env: Default::default(),
-            cwd: Some(PathBuf::from("/test/path")),
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            show_summary: true,
-            show_command: true,
-            show_rerun: true,
-        };
-
-        let result = futures::executor::block_on(locator.run(build_config));
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("can't locate debug binary")
-        );
-    }
-
-    #[test]
-    fn test_run_go_test_with_tags() {
-        let locator = GoLocator;
-        let build_config = SpawnInTerminal {
-            id: TaskId("test_task".to_string()),
-            full_label: "go test".to_string(),
-            label: "go test".to_string(),
-            command: "go".into(),
-            args: vec![
-                "test".into(),
-                "-c".into(),
-                "-tags".into(),
-                "integration".into(),
-                "-gcflags \"all=-N -l\"".into(),
-                "-o".into(),
-                "__debug_binary".into(),
-            ],
-            command_label: "go test -c -tags integration -gcflags \"all=-N -l\" -o __debug_binary"
-                .to_string(),
-            env: Default::default(),
-            cwd: Some(PathBuf::from("/test/path")),
-            use_new_terminal: false,
-            allow_concurrent_runs: false,
-            reveal: RevealStrategy::Always,
-            reveal_target: RevealTarget::Dock,
-            hide: HideStrategy::Never,
-            shell: Shell::System,
-            show_summary: true,
-            show_command: true,
-            show_rerun: true,
-        };
-
-        let result = futures::executor::block_on(locator.run(build_config));
-        assert!(result.is_ok());
-
-        if let Ok(DebugRequest::Launch(launch_request)) = result {
-            assert!(launch_request.program.ends_with("__debug_binary"));
-            assert_eq!(
-                launch_request.args,
-                vec!["-test.v".to_string(), "-test.run=${ZED_SYMBOL}".to_string()]
-            );
-        } else {
-            panic!("Expected LaunchRequest");
-        }
     }
 }

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -264,7 +264,7 @@ Given an externally-ran web server (e.g. with `npx serve` or `npx live-server`) 
 #### Go
 
 Zed uses [delve](https://github.com/go-delve/delve?tab=readme-ov-file) to debug Go applications. Zed will automatically create debug scenarios for `func main` in your main packages, and also
-for any tests, so you can use the Play button in the gutter to debug these without configuration.
+for any tests, so you can use the Play button in the gutter to debug these without configuration. We do not yet support attaching to an existing running copy of delve.
 
 ##### Debug Go Packages
 
@@ -329,6 +329,29 @@ and the "build" command should build that.
       "__debug_unit",
       "./pkg/..."
     ]
+  }
+}
+```
+
+### Ruby
+
+To run a ruby task in the debugger, you will need to configure it in the `.zed/debug.json` file in your project. We don't yet have automatic detection of ruby tasks, nor do we support connecting to an existing process.
+
+The configuration should look like this:
+
+```json
+{
+  {
+    "adapter": "Ruby",
+    "label": "Run CLI",
+    "script": "cli.rb"
+    // If you want to customize how the script is run (for example using bundle exec)
+    // use "command" instead.
+    // "command": "bundle exec cli.rb"
+    //
+    // "args": []
+    // "env": {}
+    // "cwd": ""
   }
 }
 ```

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -274,8 +274,8 @@ To debug a specific package, you can do so by setting the Delve mode to "debug".
 [
   {
     "label": "Run server",
-    "request": "launch",
     "adapter": "Delve",
+    "request": "launch",
     "mode": "debug",
     // For Delve, the program is the package name
     "program": "./cmd/server"
@@ -293,8 +293,8 @@ To debug the tests for a package, set the Delve mode to "test". The "program" is
 [
   {
     "label": "Run integration tests",
-    "request": "launch",
     "adapter": "Delve",
+    "request": "launch",
     "mode": "test",
     "program": ".",
     "buildFlags": ["-tags", "integration"]
@@ -313,6 +313,10 @@ and the "build" command should build that.
 {
   "label": "Debug Prebuilt Unit Tests",
   "adapter": "Delve",
+  "request": "launch",
+  "mode": "exec",
+  "program": "${ZED_WORKTREE_ROOT}/__debug_unit",
+  "args": ["-test.v", "-test.run=${ZED_SYMBOL}"],
   "build": {
     "command": "go",
     "args": [
@@ -325,9 +329,7 @@ and the "build" command should build that.
       "__debug_unit",
       "./pkg/..."
     ]
-  },
-  "program": "${ZED_WORKTREE_ROOT}/__debug_unit",
-  "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
+  }
 }
 ```
 

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -261,6 +261,93 @@ Given an externally-ran web server (e.g. with `npx serve` or `npx live-server`) 
 ]
 ```
 
+#### Go
+
+##### Debug Go Tests with Build Tags
+
+Go build tags (build constraints) allow conditional compilation of code. When debugging Go applications or tests that require specific build tags, you can configure them in your debug scenarios:
+
+```json
+[
+  {
+    "label": "Debug Go Test with Integration Tags",
+    "adapter": "Delve",
+    "build": {
+      "label": "Build Go Test with Tags",
+      "command": "go",
+      "args": [
+        "test",
+        "-c",
+        "-tags",
+        "integration",
+        "-gcflags=\"all=-N -l\"",
+        "-o",
+        "__debug_test",
+        "./pkg/..."
+      ]
+    },
+    "program": "${ZED_WORKTREE_ROOT}/__debug_test",
+    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"],
+    "cwd": "${ZED_WORKTREE_ROOT}"
+  }
+]
+```
+
+##### Multiple Tag Configurations
+
+You can create different debug configurations for different tag combinations:
+
+```json
+[
+  {
+    "label": "Debug Unit Tests",
+    "adapter": "Delve",
+    "build": {
+      "command": "go",
+      "args": [
+        "test",
+        "-c",
+        "-tags",
+        "unit",
+        "-gcflags\"all=-N -l\"",
+        "-o",
+        "__debug_unit",
+        "./pkg/..."
+      ]
+    },
+    "program": "${ZED_WORKTREE_ROOT}/__debug_unit",
+    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
+  },
+  {
+    "label": "Debug Integration Tests",
+    "adapter": "Delve",
+    "build": {
+      "command": "go",
+      "args": [
+        "test",
+        "-c",
+        "-tags",
+        "integration",
+        "-gcflags",
+        "all=-N -l",
+        "-o",
+        "__debug_integration",
+        "./pkg/..."
+      ]
+    },
+    "program": "${ZED_WORKTREE_ROOT}/__debug_integration",
+    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
+  }
+]
+```
+
+**Important Build Arguments for Go:**
+
+- `-c`: Compile the test binary but don't run it
+- `-gcflags "all=-N -l"`: Disable optimizations for better debugging experience
+- `-o <filename>`: Specify output binary name (use different names for different tag configurations)
+- `-tags <taglist>`: Comma-separated list of build tags
+
 ## Breakpoints
 
 To set a breakpoint, simply click next to the line number in the editor gutter.

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -278,7 +278,7 @@ To debug a specific package, you can do so by setting the Delve mode to "debug".
     "adapter": "Delve",
     "mode": "debug",
     // For Delve, the program is the package name
-    "program": "./cmd/server",
+    "program": "./cmd/server"
     // "args": [],
     // "buildFlags": [],
   }
@@ -288,6 +288,7 @@ To debug a specific package, you can do so by setting the Delve mode to "debug".
 ##### Debug Go Tests
 
 To debug the tests for a package, set the Delve mode to "test". The "program" is still the package name, and you can use the "buildFlags" to do things like set tags, and the "args" to set args on the test binary. (See `go help testflags` for more information on doing that).
+
 ```json
 [
   {
@@ -296,13 +297,12 @@ To debug the tests for a package, set the Delve mode to "test". The "program" is
     "adapter": "Delve",
     "mode": "test",
     "program": ".",
-    "buildFlags": ["-tags", "integration"],
+    "buildFlags": ["-tags", "integration"]
     // To filter down to just the test your cursor is in:
     // "args": ["-test.run", "$ZED_SYMBOL"]
   }
 ]
 ```
-
 
 ##### Build and debug separately
 
@@ -310,25 +310,25 @@ If you need to build your application with a specific command, you can use the "
 and the "build" command should build that.
 
 ```json
-  {
-    "label": "Debug Prebuilt Unit Tests",
-    "adapter": "Delve",
-    "build": {
-      "command": "go",
-      "args": [
-        "test",
-        "-c",
-        "-tags",
-        "unit",
-        "-gcflags\"all=-N -l\"",
-        "-o",
-        "__debug_unit",
-        "./pkg/..."
-      ]
-    },
-    "program": "${ZED_WORKTREE_ROOT}/__debug_unit",
-    "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
-  }
+{
+  "label": "Debug Prebuilt Unit Tests",
+  "adapter": "Delve",
+  "build": {
+    "command": "go",
+    "args": [
+      "test",
+      "-c",
+      "-tags",
+      "unit",
+      "-gcflags\"all=-N -l\"",
+      "-o",
+      "__debug_unit",
+      "./pkg/..."
+    ]
+  },
+  "program": "${ZED_WORKTREE_ROOT}/__debug_unit",
+  "args": ["-test.v", "-test.run=${ZED_SYMBOL}"]
+}
 ```
 
 ## Breakpoints

--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -263,7 +263,8 @@ Given an externally-ran web server (e.g. with `npx serve` or `npx live-server`) 
 
 #### Go
 
-Zed uses [delve](https://github.com/go-delve/delve?tab=readme-ov-file) to debug Go applications. By default Zed will detect tasks of the form `go run ...` or `go test ...` and automatically convert those to the appropriate debug configuration for Delve.
+Zed uses [delve](https://github.com/go-delve/delve?tab=readme-ov-file) to debug Go applications. Zed will automatically create debug scenarios for `func main` in your main packages, and also
+for any tests, so you can use the Play button in the gutter to debug these without configuration.
 
 ##### Debug Go Packages
 


### PR DESCRIPTION
Release Notes:

- debugger: Use delve to build go debug executables, and pass arguments through.
