### PR TITLE
Fix block cursor using placeholder text even when it's not displayed

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1559,7 +1559,7 @@ impl EditorElement {
                         snapshot
                             .grapheme_at(cursor_position)
                             .or_else(|| {
-                                if cursor_column == 0 {
+                                if snapshot.is_empty() {
                                     snapshot.placeholder_text().and_then(|s| {
                                         s.graphemes(true).next().map(|s| s.to_string().into())
                                     })


### PR DESCRIPTION
The condition for displaying the first char of the placeholder text in the block cursor was `cursor_column == 0`. This meant that it was displayed on the first column even when the placeholder text is not being displayed. Instead this now shows it only when `snapshot.is_empty()` - the same condition used to determine whether to show placeholder text.

In the case of vim mode + agent panel message editor, this meant that if you did `shift-enter` to make a newline and then `escape` to enter normal mode, the block cursor would show `M` inside it as that's the first character of the placeholder text "Message the agent - @ to include context"

Release Notes:

- N/A
