### PR TITLE
debugger beta: Fix inline value provider panic

### DIFF
--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -576,7 +576,12 @@ impl DapStore {
             const LIMIT: usize = 100;
 
             if value.len() > LIMIT {
-                value.truncate(LIMIT);
+                let mut index = LIMIT;
+                // If index isn't a char boundary truncate will cause a panic
+                while !value.is_char_boundary(index) {
+                    index -= 1;
+                }
+                value.truncate(index);
                 value.push_str("...");
             }
 


### PR DESCRIPTION
Closes #32143

Release Notes:

- debugger beta: Fix panic that could occur when generating inline values
