### PR TITLE
freebsd: Improve nightly builds of zed-remote-server

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -172,6 +172,9 @@ jobs:
     if: github.repository_owner == 'zed-industries'
     runs-on: github-8vcpu-ubuntu-2404
     needs: tests
+    env:
+      DIGITALOCEAN_SPACES_ACCESS_KEY: ${{ secrets.DIGITALOCEAN_SPACES_ACCESS_KEY }}
+      DIGITALOCEAN_SPACES_SECRET_KEY: ${{ secrets.DIGITALOCEAN_SPACES_SECRET_KEY }}
     name: Build Zed on FreeBSD
     # env:
     #   MYTOKEN : ${{ secrets.MYTOKEN }}
@@ -205,23 +208,8 @@ jobs:
             rm -rf target/
             cargo clean
 
-      - name: Upload Artifact to Workflow - zed-remote-server (run-bundling)
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
-        if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
-        with:
-          name: zed-remote-server-${{ github.event.pull_request.head.sha || github.sha }}-x86_64-unknown-freebsd.gz
-          path: out/zed-remote-server-freebsd-x86_64.gz
-
-      - name: Upload Artifacts to release
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
-        if: ${{ !(contains(github.event.pull_request.labels.*.name, 'run-bundling')) }}
-        with:
-          draft: true
-          prerelease: ${{ env.RELEASE_CHANNEL == 'preview' }}
-          files: |
-            out/zed-remote-server-freebsd-x86_64.gz
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload Zed Nightly
+        run: script/upload-nightly freebsd
 
   bundle-nix:
     name: Build and cache Nix package

--- a/script/upload-nightly
+++ b/script/upload-nightly
@@ -4,7 +4,7 @@
 bash -euo pipefail
 source script/lib/blob-store.sh
 
-allowed_targets=("linux-targz" "macos")
+allowed_targets=("linux-targz" "macos" "freebsd")
 is_allowed_target() {
     for val in "${allowed_targets[@]}"; do
         if [[ "$1" == "$val" ]]; then
@@ -54,6 +54,9 @@ case "$target" in
         done
         upload_to_blob_store $bucket_name "target/latest-sha" "nightly/latest-sha-linux-targz"
         rm -f "target/latest-sha"
+        ;;
+    freebsd)
+        echo "No freebsd client build (yet)."
         ;;
     *)
         echo "Error: Unknown target '$target'"


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/29561

On nightly: Don't create a release and don't upload artifact to workflow.
Add freebsd support to upload-nightly

Release Notes:

- N/A
