### PR TITLE
inline assistant: Do not dismiss while generating when hitting enter

### DIFF
--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -765,9 +765,6 @@ impl InlineAssistant {
             PromptEditorEvent::CancelRequested => {
                 self.finish_assist(assist_id, true, window, cx);
             }
-            PromptEditorEvent::DismissRequested => {
-                self.dismiss_assist(assist_id, window, cx);
-            }
             PromptEditorEvent::Resized { .. } => {
                 // This only matters for the terminal inline assistant
             }

--- a/crates/agent/src/inline_prompt_editor.rs
+++ b/crates/agent/src/inline_prompt_editor.rs
@@ -403,9 +403,7 @@ impl<T: 'static> PromptEditor<T> {
             CodegenStatus::Idle => {
                 cx.emit(PromptEditorEvent::StartRequested);
             }
-            CodegenStatus::Pending => {
-                cx.emit(PromptEditorEvent::DismissRequested);
-            }
+            CodegenStatus::Pending => {}
             CodegenStatus::Done => {
                 if self.edited_since_done {
                     cx.emit(PromptEditorEvent::StartRequested);
@@ -831,7 +829,6 @@ pub enum PromptEditorEvent {
     StopRequested,
     ConfirmRequested { execute: bool },
     CancelRequested,
-    DismissRequested,
     Resized { height_in_lines: u8 },
 }
 

--- a/crates/agent/src/terminal_inline_assistant.rs
+++ b/crates/agent/src/terminal_inline_assistant.rs
@@ -167,9 +167,6 @@ impl TerminalInlineAssistant {
             PromptEditorEvent::CancelRequested => {
                 self.finish_assist(assist_id, true, false, window, cx);
             }
-            PromptEditorEvent::DismissRequested => {
-                self.dismiss_assist(assist_id, window, cx);
-            }
             PromptEditorEvent::Resized { height_in_lines } => {
                 self.insert_prompt_editor_into_terminal(assist_id, *height_in_lines, window, cx);
             }


### PR DESCRIPTION
Closes #32798

Release Notes:

- Fixed an issue where the inline assistant would be dismissed when hitting enter while generating code