### PR TITLE
docs: Fix typo in SUMMARY.md

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -147,7 +147,7 @@
   - [macOS](./development/macos.md)
   - [Linux](./development/linux.md)
   - [Windows](./development/windows.md)
-  - [FreeBSD}(./development/freebsd.md)]
+  - [FreeBSD](./development/freebsd.md)
   - [Local Collaboration](./development/local-collaboration.md)
   - [Using Debuggers](./development/debuggers.md)
 - [Release Process](./development/releases.md)


### PR DESCRIPTION
- Follow-up to: https://github.com/zed-industries/zed/pull/30981
- See also: https://github.com/zed-industries/zed/pull/30844
- See also: https://github.com/zed-industries/zed/pull/31073

Changes made to docs tests meant that failure to build docs did not prevent an automerge.
This resulted in breaking main in 65a93a0036acfa680dbf2ba859d8641876ea6057 [action run link](https://github.com/zed-industries/zed/actions/runs/15501437863).

CC: @probably-neb 

Release Notes:

- N/A
