### PR TITLE
Add `git: open modified files` action

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -115,6 +115,7 @@
       "ctrl-\"": "editor::ExpandAllDiffHunks",
       "ctrl-i": "editor::ShowSignatureHelp",
       "alt-g b": "git::Blame",
+      "alt-g m": "git::OpenModifiedFiles",
       "menu": "editor::OpenContextMenu",
       "shift-f10": "editor::OpenContextMenu",
       "ctrl-shift-e": "editor::ToggleEditPrediction",

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -139,6 +139,7 @@
       "cmd-'": "editor::ToggleSelectedDiffHunks",
       "cmd-\"": "editor::ExpandAllDiffHunks",
       "cmd-alt-g b": "git::Blame",
+      "cmd-alt-g m": "git::OpenModifiedFiles",
       "cmd-i": "editor::ShowSignatureHelp",
       "f9": "editor::ToggleBreakpoint",
       "shift-f9": "editor::EditLogBreakpoint",

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -57,6 +57,7 @@ actions!(
         ExpandCommitEditor,
         GenerateCommitMessage,
         Init,
+        OpenModifiedFiles,
     ]
 );
 

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -149,7 +149,11 @@ pub fn init(cx: &mut App) {
     .detach();
 }
 
-fn open_modified_files(workspace: &mut Workspace, window: &mut Window, cx: &mut Context<Workspace>) {
+fn open_modified_files(
+    workspace: &mut Workspace,
+    window: &mut Window,
+    cx: &mut Context<Workspace>,
+) {
     let Some(panel) = workspace.panel::<git_panel::GitPanel>(cx) else {
         return;
     };


### PR DESCRIPTION
Ported over a vscode/cursor command that I like using : )

Release Notes:

- Added "open modified files" command