### PR TITLE
Enable cross-region inference for Claude 4 family models on Amazon Bedrock provider

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -452,6 +452,10 @@ impl Model {
                 | Model::Claude3_5SonnetV2
                 | Model::Claude3_7Sonnet
                 | Model::Claude3_7SonnetThinking
+                | Model::ClaudeSonnet4
+                | Model::ClaudeSonnet4Thinking
+                | Model::ClaudeOpus4
+                | Model::ClaudeOpus4Thinking
                 | Model::Claude3Haiku
                 | Model::Claude3Opus
                 | Model::Claude3Sonnet


### PR DESCRIPTION
These models require cross-region inference, and it currently fails if you try to use them:
```
Invocation of model ID anthropic.claude-sonnet-4-20250514-v1:0 with on-demand throughput isn’t supported. 
```

Release Notes:

- Enable cross-region inference for Claude 4 family models on Amazon Bedrock provider