### PR TITLE
debugger: Special-case `npm` et al. as `program` field for JS debug definitions

### DIFF
--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -77,7 +77,10 @@ impl JsDebugAdapter {
                 .and_then(|value| value.as_str().map(str::to_owned))
             {
                 match program.as_str() {
-                    "npm" | "pnpm" | "yarn" | "bun" => {
+                    "npm" | "pnpm" | "yarn" | "bun"
+                        if !configuration.contains_key("runtimeExecutable")
+                            && !configuration.contains_key("runtimeArgs") =>
+                    {
                         configuration.remove("program");
                         configuration.insert("runtimeExecutable".to_owned(), program.into());
                         if let Some(args) = configuration.remove("args") {


### PR DESCRIPTION
Send `runtimeExecutable` and `runtimeArgs` instead of `program` and `args` to avoid the DAP implicitly wrapping the command in `node`. 

This means that putting `pnpm vitest <file>` as the command in the launch modal will work, as will this in debug.json:

```
[
  {
    "adapter": "JavaScript",
    "type": "pwa-node",
    "label": "Label",
    "request": "launch",
    "program": "pnpm",
    "args": ["vitest", "<file>"],
    "cwd": "/Users/name/project"
  }
]
```


Release Notes:

- Debugger Beta: made it possible to use commands like `pnpm <subcommand> <args>` in the launch modal and debug.json
