### PR TITLE
Stop formatting SQL by default with prettier

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1544,12 +1544,6 @@
         "allowed": true
       }
     },
-    "SQL": {
-      "prettier": {
-        "allowed": true,
-        "plugins": ["prettier-plugin-sql"]
-      }
-    },
     "Starlark": {
       "language_servers": ["starpls", "!buck2-lsp", "..."]
     },


### PR DESCRIPTION
- Closes: https://github.com/zed-industries/zed/discussions/32261
- Follow-up to: https://github.com/zed-extensions/sql/pull/19
- Follow-up to: https://github.com/zed-industries/zed/pull/32003

The underlying `sql-formatter` used by `prettier-plugin-sql` needs to have the SQL dialect (mysql, postgresql) passed as the prettier language name, while Zed passes `sql`, which default will corrupt sql files with vendor specific extensions (postgresql jsonb operators, etc).

I improved the [Zed SQL Language Docs](https://zed.dev/docs/languages/sql) in https://github.com/zed-industries/zed/pull/32003 to show how to use `sql-formatter` directly as an external formatter.

Release Notes:

- SQL: Disable `format_on_save` using `prettier-plugin-sql` by default. Please see the [Zed SQL Language Docs](https://zed.dev/docs/languages/sql) for settings to use `sql-formatter` directly instead. 