### PR TITLE
debugger: Fix panic when handling invalid `RunInTerminal` request

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4050,7 +4050,7 @@ dependencies = [
 [[package]]
 name = "dap-types"
 version = "0.0.1"
-source = "git+https://github.com/zed-industries/dap-types?rev=68516de327fa1be15214133a0a2e52a12982ce75#68516de327fa1be15214133a0a2e52a12982ce75"
+source = "git+https://github.com/zed-industries/dap-types?rev=cef124a5109d6fd44a3f986882d78ce40b8d4fb5#cef124a5109d6fd44a3f986882d78ce40b8d4fb5"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -435,7 +435,7 @@ core-foundation-sys = "0.8.6"
 core-video = { version = "0.4.3", features = ["metal"] }
 criterion = { version = "0.5", features = ["html_reports"] }
 ctor = "0.4.0"
-dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "68516de327fa1be15214133a0a2e52a12982ce75" }
+dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "cef124a5109d6fd44a3f986882d78ce40b8d4fb5" }
 dashmap = "6.0"
 derive_more = "0.99.17"
 dirs = "4.0"


### PR DESCRIPTION
The new dap-types version has a default to cwd for the RunInTerminalRequest

Closes #31695

Release Notes:

- debugger beta: Fix panic that occurred when a debug adapter sent an invalid `RunInTerminal` request
