### PR TITLE
Disable nav history in vim scrolls

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1,6 +1,7 @@
 use crate::{
     Anchor, Autoscroll, Editor, EditorEvent, EditorSettings, ExcerptId, ExcerptRange, FormatTarget,
-    MultiBuffer, MultiBufferSnapshot, NavigationData, SearchWithinRange, ToPoint as _,
+    MultiBuffer, MultiBufferSnapshot, NavigationData, SearchWithinRange, SelectionEffects,
+    ToPoint as _,
     editor_settings::SeedQuerySetting,
     persistence::{DB, SerializedEditor},
     scroll::ScrollAnchor,
@@ -611,12 +612,13 @@ impl Item for Editor {
             if newest_selection.head() == offset {
                 false
             } else {
-                let nav_history = self.nav_history.take();
                 self.set_scroll_anchor(scroll_anchor, window, cx);
-                self.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
-                    s.select_ranges([offset..offset])
-                });
-                self.nav_history = nav_history;
+                self.change_selections(
+                    SelectionEffects::default().nav_history(false),
+                    window,
+                    cx,
+                    |s| s.select_ranges([offset..offset]),
+                );
                 true
             }
         } else {

--- a/crates/editor/src/jsx_tag_auto_close.rs
+++ b/crates/editor/src/jsx_tag_auto_close.rs
@@ -8,7 +8,7 @@ use util::ResultExt as _;
 use language::{BufferSnapshot, JsxTagAutoCloseConfig, Node};
 use text::{Anchor, OffsetRangeExt as _};
 
-use crate::Editor;
+use crate::{Editor, SelectionEffects};
 
 pub struct JsxTagCompletionState {
     edit_index: usize,
@@ -600,9 +600,14 @@ pub(crate) fn handle_from(
                     })
                     .collect::<Vec<_>>();
                 this.update_in(cx, |this, window, cx| {
-                    this.change_selections_without_updating_completions(None, window, cx, |s| {
-                        s.select(base_selections);
-                    });
+                    this.change_selections(
+                        SelectionEffects::no_scroll().completions(false),
+                        window,
+                        cx,
+                        |s| {
+                            s.select(base_selections);
+                        },
+                    );
                 })
                 .ok()?;
             }

--- a/crates/editor/src/scroll/autoscroll.rs
+++ b/crates/editor/src/scroll/autoscroll.rs
@@ -1,12 +1,13 @@
 use crate::{
-    DisplayRow, Editor, EditorMode, LineWithInvisibles, RowExt, display_map::ToDisplayPoint,
+    DisplayRow, Editor, EditorMode, LineWithInvisibles, RowExt, SelectionEffects,
+    display_map::ToDisplayPoint,
 };
 use gpui::{Bounds, Context, Pixels, Window, px};
 use language::Point;
 use multi_buffer::Anchor;
 use std::{cmp, f32};
 
-#[derive(PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum Autoscroll {
     Next,
     Strategy(AutoscrollStrategy, Option<Anchor>),
@@ -66,7 +67,16 @@ impl Autoscroll {
     }
 }
 
