### PR TITLE
Hush breakpoint deserialization logs

### DIFF
--- a/crates/project/src/debugger/breakpoint_store.rs
+++ b/crates/project/src/debugger/breakpoint_store.rs
@@ -840,7 +840,7 @@ impl BreakpointStore {
                         } else {
                             "breakpoint"
                         };
-                        log::info!("Deserialized {count} {breakpoint_str} at path: {path}");
+                        log::debug!("Deserialized {count} {breakpoint_str} at path: {path}");
                     }
 
                     this.breakpoints = new_breakpoints;


### PR DESCRIPTION
Release Notes:

- debugger: Remove "Deserializing N breakpoints" from the Zed log
