### PR TITLE
Store pulled diagnostics' result_ids more persistently

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -21941,7 +21941,7 @@ async fn test_pulling_diagnostics(cx: &mut TestAppContext) {
                 .expect("created a singleton buffer")
                 .read(cx)
                 .remote_id();
-            let buffer_result_id = project.lsp_store().read(cx).result_id(buffer_id);
+            let buffer_result_id = project.lsp_store().read(cx).result_id(buffer_id, cx);
             assert_eq!(expected, buffer_result_id);
         });
     };

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -4050,7 +4050,7 @@ impl LspCommand for GetDocumentDiagnostics {
         let buffer_id = buffer.update(&mut cx, |buffer, _| buffer.remote_id())?;
         Ok(Self {
             previous_result_id: lsp_store
-                .update(&mut cx, |lsp_store, _| lsp_store.result_id(buffer_id))?,
+                .update(&mut cx, |lsp_store, cx| lsp_store.result_id(buffer_id, cx))?,
         })
     }
 


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/19230

`BufferId` can change between file reopens: e.g. open the buffer, close it, go back in history to reopen it — the 2nd one will have a different `BufferId`, but the same `result_ids` semantically.

Release Notes:

- N/A
