### PR TITLE
vim: Add color to mode status

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1681,7 +1681,9 @@
     // Specify the mode as the key and the shape as the value.
     // The mode can be one of the following: "normal", "replace", "insert", "visual".
     // The shape can be one of the following: "block", "bar", "underline", "hollow".
-    "cursor_shape": {}
+    "cursor_shape": {},
+    // Adds color to the mode in the status bar
+    "colored_mode": false
   },
   // The server to connect to. If the environment variable
   // ZED_SERVER_URL is set, it will override this setting.

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -28,8 +28,8 @@ use std::{fmt::Display, ops::Range, sync::Arc};
 use text::{Bias, ToPoint};
 use theme::ThemeSettings;
 use ui::{
-    ActiveTheme, Context, Div, FluentBuilder, KeyBinding, ParentElement, SharedString, Styled,
-    StyledTypography, Window, h_flex, rems,
+    ActiveTheme, Color, Context, Div, FluentBuilder, KeyBinding, ParentElement, SharedString,
+    Styled, StyledTypography, Window, h_flex, rems,
 };
 use util::ResultExt;
 use workspace::searchable::Direction;
@@ -65,6 +65,18 @@ impl Mode {
         match self {
             Self::Visual | Self::VisualLine | Self::VisualBlock => true,
             Self::Normal | Self::Insert | Self::Replace | Self::HelixNormal => false,
+        }
+    }
+
+    pub fn color(&self) -> Color {
+        match self {
+            Mode::Normal => Color::Accent,
+            Mode::Insert => Color::Created,
+            Mode::Replace => Color::Deleted,
+            Mode::Visual => Color::Conflict,
+            Mode::VisualLine => Color::Conflict,
+            Mode::VisualBlock => Color::Conflict,
+            Mode::HelixNormal => Color::Accent,
         }
     }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1731,6 +1731,7 @@ struct VimSettings {
     pub custom_digraphs: HashMap<String, Arc<str>>,
     pub highlight_on_yank_duration: u64,
     pub cursor_shape: CursorShapeSettings,
+    pub colored_mode: bool,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1743,6 +1744,7 @@ struct VimSettingsContent {
     pub custom_digraphs: Option<HashMap<String, Arc<str>>>,
     pub highlight_on_yank_duration: Option<u64>,
     pub cursor_shape: Option<CursorShapeSettings>,
+    pub colored_mode: Option<bool>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -1802,6 +1804,7 @@ impl Settings for VimSettings {
                 .highlight_on_yank_duration
                 .ok_or_else(Self::missing_default)?,
             cursor_shape: settings.cursor_shape.ok_or_else(Self::missing_default)?,
+            colored_mode: settings.colored_mode.ok_or_else(Self::missing_default)?,
         })
     }
 


### PR DESCRIPTION

![image](https://github.com/user-attachments/assets/ddecbb71-0ac3-407c-9657-1f1f3eb67b3e)
![image](https://github.com/user-attachments/assets/5492d756-0ea4-4a53-a3f6-8dee9a0e6b8d)


Release Notes:

- Vim: Add color to mode status
