### PR TITLE
debugger: Run jest tests serially

### DIFF
--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -11,6 +11,8 @@ pub(crate) struct NodeLocator;
 
 const TYPESCRIPT_RUNNER_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("TYPESCRIPT_RUNNER"));
+const TYPESCRIPT_JEST_TASK_VARIABLE: VariableName =
+    VariableName::Custom(Cow::Borrowed("TYPESCRIPT_JEST"));
 
 #[async_trait]
 impl DapLocator for NodeLocator {
@@ -41,7 +43,15 @@ impl DapLocator for NodeLocator {
             .join("node_modules")
             .join(".bin")
             .join(test_library);
-        let args = build_config.args[1..].to_vec();
+
+        let mut args = if test_library == "jest"
+            || test_library == &TYPESCRIPT_JEST_TASK_VARIABLE.template_value()
+        {
+            vec!["--runInBand".to_owned()]
+        } else {
+            vec![]
+        };
+        args.extend(build_config.args[1..].iter().cloned());
 
         let config = serde_json::json!({
             "request": "launch",


### PR DESCRIPTION
Pass `--runInBand` to jest when debugging. This prevents jest from creating a bunch of child processes that clutter the session list.

It might be a bit more natural to add this argument in the test templates themselves, but I don't think we want to give up parallelism when running via `task: spawn`.

Release Notes:

- N/A (JS locator is still gated)