### PR TITLE
Trigger formatting effects when saving unmodified singleton buffers

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -219,6 +219,9 @@
   "inline_code_actions": true,
   // Whether to allow drag and drop text selection in buffer.
   "drag_and_drop_selection": true,
+  // Whether to save singleton buffers that are not dirty.
+  // This will "touch" the file and related tools enabled, e.g. formatters.
+  "save_non_dirty_buffers": true,
   // What to do when go to definition yields no results.
   //
   // 1. Do nothing: `none`

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15636,6 +15636,10 @@ impl Editor {
         ))
     }
 
+    fn save_non_dirty_buffers(&self, cx: &App) -> bool {
+        self.is_singleton(cx) && EditorSettings::get_global(cx).save_non_dirty_buffers
+    }
+
     fn perform_format(
         &mut self,
         project: Entity<Project>,
@@ -15648,7 +15652,7 @@ impl Editor {
         let (buffers, target) = match target {
             FormatTarget::Buffers => {
                 let mut buffers = buffer.read(cx).all_buffers();
-                if trigger == FormatTrigger::Save {
+                if trigger == FormatTrigger::Save && !self.save_non_dirty_buffers(cx) {
                     buffers.retain(|buffer| buffer.read(cx).is_dirty());
                 }
                 (buffers, LspFormatTarget::Buffers)

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -50,6 +50,7 @@ pub struct EditorSettings {
     pub diagnostics_max_severity: Option<DiagnosticSeverity>,
     pub inline_code_actions: bool,
     pub drag_and_drop_selection: bool,
+    pub save_non_dirty_buffers: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
@@ -502,6 +503,12 @@ pub struct EditorSettingsContent {
     ///
     /// Default: true
     pub drag_and_drop_selection: Option<bool>,
+
+    /// Whether to save singleton buffers that are not dirty.
+    /// This will "touch" the file and related tools enabled, e.g. formatters.
+    ///
+    /// Default: true
+    pub save_non_dirty_buffers: Option<bool>,
 }
 
 // Toolbar related settings


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/12091

Release Notes:

- Fixed formatting effects not triggered when saving unmodified singleton buffers