### PR TITLE
language_models: Fix Copilot models not loading

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -60,17 +60,6 @@ impl State {
     }
 }
 
-fn apply_settings_to_copilot_chat(cx: &mut App) {
-    if let Some(copilot_chat) = CopilotChat::global(cx) {
-        let settings = AllLanguageModelSettings::get_global(cx)
-            .copilot_chat
-            .clone();
-        copilot_chat.update(cx, |chat, cx| {
-            chat.set_settings(settings, cx);
-        });
-    }
-}
-
 impl CopilotChatLanguageModelProvider {
     pub fn new(cx: &mut App) -> Self {
         let state = cx.new(|cx| {
@@ -79,7 +68,14 @@ impl CopilotChatLanguageModelProvider {
             State {
                 _copilot_chat_subscription: copilot_chat_subscription,
                 _settings_subscription: cx.observe_global::<SettingsStore>(|_, cx| {
-                    apply_settings_to_copilot_chat(cx);
+                    if let Some(copilot_chat) = CopilotChat::global(cx) {
+                        let settings = AllLanguageModelSettings::get_global(cx)
+                            .copilot_chat
+                            .clone();
+                        copilot_chat.update(cx, |chat, cx| {
+                            chat.set_settings(settings, cx);
+                        });
+                    }
                     cx.notify();
                 }),
             }

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -60,6 +60,17 @@ impl State {
     }
 }
 
+fn apply_settings_to_copilot_chat(cx: &mut App) {
+    if let Some(copilot_chat) = CopilotChat::global(cx) {
+        let settings = AllLanguageModelSettings::get_global(cx)
+            .copilot_chat
+            .clone();
+        copilot_chat.update(cx, |chat, cx| {
+            chat.set_settings(settings, cx);
+        });
+    }
+}
+
 impl CopilotChatLanguageModelProvider {
     pub fn new(cx: &mut App) -> Self {
         let state = cx.new(|cx| {
@@ -68,6 +79,7 @@ impl CopilotChatLanguageModelProvider {
             State {
                 _copilot_chat_subscription: copilot_chat_subscription,
                 _settings_subscription: cx.observe_global::<SettingsStore>(|_, cx| {
+                    apply_settings_to_copilot_chat(cx);
                     cx.notify();
                 }),
             }


### PR DESCRIPTION
Recently in this PR: https://github.com/zed-industries/zed/pull/32248 github copilot settings was introduced. This had missing settings update which was leading to github copilot models not getting fetched. This had missing subscription to update the settings inside the copilot language model provider. Which caused it not show models at all.

cc @osiewicz 

Release Notes:

- N/A
