### PR TITLE
debugger: Specify runtimeExecutable in output of node locator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8993,7 +8993,6 @@ dependencies = [
  "tree-sitter-yaml",
  "unindent",
  "util",
- "which 6.0.3",
  "workspace",
  "workspace-hack",
 ]

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -88,7 +88,6 @@ tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-yaml = { workspace = true, optional = true }
 util.workspace = true
-which.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -46,6 +46,7 @@ impl DapLocator for NodeLocator {
         let config = serde_json::json!({
             "request": "launch",
             "type": "pwa-node",
+            "runtimeExecutable": TYPESCRIPT_RUNNER_VARIABLE.template_value(),
             "program": program_path,
             "args": args,
             "cwd": build_config.cwd.clone(),
@@ -63,6 +64,6 @@ impl DapLocator for NodeLocator {
     }
 
     async fn run(&self, _: SpawnInTerminal) -> Result<DebugRequest> {
-        bail!("Python locator should not require DapLocator::run to be ran");
+        bail!("JavaScript locator should not require DapLocator::run to be ran");
     }
 }

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -46,8 +46,7 @@ impl DapLocator for NodeLocator {
         let config = serde_json::json!({
             "request": "launch",
             "type": "pwa-node",
-            "runtimeExecutable": TYPESCRIPT_RUNNER_VARIABLE.template_value(),
-            "program": program_path,
+            "runtimeExecutable": program_path,
             "args": args,
             "cwd": build_config.cwd.clone(),
             "runtimeArgs": ["--inspect-brk"],


### PR DESCRIPTION
This appears to fix some cases where we fail to launch JS tests under the debugger.

Release Notes:

- N/A (node locator is still gated)