### PR TITLE
docs: Update Ruby docs about `args` syntax in tasks

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -304,8 +304,6 @@ To run tests in your Ruby project, you can set up custom tasks in your local `.z
 ]
 ```
 
-Note: We can't use `args` here because of the way quotes are handled.
-
 ### Minitest
 
 Plain minitest does not support running tests by line number, only by name, so we need to use `$ZED_CUSTOM_RUBY_TEST_NAME` instead:


### PR DESCRIPTION
Due to https://github.com/zed-industries/zed/pull/32345

cc @vitallium 

Release Notes:

- N/A
