### PR TITLE
ci: Suppress evals on forks

### DIFF
--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -30,6 +30,7 @@ jobs:
   noop:
     name: No-op
     runs-on: ubuntu-latest
+    if: github.repository_owner == 'zed-industries'
     steps:
       - name: No-op
         run: echo "Nothing to do"

--- a/.github/workflows/unit_evals.yml
+++ b/.github/workflows/unit_evals.yml
@@ -19,6 +19,7 @@ env:
 
 jobs:
   unit_evals:
+    if: github.repository_owner == 'zed-industries'
     timeout-minutes: 60
     name: Run unit evals
     runs-on:


### PR DESCRIPTION
Be kind to those with Zed forks.

Example [action run on fork](https://github.com/G36maid/freebsd-ports-zed/actions/runs/15525942275) where [this job](https://github.com/G36maid/freebsd-ports-zed/actions/runs/15549650437/job/43777665341) will wait forever. Sorry @G36maid

Release Notes:

- N/A
