### PR TITLE
edit_file: Let agent specify locations of edit chunks

### DIFF
--- a/crates/assistant_tools/src/edit_agent.rs
+++ b/crates/assistant_tools/src/edit_agent.rs
@@ -433,7 +433,7 @@ impl EditAgent {
         let task = cx.background_spawn(async move {
             let mut matcher = StreamingFuzzyMatcher::new(snapshot);
             while let Some(edit_event) = edit_events.next().await {
-                let EditParserEvent::OldTextChunk { chunk, done } = edit_event? else {
+                let EditParserEvent::OldTextChunk { chunk, done, line_hint: _ } = edit_event? else {
                     break;
                 };
 

--- a/crates/assistant_tools/src/edit_agent/edit_parser.rs
+++ b/crates/assistant_tools/src/edit_agent/edit_parser.rs
@@ -87,7 +87,7 @@ impl EditParser {
                         *start = false;
                     }
 
-                    let line_hint = line_hint.clone();
+                    let line_hint = *line_hint;
                     if let Some(tag_range) = self.find_end_tag() {
                         let mut chunk = self.buffer[..tag_range.start].to_string();
                         if chunk.ends_with('\n') {
@@ -185,8 +185,7 @@ impl EditParser {
         LINE_HINT_REGEX
             .captures(tag)
             .and_then(|caps| caps.get(1))
-            .map(|m| m.as_str().parse::<u32>().ok())
-            .flatten()
+            .and_then(|m| m.as_str().parse::<u32>().ok())
     }
 
     pub fn finish(self) -> EditParserMetrics {

--- a/crates/assistant_tools/src/edit_agent/edit_parser.rs
+++ b/crates/assistant_tools/src/edit_agent/edit_parser.rs
@@ -180,7 +180,7 @@ impl EditParser {
 
     fn parse_line_hint(&self, tag: &str) -> Option<u32> {
         static LINE_HINT_REGEX: std::sync::LazyLock<Regex> =
-            std::sync::LazyLock::new(|| Regex::new(r#"line_hint=(?:"|)(\d+)"#).unwrap());
+            std::sync::LazyLock::new(|| Regex::new(r#"line=(?:"|)(\d+)"#).unwrap());
 
         LINE_HINT_REGEX
             .captures(tag)

--- a/crates/assistant_tools/src/edit_agent/evals.rs
+++ b/crates/assistant_tools/src/edit_agent/evals.rs
@@ -438,14 +438,21 @@ fn eval_disable_cursor_blinking() {
 #[test]
 #[cfg_attr(not(feature = "eval"), ignore)]
 fn eval_from_pixels_constructor() {
-    // Results for 2025-05-22
+    // Results for 2025-06-13
+    //
+    // The outcome of this evaluation depends heavily on the LINE_HINT_TOLERANCE
+    // value. Higher values improve the pass rate but may sometimes cause
+    // edits to be misapplied. In the context of this eval, this means
+    // the agent might add from_pixels tests in incorrect locations
+    // (e.g., at the beginning of the file), yet the evaluation may still
+    // rate it highly.
     //
     //  Model                          | Pass rate
     // ============================================
     //
-    //  claude-3.7-sonnet              |
-    //  gemini-2.5-pro-preview-03-25   |  0.94
-    //  gemini-2.5-flash-preview-04-17 |
+    //  claude-4.0-sonnet              |  0.99
+    //  claude-3.7-sonnet              |  0.88
+    //  gemini-2.5-pro-preview-03-25   |  0.96
     //  gpt-4.1                        |
     let input_file_path = "root/canvas.rs";
     let input_file_content = include_str!("evals/fixtures/from_pixels_constructor/before.rs");

--- a/crates/assistant_tools/src/edit_agent/streaming_fuzzy_matcher.rs
+++ b/crates/assistant_tools/src/edit_agent/streaming_fuzzy_matcher.rs
@@ -195,8 +195,10 @@ impl StreamingFuzzyMatcher {
 
     /// Return the best match with starting position close enough to line_hint.
     pub fn select_best_match(&self) -> Option<Range<usize>> {
-        // Allow line hint to be off by that many lines
-        const LINE_HINT_TOLERANCE: u32 = 50;
+        // Allow line hint to be off by that many lines.
+        // Higher values increase probability of applying edits to a wrong place,
+        // Lower values increase edits failures and overall conversation length.
+        const LINE_HINT_TOLERANCE: u32 = 200;
 
         if self.matches.is_empty() {
             return None;
@@ -207,7 +209,7 @@ impl StreamingFuzzyMatcher {
         }
 
         let Some(line_hint) = self.line_hint else {
-            // Multiple ambigous matches
+            // Multiple ambiguous matches
             return None;
         };
 

--- a/crates/assistant_tools/src/edit_agent/streaming_fuzzy_matcher.rs
+++ b/crates/assistant_tools/src/edit_agent/streaming_fuzzy_matcher.rs
@@ -10,8 +10,9 @@ const DELETION_COST: u32 = 10;
 pub struct StreamingFuzzyMatcher {
     snapshot: TextBufferSnapshot,
     query_lines: Vec<String>,
+    line_hint: Option<u32>,
     incomplete_line: String,
-    best_matches: Vec<Range<usize>>,
+    matches: Vec<Range<usize>>,
     matrix: SearchMatrix,
 }
 
@@ -21,8 +22,9 @@ impl StreamingFuzzyMatcher {
         Self {
             snapshot,
             query_lines: Vec::new(),
+            line_hint: None,
             incomplete_line: String::new(),
-            best_matches: Vec::new(),
+            matches: Vec::new(),
             matrix: SearchMatrix::new(buffer_line_count + 1),
         }
     }
@@ -41,9 +43,10 @@ impl StreamingFuzzyMatcher {
     ///
     /// Returns `Some(range)` if a match has been found with the accumulated
     /// query so far, or `None` if no suitable match exists yet.
-    pub fn push(&mut self, chunk: &str) -> Option<Range<usize>> {
+    pub fn push(&mut self, chunk: &str, line_hint: Option<u32>) -> Option<Range<usize>> {
         // Add the chunk to our incomplete line buffer
         self.incomplete_line.push_str(chunk);
+        self.line_hint = line_hint;
 
         if let Some((last_pos, _)) = self.incomplete_line.match_indices('\n').next_back() {
             let complete_part = &self.incomplete_line[..=last_pos];
@@ -55,20 +58,11 @@ impl StreamingFuzzyMatcher {
 
             self.incomplete_line.replace_range(..last_pos + 1, "");
 
-            self.best_matches = self.resolve_location_fuzzy();
-
-            if let Some(first_match) = self.best_matches.first() {
-                Some(first_match.clone())
-            } else {
-                None
-            }
-        } else {
-            if let Some(first_match) = self.best_matches.first() {
-                Some(first_match.clone())
-            } else {
-                None
-            }
+            self.matches = self.resolve_location_fuzzy();
         }
+
+        let best_match = self.select_best_match();
+        best_match.or_else(|| self.matches.first().cloned())
     }
 
     /// Finish processing and return the final best match(es).
@@ -80,9 +74,9 @@ impl StreamingFuzzyMatcher {
         if !self.incomplete_line.is_empty() {
             self.query_lines.push(self.incomplete_line.clone());
             self.incomplete_line.clear();
-            self.best_matches = self.resolve_location_fuzzy();
+            self.matches = self.resolve_location_fuzzy();
         }
-        self.best_matches.clone()
+        self.matches.clone()
     }
 
     fn resolve_location_fuzzy(&mut self) -> Vec<Range<usize>> {
@@ -197,6 +191,41 @@ impl StreamingFuzzyMatcher {
         }
 
         valid_matches.into_iter().map(|(_, range)| range).collect()
+    }
+
+    /// Return the best match with starting position close enough to line_hint.
+    pub fn select_best_match(&self) -> Option<Range<usize>> {
+        // Allow line hint to be off by that many lines
+        const LINE_HINT_TOLERANCE: u32 = 50;
+
+        if self.matches.is_empty() {
+            return None;
+        }
+
+        if self.matches.len() == 1 {
+            return self.matches.first().cloned();
+        }
+
+        let Some(line_hint) = self.line_hint else {
+            // Multiple ambigous matches
+            return None;
+        };
+
+        let mut best_match = None;
+        let mut best_distance = u32::MAX;
+
+        for range in &self.matches {
+            let start_point = self.snapshot.offset_to_point(range.start);
+            let start_line = start_point.row;
+            let distance = start_line.abs_diff(line_hint);
+
+            if distance <= LINE_HINT_TOLERANCE && distance < best_distance {
+                best_distance = distance;
+                best_match = Some(range.clone());
+            }
+        }
+
+        best_match
     }
 }
 
@@ -640,6 +669,52 @@ mod tests {
         );
     }
 
+    #[gpui::test]
+    fn test_line_hint_selection() {
+        let text = indoc! {r#"
+            fn first_function() {
+                return 42;
+            }
+
+            fn second_function() {
+                return 42;
+            }
+
+            fn third_function() {
+                return 42;
+            }
+        "#};
+
+        let buffer = TextBuffer::new(0, BufferId::new(1).unwrap(), text.to_string());
+        let snapshot = buffer.snapshot();
+        let mut matcher = StreamingFuzzyMatcher::new(snapshot.clone());
+
+        // Given a query that matches all three functions
+        let query = "return 42;\n";
+
+        // Test with line hint pointing to second function (around line 5)
+        let best_match = matcher.push(query, Some(5)).expect("Failed to match query");
+
+        let matched_text = snapshot
+            .text_for_range(best_match.clone())
+            .collect::<String>();
+        assert!(matched_text.contains("return 42;"));
+        assert_eq!(
+            best_match,
+            63..77,
+            "Expected to match `second_function` based on the line hint"
+        );
+
+        let mut matcher = StreamingFuzzyMatcher::new(snapshot.clone());
+        matcher.push(query, None);
+        matcher.finish();
+        let best_match = matcher.select_best_match();
+        assert!(
+            best_match.is_none(),
+            "Best match should be None when query cannot be uniquely resolved"
+        );
+    }
+
     #[track_caller]
     fn assert_location_resolution(text_with_expected_range: &str, query: &str, rng: &mut StdRng) {
         let (text, expected_ranges) = marked_text_ranges(text_with_expected_range, false);
@@ -653,7 +728,7 @@ mod tests {
 
         // Push chunks incrementally
         for chunk in &chunks {
-            matcher.push(chunk);
+            matcher.push(chunk, None);
         }
 
         let actual_ranges = matcher.finish();
@@ -706,7 +781,7 @@ mod tests {
 
     fn push(finder: &mut StreamingFuzzyMatcher, chunk: &str) -> Option<String> {
         finder
-            .push(chunk)
+            .push(chunk, None)
             .map(|range| finder.snapshot.text_for_range(range).collect::<String>())
     }
 

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -333,14 +333,18 @@ impl Tool for EditFileTool {
                 );
                 anyhow::ensure!(
                     ambiguous_ranges.is_empty(),
-                    // TODO: Include ambiguous_ranges, converted to line numbers.
-                    //       This would work best if we add `line_hint` parameter
-                    //       to edit_file_tool
-                    formatdoc! {"
-                        <old_text> matches more than one position in the file. Read the
-                        relevant sections of {input_path} again and extend <old_text> so
-                        that I can perform the requested edits.
-                    "}
+                    {
+                        let line_numbers = ambiguous_ranges
+                            .iter()
+                            .map(|range| range.start.to_string())
+                            .collect::<Vec<_>>()
+                            .join(", ");
+                        formatdoc! {"
+                            <old_text> matches more than one position in the file (lines: {line_numbers}). Read the
+                            relevant sections of {input_path} again and extend <old_text> so
+                            that I can perform the requested edits.
+                        "}
+                    }
                 );
                 Ok(ToolResultOutput {
                     content: ToolResultContent::Text("No edits were made.".into()),

--- a/crates/assistant_tools/src/templates/edit_file_prompt.hbs
+++ b/crates/assistant_tools/src/templates/edit_file_prompt.hbs
@@ -3,21 +3,21 @@ You MUST respond with a series of edits to a file, using the following format:
 ```
 <edits>
 
-<old_text>
+<old_text line=10>
 OLD TEXT 1 HERE
 </old_text>
 <new_text>
 NEW TEXT 1 HERE
 </new_text>
 
-<old_text>
+<old_text line=456>
 OLD TEXT 2 HERE
 </old_text>
 <new_text>
 NEW TEXT 2 HERE
 </new_text>
 
-<old_text>
+<old_text line=42>
 OLD TEXT 3 HERE
 </old_text>
 <new_text>
@@ -33,6 +33,7 @@ NEW TEXT 3 HERE
 - `<old_text>` must exactly match existing file content, including indentation
 - `<old_text>` must come from the actual file, not an outline
 - `<old_text>` cannot be empty
+- `line` should be a starting line number for the text to be replaced
 - Be minimal with replacements:
   - For unique lines, include only those lines
   - For non-unique lines, include enough context to identify them
@@ -48,7 +49,7 @@ Claude and gpt-4.1 don't really need it. --}}
 <example>
 <edits>
 
-<old_text>
+<old_text line=3>
 struct User {
     name: String,
     email: String,
@@ -62,7 +63,7 @@ struct User {
 }
 </new_text>
 
-<old_text>
+<old_text line=25>
     let user = User {
         name: String::from("John"),
         email: String::from("john@example.com"),


### PR DESCRIPTION
These changes help the agent edit files when `<old_text>` matches more than one location.

First, the agent can specify an optional `<old_text line=XX>` parameter. When this is provided and multiple matches exist, we use this hint to identify the best match.

Second, when there is ambiguity in matches, we now return the agent a more helpful message listing the line numbers of all possible matches.

Together, these changes should reduce the number of misplaced edits and agent confusion.

I have ensured the LLM Worker works with these prompt changes.


Release Notes:

- Agent: Improved locating edits
