### PR TITLE
debugger: Mark DebugAdapterBinary::program as optional

### DIFF
--- a/crates/collab/src/tests/remote_editing_collaboration_tests.rs
+++ b/crates/collab/src/tests/remote_editing_collaboration_tests.rs
@@ -671,7 +671,7 @@ async fn test_remote_server_debugger(
     });
 
     session.update(cx_a, |session, _| {
-        assert_eq!(session.binary().command, "ssh");
+        assert_eq!(session.binary().command.as_deref(), Some("ssh"));
     });
 
     let shutdown_session = workspace.update(cx_a, |workspace, cx| {

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -437,7 +437,7 @@ impl DebugAdapter for FakeAdapter {
         _: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
         Ok(DebugAdapterBinary {
-            command: "command".into(),
+            command: Some("command".into()),
             arguments: vec![],
             connection: None,
             envs: HashMap::default(),

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -181,7 +181,7 @@ impl DebugTaskDefinition {
 /// Created from a [DebugTaskDefinition], this struct describes how to spawn the debugger to create a previously-configured debug session.
 #[derive(Debug, Clone, PartialEq)]
 pub struct DebugAdapterBinary {
-    pub command: String,
+    pub command: Option<String>,
     pub arguments: Vec<String>,
     pub envs: HashMap<String, String>,
     pub cwd: Option<PathBuf>,

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -297,7 +297,7 @@ mod tests {
         let client = DebugAdapterClient::start(
             crate::client::SessionId(1),
             DebugAdapterBinary {
-                command: "command".into(),
+                command: Some("command".into()),
                 arguments: Default::default(),
                 envs: Default::default(),
                 connection: None,
@@ -367,7 +367,7 @@ mod tests {
         let client = DebugAdapterClient::start(
             crate::client::SessionId(1),
             DebugAdapterBinary {
-                command: "command".into(),
+                command: Some("command".into()),
                 arguments: Default::default(),
                 envs: Default::default(),
                 connection: None,
@@ -420,7 +420,7 @@ mod tests {
         let client = DebugAdapterClient::start(
             crate::client::SessionId(1),
             DebugAdapterBinary {
-                command: "command".into(),
+                command: Some("command".into()),
                 arguments: Default::default(),
                 envs: Default::default(),
                 connection: None,

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -359,7 +359,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
         };
 
         Ok(DebugAdapterBinary {
-            command: command.unwrap(),
+            command: Some(command.unwrap()),
             cwd: Some(delegate.worktree_root_path().to_path_buf()),
             arguments: vec![
                 "--settings".into(),

--- a/crates/dap_adapters/src/gdb.rs
+++ b/crates/dap_adapters/src/gdb.rs
@@ -183,7 +183,7 @@ impl DebugAdapter for GdbDebugAdapter {
         };
 
         Ok(DebugAdapterBinary {
-            command: gdb_path,
+            command: Some(gdb_path),
             arguments: vec!["-i=dap".into()],
             envs: HashMap::default(),
             cwd: Some(delegate.worktree_root_path().to_path_buf()),

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -463,7 +463,7 @@ impl DebugAdapter for GoDebugAdapter {
         };
 
         Ok(DebugAdapterBinary {
-            command: minidelve_path.to_string_lossy().into_owned(),
+            command: Some(minidelve_path.to_string_lossy().into_owned()),
             arguments,
             cwd: Some(cwd),
             envs: HashMap::default(),

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -69,12 +69,14 @@ impl JsDebugAdapter {
         let (host, port, timeout) = crate::configure_tcp_connection(tcp_connection).await?;
 
         Ok(DebugAdapterBinary {
-            command: delegate
-                .node_runtime()
-                .binary_path()
-                .await?
-                .to_string_lossy()
-                .into_owned(),
+            command: Some(
+                delegate
+                    .node_runtime()
+                    .binary_path()
+                    .await?
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
             arguments: vec![
                 adapter_path
                     .join(Self::ADAPTER_PATH)

--- a/crates/dap_adapters/src/php.rs
+++ b/crates/dap_adapters/src/php.rs
@@ -72,12 +72,14 @@ impl PhpDebugAdapter {
         let (host, port, timeout) = crate::configure_tcp_connection(tcp_connection).await?;
 
         Ok(DebugAdapterBinary {
-            command: delegate
-                .node_runtime()
-                .binary_path()
-                .await?
-                .to_string_lossy()
-                .into_owned(),
+            command: Some(
+                delegate
+                    .node_runtime()
+                    .binary_path()
+                    .await?
+                    .to_string_lossy()
+                    .into_owned(),
+            ),
             arguments: vec![
                 adapter_path
                     .join(Self::ADAPTER_PATH)

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -187,7 +187,7 @@ impl PythonDebugAdapter {
         );
 
         Ok(DebugAdapterBinary {
-            command: python_command,
+            command: Some(python_command),
             arguments,
             connection: Some(adapters::TcpArguments {
                 host,

--- a/crates/dap_adapters/src/ruby.rs
+++ b/crates/dap_adapters/src/ruby.rs
@@ -175,7 +175,7 @@ impl DebugAdapter for RubyDebugAdapter {
         arguments.extend(ruby_config.args);
 
         Ok(DebugAdapterBinary {
-            command: rdbg_path.to_string_lossy().to_string(),
+            command: Some(rdbg_path.to_string_lossy().to_string()),
             arguments,
             connection: Some(dap::adapters::TcpArguments {
                 host,

--- a/crates/extension_api/wit/since_v0.6.0/dap.wit
+++ b/crates/extension_api/wit/since_v0.6.0/dap.wit
@@ -50,7 +50,7 @@ interface dap {
     }
 
     record debug-adapter-binary {
-        command: string,
+        command: option<string>,
         arguments: list<string>,
         envs: env-vars,
         cwd: option<string>,

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -258,14 +258,17 @@ impl DapStore {
 
                     let (program, args) = wrap_for_ssh(
                         &ssh_command,
-                        Some((&binary.command, &binary.arguments)),
+                        binary
+                            .command
+                            .as_ref()
+                            .map(|command| (command, &binary.arguments)),
                         binary.cwd.as_deref(),
                         binary.envs,
                         None,
                     );
 
                     Ok(DebugAdapterBinary {
-                        command: program,
+                        command: Some(program),
                         arguments: args,
                         envs: HashMap::default(),
                         cwd: None,

--- a/crates/proto/proto/debugger.proto
+++ b/crates/proto/proto/debugger.proto
@@ -496,7 +496,7 @@ message GetDebugAdapterBinary {
 }
 
 message DebugAdapterBinary {
-    string command = 1;
+    optional string command = 1;
     repeated string arguments = 2;
     map<string, string> envs = 3;
     optional string cwd = 4;


### PR DESCRIPTION
This allows us to support debugging with a debug adapter not managed by Zed. Note that this is not a user facing change, as DebugAdapterBinary is used to determine how to spawn a debugger. Thus, this should not break any configs or anything like that.

Closes #ISSUE

Release Notes:

- N/A
