### PR TITLE
x11: Fix keymap reload to happen on XkbMapNotify not MapNotify

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -826,7 +826,7 @@ impl X11Client {
                 self.reset_ime();
                 window.handle_ime_delete();
             }
-            Event::XkbNewKeyboardNotify(_) | Event::MapNotify(_) => {
+            Event::XkbNewKeyboardNotify(_) | Event::XkbMapNotify(_) => {
                 let mut state = self.0.borrow_mut();
                 let xkb_state = {
                     let xkb_keymap = xkbc::x11::keymap_new_from_device(


### PR DESCRIPTION
Keyboard hot reloading was added in #15059, but also reloaded this on MapNotify instead of XkbMapNotify, so it wasn't handling keymap change events and was instead reloading when windows are mapped (typically when they go from a minimized / other workspace state to being visible).

Release Notes:

- N/A