### PR TITLE
editor: Adjust scope for prefer label for snippet workaround

### DIFF
--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -38,5 +38,5 @@ completion_query_characters = ["-", "."]
 opt_into_language_servers = ["tailwindcss-language-server"]
 prefer_label_for_snippet = true
 
-[overrides.call_expression_with_type_arguments]
+[overrides.function_name_before_type_arguments]
 prefer_label_for_snippet = true

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -38,5 +38,5 @@ completion_query_characters = ["-", "."]
 opt_into_language_servers = ["tailwindcss-language-server"]
 prefer_label_for_snippet = true
 
-[overrides.call_expression]
+[overrides.call_expression_with_type_arguments]
 prefer_label_for_snippet = true

--- a/crates/languages/src/tsx/overrides.scm
+++ b/crates/languages/src/tsx/overrides.scm
@@ -15,5 +15,5 @@
 ] @default
 
 (_ value: (call_expression
-  function: (identifier)
-  type_arguments: (type_arguments)) @call_expression_with_type_arguments)
+  function: (identifier) @function_name_before_type_arguments
+  type_arguments: (type_arguments)))

--- a/crates/languages/src/tsx/overrides.scm
+++ b/crates/languages/src/tsx/overrides.scm
@@ -14,4 +14,6 @@
   (jsx_expression)
 ] @default
 
-(_ value: (call_expression) @call_expression)
+(_ value: (call_expression
+  function: (identifier)
+  type_arguments: (type_arguments)) @call_expression_with_type_arguments)

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -25,5 +25,5 @@ documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 completion_query_characters = ["."]
 prefer_label_for_snippet = true
 
-[overrides.call_expression]
+[overrides.call_expression_with_type_arguments]
 prefer_label_for_snippet = true

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -25,5 +25,5 @@ documentation = { start = "/**", end = "*/", prefix = "* ", tab_size = 1 }
 completion_query_characters = ["."]
 prefer_label_for_snippet = true
 
-[overrides.call_expression_with_type_arguments]
+[overrides.function_name_before_type_arguments]
 prefer_label_for_snippet = true

--- a/crates/languages/src/typescript/overrides.scm
+++ b/crates/languages/src/typescript/overrides.scm
@@ -2,5 +2,5 @@
 (string) @string
 
 (_ value: (call_expression
-  function: (identifier)
-  type_arguments: (type_arguments)) @call_expression_with_type_arguments)
+  function: (identifier) @function_name_before_type_arguments
+  type_arguments: (type_arguments)))

--- a/crates/languages/src/typescript/overrides.scm
+++ b/crates/languages/src/typescript/overrides.scm
@@ -1,4 +1,6 @@
 (comment) @comment.inclusive
 (string) @string
 
-(_ value: (call_expression) @call_expression)
+(_ value: (call_expression
+  function: (identifier)
+  type_arguments: (type_arguments)) @call_expression_with_type_arguments)


### PR DESCRIPTION
Closes #32159

This PR refines the scope to match just the function name with **the type argument** instead of the whole call expression.

Matching to whole call expression prevented methods from expanding inside the function argument. For example, `const foo = bar(someMethod(2)^);` instead of `const foo = bar(someMethod^)`; 

Follow-up for https://github.com/zed-industries/zed/pull/30312, https://github.com/zed-industries/zed/pull/30351. Mistakenly regressed since https://github.com/zed-industries/zed/pull/31872 when we stopped receiving `insert_range` for this particular case and fallback to `replace_range`.

Release Notes:

- Fixed issue where code completion in TypeScript function arguments sometimes omitted the dot separator, for example resulting in `NumberparseInt` instead of `Number.parseInt(string)`.