### PR TITLE
pane: Apply `max_tabs` change immediately

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -3867,6 +3867,7 @@ mod tests {
         for i in 0..7 {
             add_labeled_item(&pane, format!("{}", i).as_str(), false, cx);
         }
+
         set_max_tabs(cx, Some(5));
         add_labeled_item(&pane, "7", false, cx);
         // Remove items to respect the max tab cap.
@@ -3901,6 +3902,27 @@ mod tests {
             ],
             cx,
         );
+    }
+
+    #[gpui::test]
+    async fn test_reduce_max_tabs_closes_existing_items(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = FakeFs::new(cx.executor());
+
+        let project = Project::test(fs, None, cx).await;
+        let (workspace, cx) =
+            cx.add_window_view(|window, cx| Workspace::test_new(project.clone(), window, cx));
+        let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
+
+        set_max_tabs(cx, Some(5));
+
+        for i in 1..=5 {
+            add_labeled_item(&pane, format!("{}", i).as_str(), false, cx);
+        }
+
+        set_max_tabs(cx, Some(4));
+
+        assert_item_labels(&pane, ["2", "3", "4", "5*"], cx);
     }
 
     #[gpui::test]

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1462,9 +1462,10 @@ impl Pane {
         // using their index position, hence removing from the end
         // of the list first to avoid changing indexes.
         index_list.sort_unstable();
-        index_list.iter().rev().for_each(|&index| {
-            self._remove_item(index, false, false, None, window, cx);
-        });
+        index_list
+            .iter()
+            .rev()
+            .for_each(|&index| self._remove_item(index, false, false, None, window, cx));
     }
 
     // Usually when you close an item that has unsaved changes, we prompt you to

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -32,6 +32,7 @@ use settings::{Settings, SettingsStore};
 use std::{
     any::Any,
     cmp, fmt, mem,
+    num::NonZeroUsize,
     ops::ControlFlow,
     path::PathBuf,
     rc::Rc,
@@ -323,6 +324,7 @@ pub struct Pane {
     >,
     render_tab_bar: Rc<dyn Fn(&mut Pane, &mut Window, &mut Context<Pane>) -> AnyElement>,
     show_tab_bar_buttons: bool,
+    current_max_tabs: Option<NonZeroUsize>,
     _subscriptions: Vec<Subscription>,
     tab_bar_scroll_handle: ScrollHandle,
     /// Is None if navigation buttons are permanently turned off (and should not react to setting changes).
@@ -425,11 +427,12 @@ impl Pane {
             cx.on_focus(&focus_handle, window, Pane::focus_in),
             cx.on_focus_in(&focus_handle, window, Pane::focus_in),
             cx.on_focus_out(&focus_handle, window, Pane::focus_out),
-            cx.observe_global::<SettingsStore>(Self::settings_changed),
+            cx.observe_global_in::<SettingsStore>(window, Self::settings_changed),
             cx.subscribe(&project, Self::project_events),
         ];
 
         let handle = cx.entity().downgrade();
+
         Self {
             alternate_file_items: (None, None),
             focus_handle,
@@ -440,6 +443,7 @@ impl Pane {
             zoomed: false,
             active_item_index: 0,
             preview_item_id: None,
+            current_max_tabs: WorkspaceSettings::get_global(cx).max_tabs,
             last_focus_handle_by_item: Default::default(),
             nav_history: NavHistory(Arc::new(Mutex::new(NavHistoryState {
                 mode: NavigationMode::Normal,
@@ -620,17 +624,25 @@ impl Pane {
         }
     }
 
-    fn settings_changed(&mut self, cx: &mut Context<Self>) {
+    fn settings_changed(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let tab_bar_settings = TabBarSettings::get_global(cx);
+        let new_max_tabs = WorkspaceSettings::get_global(cx).max_tabs;
 
         if let Some(display_nav_history_buttons) = self.display_nav_history_buttons.as_mut() {
             *display_nav_history_buttons = tab_bar_settings.show_nav_history_buttons;
         }
+
         self.show_tab_bar_buttons = tab_bar_settings.show_tab_bar_buttons;
 
         if !PreviewTabsSettings::get_global(cx).enabled {
             self.preview_item_id = None;
         }
+
+        if new_max_tabs != self.current_max_tabs {
+            self.current_max_tabs = new_max_tabs;
+            self.close_items_over_max_tabs(window, cx);
+        }
+
         self.update_diagnostics(cx);
         cx.notify();
     }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -936,7 +936,7 @@ impl Pane {
             .any(|existing_item| existing_item.item_id() == item.item_id());
 
         if !item_already_exists {
-            self.close_items_on_file_open(window, cx);
+            self.close_items_on_item_open(window, cx);
         }
 
         if item.is_singleton(cx) {
@@ -1422,7 +1422,7 @@ impl Pane {
         )
     }
 
-    fn close_items_on_file_open(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+    fn close_items_on_item_open(&mut self, window: &mut Window, cx: &mut Context<Self>) {
         let target = self.max_tabs.map(|m| m.get());
         let protect_active_item = false;
         self.close_items_to_target_count(target, protect_active_item, window, cx);


### PR DESCRIPTION
Closes #32217

Follow up of https://github.com/zed-industries/zed/pull/32301, sorry about the messy rebase in the previous PR.

Release Notes: 
- Fixed `max_tabs` setting not applying immediately when changed
 
TODO: 
- [x] Fix the off-by-one bug (currently closing one more tab than the max_tabs setting) while perserving "+1 Tab Allowance" feature.
- [x] Investigate Double Invocation of `settings_changed`
- [x] Write test that:
  - Sets max_tabs to `n`
  - Opens `n` buffers
  - Changes max_tabs to `n-1`
  - Asserts we have exactly `n-1` buffers remaining