### PR TITLE
editor: Support both cursor and mouse based columnar selection

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -928,6 +928,16 @@ enum SelectionDragState {
     },
 }
 
+enum ColumnarSelectionState {
+    FromMouse {
+        selection_tail: Anchor,
+        display_point: Option<DisplayPoint>,
+    },
+    FromSelection {
+        selection_tail: Anchor,
+    },
+}
+
 /// Represents a breakpoint indicator that shows up when hovering over lines in the gutter that don't have
 /// a breakpoint on them.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -955,9 +965,7 @@ pub struct Editor {
     /// When inline assist editors are linked, they all render cursors because
     /// typing enters text into each of them, even the ones that aren't focused.
     pub(crate) show_cursor_when_unfocused: bool,
-    columnar_selection_tail: Option<Anchor>,
-    columnar_display_point: Option<DisplayPoint>,
-    columnar_mode: Option<ColumnarMode>,
+    columnar_selection_state: Option<ColumnarSelectionState>,
     add_selections_state: Option<AddSelectionsState>,
     select_next_state: Option<SelectNextState>,
     select_prev_state: Option<SelectNextState>,
@@ -1892,9 +1900,7 @@ impl Editor {
             display_map: display_map.clone(),
             selections,
             scroll_manager: ScrollManager::new(cx),
-            columnar_selection_tail: None,
-            columnar_display_point: None,
-            columnar_mode: None,
+            columnar_selection_state: None,
             add_selections_state: None,
             select_next_state: None,
             select_prev_state: None,
@@ -3377,8 +3383,6 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        self.columnar_mode = Some(mode);
-
         if !self.focus_handle.is_focused(window) {
             self.last_focused_descendant = None;
             window.focus(&self.focus_handle);
@@ -3398,29 +3402,30 @@ impl Editor {
                     SelectMode::Character,
                 );
             });
-            if matches!(self.columnar_mode, Some(ColumnarMode::FromMouse)) {
-                if position.column() != goal_column {
-                    self.columnar_display_point =
-                        Some(DisplayPoint::new(position.row(), goal_column));
-                } else {
-                    self.columnar_display_point = None;
-                }
-            }
-        }
+        };
 
         let tail = self.selections.newest::<Point>(cx).tail();
-        self.columnar_selection_tail = Some(display_map.buffer_snapshot.anchor_before(tail));
+        let selection_anchor = display_map.buffer_snapshot.anchor_before(tail);
+        self.columnar_selection_state = match mode {
+            ColumnarMode::FromMouse => Some(ColumnarSelectionState::FromMouse {
+                selection_tail: selection_anchor,
+                display_point: if reset {
+                    if position.column() != goal_column {
+                        Some(DisplayPoint::new(position.row(), goal_column))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                },
+            }),
+            ColumnarMode::FromSelection => Some(ColumnarSelectionState::FromSelection {
+                selection_tail: selection_anchor,
+            }),
+        };
 
         if !reset {
-            self.columnar_display_point = None;
-            self.select_columns(
-                tail.to_display_point(&display_map),
-                position,
-                goal_column,
-                &display_map,
-                window,
-                cx,
-            );
+            self.select_columns(position, goal_column, &display_map, window, cx);
         }
     }
 
