### PR TITLE
Add CI check that `cmd-` is not in linux keymaps + check other mods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,9 @@ jobs:
       - name: Check for todo! and FIXME comments
         run: script/check-todos
 
+      - name: Check modifier use in keymaps
+        run: script/check-keymaps
+
       - name: Run style checks
         uses: ./.github/actions/check_style
 

--- a/script/check-keymaps
+++ b/script/check-keymaps
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+pattern='cmd-'
+result=$(git grep --no-color --line-number --fixed-strings -e "$pattern" -- \
+  'assets/keymaps/' \
+  ':(exclude)assets/keymaps/storybook.json' \
+  ':(exclude)assets/keymaps/default-macos.json' \
+  ':(exclude)assets/keymaps/macos/*.json' || true)
+
+if [[ -n "${result}" ]]; then
+  echo "${result}"
+  echo "Error: Found 'cmd-' in non-macOS keymap files."
+  exit 1
+fi
+
+pattern='super-|win-|fn-'
+result=$(git grep --no-color --line-number --fixed-strings -e "$pattern" -- \
+  'assets/keymaps/' || true)
+
+if [[ -n "${result}" ]]; then
+  echo "${result}"
+  echo "Error: Found 'super-', 'win-', or 'fn-' in keymap files. Currently these aren't used."
+  exit 1
+fi

--- a/script/check-todos
+++ b/script/check-todos
@@ -8,7 +8,7 @@ result=$(git grep --no-color --ignore-case --line-number --extended-regexp -e $p
   ':(exclude).github/workflows/ci.yml' \
   ':(exclude)*criteria.md' \
   ':(exclude)*prompt.md' || true)
-echo "${result}"
 if [[ -n "${result}" ]]; then
+  echo "${result}"
   exit 1
 fi


### PR DESCRIPTION
Motivation for the `cmd-` check is that there were a couple keybindings using `cmd-` in the linux keymap and so these were bound to super / windows

Release Notes:

- N/A