### PR TITLE
debugger: Select first stack frame with valid path

### DIFF
--- a/crates/debugger_ui/src/tests/stack_frame_list.rs
+++ b/crates/debugger_ui/src/tests/stack_frame_list.rs
@@ -718,7 +718,7 @@ async fn test_collapsed_entries(executor: BackgroundExecutor, cx: &mut TestAppCo
                 stack_frame_list.entries()
             );
 
-            stack_frame_list.expand_collapsed_entry(1);
+            stack_frame_list.expand_collapsed_entry(1, cx);
 
             assert_eq!(
                 &vec![
@@ -735,7 +735,7 @@ async fn test_collapsed_entries(executor: BackgroundExecutor, cx: &mut TestAppCo
                 stack_frame_list.entries()
             );
 
-            stack_frame_list.expand_collapsed_entry(4);
+            stack_frame_list.expand_collapsed_entry(4, cx);
 
             assert_eq!(
                 &vec![


### PR DESCRIPTION
This PR addresses an issue where we could get a stack frame list and automatically select a stack frame that didn't have a valid path. Causing a failure on Zed's end to select/update the active debug line. The fix for this is selecting the first non-subtle stack frame that has the optional path parameter.

We also made subtle stack frames move into their own collapsable list as well.

Release Notes:

- debugger: Fix edge case where hitting a breakpoint wouldn't take you to the active debug line
