### PR TITLE
docs: Condense Ruby test framework docs

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -341,28 +341,4 @@ Plain minitest does not support running tests by line number, only by name, so w
 ]
 ```
 
-### quickdraw
-
-```json
-[
-  {
-    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
-    "command": "bundle",
-    "args": ["exec", "qt", "exec", "qt", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
-    "tags": ["ruby-test"]
-  }
-]
-```
-
-### tldr
-
-```json
-[
-  {
-    "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
-    "command": "bundle",
-    "args": ["exec", "tldr", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
-    "tags": ["ruby-test"]
-  }
-]
-```
+Similar task syntax can be used for other test frameworks such as `quickdraw` or `tldr`.


### PR DESCRIPTION
Since `tldr` and `quickdraw` use the same kind of task syntax as RSpec, I don't think it's necessary to have separate examples.

cc @joeldrapper @vitallium 

Release Notes:

- N/A
