### PR TITLE
git_ui: Add collapse_untracked_diff settings to improve usability for untracked files

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -700,6 +700,10 @@
     //
     // Default: false
     "sort_by_path": false,
+    // Whether to collapse untracked files in the diff panel.
+    //
+    // Default: false
+    "collapse_untracked_diff": false,
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -70,6 +70,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub sort_by_path: Option<bool>,
+
+    /// Whether to collapse untracked files in the diff panel.
+    ///
+    /// Default: false
+    pub collapse_untracked_diff: Option<bool>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -81,6 +86,7 @@ pub struct GitPanelSettings {
     pub scrollbar: ScrollbarSettings,
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
+    pub collapse_untracked_diff: bool,
 }
 
 impl Settings for GitPanelSettings {


### PR DESCRIPTION
In repositories with untracked files that are not intended to be added, showing the expanded diffs in the panel is confusing, as it places the changes side by side with changes in tracked files.

This change adds a setting, collapse_untracked_diff, that can be enabled to collapse untracked diffs by default when the panel is opened.

See https://github.com/zed-industries/zed/pull/31855#issuecomment-2957547018 (and previous comment for examples of why this is useful).

Example before this change, or with the setting in its default state:

![image](https://github.com/user-attachments/assets/f974c849-7ebf-424e-9397-442a6cc2513b)

Example after this change with the setting set to `true`:

![image](https://github.com/user-attachments/assets/bd8934f5-bd9a-4f5a-b723-cd4b798d2c2c)

Release Notes:

- Git: Added `collapse_untracked_diff` setting to auto-collapse untracked diffs