### PR TITLE
client: Fix an issue where non-IP proxy URLs didn’t resolve correctly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,7 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "gpui_tokio",
+ "hickory-resolver",
  "http_client",
  "http_client_tls",
  "httparse",
@@ -4904,6 +4905,18 @@ name = "endi"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3d8a32ae18130a3c84dd492d4215c3d913c3b07c6b63c2eb3eb7ff1101ab7bf"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
+]
 
 [[package]]
 name = "enumflags2"
@@ -7483,6 +7496,51 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
 
 [[package]]
+name = "hickory-proto"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92652067c9ce6f66ce53cc38d1169daa36e6e7eb7dd3b63b5103bd9d97117248"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.8.5",
+ "thiserror 1.0.69",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.24.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb117a1ca520e111743ab2f6688eddee69db4e0ea242545a604dce8a66fd22e"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "lru-cache",
+ "once_cell",
+ "parking_lot",
+ "rand 0.8.5",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "hidden-trait"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8349,6 +8407,18 @@ dependencies = [
  "tempfile",
  "uuid",
  "windows 0.58.0",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-sys 0.48.0",
+ "winreg 0.50.0",
 ]
 
 [[package]]
@@ -9236,6 +9306,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linkify"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9493,6 +9569,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
  "hashbrown 0.15.3",
+]
+
+[[package]]
+name = "lru-cache"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
+dependencies = [
+ "linked-hash-map",
 ]
 
 [[package]]
@@ -13326,6 +13411,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.9",
+ "hickory-resolver",
  "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
@@ -13381,6 +13467,12 @@ dependencies = [
  "tokio",
  "workspace-hack",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95325155c684b1c89f7765e30bc1c42e4a6da51ca513615660cb8a62ef9a88e3"
 
 [[package]]
 name = "resvg"
@@ -18302,6 +18394,12 @@ dependencies = [
  "redox_syscall 0.5.11",
  "wasite",
 ]
+
+[[package]]
+name = "widestring"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd7cf3379ca1aac9eea11fba24fd7e315d621f8dfe35c8d7d2be8b793726e07d"
 
 [[package]]
 name = "wiggle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -524,6 +524,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "951c77
     "rustls-tls-native-roots",
     "socks",
     "stream",
+    "hickory-dns",
 ] }
 rsa = "0.9.6"
 runtimelib = {  git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734", default-features = false, features = [

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -56,6 +56,7 @@ worktree.workspace = true
 telemetry.workspace = true
 tokio.workspace = true
 workspace-hack.workspace = true
+hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 
 [dev-dependencies]
 clock = { workspace = true, features = ["test-support"] }

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -28,6 +28,9 @@ feature_flags.workspace = true
 futures.workspace = true
 gpui.workspace = true
 gpui_tokio.workspace = true
+# Don't update `hickory-resolver`, it has a bug that causes it to not resolve DNS queries correctly.
+# See https://github.com/hickory-dns/hickory-dns/issues/3048
+hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 http_client.workspace = true
 http_client_tls.workspace = true
 httparse = "1.10"
@@ -56,7 +59,6 @@ worktree.workspace = true
 telemetry.workspace = true
 tokio.workspace = true
 workspace-hack.workspace = true
-hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 
 [dev-dependencies]
 clock = { workspace = true, features = ["test-support"] }

--- a/crates/client/src/proxy.rs
+++ b/crates/client/src/proxy.rs
@@ -8,21 +8,19 @@ use hickory_resolver::{TokioAsyncResolver, config::LookupIpStrategy, system_conf
 use http_client::Url;
 use http_proxy::{HttpProxyType, connect_http_proxy_stream, parse_http_proxy};
 use socks_proxy::{SocksVersion, connect_socks_proxy_stream, parse_socks_proxy};
+use util::ResultExt;
 
 pub(crate) async fn connect_proxy_stream(
     proxy: &Url,
     rpc_host: (&str, u16),
 ) -> Result<Box<dyn AsyncReadWrite>> {
-    let Some(((proxy_domain, proxy_port), proxy_type)) = parse_proxy_type(proxy) else {
+    let Some(((proxy_domain, proxy_port), proxy_type)) = parse_proxy_type(proxy).await else {
         // If parsing the proxy URL fails, we must avoid falling back to an insecure connection.
         // SOCKS proxies are often used in contexts where security and privacy are critical,
         // so any fallback could expose users to significant risks.
         anyhow::bail!("Parsing proxy url type failed");
     };
 
-    let proxy_domain = resolve_proxy_url_if_needed(proxy_domain)
-        .await
-        .context("Failed to resolve proxy domain")?;
     // Connect to proxy and wrap protocol later
     let stream = tokio::net::TcpStream::connect((proxy_domain.as_str(), proxy_port))
         .await
@@ -38,27 +36,16 @@ pub(crate) async fn connect_proxy_stream(
     Ok(proxy_stream)
 }
 
-async fn resolve_proxy_url_if_needed(proxy_domain: String) -> Result<String> {
-    let (config, mut opts) = system_conf::read_system_conf().unwrap();
-    opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
-    let resolver = TokioAsyncResolver::tokio(config, opts);
-    let ip = resolver
-        .lookup_ip(proxy_domain.as_str())
-        .await?
-        .into_iter()
-        .next()
-        .ok_or_else(|| anyhow::anyhow!("No IP found for proxy domain {proxy_domain}"))?;
-    Ok(ip.to_string())
-}
-
 enum ProxyType<'t> {
     SocksProxy(SocksVersion<'t>),
     HttpProxy(HttpProxyType<'t>),
 }
 
-fn parse_proxy_type(proxy: &Url) -> Option<((String, u16), ProxyType<'_>)> {
+async fn parse_proxy_type(proxy: &Url) -> Option<((String, u16), ProxyType<'_>)> {
     let scheme = proxy.scheme();
-    let host = proxy.host()?.to_string();
+    let host = resolve_proxy_url_if_needed(proxy.host()?.to_string())
+        .await
+        .log_err()?;
     let port = proxy.port_or_known_default()?;
     let proxy_type = match scheme {
         scheme if scheme.starts_with("socks") => {
@@ -71,6 +58,19 @@ fn parse_proxy_type(proxy: &Url) -> Option<((String, u16), ProxyType<'_>)> {
     }?;
 
     Some(((host, port), proxy_type))
+}
+
+async fn resolve_proxy_url_if_needed(proxy_domain: String) -> Result<String> {
+    let (config, mut opts) = system_conf::read_system_conf().unwrap();
+    opts.ip_strategy = LookupIpStrategy::Ipv4AndIpv6;
+    let resolver = TokioAsyncResolver::tokio(config, opts);
+    let ip = resolver
+        .lookup_ip(proxy_domain.as_str())
+        .await?
+        .into_iter()
+        .next()
+        .ok_or_else(|| anyhow::anyhow!("No IP found for proxy domain {proxy_domain}"))?;
+    Ok(ip.to_string())
 }
 
 pub(crate) trait AsyncReadWrite:


### PR DESCRIPTION
If the proxy URL is in the form of `example.com` instead of a raw IP address, and `example.com` isn't a well-known domain, then the default URL resolution can fail.

The test setup:

A Linux machine runs a CoreDNS server with a custom entry: `10.254.7.38 example.com`. On a Windows machine, if the proxy URL is set to `example.com`, the resolved address does **not** end up being `10.254.7.38`.

Using `hickory_resolver` for more advanced DNS resolution fixes this issue.


Release Notes:

- Fixed proxy URL resolution when using custom DNS entries.
