### PR TITLE
editor: Respect `multi_cursor_modifier` setting when making columnar selections using mouse

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -101,11 +101,11 @@
     // The second option is decimal.
     "unit": "binary"
   },
-  // Determines which modifier key to hold down when clicking to add multiple cursors.
+  // Determines the modifier to be used to add multiple cursors with the mouse.
   //
-  // 1. Use `alt` on Linux/Windows, and `opt` on MacOS:
+  // 1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:
   //    "alt"
-  // 2. Use `ctrl` on Linux/Windows, and `cmd` on MacOS:
+  // 2. Maps `Control` on Linux and Windows and to `Command` on MacOS:
   //    "cmd_or_ctrl" (alias: "cmd", "ctrl")
   "multi_cursor_modifier": "alt",
   // Whether to enable vim modes and key bindings.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -101,7 +101,7 @@
     // The second option is decimal.
     "unit": "binary"
   },
-  // Determines the modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.
+  // Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
   //
   // 1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:
   //    "alt"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -101,7 +101,7 @@
     // The second option is decimal.
     "unit": "binary"
   },
-  // Determines the modifier to be used to add multiple cursors with the mouse.
+  // Determines the modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.
   //
   // 1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:
   //    "alt"

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -101,9 +101,12 @@
     // The second option is decimal.
     "unit": "binary"
   },
-  // The key to use for adding multiple cursors
-  // Currently "alt" or "cmd_or_ctrl"  (also aliased as
-  // "cmd" and "ctrl") are supported.
+  // Determines which modifier key to hold down when clicking to add multiple cursors.
+  //
+  // 1. Use `alt` on Linux/Windows, and `opt` on MacOS:
+  //    "alt"
+  // 2. Use `ctrl` on Linux/Windows, and `cmd` on MacOS:
+  //    "cmd_or_ctrl" (alias: "cmd", "ctrl")
   "multi_cursor_modifier": "alt",
   // Whether to enable vim modes and key bindings.
   "vim_mode": false,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -213,10 +213,13 @@ use workspace::{
     searchable::SearchEvent,
 };
 
-use crate::signature_help::{SignatureHelpHiddenBy, SignatureHelpState};
 use crate::{
     code_context_menus::CompletionsMenuSource,
     hover_links::{find_url, find_url_from_range},
+};
+use crate::{
+    editor_settings::MultiCursorModifier,
+    signature_help::{SignatureHelpHiddenBy, SignatureHelpState},
 };
 
 pub const FILE_HEADER_HEIGHT: u32 = 2;
@@ -252,14 +255,6 @@ pub type RenderDiffHunkControlsFn = Arc<
         &mut App,
     ) -> AnyElement,
 >;
-
-const COLUMNAR_SELECTION_MODIFIERS: Modifiers = Modifiers {
-    alt: true,
-    shift: true,
-    control: false,
-    platform: false,
-    function: false,
-};
 
 struct InlineValueCache {
     enabled: bool,
@@ -7091,6 +7086,10 @@ impl Editor {
         )
     }
 
