### PR TITLE
Decrease the size of the branch picker icon

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -595,6 +595,7 @@ impl TitleBar {
                             .icon(IconName::GitBranch)
                             .icon_position(IconPosition::Start)
                             .icon_color(Color::Muted)
+                            .icon_size(IconSize::Indicator)
                     },
                 ),
         )


### PR DESCRIPTION
<img width="323" alt="image" src="https://github.com/user-attachments/assets/0060eaf3-35f9-4f0f-b9b6-e26ffad853c2" />

<img width="323" alt="image" src="https://github.com/user-attachments/assets/57b66dae-2a74-401f-82c1-8fc730a98fb0 " />

Release Notes:

- Adjusted size of the icon inside the title bar's branch picker when that's turned on.
