### PR TITLE
Include .NET project identification in telemetry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2834,6 +2834,7 @@ dependencies = [
  "paths",
  "postage",
  "rand 0.8.5",
+ "regex",
  "release_channel",
  "rpc",
  "rustls-pki-types",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -39,6 +39,7 @@ paths.workspace = true
 parking_lot.workspace = true
 postage.workspace = true
 rand.workspace = true
+regex.workspace = true
 release_channel.workspace = true
 rpc = { workspace = true, features = ["gpui"] }
 schemars.workspace = true


### PR DESCRIPTION
With Windows support on the horizon this year, we'll want to know how much .NET dev happens in Zed, so we can know how to prioritize bug fixes or enhancements to the dev experience in this framework.

Release Notes:

- N/A
