### PR TITLE
debugger: Use JS adapter's suggested names for child sessions

### DIFF
--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -369,6 +369,10 @@ pub trait DebugAdapter: 'static + Send + Sync {
     }
 
     async fn dap_schema(&self) -> serde_json::Value;
+
+    fn label_for_child_session(&self, _args: &StartDebuggingRequestArguments) -> Option<String> {
+        None
+    }
 }
 
 #[cfg(any(test, feature = "test-support"))]

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -431,4 +431,9 @@ impl DebugAdapter for JsDebugAdapter {
         self.get_installed_binary(delegate, &config, user_installed_path, cx)
             .await
     }
+
+    fn label_for_child_session(&self, args: &StartDebuggingRequestArguments) -> Option<String> {
+        let label = args.configuration.get("name")?.as_str()?;
+        Some(label.to_owned())
+    }
 }


### PR DESCRIPTION
Also introduces an extension point for other adapters to do this if it turns out they also send this information.

Release Notes:

- N/A (JS locator is still gated)