### PR TITLE
X11: Fix handling of key remapping

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -891,6 +891,12 @@ impl X11Client {
                     locked_layout,
                 };
                 state.xkb = xkb_state;
+                if let Some(mut callback) = state.common.callbacks.keyboard_layout_change.take() {
+                    drop(state);
+                    callback();
+                    state = self.0.borrow_mut();
+                    state.common.callbacks.keyboard_layout_change = Some(callback);
+                }
             }
             Event::XkbStateNotify(event) => {
                 let mut state = self.0.borrow_mut();

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -349,13 +349,21 @@ impl X11Client {
         let events = xkb::EventType::STATE_NOTIFY
             | xkb::EventType::MAP_NOTIFY
             | xkb::EventType::NEW_KEYBOARD_NOTIFY;
+        let map_notify_parts = xkb::MapPart::KEY_TYPES
+            | xkb::MapPart::KEY_SYMS
+            | xkb::MapPart::MODIFIER_MAP
+            | xkb::MapPart::EXPLICIT_COMPONENTS
+            | xkb::MapPart::KEY_ACTIONS
+            | xkb::MapPart::KEY_BEHAVIORS
+            | xkb::MapPart::VIRTUAL_MODS
+            | xkb::MapPart::VIRTUAL_MOD_MAP;
         xcb_connection
             .xkb_select_events(
                 xkb::ID::USE_CORE_KBD.into(),
                 0u8.into(),
                 events,
-                0u8.into(),
-                0u8.into(),
+                map_notify_parts,
+                map_notify_parts,
                 &xkb::SelectEventsAux::new(),
             )
             .unwrap();


### PR DESCRIPTION
Closes #27384

I wrote #32771 before seeing #27384, and hoped that change would fix it.  It didn't because `XkbSelectNotify` wants a mask of which types of `XkbMapNotify` to deliver, and otherwise won't send them.

I noticed quite a few events are sent just for remapping a single keycode, so I updated the event loop to deduplicate these events (since the handler does not attempt to apply them and instead just re-queries keyboard info).

Also adds a missing call of `keyboard_layout_change` on `XkbMapNotify` and `XkbNewKeyboardNotify`.

Release Notes:

- x11: Fixed handling of key remapping occurring while Zed is running (e.g. xmodmap)