### PR TITLE
debugger: Focus child sessions if parent has never stopped

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -404,7 +404,11 @@ impl DebugPanel {
                 });
                 (session, task)
             })?;
-            Self::register_session(this, session, false, cx).await?;
+            // Focus child sessions if the parent has never emitted a stopped event;
+            // this improves our JavaScript experience, as it always spawns a "main" session that then spawns subsessions.
+            let parent_ever_stopped =
+                parent_session.update(cx, |this, _| this.has_ever_stopped())?;
+            Self::register_session(this, session, !parent_ever_stopped, cx).await?;
             task.await
         })
         .detach_and_log_err(cx);

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -444,18 +444,20 @@ async fn test_handle_start_debugging_request(
         .update(cx, |workspace, _window, cx| {
             let debug_panel = workspace.panel::<DebugPanel>(cx).unwrap();
 
-            // Active session does not change on spawn.
+            // Active session changes on spawn, as the parent has never stopped.
             let active_session = debug_panel
                 .read(cx)
                 .active_session()
                 .unwrap()
                 .read(cx)
                 .session(cx);
-
-            assert_eq!(active_session, sessions[0].read(cx).session(cx));
-            assert!(active_session.read(cx).parent_session().is_none());
-
             let current_sessions = debug_panel.read(cx).sessions();
+            assert_eq!(active_session, current_sessions[1].read(cx).session(cx));
+            assert_eq!(
+                active_session.read(cx).parent_session(),
+                Some(&current_sessions[0].read(cx).session(cx))
+            );
+
             assert_eq!(current_sessions.len(), 2);
             assert_eq!(current_sessions[0], sessions[0]);
 


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- When debugging JavaScript, Zed will now preselect child sessions by default.
