### PR TITLE
Pull diagnostics fixes

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1034,9 +1034,14 @@
     "button": true,
     // Whether to show warnings or not by default.
     "include_warnings": true,
-    // Minimum time to wait before pulling diagnostics from the language server(s).
-    // 0 turns the debounce off, `null` disables the feature.
-    "lsp_pull_diagnostics_debounce_ms": 50,
+    // Settings for using LSP pull diagnostics mechanism in Zed.
+    "lsp_pull_diagnostics": {
+      // Whether to pull for diagnostics or not.
+      "enabled": true,
+      // Minimum time to wait before pulling diagnostics from the language server(s).
+      // 0 turns the debounce off.
+      "debounce_ms": 50
+    },
     // Settings for inline diagnostics
     "inline": {
       // Whether to show diagnostics inline or not

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -356,7 +356,7 @@ impl Server {
             .add_message_handler(broadcast_project_message_from_host::<proto::BufferSaved>)
             .add_message_handler(broadcast_project_message_from_host::<proto::UpdateDiffBases>)
             .add_message_handler(
-                broadcast_project_message_from_host::<proto::RefreshDocumentsDiagnostics>,
+                broadcast_project_message_from_host::<proto::PullWorkspaceDiagnostics>,
             )
             .add_request_handler(get_users)
             .add_request_handler(fuzzy_search_users)

--- a/crates/diagnostics/src/diagnostics_tests.rs
+++ b/crates/diagnostics/src/diagnostics_tests.rs
@@ -105,7 +105,7 @@ async fn test_diagnostics(cx: &mut TestAppContext) {
             }
             ],
             version: None
-        }, DiagnosticSourceKind::Pushed, &[], cx).unwrap();
+        }, None, DiagnosticSourceKind::Pushed, &[], cx).unwrap();
     });
 
     // Open the project diagnostics view while there are already diagnostics.
@@ -176,6 +176,7 @@ async fn test_diagnostics(cx: &mut TestAppContext) {
                     }],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -262,6 +263,7 @@ async fn test_diagnostics(cx: &mut TestAppContext) {
                     ],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -370,6 +372,7 @@ async fn test_diagnostics_with_folds(cx: &mut TestAppContext) {
                     }],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -468,6 +471,7 @@ async fn test_diagnostics_multiple_servers(cx: &mut TestAppContext) {
                     }],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -511,6 +515,7 @@ async fn test_diagnostics_multiple_servers(cx: &mut TestAppContext) {
                     }],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -553,6 +558,7 @@ async fn test_diagnostics_multiple_servers(cx: &mut TestAppContext) {
                     }],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -566,6 +572,7 @@ async fn test_diagnostics_multiple_servers(cx: &mut TestAppContext) {
                     diagnostics: vec![],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -607,6 +614,7 @@ async fn test_diagnostics_multiple_servers(cx: &mut TestAppContext) {
                     }],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -740,6 +748,7 @@ async fn test_random_diagnostics_blocks(cx: &mut TestAppContext, mut rng: StdRng
                                 diagnostics: diagnostics.clone(),
                                 version: None,
                             },
+                            None,
                             DiagnosticSourceKind::Pushed,
                             &[],
                             cx,
@@ -928,6 +937,7 @@ async fn test_random_diagnostics_with_inlays(cx: &mut TestAppContext, mut rng: S
                                 diagnostics: diagnostics.clone(),
                                 version: None,
                             },
+                            None,
                             DiagnosticSourceKind::Pushed,
                             &[],
                             cx,
@@ -984,6 +994,7 @@ async fn active_diagnostics_dismiss_after_invalidation(cx: &mut TestAppContext) 
                             ..Default::default()
                         }],
                     },
+                    None,
                     DiagnosticSourceKind::Pushed,
                     &[],
                     cx,
@@ -1018,6 +1029,7 @@ async fn active_diagnostics_dismiss_after_invalidation(cx: &mut TestAppContext) 
                         version: None,
                         diagnostics: Vec::new(),
                     },
+                    None,
                     DiagnosticSourceKind::Pushed,
                     &[],
                     cx,
@@ -1100,6 +1112,7 @@ async fn cycle_through_same_place_diagnostics(cx: &mut TestAppContext) {
                             },
                         ],
                     },
+                    None,
                     DiagnosticSourceKind::Pushed,
                     &[],
                     cx,
