### PR TITLE
gpui: Add the `windows-manifest` feature to embed manifest, enable by default

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -12,7 +12,7 @@ license = "Apache-2.0"
 workspace = true
 
 [features]
-default = ["http_client", "font-kit", "wayland", "x11"]
+default = ["http_client", "font-kit", "wayland", "x11", "windows-manifest"]
 test-support = [
     "leak-detection",
     "collections/test-support",
@@ -69,7 +69,7 @@ x11 = [
     "open",
     "scap",
 ]
-
+windows-manifest = []
 
 [lib]
 path = "src/gpui.rs"

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -17,7 +17,7 @@ fn main() {
             #[cfg(target_os = "macos")]
             macos::build();
         }
-        #[cfg(target_os = "windows")]
+        #[cfg(all(target_os = "windows", feature = "windows-manifest"))]
         Ok("windows") => {
             let manifest = std::path::Path::new("resources/windows/gpui.manifest.xml");
             let rc_file = std::path::Path::new("resources/windows/gpui.rc");


### PR DESCRIPTION
Gpui's build.rs will embed a manifest file into the Windows binary, but sometimes we want to customize it, so I added a feature called `no-windows-manifest` to disable this behavior.

Release Notes:

- N/A
