### PR TITLE
Fix shell environment loading for Zed installations with spaces in path

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -38,8 +38,12 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
     }
     // cd into the directory, triggering directory specific side-effects (asdf, direnv, etc)
     command_string.push_str(&format!("cd '{}';", directory.display()));
-    command_string.push_str(&format!("sh -c '{zed_path} --printenv >&{ENV_OUTPUT_FD}';"));
+    command_string.push_str(&format!(
+        "sh -c \"{} --printenv >&{}\";",
+        zed_path, ENV_OUTPUT_FD
+    ));
     command.args(["-i", "-c", &command_string]);
+
     super::set_pre_exec_to_start_new_session(&mut command);
 
     let (env_output, process_output) = spawn_and_read_fd(command, ENV_OUTPUT_FD)?;


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/32637

When Zed is installed in a path containing spaces (e.g., `/Applications/Zed Nightly.app/Contents/MacOS/zed`), environment variable loading fails and leaves this in the Zed log:

```
login shell exited with exit status: 127. stdout: "", stderr: "Nightly.app/Contents/MacOS/zed --printenv >&0: /Applications/Zed: No such file or directory"
```

This was not part a release (only broke in nightly), but fixes it the issue in any case when the path to the Zed.app bundle has a space (e.g. "Zed Nightly.app")

Release Notes:

- N/A