### PR TITLE
windows: Show error messages when zed failed to lanuch

### DIFF
--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -142,7 +142,11 @@ pub fn guess_compositor() -> &'static str {
 
 #[cfg(target_os = "windows")]
 pub(crate) fn current_platform(_headless: bool) -> Rc<dyn Platform> {
-    Rc::new(WindowsPlatform::new())
+    Rc::new(
+        WindowsPlatform::new()
+            .inspect_err(|err| show_error("Error: Zed failed to launch", err.to_string()))
+            .unwrap(),
+    )
 }
 
 pub(crate) trait Platform: 'static {

--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -10,7 +10,6 @@ pub struct BladeContext {
 
 impl BladeContext {
     pub fn new() -> anyhow::Result<Self> {
-        println!("==> Initializing Blade GPU context...");
         let device_id_forced = match std::env::var("ZED_DEVICE_ID") {
             Ok(val) => parse_pci_id(&val)
                 .context("Failed to parse device ID from `ZED_DEVICE_ID` environment variable")
@@ -33,7 +32,6 @@ impl BladeContext {
             }
             .map_err(|e| anyhow::anyhow!("{e:?}"))?,
         );
-        println!("==> Finish initializing Blade GPU context...");
         Ok(Self { gpu })
     }
 }

--- a/crates/gpui/src/platform/blade/blade_context.rs
+++ b/crates/gpui/src/platform/blade/blade_context.rs
@@ -10,6 +10,7 @@ pub struct BladeContext {
 
 impl BladeContext {
     pub fn new() -> anyhow::Result<Self> {
+        println!("==> Initializing Blade GPU context...");
         let device_id_forced = match std::env::var("ZED_DEVICE_ID") {
             Ok(val) => parse_pci_id(&val)
                 .context("Failed to parse device ID from `ZED_DEVICE_ID` environment variable")
@@ -32,6 +33,7 @@ impl BladeContext {
             }
             .map_err(|e| anyhow::anyhow!("{e:?}"))?,
         );
+        println!("==> Finish initializing Blade GPU context...");
         Ok(Self { gpu })
     }
 }

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -331,6 +331,7 @@ impl BladeRenderer {
         window: &I,
         config: BladeSurfaceConfig,
     ) -> anyhow::Result<Self> {
+        println!("1");
         let surface_config = gpu::SurfaceConfig {
             size: config.size,
             usage: gpu::TextureUsage::TARGET,
@@ -342,30 +343,37 @@ impl BladeRenderer {
         let surface = context
             .gpu
             .create_surface_configured(window, surface_config)
-            .unwrap();
+            .map_err(|err| anyhow::anyhow!("Failed to create surface: {err:?}"))?;
+        println!("2");
 
         let command_encoder = context.gpu.create_command_encoder(gpu::CommandEncoderDesc {
             name: "main",
             buffer_count: 2,
         });
+        println!("3");
         // workaround for https://github.com/zed-industries/zed/issues/26143
         let path_sample_count = std::env::var("ZED_PATH_SAMPLE_COUNT")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_PATH_SAMPLE_COUNT);
+        println!("4");
         let pipelines = BladePipelines::new(&context.gpu, surface.info(), path_sample_count);
+        println!("5");
         let instance_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: gpu::Memory::Shared,
             min_chunk_size: 0x1000,
             alignment: 0x40, // Vulkan `minStorageBufferOffsetAlignment` on Intel Xe
         });
+        println!("6");
         let atlas = Arc::new(BladeAtlas::new(&context.gpu, path_sample_count));
+        println!("7");
         let atlas_sampler = context.gpu.create_sampler(gpu::SamplerDesc {
             name: "atlas",
             mag_filter: gpu::FilterMode::Linear,
             min_filter: gpu::FilterMode::Linear,
             ..Default::default()
         });
+        println!("8");
 
         #[cfg(target_os = "macos")]
         let core_video_texture_cache = unsafe {

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -331,7 +331,6 @@ impl BladeRenderer {
         window: &I,
         config: BladeSurfaceConfig,
     ) -> anyhow::Result<Self> {
-        println!("1");
         let surface_config = gpu::SurfaceConfig {
             size: config.size,
             usage: gpu::TextureUsage::TARGET,
@@ -344,36 +343,29 @@ impl BladeRenderer {
             .gpu
             .create_surface_configured(window, surface_config)
             .map_err(|err| anyhow::anyhow!("Failed to create surface: {err:?}"))?;
-        println!("2");
 
         let command_encoder = context.gpu.create_command_encoder(gpu::CommandEncoderDesc {
             name: "main",
             buffer_count: 2,
         });
-        println!("3");
         // workaround for https://github.com/zed-industries/zed/issues/26143
         let path_sample_count = std::env::var("ZED_PATH_SAMPLE_COUNT")
             .ok()
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_PATH_SAMPLE_COUNT);
-        println!("4");
         let pipelines = BladePipelines::new(&context.gpu, surface.info(), path_sample_count);
-        println!("5");
         let instance_belt = BufferBelt::new(BufferBeltDescriptor {
             memory: gpu::Memory::Shared,
             min_chunk_size: 0x1000,
             alignment: 0x40, // Vulkan `minStorageBufferOffsetAlignment` on Intel Xe
         });
-        println!("6");
         let atlas = Arc::new(BladeAtlas::new(&context.gpu, path_sample_count));
-        println!("7");
         let atlas_sampler = context.gpu.create_sampler(gpu::SamplerDesc {
             name: "atlas",
             mag_filter: gpu::FilterMode::Linear,
             min_filter: gpu::FilterMode::Linear,
             ..Default::default()
         });
-        println!("8");
 
         #[cfg(target_os = "macos")]
         let core_video_texture_cache = unsafe {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -81,9 +81,9 @@ impl WindowsPlatformState {
 }
 
 impl WindowsPlatform {
-    pub(crate) fn new() -> anyhow::Result<Self> {
+    pub(crate) fn new() -> Result<Self> {
         unsafe {
-            OleInitialize(None).expect("unable to initialize Windows OLE");
+            OleInitialize(None).context("unable to initialize Windows OLE")?;
         }
         let (main_sender, main_receiver) = flume::unbounded::<Runnable>();
         let main_thread_id_win32 = unsafe { GetCurrentThreadId() };
@@ -97,17 +97,17 @@ impl WindowsPlatform {
         let foreground_executor = ForegroundExecutor::new(dispatcher);
         let bitmap_factory = ManuallyDrop::new(unsafe {
             CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
-                .expect("Error creating bitmap factory.")
+                .context("Error creating bitmap factory.")?
         });
         let text_system = Arc::new(
             DirectWriteTextSystem::new(&bitmap_factory)
-                .expect("Error creating DirectWriteTextSystem"),
+                .context("Error creating DirectWriteTextSystem")?,
         );
         let icon = load_icon().unwrap_or_default();
         let state = RefCell::new(WindowsPlatformState::new());
         let raw_window_handles = RwLock::new(SmallVec::new());
-        let gpu_context = BladeContext::new().expect("Unable to init GPU context");
-        let windows_version = WindowsVersion::new().expect("Error retrieve windows version");
+        let gpu_context = BladeContext::new().context("Unable to init GPU context")?;
+        let windows_version = WindowsVersion::new().context("Error retrieve windows version")?;
 
         Ok(Self {
             state,

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -81,7 +81,7 @@ impl WindowsPlatformState {
 }
 
 impl WindowsPlatform {
-    pub(crate) fn new() -> Self {
+    pub(crate) fn new() -> anyhow::Result<Self> {
         unsafe {
             OleInitialize(None).expect("unable to initialize Windows OLE");
         }
@@ -109,7 +109,7 @@ impl WindowsPlatform {
         let gpu_context = BladeContext::new().expect("Unable to init GPU context");
         let windows_version = WindowsVersion::new().expect("Error retrieve windows version");
 
-        Self {
+        Ok(Self {
             state,
             raw_window_handles,
             gpu_context,
@@ -122,7 +122,7 @@ impl WindowsPlatform {
             bitmap_factory,
             validation_number,
             main_thread_id_win32,
-        }
+        })
     }
 
     fn redraw_all(&self) {

--- a/crates/gpui/src/platform/windows/util.rs
+++ b/crates/gpui/src/platform/windows/util.rs
@@ -187,12 +187,12 @@ fn is_color_light(color: &Color) -> bool {
     ((5 * color.G as u32) + (2 * color.R as u32) + color.B as u32) > (8 * 128)
 }
 
-pub(crate) fn show_error(content: String) {
+pub(crate) fn show_error(title: &str, content: &str) {
     let _ = unsafe {
         MessageBoxW(
             None,
             &HSTRING::from(content),
-            windows::core::w!("Error: Zed failed to launch"),
+            &HSTRING::from(title),
             MB_ICONERROR | MB_SYSTEMMODAL,
         )
     };

--- a/crates/gpui/src/platform/windows/util.rs
+++ b/crates/gpui/src/platform/windows/util.rs
@@ -8,7 +8,7 @@ use windows::{
     },
     Wdk::System::SystemServices::RtlGetVersion,
     Win32::{Foundation::*, Graphics::Dwm::*, UI::WindowsAndMessaging::*},
-    core::BOOL,
+    core::{BOOL, HSTRING},
 };
 
 use crate::*;
@@ -185,4 +185,15 @@ pub(crate) fn system_appearance() -> Result<WindowAppearance> {
 #[inline(always)]
 fn is_color_light(color: &Color) -> bool {
     ((5 * color.G as u32) + (2 * color.R as u32) + color.B as u32) > (8 * 128)
+}
+
+pub(crate) fn show_error(content: String) {
+    let _ = unsafe {
+        MessageBoxW(
+            None,
+            &HSTRING::from(content),
+            windows::core::w!("Error: Zed failed to launch"),
+            MB_ICONERROR | MB_SYSTEMMODAL,
+        )
+    };
 }

--- a/crates/gpui/src/platform/windows/util.rs
+++ b/crates/gpui/src/platform/windows/util.rs
@@ -187,7 +187,7 @@ fn is_color_light(color: &Color) -> bool {
     ((5 * color.G as u32) + (2 * color.R as u32) + color.B as u32) > (8 * 128)
 }
 
-pub(crate) fn show_error(title: &str, content: &str) {
+pub(crate) fn show_error(title: &str, content: String) {
     let _ = unsafe {
         MessageBoxW(
             None,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1288,26 +1288,9 @@ mod windows_renderer {
     use crate::platform::blade::{BladeContext, BladeRenderer, BladeSurfaceConfig};
     use raw_window_handle as rwh;
     use std::num::NonZeroIsize;
-    use windows::{
-        Win32::{
-            Foundation::HWND,
-            UI::WindowsAndMessaging::{GWLP_HINSTANCE, MB_ICONERROR, MB_SYSTEMMODAL, MessageBoxW},
-        },
-        core::HSTRING,
-    };
+    use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::GWLP_HINSTANCE};
 
-    use crate::get_window_long;
-
-    fn show_error(content: String) {
-        let _ = unsafe {
-            MessageBoxW(
-                None,
-                &HSTRING::from(content),
-                windows::core::w!("Error: Zed failed to connect to the GPU renderer"),
-                MB_ICONERROR | MB_SYSTEMMODAL,
-            )
-        };
-    }
+    use crate::{get_window_long, show_error};
 
     pub(super) fn init(
         context: &BladeContext,
@@ -1319,8 +1302,12 @@ mod windows_renderer {
             size: Default::default(),
             transparent,
         };
-        println!("==> Initializing BladeRenderer with hwnd: {:?}", hwnd);
-        BladeRenderer::new(context, &raw, config).inspect_err(|err| show_error(err.to_string()))
+        BladeRenderer::new(context, &raw, config).inspect_err(|err| {
+            show_error(
+                "Error: Zed failed to initialize BladeRenderer",
+                err.to_string().as_str(),
+            )
+        })
     }
 
     struct RawWindow {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1303,7 +1303,7 @@ mod windows_renderer {
             MessageBoxW(
                 None,
                 &HSTRING::from(content),
-                windows::core::w!("Error: Zed update failed."),
+                windows::core::w!("Error: Zed failed to connect to the GPU renderer"),
                 MB_ICONERROR | MB_SYSTEMMODAL,
             )
         };

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1319,7 +1319,7 @@ mod windows_renderer {
             size: Default::default(),
             transparent,
         };
-        BladeRenderer::new(context, &raw, config)
+        BladeRenderer::new(context, &raw, config).inspect_err(|err| show_error(err.to_string()))
     }
 
     struct RawWindow {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1288,9 +1288,26 @@ mod windows_renderer {
     use crate::platform::blade::{BladeContext, BladeRenderer, BladeSurfaceConfig};
     use raw_window_handle as rwh;
     use std::num::NonZeroIsize;
-    use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::GWLP_HINSTANCE};
+    use windows::{
+        Win32::{
+            Foundation::HWND,
+            UI::WindowsAndMessaging::{GWLP_HINSTANCE, MB_ICONERROR, MB_SYSTEMMODAL, MessageBoxW},
+        },
+        core::HSTRING,
+    };
 
     use crate::get_window_long;
+
+    fn show_error(content: String) {
+        let _ = unsafe {
+            MessageBoxW(
+                None,
+                &HSTRING::from(content),
+                windows::core::w!("Error: Zed update failed."),
+                MB_ICONERROR | MB_SYSTEMMODAL,
+            )
+        };
+    }
 
     pub(super) fn init(
         context: &BladeContext,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1305,7 +1305,7 @@ mod windows_renderer {
         BladeRenderer::new(context, &raw, config).inspect_err(|err| {
             show_error(
                 "Error: Zed failed to initialize BladeRenderer",
-                err.to_string().as_str(),
+                err.to_string(),
             )
         })
     }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -1319,6 +1319,7 @@ mod windows_renderer {
             size: Default::default(),
             transparent,
         };
+        println!("==> Initializing BladeRenderer with hwnd: {:?}", hwnd);
         BladeRenderer::new(context, &raw, config).inspect_err(|err| show_error(err.to_string()))
     }
 


### PR DESCRIPTION
Now, if either `WindowsPlatform` or `BladeRenderer` fails to initialize, a window will pop up to notify the user.

![image](https://github.com/user-attachments/assets/40fe7f1d-5218-4ee2-b4ec-0945fed2b743)


Release Notes:

- N/A
