### PR TITLE
debugger: Fix a couple of issues with vitest

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -175,7 +175,10 @@ impl PackageJsonData {
                     "vitest".to_owned(),
                     "run".to_owned(),
                     "--testNamePattern".to_owned(),
-                    format!("\"{}\"", "vitest".to_owned()),
+                    format!(
+                        "\"{}\"",
+                        TYPESCRIPT_VITEST_TEST_NAME_VARIABLE.template_value()
+                    ),
                     VariableName::RelativeFile.template_value(),
                 ],
                 tags: vec![

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -54,6 +54,10 @@ impl DapLocator for NodeLocator {
             "runtimeExecutable": program_path,
             "args": args,
             "cwd": build_config.cwd.clone(),
+            "env": {
+                "VITEST_MIN_FORKS": "0",
+                "VITEST_MAX_FORKS": "1"
+            },
             "runtimeArgs": ["--inspect-brk"],
             "console": "integratedTerminal",
         });


### PR DESCRIPTION
- Pass the right test name filter
- Limit the number of forks used by the testing pool in the spirit of #32473

Release Notes:

- Debugger Beta: switched to running vitest tests serially when debugging.
