### PR TITLE
vim: Exit temporary normal after scroll

### DIFF
--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -56,6 +56,7 @@ impl Vim {
     ) {
         let amount = by(Vim::take_count(cx).map(|c| c as f32));
         Vim::take_forced_motion(cx);
+        self.exit_temporary_normal(window, cx);
         self.update_editor(window, cx, |_, editor, window, cx| {
             scroll_editor(editor, move_cursor, &amount, window, cx)
         });


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- vim: Exit temporary normal after scrolling
