### PR TITLE
editor: Fix select when click on existing selection

### DIFF
--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -915,8 +915,8 @@ impl Vim {
         if mode == Mode::Normal || mode != last_mode {
             self.current_tx.take();
             self.current_anchor.take();
-            self.update_editor(window, cx, |_, editor, window, cx| {
-                editor.drop_selection(None, false, window, cx);
+            self.update_editor(window, cx, |_, editor, _, _| {
+                editor.clear_selection_drag_state();
             });
         }
         Vim::take_forced_motion(cx);


### PR DESCRIPTION
Follow-up for https://github.com/zed-industries/zed/pull/30671

Now, when clicking on an existing selection, the cursor will change on `mouse_up` when `drag_and_drop_selection` is `true`. When `drag_and_drop_selection` is `false`, it will change on `mouse_down` (previous default).

Release Notes:

- N/A
