### PR TITLE
extension_host: Fix SSH reconnect breaks language server

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1682,12 +1682,15 @@ impl ExtensionStore {
 
     pub fn register_ssh_client(&mut self, client: Entity<SshRemoteClient>, cx: &mut Context<Self>) {
         let connection_options = client.read(cx).connection_options();
-        if self.ssh_clients.contains_key(&connection_options.ssh_url()) {
-            return;
+        let ssh_url = connection_options.ssh_url();
+
+        if let Some(existing_client) = self.ssh_clients.get(&ssh_url) {
+            if existing_client.upgrade().is_some() {
+                return;
+            }
         }
 
-        self.ssh_clients
-            .insert(connection_options.ssh_url(), client.downgrade());
+        self.ssh_clients.insert(ssh_url, client.downgrade());
         self.ssh_registered_tx.unbounded_send(()).ok();
     }
 }


### PR DESCRIPTION
Closes #29032

This PR fixes an issue where reconnecting to SSH Remote would result in a broken language server. 

This was caused by SSH clients not registering because the `ssh_clients` map would still contain an entry from a previously killed SSH server. For fix, now we also check if its value has been dropped.

Release Notes:

- Fixed issue where reconnecting to SSH Remote would result in broken code completions and diagnostics.
