### PR TITLE
Suppress auto-update failures when offline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1167,6 +1167,7 @@ dependencies = [
  "settings",
  "smol",
  "tempfile",
+ "util",
  "which 6.0.3",
  "workspace",
  "workspace-hack",

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -485,7 +485,7 @@ impl ActivityIndicator {
         // Show any application auto-update info.
         if let Some(updater) = &self.auto_updater {
             return match &updater.read(cx).status() {
-                AutoUpdateStatus::Checking => Some(Content {
+                AutoUpdateStatus::Checking { .. } => Some(Content {
                     icon: Some(
                         Icon::new(IconName::Download)
                             .size(IconSize::Small)

--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -27,6 +27,7 @@ serde_json.workspace = true
 settings.workspace = true
 smol.workspace = true
 tempfile.workspace = true
+util.workspace = true
 workspace.workspace = true
 workspace-hack.workspace = true
 

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -660,7 +660,7 @@ impl TitleBar {
                     Some(AutoUpdateStatus::Updated { .. }) => "Please restart Zed to Collaborate",
                     Some(AutoUpdateStatus::Installing { .. })
                     | Some(AutoUpdateStatus::Downloading { .. })
-                    | Some(AutoUpdateStatus::Checking) => "Updating...",
+                    | Some(AutoUpdateStatus::Checking { .. }) => "Updating...",
                     Some(AutoUpdateStatus::Idle) | Some(AutoUpdateStatus::Errored) | None => {
                         "Please update Zed to Collaborate"
                     }

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -10,7 +10,7 @@ pub fn app_menus() -> Vec<Menu> {
             name: "Zed".into(),
             items: vec![
                 MenuItem::action("About Zed…", zed_actions::About),
-                MenuItem::action("Check for Updates", auto_update::Check),
+                MenuItem::action("Check for Updates", auto_update::Check { manual: true }),
                 MenuItem::separator(),
                 MenuItem::submenu(Menu {
                     name: "Settings".into(),


### PR DESCRIPTION
Don't immediately show "auto-update failed" errors in the status bar when launching zed offline or when a periodic auto-update check is triggered when you are offline.

Manual checks (via menu or action) or errors after the initial version check succeeds (download/extraction failure) are unchanged.

Release Notes:

- N/A
