### PR TITLE
editor: Add trailing whitespace rendering

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7218,7 +7218,7 @@ impl LineWithInvisibles {
                     previous_start = start;
                     paint(window, cx);
                 }
-            },
+            }
 
             // For a whitespace to be on a boundary, any of the following conditions need to be met:
             // - It is a tab

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -7209,6 +7209,17 @@ impl LineWithInvisibles {
                 paint(window, cx);
             }),
 
+            ShowWhitespaceSetting::Trailing => {
+                let mut previous_start = self.len;
+                for ([start, end], paint) in invisible_iter.rev() {
+                    if previous_start != end {
+                        break;
+                    }
+                    previous_start = start;
+                    paint(window, cx);
+                }
+            },
+
             // For a whitespace to be on a boundary, any of the following conditions need to be met:
             // - It is a tab
             // - It is adjacent to an edge (start or end)

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -765,6 +765,8 @@ pub enum ShowWhitespaceSetting {
     /// - It is adjacent to an edge (start or end)
     /// - It is adjacent to a whitespace (left or right)
     Boundary,
+    /// Draw whitespaces only after non-whitespace characters.
+    Trailing,
 }
 
 /// Controls which formatter should be used when formatting code.
@@ -1452,7 +1454,8 @@ impl settings::Settings for AllLanguageSettings {
         vscode.bool_setting("editor.inlineSuggest.enabled", &mut d.show_edit_predictions);
         vscode.enum_setting("editor.renderWhitespace", &mut d.show_whitespaces, |s| {
             Some(match s {
-                "boundary" | "trailing" => ShowWhitespaceSetting::Boundary,
+                "boundary" => ShowWhitespaceSetting::Boundary,
+                "trailing" => ShowWhitespaceSetting::Trailing,
                 "selection" => ShowWhitespaceSetting::Selection,
                 "all" => ShowWhitespaceSetting::All,
                 _ => ShowWhitespaceSetting::None,


### PR DESCRIPTION
Closes #5237

- Adds "trailing" option for "show_whitespaces" in settings.json
- Supports importing this setting from vscode

The option in question will render only whitespace characters that appear after every non-whitespace character in a given line.

Release Notes:

- Added trailing whitespace rendering