### PR TITLE
Run preferred code actions on `ToggleCodeActions { "quick_launch": true }`

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -78,9 +78,8 @@ pub struct ToggleCodeActions {
     #[serde(default)]
     #[serde(skip)]
     pub deployed_from: Option<CodeActionSource>,
-    // Run first available task if there is only one.
+    // Run the preferred action or the first available task if there is only one.
     #[serde(default)]
-    #[serde(skip)]
     pub quick_launch: bool,
 }
 


### PR DESCRIPTION
Closes #32266

# Summary

I have created this PR for the sake of discussion. Its working locally but not of production quality due to the indirect index sent to `ConfirmCodeAction`. I would be open to mentorship to get it refactored appropriately or happy to let a maintainer take it from here.

keybindings.json
```
...
      "space f": ["editor::ToggleCodeActions", { "quick_launch": true }],
...
```



# Release Notes:

- When there is a preferred CodeAction run that on ToggleCodeActions{"quick_launch": true}

# Questions for the zed-industries:

- Is this fix directionally correct? Specifically is this functionality best implemented under the ` ToggleCodeActions{"quick_launch": true}` editor command?
- i suspect an acceptable version of this fix is:
  1. In toggle_code_actions, query actions to see if there is a `preferred` action
  2. **Some how communicate that `ConfirmCodeAction` should `quick_launch`** without being specific about the index
  3. In `confirm_code_action` if in`quick_launch` mode, run the preferred code action or the singular template.
 
  The question is the **some how communicate**, I was thinking perhaps this: `ConfirmCodeAction{ action_ix: None, quick_launch: true}`