@@ -3434,11 +3439,8 @@ impl Editor {
     ) {
         let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
 
-        if let Some(tail) = self.columnar_selection_tail.as_ref() {
-            let tail = self
-                .columnar_display_point
-                .unwrap_or_else(|| tail.to_display_point(&display_map));
-            self.select_columns(tail, position, goal_column, &display_map, window, cx);
+        if self.columnar_selection_state.is_some() {
+            self.select_columns(position, goal_column, &display_map, window, cx);
         } else if let Some(mut pending) = self.selections.pending_anchor() {
             let buffer = self.buffer.read(cx).snapshot(cx);
             let head;
@@ -3525,7 +3527,7 @@ impl Editor {
     }
 
     fn end_selection(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        self.columnar_selection_tail.take();
+        self.columnar_selection_state.take();
         if self.selections.pending_anchor().is_some() {
             let selections = self.selections.all::<usize>(cx);
             self.change_selections(None, window, cx, |s| {
@@ -3537,13 +3539,26 @@ impl Editor {
 
     fn select_columns(
         &mut self,
-        tail: DisplayPoint,
         head: DisplayPoint,
         goal_column: u32,
         display_map: &DisplaySnapshot,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        let Some(columnar_state) = self.columnar_selection_state.as_ref() else {
+            return;
+        };
+
+        let tail = match columnar_state {
+            ColumnarSelectionState::FromMouse {
+                selection_tail,
+                display_point,
+            } => display_point.unwrap_or_else(|| selection_tail.to_display_point(&display_map)),
+            ColumnarSelectionState::FromSelection { selection_tail } => {
+                selection_tail.to_display_point(&display_map)
+            }
+        };
+
         let start_row = cmp::min(tail.row(), head.row());
         let end_row = cmp::max(tail.row(), head.row());
         let start_column = cmp::min(tail.column(), goal_column);
@@ -3553,7 +3568,7 @@ impl Editor {
         let selection_ranges = (start_row.0..=end_row.0)
             .map(DisplayRow)
             .filter_map(|row| {
-                if (matches!(self.columnar_mode, Some(ColumnarMode::FromMouse))
+                if (matches!(columnar_state, ColumnarSelectionState::FromMouse { .. })
                     || start_column <= display_map.line_len(row))
                     && !display_map.is_block_line(row)
                 {
@@ -3574,8 +3589,8 @@ impl Editor {
             })
             .collect::<Vec<_>>();
 
-        let ranges = match self.columnar_mode {
-            Some(ColumnarMode::FromMouse) => {
+        let ranges = match columnar_state {
+            ColumnarSelectionState::FromMouse { .. } => {
                 let mut non_empty_ranges = selection_ranges
                     .iter()
                     .filter(|selection_range| selection_range.start != selection_range.end)
@@ -3609,11 +3624,11 @@ impl Editor {
         };
 
         pending_nonempty_selection
-            || (self.columnar_selection_tail.is_some() && self.selections.disjoint.len() > 1)
+            || (self.columnar_selection_state.is_some() && self.selections.disjoint.len() > 1)
     }
 
     pub fn has_pending_selection(&self) -> bool {
-        self.selections.pending_anchor().is_some() || self.columnar_selection_tail.is_some()
+        self.selections.pending_anchor().is_some() || self.columnar_selection_state.is_some()
     }
 
     pub fn cancel(&mut self, _: &Cancel, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -728,7 +728,7 @@ impl EditorElement {
             editor.select(
                 SelectPhase::Begin {
                     position,
-                    add: Editor::multi_cursor_modifier(false, &modifiers, cx),
+                    add: Editor::multi_cursor_modifier(true, &modifiers, cx),
                     click_count,
                 },
                 window,


### PR DESCRIPTION
Closes #32584

In https://github.com/zed-industries/zed/pull/31888, we changed the default `opt + shift` behavior to start columnar selection from the mouse position (Sublime-like behavior) instead of from the existing selection head (VSCode-like behavior).

It turns out there is a use case for creating columnar selection from an existing selection head as well, such as creating a consecutive multi-cursor from existing selection head with just a click instead of dragging.

This PR brings back columnar selection from the selection head via `opt + shift`, while retaining columnar selection from the mouse position, which is now mapped to the new `cmd + shift` binding.

Note: If you like to swap the binding, you can use [existing multi cursor modifier setting](https://zed.dev/docs/configuring-zed?highlight=multi_cursor_modifier#multi-cursor-modifier).

Release Notes:

- Added `cmd + shift` to start columnar selection from the mouse position.
- Restored `opt + shift` to create columnar selection (or consecutive multi-cursor on click) from the selection head.

