### PR TITLE
languages: Bump ESLint LSP server to version 3.0.10

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -836,8 +836,8 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
-    const CURRENT_VERSION: &'static str = "2.4.4";
-    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
+    const CURRENT_VERSION: &'static str = "3.0.10";
+    const CURRENT_VERSION_TAG_NAME: &'static str = "release/3.0.10";
 
     #[cfg(not(windows))]
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
@@ -915,9 +915,7 @@ impl LspAdapter for EsLintLspAdapter {
                     "enable": true
                 }
             },
-            "experimental": {
-                "useFlatConfig": use_flat_config,
-            },
+            "useFlatConfig": use_flat_config,
         });
 
         let override_options = cx.update(|cx| {


### PR DESCRIPTION
Testing project: https://github.com/imumesh18/zed-testing

I have attached the logs from the eslint lsp server. Confirming that we are indeed calling  `textDocument/diagnostic` and we are receiving the error response as well from lsp. Please check the attached log for it.

<details>
<summary>Server Log</summary>

```

// Send:
{"jsonrpc":"2.0","method":"workspace/didChangeConfiguration","params":{"settings":{"":{"validate":"on","rulesCustomizations":[],"run":"onType","nodePath":null,"workingDirectory":{"mode":"auto"},"workspaceFolder":{"uri":"/Users/umesh/code/zed-testing","name":"zed-testing"},"problems":{},"codeActionOnSave":{"enable":true},"codeAction":{"disableRuleComment":{"enable":true,"location":"separateLine"},"showDocumentation":{"enable":true}},"useFlatConfig":true}}}}

// Receive:
{"jsonrpc":"2.0","id":6,"method":"workspace/diagnostic/refresh"}

// Send:
{"jsonrpc":"2.0","id":6,"result":null}

// Send:
{"jsonrpc":"2.0","id":8,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":9,"character":3},"end":{"line":9,"character":3}},"context":{"diagnostics":[],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":7,"method":"workspace/configuration","params":{"items":[{"scopeUri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","section":""}]}}

// Send:
{"jsonrpc":"2.0","id":7,"result":[{"validate":"on","rulesCustomizations":[],"run":"onType","nodePath":null,"workingDirectory":{"mode":"auto"},"workspaceFolder":{"uri":"/Users/umesh/code/zed-testing","name":"zed-testing"},"problems":{},"codeActionOnSave":{"enable":true},"codeAction":{"disableRuleComment":{"enable":true,"location":"separateLine"},"showDocumentation":{"enable":true}},"useFlatConfig":true}]}

// Receive:
{"jsonrpc":"2.0","id":8,"result":[]}

// Send:
{"jsonrpc":"2.0","id":9,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":12,"character":20},"end":{"line":12,"character":20}},"context":{"diagnostics":[],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":9,"result":[]}

// Send:
{"jsonrpc":"2.0","id":10,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":11,"character":37},"end":{"line":11,"character":37}},"context":{"diagnostics":[],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":10,"result":[]}

// Send:
{"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"}}}

// Send:
{"jsonrpc":"2.0","id":11,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":3,"character":0},"end":{"line":14,"character":0}},"context":{"diagnostics":[{"range":{"start":{"line":4,"character":8},"end":{"line":4,"character":22}},"severity":1,"code":"@typescript-eslint/no-unused-vars","source":"eslint","message":"'unusedVariable' is assigned a value but never used."},{"range":{"start":{"line":4,"character":8},"end":{"line":4,"character":22}},"severity":4,"code":6133,"source":"ts","message":"'unusedVariable' is declared but its value is never read."},{"range":{"start":{"line":7,"character":6},"end":{"line":7,"character":14}},"severity":1,"code":2367,"source":"ts","message":"This comparison appears to be unintentional because the types 'number' and 'string' have no overlap."},{"range":{"start":{"line":13,"character":2},"end":{"line":13,"character":52}},"severity":1,"code":"no-var","source":"eslint","message":"Unexpected var, use let or const instead."},{"range":{"start":{"line":13,"character":6},"end":{"line":13,"character":22}},"severity":1,"code":"@typescript-eslint/no-unused-vars","source":"eslint","message":"'oldStyleVariable' is assigned a value but never used."},{"range":{"start":{"line":13,"character":6},"end":{"line":13,"character":22}},"severity":4,"code":6133,"source":"ts","message":"'oldStyleVariable' is declared but its value is never read."}],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":11,"result":[{"title":"Disable @typescript-eslint/no-unused-vars for this line","command":{"title":"Disable @typescript-eslint/no-unused-vars for this line","command":"eslint.applyDisableLine","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"@typescript-eslint/no-unused-vars"}]},"kind":"quickfix"},{"title":"Disable @typescript-eslint/no-unused-vars for the entire file","command":{"title":"Disable @typescript-eslint/no-unused-vars for the entire file","command":"eslint.applyDisableFile","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"@typescript-eslint/no-unused-vars"}]},"kind":"quickfix"},{"title":"Show documentation for @typescript-eslint/no-unused-vars","command":{"title":"Show documentation for @typescript-eslint/no-unused-vars","command":"eslint.openRuleDoc","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"@typescript-eslint/no-unused-vars"}]},"kind":"quickfix"},{"title":"Fix this no-var problem","command":{"title":"Fix this no-var problem","command":"eslint.applySingleFix","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"no-var"}]},"kind":"quickfix","diagnostics":[{"message":"Unexpected var, use let or const instead.","severity":1,"source":"eslint","range":{"start":{"line":13,"character":2},"end":{"line":13,"character":52}},"code":"no-var","codeDescription":{"href":"https://eslint.org/docs/latest/rules/no-var"}}],"isPreferred":true},{"title":"Disable no-var for this line","command":{"title":"Disable no-var for this line","command":"eslint.applyDisableLine","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"no-var"}]},"kind":"quickfix"},{"title":"Disable no-var for the entire file","command":{"title":"Disable no-var for the entire file","command":"eslint.applyDisableFile","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"no-var"}]},"kind":"quickfix"},{"title":"Show documentation for no-var","command":{"title":"Show documentation for no-var","command":"eslint.openRuleDoc","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0,"ruleId":"no-var"}]},"kind":"quickfix"},{"title":"Fix all auto-fixable problems","command":{"title":"Fix all auto-fixable problems","command":"eslint.applyAllFixes","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":0}]},"kind":"quickfix"}]}

// Send:
{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":1},"contentChanges":[{"range":{"start":{"line":3,"character":2},"end":{"line":3,"character":2}},"text":"// "},{"range":{"start":{"line":4,"character":2},"end":{"line":4,"character":2}},"text":"// "},{"range":{"start":{"line":6,"character":2},"end":{"line":6,"character":2}},"text":"// "},{"range":{"start":{"line":7,"character":2},"end":{"line":7,"character":2}},"text":"// "},{"range":{"start":{"line":8,"character":2},"end":{"line":8,"character":2}},"text":"// "},{"range":{"start":{"line":9,"character":2},"end":{"line":9,"character":2}},"text":"// "},{"range":{"start":{"line":11,"character":2},"end":{"line":11,"character":2}},"text":"// "},{"range":{"start":{"line":12,"character":2},"end":{"line":12,"character":2}},"text":"// "},{"range":{"start":{"line":13,"character":2},"end":{"line":13,"character":2}},"text":"// "}]}}

// Send:
{"jsonrpc":"2.0","id":12,"method":"textDocument/diagnostic","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"identifier":"eslint","previousResultId":null}}

// Receive:
{"jsonrpc":"2.0","method":"eslint/status","params":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","state":1,"validationTime":18}}

// Receive:
{"jsonrpc":"2.0","id":12,"result":{"kind":"full","items":[]}}

// Send:
{"jsonrpc":"2.0","id":13,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":3,"character":0},"end":{"line":14,"character":0}},"context":{"diagnostics":[{"range":{"start":{"line":4,"character":11},"end":{"line":4,"character":25}},"severity":4,"code":6133,"source":"ts","message":"'unusedVariable' is declared but its value is never read."},{"range":{"start":{"line":7,"character":9},"end":{"line":7,"character":17}},"severity":1,"code":2367,"source":"ts","message":"This comparison appears to be unintentional because the types 'number' and 'string' have no overlap."},{"range":{"start":{"line":13,"character":9},"end":{"line":13,"character":25}},"severity":4,"code":6133,"source":"ts","message":"'oldStyleVariable' is declared but its value is never read."}],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":13,"result":[]}

// Send:
{"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"}}}

// Send:
{"jsonrpc":"2.0","id":14,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":13,"character":7},"end":{"line":13,"character":7}},"context":{"diagnostics":[],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":14,"result":[]}

// Send:
{"jsonrpc":"2.0","id":15,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":3,"character":0},"end":{"line":14,"character":0}},"context":{"diagnostics":[],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":15,"result":[]}

// Send:
{"jsonrpc":"2.0","method":"textDocument/didChange","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2},"contentChanges":[{"range":{"start":{"line":3,"character":2},"end":{"line":3,"character":5}},"text":""},{"range":{"start":{"line":4,"character":2},"end":{"line":4,"character":5}},"text":""},{"range":{"start":{"line":6,"character":2},"end":{"line":6,"character":5}},"text":""},{"range":{"start":{"line":7,"character":2},"end":{"line":7,"character":5}},"text":""},{"range":{"start":{"line":8,"character":2},"end":{"line":8,"character":5}},"text":""},{"range":{"start":{"line":9,"character":2},"end":{"line":9,"character":5}},"text":""},{"range":{"start":{"line":11,"character":2},"end":{"line":11,"character":5}},"text":""},{"range":{"start":{"line":12,"character":2},"end":{"line":12,"character":5}},"text":""},{"range":{"start":{"line":13,"character":2},"end":{"line":13,"character":5}},"text":""}]}}

// Send:
{"jsonrpc":"2.0","id":16,"method":"textDocument/diagnostic","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"identifier":"eslint","previousResultId":null}}

// Receive:
{"jsonrpc":"2.0","method":"eslint/status","params":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","state":1,"validationTime":15}}

// Receive:
{"jsonrpc":"2.0","id":16,"result":{"kind":"full","items":[{"message":"'unusedVariable' is assigned a value but never used.","severity":1,"source":"eslint","range":{"start":{"line":4,"character":8},"end":{"line":4,"character":22}},"code":"@typescript-eslint/no-unused-vars","codeDescription":{"href":"https://typescript-eslint.io/rules/no-unused-vars"}},{"message":"Unexpected var, use let or const instead.","severity":1,"source":"eslint","range":{"start":{"line":13,"character":2},"end":{"line":13,"character":52}},"code":"no-var","codeDescription":{"href":"https://eslint.org/docs/latest/rules/no-var"}},{"message":"'oldStyleVariable' is assigned a value but never used.","severity":1,"source":"eslint","range":{"start":{"line":13,"character":6},"end":{"line":13,"character":22}},"code":"@typescript-eslint/no-unused-vars","codeDescription":{"href":"https://typescript-eslint.io/rules/no-unused-vars"}}]}}

// Send:
{"jsonrpc":"2.0","id":17,"method":"textDocument/codeAction","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"},"range":{"start":{"line":3,"character":0},"end":{"line":14,"character":0}},"context":{"diagnostics":[{"range":{"start":{"line":4,"character":8},"end":{"line":4,"character":22}},"severity":1,"code":"@typescript-eslint/no-unused-vars","source":"eslint","message":"'unusedVariable' is assigned a value but never used."},{"range":{"start":{"line":13,"character":2},"end":{"line":13,"character":52}},"severity":1,"code":"no-var","source":"eslint","message":"Unexpected var, use let or const instead."},{"range":{"start":{"line":13,"character":6},"end":{"line":13,"character":22}},"severity":1,"code":"@typescript-eslint/no-unused-vars","source":"eslint","message":"'oldStyleVariable' is assigned a value but never used."}],"only":["quickfix","source.fixAll.eslint"]}}}

// Receive:
{"jsonrpc":"2.0","id":17,"result":[{"title":"Disable @typescript-eslint/no-unused-vars for this line","command":{"title":"Disable @typescript-eslint/no-unused-vars for this line","command":"eslint.applyDisableLine","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"@typescript-eslint/no-unused-vars"}]},"kind":"quickfix"},{"title":"Disable @typescript-eslint/no-unused-vars for the entire file","command":{"title":"Disable @typescript-eslint/no-unused-vars for the entire file","command":"eslint.applyDisableFile","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"@typescript-eslint/no-unused-vars"}]},"kind":"quickfix"},{"title":"Show documentation for @typescript-eslint/no-unused-vars","command":{"title":"Show documentation for @typescript-eslint/no-unused-vars","command":"eslint.openRuleDoc","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"@typescript-eslint/no-unused-vars"}]},"kind":"quickfix"},{"title":"Fix this no-var problem","command":{"title":"Fix this no-var problem","command":"eslint.applySingleFix","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"no-var"}]},"kind":"quickfix","diagnostics":[{"message":"Unexpected var, use let or const instead.","severity":1,"source":"eslint","range":{"start":{"line":13,"character":2},"end":{"line":13,"character":52}},"code":"no-var","codeDescription":{"href":"https://eslint.org/docs/latest/rules/no-var"}}],"isPreferred":true},{"title":"Disable no-var for this line","command":{"title":"Disable no-var for this line","command":"eslint.applyDisableLine","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"no-var"}]},"kind":"quickfix"},{"title":"Disable no-var for the entire file","command":{"title":"Disable no-var for the entire file","command":"eslint.applyDisableFile","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"no-var"}]},"kind":"quickfix"},{"title":"Show documentation for no-var","command":{"title":"Show documentation for no-var","command":"eslint.openRuleDoc","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2,"ruleId":"no-var"}]},"kind":"quickfix"},{"title":"Fix all auto-fixable problems","command":{"title":"Fix all auto-fixable problems","command":"eslint.applyAllFixes","arguments":[{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx","version":2}]},"kind":"quickfix"}]}

// Send:
{"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{"uri":"file:///Users/umesh/code/zed-testing/src/app/page.tsx"}}}
```

</details>

Release Notes:

- Bump ESLint LSP server to version 3.0.10
