### PR TITLE
ci: Switch Linux arm from buildjet to github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,7 +683,7 @@ jobs:
     timeout-minutes: 60
     name: Linux arm64 release bundle
     runs-on:
-      - buildjet-16vcpu-ubuntu-2204-arm
+      - hosted-linux-arm-1
     if: |
       startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling')


### PR DESCRIPTION
This is a test to verify that we can build linux release arm on github runners as we've had some buildjet issues lately.

Release Notes:

- N/A
