### PR TITLE
Rewrite documentation comment for right movement

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -58,8 +58,8 @@ pub fn saturating_left(map: &DisplaySnapshot, mut point: DisplayPoint) -> Displa
     map.clip_point(point, Bias::Left)
 }
 
-/// Returns a column to the right of the current point, doing nothing
-// if that point is at the end of the line.
+/// Returns a column to the right of the current point, wrapping
+/// to the next line if that point is at the end of line.
 pub fn right(map: &DisplaySnapshot, mut point: DisplayPoint) -> DisplayPoint {
     if point.column() < map.line_len(point.row()) {
         *point.column_mut() += 1;


### PR DESCRIPTION
I don't think the documentation comment is saying the right thing. This version is more similar to the comment of the left movement function.

Release Notes:

- N/A
