### PR TITLE
agent: Suggest turning burn mode on when close to the context window limit

### DIFF
--- a/crates/ui/src/components/callout.rs
+++ b/crates/ui/src/components/callout.rs
@@ -110,7 +110,7 @@ impl RenderOnce for Callout {
                                 |this| {
                                     this.child(
                                         h_flex()
-                                            .gap_1()
+                                            .gap_0p5()
                                             .when_some(self.secondary_action, |this, action| {
                                                 this.child(action)
                                             })


### PR DESCRIPTION
Previously, upon getting close to reaching the context window, we'd just suggest creating a new thread using the summary of the current one. Now, we also suggest turning burn mode on as an alternative action to solve the context window problem.

Release Notes:

- agent: Added a suggestion to turn burn mode on when getting close to the context window limit.