@@ -1239,6 +1252,7 @@ async fn test_diagnostics_with_links(cx: &mut TestAppContext) {
                         ..Default::default()
                     }],
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -1291,6 +1305,7 @@ async fn test_hover_diagnostic_and_info_popovers(cx: &mut gpui::TestAppContext) 
                         ..Default::default()
                     }],
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -1393,6 +1408,7 @@ async fn test_diagnostics_with_code(cx: &mut TestAppContext) {
                     ],
                     version: None,
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15966,11 +15966,13 @@ impl Editor {
 
     fn pull_diagnostics(&mut self, window: &Window, cx: &mut Context<Self>) -> Option<()> {
         let project = self.project.as_ref()?.downgrade();
-        let debounce = Duration::from_millis(
-            ProjectSettings::get_global(cx)
-                .diagnostics
-                .lsp_pull_diagnostics_debounce_ms?,
-        );
+        let pull_diagnostics_settings = ProjectSettings::get_global(cx)
+            .diagnostics
+            .lsp_pull_diagnostics;
+        if !pull_diagnostics_settings.enabled {
+            return None;
+        }
+        let debounce = Duration::from_millis(pull_diagnostics_settings.debounce_ms);
         let buffers = self.buffer.read(cx).all_buffers();
 
         self.pull_diagnostics_task = cx.spawn_in(window, async move |editor, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -18735,12 +18735,15 @@ impl Editor {
                 }
                 if let Some(project) = self.project.as_ref() {
                     project.update(cx, |project, cx| {
-                        // Diagnostics are not local: an edit within one file (`pub mod foo()` -> `pub mod bar()`), may cause errors in another files with `foo()`.
-                        // Hence, emit a project-wide event to pull for every buffer's diagnostics that has an open editor.
                         if edited_buffer
                             .as_ref()
                             .is_some_and(|buffer| buffer.read(cx).file().is_some())
                         {
+                            // Diagnostics are not local: an edit within one file (`pub mod foo()` -> `pub mod bar()`), may cause errors in another files with `foo()`.
+                            // Hence, emit a project-wide event to pull for every buffer's diagnostics that has an open editor.
+                            // TODO: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#diagnostic_refresh explains the flow how
+                            // diagnostics should be pulled: instead of pulling every open editor's buffer's diagnostics (which happens effectively due to emitting this event),
+                            // we should only pull for the current buffer's diagnostics and get the rest via the workspace diagnostics LSP request — this is not implemented yet.
                             cx.emit(project::Event::PullWorkspaceDiagnostics);
                         }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1700,7 +1700,7 @@ impl Editor {
                             }
                             editor.pull_diagnostics(window, cx);
                         }
-                        project::Event::RefreshDocumentsDiagnostics => {
+                        project::Event::PullWorkspaceDiagnostics => {
                             editor.pull_diagnostics(window, cx);
                         }
                         project::Event::SnippetEdit(id, snippet_edits) => {
@@ -18741,7 +18741,7 @@ impl Editor {
                             .as_ref()
                             .is_some_and(|buffer| buffer.read(cx).file().is_some())
                         {
-                            cx.emit(project::Event::RefreshDocumentsDiagnostics);
+                            cx.emit(project::Event::PullWorkspaceDiagnostics);
                         }
 
                         if let Some(buffer) = edited_buffer {

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -21855,7 +21855,7 @@ fn assert_hunk_revert(
     assert_eq!(actual_hunk_statuses_before, expected_hunk_statuses_before);
 }
 
-#[gpui::test]
+#[gpui::test(iterations = 10)]
 async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
@@ -21913,7 +21913,8 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
     let fake_server = fake_servers.next().await.unwrap();
     let mut first_request = fake_server
         .set_request_handler::<lsp::request::DocumentDiagnosticRequest, _, _>(move |params, _| {
-            counter.fetch_add(1, atomic::Ordering::Release);
+            let new_result_id = counter.fetch_add(1, atomic::Ordering::Release) + 1;
+            let result_id = Some(new_result_id.to_string());
             assert_eq!(
                 params.text_document.uri,
                 lsp::Url::from_file_path(path!("/a/first.rs")).unwrap()
@@ -21924,13 +21925,27 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
                         related_documents: None,
                         full_document_diagnostic_report: lsp::FullDocumentDiagnosticReport {
                             items: Vec::new(),
-                            result_id: None,
+                            result_id,
                         },
                     }),
                 ))
             }
         });
 
+    let ensure_result_id = |expected: Option<String>, cx: &mut TestAppContext| {
+        editor.update(cx, |editor, cx| {
+            let buffer_result_id = editor
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .expect("created a singleton buffer")
+                .read(cx)
+                .result_id();
+            assert_eq!(expected, buffer_result_id);
+        });
+    };
+
+    ensure_result_id(None, cx);
     cx.executor().advance_clock(Duration::from_millis(60));
     cx.executor().run_until_parked();
     assert_eq!(
@@ -21942,6 +21957,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
         .next()
         .await
         .expect("should have sent the first diagnostics pull request");
+    ensure_result_id(Some("1".to_string()), cx);
 
     // Editing should trigger diagnostics
     editor.update_in(cx, |editor, window, cx| {
@@ -21954,6 +21970,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
         2,
         "Editing should trigger diagnostic request"
     );
+    ensure_result_id(Some("2".to_string()), cx);
 
     // Moving cursor should not trigger diagnostic request
     editor.update_in(cx, |editor, window, cx| {
@@ -21968,6 +21985,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
         2,
         "Cursor movement should not trigger diagnostic request"
     );
+    ensure_result_id(Some("2".to_string()), cx);
 
     // Multiple rapid edits should be debounced
     for _ in 0..5 {
@@ -21981,7 +21999,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
     let final_requests = diagnostic_requests.load(atomic::Ordering::Acquire);
     assert!(
         final_requests <= 4,
-        "Multiple rapid edits should be debounced (got {} requests)",
-        final_requests
+        "Multiple rapid edits should be debounced (got {final_requests} requests)",
     );
+    ensure_result_id(Some(final_requests.to_string()), cx);
 }

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13940,6 +13940,7 @@ async fn go_to_prev_overlapping_diagnostic(executor: BackgroundExecutor, cx: &mu
                             },
                         ],
                     },
+                    None,
                     DiagnosticSourceKind::Pushed,
                     &[],
                     cx,

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -127,6 +127,8 @@ pub struct Buffer {
     has_unsaved_edits: Cell<(clock::Global, bool)>,
     change_bits: Vec<rc::Weak<Cell<bool>>>,
     _subscriptions: Vec<gpui::Subscription>,
+    /// The result id received last time when pulling diagnostics for this buffer.
+    pull_diagnostics_result_id: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
@@ -955,6 +957,7 @@ impl Buffer {
             completion_triggers_timestamp: Default::default(),
             deferred_ops: OperationQueue::new(),
             has_conflict: false,
+            pull_diagnostics_result_id: None,
             change_bits: Default::default(),
             _subscriptions: Vec::new(),
         }
@@ -2739,6 +2742,14 @@ impl Buffer {
     /// Whether we should preserve the preview status of a tab containing this buffer.
     pub fn preserve_preview(&self) -> bool {
         !self.has_edits_since(&self.preview_version)
+    }
+
+    pub fn result_id(&self) -> Option<String> {
+        self.pull_diagnostics_result_id.clone()
+    }
+
+    pub fn set_result_id(&mut self, result_id: Option<String>) {
+        self.pull_diagnostics_result_id = result_id;
     }
 }
 

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -3832,7 +3832,7 @@ impl LspCommand for GetDocumentDiagnostics {
     fn to_lsp(
         &self,
         path: &Path,
-        _: &Buffer,
+        buffer: &Buffer,
         language_server: &Arc<LanguageServer>,
         _: &App,
     ) -> Result<lsp::DocumentDiagnosticParams> {
@@ -3849,7 +3849,7 @@ impl LspCommand for GetDocumentDiagnostics {
                 uri: file_path_to_lsp_url(path)?,
             },
             identifier,
-            previous_result_id: None,
+            previous_result_id: buffer.result_id(),
             partial_result_params: Default::default(),
             work_done_progress_params: Default::default(),
         })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -255,8 +255,8 @@ impl LocalLspStore {
             let fs = self.fs.clone();
             let pull_diagnostics = ProjectSettings::get_global(cx)
                 .diagnostics
-                .lsp_pull_diagnostics_debounce_ms
-                .is_some();
+                .lsp_pull_diagnostics
+                .enabled;
             cx.spawn(async move |cx| {
                 let result = async {
                     let toolchains = this.update(cx, |this, cx| this.toolchain_store(cx))?;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -872,9 +872,9 @@ impl LocalLspStore {
                     let mut cx = cx.clone();
                     async move {
                         this.update(&mut cx, |this, cx| {
-                            cx.emit(LspStoreEvent::RefreshDocumentsDiagnostics);
+                            cx.emit(LspStoreEvent::PullWorkspaceDiagnostics);
                             this.downstream_client.as_ref().map(|(client, project_id)| {
-                                client.send(proto::RefreshDocumentsDiagnostics {
+                                client.send(proto::PullWorkspaceDiagnostics {
                                     project_id: *project_id,
                                 })
                             })
@@ -3497,7 +3497,7 @@ pub enum LspStoreEvent {
         edits: Vec<(lsp::Range, Snippet)>,
         most_recent_edit: clock::Lamport,
     },
-    RefreshDocumentsDiagnostics,
+    PullWorkspaceDiagnostics,
 }
 
 #[derive(Clone, Debug, Serialize)]
@@ -3545,7 +3545,7 @@ impl LspStore {
         client.add_entity_request_handler(Self::handle_register_buffer_with_language_servers);
         client.add_entity_request_handler(Self::handle_rename_project_entry);
         client.add_entity_request_handler(Self::handle_language_server_id_for_name);
-        client.add_entity_request_handler(Self::handle_refresh_documents_diagnostics);
+        client.add_entity_request_handler(Self::handle_pull_workspace_diagnostics);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetCodeActions>);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetCompletions>);
         client.add_entity_request_handler(Self::handle_lsp_command::<GetHover>);
@@ -8171,13 +8171,13 @@ impl LspStore {
         Ok(proto::Ack {})
     }
 
-    async fn handle_refresh_documents_diagnostics(
+    async fn handle_pull_workspace_diagnostics(
         this: Entity<Self>,
-        _: TypedEnvelope<proto::RefreshDocumentsDiagnostics>,
+        _: TypedEnvelope<proto::PullWorkspaceDiagnostics>,
         mut cx: AsyncApp,
     ) -> Result<proto::Ack> {
         this.update(&mut cx, |_, cx| {
-            cx.emit(LspStoreEvent::RefreshDocumentsDiagnostics);
+            cx.emit(LspStoreEvent::PullWorkspaceDiagnostics);
         })?;
         Ok(proto::Ack {})
     }

--- a/crates/project/src/lsp_store/clangd_ext.rs
+++ b/crates/project/src/lsp_store/clangd_ext.rs
@@ -84,6 +84,7 @@ pub fn register_notifications(
                     this.merge_diagnostics(
                         server_id,
                         mapped_diagnostics,
+                        None,
                         DiagnosticSourceKind::Pushed,
                         &adapter.disk_based_diagnostic_sources,
                         |diag, _| !is_inactive_region(diag),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3732,6 +3732,7 @@ impl Project {
         &mut self,
         language_server_id: LanguageServerId,
         source_kind: DiagnosticSourceKind,
+        result_id: Option<String>,
         params: lsp::PublishDiagnosticsParams,
         disk_based_sources: &[String],
         cx: &mut Context<Self>,
@@ -3740,6 +3741,7 @@ impl Project {
             lsp_store.update_diagnostics(
                 language_server_id,
                 params,
+                result_id,
                 source_kind,
                 disk_based_sources,
                 cx,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -317,7 +317,7 @@ pub enum Event {
     SnippetEdit(BufferId, Vec<(lsp::Range, Snippet)>),
     ExpandedAllForEntry(WorktreeId, ProjectEntryId),
     AgentLocationChanged,
-    RefreshDocumentsDiagnostics,
+    PullWorkspaceDiagnostics,
 }
 
 pub struct AgentLocationChanged;
@@ -2814,9 +2814,7 @@ impl Project {
             }
             LspStoreEvent::RefreshInlayHints => cx.emit(Event::RefreshInlayHints),
             LspStoreEvent::RefreshCodeLens => cx.emit(Event::RefreshCodeLens),
-            LspStoreEvent::RefreshDocumentsDiagnostics => {
-                cx.emit(Event::RefreshDocumentsDiagnostics)
-            }
+            LspStoreEvent::PullWorkspaceDiagnostics => cx.emit(Event::PullWorkspaceDiagnostics),
             LspStoreEvent::LanguageServerPrompt(prompt) => {
                 cx.emit(Event::LanguageServerPrompt(prompt.clone()))
             }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -127,9 +127,8 @@ pub struct DiagnosticsSettings {
     /// Whether or not to include warning diagnostics.
     pub include_warnings: bool,
 
-    /// Minimum time to wait before pulling diagnostics from the language server(s).
-    /// 0 turns the debounce off, None disables the feature.
-    pub lsp_pull_diagnostics_debounce_ms: Option<u64>,
+    /// Settings for using LSP pull diagnostics mechanism in Zed.
+    pub lsp_pull_diagnostics: LspPullDiagnosticsSettings,
 
     /// Settings for showing inline diagnostics.
     pub inline: InlineDiagnosticsSettings,
@@ -148,6 +147,26 @@ impl DiagnosticsSettings {
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(default)]
+pub struct LspPullDiagnosticsSettings {
+    /// Whether to pull for diagnostics or not.
+    ///
+    /// Default: true
+    #[serde(default = "default_true")]
+    pub enabled: bool,
+    /// Minimum time to wait before pulling diagnostics from the language server(s).
+    /// 0 turns the debounce off.
+    ///
+    /// Default: 50
+    #[serde(default = "default_lsp_diagnostics_pull_debounce_ms")]
+    pub debounce_ms: u64,
+}
+
+fn default_lsp_diagnostics_pull_debounce_ms() -> u64 {
+    50
+}
+
+#[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
+#[serde(default)]
 pub struct InlineDiagnosticsSettings {
     /// Whether or not to show inline diagnostics
     ///
@@ -157,11 +176,13 @@ pub struct InlineDiagnosticsSettings {
     /// last editor event.
     ///
     /// Default: 150
+    #[serde(default = "default_inline_diagnostics_update_debounce_ms")]
     pub update_debounce_ms: u64,
     /// The amount of padding between the end of the source line and the start
     /// of the inline diagnostic in units of columns.
     ///
     /// Default: 4
+    #[serde(default = "default_inline_diagnostics_padding")]
     pub padding: u32,
     /// The minimum column to display inline diagnostics. This setting can be
     /// used to horizontally align inline diagnostics at some position. Lines
@@ -171,6 +192,47 @@ pub struct InlineDiagnosticsSettings {
     pub min_column: u32,
 
     pub max_severity: Option<DiagnosticSeverity>,
+}
+
+fn default_inline_diagnostics_update_debounce_ms() -> u64 {
+    150
+}
+
+fn default_inline_diagnostics_padding() -> u32 {
+    4
+}
+
+impl Default for DiagnosticsSettings {
+    fn default() -> Self {
+        Self {
+            button: true,
+            include_warnings: true,
+            lsp_pull_diagnostics: LspPullDiagnosticsSettings::default(),
+            inline: InlineDiagnosticsSettings::default(),
+            cargo: None,
+        }
+    }
+}
+
+impl Default for LspPullDiagnosticsSettings {
+    fn default() -> Self {
+        Self {
+            enabled: true,
+            debounce_ms: default_lsp_diagnostics_pull_debounce_ms(),
+        }
+    }
+}
+
+impl Default for InlineDiagnosticsSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            update_debounce_ms: default_inline_diagnostics_update_debounce_ms(),
+            padding: default_inline_diagnostics_padding(),
+            min_column: 0,
+            max_severity: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
@@ -204,30 +266,6 @@ impl DiagnosticSeverity {
             DiagnosticSeverity::Warning => Some(lsp::DiagnosticSeverity::WARNING),
             DiagnosticSeverity::Info => Some(lsp::DiagnosticSeverity::INFORMATION),
             DiagnosticSeverity::Hint => Some(lsp::DiagnosticSeverity::HINT),
-        }
-    }
-}
-
-impl Default for DiagnosticsSettings {
-    fn default() -> Self {
-        Self {
-            button: true,
-            include_warnings: true,
-            lsp_pull_diagnostics_debounce_ms: Some(30),
-            inline: InlineDiagnosticsSettings::default(),
-            cargo: None,
-        }
-    }
-}
-
-impl Default for InlineDiagnosticsSettings {
-    fn default() -> Self {
-        Self {
-            enabled: false,
-            update_debounce_ms: 150,
-            padding: 4,
-            min_column: 0,
-            max_severity: None,
         }
     }
 }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1332,6 +1332,7 @@ async fn test_single_file_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
                         ..Default::default()
                     }],
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -1350,6 +1351,7 @@ async fn test_single_file_worktrees_diagnostics(cx: &mut gpui::TestAppContext) {
                         ..Default::default()
                     }],
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -1441,6 +1443,7 @@ async fn test_omitted_diagnostics(cx: &mut gpui::TestAppContext) {
                         ..Default::default()
                     }],
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -1459,6 +1462,7 @@ async fn test_omitted_diagnostics(cx: &mut gpui::TestAppContext) {
                         ..Default::default()
                     }],
                 },
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,
@@ -2376,6 +2380,7 @@ async fn test_empty_diagnostic_ranges(cx: &mut gpui::TestAppContext) {
                     LanguageServerId(0),
                     PathBuf::from("/dir/a.rs"),
                     None,
+                    None,
                     vec![
                         DiagnosticEntry {
                             range: Unclipped(PointUtf16::new(0, 10))
@@ -2442,6 +2447,7 @@ async fn test_diagnostics_from_multiple_language_servers(cx: &mut gpui::TestAppC
                 LanguageServerId(0),
                 Path::new("/dir/a.rs").to_owned(),
                 None,
+                None,
                 vec![DiagnosticEntry {
                     range: Unclipped(PointUtf16::new(0, 0))..Unclipped(PointUtf16::new(0, 3)),
                     diagnostic: Diagnostic {
@@ -2459,6 +2465,7 @@ async fn test_diagnostics_from_multiple_language_servers(cx: &mut gpui::TestAppC
             .update_diagnostic_entries(
                 LanguageServerId(1),
                 Path::new("/dir/a.rs").to_owned(),
+                None,
                 None,
                 vec![DiagnosticEntry {
                     range: Unclipped(PointUtf16::new(0, 0))..Unclipped(PointUtf16::new(0, 3)),
@@ -4596,6 +4603,7 @@ async fn test_grouped_diagnostics(cx: &mut gpui::TestAppContext) {
             lsp_store.update_diagnostics(
                 LanguageServerId(0),
                 message,
+                None,
                 DiagnosticSourceKind::Pushed,
                 &[],
                 cx,

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -804,6 +804,6 @@ message PulledDiagnostics {
     repeated LspDiagnostic diagnostics = 5;
 }
 
-message RefreshDocumentsDiagnostics {
+message PullWorkspaceDiagnostics {
     uint64 project_id = 1;
 }

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -391,7 +391,7 @@ message Envelope {
 
         GetDocumentDiagnostics get_document_diagnostics = 350;
         GetDocumentDiagnosticsResponse get_document_diagnostics_response = 351;
-        RefreshDocumentsDiagnostics refresh_documents_diagnostics = 352; // current max
+        PullWorkspaceDiagnostics pull_workspace_diagnostics = 352; // current max
 
     }
 

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -309,7 +309,7 @@ messages!(
     (LogToDebugConsole, Background),
     (GetDocumentDiagnostics, Background),
     (GetDocumentDiagnosticsResponse, Background),
-    (RefreshDocumentsDiagnostics, Background)
+    (PullWorkspaceDiagnostics, Background)
 );
 
 request_messages!(
@@ -473,7 +473,7 @@ request_messages!(
     (GetDebugAdapterBinary, DebugAdapterBinary),
     (RunDebugLocators, DebugRequest),
     (GetDocumentDiagnostics, GetDocumentDiagnosticsResponse),
-    (RefreshDocumentsDiagnostics, Ack)
+    (PullWorkspaceDiagnostics, Ack)
 );
 
 entity_messages!(
@@ -601,7 +601,7 @@ entity_messages!(
     GetDebugAdapterBinary,
     LogToDebugConsole,
     GetDocumentDiagnostics,
-    RefreshDocumentsDiagnostics
+    PullWorkspaceDiagnostics
 );
 
 entity_messages!(


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/19230

* starts to send `result_id` in pull requests to allow servers to reply with non-full results
* fixes a bug where disk-based diagnostics were offset after pulling the diagnostics
* fixes a bug due to which pull diagnostics could not be disabled
* uses better names and comments for the workspace pull diagnostics part

Release Notes:

- N/A
