### PR TITLE
ci: Move lychee link check to script/check-links

### DIFF
--- a/.github/actions/build_docs/action.yml
+++ b/.github/actions/build_docs/action.yml
@@ -19,12 +19,6 @@ runs:
       shell: bash -euxo pipefail {0}
       run: ./script/linux
 
-    - name: Check for broken links
-      uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
-      with:
-        args: --no-progress './docs/src/**/*'
-        fail: true
-
     - name: Build book
       shell: bash -euxo pipefail {0}
       run: |

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -25,7 +25,7 @@ Here's an overview of the supported providers and tool call support:
 
 ## Use Your Own Keys {#use-your-own-keys}
 
-While Zed offers hosted versions of models through [our various plans](/ai/plans-and-usage), we're always happy to support users wanting to supply their own API keys.
+While Zed offers hosted versions of models through [our various plans](./plans-and-usage.md), we're always happy to support users wanting to supply their own API keys.
 Below, you can learn how to do that for each provider.
 
 > Using your own API keys is _free_—you do not need to subscribe to a Zed plan to use our AI features with your own keys.

--- a/script/check-links
+++ b/script/check-links
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+cargo install lychee
+cd "$(dirname "$0")/.."
+lychee --no-progress './docs/src/**/*'


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/30844

Transient link failure was blocking PR tests passing. [Example run](https://github.com/zed-industries/zed/actions/runs/15560960788/job/43812878693?pr=32458).

Release Notes:

- N/A