### PR TITLE
Do not report same project type multiple times for same worktree

### DIFF
--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -345,7 +345,7 @@ impl Telemetry {
         }
     }
 
-    pub fn report_discovered_project_events(
+    pub fn report_discovered_project_type_events(
         self: &Arc<Self>,
         worktree_id: WorktreeId,
         updated_entries_set: &UpdatedEntriesSet,

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -757,8 +757,8 @@ mod tests {
         test_project_discovery_helper(telemetry.clone(), vec!["file.vbproj"], vec!["dotnet"], 5);
         test_project_discovery_helper(telemetry.clone(), vec!["file.sln"], vec!["dotnet"], 6);
 
-        // Ensure we only detect the project type once in the presence of
-        // multiple files associated with that project type
+        // Each worktree should only send a single project type event, even when
+        // encountering multiple files associated with that project type
         test_project_discovery_helper(
             telemetry,
             vec!["global.json", "Directory.Build.props"],

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -46,7 +46,7 @@ struct TelemetryState {
     first_event_date_time: Option<Instant>,
     event_coalescer: EventCoalescer,
     max_queue_size: usize,
-    worktree_ids_reported: HashSet<WorktreeId>,
+    worktrees_with_events_sent: HashSet<WorktreeId>,
 
     os_name: String,
     app_version: String,
@@ -181,7 +181,7 @@ impl Telemetry {
             first_event_date_time: None,
             event_coalescer: EventCoalescer::new(clock.clone()),
             max_queue_size: MAX_QUEUE_LEN,
-            worktree_ids_reported: HashSet::new(),
+            worktrees_with_events_sent: HashSet::new(),
 
             os_version: None,
             os_name: os_name(),
@@ -365,7 +365,7 @@ impl Telemetry {
         let mut state = self.state.lock();
         let mut project_names = Vec::new();
 
-        if state.worktree_ids_reported.contains(&worktree_id) {
+        if state.worktrees_with_events_sent.contains(&worktree_id) {
             return project_names;
         }
 
@@ -386,7 +386,7 @@ impl Telemetry {
         }
 
         if !project_names.is_empty() {
-            state.worktree_ids_reported.insert(worktree_id);
+            state.worktrees_with_events_sent.insert(worktree_id);
         }
 
         project_names

--- a/crates/client/src/telemetry.rs
+++ b/crates/client/src/telemetry.rs
@@ -46,7 +46,7 @@ struct TelemetryState {
     first_event_date_time: Option<Instant>,
     event_coalescer: EventCoalescer,
     max_queue_size: usize,
-    worktrees_with_events_sent: HashSet<WorktreeId>,
+    worktrees_with_project_type_events_sent: HashSet<WorktreeId>,
 
     os_name: String,
     app_version: String,
@@ -181,7 +181,7 @@ impl Telemetry {
             first_event_date_time: None,
             event_coalescer: EventCoalescer::new(clock.clone()),
             max_queue_size: MAX_QUEUE_LEN,
-            worktrees_with_events_sent: HashSet::new(),
+            worktrees_with_project_type_events_sent: HashSet::new(),
 
             os_version: None,
             os_name: os_name(),
@@ -365,7 +365,10 @@ impl Telemetry {
         let mut state = self.state.lock();
         let mut project_names: HashSet<String> = HashSet::new();
 
-        if state.worktrees_with_events_sent.contains(&worktree_id) {
+        if state
+            .worktrees_with_project_type_events_sent
+            .contains(&worktree_id)
+        {
             return project_names.into_iter().collect();
         }
 
@@ -386,7 +389,9 @@ impl Telemetry {
         }
 
         if !project_names.is_empty() {
-            state.worktrees_with_events_sent.insert(worktree_id);
+            state
+                .worktrees_with_project_type_events_sent
+                .insert(worktree_id);
         }
 
         let mut project_names_vec: Vec<String> = project_names.into_iter().collect();

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2945,7 +2945,7 @@ impl Project {
             WorktreeStoreEvent::WorktreeUpdatedEntries(worktree_id, changes) => {
                 self.client()
                     .telemetry()
-                    .report_discovered_project_events(*worktree_id, changes);
+                    .report_discovered_project_type_events(*worktree_id, changes);
                 cx.emit(Event::WorktreeUpdatedEntries(*worktree_id, changes.clone()))
             }
             WorktreeStoreEvent::WorktreeDeletedEntry(worktree_id, id) => {


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/32769

Now that the project type identification telemetry can look for multiple files in order to identify the project type, we need to make sure we still only send a single event for a given worktree.

Also, simplifies project detection telemetry code

Release Notes:

- N/A
