### PR TITLE
Revert "Preserve selection direction when running `editor: open selections in multibuffer`"

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -18137,16 +18137,9 @@ impl Editor {
             .selections
             .disjoint_anchors()
             .iter()
-            .map(|selection| {
-                let range = if selection.reversed {
-                    selection.end.text_anchor..selection.start.text_anchor
-                } else {
-                    selection.start.text_anchor..selection.end.text_anchor
-                };
-                Location {
-                    buffer: buffer.clone(),
-                    range,
-                }
+            .map(|range| Location {
+                buffer: buffer.clone(),
+                range: range.start.text_anchor..range.end.text_anchor,
             })
             .collect::<Vec<_>>();
 


### PR DESCRIPTION
Reverts zed-industries/zed#31399

I found that in some cases, Zed will panic when using `editor: open selections in multibuffer` if the selection is reversed. It doesn't happen in most cases that I've tested, but in some strange edge cases (that I dont fully understand ATM), it does. I'm reverting for now, as the previous behavior is better than a panic, but will re-implement this fix to preserving selection directions in a new PR with comprehensive testing

Release Notes:

- N/A