### PR TITLE
language: Don't add final newline on format for an empty buffer

### DIFF
--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1877,6 +1877,9 @@ impl Buffer {
     /// no other whitespace.
     pub fn ensure_final_newline(&mut self, cx: &mut Context<Self>) {
         let len = self.len();
+        if len == 0 {
+            return;
+        }
         let mut offset = len;
         for chunk in self.as_rope().reversed_chunks_in_range(0..len) {
             let non_whitespace_len = chunk

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -1874,7 +1874,7 @@ impl Buffer {
     }
 
     /// Ensures that the buffer ends with a single newline character, and
-    /// no other whitespace.
+    /// no other whitespace. Skips if the buffer is empty.
     pub fn ensure_final_newline(&mut self, cx: &mut Context<Self>) {
         let len = self.len();
         if len == 0 {


### PR DESCRIPTION
Closes #32313

Release Notes:

- Fixed newline getting added on format to empty files
