### PR TITLE
Move workspace::toast_layer::RunAction to zed_actions::toast::RunAction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10206,6 +10206,7 @@ dependencies = [
  "util",
  "workspace",
  "workspace-hack",
+ "zed_actions",
 ]
 
 [[package]]

--- a/crates/notifications/Cargo.toml
+++ b/crates/notifications/Cargo.toml
@@ -35,6 +35,7 @@ ui.workspace = true
 util.workspace = true
 workspace.workspace = true
 workspace-hack.workspace = true
+zed_actions.workspace = true
 
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }

--- a/crates/notifications/src/status_toast.rs
+++ b/crates/notifications/src/status_toast.rs
@@ -3,6 +3,7 @@ use std::rc::Rc;
 use gpui::{DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, IntoElement};
 use ui::{Tooltip, prelude::*};
 use workspace::{ToastAction, ToastView};
+use zed_actions::toast;
 
 #[derive(Clone, Copy)]
 pub struct ToastIcon {
@@ -109,7 +110,7 @@ impl Render for StatusToast {
                     Button::new(action.id.clone(), action.label.clone())
                         .tooltip(Tooltip::for_action_title(
                             action.label.clone(),
-                            &workspace::RunAction,
+                            &toast::RunAction,
                         ))
                         .color(Color::Muted)
                         .when_some(action.on_click.clone(), |el, handler| {

--- a/crates/workspace/src/toast_layer.rs
+++ b/crates/workspace/src/toast_layer.rs
@@ -3,19 +3,18 @@ use std::{
     time::{Duration, Instant},
 };
 
-use gpui::{AnyView, DismissEvent, Entity, FocusHandle, ManagedView, Subscription, Task, actions};
+use gpui::{AnyView, DismissEvent, Entity, FocusHandle, ManagedView, Subscription, Task};
 use ui::{animation::DefaultAnimations, prelude::*};
+use zed_actions::toast;
 
 use crate::Workspace;
 
 const DEFAULT_TOAST_DURATION: Duration = Duration::from_secs(10);
 const MINIMUM_RESUME_DURATION: Duration = Duration::from_millis(800);
 
-actions!(toast, [RunAction]);
-
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
-        workspace.register_action(|_workspace, _: &RunAction, window, cx| {
+        workspace.register_action(|_workspace, _: &toast::RunAction, window, cx| {
             let workspace = cx.entity();
             let window = window.window_handle();
             cx.defer(move |cx| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -15,7 +15,7 @@ mod toast_layer;
 mod toolbar;
 mod workspace_settings;
 
-pub use toast_layer::{RunAction, ToastAction, ToastLayer, ToastView};
+pub use toast_layer::{ToastAction, ToastLayer, ToastView};
 
 use anyhow::{Context as _, Result, anyhow};
 use call::{ActiveCall, call_settings::CallSettings};

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -154,6 +154,12 @@ pub mod jj {
     actions!(jj, [BookmarkList]);
 }
 
+pub mod toast {
+    use gpui::actions;
+
+    actions!(toast, [RunAction]);
+}
+
 pub mod command_palette {
     use gpui::actions;
 


### PR DESCRIPTION
Cleaner to have references to this be `toast::RunAction` matching how it appears in the keymap, instead of `workspace::RunAction`.

Release Notes:

- N/A