### PR TITLE
debugger: Do not swallow `port` property when converting launch.json

### DIFF
--- a/crates/task/src/vscode_debug_format.rs
+++ b/crates/task/src/vscode_debug_format.rs
@@ -152,6 +152,7 @@ mod tests {
                         "X": "Y",
                     },
                     "type": "node",
+                    "port": 17,
                 }),
                 tcp_connection: Some(TcpArgumentsTemplate {
                     port: Some(17),

--- a/crates/task/src/vscode_debug_format.rs
+++ b/crates/task/src/vscode_debug_format.rs
@@ -33,6 +33,9 @@ impl VsCodeDebugTaskDefinition {
         if let Some(config) = config.as_object_mut() {
             if adapter == "JavaScript" {
                 config.insert("type".to_owned(), self.r#type.clone().into());
+                if let Some(port) = self.port {
+                    config.insert("port".to_owned(), port.into());
+                }
             }
         }
         let definition = DebugScenario {


### PR DESCRIPTION
with JavaScript scenarios.

Closes #32187

Release Notes:

- Fixed `port` property not being respected in debug scenarios converted from VSC's launch.json
