### PR TITLE
gpui: Merge `DevicePixels` and `ScaledPixels` into `PhysicalPixels`

### DIFF
--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -2950,7 +2950,7 @@ fn token_state(context: &Entity<AssistantContext>, cx: &App) -> Option<TokenStat
 fn size_for_image(data: &RenderImage, max_size: Size<Pixels>) -> Size<Pixels> {
     let image_size = data
         .size(0)
-        .map(|dimension| Pixels::from(u32::from(dimension)));
+        .map(|dimension| Pixels::from(dimension.as_u32()));
     let image_ratio = image_size.width / image_size.height;
     let bounds_ratio = max_size.width / max_size.height;
 

--- a/crates/gpui/src/assets.rs
+++ b/crates/gpui/src/assets.rs
@@ -1,4 +1,4 @@
-use crate::{DevicePixels, Result, SharedString, Size, size};
+use crate::{DevicePixels, PhysicalPixels, Result, SharedString, Size, size};
 use smallvec::SmallVec;
 
 use image::{Delay, Frame};
@@ -74,7 +74,10 @@ impl RenderImage {
     /// Get the size of this image, in pixels.
     pub fn size(&self, frame_index: usize) -> Size<DevicePixels> {
         let (width, height) = self.data[frame_index].buffer().dimensions();
-        size(width.into(), height.into())
+        size(
+            PhysicalPixels::from_u32(width),
+            PhysicalPixels::from_u32(height),
+        )
     }
 
     /// Get the delay of this frame from the previous

--- a/crates/gpui/src/elements/surface.rs
+++ b/crates/gpui/src/elements/surface.rs
@@ -94,7 +94,10 @@ impl Element for Surface {
         match &self.source {
             #[cfg(target_os = "macos")]
             SurfaceSource::Surface(surface) => {
-                let size = crate::size(surface.get_width().into(), surface.get_height().into());
+                let size = crate::size(
+                    crate::physical_px(surface.get_width().try_into().unwrap()),
+                    crate::physical_px(surface.get_height().try_into().unwrap()),
+                );
                 let new_bounds = self.object_fit.get_bounds(bounds, size);
                 // TODO: Add support for corner_radii
                 window.paint_surface(new_bounds, surface.clone());

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -13,7 +13,7 @@ use std::{
     cmp::{self, PartialOrd},
     fmt::{self, Display},
     hash::Hash,
-    ops::{Add, Div, Mul, MulAssign, Neg, Sub},
+    ops::{Add, Div, Mul, MulAssign, Neg, Rem, Sub},
 };
 
 use crate::{App, DisplayId};
@@ -2572,7 +2572,7 @@ impl std::ops::RemAssign for Pixels {
     }
 }
 
-impl std::ops::Rem for Pixels {
+impl Rem for Pixels {
     type Output = Self;
 
     fn rem(self, rhs: Self) -> Self {
@@ -2826,7 +2826,6 @@ impl From<usize> for Pixels {
     Clone,
     Copy,
     Default,
-    Div,
     Eq,
     Hash,
     Ord,
@@ -3000,52 +2999,48 @@ impl From<u64> for DevicePixels {
     }
 }
 
-impl Div for ScaledPixels {
-    type Output = f32;
+impl<T: Div> Div for PhysicalPixels<T> {
+    type Output = T::Output;
 
     fn div(self, rhs: Self) -> Self::Output {
         self.0 / rhs.0
     }
 }
 
-impl std::ops::DivAssign for ScaledPixels {
-    fn div_assign(&mut self, rhs: Self) {
-        *self = Self(self.0 / rhs.0);
+impl<T: Div> Div<T> for PhysicalPixels<T> {
+    type Output = PhysicalPixels<T::Output>;
+
+    fn div(self, rhs: T) -> Self::Output {
+        physical_px(self.0 / rhs)
     }
 }
 
-impl std::ops::RemAssign for ScaledPixels {
-    fn rem_assign(&mut self, rhs: Self) {
-        self.0 %= rhs.0;
+impl<T: Rem> Rem for PhysicalPixels<T> {
+    type Output = T::Output;
+
+    fn rem(self, rhs: Self) -> Self::Output {
+        self.0 % rhs.0
     }
 }
 
-impl std::ops::Rem for ScaledPixels {
-    type Output = Self;
+impl<T: Rem> Rem<T> for PhysicalPixels<T> {
+    type Output = PhysicalPixels<T::Output>;
 
-    fn rem(self, rhs: Self) -> Self {
-        Self(self.0 % rhs.0)
+    fn rem(self, rhs: T) -> Self::Output {
+        physical_px(self.0 % rhs)
     }
 }
 
-impl Mul<f32> for ScaledPixels {
-    type Output = Self;
+impl<T: Mul> Mul<T> for PhysicalPixels<T> {
+    type Output = PhysicalPixels<T::Output>;
 
-    fn mul(self, rhs: f32) -> Self {
-        Self(self.0 * rhs)
+    fn mul(self, rhs: T) -> Self::Output {
+        physical_px(self.0 * rhs)
     }
 }
 
-impl Mul<ScaledPixels> for f32 {
-    type Output = ScaledPixels;
-
-    fn mul(self, rhs: ScaledPixels) -> Self::Output {
-        rhs * self
-    }
-}
-
-impl MulAssign<f32> for ScaledPixels {
-    fn mul_assign(&mut self, rhs: f32) {
+impl<T: MulAssign> MulAssign<T> for PhysicalPixels<T> {
+    fn mul_assign(&mut self, rhs: T) {
         self.0 *= rhs;
     }
 }

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2837,7 +2837,7 @@ impl From<usize> for Pixels {
     Deserialize,
 )]
 #[repr(transparent)]
-pub struct PhysicalPixels<T>(pub T);
+pub struct PhysicalPixels<T>(T);
 
 /// Deprecated alias to physical pixels.
 pub type DevicePixels = PhysicalPixels<i32>;
@@ -2987,6 +2987,16 @@ impl PhysicalPixels<f32> {
     /// with a given scale factor.
     pub fn to_logical(self, scale_factor: f32) -> Pixels {
         px(self.0 / scale_factor)
+    }
+}
+
+impl<T> PhysicalPixels<T> {
+    /// Returns the number of physical pixels represented by `self`.
+    pub const fn raw(self) -> T
+    where
+        T: Copy,
+    {
+        self.0
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2970,12 +2970,6 @@ impl PhysicalPixels<f32> {
     }
 }
 
-impl From<DevicePixels> for i32 {
-    fn from(device_pixels: DevicePixels) -> Self {
-        device_pixels.0
-    }
-}
-
 impl From<i32> for DevicePixels {
     fn from(device_pixels: i32) -> Self {
         physical_px(device_pixels)
@@ -3003,12 +2997,6 @@ impl From<DevicePixels> for u64 {
 impl From<u64> for DevicePixels {
     fn from(device_pixels: u64) -> Self {
         physical_px(device_pixels as i32)
-    }
-}
-
-impl From<ScaledPixels> for f64 {
-    fn from(scaled_pixels: ScaledPixels) -> Self {
-        scaled_pixels.0 as f64
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -3012,12 +3012,6 @@ impl From<ScaledPixels> for f64 {
     }
 }
 
-impl From<ScaledPixels> for u32 {
-    fn from(pixels: ScaledPixels) -> Self {
-        pixels.0 as u32
-    }
-}
-
 impl Div for ScaledPixels {
     type Output = f32;
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2808,11 +2808,18 @@ impl From<usize> for Pixels {
 
 /// Represents physical pixels on the display.
 ///
-/// `DevicePixels` is a unit of measurement that refers to the actual pixels on a device's screen.
+/// `PhysicalPixels` is a unit of measurement that refers to the actual pixels on a device's screen.
 /// This type is used when precise pixel manipulation is required, such as rendering graphics or
-/// interfacing with hardware that operates on the pixel level. Unlike logical pixels that may be
-/// affected by the device's scale factor, `DevicePixels` always correspond to real pixels on the
+/// interfacing with hardware that operates on the pixel level. Unlike [logical pixels] that may be
+/// affected by the device's scale factor, `PhysicalPixels` always correspond to real pixels on the
 /// display.
+///
+/// For example, with a scale factor of 2, each [logical pixel] corresponds to 2 physical pixels.
+/// So, if you set the size of an UI element to 100 logical pixels, it will be the same as setting
+/// its size to 200 physical pixels.
+///
+/// [logical pixels]: Pixels
+/// [logical pixel]: Pixels
 #[derive(
     Add,
     AddAssign,
@@ -2831,7 +2838,24 @@ impl From<usize> for Pixels {
     Deserialize,
 )]
 #[repr(transparent)]
-pub struct DevicePixels(pub i32);
+pub struct PhysicalPixels<T>(T);
+
+/// Deprecated alias to physical pixels.
+pub type DevicePixels = PhysicalPixels<i32>;
+/// Deprecated alias to physical pixels.
+pub type ScaledPixels = PhysicalPixels<f32>;
+
+/// Deprecated alias for creating `PhysicalPixels`.
+#[expect(non_snake_case)]
+pub const fn DevicePixels(x: i32) -> DevicePixels {
+    PhysicalPixels(x)
+}
+
+/// Deprecated alias for creating `PhysicalPixels`.
+#[expect(non_snake_case)]
+pub const fn ScaledPixels(x: f32) -> ScaledPixels {
+    PhysicalPixels(x)
+}
 
 impl DevicePixels {
     /// Converts the `DevicePixels` value to the number of bytes needed to represent it in memory.
@@ -2915,17 +2939,6 @@ impl From<usize> for DevicePixels {
     }
 }
 
-/// Represents scaled pixels that take into account the device's scale factor.
-///
-/// `ScaledPixels` are used to ensure that UI elements appear at the correct size on devices
-/// with different pixel densities. When a device has a higher scale factor (such as Retina displays),
-/// a single logical pixel may correspond to multiple physical pixels. By using `ScaledPixels`,
-/// dimensions and positions can be specified in a way that scales appropriately across different
-/// display resolutions.
-#[derive(Clone, Copy, Default, Add, AddAssign, Sub, SubAssign, Div, DivAssign, PartialEq)]
-#[repr(transparent)]
-pub struct ScaledPixels(pub(crate) f32);
-
 impl ScaledPixels {
     /// Floors the `ScaledPixels` value to the nearest whole number.
     ///
@@ -2943,20 +2956,6 @@ impl ScaledPixels {
     /// Returns a new `ScaledPixels` instance with the rounded value.
     pub fn ceil(&self) -> Self {
         Self(self.0.ceil())
-    }
-}
-
-impl Eq for ScaledPixels {}
-
-impl PartialOrd for ScaledPixels {
-    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for ScaledPixels {
-    fn cmp(&self, other: &Self) -> cmp::Ordering {
-        self.0.total_cmp(&other.0)
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2887,6 +2887,12 @@ impl PhysicalPixels<i32> {
         PhysicalPixels(self.0 as f32)
     }
 
+    /// Returns the amount of logical pixels that this amount of physical pixels corresponds to,
+    /// with a given scale factor.
+    pub fn to_logical(self, scale_factor: f32) -> Pixels {
+        self.unquantize().to_logical(scale_factor)
+    }
+
     /// Converts the `DevicePixels` value to the number of bytes needed to represent it in memory.
     ///
     /// This function is useful when working with graphical data that needs to be stored in a buffer,
@@ -2955,6 +2961,12 @@ impl PhysicalPixels<f32> {
     pub fn quantize(self) -> PhysicalPixels<i32> {
         debug_assert!(i32::MIN as f32 <= self.0 && self.0 <= i32::MAX as f32);
         PhysicalPixels(self.0 as i32)
+    }
+
+    /// Returns the amount of logical pixels that this amount of physical pixels corresponds to,
+    /// with a given scale factor.
+    pub fn to_logical(self, scale_factor: f32) -> Pixels {
+        px(self.0 / scale_factor)
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -3006,18 +3006,6 @@ impl From<u64> for DevicePixels {
     }
 }
 
-impl From<DevicePixels> for usize {
-    fn from(device_pixels: DevicePixels) -> Self {
-        device_pixels.0 as usize
-    }
-}
-
-impl From<usize> for DevicePixels {
-    fn from(device_pixels: usize) -> Self {
-        physical_px(device_pixels as i32)
-    }
-}
-
 impl From<ScaledPixels> for f64 {
     fn from(scaled_pixels: ScaledPixels) -> Self {
         scaled_pixels.0 as f64
@@ -3070,22 +3058,6 @@ impl Mul<ScaledPixels> for f32 {
     type Output = ScaledPixels;
 
     fn mul(self, rhs: ScaledPixels) -> Self::Output {
-        rhs * self
-    }
-}
-
-impl Mul<usize> for ScaledPixels {
-    type Output = Self;
-
-    fn mul(self, rhs: usize) -> Self {
-        self * (rhs as f32)
-    }
-}
-
-impl Mul<ScaledPixels> for usize {
-    type Output = ScaledPixels;
-
-    fn mul(self, rhs: ScaledPixels) -> ScaledPixels {
         rhs * self
     }
 }

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2881,6 +2881,16 @@ impl PhysicalPixels<i32> {
         Self(physical_pixels as _)
     }
 
+    /// Returns the amount of physical pixels, in `u32`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cfg!(debug_assertions)` is true and `self.0` is negative.
+    pub fn as_u32(self) -> u32 {
+        debug_assert!(0 <= self.0);
+        self.0 as _
+    }
+
     /// Converts `PhysicalPixels<i32>` into `PhysicalPixels<f32>`.
     ///
     /// # Panics
@@ -2983,18 +2993,6 @@ impl PhysicalPixels<f32> {
 impl From<i32> for DevicePixels {
     fn from(device_pixels: i32) -> Self {
         physical_px(device_pixels)
-    }
-}
-
-impl From<DevicePixels> for u32 {
-    fn from(device_pixels: DevicePixels) -> Self {
-        device_pixels.0 as u32
-    }
-}
-
-impl From<DevicePixels> for u64 {
-    fn from(device_pixels: DevicePixels) -> Self {
-        device_pixels.0 as u64
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -1594,8 +1594,8 @@ impl Size<Pixels> {
     /// Converts the size from logical to physical pixels.
     pub(crate) fn to_device_pixels(self, scale_factor: f32) -> Size<DevicePixels> {
         size(
-            DevicePixels((self.width.0 * scale_factor).round() as i32),
-            DevicePixels((self.height.0 * scale_factor).round() as i32),
+            physical_px((self.width.0 * scale_factor).round() as i32),
+            physical_px((self.height.0 * scale_factor).round() as i32),
         )
     }
 }
@@ -1642,8 +1642,8 @@ impl Bounds<Pixels> {
     pub fn to_device_pixels(&self, factor: f32) -> Bounds<DevicePixels> {
         Bounds {
             origin: point(
-                DevicePixels((self.origin.x.0 * factor).round() as i32),
-                DevicePixels((self.origin.y.0 * factor).round() as i32),
+                physical_px((self.origin.x.0 * factor).round() as i32),
+                physical_px((self.origin.y.0 * factor).round() as i32),
             ),
             size: self.size.to_device_pixels(factor),
         }
@@ -2686,7 +2686,7 @@ impl Pixels {
     /// The resulting `ScaledPixels` represent the scaled value which can be used for rendering
     /// calculations where display scaling is considered.
     pub fn scale(&self, factor: f32) -> ScaledPixels {
-        ScaledPixels(self.0 * factor)
+        physical_px(self.0 * factor)
     }
 
     /// Raises the `Pixels` value to a given power.
@@ -2845,6 +2845,19 @@ pub type DevicePixels = PhysicalPixels<i32>;
 /// Deprecated alias to physical pixels.
 pub type ScaledPixels = PhysicalPixels<f32>;
 
+/// Constructs a [`PhysicalPixels`] value representing a length in physical pixels.
+///
+/// # Arguments
+///
+/// * `physical_pixels` - The number of physical pixels for the length.
+///
+/// # Returns
+///
+/// A `PhysicalPixels` representing the specified number of pixels.
+pub const fn physical_px<T>(physical_pixels: T) -> PhysicalPixels<T> {
+    PhysicalPixels(physical_pixels)
+}
+
 /// Deprecated alias for creating `PhysicalPixels`.
 #[expect(non_snake_case)]
 pub const fn DevicePixels(x: i32) -> DevicePixels {
@@ -2913,13 +2926,13 @@ impl From<DevicePixels> for i32 {
 
 impl From<i32> for DevicePixels {
     fn from(device_pixels: i32) -> Self {
-        DevicePixels(device_pixels)
+        physical_px(device_pixels)
     }
 }
 
 impl From<u32> for DevicePixels {
     fn from(device_pixels: u32) -> Self {
-        DevicePixels(device_pixels as i32)
+        physical_px(device_pixels as i32)
     }
 }
 
@@ -2937,7 +2950,7 @@ impl From<DevicePixels> for u64 {
 
 impl From<u64> for DevicePixels {
     fn from(device_pixels: u64) -> Self {
-        DevicePixels(device_pixels as i32)
+        physical_px(device_pixels as i32)
     }
 }
 
@@ -2949,19 +2962,19 @@ impl From<DevicePixels> for usize {
 
 impl From<usize> for DevicePixels {
     fn from(device_pixels: usize) -> Self {
-        DevicePixels(device_pixels as i32)
+        physical_px(device_pixels as i32)
     }
 }
 
 impl From<ScaledPixels> for DevicePixels {
     fn from(scaled: ScaledPixels) -> Self {
-        DevicePixels(scaled.0.ceil() as i32)
+        physical_px(scaled.0.ceil() as i32)
     }
 }
 
 impl From<DevicePixels> for ScaledPixels {
     fn from(device: DevicePixels) -> Self {
-        ScaledPixels(device.0 as f32)
+        physical_px(device.0 as f32)
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2870,6 +2870,17 @@ pub const fn ScaledPixels(x: f32) -> ScaledPixels {
 }
 
 impl PhysicalPixels<i32> {
+    /// Creates `PhysicalPixels<i32>` from a `u32` amount of physical pixels.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `cfg!(debug_assertions)` is true and `physical_pixels` is greatrer than
+    /// [`i32::MAX`].
+    pub(crate) fn from_u32(physical_pixels: u32) -> Self {
+        debug_assert!(physical_pixels <= i32::MAX as u32);
+        Self(physical_pixels as _)
+    }
+
     /// Converts `PhysicalPixels<i32>` into `PhysicalPixels<f32>`.
     ///
     /// # Panics
@@ -2975,12 +2986,6 @@ impl From<i32> for DevicePixels {
     }
 }
 
-impl From<u32> for DevicePixels {
-    fn from(device_pixels: u32) -> Self {
-        physical_px(device_pixels as i32)
-    }
-}
-
 impl From<DevicePixels> for u32 {
     fn from(device_pixels: DevicePixels) -> Self {
         device_pixels.0 as u32
@@ -2990,12 +2995,6 @@ impl From<DevicePixels> for u32 {
 impl From<DevicePixels> for u64 {
     fn from(device_pixels: DevicePixels) -> Self {
         device_pixels.0 as u64
-    }
-}
-
-impl From<u64> for DevicePixels {
-    fn from(device_pixels: u64) -> Self {
-        physical_px(device_pixels as i32)
     }
 }
 

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -2838,7 +2838,7 @@ impl From<usize> for Pixels {
     Deserialize,
 )]
 #[repr(transparent)]
-pub struct PhysicalPixels<T>(T);
+pub struct PhysicalPixels<T>(pub T);
 
 /// Deprecated alias to physical pixels.
 pub type DevicePixels = PhysicalPixels<i32>;
@@ -2885,9 +2885,23 @@ impl DevicePixels {
     }
 }
 
-impl fmt::Debug for DevicePixels {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{} px (device)", self.0)
+impl ScaledPixels {
+    /// Floors the `ScaledPixels` value to the nearest whole number.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new `ScaledPixels` instance with the floored value.
+    pub fn floor(&self) -> Self {
+        Self(self.0.floor())
+    }
+
+    /// Rounds the `ScaledPixels` value to the nearest whole number.
+    ///
+    /// # Returns
+    ///
+    /// Returns a new `ScaledPixels` instance with the rounded value.
+    pub fn ceil(&self) -> Self {
+        Self(self.0.ceil())
     }
 }
 
@@ -2936,32 +2950,6 @@ impl From<DevicePixels> for usize {
 impl From<usize> for DevicePixels {
     fn from(device_pixels: usize) -> Self {
         DevicePixels(device_pixels as i32)
-    }
-}
-
-impl ScaledPixels {
-    /// Floors the `ScaledPixels` value to the nearest whole number.
-    ///
-    /// # Returns
-    ///
-    /// Returns a new `ScaledPixels` instance with the floored value.
-    pub fn floor(&self) -> Self {
-        Self(self.0.floor())
-    }
-
-    /// Rounds the `ScaledPixels` value to the nearest whole number.
-    ///
-    /// # Returns
-    ///
-    /// Returns a new `ScaledPixels` instance with the rounded value.
-    pub fn ceil(&self) -> Self {
-        Self(self.0.ceil())
-    }
-}
-
-impl Debug for ScaledPixels {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}px (scaled)", self.0)
     }
 }
 
@@ -3052,6 +3040,12 @@ impl Mul<ScaledPixels> for usize {
 impl MulAssign<f32> for ScaledPixels {
     fn mul_assign(&mut self, rhs: f32) {
         self.0 *= rhs;
+    }
+}
+
+impl<T: fmt::Debug> fmt::Debug for PhysicalPixels<T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?} px (physical)", self.0)
     }
 }
 

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -352,7 +352,7 @@ impl BladeAtlasTexture {
 
 impl From<Size<DevicePixels>> for etagere::Size {
     fn from(size: Size<DevicePixels>) -> Self {
-        etagere::Size::new(size.width.into(), size.height.into())
+        etagere::Size::new(size.width.0, size.height.0)
     }
 }
 

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -1,6 +1,6 @@
 use crate::{
     AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTile, Bounds, DevicePixels, PlatformAtlas,
-    Point, Size, platform::AtlasTextureList,
+    Point, Size, physical_px, platform::AtlasTextureList,
 };
 use anyhow::Result;
 use blade_graphics as gpu;
@@ -150,8 +150,8 @@ impl BladeAtlasState {
         kind: AtlasTextureKind,
     ) -> &mut BladeAtlasTexture {
         const DEFAULT_ATLAS_SIZE: Size<DevicePixels> = Size {
-            width: DevicePixels(1024),
-            height: DevicePixels(1024),
+            width: physical_px(1024),
+            height: physical_px(1024),
         };
 
         let size = min_size.max(&DEFAULT_ATLAS_SIZE);

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -172,8 +172,8 @@ impl BladeAtlasState {
             name: "atlas",
             format,
             size: gpu::Extent {
-                width: size.width.into(),
-                height: size.height.into(),
+                width: size.width.as_u32(),
+                height: size.height.as_u32(),
                 depth: 1,
             },
             array_layer_count: 1,
@@ -245,14 +245,14 @@ impl BladeAtlasState {
                     mip_level: 0,
                     array_layer: 0,
                     origin: [
-                        upload.bounds.origin.x.into(),
-                        upload.bounds.origin.y.into(),
+                        upload.bounds.origin.x.as_u32(),
+                        upload.bounds.origin.y.as_u32(),
                         0,
                     ],
                 },
                 gpu::Extent {
-                    width: upload.bounds.size.width.into(),
-                    height: upload.bounds.size.height.into(),
+                    width: upload.bounds.size.width.as_u32(),
+                    height: upload.bounds.size.height.as_u32(),
                     depth: 1,
                 },
             );

--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -352,7 +352,7 @@ impl BladeAtlasTexture {
 
 impl From<Size<DevicePixels>> for etagere::Size {
     fn from(size: Size<DevicePixels>) -> Self {
-        etagere::Size::new(size.width.0, size.height.0)
+        etagere::Size::new(size.width.raw(), size.height.raw())
     }
 }
 

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -35,8 +35,8 @@ struct PodBounds {
 impl From<Bounds<ScaledPixels>> for PodBounds {
     fn from(bounds: Bounds<ScaledPixels>) -> Self {
         Self {
-            origin: [bounds.origin.x.0, bounds.origin.y.0],
-            size: [bounds.size.width.0, bounds.size.height.0],
+            origin: [bounds.origin.x.raw(), bounds.origin.y.raw()],
+            size: [bounds.size.width.raw(), bounds.size.height.raw()],
         }
     }
 }
@@ -472,8 +472,8 @@ impl BladeRenderer {
 
     fn update_drawable_size_impl(&mut self, size: Size<DevicePixels>, always_resize: bool) {
         let gpu_size = gpu::Extent {
-            width: size.width.0 as u32,
-            height: size.height.0 as u32,
+            width: size.width.as_u32(),
+            height: size.height.as_u32(),
             depth: 1,
         };
 

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -105,7 +105,7 @@ struct ShaderSurfacesData {
     s_surface: gpu::Sampler,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 struct PathSprite {
     bounds: Bounds<ScaledPixels>,

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -1,7 +1,7 @@
 use crate::{
     Bounds, DevicePixels, Font, FontFeatures, FontId, FontMetrics, FontRun, FontStyle, FontWeight,
-    GlyphId, LineLayout, Pixels, PlatformTextSystem, Point, RenderGlyphParams, SUBPIXEL_VARIANTS,
-    ShapedGlyph, ShapedRun, SharedString, Size, physical_px, point, size,
+    GlyphId, LineLayout, PhysicalPixels, Pixels, PlatformTextSystem, Point, RenderGlyphParams,
+    SUBPIXEL_VARIANTS, ShapedGlyph, ShapedRun, SharedString, Size, physical_px, point, size,
 };
 use anyhow::{Context as _, Ok, Result};
 use collections::HashMap;
@@ -298,7 +298,10 @@ impl CosmicTextSystemState {
             .with_context(|| format!("no image for {params:?} in font {font:?}"))?;
         Ok(Bounds {
             origin: point(image.placement.left.into(), (-image.placement.top).into()),
-            size: size(image.placement.width.into(), image.placement.height.into()),
+            size: size(
+                PhysicalPixels::from_u32(image.placement.width),
+                PhysicalPixels::from_u32(image.placement.height),
+            ),
         })
     }
 

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -311,7 +311,7 @@ impl CosmicTextSystemState {
         params: &RenderGlyphParams,
         glyph_bounds: Bounds<DevicePixels>,
     ) -> Result<(Size<DevicePixels>, Vec<u8>)> {
-        if glyph_bounds.size.width.0 == 0 || glyph_bounds.size.height.0 == 0 {
+        if glyph_bounds.size.width == physical_px(0) || glyph_bounds.size.height == physical_px(0) {
             anyhow::bail!("glyph bounds are empty");
         } else {
             let bitmap_size = glyph_bounds.size;

--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -1,7 +1,7 @@
 use crate::{
     Bounds, DevicePixels, Font, FontFeatures, FontId, FontMetrics, FontRun, FontStyle, FontWeight,
     GlyphId, LineLayout, Pixels, PlatformTextSystem, Point, RenderGlyphParams, SUBPIXEL_VARIANTS,
-    ShapedGlyph, ShapedRun, SharedString, Size, point, size,
+    ShapedGlyph, ShapedRun, SharedString, Size, physical_px, point, size,
 };
 use anyhow::{Context as _, Ok, Result};
 use collections::HashMap;
@@ -491,8 +491,8 @@ impl From<RectF> for Bounds<f32> {
 impl From<RectI> for Bounds<DevicePixels> {
     fn from(rect: RectI) -> Self {
         Bounds {
-            origin: point(DevicePixels(rect.origin_x()), DevicePixels(rect.origin_y())),
-            size: size(DevicePixels(rect.width()), DevicePixels(rect.height())),
+            origin: point(physical_px(rect.origin_x()), physical_px(rect.origin_y())),
+            size: size(physical_px(rect.width()), physical_px(rect.height())),
         }
     }
 }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -332,10 +332,10 @@ impl WaylandClientStatePtr {
 
         let text_input = state.text_input.as_ref().unwrap();
         text_input.set_cursor_rectangle(
-            bounds.origin.x.0 as i32,
-            bounds.origin.y.0 as i32,
-            bounds.size.width.0 as i32,
-            bounds.size.height.0 as i32,
+            bounds.origin.x.quantize().raw(),
+            bounds.origin.y.quantize().raw(),
+            bounds.size.width.quantize().raw(),
+            bounds.size.height.quantize().raw(),
         );
         text_input.commit();
     }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -76,7 +76,7 @@ use crate::{
     LinuxKeyboardLayout, Modifiers, ModifiersChangedEvent, MouseButton, MouseDownEvent,
     MouseExitEvent, MouseMoveEvent, MouseUpEvent, NavigationDirection, Pixels, PlatformDisplay,
     PlatformInput, PlatformKeyboardLayout, Point, SCROLL_LINES, ScaledPixels, ScrollDelta,
-    ScrollWheelEvent, Size, TouchPhase, WindowParams, point, px, size,
+    ScrollWheelEvent, Size, TouchPhase, WindowParams, physical_px, point, px, size,
 };
 use crate::{
     SharedString,
@@ -1014,10 +1014,10 @@ impl Dispatch<wl_output::WlOutput, ()> for WaylandClientStatePtr {
                 in_progress_output.scale = Some(factor);
             }
             wl_output::Event::Geometry { x, y, .. } => {
-                in_progress_output.position = Some(point(DevicePixels(x), DevicePixels(y)))
+                in_progress_output.position = Some(point(physical_px(x), physical_px(y)))
             }
             wl_output::Event::Mode { width, height, .. } => {
-                in_progress_output.size = Some(size(DevicePixels(width), DevicePixels(height)))
+                in_progress_output.size = Some(size(physical_px(width), physical_px(height)))
             }
             wl_output::Event::Done => {
                 if let Some(complete) = in_progress_output.complete() {

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -843,8 +843,8 @@ impl PlatformWindow for WaylandWindow {
         state.xdg_surface.set_window_geometry(
             state.bounds.origin.x.0 as i32,
             state.bounds.origin.y.0 as i32,
-            dp_size.width.0,
-            dp_size.height.0,
+            dp_size.width.raw(),
+            dp_size.height.raw(),
         );
 
         state

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -285,8 +285,8 @@ impl X11ClientStatePtr {
                 b.push(
                     xim::AttributeName::SpotLocation,
                     xim::Point {
-                        x: (bounds.origin.x + bounds.size.width).0 as i16,
-                        y: (bounds.origin.y + bounds.size.height).0 as i16,
+                        x: (bounds.origin.x + bounds.size.width).raw() as i16,
+                        y: (bounds.origin.y + bounds.size.height).raw() as i16,
                     },
                 );
             })

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -285,8 +285,8 @@ impl X11ClientStatePtr {
                 b.push(
                     xim::AttributeName::SpotLocation,
                     xim::Point {
-                        x: u32::from(bounds.origin.x + bounds.size.width) as i16,
-                        y: u32::from(bounds.origin.y + bounds.size.height) as i16,
+                        x: (bounds.origin.x + bounds.size.width).0 as i16,
+                        y: (bounds.origin.y + bounds.size.height).0 as i16,
                     },
                 );
             })

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -3,11 +3,11 @@ use x11rb::connection::RequestConnection;
 
 use crate::platform::blade::{BladeContext, BladeRenderer, BladeSurfaceConfig};
 use crate::{
-    AnyWindowHandle, Bounds, Decorations, DevicePixels, ForegroundExecutor, GpuSpecs, Modifiers,
-    Pixels, PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow,
-    Point, PromptButton, PromptLevel, RequestFrameOptions, ResizeEdge, ScaledPixels, Scene, Size,
-    Tiling, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControlArea,
-    WindowDecorations, WindowKind, WindowParams, X11ClientStatePtr, px, size,
+    AnyWindowHandle, Bounds, Decorations, ForegroundExecutor, GpuSpecs, Modifiers, Pixels,
+    PlatformAtlas, PlatformDisplay, PlatformInput, PlatformInputHandler, PlatformWindow, Point,
+    PromptButton, PromptLevel, RequestFrameOptions, ResizeEdge, ScaledPixels, Scene, Size, Tiling,
+    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControlArea,
+    WindowDecorations, WindowKind, WindowParams, X11ClientStatePtr, physical_px, px, size,
 };
 
 use blade_graphics as gpu;
@@ -1054,8 +1054,8 @@ impl X11WindowStatePtr {
             let gpu_size = query_render_extent(&self.xcb, self.x_window)?;
             if true {
                 state.renderer.update_drawable_size(size(
-                    DevicePixels(gpu_size.width as i32),
-                    DevicePixels(gpu_size.height as i32),
+                    physical_px(gpu_size.width as i32),
+                    physical_px(gpu_size.height as i32),
                 ));
                 resize_args = Some((state.content_size(), state.scale_factor));
             }

--- a/crates/gpui/src/platform/mac.rs
+++ b/crates/gpui/src/platform/mac.rs
@@ -33,7 +33,7 @@ mod platform;
 mod window;
 mod window_appearance;
 
-use crate::{DevicePixels, Pixels, Size, px, size};
+use crate::{DevicePixels, Pixels, Size, physical_px, px, size};
 use cocoa::{
     base::{id, nil},
     foundation::{NSAutoreleasePool, NSNotFound, NSRect, NSSize, NSString, NSUInteger},
@@ -158,6 +158,6 @@ impl From<NSRect> for Size<Pixels> {
 impl From<NSRect> for Size<DevicePixels> {
     fn from(rect: NSRect) -> Self {
         let NSSize { width, height } = rect.size;
-        size(DevicePixels(width as i32), DevicePixels(height as i32))
+        size(physical_px(width as i32), physical_px(height as i32))
     }
 }

--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -120,13 +120,13 @@ impl MetalAtlasState {
         kind: AtlasTextureKind,
     ) -> &mut MetalAtlasTexture {
         const DEFAULT_ATLAS_SIZE: Size<DevicePixels> = Size {
-            width: DevicePixels(1024),
-            height: DevicePixels(1024),
+            width: physical_px(1024),
+            height: physical_px(1024),
         };
         // Max texture size on all modern Apple GPUs. Anything bigger than that crashes in validateWithDevice.
         const MAX_ATLAS_SIZE: Size<DevicePixels> = Size {
-            width: DevicePixels(16384),
-            height: DevicePixels(16384),
+            width: physical_px(16384),
+            height: physical_px(16384),
         };
         let size = min_size.min(&MAX_ATLAS_SIZE).max(&DEFAULT_ATLAS_SIZE);
         let texture_descriptor = metal::TextureDescriptor::new();

--- a/crates/gpui/src/platform/mac/metal_atlas.rs
+++ b/crates/gpui/src/platform/mac/metal_atlas.rs
@@ -1,6 +1,6 @@
 use crate::{
     AtlasKey, AtlasTextureId, AtlasTextureKind, AtlasTile, Bounds, DevicePixels, PlatformAtlas,
-    Point, Size, platform::AtlasTextureList,
+    Point, Size, physical_px, platform::AtlasTextureList,
 };
 use anyhow::{Context as _, Result};
 use collections::FxHashMap;
@@ -130,8 +130,8 @@ impl MetalAtlasState {
         };
         let size = min_size.min(&MAX_ATLAS_SIZE).max(&DEFAULT_ATLAS_SIZE);
         let texture_descriptor = metal::TextureDescriptor::new();
-        texture_descriptor.set_width(size.width.into());
-        texture_descriptor.set_height(size.height.into());
+        texture_descriptor.set_width(size.width.as_u32().into());
+        texture_descriptor.set_height(size.height.as_u32().into());
         let pixel_format;
         let usage;
         match kind {
@@ -208,10 +208,10 @@ impl MetalAtlasTexture {
 
     fn upload(&self, bounds: Bounds<DevicePixels>, bytes: &[u8]) {
         let region = metal::MTLRegion::new_2d(
-            bounds.origin.x.into(),
-            bounds.origin.y.into(),
-            bounds.size.width.into(),
-            bounds.size.height.into(),
+            bounds.origin.x.as_u32().into(),
+            bounds.origin.y.as_u32().into(),
+            bounds.size.width.as_u32().into(),
+            bounds.size.height.as_u32().into(),
         );
         self.metal_texture.replace_region(
             region,
@@ -241,7 +241,7 @@ impl MetalAtlasTexture {
 
 impl From<Size<DevicePixels>> for etagere::Size {
     fn from(size: Size<DevicePixels>) -> Self {
-        etagere::Size::new(size.width.into(), size.height.into())
+        etagere::Size::new(size.width.0, size.height.0)
     }
 }
 

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -924,8 +924,8 @@ impl MetalRenderer {
 
         let texture = self.sprite_atlas.metal_texture(texture_id);
         let texture_size = size(
-            DevicePixels(texture.width() as i32),
-            DevicePixels(texture.height() as i32),
+            physical_px(texture.width() as i32),
+            physical_px(texture.height() as i32),
         );
         command_encoder.set_render_pipeline_state(&self.monochrome_sprites_pipeline_state);
         command_encoder.set_vertex_buffer(
@@ -989,8 +989,8 @@ impl MetalRenderer {
 
         let texture = self.sprite_atlas.metal_texture(texture_id);
         let texture_size = size(
-            DevicePixels(texture.width() as i32),
-            DevicePixels(texture.height() as i32),
+            physical_px(texture.width() as i32),
+            physical_px(texture.height() as i32),
         );
         command_encoder.set_render_pipeline_state(&self.polychrome_sprites_pipeline_state);
         command_encoder.set_vertex_buffer(

--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -2,7 +2,7 @@ use super::metal_atlas::MetalAtlas;
 use crate::{
     AtlasTextureId, Background, Bounds, ContentMask, DevicePixels, MonochromeSprite, PaintSurface,
     Path, Point, PolychromeSprite, PrimitiveBatch, Quad, ScaledPixels, Scene, Shadow, Size,
-    Surface, Underline, point, size,
+    Surface, Underline, physical_px, point, size,
 };
 use anyhow::Result;
 use block::ConcreteBlock;
@@ -1166,8 +1166,8 @@ fn new_command_encoder<'a>(
     command_encoder.set_viewport(metal::MTLViewport {
         originX: 0.0,
         originY: 0.0,
-        width: i32::from(viewport_size.width) as f64,
-        height: i32::from(viewport_size.height) as f64,
+        width: viewport_size.width.0 as f64,
+        height: viewport_size.height.0 as f64,
         znear: 0.0,
         zfar: 1.0,
     });
@@ -1332,13 +1332,13 @@ enum PathRasterizationInputIndex {
     ViewportSize = 1,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct PathSprite {
     pub bounds: Bounds<ScaledPixels>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 #[repr(C)]
 pub struct SurfaceBounds {
     pub bounds: Bounds<ScaledPixels>,

--- a/crates/gpui/src/platform/mac/screen_capture.rs
+++ b/crates/gpui/src/platform/mac/screen_capture.rs
@@ -1,5 +1,5 @@
 use crate::{
-    DevicePixels, ForegroundExecutor, SharedString, SourceMetadata,
+    DevicePixels, ForegroundExecutor, SharedString, SourceMetadata, physical_px,
     platform::{ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream},
     size,
 };

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -353,10 +353,10 @@ impl MacTextSystemState {
             // Add an extra pixel when the subpixel variant isn't zero to make room for anti-aliasing.
             let mut bitmap_size = glyph_bounds.size;
             if params.subpixel_variant.x > 0 {
-                bitmap_size.width += DevicePixels(1);
+                bitmap_size.width += physical_px(1);
             }
             if params.subpixel_variant.y > 0 {
-                bitmap_size.height += DevicePixels(1);
+                bitmap_size.height += physical_px(1);
             }
             let bitmap_size = bitmap_size;
 
@@ -582,8 +582,8 @@ impl From<RectF> for Bounds<f32> {
 impl From<RectI> for Bounds<DevicePixels> {
     fn from(rect: RectI) -> Self {
         Bounds {
-            origin: point(DevicePixels(rect.origin_x()), DevicePixels(rect.origin_y())),
-            size: size(DevicePixels(rect.width()), DevicePixels(rect.height())),
+            origin: point(physical_px(rect.origin_x()), physical_px(rect.origin_y())),
+            size: size(physical_px(rect.width()), physical_px(rect.height())),
         }
     }
 }

--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -2,7 +2,7 @@ use crate::{
     Bounds, DevicePixels, Font, FontFallbacks, FontFeatures, FontId, FontMetrics, FontRun,
     FontStyle, FontWeight, GlyphId, LineLayout, Pixels, PlatformTextSystem, Point,
     RenderGlyphParams, Result, SUBPIXEL_VARIANTS, ShapedGlyph, ShapedRun, SharedString, Size,
-    point, px, size, swap_rgba_pa_to_bgra,
+    physical_px, point, px, size, swap_rgba_pa_to_bgra,
 };
 use anyhow::anyhow;
 use cocoa::appkit::CGFloat;

--- a/crates/gpui/src/platform/scap_screen_capture.rs
+++ b/crates/gpui/src/platform/scap_screen_capture.rs
@@ -1,7 +1,7 @@
 //! Screen capture for Linux and Windows
 use crate::{
     DevicePixels, ForegroundExecutor, ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream,
-    Size, SourceMetadata, size,
+    Size, SourceMetadata, physical_px, size,
 };
 use anyhow::{Context as _, Result, anyhow};
 use futures::channel::oneshot;
@@ -58,8 +58,8 @@ fn get_screen_targets(sources_tx: oneshot::Sender<Result<Vec<ScapCaptureSource>>
             .filter_map(|target| match target {
                 scap::Target::Display(display) => {
                     let size = Size {
-                        width: DevicePixels(display.width as i32),
-                        height: DevicePixels(display.height as i32),
+                        width: physical_px(display.width as i32),
+                        height: physical_px(display.height as i32),
                     };
                     Some(ScapCaptureSource {
                         target: display,
@@ -276,7 +276,7 @@ fn frame_size(frame: &scap::frame::Frame) -> Size<DevicePixels> {
         scap::frame::Frame::BGR0(frame) => (frame.width, frame.height),
         scap::frame::Frame::BGRA(frame) => (frame.width, frame.height),
     };
-    size(DevicePixels(width), DevicePixels(height))
+    size(physical_px(width), physical_px(height))
 }
 
 /// This is used by `get_screen_targets` and `start_default_target_screen_capture` to turn their

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -2,7 +2,8 @@ use crate::{
     AnyWindowHandle, BackgroundExecutor, ClipboardItem, CursorStyle, DevicePixels,
     ForegroundExecutor, Keymap, NoopTextSystem, Platform, PlatformDisplay, PlatformKeyboardLayout,
     PlatformTextSystem, PromptButton, ScreenCaptureFrame, ScreenCaptureSource, ScreenCaptureStream,
-    SourceMetadata, Task, TestDisplay, TestWindow, WindowAppearance, WindowParams, size,
+    SourceMetadata, Task, TestDisplay, TestWindow, WindowAppearance, WindowParams, physical_px,
+    size,
 };
 use anyhow::Result;
 use collections::VecDeque;
@@ -53,7 +54,7 @@ impl ScreenCaptureSource for TestScreenCaptureSource {
             id: 0,
             is_main: None,
             label: None,
-            resolution: size(DevicePixels(1), DevicePixels(1)),
+            resolution: size(physical_px(1), physical_px(1)),
         })
     }
 

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -181,7 +181,7 @@ fn handle_size_msg(
 
     let width = lparam.loword().max(1) as i32;
     let height = lparam.hiword().max(1) as i32;
-    let new_size = size(DevicePixels(width), DevicePixels(height));
+    let new_size = size(physical_px(width), physical_px(height));
     let scale_factor = lock.scale_factor;
     if lock.restore_from_minimized.is_some() {
         lock.callbacks.request_frame = lock.restore_from_minimized.take();
@@ -470,7 +470,7 @@ fn handle_mouse_down_msg(
     };
     let x = lparam.signed_loword();
     let y = lparam.signed_hiword();
-    let physical_point = point(DevicePixels(x as i32), DevicePixels(y as i32));
+    let physical_point = point(physical_px(x as i32), physical_px(y as i32));
     let click_count = lock.click_state.update(button, physical_point);
     let scale_factor = lock.scale_factor;
     drop(lock);
@@ -974,7 +974,7 @@ fn handle_nc_mouse_down_msg(
             y: lparam.signed_hiword().into(),
         };
         unsafe { ScreenToClient(handle, &mut cursor_point).ok().log_err() };
-        let physical_point = point(DevicePixels(cursor_point.x), DevicePixels(cursor_point.y));
+        let physical_point = point(physical_px(cursor_point.x), physical_px(cursor_point.y));
         let click_count = lock.click_state.update(button, physical_point);
         drop(lock);
 

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1297,7 +1297,7 @@ fn set_window_composition_attribute(hwnd: HWND, color: Option<Color>, state: u32
 #[cfg(test)]
 mod tests {
     use super::ClickState;
-    use crate::{DevicePixels, MouseButton, point};
+    use crate::{MouseButton, physical_px, point};
     use std::time::Duration;
 
     #[test]

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -92,7 +92,7 @@ impl WindowsWindowState {
         };
         let origin = logical_point(cs.x as f32, cs.y as f32, scale_factor);
         let logical_size = {
-            let physical_size = size(DevicePixels(cs.cx), DevicePixels(cs.cy));
+            let physical_size = size(physical_px(cs.cx), physical_px(cs.cy));
             physical_size.to_pixels(scale_factor)
         };
         let fullscreen_restore_bounds = Bounds {
@@ -1222,7 +1222,7 @@ fn calculate_client_rect(
     let top = rect.top + top_offset;
     let right = rect.right - right_offset;
     let bottom = rect.bottom - bottom_offset;
-    let physical_size = size(DevicePixels(right - left), DevicePixels(bottom - top));
+    let physical_size = size(physical_px(right - left), physical_px(bottom - top));
     Bounds {
         origin: logical_point(left as f32, top as f32, scale_factor),
         size: physical_size.to_pixels(scale_factor),
@@ -1304,24 +1304,24 @@ mod tests {
     fn test_double_click_interval() {
         let mut state = ClickState::new();
         assert_eq!(
-            state.update(MouseButton::Left, point(DevicePixels(0), DevicePixels(0))),
+            state.update(MouseButton::Left, point(physical_px(0), physical_px(0))),
             1
         );
         assert_eq!(
-            state.update(MouseButton::Right, point(DevicePixels(0), DevicePixels(0))),
+            state.update(MouseButton::Right, point(physical_px(0), physical_px(0))),
             1
         );
         assert_eq!(
-            state.update(MouseButton::Left, point(DevicePixels(0), DevicePixels(0))),
+            state.update(MouseButton::Left, point(physical_px(0), physical_px(0))),
             1
         );
         assert_eq!(
-            state.update(MouseButton::Left, point(DevicePixels(0), DevicePixels(0))),
+            state.update(MouseButton::Left, point(physical_px(0), physical_px(0))),
             2
         );
         state.last_click -= Duration::from_millis(700);
         assert_eq!(
-            state.update(MouseButton::Left, point(DevicePixels(0), DevicePixels(0))),
+            state.update(MouseButton::Left, point(physical_px(0), physical_px(0))),
             1
         );
     }
@@ -1330,19 +1330,19 @@ mod tests {
     fn test_double_click_spatial_tolerance() {
         let mut state = ClickState::new();
         assert_eq!(
-            state.update(MouseButton::Left, point(DevicePixels(-3), DevicePixels(0))),
+            state.update(MouseButton::Left, point(physical_px(-3), physical_px(0))),
             1
         );
         assert_eq!(
-            state.update(MouseButton::Left, point(DevicePixels(0), DevicePixels(3))),
+            state.update(MouseButton::Left, point(physical_px(0), physical_px(3))),
             2
         );
         assert_eq!(
-            state.update(MouseButton::Right, point(DevicePixels(3), DevicePixels(2))),
+            state.update(MouseButton::Right, point(physical_px(3), physical_px(2))),
             1
         );
         assert_eq!(
-            state.update(MouseButton::Right, point(DevicePixels(10), DevicePixels(0))),
+            state.update(MouseButton::Right, point(physical_px(10), physical_px(0))),
             1
         );
     }

--- a/crates/gpui/src/scene.rs
+++ b/crates/gpui/src/scene.rs
@@ -534,7 +534,7 @@ impl TransformationMatrix {
     pub fn translate(mut self, point: Point<ScaledPixels>) -> Self {
         self.compose(Self {
             rotation_scale: [[1.0, 0.0], [0.0, 1.0]],
-            translation: [point.x.0, point.y.0],
+            translation: [point.x.raw(), point.y.raw()],
         })
     }
 

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -46,7 +46,8 @@ impl ObjectFit {
         bounds: Bounds<Pixels>,
         image_size: Size<DevicePixels>,
     ) -> Bounds<Pixels> {
-        let image_size = image_size.map(|dimension| Pixels::from(u32::from(dimension)));
+        // NB: this reinterprets physical pixels as logical pixels without scaling them properly
+        let image_size = image_size.map(|dimension| dimension.to_logical(1.));
         let image_ratio = image_size.width / image_size.height;
         let bounds_ratio = bounds.size.width / bounds.size.height;
 

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -85,7 +85,7 @@ impl SvgRenderer {
         };
 
         // Render the SVG to a pixmap with the specified width and height.
-        let mut pixmap = resvg::tiny_skia::Pixmap::new(size.width.into(), size.height.into())
+        let mut pixmap = resvg::tiny_skia::Pixmap::new(size.width.as_u32(), size.height.as_u32())
             .ok_or(usvg::Error::InvalidSize)?;
 
         let scale = size.width.0 as f32 / tree.size().width();

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -88,7 +88,7 @@ impl SvgRenderer {
         let mut pixmap = resvg::tiny_skia::Pixmap::new(size.width.as_u32(), size.height.as_u32())
             .ok_or(usvg::Error::InvalidSize)?;
 
-        let scale = size.width.0 as f32 / tree.size().width();
+        let scale = size.width.raw() as f32 / tree.size().width();
         let transform = resvg::tiny_skia::Transform::from_scale(scale, scale);
 
         resvg::render(&tree, transform, &mut pixmap.as_mut());

--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -1,4 +1,4 @@
-use crate::{AssetSource, DevicePixels, IsZero, Result, SharedString, Size};
+use crate::{AssetSource, DevicePixels, IsZero, Result, SharedString, Size, physical_px};
 use resvg::tiny_skia::Pixmap;
 use std::{
     hash::Hash,
@@ -79,8 +79,8 @@ impl SvgRenderer {
         let size = match size {
             SvgSize::Size(size) => size,
             SvgSize::ScaleFactor(scale) => crate::size(
-                DevicePixels((tree.size().width() * scale) as i32),
-                DevicePixels((tree.size().height() * scale) as i32),
+                physical_px((tree.size().width() * scale) as i32),
+                physical_px((tree.size().height() * scale) as i32),
             ),
         };
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2869,8 +2869,8 @@ impl Window {
         let scale_factor = self.scale_factor();
         let glyph_origin = origin.scale(scale_factor);
         let subpixel_variant = Point {
-            x: (glyph_origin.x.0.fract() * SUBPIXEL_VARIANTS as f32).floor() as u8,
-            y: (glyph_origin.y.0.fract() * SUBPIXEL_VARIANTS as f32).floor() as u8,
+            x: (glyph_origin.x.raw().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8,
+            y: (glyph_origin.y.raw().fract() * SUBPIXEL_VARIANTS as f32).floor() as u8,
         };
         let params = RenderGlyphParams {
             font_id,
@@ -2988,9 +2988,9 @@ impl Window {
         let bounds = bounds.scale(scale_factor);
         let params = RenderSvgParams {
             path,
-            size: bounds.size.map(|pixels| {
-                DevicePixels::from((pixels.0 * SMOOTH_SVG_SCALE_FACTOR).ceil() as i32)
-            }),
+            size: bounds
+                .size
+                .map(|pixels| (pixels * SMOOTH_SVG_SCALE_FACTOR).ceil().quantize()),
         };
 
         let Some(tile) =

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -8,15 +8,15 @@ use crate::{
     FileDropEvent, FontId, Global, GlobalElementId, GlyphId, GpuSpecs, Hsla, InputHandler, IsZero,
     KeyBinding, KeyContext, KeyDownEvent, KeyEvent, Keystroke, KeystrokeEvent, LayoutId,
     LineLayoutIndex, Modifiers, ModifiersChangedEvent, MonochromeSprite, MouseButton, MouseEvent,
-    MouseMoveEvent, MouseUpEvent, Path, Pixels, PlatformAtlas, PlatformDisplay, PlatformInput,
-    PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, PromptButton, PromptLevel, Quad,
-    Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams, Replay, ResizeEdge,
-    SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS, ScaledPixels, Scene, Shadow, SharedString, Size,
-    StrikethroughStyle, Style, SubscriberSet, Subscription, TabHandles, TaffyLayoutEngine, Task,
-    TextStyle, TextStyleRefinement, TransformationMatrix, Underline, UnderlineStyle,
-    WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControls, WindowDecorations,
-    WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, px, rems, size,
-    transparent_black,
+    MouseMoveEvent, MouseUpEvent, Path, PhysicalPixels, Pixels, PlatformAtlas, PlatformDisplay,
+    PlatformInput, PlatformInputHandler, PlatformWindow, Point, PolychromeSprite, PromptButton,
+    PromptLevel, Quad, Render, RenderGlyphParams, RenderImage, RenderImageParams, RenderSvgParams,
+    Replay, ResizeEdge, SMOOTH_SVG_SCALE_FACTOR, SUBPIXEL_VARIANTS, ScaledPixels, Scene, Shadow,
+    SharedString, Size, StrikethroughStyle, Style, SubscriberSet, Subscription, TabHandles,
+    TaffyLayoutEngine, Task, TextStyle, TextStyleRefinement, TransformationMatrix, Underline,
+    UnderlineStyle, WindowAppearance, WindowBackgroundAppearance, WindowBounds, WindowControls,
+    WindowDecorations, WindowOptions, WindowParams, WindowTextSystem, point, prelude::*, px, rems,
+    size, transparent_black,
 };
 use anyhow::{Context as _, Result, anyhow};
 use collections::{FxHashMap, FxHashSet};
@@ -2891,8 +2891,9 @@ impl Window {
                 })?
                 .expect("Callback above only errors or returns Some");
             let bounds = Bounds {
-                origin: glyph_origin.map(|px| px.floor()) + raster_bounds.origin.map(Into::into),
-                size: tile.bounds.size.map(Into::into),
+                origin: glyph_origin.map(|px| px.floor())
+                    + raster_bounds.origin.map(PhysicalPixels::unquantize),
+                size: tile.bounds.size.map(PhysicalPixels::unquantize),
             };
             let content_mask = self.content_mask().scale(scale_factor);
             self.next_frame.scene.insert_primitive(MonochromeSprite {
@@ -2948,8 +2949,9 @@ impl Window {
                 .expect("Callback above only errors or returns Some");
 
             let bounds = Bounds {
-                origin: glyph_origin.map(|px| px.floor()) + raster_bounds.origin.map(Into::into),
-                size: tile.bounds.size.map(Into::into),
+                origin: glyph_origin.map(|px| px.floor())
+                    + raster_bounds.origin.map(PhysicalPixels::unquantize),
+                size: tile.bounds.size.map(PhysicalPixels::unquantize),
             };
             let content_mask = self.content_mask().scale(scale_factor);
             let opacity = self.element_opacity();

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -6,7 +6,7 @@ use base64::write::EncoderWriter;
 use cloud_llm_client::{CompletionIntent, CompletionMode};
 use gpui::{
     App, AppContext as _, DevicePixels, Image, ImageFormat, ObjectFit, SharedString, Size, Task,
-    point, px, size,
+    physical_px, point, px, size,
 };
 use image::codecs::png::PngEncoder;
 use serde::{Deserialize, Serialize};
@@ -61,7 +61,7 @@ impl LanguageModelImage {
         }
 
         Some(Self {
-            size: size(DevicePixels(width?), DevicePixels(height?)),
+            size: size(physical_px(width?), physical_px(height?)),
             source: SharedString::from(source.to_string()),
         })
     }
@@ -83,7 +83,7 @@ impl LanguageModelImage {
     pub fn empty() -> Self {
         Self {
             source: "".into(),
-            size: size(DevicePixels(0), DevicePixels(0)),
+            size: size(physical_px(0), physical_px(0)),
         }
     }
 
@@ -105,7 +105,7 @@ impl LanguageModelImage {
 
             let width = dynamic_image.width();
             let height = dynamic_image.height();
-            let image_size = size(DevicePixels(width as i32), DevicePixels(height as i32));
+            let image_size = size(physical_px(width as i32), physical_px(height as i32));
 
             let base64_image = {
                 if image_size.width.0 > ANTHROPIC_SIZE_LIMT as i32

--- a/crates/language_model/src/request.rs
+++ b/crates/language_model/src/request.rs
@@ -108,8 +108,8 @@ impl LanguageModelImage {
             let image_size = size(physical_px(width as i32), physical_px(height as i32));
 
             let base64_image = {
-                if image_size.width.0 > ANTHROPIC_SIZE_LIMT as i32
-                    || image_size.height.0 > ANTHROPIC_SIZE_LIMT as i32
+                if image_size.width.unquantize() > physical_px(ANTHROPIC_SIZE_LIMT)
+                    || image_size.height.unquantize() > physical_px(ANTHROPIC_SIZE_LIMT)
                 {
                     let new_bounds = ObjectFit::ScaleDown.get_bounds(
                         gpui::Bounds {
@@ -142,8 +142,8 @@ impl LanguageModelImage {
     }
 
     pub fn estimate_tokens(&self) -> usize {
-        let width = self.size.width.0.unsigned_abs() as usize;
-        let height = self.size.height.0.unsigned_abs() as usize;
+        let width = self.size.width.raw().unsigned_abs() as usize;
+        let height = self.size.height.raw().unsigned_abs() as usize;
 
         // From: https://docs.anthropic.com/en/docs/build-with-claude/vision#calculate-image-costs
         // Note that are a lot of conditions on Anthropic's API, and OpenAI doesn't use this,

--- a/crates/livekit_client/src/livekit_client/playback.rs
+++ b/crates/livekit_client/src/livekit_client/playback.rs
@@ -329,8 +329,8 @@ pub(crate) async fn capture_local_video_track(
     let metadata = capture_source.metadata()?;
     let track_source = gpui_tokio::Tokio::spawn(cx, async move {
         NativeVideoSource::new(VideoResolution {
-            width: metadata.resolution.width.0 as u32,
-            height: metadata.resolution.height.0 as u32,
+            width: metadata.resolution.width.as_u32(),
+            height: metadata.resolution.height.as_u32(),
         })
     })?
     .await?;

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -543,7 +543,8 @@ impl TitleBar {
                                     .unwrap_or_else(|| SharedString::from("Unknown screen"));
                                 let resolution = SharedString::from(format!(
                                     "{} × {}",
-                                    meta.resolution.width.0, meta.resolution.height.0
+                                    meta.resolution.width.raw(),
+                                    meta.resolution.height.raw()
                                 ));
                                 this.push_item(ContextMenuItem::CustomEntry {
                                     entry_render: Box::new(move |_, _| {


### PR DESCRIPTION
This PR merges `DevicePixels` and `ScaledPixels` into `PhysicalPixels` -- a type representing the physical amount of pixels on the screen. `PhysicalPixels` is generic over the scalar value with the two options currently used being `f32` and `i32`.

I've also removed some lossy/useless trait impls while doing the merge.

I've left removing the deprecated aliases (`DevicePixels` and `ScaledPixels`) for a follow-up.

Release Notes:

- N/A
