### PR TITLE
Deploy code runner menu from correct display row

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5717,7 +5717,7 @@ impl Editor {
         self.discard_inline_completion(false, cx);
 
         let multibuffer_point = match &action.deployed_from {
-            Some(CodeActionSource::Indicator(row)) => {
+            Some(CodeActionSource::Indicator(row)) | Some(CodeActionSource::RunMenu(row)) => {
                 DisplayPoint::new(*row, 0).to_point(&snapshot)
             }
             _ => self.selections.newest::<Point>(cx).head(),


### PR DESCRIPTION
This fixes a bug introduced in #32579 where the code runner menu would be deployed from the most recent cursor position instead of the row that the runner icon was rendered on.

Release Notes:

- N/A
