### PR TITLE
debugger: Improve logging of debug sessions

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -218,7 +218,7 @@ impl DebugAdapterClient {
 
     pub fn add_log_handler<F>(&self, f: F, kind: LogKind)
     where
-        F: 'static + Send + FnMut(IoKind, &str),
+        F: 'static + Send + FnMut(IoKind, Option<&str>, &str),
     {
         self.transport_delegate.add_log_handler(f, kind);
     }

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -520,17 +520,13 @@ impl TransportDelegate {
             Err(e) => return ConnectionResult::Result(Err(e)),
         };
 
-        let message = match serde_json::from_str::<Message>(message_str)
-            .context("deserializing server message")
-        {
-            Ok(message) => message,
-            Err(e) => return ConnectionResult::Result(Err(e)),
-        };
+        let message =
+            serde_json::from_str::<Message>(message_str).context("deserializing server message");
 
         if let Some(log_handlers) = log_handlers {
             let command = match &message {
-                Message::Request(request) => Some(request.command.as_str()),
-                Message::Response(response) => Some(response.command.as_str()),
+                Ok(Message::Request(request)) => Some(request.command.as_str()),
+                Ok(Message::Response(response)) => Some(response.command.as_str()),
                 _ => None,
             };
 
@@ -541,7 +537,7 @@ impl TransportDelegate {
             }
         }
 
-        ConnectionResult::Result(Ok(message))
+        ConnectionResult::Result(message)
     }
 
     pub async fn shutdown(&self) -> Result<()> {

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -304,7 +304,7 @@ impl LogStore {
                 )
                 .ok()
             })
-            .map(|string| SharedString::from(string))
+            .map(SharedString::from)
             .unwrap_or(message)
         } else {
             message
@@ -391,9 +391,8 @@ impl LogStore {
     fn clean_sessions(&mut self, cx: &mut Context<Self>) {
         let mut to_remove = self.debug_sessions.len().saturating_sub(MAX_SESSIONS);
         self.debug_sessions.retain(|session| {
-            if dbg!(to_remove) > 0 && dbg!(session.is_terminated) {
+            if to_remove > 0 && session.is_terminated {
                 to_remove -= 1;
-                dbg!("Removing a session");
                 return false;
             }
             true
@@ -694,13 +693,11 @@ impl DapLogView {
             .debug_sessions
             .iter()
             .rev()
-            .filter_map(|state| {
-                Some(DapMenuItem {
-                    session_id: state.id,
-                    adapter_name: state.adapter_name.clone(),
-                    has_adapter_logs: state.has_adapter_logs,
-                    selected_entry: self.current_view.map_or(LogKind::Adapter, |(_, kind)| kind),
-                })
+            .map(|state| DapMenuItem {
+                session_id: state.id,
+                adapter_name: state.adapter_name.clone(),
+                has_adapter_logs: state.has_adapter_logs,
+                selected_entry: self.current_view.map_or(LogKind::Adapter, |(_, kind)| kind),
             })
             .collect::<Vec<_>>()
     }

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -700,6 +700,8 @@ impl DapStore {
 
         let shutdown_task = session.update(cx, |this, cx| this.shutdown(cx));
 
+        cx.emit(DapStoreEvent::DebugClientShutdown(session_id));
+
         cx.background_spawn(async move {
             if shutdown_children.len() > 0 {
                 let _ = join_all(shutdown_children).await;


### PR DESCRIPTION
This PR fixes a common issue where a debug session won't start up and user's weren't able to get any logs from the debug session. We now do these three things

1. We now store a history of debug sessions
2. We added a new option to only look at the initialization sequence 
3. We default to selecting a session in dap log view in stead of none

Release Notes:

- debugger: Add history to debug session logging