+    fn columnar_selection_modifiers(multi_cursor_modifier: bool, modifiers: &Modifiers) -> bool {
+        modifiers.shift && multi_cursor_modifier && modifiers.number_of_modifiers() == 2
+    }
+
     fn update_selection_mode(
         &mut self,
         modifiers: &Modifiers,
@@ -7098,7 +7097,15 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if modifiers != &COLUMNAR_SELECTION_MODIFIERS || self.selections.pending.is_none() {
+        let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
+        let multi_cursor_modifier = match multi_cursor_setting {
+            MultiCursorModifier::Alt => modifiers.alt,
+            MultiCursorModifier::CmdOrCtrl => modifiers.secondary(),
+        };
+
+        if !Self::columnar_selection_modifiers(multi_cursor_modifier, modifiers)
+            || self.selections.pending.is_none()
+        {
             return;
         }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7086,6 +7086,14 @@ impl Editor {
         )
     }
 
+    fn multi_cursor_modifier(modifiers: &Modifiers, cx: &mut Context<Self>) -> bool {
+        let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
+        match multi_cursor_setting {
+            MultiCursorModifier::Alt => modifiers.alt,
+            MultiCursorModifier::CmdOrCtrl => modifiers.secondary(),
+        }
+    }
+
     fn columnar_selection_modifiers(multi_cursor_modifier: bool, modifiers: &Modifiers) -> bool {
         modifiers.shift && multi_cursor_modifier && modifiers.number_of_modifiers() == 2
     }
@@ -7097,12 +7105,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
-        let multi_cursor_modifier = match multi_cursor_setting {
-            MultiCursorModifier::Alt => modifiers.alt,
-            MultiCursorModifier::CmdOrCtrl => modifiers.secondary(),
-        };
-
+        let multi_cursor_modifier = Self::multi_cursor_modifier(modifiers, cx);
         if !Self::columnar_selection_modifiers(multi_cursor_modifier, modifiers)
             || self.selections.pending.is_none()
         {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7086,11 +7086,22 @@ impl Editor {
         )
     }
 
-    fn multi_cursor_modifier(modifiers: &Modifiers, cx: &mut Context<Self>) -> bool {
+    fn multi_cursor_modifier(
+        cursor_event: bool,
+        modifiers: &Modifiers,
+        cx: &mut Context<Self>,
+    ) -> bool {
         let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
-        match multi_cursor_setting {
-            MultiCursorModifier::Alt => modifiers.alt,
-            MultiCursorModifier::CmdOrCtrl => modifiers.secondary(),
+        if cursor_event {
+            match multi_cursor_setting {
+                MultiCursorModifier::Alt => modifiers.alt,
+                MultiCursorModifier::CmdOrCtrl => modifiers.secondary(),
+            }
+        } else {
+            match multi_cursor_setting {
+                MultiCursorModifier::Alt => modifiers.secondary(),
+                MultiCursorModifier::CmdOrCtrl => modifiers.alt,
+            }
         }
     }
 
@@ -7105,7 +7116,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let multi_cursor_modifier = Self::multi_cursor_modifier(modifiers, cx);
+        let multi_cursor_modifier = Self::multi_cursor_modifier(true, modifiers, cx);
         if !Self::columnar_selection_modifiers(multi_cursor_modifier, modifiers)
             || self.selections.pending.is_none()
         {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -422,7 +422,7 @@ pub struct EditorSettingsContent {
     /// Default: always
     pub seed_search_query_from_cursor: Option<SeedQuerySetting>,
     pub use_smartcase_search: Option<bool>,
-    /// Determines the modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.
+    /// Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
     ///
     /// Default: alt
     pub multi_cursor_modifier: Option<MultiCursorModifier>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -422,7 +422,7 @@ pub struct EditorSettingsContent {
     /// Default: always
     pub seed_search_query_from_cursor: Option<SeedQuerySetting>,
     pub use_smartcase_search: Option<bool>,
-    /// The key to use for adding multiple cursors
+    /// Determines which modifier key to hold down when clicking to add multiple cursors.
     ///
     /// Default: alt
     pub multi_cursor_modifier: Option<MultiCursorModifier>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -422,7 +422,7 @@ pub struct EditorSettingsContent {
     /// Default: always
     pub seed_search_query_from_cursor: Option<SeedQuerySetting>,
     pub use_smartcase_search: Option<bool>,
-    /// Determines which modifier key to hold down when clicking to add multiple cursors.
+    /// Determines the modifier to be used to add multiple cursors with the mouse.
     ///
     /// Default: alt
     pub multi_cursor_modifier: Option<MultiCursorModifier>,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -422,7 +422,7 @@ pub struct EditorSettingsContent {
     /// Default: always
     pub seed_search_query_from_cursor: Option<SeedQuerySetting>,
     pub use_smartcase_search: Option<bool>,
-    /// Determines the modifier to be used to add multiple cursors with the mouse.
+    /// Determines the modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.
     ///
     /// Default: alt
     pub multi_cursor_modifier: Option<MultiCursorModifier>,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -678,7 +678,7 @@ impl EditorElement {
         let point_for_position = position_map.point_for_position(event.position);
         let position = point_for_position.previous_valid;
 
-        let multi_cursor_modifier = Editor::multi_cursor_modifier(&modifiers, cx);
+        let multi_cursor_modifier = Editor::multi_cursor_modifier(true, &modifiers, cx);
 
         if Editor::columnar_selection_modifiers(multi_cursor_modifier, &modifiers) {
             editor.select(
@@ -864,7 +864,7 @@ impl EditorElement {
         let text_hitbox = &position_map.text_hitbox;
         let pending_nonempty_selections = editor.has_pending_nonempty_selection();
 
-        let hovered_link_modifier = !Editor::multi_cursor_modifier(&event.modifiers(), cx);
+        let hovered_link_modifier = Editor::multi_cursor_modifier(false, &event.modifiers(), cx);
 
         if !pending_nonempty_selections && hovered_link_modifier && text_hitbox.is_hovered(window) {
             let point = position_map.point_for_position(event.up.position);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -679,11 +679,7 @@ impl EditorElement {
         let point_for_position = position_map.point_for_position(event.position);
         let position = point_for_position.previous_valid;
 
-        let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
-        let multi_cursor_modifier = match multi_cursor_setting {
-            MultiCursorModifier::Alt => modifiers.alt,
-            MultiCursorModifier::CmdOrCtrl => modifiers.secondary(),
-        };
+        let multi_cursor_modifier = Editor::multi_cursor_modifier(&modifiers, cx);
 
         if Editor::columnar_selection_modifiers(multi_cursor_modifier, &modifiers) {
             editor.select(
@@ -869,11 +865,7 @@ impl EditorElement {
         let text_hitbox = &position_map.text_hitbox;
         let pending_nonempty_selections = editor.has_pending_nonempty_selection();
 
-        let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
-        let hovered_link_modifier = match multi_cursor_setting {
-            MultiCursorModifier::Alt => event.modifiers().secondary(),
-            MultiCursorModifier::CmdOrCtrl => event.modifiers().alt,
-        };
+        let hovered_link_modifier = !Editor::multi_cursor_modifier(&event.modifiers(), cx);
 
         if !pending_nonempty_selections && hovered_link_modifier && text_hitbox.is_hovered(window) {
             let point = position_map.point_for_position(event.up.position);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -17,8 +17,7 @@ use crate::{
     },
     editor_settings::{
         CurrentLineHighlight, DoubleClickInMultibuffer, MinimapThumb, MinimapThumbBorder,
-        MultiCursorModifier, ScrollBeyondLastLine, ScrollbarAxes, ScrollbarDiagnostics,
-        ShowMinimap, ShowScrollbar,
+        ScrollBeyondLastLine, ScrollbarAxes, ScrollbarDiagnostics, ShowMinimap, ShowScrollbar,
     },
     git::blame::{BlameRenderer, GitBlame, GlobalBlameRenderer},
     hover_popover::{

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -120,7 +120,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let hovered_link_modifier = !Editor::multi_cursor_modifier(&modifiers, cx);
+        let hovered_link_modifier = Editor::multi_cursor_modifier(false, &modifiers, cx);
         if !hovered_link_modifier || self.has_pending_selection() {
             self.hide_hovered_link(cx);
             return;

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -120,11 +120,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let multi_cursor_setting = EditorSettings::get_global(cx).multi_cursor_modifier;
-        let hovered_link_modifier = match multi_cursor_setting {
-            MultiCursorModifier::Alt => modifiers.secondary(),
-            MultiCursorModifier::CmdOrCtrl => modifiers.alt,
-        };
+        let hovered_link_modifier = !Editor::multi_cursor_modifier(&modifiers, cx);
         if !hovered_link_modifier || self.has_pending_selection() {
             self.hide_hovered_link(cx);
             return;

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -1,7 +1,7 @@
 use crate::{
     Anchor, Editor, EditorSettings, EditorSnapshot, FindAllReferences, GoToDefinition,
     GoToTypeDefinition, GotoDefinitionKind, InlayId, Navigated, PointForPosition, SelectPhase,
-    editor_settings::{GoToDefinitionFallback, MultiCursorModifier},
+    editor_settings::GoToDefinitionFallback,
     hover_popover::{self, InlayHover},
     scroll::ScrollAmount,
 };

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1926,13 +1926,13 @@ Example:
 
 ## Multi Cursor Modifier
 
-- Description: Determines which modifier key to hold down when clicking to add multiple cursors.
+- Description: Determines the modifier to be used to add multiple cursors with the mouse.
 - Setting: `multi_cursor_modifier`
 - Default: `alt`
 
 **Options**
 
-1. Use `alt` on Linux/Windows, and `opt` on MacOS:
+1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:
 
 ```json
 {
@@ -1940,7 +1940,7 @@ Example:
 }
 ```
 
-2. Use `ctrl` on Linux/Windows, and `cmd` on MacOS:
+2. Maps `Control` on Linux and Windows and to `Command` on MacOS:
 
 ```json
 {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1926,7 +1926,7 @@ Example:
 
 ## Multi Cursor Modifier
 
-- Description: Determines the modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.
+- Description: Determines the modifier to be used to add multiple cursors with the mouse. The open hover link mouse gestures will adapt such that it do not conflict with the multicursor modifier.
 - Setting: `multi_cursor_modifier`
 - Default: `alt`
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1936,7 +1936,7 @@ Example:
 
 ```jsonc
 {
-  "multi_cursor_modifier": "alt"
+  "multi_cursor_modifier": "alt",
 }
 ```
 
@@ -1944,7 +1944,7 @@ Example:
 
 ```jsonc
 {
-  "multi_cursor_modifier": "cmd_or_ctrl" // alias: "cmd", "ctrl"
+  "multi_cursor_modifier": "cmd_or_ctrl", // alias: "cmd", "ctrl"
 }
 ```
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1926,7 +1926,7 @@ Example:
 
 ## Multi Cursor Modifier
 
-- Description: Determines the modifier to be used to add multiple cursors with the mouse.
+- Description: Determines the modifier to be used to add multiple cursors with the mouse. The Go to Definition and Open Link mouse gestures will adapt such that they do not conflict with the multicursor modifier.
 - Setting: `multi_cursor_modifier`
 - Default: `alt`
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1934,7 +1934,7 @@ Example:
 
 1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:
 
-```json
+```jsonc
 {
   "multi_cursor_modifier": "alt"
 }
@@ -1942,7 +1942,7 @@ Example:
 
 2. Maps `Control` on Linux and Windows and to `Command` on MacOS:
 
-```json
+```jsonc
 {
   "multi_cursor_modifier": "cmd_or_ctrl" // alias: "cmd", "ctrl"
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1924,6 +1924,30 @@ Example:
 
 `boolean` values
 
+## Multi Cursor Modifier
+
+- Description: Determines which modifier key to hold down when clicking to add multiple cursors.
+- Setting: `multi_cursor_modifier`
+- Default: `alt`
+
+**Options**
+
+1. Use `alt` on Linux/Windows, and `opt` on MacOS:
+
+```json
+{
+  "multi_cursor_modifier": "alt"
+}
+```
+
+2. Use `ctrl` on Linux/Windows, and `cmd` on MacOS:
+
+```json
+{
+  "multi_cursor_modifier": "cmd_or_ctrl" // alias: "cmd", "ctrl"
+}
+```
+
 ## Hover Popover Enabled
 
 - Description: Whether or not to show the informational hover box when moving the mouse over symbols in the editor.


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/31181

Release Notes:

- Added the `multi_cursor_modifier` setting to be respected when making columnar selections using the mouse drag.
