### PR TITLE
docs: Add link to MCP extensions in the overview page

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -8,3 +8,4 @@ Zed lets you add new functionality using user-defined extensions.
   - [Developing Themes](./extensions/themes.md)
   - [Developing Icon Themes](./extensions/icon-themes.md)
   - [Developing Slash Commands](./extensions/slash-commands.md)
+  - [Developing MCP Servers](./extensions/mcp-extensions.md)

--- a/docs/src/extensions/mcp-extensions.md
+++ b/docs/src/extensions/mcp-extensions.md
@@ -35,7 +35,7 @@ If you need to download the MCP server from an external source—like GitHub Rel
 
 ## Available Extensions
 
-Check out all the MCP servers that have already been exposed as Zed extensions [on Zed's site](https://zed.dev/extensions?filter=context-servers).
+Check out all the MCP servers that have already been exposed as extensions [on Zed's site](https://zed.dev/extensions?filter=context-servers).
 
 We recommend taking a look at their repositories as a way to understand how they are generally created and structured.
 


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/32422. Missed this one in this latest round of MCP-related docs changes.

Release Notes:

- N/A
