### PR TITLE
editor: Fix certain unwanted pre-emptive keys been shown in buffer

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19742,7 +19742,7 @@ impl Editor {
             .flatten()
             .filter_map(|keystroke| {
                 if keystroke.modifiers.is_subset_of(&Modifiers::shift()) {
-                    Some(keystroke.key_char.clone().unwrap_or(keystroke.key.clone()))
+                    keystroke.key_char.clone()
                 } else {
                     None
                 }


### PR DESCRIPTION
Closes #32456

https://github.com/zed-industries/zed/pull/32007 added showing pre-emptive keys for multi-key bindings. But for certain keys like "control", "backspace", "escape", "shift", "f1", etc., shouldn't be shown as these keys would not end up in buffer after pending input delay. This PR changes it to use just `key_char`, as it represents actual text that will end up in buffer and is `None` for all mentioned keys. 

https://github.com/zed-industries/zed/blob/fad4c17c97927626792228bfbf92494b4cd35c40/crates/gpui/src/platform/keystroke.rs#L14-L21

cc @ConradIrwin 

Release Notes:

- Fixed issue where triggering multi-key binding like "shift", "control", etc. would write them to the buffer for a short time.
