### PR TITLE
Fixed typo in SQL language documentation

### DIFF
--- a/docs/src/languages/sql.md
+++ b/docs/src/languages/sql.md
@@ -14,7 +14,7 @@ Zed supports auto-formatting SQL using external tools like [`sql-formatter`](htt
 npm install -g sql-formatter
 ```
 
-2. Ensure `shfmt` is available in your path and check the version:
+2. Ensure `sql-formatter` is available in your path and check the version:
 
 ```sh
 which sql-formatter


### PR DESCRIPTION
Fixed typo in bullet 2 (line 17) referring to `shfmt` instead of `sql-formatter`

Release Notes: 

- N/A
