### PR TITLE
terminal: Add confirmation pop-up on closing terminal pane

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1715,7 +1715,7 @@ impl Item for TerminalView {
 
     fn save(
         &mut self,
-        _should_format: bool,
+        _should_format: workspace::item::SaveOptions,
         _project: Entity<Project>,
         _window: &mut Window,
         _cx: &mut Context<Self>,


### PR DESCRIPTION
This change introduces a confirmation pop-up for terminals with running child processes such as an SSH session or other tasks the user may want to avoid inadvertently interrupting. This feature was suggested in #20051.

This is achieved in a similar way to the behavior expected of editor tabs containing unsaved tabs, by considering a terminal view as dirty if it has child processes when closing, and displaying a native confirmation dialogue if that is the case.
To this end, the `has_active_child_processes_readonly` function was added to the `pty_info.rs` file of the `terminal` crate, and the `is_dirty` and `can_save` methods were implemented in the `terminal_view` crate.

Release Notes:

- Added confirmation pop-up on closing terminals with running processes
