### PR TITLE
Hide the notifications panel by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -716,7 +716,7 @@
   },
   "notification_panel": {
     // Whether to show the notification panel button in the status bar.
-    "button": true,
+    "button": false,
     // Where to dock the notification panel. Can be 'left' or 'right'.
     "dock": "right",
     // Default width of the notification panel.

--- a/crates/collab_ui/src/panel_settings.rs
+++ b/crates/collab_ui/src/panel_settings.rs
@@ -56,7 +56,7 @@ pub struct NotificationPanelSettings {
 pub struct PanelSettingsContent {
     /// Whether to show the panel button in the status bar.
     ///
-    /// Default: true
+    /// Default: false
     pub button: Option<bool>,
     /// Where to dock the panel.
     ///


### PR DESCRIPTION
Release Notes:

- The notifications panel is hidden by default now
