### PR TITLE
debugger: Pass --nocapture to cargo tests when building debug tasks with locator

### DIFF
--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -57,10 +57,10 @@ impl DapLocator for CargoLocator {
         }
 
         match cargo_action.as_ref() {
-            "run" => {
+            "run" | "r" => {
                 *cargo_action = "build".to_owned();
             }
-            "test" | "bench" => {
+            "test" | "t" | "bench" => {
                 let delimiter = task_template
                     .args
                     .iter()
@@ -133,7 +133,10 @@ impl DapLocator for CargoLocator {
             !executables.is_empty(),
             "Couldn't get executable in cargo locator"
         );
-        let is_test = build_config.args.first().map_or(false, |arg| arg == "test");
+        let is_test = build_config
+            .args
+            .first()
+            .map_or(false, |arg| arg == "test" || arg == "t");
 
         let mut test_name = None;
         if is_test {
@@ -161,7 +164,10 @@ impl DapLocator for CargoLocator {
             anyhow::bail!("Couldn't get executable in cargo locator");
         };
 
-        let args = test_name.into_iter().collect();
+        let mut args: Vec<_> = test_name.into_iter().collect();
+        if is_test {
+            args.push("--nocapture".to_owned());
+        }
 
         Ok(DebugRequest::Launch(task::LaunchRequest {
             program: executable,


### PR DESCRIPTION
Release Notes:

- Add --nocapture as a default argument when debugging rust tests
