### PR TITLE
project_panel: Allow collapse all from workspace context

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -260,6 +260,14 @@ pub fn init(cx: &mut App) {
                 setting.hide_gitignore = Some(!setting.hide_gitignore.unwrap_or(false));
             })
         });
+
+        workspace.register_action(|workspace, action: &CollapseAllEntries, window, cx| {
+            if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
+                panel.update(cx, |panel, cx| {
+                    panel.collapse_all_entries(action, window, cx);
+                });
+            }
+        });
     })
     .detach();
 }


### PR DESCRIPTION
Closes #4385

Allow action `project_panel::CollapseAllEntries` to trigger from workspace context without focusing the project panel. 

Release Notes:

- Added a way to collapse all entries in the Project Panel  without having to focus it. This can be done by using the `project_panel::CollapseAllEntries` action.
