### PR TITLE
Add disable_click_through_mac setting for macOS

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -141,6 +141,10 @@
   //  3. Never close the window
   //         "when_closing_with_no_tabs": "keep_window_open",
   "when_closing_with_no_tabs": "platform_default",
+  // Whether to disable click-through behavior on macOS.
+  // When enabled, clicks on inactive Zed windows will only focus the window
+  // without activating buttons or other UI elements.
+  "disable_click_through_mac": false,
   // What to do when the last window is closed.
   // May take 2 values:
   //  1. Use the current platform's convention

--- a/crates/agent/src/ui/agent_notification.rs
+++ b/crates/agent/src/ui/agent_notification.rs
@@ -62,6 +62,7 @@ impl AgentNotification {
             app_id: Some(app_id.to_owned()),
             window_min_size: None,
             window_decorations: Some(WindowDecorations::Client),
+            ..Default::default()
         }
     }
 }

--- a/crates/collab_ui/src/collab_ui.rs
+++ b/crates/collab_ui/src/collab_ui.rs
@@ -66,5 +66,6 @@ fn notification_window_options(
         app_id: Some(app_id.to_owned()),
         window_min_size: None,
         window_decorations: Some(WindowDecorations::Client),
+        ..Default::default()
     }
 }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -446,6 +446,8 @@ pub(crate) trait PlatformWindow: HasWindowHandle + HasDisplayHandle {
     // macOS specific methods
     fn set_edited(&mut self, _edited: bool) {}
     fn show_character_palette(&self) {}
+    #[cfg(target_os = "macos")]
+    fn set_disable_click_through(&self, _disable: bool) {}
     fn titlebar_double_click(&self) {}
 
     #[cfg(target_os = "windows")]
@@ -1050,6 +1052,10 @@ pub struct WindowOptions {
     /// Whether to use client or server side decorations. Wayland only
     /// Note that this may be ignored.
     pub window_decorations: Option<WindowDecorations>,
+
+    /// Whether to disable click-through behavior on macOS.
+    #[cfg(target_os = "macos")]
+    pub disable_click_through_mac: bool,
 }
 
 /// The variables that can be configured when creating a new window
@@ -1089,6 +1095,9 @@ pub(crate) struct WindowParams {
     pub display_id: Option<DisplayId>,
 
     pub window_min_size: Option<Size<Pixels>>,
+
+    #[cfg(target_os = "macos")]
+    pub disable_click_through_mac: bool,
 }
 
 /// Represents the status of how a window should be opened.
@@ -1139,6 +1148,8 @@ impl Default for WindowOptions {
             app_id: None,
             window_min_size: None,
             window_decorations: None,
+            #[cfg(target_os = "macos")]
+            disable_click_through_mac: false,
         }
     }
 }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -884,6 +884,8 @@ impl Window {
             app_id,
             window_min_size,
             window_decorations,
+            #[cfg(target_os = "macos")]
+            disable_click_through_mac,
         } = options;
 
         let bounds = window_bounds
@@ -900,6 +902,8 @@ impl Window {
                 show,
                 display_id,
                 window_min_size,
+                #[cfg(target_os = "macos")]
+                disable_click_through_mac,
             },
         )?;
         let display_id = platform_window.display().map(|display| display.id());
@@ -1562,6 +1566,13 @@ impl Window {
     /// Toggle zoom on the window.
     pub fn zoom_window(&self) {
         self.platform_window.zoom();
+    }
+
+    /// Set whether click-through behavior is disabled on macOS.
+    /// When disabled, clicks on inactive windows will only focus the window without activating UI elements.
+    #[cfg(target_os = "macos")]
+    pub fn set_disable_click_through(&self, disable: bool) {
+        self.platform_window.set_disable_click_through(disable);
     }
 
     /// Opens the native title bar context menu, useful when implementing client side decorations (Wayland and X11)

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -106,6 +106,8 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut App) {
     let mut prev_buffer_font_size_settings =
         ThemeSettings::get_global(cx).buffer_font_size_settings();
     let mut prev_ui_font_size_settings = ThemeSettings::get_global(cx).ui_font_size_settings();
+    #[cfg(target_os = "macos")]
+    let mut prev_disable_click_through = ThemeSettings::get_global(cx).disable_click_through_mac;
     cx.observe_global::<SettingsStore>(move |cx| {
         let buffer_font_size_settings = ThemeSettings::get_global(cx).buffer_font_size_settings();
         if buffer_font_size_settings != prev_buffer_font_size_settings {
@@ -117,6 +119,15 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut App) {
         if ui_font_size_settings != prev_ui_font_size_settings {
             prev_ui_font_size_settings = ui_font_size_settings;
             reset_ui_font_size(cx);
+        }
+
+        #[cfg(target_os = "macos")]
+        {
+            let disable_click_through = ThemeSettings::get_global(cx).disable_click_through_mac;
+            if disable_click_through != prev_disable_click_through {
+                prev_disable_click_through = disable_click_through;
+                crate::settings::update_click_through_for_all_windows(cx);
+            }
         }
     })
     .detach();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -250,6 +250,8 @@ pub fn build_window_options(display_uuid: Option<Uuid>, cx: &mut App) -> WindowO
             width: px(360.0),
             height: px(240.0),
         }),
+        #[cfg(target_os = "macos")]
+        disable_click_through_mac: ThemeSettings::get_global(cx).disable_click_through_mac,
     }
 }
 


### PR DESCRIPTION
Making this a draft PR since I'm not sure how the zed team feels about having a macos specific setting like this.
This ports over a setting I used to use in vscode/cursor called `window.clickThroughInactive`.

Release Notes:

- Added `disable_click_through_mac` setting to prevent clicking through inactive windows on macOS. When enabled, clicks on inactive Zed windows will only focus the window without activating buttons or other UI elements.