### PR TITLE
assistant_tools: Enable diff-fenced edit parser for all Gemini models

### DIFF
--- a/crates/assistant_tools/src/edit_agent/edit_parser.rs
+++ b/crates/assistant_tools/src/edit_agent/edit_parser.rs
@@ -75,7 +75,7 @@ impl FromStr for EditFormat {
 impl EditFormat {
     /// Return an optimal edit format for the language model
     pub fn from_model(model: Arc<dyn LanguageModel>) -> anyhow::Result<Self> {
-        if model.provider_id().0 == "google" {
+        if model.provider_id().0 == "google" || model.id().0.to_lowercase().contains("gemini") {
             Ok(EditFormat::DiffFenced)
         } else {
             Ok(EditFormat::XmlTags)


### PR DESCRIPTION
I saw recently we added diff-fenced edit parser which improves the overall edit performance of gemini models in this PR: #32737. The idea is to enable it to all the models which has gemini as their id as this will help copilot and openrouter provider as they seem to aggregate all these models under one umbrella. I thought about adding a new method in LanguageModel as vendor_name() which returns the underlying actual model provider name but felt like a too early abstraction for a method to be used at one place.

cc @osyvokon 

Release Notes:

- N/A
