### PR TITLE
agent: Make MCP tool name unique

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -106,6 +106,7 @@ dependencies = [
  "proto",
  "rand 0.8.5",
  "ref-cast",
+ "regex",
  "release_channel",
  "rope",
  "rules_library",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -100,6 +100,7 @@ workspace.workspace = true
 zed_actions.workspace = true
 zed_llm_client.workspace = true
 zstd.workspace = true
+regex.workspace = true
 
 [dev-dependencies]
 assistant_tools.workspace = true

--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -842,7 +842,7 @@ impl AgentConfiguration {
                             .hover(|style| style.bg(cx.theme().colors().element_hover))
                             .rounded_sm()
                             .child(
-                                Label::new(tool.name())
+                                Label::new(tool.ui_name())
                                     .buffer_font(cx)
                                     .size(LabelSize::Small),
                             )

--- a/crates/agent/src/agent_configuration/tool_picker.rs
+++ b/crates/agent/src/agent_configuration/tool_picker.rs
@@ -112,7 +112,7 @@ impl ToolPickerDelegate {
                 ToolSource::Native => {
                     if mode == ToolPickerMode::BuiltinTools {
                         items.extend(tools.into_iter().map(|tool| PickerItem::Tool {
-                            name: tool.name().into(),
+                            name: tool.ui_name().into(),
                             server_id: None,
                         }));
                     }
@@ -124,7 +124,7 @@ impl ToolPickerDelegate {
                             server_id: server_id.clone(),
                         });
                         items.extend(tools.into_iter().map(|tool| PickerItem::Tool {
-                            name: tool.name().into(),
+                            name: tool.ui_name().into(),
                             server_id: Some(server_id.clone()),
                         }));
                     }

--- a/crates/assistant_tool/src/assistant_tool.rs
+++ b/crates/assistant_tool/src/assistant_tool.rs
@@ -203,6 +203,11 @@ pub trait Tool: 'static + Send + Sync {
     /// Returns the name of the tool.
     fn name(&self) -> String;
 
+    /// Returns the name to be displayed in the UI for this tool.
+    fn ui_name(&self) -> String {
+        self.name()
+    }
+
     /// Returns the description of the tool.
     fn description(&self) -> String;
 


### PR DESCRIPTION
Follow up to this: https://github.com/zed-industries/zed/pull/30600, as this was reverted due the final tool name after appending the server name was not being compliant with expected condition of tool name from anthropic: ^[a-zA-Z0-9_-]{1,64}$. I have updated the approach to add extra checks and convert the string to something which is more acceptable by the providers.

Closes #31903

Release Notes:

- Make MCP tool name unique in agent
