### PR TITLE
debugger: Handle session restart failures instead of hanging

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -358,7 +358,7 @@ impl DebugPanel {
                             .console_output(cx)
                             .unbounded_send(format!(
                                 "Session failed to restart with error: {}",
-                                error.to_string()
+                                error
                             ))
                             .ok();
                         session.shutdown(cx)

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -111,7 +111,6 @@ pub fn init(cx: &mut App) {
                     }
 
                     let caps = running_state.capabilities(cx);
-                    let supports_restart = caps.supports_restart_request.unwrap_or_default();
                     let supports_step_back = caps.supports_step_back.unwrap_or_default();
                     let supports_detach = running_state.session().read(cx).is_attached();
                     let status = running_state.thread_status(cx);
@@ -204,13 +203,13 @@ pub fn init(cx: &mut App) {
                                 .ok();
                         })
                     })
-                    .when(supports_restart, |div| {
+                    .on_action({
                         let active_item = active_item.clone();
-                        div.on_action(move |_: &Restart, _, cx| {
+                        move |_: &Restart, _, cx| {
                             active_item
                                 .update(cx, |item, cx| item.restart_session(cx))
                                 .ok();
-                        })
+                        }
                     })
                     .on_action({
                         let active_item = active_item.clone();


### PR DESCRIPTION
I also enabled the `Restart` action even for sessions that don't support restarting because we have a restart fallback now.

Closes #31408

Release Notes:

- Fix bug where a debugger session would never be shutdown on a failed restart attempt
