### PR TITLE
Fix anchor biases for completion replacement ranges (esp slash commands) (cherry-pick #32262)

### DIFF
--- a/crates/agent/src/context_picker/completion_provider.rs
+++ b/crates/agent/src/context_picker/completion_provider.rs
@@ -767,7 +767,7 @@ impl CompletionProvider for ContextPickerCompletionProvider {
 
         let snapshot = buffer.read(cx).snapshot();
         let source_range = snapshot.anchor_before(state.source_range.start)
-            ..snapshot.anchor_before(state.source_range.end);
+            ..snapshot.anchor_after(state.source_range.end);
 
         let thread_store = self.thread_store.clone();
         let text_thread_store = self.text_thread_store.clone();

--- a/crates/assistant_context_editor/src/slash_command.rs
+++ b/crates/assistant_context_editor/src/slash_command.rs
@@ -240,13 +240,14 @@ impl SlashCommandCompletionProvider {
 
                 Ok(vec![project::CompletionResponse {
                     completions,
-                    is_incomplete: false,
+                    // TODO: Could have slash commands indicate whether their completions are incomplete.
+                    is_incomplete: true,
                 }])
             })
         } else {
             Task::ready(Ok(vec![project::CompletionResponse {
                 completions: Vec::new(),
-                is_incomplete: false,
+                is_incomplete: true,
             }]))
         }
     }
@@ -275,17 +276,17 @@ impl CompletionProvider for SlashCommandCompletionProvider {
                     position.row,
                     call.arguments.last().map_or(call.name.end, |arg| arg.end) as u32,
                 );
-                let command_range = buffer.anchor_after(command_range_start)
+                let command_range = buffer.anchor_before(command_range_start)
                     ..buffer.anchor_after(command_range_end);
 
                 let name = line[call.name.clone()].to_string();
                 let (arguments, last_argument_range) = if let Some(argument) = call.arguments.last()
                 {
                     let last_arg_start =
-                        buffer.anchor_after(Point::new(position.row, argument.start as u32));
+                        buffer.anchor_before(Point::new(position.row, argument.start as u32));
                     let first_arg_start = call.arguments.first().expect("we have the last element");
-                    let first_arg_start =
-                        buffer.anchor_after(Point::new(position.row, first_arg_start.start as u32));
+                    let first_arg_start = buffer
+                        .anchor_before(Point::new(position.row, first_arg_start.start as u32));
                     let arguments = call
                         .arguments
                         .into_iter()
@@ -298,7 +299,7 @@ impl CompletionProvider for SlashCommandCompletionProvider {
                     )
                 } else {
                     let start =
-                        buffer.anchor_after(Point::new(position.row, call.name.start as u32));
+                        buffer.anchor_before(Point::new(position.row, call.name.start as u32));
                     (None, start..buffer_position)
                 };
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5046,7 +5046,13 @@ impl Editor {
             return;
         }
 
-        let position = self.selections.newest_anchor().head();
+        let multibuffer_snapshot = self.buffer.read(cx).read(cx);
+
+        let position = self
+            .selections
+            .newest_anchor()
+            .head()
+            .bias_right(&multibuffer_snapshot);
         if position.diff_base_anchor.is_some() {
             return;
         }
@@ -5059,8 +5065,9 @@ impl Editor {
         let buffer_snapshot = buffer.read(cx).snapshot();
 
         let query: Option<Arc<String>> =
-            Self::completion_query(&self.buffer.read(cx).read(cx), position)
-                .map(|query| query.into());
+            Self::completion_query(&multibuffer_snapshot, position).map(|query| query.into());
+
+        drop(multibuffer_snapshot);
 
         let provider = match requested_source {
             Some(CompletionsMenuSource::Normal) | None => self.completion_provider.clone(),

--- a/crates/inspector_ui/src/div_inspector.rs
+++ b/crates/inspector_ui/src/div_inspector.rs
@@ -726,7 +726,7 @@ fn completion_replace_range(snapshot: &BufferSnapshot, anchor: &Anchor) -> Optio
 
     if end_in_line > start_in_line {
         let replace_start = snapshot.anchor_before(line_start + start_in_line);
-        let replace_end = snapshot.anchor_before(line_start + end_in_line);
+        let replace_end = snapshot.anchor_after(line_start + end_in_line);
         Some(replace_start..replace_end)
     } else {
         None


### PR DESCRIPTION
Closes #32205

The issue was that in some places the end of the replacement range used anchors with `Bias::Left` instead of `Bias::Right`. Before #31872 completions were recomputed on every change and so the anchor bias didn't matter.  After that change, the end anchor didn't move as the user's typing. Changing it to `Bias::Right` to "stick" to the character to the right of the cursor fixes this.

Also fixes slash command arguments to now have `is_incomplete: true`, since some of the argument providers do limited fuzzy matching.

Release Notes:

- Fixed slash command completions in agent text threads to replace the user's query text (Preview Only)