### PR TITLE
editor: Ensure mouse cursor is shown again on mouse move

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2289,27 +2289,24 @@ impl Editor {
     }
 
     fn show_mouse_cursor(&mut self, cx: &mut Context<Self>) {
-        self.set_hide_mouse_cursor(false, cx)
+        if self.mouse_cursor_hidden {
+            self.mouse_cursor_hidden = false;
+            cx.notify();
+        }
     }
 
     pub fn hide_mouse_cursor(&mut self, origin: HideMouseCursorOrigin, cx: &mut Context<Self>) {
-        self.set_hide_mouse_cursor(
-            match origin {
-                HideMouseCursorOrigin::TypingAction => {
-                    matches!(
-                        self.hide_mouse_mode,
-                        HideMouseMode::OnTyping | HideMouseMode::OnTypingAndMovement
-                    )
-                }
-                HideMouseCursorOrigin::MovementAction => {
-                    matches!(self.hide_mouse_mode, HideMouseMode::OnTypingAndMovement)
-                }
-            },
-            cx,
-        );
-    }
-
-    fn set_hide_mouse_cursor(&mut self, hide_mouse_cursor: bool, cx: &mut Context<Self>) {
+        let hide_mouse_cursor = match origin {
+            HideMouseCursorOrigin::TypingAction => {
+                matches!(
+                    self.hide_mouse_mode,
+                    HideMouseMode::OnTyping | HideMouseMode::OnTypingAndMovement
+                )
+            }
+            HideMouseCursorOrigin::MovementAction => {
+                matches!(self.hide_mouse_mode, HideMouseMode::OnTypingAndMovement)
+            }
+        };
         if self.mouse_cursor_hidden != hide_mouse_cursor {
             self.mouse_cursor_hidden = hide_mouse_cursor;
             cx.notify();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -328,7 +328,6 @@ enum DisplayDiffHunk {
     },
 }
 
-#[derive(Copy, Clone)]
 pub enum HideMouseCursorOrigin {
     TypingAction,
     MovementAction,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1081,7 +1081,7 @@ impl EditorElement {
         let text_hovered = text_hitbox.is_hovered(window);
         let gutter_hovered = gutter_hitbox.is_hovered(window);
         editor.set_gutter_hovered(gutter_hovered, cx);
-        editor.mouse_cursor_hidden = false;
+        editor.show_mouse_cursor(cx);
 
         let point_for_position = position_map.point_for_position(event.position);
         let valid_point = point_for_position.previous_valid;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -790,8 +790,8 @@ impl Vim {
         if let Some(action) = keystroke_event.action.as_ref() {
             // Keystroke is handled by the vim system, so continue forward
             if action.name().starts_with("vim::") {
-                self.update_editor(window, cx, |_, editor, _, _| {
-                    editor.hide_mouse_cursor(&HideMouseCursorOrigin::MovementAction)
+                self.update_editor(window, cx, |_, editor, _, cx| {
+                    editor.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx)
                 });
                 return;
             }


### PR DESCRIPTION
Closes #32787
Follow-up to #27519 and #32408 

This PR fixes an issue where the mouse cursor would stay hidden after typing in the editor.

Before #32408, we would rerender the editor on every mouse move. Now, we (correctly) only do this if a rerender is actually required. This caused a small regression for hiding the mouse cursor though: Due to the view now being cached, we do not neccessarily update the mouse cursor style so it is shown again. The boolean is updated but the view is not, resulting in the cursor style being kept until another action is performed. This is an issue with both Stable and Preview (due to some other changes, the issue is slightly worse on Preview though, see https://github.com/zed-industries/zed/pull/32596#issuecomment-2969258800 and https://github.com/zed-industries/zed/pull/32596#issuecomment-2969357248 for some more context).

This PR ensures that the cursor is shown again by scheduling a redraw of the editor whenever the boolean is updated.

The change should not cause any performance regressions: In most cases where we want to hide the mouse, the editor is about to be rerendered anyway, hence this would not change anything. For cases where we want to show the cursor again, this ensures that we actually end up doing so by rerendering the editor once.

Release Notes:

- Fixed an issue where the mouse cursor would sometimes stay hidden after typing in editors with the `hide_mouse` setting enabled.
