### PR TITLE
ci: Require check_docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -498,6 +498,7 @@ jobs:
     needs:
       - job_spec
       - style
+      - check_docs
       - migration_checks
       # run_tests: If adding required tests, add them here and to script below.
       - workspace_hack
@@ -515,7 +516,8 @@ jobs:
           # Check dependent jobs...
           RET_CODE=0
           # Always check style
-          [[ "${{ needs.style.result }}" != 'success' ]] && { RET_CODE=1; echo "style tests failed"; }
+          [[ "${{ needs.style.result }}"      != 'success' ]] && { RET_CODE=1; echo "style tests failed"; }
+          [[ "${{ needs.check_docs.result }}" != 'success' ]] && { RET_CODE=1; echo "docs checks failed"; }
 
           # Only check test jobs if they were supposed to run
           if [[ "${{ needs.job_spec.outputs.run_tests }}" == "true" ]]; then


### PR DESCRIPTION
Previously, broken `check_docs` would not prevent merge/automerge.
Introduced in:
- https://github.com/zed-industries/zed/pull/31073

Release Notes:

- N/A
