### PR TITLE
gpui: Bind unused `function` modifier to xkb Mod3 on Linux

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -847,12 +847,14 @@ impl crate::Modifiers {
             keymap_state.mod_name_is_active(xkb::MOD_NAME_CTRL, xkb::STATE_MODS_EFFECTIVE);
         let platform =
             keymap_state.mod_name_is_active(xkb::MOD_NAME_LOGO, xkb::STATE_MODS_EFFECTIVE);
+        let function =
+            keymap_state.mod_name_is_active(xkb::MOD_NAME_MOD3, xkb::STATE_MODS_EFFECTIVE);
         Self {
             shift,
             alt,
             control,
             platform,
-            function: false,
+            function,
         }
     }
 }

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -59,7 +59,7 @@ Each keypress is a sequence of modifiers followed by a key. The modifiers are:
 - `cmd-`, `win-` or `super-` for the platform modifier (Command on macOS, Windows key on Windows, and the Super key on Linux).
 - `alt-` for alt (option on macOS)
 - `shift-` The shift key
-- `fn-` The function key
+- `fn-` or `mod3-` for the function key on macOS or the Mod3 `xkb` modifier on Linux
 - `secondary-` Equivalent to `cmd` when Zed is running on macOS and `ctrl` when on Windows and Linux
 
 The keys can be any single unicode codepoint that your keyboard generates (for example `a`, `0`, `£` or `ç`), or any named key (`tab`, `f1`, `shift`, or `cmd`). If you are using a non-Latin layout (e.g. Cyrillic), you can bind either to the cyrillic character, or the latin character that key generates with `cmd` pressed.


### PR DESCRIPTION
The `fn` modifier bit is currently unused on Linux, which is a shame considering Linux supports 8 (!) independent physical modifiers. Here I'm binding it to the XKB Mod3 / ISO_Level5_Shift modifier bit.

## Justification for the choice of Mod3:

- It is easily configurable with a builtin xkb option
- It is not commonly used by standard layouts
- It has prior art of being rebound by power users.

XKB modifier names in practice are not very consistent across layouts/distros and can be a little confusing,
so I opted to go with the predefined names instead of a keysym like Hyper.

The predefined XKB modifier names and `pc105` bindings (the default) are:

Shift
Lock (this is CapsLock)
Control
Mod1 (usually bound to Alt/Meta)
Mod2 (usually NumLock)
Mod3 (ISO_Level5_Shift)
Mod4 (bound to both Super and Hyper by default)
Mod5 (ISO_Level3_Shift, the Compose key or AltGr for layouts like us-intl)

Mod3 is rarely used outside of specific international layouts, and can be bound to a key such as CapsLock  with the "Key to choose the 5th level" xkb options. On Gnome, these are available through Gnome Tweaks.

Instead of `mod3`, we could call it `lvl5`  (as it is the name exposed to the user when choosing layout options through distro GUIs) or `hyper` (It takes some knowledge to unbind the `Hyper` keysym from Mod4, but it does look better and works with other programs like Emacs. The word "hyper" is overloaded, however; some keyboard manufacturers use it as a name for an "all modifiers together" key).

Some info on how XKB works:

https://wiki.archlinux.org/title/X_keyboard_extension


Release Notes:

- Added support for an additional modifier key on Linux (Mod3/ISO_Level5_Shift)
