### PR TITLE
Bail and signal error when the cwd of a resolved task doesn't exist

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15831,6 +15831,7 @@ dependencies = [
  "serde_json_lenient",
  "sha2",
  "shellexpand 2.1.2",
+ "smol",
  "util",
  "workspace-hack",
  "zed_actions",

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -847,8 +847,17 @@ impl RunningState {
                         (task, None)
                     }
                 };
-                let Some(task) = task_template.resolve_task("debug-build-task", &task_context) else {
+                let Some(task) = task_template.resolve_task_and_check_cwd("debug-build-task", &task_context, cx.background_executor().clone()) else {
                     anyhow::bail!("Could not resolve task variables within a debug scenario");
+                };
+                let task = match task.await {
+                    Ok(task) => task,
+                    Err(e) => {
+                        workspace.update(cx, |workspace, cx| {
+                            workspace.show_error(&e, cx);
+                        }).ok();
+                        return Err(e)
+                    }
                 };
 
                 let locator_name = if let Some(locator_name) = locator_name {

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -29,6 +29,7 @@ serde_json.workspace = true
 serde_json_lenient.workspace = true
 sha2.workspace = true
 shellexpand.workspace = true
+smol.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
 zed_actions.workspace = true

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -1461,10 +1461,27 @@ impl workspace::TerminalProvider for TerminalProvider {
         &self,
         task: SpawnInTerminal,
         window: &mut Window,
-        cx: &mut App,
+        cx: &mut Context<Workspace>,
     ) -> Task<Option<Result<ExitStatus>>> {
         let terminal_panel = self.0.clone();
+        let workspace = cx.weak_entity();
         window.spawn(cx, async move |cx| {
+            if let Some(cwd) = task.cwd.as_deref() {
+                let result = match smol::fs::metadata(cwd).await {
+                    Ok(metadata) if metadata.is_dir() => Ok(()),
+                    Ok(_) => Err(anyhow!("cwd for resolved task is not a directory: {cwd:?}")),
+                    Err(e) => Err(e).context(format!("reading cwd of resolved task: {cwd:?}")),
+                };
+                if let Err(e) = result {
+                    workspace
+                        .update(cx, |workspace, cx| {
+                            workspace.show_error(&e, cx);
+                        })
+                        .ok();
+                    return None;
+                }
+            }
+
             let terminal = terminal_panel
                 .update_in(cx, |terminal_panel, window, cx| {
                     terminal_panel.spawn_task(&task, window, cx)

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -135,7 +135,7 @@ pub trait TerminalProvider {
         &self,
         task: SpawnInTerminal,
         window: &mut Window,
-        cx: &mut App,
+        cx: &mut Context<Workspace>,
     ) -> Task<Option<Result<ExitStatus>>>;
 }
 


### PR DESCRIPTION
Closes #32688

Release Notes:

- Fixed tasks (including build tasks for debug configurations) silently using `/` as a working directory when the specified `cwd` didn't exist.