### PR TITLE
Don't spawn Anthropic telemetry event when API key is missing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8944,6 +8944,7 @@ dependencies = [
  "http_client",
  "icons",
  "image",
+ "log",
  "parking_lot",
  "proto",
  "schemars",

--- a/crates/language_model/Cargo.toml
+++ b/crates/language_model/Cargo.toml
@@ -26,6 +26,7 @@ gpui.workspace = true
 http_client.workspace = true
 icons.workspace = true
 image.workspace = true
+log.workspace = true
 parking_lot.workspace = true
 proto.workspace = true
 schemars.workspace = true


### PR DESCRIPTION
Minor refactor that I'm extracting from a branch because it can stand alone.

- Now we no longer spawn an executor for `report_anthropic_event` if it's just going to immediately fail due to API key being missing
- `report_anthropic_event` now takes a `String` API key instead of `Option<String>` and the error reporting if the key is missing has been moved to the caller.
- `report_anthropic_event` is longer coupled to `AnthropicError`, because all it ever did was generate an `AnthropicEvent::Other`, which in turn was then only used for `log_err` - so, can just be an `anyhow::Result`.

Release Notes:

- N/A
