### PR TITLE
Don't push to selection history if selections are empty

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1242,6 +1242,13 @@ impl SelectionHistory {
         transaction_id: TransactionId,
         selections: Arc<[Selection<Anchor>]>,
     ) {
+        if selections.is_empty() {
+            log::error!(
+                "SelectionHistory::insert_transaction called with empty selections. Caller: {}",
+                std::panic::Location::caller()
+            );
+            return;
+        }
         self.selections_by_transaction
             .insert(transaction_id, (selections, None));
     }


### PR DESCRIPTION
I got a panic during undo but haven't been able to repro it.  Potentially a consequence of my changes in #31731

> Thread "main" panicked with "There must be at least one selection" at crates/editor/src/selections_collection.rs

Leaving release notes blank as I'm not sure this actually fixes the panic 

Release Notes:

- N/A