-#[derive(PartialEq, Eq, Default, Clone, Copy)]
+impl Into<SelectionEffects> for Option<Autoscroll> {
+    fn into(self) -> SelectionEffects {
+        match self {
+            Some(autoscroll) => SelectionEffects::scroll(autoscroll),
+            None => SelectionEffects::no_scroll(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Default, Clone, Copy)]
 pub enum AutoscrollStrategy {
     Fit,
     Newest,

--- a/crates/editor/src/test/editor_lsp_test_context.rs
+++ b/crates/editor/src/test/editor_lsp_test_context.rs
@@ -169,6 +169,12 @@ impl EditorLspTestContext {
                 .expect("Opened test file wasn't an editor")
         });
         editor.update_in(&mut cx, |editor, window, cx| {
+            let nav_history = workspace
+                .read(cx)
+                .active_pane()
+                .read(cx)
+                .nav_history_for_item(&cx.entity());
+            editor.set_nav_history(Some(nav_history));
             window.focus(&editor.focus_handle(cx))
         });
 

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -1,6 +1,6 @@
 use crate::Vim;
 use editor::{
-    DisplayPoint, Editor, EditorSettings,
+    DisplayPoint, Editor, EditorSettings, SelectionEffects,
     display_map::{DisplayRow, ToDisplayPoint},
     scroll::ScrollAmount,
 };
@@ -100,69 +100,76 @@ fn scroll_editor(
     let top_anchor = editor.scroll_manager.anchor().anchor;
     let vertical_scroll_margin = EditorSettings::get_global(cx).vertical_scroll_margin;
 
-    editor.change_selections(None, window, cx, |s| {
-        s.move_with(|map, selection| {
-            let mut head = selection.head();
-            let top = top_anchor.to_display_point(map);
-            let starting_column = head.column();
+    editor.change_selections(
+        SelectionEffects::no_scroll().nav_history(false),
+        window,
+        cx,
+        |s| {
+            s.move_with(|map, selection| {
+                let mut head = selection.head();
+                let top = top_anchor.to_display_point(map);
+                let starting_column = head.column();
 
-            let vertical_scroll_margin =
-                (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
+                let vertical_scroll_margin =
+                    (vertical_scroll_margin as u32).min(visible_line_count as u32 / 2);
 
-            if preserve_cursor_position {
-                let old_top = old_top_anchor.to_display_point(map);
-                let new_row = if old_top.row() == top.row() {
-                    DisplayRow(
-                        head.row()
-                            .0
-                            .saturating_add_signed(amount.lines(visible_line_count) as i32),
-                    )
+                if preserve_cursor_position {
+                    let old_top = old_top_anchor.to_display_point(map);
+                    let new_row = if old_top.row() == top.row() {
+                        DisplayRow(
+                            head.row()
+                                .0
+                                .saturating_add_signed(amount.lines(visible_line_count) as i32),
+                        )
+                    } else {
+                        DisplayRow(top.row().0 + selection.head().row().0 - old_top.row().0)
+                    };
+                    head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
+                }
+
+                let min_row = if top.row().0 == 0 {
+                    DisplayRow(0)
                 } else {
-                    DisplayRow(top.row().0 + selection.head().row().0 - old_top.row().0)
+                    DisplayRow(top.row().0 + vertical_scroll_margin)
                 };
-                head = map.clip_point(DisplayPoint::new(new_row, head.column()), Bias::Left)
-            }
 
-            let min_row = if top.row().0 == 0 {
-                DisplayRow(0)
-            } else {
-                DisplayRow(top.row().0 + vertical_scroll_margin)
-            };
+                let max_visible_row = top.row().0.saturating_add(
+                    (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
+                );
+                // scroll off the end.
+                let max_row = if top.row().0 + visible_line_count as u32 >= map.max_point().row().0
+                {
+                    map.max_point().row()
+                } else {
+                    DisplayRow(
+                        (top.row().0 + visible_line_count as u32)
+                            .saturating_sub(1 + vertical_scroll_margin),
+                    )
+                };
 
-            let max_visible_row = top.row().0.saturating_add(
-                (visible_line_count as u32).saturating_sub(1 + vertical_scroll_margin),
-            );
-            // scroll off the end.
-            let max_row = if top.row().0 + visible_line_count as u32 >= map.max_point().row().0 {
-                map.max_point().row()
-            } else {
-                DisplayRow(
-                    (top.row().0 + visible_line_count as u32)
-                        .saturating_sub(1 + vertical_scroll_margin),
-                )
-            };
+                let new_row = if full_page_up {
+                    // Special-casing ctrl-b/page-up, which is special-cased by Vim, it seems
+                    // to always put the cursor on the last line of the page, even if the cursor
+                    // was before that.
+                    DisplayRow(max_visible_row)
+                } else if head.row() < min_row {
+                    min_row
+                } else if head.row() > max_row {
+                    max_row
+                } else {
+                    head.row()
+                };
+                let new_head =
+                    map.clip_point(DisplayPoint::new(new_row, starting_column), Bias::Left);
 
-            let new_row = if full_page_up {
-                // Special-casing ctrl-b/page-up, which is special-cased by Vim, it seems
-                // to always put the cursor on the last line of the page, even if the cursor
-                // was before that.
-                DisplayRow(max_visible_row)
-            } else if head.row() < min_row {
-                min_row
-            } else if head.row() > max_row {
-                max_row
-            } else {
-                head.row()
-            };
-            let new_head = map.clip_point(DisplayPoint::new(new_row, starting_column), Bias::Left);
-
-            if selection.is_empty() {
-                selection.collapse_to(new_head, selection.goal)
-            } else {
-                selection.set_head(new_head, selection.goal)
-            };
-        })
-    });
+                if selection.is_empty() {
+                    selection.collapse_to(new_head, selection.goal)
+                } else {
+                    selection.set_head(new_head, selection.goal)
+                };
+            })
+        },
+    );
 }
 
 #[cfg(test)]
@@ -422,5 +429,21 @@ mod test {
             cx.simulate_shared_keystrokes("ctrl-y").await;
             cx.shared_state().await.assert_matches();
         }
+    }
+
+    #[gpui::test]
+    async fn test_scroll_jumps(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+
+        cx.set_scroll_height(20).await;
+
+        let content = "ˇ".to_owned() + &sample_text(52, 2, 'a');
+        cx.set_shared_state(&content).await;
+
+        cx.simulate_shared_keystrokes("shift-g g g").await;
+        cx.simulate_shared_keystrokes("ctrl-d ctrl-d ctrl-o").await;
+        cx.shared_state().await.assert_matches();
+        cx.simulate_shared_keystrokes("ctrl-o").await;
+        cx.shared_state().await.assert_matches();
     }
 }

--- a/crates/vim/test_data/test_scroll_jumps.json
+++ b/crates/vim/test_data/test_scroll_jumps.json
@@ -1,0 +1,12 @@
+{"SetOption":{"value":"scrolloff=3"}}
+{"SetOption":{"value":"lines=22"}}
+{"Put":{"state":"ˇaa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz\n{{\n||\n}}\n~~\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n"}}
+{"Key":"shift-g"}
+{"Key":"g"}
+{"Key":"g"}
+{"Key":"ctrl-d"}
+{"Key":"ctrl-d"}
+{"Key":"ctrl-o"}
+{"Get":{"state":"aa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz\n{{\n||\n}}\n~~\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\nˇ","mode":"Normal"}}
+{"Key":"ctrl-o"}
+{"Get":{"state":"ˇaa\nbb\ncc\ndd\nee\nff\ngg\nhh\nii\njj\nkk\nll\nmm\nnn\noo\npp\nqq\nrr\nss\ntt\nuu\nvv\nww\nxx\nyy\nzz\n{{\n||\n}}\n~~\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n\n","mode":"Normal"}}


### PR DESCRIPTION
Reland of #30345 to fix merge conflicts with the new skip-completions
option

Fixes #29431
Fixes #17592

Release Notes:

- vim: Scrolls are no longer added to the jumplist
