### PR TITLE
gpui: Fix data_table example overflow subtracting crash error

### DIFF
--- a/crates/gpui/examples/data_table.rs
+++ b/crates/gpui/examples/data_table.rs
@@ -1,8 +1,4 @@
-use std::{
-    ops::Range,
-    rc::Rc,
-    time::{Duration, Instant},
-};
+use std::{ops::Range, rc::Rc, time::Duration};
 
 use gpui::{
     App, Application, Bounds, Context, MouseDownEvent, MouseMoveEvent, MouseUpEvent, Pixels, Point,
@@ -22,7 +18,7 @@ pub struct Quote {
     open: f64,
     high: f64,
     low: f64,
-    timestamp: Instant,
+    timestamp: Duration,
     volume: i64,
     turnover: f64,
     ttm: f64,
@@ -50,8 +46,7 @@ impl Quote {
         let open = prev_close + rng.gen_range(-3.0..3.0);
         let high = (prev_close + rng.gen_range::<f64, _>(0.0..10.0)).max(open);
         let low = (prev_close - rng.gen_range::<f64, _>(0.0..10.0)).min(open);
-        // Randomize the timestamp in the past 24 hours
-        let timestamp = Instant::now() - Duration::from_secs(rng.gen_range(0..86400));
+        let timestamp = Duration::from_secs(rng.gen_range(0..86400));
         let volume = rng.gen_range(1_000_000..100_000_000);
         let turnover = last_done * volume as f64;
         let symbol = {
@@ -170,7 +165,7 @@ impl TableRow {
                     .child(format!("{:.2}%", self.quote.change())),
                 "timestamp" => div()
                     .text_color(color)
-                    .child(format!("{:?}", self.quote.timestamp.elapsed().as_secs())),
+                    .child(format!("{:?}", self.quote.timestamp.as_secs())),
                 "open" => div()
                     .text_color(color)
                     .child(format!("{:.2}", self.quote.open)),


### PR DESCRIPTION
Release Notes:

- N/A

Just make a simple change to avoid crash.

```
thread 'main' panicked at library\std\src\time.rs:436:33:
overflow when subtracting duration from instant
stack backtrace:
   0: std::panicking::begin_panic_handler
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library\std\src\panicking.rs:697
   1: core::panicking::panic_fmt
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library\core\src\panicking.rs:75
   2: core::panicking::panic_display
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library\core\src\panicking.rs:261
   3: core::option::expect_failed
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library\core\src\option.rs:2024
   4: core::option::Option::expect
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library\core\src\option.rs:933
   5: std::time::impl$3::sub
             at /rustc/17067e9ac6d7ecb70e50f92c1944e545188d2359/library\std\src\time.rs:436
   6: data_table::Quote::random
             at .\crates\gpui\examples\data_table.rs:54
```