### PR TITLE
feat(git-ui): add customizable AI commit message prompt setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -699,7 +699,10 @@
       //
       // Default: inherits editor scrollbar settings
       "show": null
-    }
+    },
+    // Prompt to use when generating a commit message
+    // with ai.
+    "commit_message_prompt": null
   },
   "message_editor": {
     // Whether to automatically replace emoji shortcodes with emoji characters.

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1786,14 +1786,23 @@ impl GitPanel {
                 })?;
 
                 let text_empty = subject.trim().is_empty();
+                const PROMPT: &str = include_str!("commit_message_prompt.txt");
 
-                let content = if text_empty {
-                    format!("{PROMPT}\nHere are the changes in this commit:\n{diff_text}")
+                let custom_prompt = cx.read_global::<SettingsStore, Option<String>>(|_s, cx|{
+                    GitPanelSettings::get_global(cx).commit_message_prompt.clone()
+                });
+
+                let prompt = if let Ok(Some(custom_prompt)) = custom_prompt {
+                    std::borrow::Cow::Owned(custom_prompt)
                 } else {
-                    format!("{PROMPT}\nHere is the user's subject line:\n{subject}\nHere are the changes in this commit:\n{diff_text}\n")
+                    std::borrow::Cow::Borrowed(PROMPT)
                 };
 
-                const PROMPT: &str = include_str!("commit_message_prompt.txt");
+                let content = if text_empty {
+                    format!("{prompt}\nHere are the changes in this commit:\n{diff_text}")
+                } else {
+                    format!("{prompt}\nHere is the user's subject line:\n{subject}\nHere are the changes in this commit:\n{diff_text}\n")
+                };
 
                 let request = LanguageModelRequest {
                     thread_id: None,

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -70,6 +70,10 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub sort_by_path: Option<bool>,
+
+    /// Prompt to use when generating a commit message
+    /// with ai.
+    pub commit_message_prompt: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -81,6 +85,7 @@ pub struct GitPanelSettings {
     pub scrollbar: ScrollbarSettings,
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
+    pub commit_message_prompt: Option<String>,
 }
 
 impl Settings for GitPanelSettings {


### PR DESCRIPTION
- Added `commit_message_prompt` option to `GitPanelSettings` to allow users to specify a custom prompt for AI-generated commit messages. - Updated `GitPanel` to use the custom prompt if set, falling back to the default prompt otherwise.

Closes #26823 

Release Notes:

![CleanShot 2025-06-08 at 23 17 19@2x](https://github.com/user-attachments/assets/404bff37-47b5-4786-a7b6-5fcf3510332a)

https://github.com/user-attachments/assets/759900a7-040d-4973-90fc-5e012d84f922


