### PR TITLE
Allow identifiers in TypeScript/JavaScript test names

### DIFF
--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -75,7 +75,10 @@
         ] @context
         (#any-of? @_name "it" "test" "describe" "context" "suite")
         arguments: (
-            arguments . (string (string_fragment) @name)
+            arguments . [
+                (string (string_fragment) @name)
+                (identifier) @name
+            ]
         )
     )
 ) @item
@@ -92,7 +95,10 @@
             (#eq? @_property "each")
         )
         arguments: (
-            arguments . (string (string_fragment) @name)
+            arguments . [
+                (string (string_fragment) @name)
+                (identifier) @name
+            ]
         )
     )
 ) @item

--- a/crates/languages/src/javascript/runnables.scm
+++ b/crates/languages/src/javascript/runnables.scm
@@ -13,7 +13,10 @@
         ]
         (#any-of? @_name "it" "test" "describe" "context" "suite")
         arguments: (
-            arguments . (string (string_fragment) @run)
+            arguments . [
+                (string (string_fragment) @run)
+                (identifier) @run
+            ]
         )
     ) @_js-test
 
@@ -32,7 +35,10 @@
             (#eq? @_property "each")
         )
         arguments: (
-            arguments . (string (string_fragment) @run)
+            arguments . [
+                (string (string_fragment) @run)
+                (identifier) @run
+            ]
         )
     ) @_js-test
 

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -83,7 +83,10 @@
         ] @context
         (#any-of? @_name "it" "test" "describe" "context" "suite")
         arguments: (
-            arguments . (string (string_fragment) @name)
+            arguments . [
+                (string (string_fragment) @name)
+                (identifier) @name
+            ]
         )
     )
 ) @item
@@ -100,7 +103,10 @@
             (#any-of? @_property "each")
         )
         arguments: (
-            arguments . (string (string_fragment) @name)
+            arguments . [
+                (string (string_fragment) @name)
+                (identifier) @name
+            ]
         )
     )
 ) @item

--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -13,7 +13,10 @@
         ]
         (#any-of? @_name "it" "test" "describe" "context" "suite")
         arguments: (
-            arguments . (string (string_fragment) @run)
+            arguments . [
+                (string (string_fragment) @run)
+                (identifier) @run
+            ]
         )
     ) @_js-test
 
@@ -32,7 +35,10 @@
             (#any-of? @_property "each")
         )
         arguments: (
-            arguments . (string (string_fragment) @run)
+            arguments . [
+                (string (string_fragment) @run)
+                (identifier) @run
+            ]
         )
     ) @_js-test
 


### PR DESCRIPTION
Current behavior (not detected as runnable):

<img width="1105" alt="image" src="https://github.com/user-attachments/assets/7d3b7936-43d8-4645-bbbb-e81ed5f9b35a" />

New behavior:


https://github.com/user-attachments/assets/524e2a56-cb30-4dc0-98ec-b34b510015e0

Release Notes:

- Improved detection of runnable TypeScript/JavaScript test cases when they contain identifier
