### PR TITLE
project_panel: Don't add extra margin-left to file name labels

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4413,8 +4413,7 @@ impl ProjectPanel {
                                     )
                                 }
                             })
-                        }
-                        .ml_1(),
+                        },
                     )
                     .on_secondary_mouse_down(cx.listener(
                         move |this, event: &MouseDownEvent, window, cx| {


### PR DESCRIPTION
In this PR I want to improve the UI of the project panel's files tree. Currently, the project panel renders an extra gap between file icons and the file name, making it visually unpleasant. The changes in the PR remove the gap, bringing the labels closer to their icon:

_Before/After_

<img width="647" alt="zed-before-after" src="https://github.com/user-attachments/assets/d815c075-f1f8-4a77-a3b3-d1275988a5dc" />

Also, this extra gap between the icon and the label seems inconsistent with how other similar components, which are based on the `ListItem`, are used.

Release Notes:

- Fixed an extra gap between the file icon and the file name label in the project panel.
