### PR TITLE
context server: Make requests type safe

### DIFF
--- a/crates/agent/src/context_server_tool.rs
+++ b/crates/agent/src/context_server_tool.rs
@@ -104,7 +104,15 @@ impl Tool for ContextServerTool {
                     tool_name,
                     arguments
                 );
-                let response = protocol.run_tool(tool_name, arguments).await?;
+                let response = protocol
+                    .request::<context_server::types::CallTool>(
+                        context_server::types::CallToolParams {
+                            name: tool_name,
+                            arguments,
+                            meta: None,
+                        },
+                    )
+                    .await?;
 
                 let mut result = String::new();
                 for content in response.content {

--- a/crates/agent/src/context_server_tool.rs
+++ b/crates/agent/src/context_server_tool.rs
@@ -105,7 +105,7 @@ impl Tool for ContextServerTool {
                     arguments
                 );
                 let response = protocol
-                    .request::<context_server::types::CallTool>(
+                    .request::<context_server::types::request::CallTool>(
                         context_server::types::CallToolParams {
                             name: tool_name,
                             arguments,

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -567,7 +567,7 @@ impl ThreadStore {
 
             if protocol.capable(context_server::protocol::ServerCapability::Tools) {
                 if let Some(response) = protocol
-                    .request::<context_server::types::ListTools>(())
+                    .request::<context_server::types::request::ListTools>(())
                     .await
                     .log_err()
                 {

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -566,10 +566,14 @@ impl ThreadStore {
             };
 
             if protocol.capable(context_server::protocol::ServerCapability::Tools) {
-                if let Some(response) = protocol.request::<context_server::types::ListTools>(()).await.log_err() {
+                if let Some(response) = protocol
+                    .request::<context_server::types::ListTools>(())
+                    .await
+                    .log_err()
+                {
                     let tool_ids = tool_working_set
                         .update(cx, |tool_working_set, _| {
-                        response
+                            response
                                 .tools
                                 .into_iter()
                                 .map(|tool| {

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -546,10 +546,10 @@ impl ThreadStore {
                                     };
 
                                     if protocol.capable(context_server::protocol::ServerCapability::Tools) {
-                                        if let Some(tools) = protocol.list_tools().await.log_err() {
+                                        if let Some(response) = protocol.request::<context_server::types::ListTools>(()).await.log_err() {
                                             let tool_ids = tool_working_set
                                                 .update(cx, |tool_working_set, _| {
-                                                    tools
+                                                    response
                                                         .tools
                                                         .into_iter()
                                                         .map(|tool| {

--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -841,8 +841,8 @@ impl ContextStore {
                                     };
 
                                     if protocol.capable(context_server::protocol::ServerCapability::Prompts) {
-                                        if let Some(prompts) = protocol.list_prompts().await.log_err() {
-                                            let slash_command_ids = prompts
+                                        if let Some(response) = protocol.request::<context_server::types::PromptsList>(()).await.log_err() {
+                                            let slash_command_ids = response.prompts
                                                 .into_iter()
                                                 .filter(assistant_slash_commands::acceptable_prompt)
                                                 .map(|prompt| {

--- a/crates/assistant_context_editor/src/context_store.rs
+++ b/crates/assistant_context_editor/src/context_store.rs
@@ -865,7 +865,7 @@ impl ContextStore {
 
             if protocol.capable(context_server::protocol::ServerCapability::Prompts) {
                 if let Some(response) = protocol
-                    .request::<context_server::types::PromptsList>(())
+                    .request::<context_server::types::request::PromptsList>(())
                     .await
                     .log_err()
                 {

--- a/crates/assistant_slash_commands/src/context_server_command.rs
+++ b/crates/assistant_slash_commands/src/context_server_command.rs
@@ -86,20 +86,26 @@ impl SlashCommand for ContextServerSlashCommand {
             cx.foreground_executor().spawn(async move {
                 let protocol = server.client().context("Context server not initialized")?;
 
-                let completion_result = protocol
-                    .completion(
-                        context_server::types::CompletionReference::Prompt(
-                            context_server::types::PromptReference {
-                                r#type: context_server::types::PromptReferenceType::Prompt,
-                                name: prompt_name,
+                let response = protocol
+                    .request::<context_server::types::CompletionComplete>(
+                        context_server::types::CompletionCompleteParams {
+                            reference: context_server::types::CompletionReference::Prompt(
+                                context_server::types::PromptReference {
+                                    ty: context_server::types::PromptReferenceType::Prompt,
+                                    name: prompt_name,
+                                },
+                            ),
+                            argument: context_server::types::CompletionArgument {
+                                name: arg_name,
+                                value: arg_value,
                             },
-                        ),
-                        arg_name,
-                        arg_value,
+                            meta: None,
+                        },
                     )
                     .await?;
 
-                let completions = completion_result
+                let completions = response
+                    .completion
                     .values
                     .into_iter()
                     .map(|value| ArgumentCompletion {
@@ -138,10 +144,18 @@ impl SlashCommand for ContextServerSlashCommand {
         if let Some(server) = store.get_running_server(&server_id) {
             cx.foreground_executor().spawn(async move {
                 let protocol = server.client().context("Context server not initialized")?;
-                let result = protocol.run_prompt(&prompt_name, prompt_args).await?;
+                let response = protocol
+                    .request::<context_server::types::PromptsGet>(
+                        context_server::types::PromptsGetParams {
+                            name: prompt_name.clone(),
+                            arguments: Some(prompt_args),
+                            meta: None,
+                        },
+                    )
+                    .await?;
 
                 anyhow::ensure!(
-                    result
+                    response
                         .messages
                         .iter()
                         .all(|msg| matches!(msg.role, context_server::types::Role::User)),
@@ -149,7 +163,7 @@ impl SlashCommand for ContextServerSlashCommand {
                 );
 
                 // Extract text from user messages into a single prompt string
-                let mut prompt = result
+                let mut prompt = response
                     .messages
                     .into_iter()
                     .filter_map(|msg| match msg.content {
@@ -167,7 +181,7 @@ impl SlashCommand for ContextServerSlashCommand {
                         range: 0..(prompt.len()),
                         icon: IconName::ZedAssistant,
                         label: SharedString::from(
-                            result
+                            response
                                 .description
                                 .unwrap_or(format!("Result from {}", prompt_name)),
                         ),

--- a/crates/assistant_slash_commands/src/context_server_command.rs
+++ b/crates/assistant_slash_commands/src/context_server_command.rs
@@ -87,7 +87,7 @@ impl SlashCommand for ContextServerSlashCommand {
                 let protocol = server.client().context("Context server not initialized")?;
 
                 let response = protocol
-                    .request::<context_server::types::CompletionComplete>(
+                    .request::<context_server::types::request::CompletionComplete>(
                         context_server::types::CompletionCompleteParams {
                             reference: context_server::types::CompletionReference::Prompt(
                                 context_server::types::PromptReference {
@@ -145,7 +145,7 @@ impl SlashCommand for ContextServerSlashCommand {
             cx.foreground_executor().spawn(async move {
                 let protocol = server.client().context("Context server not initialized")?;
                 let response = protocol
-                    .request::<context_server::types::PromptsGet>(
+                    .request::<context_server::types::request::PromptsGet>(
                         context_server::types::PromptsGetParams {
                             name: prompt_name.clone(),
                             arguments: Some(prompt_args),

--- a/crates/context_server/Cargo.toml
+++ b/crates/context_server/Cargo.toml
@@ -11,6 +11,9 @@ workspace = true
 [lib]
 path = "src/context_server.rs"
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/context_server/src/context_server.rs
+++ b/crates/context_server/src/context_server.rs
@@ -1,5 +1,7 @@
 pub mod client;
 pub mod protocol;
+#[cfg(any(test, feature = "test-support"))]
+pub mod test;
 pub mod transport;
 pub mod types;
 

--- a/crates/context_server/src/protocol.rs
+++ b/crates/context_server/src/protocol.rs
@@ -42,7 +42,7 @@ impl ModelContextProtocol {
 
         let response: types::InitializeResponse = self
             .inner
-            .request(types::Initialize::METHOD, params)
+            .request(types::request::Initialize::METHOD, params)
             .await?;
 
         anyhow::ensure!(

--- a/crates/context_server/src/protocol.rs
+++ b/crates/context_server/src/protocol.rs
@@ -6,10 +6,9 @@
 //! of messages.
 
 use anyhow::Result;
-use collections::HashMap;
 
 use crate::client::Client;
-use crate::types;
+use crate::types::{self, Request};
 
 pub struct ModelContextProtocol {
     inner: Client,
@@ -43,7 +42,7 @@ impl ModelContextProtocol {
 
         let response: types::InitializeResponse = self
             .inner
-            .request(types::RequestType::Initialize.as_str(), params)
+            .request(types::Initialize::METHOD, params)
             .await?;
 
         anyhow::ensure!(
@@ -94,137 +93,7 @@ impl InitializedContextServerProtocol {
         }
     }
 
-    fn check_capability(&self, capability: ServerCapability) -> Result<()> {
-        anyhow::ensure!(
-            self.capable(capability),
-            "Server does not support {capability:?} capability"
-        );
-        Ok(())
-    }
-
-    /// List the MCP prompts.
-    pub async fn list_prompts(&self) -> Result<Vec<types::Prompt>> {
-        self.check_capability(ServerCapability::Prompts)?;
-
-        let response: types::PromptsListResponse = self
-            .inner
-            .request(
-                types::RequestType::PromptsList.as_str(),
-                serde_json::json!({}),
-            )
-            .await?;
-
-        Ok(response.prompts)
-    }
-
-    /// List the MCP resources.
-    pub async fn list_resources(&self) -> Result<types::ResourcesListResponse> {
-        self.check_capability(ServerCapability::Resources)?;
-
-        let response: types::ResourcesListResponse = self
-            .inner
-            .request(
-                types::RequestType::ResourcesList.as_str(),
-                serde_json::json!({}),
-            )
-            .await?;
-
-        Ok(response)
-    }
-
-    /// Executes a prompt with the given arguments and returns the result.
-    pub async fn run_prompt<P: AsRef<str>>(
-        &self,
-        prompt: P,
-        arguments: HashMap<String, String>,
-    ) -> Result<types::PromptsGetResponse> {
-        self.check_capability(ServerCapability::Prompts)?;
-
-        let params = types::PromptsGetParams {
-            name: prompt.as_ref().to_string(),
-            arguments: Some(arguments),
-            meta: None,
-        };
-
-        let response: types::PromptsGetResponse = self
-            .inner
-            .request(types::RequestType::PromptsGet.as_str(), params)
-            .await?;
-
-        Ok(response)
-    }
-
-    pub async fn completion<P: Into<String>>(
-        &self,
-        reference: types::CompletionReference,
-        argument: P,
-        value: P,
-    ) -> Result<types::Completion> {
-        let params = types::CompletionCompleteParams {
-            r#ref: reference,
-            argument: types::CompletionArgument {
-                name: argument.into(),
-                value: value.into(),
-            },
-            meta: None,
-        };
-        let result: types::CompletionCompleteResponse = self
-            .inner
-            .request(types::RequestType::CompletionComplete.as_str(), params)
-            .await?;
-
-        let completion = types::Completion {
-            values: result.completion.values,
-            total: types::CompletionTotal::from_options(
-                result.completion.has_more,
-                result.completion.total,
-            ),
-        };
-
-        Ok(completion)
-    }
-
-    /// List MCP tools.
-    pub async fn list_tools(&self) -> Result<types::ListToolsResponse> {
-        self.check_capability(ServerCapability::Tools)?;
-
-        let response = self
-            .inner
-            .request::<types::ListToolsResponse>(types::RequestType::ListTools.as_str(), ())
-            .await?;
-
-        Ok(response)
-    }
-
-    /// Executes a tool with the given arguments
-    pub async fn run_tool<P: AsRef<str>>(
-        &self,
-        tool: P,
-        arguments: Option<HashMap<String, serde_json::Value>>,
-    ) -> Result<types::CallToolResponse> {
-        self.check_capability(ServerCapability::Tools)?;
-
-        let params = types::CallToolParams {
-            name: tool.as_ref().to_string(),
-            arguments,
-            meta: None,
-        };
-
-        let response: types::CallToolResponse = self
-            .inner
-            .request(types::RequestType::CallTool.as_str(), params)
-            .await?;
-
-        Ok(response)
-    }
-}
-
-impl InitializedContextServerProtocol {
-    pub async fn request<R: serde::de::DeserializeOwned>(
-        &self,
-        method: &str,
-        params: impl serde::Serialize,
-    ) -> Result<R> {
-        self.inner.request(method, params).await
+    pub async fn request<T: Request>(&self, params: T::Params) -> Result<T::Response> {
+        self.inner.request(T::METHOD, params).await
     }
 }

--- a/crates/context_server/src/test.rs
+++ b/crates/context_server/src/test.rs
@@ -14,7 +14,7 @@ pub fn create_fake_transport(
     executor: BackgroundExecutor,
 ) -> FakeTransport {
     let name = name.into();
-    FakeTransport::new(executor).on_request::<crate::types::Initialize>(move |_params| {
+    FakeTransport::new(executor).on_request::<crate::types::request::Initialize>(move |_params| {
         create_initialize_response(name.clone())
     })
 }

--- a/crates/context_server/src/test.rs
+++ b/crates/context_server/src/test.rs
@@ -1,0 +1,118 @@
+use anyhow::Context as _;
+use collections::HashMap;
+use futures::{Stream, StreamExt as _, lock::Mutex};
+use gpui::BackgroundExecutor;
+use std::{pin::Pin, sync::Arc};
+
+use crate::{
+    transport::Transport,
+    types::{Implementation, InitializeResponse, ProtocolVersion, ServerCapabilities},
+};
+
+pub fn create_fake_transport(
+    name: impl Into<String>,
+    executor: BackgroundExecutor,
+) -> FakeTransport {
+    let name = name.into();
+    FakeTransport::new(executor).on_request::<crate::types::Initialize>(move |_params| {
+        create_initialize_response(name.clone())
+    })
+}
+
+fn create_initialize_response(server_name: String) -> InitializeResponse {
+    InitializeResponse {
+        protocol_version: ProtocolVersion(crate::types::LATEST_PROTOCOL_VERSION.to_string()),
+        server_info: Implementation {
+            name: server_name,
+            version: "1.0.0".to_string(),
+        },
+        capabilities: ServerCapabilities::default(),
+        meta: None,
+    }
+}
+
+pub struct FakeTransport {
+    request_handlers:
+        HashMap<&'static str, Arc<dyn Fn(serde_json::Value) -> serde_json::Value + Send + Sync>>,
+    tx: futures::channel::mpsc::UnboundedSender<String>,
+    rx: Arc<Mutex<futures::channel::mpsc::UnboundedReceiver<String>>>,
+    executor: BackgroundExecutor,
+}
+
+impl FakeTransport {
+    pub fn new(executor: BackgroundExecutor) -> Self {
+        let (tx, rx) = futures::channel::mpsc::unbounded();
+        Self {
+            request_handlers: Default::default(),
+            tx,
+            rx: Arc::new(Mutex::new(rx)),
+            executor,
+        }
+    }
+
+    pub fn on_request<T: crate::types::Request>(
+        mut self,
+        handler: impl Fn(T::Params) -> T::Response + Send + Sync + 'static,
+    ) -> Self {
+        self.request_handlers.insert(
+            T::METHOD,
+            Arc::new(move |value| {
+                let params = value.get("params").expect("Missing parameters").clone();
+                let params: T::Params =
+                    serde_json::from_value(params).expect("Invalid parameters received");
+                let response = handler(params);
+                serde_json::to_value(response).unwrap()
+            }),
+        );
+        self
+    }
+}
+
+#[async_trait::async_trait]
+impl Transport for FakeTransport {
+    async fn send(&self, message: String) -> anyhow::Result<()> {
+        if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&message) {
+            let id = msg.get("id").and_then(|id| id.as_u64()).unwrap_or(0);
+
+            if let Some(method) = msg.get("method") {
+                let method = method.as_str().expect("Invalid method received");
+                if let Some(handler) = self.request_handlers.get(method) {
+                    let payload = handler(msg);
+                    let response = serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": payload
+                    });
+                    self.tx
+                        .unbounded_send(response.to_string())
+                        .context("sending a message")?;
+                } else {
+                    log::debug!("No handler registered for MCP request '{method}'");
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn receive(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
+        let rx = self.rx.clone();
+        let executor = self.executor.clone();
+        Box::pin(futures::stream::unfold(rx, move |rx| {
+            let executor = executor.clone();
+            async move {
+                let mut rx_guard = rx.lock().await;
+                executor.simulate_random_delay().await;
+                if let Some(message) = rx_guard.next().await {
+                    drop(rx_guard);
+                    Some((message, rx))
+                } else {
+                    None
+                }
+            }
+        }))
+    }
+
+    fn receive_err(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
+        Box::pin(futures::stream::empty())
+    }
+}

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -83,6 +83,7 @@ request!("roots/list", ListRoots, (), ListRootsResponse);
 pub struct ProtocolVersion(pub String);
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InitializeParams {
     pub protocol_version: ProtocolVersion,
     pub capabilities: ClientCapabilities,
@@ -92,6 +93,7 @@ pub struct InitializeParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CallToolParams {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -101,6 +103,7 @@ pub struct CallToolParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesUnsubscribeParams {
     pub uri: Url,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -108,6 +111,7 @@ pub struct ResourcesUnsubscribeParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesSubscribeParams {
     pub uri: Url,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -115,6 +119,7 @@ pub struct ResourcesSubscribeParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesReadParams {
     pub uri: Url,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -122,6 +127,7 @@ pub struct ResourcesReadParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct LoggingSetLevelParams {
     pub level: LoggingLevel,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -129,6 +135,7 @@ pub struct LoggingSetLevelParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptsGetParams {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -138,6 +145,7 @@ pub struct PromptsGetParams {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompletionCompleteParams {
     #[serde(rename = "ref")]
     pub reference: CompletionReference,
@@ -154,6 +162,7 @@ pub enum CompletionReference {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptReference {
     #[serde(rename = "type")]
     pub ty: PromptReferenceType,
@@ -161,6 +170,7 @@ pub struct PromptReference {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourceReference {
     #[serde(rename = "type")]
     pub ty: PromptReferenceType,
@@ -177,12 +187,14 @@ pub enum PromptReferenceType {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompletionArgument {
     pub name: String,
     pub value: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InitializeResponse {
     pub protocol_version: ProtocolVersion,
     pub capabilities: ServerCapabilities,
@@ -192,6 +204,7 @@ pub struct InitializeResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesReadResponse {
     pub contents: Vec<ResourceContentsType>,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -206,6 +219,7 @@ pub enum ResourceContentsType {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesListResponse {
     pub resources: Vec<Resource>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -215,12 +229,14 @@ pub struct ResourcesListResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SamplingMessage {
     pub role: Role,
     pub content: MessageContent,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateMessageRequest {
     pub messages: Vec<SamplingMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -239,6 +255,7 @@ pub struct CreateMessageRequest {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateMessageResult {
     pub role: Role,
     pub content: MessageContent,
@@ -248,6 +265,7 @@ pub struct CreateMessageResult {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptMessage {
     pub role: Role,
     pub content: MessageContent,
@@ -285,6 +303,7 @@ pub enum MessageContent {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct MessageAnnotations {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub audience: Option<Vec<Role>>,
@@ -293,6 +312,7 @@ pub struct MessageAnnotations {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptsGetResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
@@ -302,6 +322,7 @@ pub struct PromptsGetResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptsListResponse {
     pub prompts: Vec<Prompt>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -311,6 +332,7 @@ pub struct PromptsListResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompletionCompleteResponse {
     pub completion: CompletionResult,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -318,6 +340,7 @@ pub struct CompletionCompleteResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CompletionResult {
     pub values: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -329,6 +352,7 @@ pub struct CompletionResult {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Prompt {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -338,6 +362,7 @@ pub struct Prompt {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptArgument {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -347,6 +372,7 @@ pub struct PromptArgument {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ClientCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, serde_json::Value>>,
@@ -357,6 +383,7 @@ pub struct ClientCapabilities {
 }
 
 #[derive(Default, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ServerCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub experimental: Option<HashMap<String, serde_json::Value>>,
@@ -371,12 +398,14 @@ pub struct ServerCapabilities {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct PromptsCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub list_changed: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourcesCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub subscribe: Option<bool>,
@@ -385,18 +414,21 @@ pub struct ResourcesCapabilities {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ToolsCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub list_changed: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RootsCapabilities {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub list_changed: Option<bool>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Tool {
     pub name: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -405,12 +437,14 @@ pub struct Tool {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Implementation {
     pub name: String,
     pub version: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Resource {
     pub uri: Url,
     pub name: String,
@@ -421,6 +455,7 @@ pub struct Resource {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourceContents {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -428,6 +463,7 @@ pub struct ResourceContents {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TextResourceContents {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -436,6 +472,7 @@ pub struct TextResourceContents {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct BlobResourceContents {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -444,6 +481,7 @@ pub struct BlobResourceContents {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ResourceTemplate {
     pub uri_template: String,
     pub name: String,
@@ -467,6 +505,7 @@ pub enum LoggingLevel {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ModelPreferences {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub hints: Option<Vec<ModelHint>>,
@@ -479,12 +518,14 @@ pub struct ModelPreferences {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ModelHint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub enum NotificationType {
     Initialized,
     Progress,
@@ -532,6 +573,7 @@ pub enum ProgressToken {
 }
 
 #[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ProgressParams {
     pub progress_token: ProgressToken,
     pub progress: f64,
@@ -563,6 +605,7 @@ pub struct Completion {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CallToolResponse {
     pub content: Vec<ToolResponseContent>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -583,6 +626,7 @@ pub enum ToolResponseContent {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ListToolsResponse {
     pub tools: Vec<Tool>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -592,6 +636,7 @@ pub struct ListToolsResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ListResourceTemplatesResponse {
     pub resource_templates: Vec<ResourceTemplate>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -601,6 +646,7 @@ pub struct ListResourceTemplatesResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ListRootsResponse {
     pub roots: Vec<Root>,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
@@ -608,6 +654,7 @@ pub struct ListRootsResponse {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Root {
     pub uri: Url,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -5,78 +5,82 @@ use url::Url;
 
 pub const LATEST_PROTOCOL_VERSION: &str = "2024-11-05";
 
+pub mod request {
+    use super::*;
+
+    macro_rules! request {
+        ($method:expr, $name:ident, $params:ty, $response:ty) => {
+            pub struct $name;
+
+            impl Request for $name {
+                type Params = $params;
+                type Response = $response;
+                const METHOD: &'static str = $method;
+            }
+        };
+    }
+
+    request!(
+        "initialize",
+        Initialize,
+        InitializeParams,
+        InitializeResponse
+    );
+    request!("tools/call", CallTool, CallToolParams, CallToolResponse);
+    request!(
+        "resources/unsubscribe",
+        ResourcesUnsubscribe,
+        ResourcesUnsubscribeParams,
+        ()
+    );
+    request!(
+        "resources/subscribe",
+        ResourcesSubscribe,
+        ResourcesSubscribeParams,
+        ()
+    );
+    request!(
+        "resources/read",
+        ResourcesRead,
+        ResourcesReadParams,
+        ResourcesReadResponse
+    );
+    request!("resources/list", ResourcesList, (), ResourcesListResponse);
+    request!(
+        "logging/setLevel",
+        LoggingSetLevel,
+        LoggingSetLevelParams,
+        ()
+    );
+    request!(
+        "prompts/get",
+        PromptsGet,
+        PromptsGetParams,
+        PromptsGetResponse
+    );
+    request!("prompts/list", PromptsList, (), PromptsListResponse);
+    request!(
+        "completion/complete",
+        CompletionComplete,
+        CompletionCompleteParams,
+        CompletionCompleteResponse
+    );
+    request!("ping", Ping, (), ());
+    request!("tools/list", ListTools, (), ListToolsResponse);
+    request!(
+        "resources/templates/list",
+        ListResourceTemplates,
+        (),
+        ListResourceTemplatesResponse
+    );
+    request!("roots/list", ListRoots, (), ListRootsResponse);
+}
+
 pub trait Request {
     type Params: DeserializeOwned + Serialize + Send + Sync + 'static;
     type Response: DeserializeOwned + Serialize + Send + Sync + 'static;
     const METHOD: &'static str;
 }
-
-macro_rules! request {
-    ($method:expr, $name:ident, $params:ty, $response:ty) => {
-        pub struct $name;
-
-        impl Request for $name {
-            type Params = $params;
-            type Response = $response;
-            const METHOD: &'static str = $method;
-        }
-    };
-}
-
-request!(
-    "initialize",
-    Initialize,
-    InitializeParams,
-    InitializeResponse
-);
-request!("tools/call", CallTool, CallToolParams, CallToolResponse);
-request!(
-    "resources/unsubscribe",
-    ResourcesUnsubscribe,
-    ResourcesUnsubscribeParams,
-    ()
-);
-request!(
-    "resources/subscribe",
-    ResourcesSubscribe,
-    ResourcesSubscribeParams,
-    ()
-);
-request!(
-    "resources/read",
-    ResourcesRead,
-    ResourcesReadParams,
-    ResourcesReadResponse
-);
-request!("resources/list", ResourcesList, (), ResourcesListResponse);
-request!(
-    "logging/setLevel",
-    LoggingSetLevel,
-    LoggingSetLevelParams,
-    ()
-);
-request!(
-    "prompts/get",
-    PromptsGet,
-    PromptsGetParams,
-    PromptsGetResponse
-);
-request!("prompts/list", PromptsList, (), PromptsListResponse);
-request!(
-    "completion/complete",
-    CompletionComplete,
-    CompletionCompleteParams,
-    CompletionCompleteResponse
-);
-request!("ping", Ping, (), ());
-request!("tools/list", ListTools, (), ListToolsResponse);
-request!(
-    "resources/templates/list",
-    ListResourceTemplates,
-    (),
-    ListResourceTemplatesResponse
-);
-request!("roots/list", ListRoots, (), ListRootsResponse);
 
 #[derive(Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(transparent)]

--- a/crates/context_server/src/types.rs
+++ b/crates/context_server/src/types.rs
@@ -139,7 +139,8 @@ pub struct PromptsGetParams {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CompletionCompleteParams {
-    pub r#ref: CompletionReference,
+    #[serde(rename = "ref")]
+    pub reference: CompletionReference,
     pub argument: CompletionArgument,
     #[serde(rename = "_meta", skip_serializing_if = "Option::is_none")]
     pub meta: Option<HashMap<String, serde_json::Value>>,
@@ -154,13 +155,15 @@ pub enum CompletionReference {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct PromptReference {
-    pub r#type: PromptReferenceType,
+    #[serde(rename = "type")]
+    pub ty: PromptReferenceType,
     pub name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ResourceReference {
-    pub r#type: PromptReferenceType,
+    #[serde(rename = "type")]
+    pub ty: PromptReferenceType,
     pub uri: Url,
 }
 

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -91,6 +91,7 @@ workspace-hack.workspace = true
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }
 collections = { workspace = true, features = ["test-support"] }
+context_server = { workspace = true, features = ["test-support"] }
 buffer_diff = { workspace = true, features = ["test-support"] }
 dap = { workspace = true, features = ["test-support"] }
 dap_adapters = { workspace = true, features = ["test-support"] }

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -499,14 +499,10 @@ impl ContextServerStore {
 mod tests {
     use super::*;
     use crate::{FakeFs, Project, project_settings::ProjectSettings};
-    use context_server::{
-        transport::Transport,
-        types::{self, Implementation, InitializeResponse, ProtocolVersion, ServerCapabilities},
-    };
-    use futures::{Stream, StreamExt as _, lock::Mutex};
-    use gpui::{AppContext, BackgroundExecutor, TestAppContext, UpdateGlobal as _};
+    use context_server::test::create_fake_transport;
+    use gpui::{AppContext, TestAppContext, UpdateGlobal as _};
     use serde_json::json;
-    use std::{cell::RefCell, pin::Pin, rc::Rc};
+    use std::{cell::RefCell, rc::Rc};
     use util::path;
 
     #[gpui::test]
@@ -975,115 +971,5 @@ mod tests {
         let project = Project::test(fs.clone(), [path!("/test").as_ref()], cx).await;
 
         (fs, project)
-    }
-
-    fn create_fake_transport(
-        name: impl Into<String>,
-        executor: BackgroundExecutor,
-    ) -> FakeTransport {
-        let name = name.into();
-        FakeTransport::new(executor).on_request::<types::Initialize>(move |_params| {
-            create_initialize_response(name.clone())
-        })
-    }
-
-    fn create_initialize_response(server_name: String) -> InitializeResponse {
-        InitializeResponse {
-            protocol_version: ProtocolVersion(types::LATEST_PROTOCOL_VERSION.to_string()),
-            server_info: Implementation {
-                name: server_name,
-                version: "1.0.0".to_string(),
-            },
-            capabilities: ServerCapabilities::default(),
-            meta: None,
-        }
-    }
-
-    struct FakeTransport {
-        request_handlers: HashMap<
-            &'static str,
-            Arc<dyn Fn(serde_json::Value) -> serde_json::Value + Send + Sync>,
-        >,
-        tx: futures::channel::mpsc::UnboundedSender<String>,
-        rx: Arc<Mutex<futures::channel::mpsc::UnboundedReceiver<String>>>,
-        executor: BackgroundExecutor,
-    }
-
-    impl FakeTransport {
-        fn new(executor: BackgroundExecutor) -> Self {
-            let (tx, rx) = futures::channel::mpsc::unbounded();
-            Self {
-                request_handlers: Default::default(),
-                tx,
-                rx: Arc::new(Mutex::new(rx)),
-                executor,
-            }
-        }
-
-        fn on_request<T: context_server::types::Request>(
-            mut self,
-            handler: impl Fn(T::Params) -> T::Response + Send + Sync + 'static,
-        ) -> Self {
-            self.request_handlers.insert(
-                T::METHOD,
-                Arc::new(move |value| {
-                    let params = value.get("params").expect("Missing parameters").clone();
-                    let params: T::Params =
-                        serde_json::from_value(params).expect("Invalid parameters received");
-                    let response = handler(params);
-                    serde_json::to_value(response).unwrap()
-                }),
-            );
-            self
-        }
-    }
-
-    #[async_trait::async_trait]
-    impl Transport for FakeTransport {
-        async fn send(&self, message: String) -> Result<()> {
-            if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&message) {
-                let id = msg.get("id").and_then(|id| id.as_u64()).unwrap_or(0);
-
-                if let Some(method) = msg.get("method") {
-                    let method = method.as_str().expect("Invalid method received");
-                    if let Some(handler) = self.request_handlers.get(method) {
-                        let payload = handler(msg);
-                        let response = serde_json::json!({
-                            "jsonrpc": "2.0",
-                            "id": id,
-                            "result": payload
-                        });
-                        self.tx
-                            .unbounded_send(response.to_string())
-                            .context("sending a message")?;
-                    } else {
-                        log::debug!("No handler registered for MCP request '{method}'");
-                    }
-                }
-            }
-            Ok(())
-        }
-
-        fn receive(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
-            let rx = self.rx.clone();
-            let executor = self.executor.clone();
-            Box::pin(futures::stream::unfold(rx, move |rx| {
-                let executor = executor.clone();
-                async move {
-                    let mut rx_guard = rx.lock().await;
-                    executor.simulate_random_delay().await;
-                    if let Some(message) = rx_guard.next().await {
-                        drop(rx_guard);
-                        Some((message, rx))
-                    } else {
-                        None
-                    }
-                }
-            }))
-        }
-
-        fn receive_err(&self) -> Pin<Box<dyn Stream<Item = String> + Send>> {
-            Box::pin(futures::stream::empty())
-        }
     }
 }

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -501,10 +501,7 @@ mod tests {
     use crate::{FakeFs, Project, project_settings::ProjectSettings};
     use context_server::{
         transport::Transport,
-        types::{
-            self, Implementation, InitializeResponse, ProtocolVersion, RequestType,
-            ServerCapabilities,
-        },
+        types::{self, Implementation, InitializeResponse, ProtocolVersion, ServerCapabilities},
     };
     use futures::{Stream, StreamExt as _, lock::Mutex};
     use gpui::{AppContext, BackgroundExecutor, TestAppContext, UpdateGlobal as _};


### PR DESCRIPTION
This changes the context server crate so that the input/output for a request are encoded at the type level, similar to how it is done for LSP requests.

This also makes it easier to write tests that mock context servers, e.g. you can write something like this now when using the `test-support` feature of the `context-server` crate:

```rust
create_fake_transport("mcp-1", cx.background_executor())
    .on_request::<context_server::types::request::PromptsList>(|_params| {
        PromptsListResponse {
            prompts: vec![/* some prompts */],
            ..
        }
    })
```

Release Notes:

- N/A
