### PR TITLE
agent: Don't stop following after edits

### DIFF
--- a/crates/agent/src/agent_diff.rs
+++ b/crates/agent/src/agent_diff.rs
@@ -1513,7 +1513,7 @@ impl AgentDiff {
                     multibuffer.add_diff(diff_handle.clone(), cx);
                 });
 
-                let new_state = if thread.read(cx).has_pending_edit_tool_uses() {
+                let new_state = if thread.read(cx).is_generating() {
                     EditorState::Generating
                 } else {
                     EditorState::Reviewing


### PR DESCRIPTION
This is reverting a change from #32071 which caused agent following to
stop after the file was edited.

This will reintroduce the behavior that the keyboard shortcuts don't
work until the model is done generating, but we will revisit that
afterwards.

Release Notes:

- agent: Fix a regression in agent following behavior after file edits
