### PR TITLE
editor: Fix code action not visible until mouse move or buffer interaction

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -5890,13 +5890,13 @@ impl Editor {
                         scroll_handle: UniformListScrollHandle::default(),
                         deployed_from,
                     }));
+                cx.notify();
                 if spawn_straight_away {
                     if let Some(task) = editor.confirm_code_action(
                         &ConfirmCodeAction { item_ix: Some(0) },
                         window,
                         cx,
                     ) {
-                        cx.notify();
                         return task;
                     }
                 }


### PR DESCRIPTION
Closes #32796

Regressed since https://github.com/zed-industries/zed/pull/32408. Fixed in same way as other related PRs https://github.com/zed-industries/zed/pull/32683, https://github.com/zed-industries/zed/pull/32692, https://github.com/zed-industries/zed/pull/32795.

Release Notes:

- Fixed issue where code actions are not visible until the mouse is moved when the `cursor_blink` setting is `false`.
