### PR TITLE
Filter language server completions even when `is_incomplete: true`

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5139,10 +5139,13 @@ impl Editor {
             .as_ref()
             .map_or(true, |provider| provider.filter_completions());
 
-        // When `is_incomplete` is false, can filter completions instead of re-querying when the
-        // current query is a suffix of the initial query.
         if let Some(CodeContextMenu::Completions(menu)) = self.context_menu.borrow_mut().as_mut() {
-            if !menu.is_incomplete && filter_completions {
+            if filter_completions {
+                menu.filter(query.clone(), provider.clone(), window, cx);
+            }
+            // When `is_incomplete` is false, no need to re-query completions when the current query
+            // is a suffix of the initial query.
+            if !menu.is_incomplete {
                 // If the new query is a suffix of the old query (typing more characters) and
                 // the previous result was complete, the existing completions can be filtered.
                 //
@@ -5160,7 +5163,6 @@ impl Editor {
                         menu.initial_position.to_offset(&snapshot) == position.to_offset(&snapshot)
                     };
                     if position_matches {
-                        menu.filter(query.clone(), provider.clone(), window, cx);
                         return;
                     }
                 }


### PR DESCRIPTION
In #31872 I changed the behavior of completions to not filter instead of requerying completions when `is_incomplete: false`. Unfortunately this also stopped filtering completions when `is_incomplete: true` - we still want to filter the incomplete completions so that the menu updates quickly even when completions are slow.  This does mean that the completions menu will display partial results, hopefully only briefly while waiting for fresh completions.

Thanks to @mikayla-maki for noticing the regression.  Thankfully just in time to fix it before this makes it into a stable release.  Leaving off release notes since I will cherry-pick this to the current preview version, 190.x, and there probably won't be a preview release before the next stable.

Release Notes:

- N/A