### PR TITLE
debugger: Strip ANSI escapes from console output just before rendering

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4269,6 +4269,7 @@ dependencies = [
  "client",
  "collections",
  "command_palette_hooks",
+ "console",
  "dap",
  "dap_adapters",
  "db",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -429,6 +429,7 @@ circular-buffer = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 cocoa = "0.26"
 cocoa-foundation = "0.2.0"
+console = { version = "0.15.11", default-features = false, features = ["ansi-parsing"] }
 convert_case = "0.8.0"
 core-foundation = "0.10.0"
 core-foundation-sys = "0.8.6"

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -30,6 +30,7 @@ anyhow.workspace = true
 client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
+console.workspace = true
 dap.workspace = true
 dap_adapters = { workspace = true, optional = true }
 db.workspace = true

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -139,8 +139,9 @@ impl Console {
             let mut to_insert = String::default();
             for event in events {
                 use std::fmt::Write;
-
-                _ = write!(to_insert, "{}\n", event.output.trim_end());
+                
+                let output = ::console::strip_ansi_codes(event.output.trim_end());
+                _ = write!(to_insert, "{output}\n");
             }
 
             console.set_read_only(false);


### PR DESCRIPTION
Not sure that we want to do this yet, but putting it up as one ready-to-merge option.

Release Notes:

- Debugger Beta: started stripping ANSI escape codes from debug console output.