### PR TITLE
debugger: Process ANSI color escape codes in console

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,6 +4265,7 @@ dependencies = [
 name = "debugger_ui"
 version = "0.1.0"
 dependencies = [
+ "alacritty_terminal",
  "anyhow",
  "client",
  "collections",

--- a/crates/agent/src/inline_assistant.rs
+++ b/crates/agent/src/inline_assistant.rs
@@ -1353,11 +1353,18 @@ impl InlineAssistant {
                 editor.clear_highlights::<InlineAssist>(cx);
             } else {
                 editor.highlight_text::<InlineAssist>(
-                    foreground_ranges,
-                    HighlightStyle {
-                        fade_out: Some(0.6),
-                        ..Default::default()
-                    },
+                    foreground_ranges
+                        .into_iter()
+                        .map(|range| {
+                            (
+                                range,
+                                HighlightStyle {
+                                    fade_out: Some(0.6),
+                                    ..Default::default()
+                                },
+                            )
+                        })
+                        .collect(),
                     cx,
                 );
             }

--- a/crates/collab_ui/src/chat_panel/message_editor.rs
+++ b/crates/collab_ui/src/chat_panel/message_editor.rs
@@ -193,10 +193,10 @@ impl MessageEditor {
             let highlights = editor.text_highlights::<Self>(cx);
             let text = editor.text(cx);
             let snapshot = editor.buffer().read(cx).snapshot(cx);
-            let mentions = if let Some((_, ranges)) = highlights {
+            let mentions = if let Some(ranges) = highlights {
                 ranges
                     .iter()
-                    .map(|range| range.to_offset(&snapshot))
+                    .map(|(range, _)| range.to_offset(&snapshot))
                     .zip(self.mentions.iter().copied())
                     .collect()
             } else {
@@ -483,20 +483,19 @@ impl MessageEditor {
                             let end = multi_buffer.anchor_after(range.end);
 
                             mentioned_user_ids.push(user.id);
-                            anchor_ranges.push(start..end);
+                            anchor_ranges.push((
+                                start..end,
+                                HighlightStyle {
+                                    font_weight: Some(FontWeight::BOLD),
+                                    ..Default::default()
+                                },
+                            ));
                         }
                     }
                 }
 
                 editor.clear_highlights::<Self>(cx);
-                editor.highlight_text::<Self>(
-                    anchor_ranges,
-                    HighlightStyle {
-                        font_weight: Some(FontWeight::BOLD),
-                        ..Default::default()
-                    },
-                    cx,
-                )
+                editor.highlight_text::<Self>(anchor_ranges, cx)
             });
 
             this.mentions = mentioned_user_ids;

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -26,6 +26,7 @@ test-support = [
 ]
 
 [dependencies]
+alacritty_terminal.workspace = true
 anyhow.workspace = true
 client.workspace = true
 collections.workspace = true

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -522,6 +522,12 @@ impl ansi::Handler for ConsoleHandler {
         self.pos += 1;
     }
 
+    fn put_tab(&mut self, count: u16) {
+        self.output
+            .extend(std::iter::repeat('\t').take(count as usize));
+        self.pos += count as usize;
+    }
+
     fn terminal_attribute(&mut self, attr: ansi::Attr) {
         match attr {
             ansi::Attr::Foreground(color) => {

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -6,11 +6,13 @@ use alacritty_terminal::vte::ansi;
 use anyhow::Result;
 use collections::HashMap;
 use dap::OutputEvent;
-use editor::{Bias, CompletionProvider, Editor, EditorElement, EditorStyle, ExcerptId};
+use editor::{
+    BackgroundHighlight, Bias, CompletionProvider, Editor, EditorElement, EditorStyle, ExcerptId,
+};
 use fuzzy::StringMatchCandidate;
 use gpui::{
-    Context, Entity, FocusHandle, Focusable, HighlightStyle, Render, Subscription, Task, TextStyle,
-    WeakEntity,
+    Context, Entity, FocusHandle, Focusable, HighlightStyle, Hsla, Render, Subscription, Task,
+    TextStyle, WeakEntity,
 };
 use language::{Buffer, CodeLabel, ToOffset};
 use menu::Confirm;
@@ -20,7 +22,7 @@ use project::{
 };
 use settings::Settings;
 use std::{cell::RefCell, ops::Range, rc::Rc, usize};
-use theme::ThemeSettings;
+use theme::{Theme, ThemeSettings};
 use ui::{Divider, prelude::*};
 
 pub struct Console {
@@ -153,12 +155,20 @@ impl Console {
             .advance(&mut self.ansi_handler, to_insert.as_bytes());
         let output = std::mem::take(&mut self.ansi_handler.output);
         let mut spans = std::mem::take(&mut self.ansi_handler.spans);
+        let mut background_spans = std::mem::take(&mut self.ansi_handler.background_spans);
         if self.ansi_handler.current_range_start < len + output.len() {
             spans.push((
                 self.ansi_handler.current_range_start..len + output.len(),
                 self.ansi_handler.current_color,
             ));
             self.ansi_handler.current_range_start = len + output.len();
+        }
+        if self.ansi_handler.current_background_range_start < len + output.len() {
+            background_spans.push((
+                self.ansi_handler.current_background_range_start..len + output.len(),
+                self.ansi_handler.current_background_color,
+            ));
+            self.ansi_handler.current_background_range_start = len + output.len();
         }
 
         self.console.update(cx, |console, cx| {
@@ -167,8 +177,8 @@ impl Console {
             console.set_read_only(false);
             console.move_to_end(&editor::actions::MoveToEnd, window, cx);
             console.insert(&output, window, cx);
-
             let buffer = console.buffer().read(cx).snapshot(cx);
+
             let mut highlights = console
                 .remove_text_highlights::<ConsoleAnsiHighlight>(cx)
                 .unwrap_or_default();
@@ -187,6 +197,130 @@ impl Console {
                 highlights.push((range, style));
             }
             console.highlight_text::<ConsoleAnsiHighlight>(highlights, cx);
+
+            let mut background_highlights = console
+                .clear_background_highlights::<ConsoleAnsiHighlight>(cx)
+                .unwrap_or_default();
+            for (range, color) in background_spans {
+                let Some(color) = color else { continue };
+                let start = range.start + len;
+                let range = start..range.end + len;
+                let range = buffer.anchor_after(range.start)..buffer.anchor_before(range.end);
+
+                let color_fetcher: fn(&Theme) -> Hsla = match color {
+                    // Named and theme defined colors
+                    ansi::Color::Named(n) => match n {
+                        ansi::NamedColor::Black => |theme| theme.colors().terminal_ansi_black,
+                        ansi::NamedColor::Red => |theme| theme.colors().terminal_ansi_red,
+                        ansi::NamedColor::Green => |theme| theme.colors().terminal_ansi_green,
+                        ansi::NamedColor::Yellow => |theme| theme.colors().terminal_ansi_yellow,
+                        ansi::NamedColor::Blue => |theme| theme.colors().terminal_ansi_blue,
+                        ansi::NamedColor::Magenta => |theme| theme.colors().terminal_ansi_magenta,
+                        ansi::NamedColor::Cyan => |theme| theme.colors().terminal_ansi_cyan,
+                        ansi::NamedColor::White => |theme| theme.colors().terminal_ansi_white,
+                        ansi::NamedColor::BrightBlack => {
+                            |theme| theme.colors().terminal_ansi_bright_black
+                        }
+                        ansi::NamedColor::BrightRed => {
+                            |theme| theme.colors().terminal_ansi_bright_red
+                        }
+                        ansi::NamedColor::BrightGreen => {
+                            |theme| theme.colors().terminal_ansi_bright_green
+                        }
+                        ansi::NamedColor::BrightYellow => {
+                            |theme| theme.colors().terminal_ansi_bright_yellow
+                        }
+                        ansi::NamedColor::BrightBlue => {
+                            |theme| theme.colors().terminal_ansi_bright_blue
+                        }
+                        ansi::NamedColor::BrightMagenta => {
+                            |theme| theme.colors().terminal_ansi_bright_magenta
+                        }
+                        ansi::NamedColor::BrightCyan => {
+                            |theme| theme.colors().terminal_ansi_bright_cyan
+                        }
+                        ansi::NamedColor::BrightWhite => {
+                            |theme| theme.colors().terminal_ansi_bright_white
+                        }
+                        ansi::NamedColor::Foreground => |theme| theme.colors().terminal_foreground,
+                        ansi::NamedColor::Background => |theme| theme.colors().terminal_background,
+                        ansi::NamedColor::Cursor => |theme| theme.players().local().cursor,
+                        ansi::NamedColor::DimBlack => {
+                            |theme| theme.colors().terminal_ansi_dim_black
+                        }
+                        ansi::NamedColor::DimRed => |theme| theme.colors().terminal_ansi_dim_red,
+                        ansi::NamedColor::DimGreen => {
+                            |theme| theme.colors().terminal_ansi_dim_green
+                        }
+                        ansi::NamedColor::DimYellow => {
+                            |theme| theme.colors().terminal_ansi_dim_yellow
+                        }
+                        ansi::NamedColor::DimBlue => |theme| theme.colors().terminal_ansi_dim_blue,
+                        ansi::NamedColor::DimMagenta => {
+                            |theme| theme.colors().terminal_ansi_dim_magenta
+                        }
+                        ansi::NamedColor::DimCyan => |theme| theme.colors().terminal_ansi_dim_cyan,
+                        ansi::NamedColor::DimWhite => {
+                            |theme| theme.colors().terminal_ansi_dim_white
+                        }
+                        ansi::NamedColor::BrightForeground => {
+                            |theme| theme.colors().terminal_bright_foreground
+                        }
+                        ansi::NamedColor::DimForeground => {
+                            |theme| theme.colors().terminal_dim_foreground
+                        }
+                    },
+                    // 'True' colors
+                    ansi::Color::Spec(_) => |theme| theme.colors().editor_background,
+                    // 8 bit, indexed colors
+                    ansi::Color::Indexed(i) => {
+                        match i {
+                            // 0-15 are the same as the named colors above
+                            0 => |theme| theme.colors().terminal_ansi_black,
+                            1 => |theme| theme.colors().terminal_ansi_red,
+                            2 => |theme| theme.colors().terminal_ansi_green,
+                            3 => |theme| theme.colors().terminal_ansi_yellow,
+                            4 => |theme| theme.colors().terminal_ansi_blue,
+                            5 => |theme| theme.colors().terminal_ansi_magenta,
+                            6 => |theme| theme.colors().terminal_ansi_cyan,
+                            7 => |theme| theme.colors().terminal_ansi_white,
+                            8 => |theme| theme.colors().terminal_ansi_bright_black,
+                            9 => |theme| theme.colors().terminal_ansi_bright_red,
+                            10 => |theme| theme.colors().terminal_ansi_bright_green,
+                            11 => |theme| theme.colors().terminal_ansi_bright_yellow,
+                            12 => |theme| theme.colors().terminal_ansi_bright_blue,
+                            13 => |theme| theme.colors().terminal_ansi_bright_magenta,
+                            14 => |theme| theme.colors().terminal_ansi_bright_cyan,
+                            15 => |theme| theme.colors().terminal_ansi_bright_white,
+                            // 16-231 are a 6x6x6 RGB color cube, mapped to 0-255 using steps defined by XTerm.
+                            // See: https://github.com/xterm-x11/xterm-snapshots/blob/master/256colres.pl
+                            // 16..=231 => {
+                            //     let (r, g, b) = rgb_for_index(index as u8);
+                            //     rgba_color(
+                            //         if r == 0 { 0 } else { r * 40 + 55 },
+                            //         if g == 0 { 0 } else { g * 40 + 55 },
+                            //         if b == 0 { 0 } else { b * 40 + 55 },
+                            //     )
+                            // }
+                            // 232-255 are a 24-step grayscale ramp from (8, 8, 8) to (238, 238, 238).
+                            // 232..=255 => {
+                            //     let i = index as u8 - 232; // Align index to 0..24
+                            //     let value = i * 10 + 8;
+                            //     rgba_color(value, value, value)
+                            // }
+                            // For compatibility with the alacritty::Colors interface
+                            // See: https://github.com/alacritty/alacritty/blob/master/alacritty_terminal/src/term/color.rs
+                            _ => |_| gpui::black(),
+                        }
+                    }
+                };
+
+                background_highlights.push(BackgroundHighlight {
+                    range,
+                    color_fetcher,
+                });
+            }
+            console.highlight_background_ranges::<ConsoleAnsiHighlight>(background_highlights, cx);
 
             console.set_read_only(true);
 
@@ -506,8 +640,11 @@ impl ConsoleQueryBarCompletionProvider {
 struct ConsoleHandler {
     output: String,
     spans: Vec<(Range<usize>, Option<ansi::Color>)>,
+    background_spans: Vec<(Range<usize>, Option<ansi::Color>)>,
     current_range_start: usize,
+    current_background_range_start: usize,
     current_color: Option<ansi::Color>,
+    current_background_color: Option<ansi::Color>,
     pos: usize,
 }
 
@@ -538,11 +675,15 @@ impl ansi::Handler for ConsoleHandler {
                 self.current_color = Some(color);
                 self.current_range_start = self.pos;
             }
-            // FIXME
-            ansi::Attr::Background(_color) => {}
+            ansi::Attr::Background(color) => {
+                self.background_spans.push((
+                    self.current_background_range_start..self.output.len(),
+                    self.current_background_color,
+                ));
+                self.current_background_color = Some(color);
+                self.current_background_range_start = self.pos;
+            }
             _ => {}
         }
     }
-
-    // FIXME other methods may be important
 }

--- a/crates/debugger_ui/src/tests/console.rs
+++ b/crates/debugger_ui/src/tests/console.rs
@@ -110,7 +110,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
     client
         .fake_event(dap::messages::Events::Output(dap::OutputEvent {
             category: Some(dap::OutputEventCategory::Stdout),
-            output: "Second output line after thread stopped!".to_string(),
+            output: "\tSecond output line after thread stopped!".to_string(),
             data: None,
             variables_reference: None,
             source: None,
@@ -124,7 +124,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
     client
         .fake_event(dap::messages::Events::Output(dap::OutputEvent {
             category: Some(dap::OutputEventCategory::Console),
-            output: "Second console output line after thread stopped!".to_string(),
+            output: "\tSecond console output line after thread stopped!".to_string(),
             data: None,
             variables_reference: None,
             source: None,
@@ -150,7 +150,7 @@ async fn test_handle_output_event(executor: BackgroundExecutor, cx: &mut TestApp
                 .unwrap();
 
             assert_eq!(
-                "First console output line before thread stopped!\nFirst output line before thread stopped!\nSecond output line after thread stopped!\nSecond console output line after thread stopped!\n",
+                "First console output line before thread stopped!\nFirst output line before thread stopped!\n\tSecond output line after thread stopped!\n\tSecond console output line after thread stopped!\n",
                 active_session_panel.read(cx).running_state().read(cx).console().read(cx).editor().read(cx).text(cx).as_str()
             );
         })

--- a/crates/editor/src/display_map/custom_highlights.rs
+++ b/crates/editor/src/display_map/custom_highlights.rs
@@ -12,6 +12,8 @@ use std::{
 };
 use sum_tree::TreeMap;
 
+use crate::display_map::TextHighlights;
+
 pub struct CustomHighlightsChunks<'a> {
     buffer_chunks: MultiBufferChunks<'a>,
     buffer_chunk: Option<Chunk<'a>>,
@@ -20,7 +22,7 @@ pub struct CustomHighlightsChunks<'a> {
 
     highlight_endpoints: Peekable<vec::IntoIter<HighlightEndpoint>>,
     active_highlights: BTreeMap<TypeId, HighlightStyle>,
-    text_highlights: Option<&'a TreeMap<TypeId, Arc<(HighlightStyle, Vec<Range<Anchor>>)>>>,
+    text_highlights: Option<&'a TextHighlights>,
 }
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
@@ -35,7 +37,7 @@ impl<'a> CustomHighlightsChunks<'a> {
     pub fn new(
         range: Range<usize>,
         language_aware: bool,
-        text_highlights: Option<&'a TreeMap<TypeId, Arc<(HighlightStyle, Vec<Range<Anchor>>)>>>,
+        text_highlights: Option<&'a TextHighlights>,
         multibuffer_snapshot: &'a MultiBufferSnapshot,
     ) -> Self {
         Self {
@@ -66,7 +68,7 @@ impl<'a> CustomHighlightsChunks<'a> {
 
 fn create_highlight_endpoints(
     range: &Range<usize>,
-    text_highlights: Option<&TreeMap<TypeId, Arc<(HighlightStyle, Vec<Range<Anchor>>)>>>,
+    text_highlights: Option<&TextHighlights>,
     buffer: &MultiBufferSnapshot,
 ) -> iter::Peekable<vec::IntoIter<HighlightEndpoint>> {
     let mut highlight_endpoints = Vec::new();
@@ -74,10 +76,7 @@ fn create_highlight_endpoints(
         let start = buffer.anchor_after(range.start);
         let end = buffer.anchor_after(range.end);
         for (&tag, text_highlights) in text_highlights.iter() {
-            let style = text_highlights.0;
-            let ranges = &text_highlights.1;
-
-            let start_ix = match ranges.binary_search_by(|probe| {
+            let start_ix = match text_highlights.binary_search_by(|(probe, _)| {
                 let cmp = probe.end.cmp(&start, &buffer);
                 if cmp.is_gt() {
                     cmp::Ordering::Greater
@@ -88,7 +87,7 @@ fn create_highlight_endpoints(
                 Ok(i) | Err(i) => i,
             };
 
-            for range in &ranges[start_ix..] {
+            for (range, style) in &text_highlights[start_ix..] {
                 if range.start.cmp(&end, &buffer).is_ge() {
                     break;
                 }
@@ -97,13 +96,13 @@ fn create_highlight_endpoints(
                     offset: range.start.to_offset(&buffer),
                     is_start: true,
                     tag,
-                    style,
+                    style: *style,
                 });
                 highlight_endpoints.push(HighlightEndpoint {
                     offset: range.end.to_offset(&buffer),
                     is_start: false,
                     tag,
-                    style,
+                    style: *style,
                 });
             }
         }

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1593,16 +1593,16 @@ mod tests {
             log::info!("highlighting text ranges {text_highlight_ranges:?}");
             text_highlights.insert(
                 TypeId::of::<()>(),
-                Arc::new((
-                    HighlightStyle::default(),
-                    text_highlight_ranges
-                        .into_iter()
-                        .map(|range| {
+                text_highlight_ranges
+                    .into_iter()
+                    .map(|range| {
+                        (
                             buffer_snapshot.anchor_before(range.start)
-                                ..buffer_snapshot.anchor_after(range.end)
-                        })
-                        .collect(),
-                )),
+                                ..buffer_snapshot.anchor_after(range.end),
+                            HighlightStyle::default(),
+                        )
+                    })
+                    .collect(),
             );
 
             let mut inlay_highlights = InlayHighlights::default();

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1085,7 +1085,7 @@ mod tests {
     use project::{InlayHint, InlayHintLabel, ResolveState};
     use rand::prelude::*;
     use settings::SettingsStore;
-    use std::{any::TypeId, cmp::Reverse, env, sync::Arc};
+    use std::{any::TypeId, cmp::Reverse, env};
     use sum_tree::TreeMap;
     use text::Patch;
     use util::post_inc;

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -19392,8 +19392,10 @@ async fn test_folding_buffer_when_multibuffer_has_only_one_excerpt(cx: &mut Test
         let multi_buffer_snapshot = editor.buffer().read(cx).snapshot(cx);
         let highlight_range = selection_range.clone().to_anchors(&multi_buffer_snapshot);
         editor.highlight_text::<TestHighlight>(
-            vec![highlight_range.clone()],
-            HighlightStyle::color(Hsla::green()),
+            vec![(
+                highlight_range.clone(),
+                HighlightStyle::color(Hsla::green()),
+            )],
             cx,
         );
         editor.change_selections(None, window, cx, |s| s.select_ranges(Some(highlight_range)));

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13697,7 +13697,7 @@ fn test_highlighted_ranges(cx: &mut TestAppContext) {
         let mut highlighted_ranges = editor.background_highlights_in_range(
             anchor_range(Point::new(3, 4)..Point::new(7, 4)),
             &snapshot,
-            cx.theme().colors(),
+            cx.theme(),
         );
         // Enforce a consistent ordering based on color without relying on the ordering of the
         // highlight's `TypeId` which is non-executor.
@@ -13727,7 +13727,7 @@ fn test_highlighted_ranges(cx: &mut TestAppContext) {
             editor.background_highlights_in_range(
                 anchor_range(Point::new(5, 6)..Point::new(6, 4)),
                 &snapshot,
-                cx.theme().colors(),
+                cx.theme(),
             ),
             &[(
                 DisplayPoint::new(DisplayRow(6), 3)..DisplayPoint::new(DisplayRow(6), 5),
@@ -20336,7 +20336,7 @@ async fn test_rename_with_duplicate_edits(cx: &mut TestAppContext) {
         let highlight_range = highlight_range.to_anchors(&editor.buffer().read(cx).snapshot(cx));
         editor.highlight_background::<DocumentHighlightRead>(
             &[highlight_range],
-            |c| c.editor_document_highlight_read_background,
+            |c| c.colors().editor_document_highlight_read_background,
             cx,
         );
     });
@@ -20414,7 +20414,7 @@ async fn test_rename_without_prepare(cx: &mut TestAppContext) {
         let highlight_range = highlight_range.to_anchors(&editor.buffer().read(cx).snapshot(cx));
         editor.highlight_background::<DocumentHighlightRead>(
             &[highlight_range],
-            |c| c.editor_document_highlight_read_background,
+            |c| c.colors().editor_document_highlight_read_background,
             cx,
         );
     });

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6101,7 +6101,7 @@ impl EditorElement {
                                 );
                             }
 
-                            for (background_highlight_id, (_, background_ranges)) in
+                            for (background_highlight_id, background_highlights) in
                                 background_highlights.iter()
                             {
                                 let is_search_highlights = *background_highlight_id
@@ -6120,18 +6120,22 @@ impl EditorElement {
                                     if is_symbol_occurrences {
                                         color.fade_out(0.5);
                                     }
-                                    let marker_row_ranges = background_ranges.iter().map(|range| {
-                                        let display_start = range
-                                            .start
-                                            .to_display_point(&snapshot.display_snapshot);
-                                        let display_end =
-                                            range.end.to_display_point(&snapshot.display_snapshot);
-                                        ColoredRange {
-                                            start: display_start.row(),
-                                            end: display_end.row(),
-                                            color,
-                                        }
-                                    });
+                                    let marker_row_ranges =
+                                        background_highlights.iter().map(|highlight| {
+                                            let display_start = highlight
+                                                .range
+                                                .start
+                                                .to_display_point(&snapshot.display_snapshot);
+                                            let display_end = highlight
+                                                .range
+                                                .end
+                                                .to_display_point(&snapshot.display_snapshot);
+                                            ColoredRange {
+                                                start: display_start.row(),
+                                                end: display_end.row(),
+                                                color,
+                                            }
+                                        });
                                     marker_quads.extend(
                                         scrollbar_layout
                                             .marker_quads_for_ranges(marker_row_ranges, Some(1)),
@@ -8025,7 +8029,7 @@ impl Element for EditorElement {
                             editor.read(cx).background_highlights_in_range(
                                 start_anchor..end_anchor,
                                 &snapshot.display_snapshot,
-                                cx.theme().colors(),
+                                cx.theme(),
                             )
                         })
                         .unwrap_or_default();

--- a/crates/editor/src/highlight_matching_bracket.rs
+++ b/crates/editor/src/highlight_matching_bracket.rs
@@ -35,7 +35,7 @@ pub fn refresh_matching_bracket_highlights(
                 opening_range.to_anchors(&snapshot.buffer_snapshot),
                 closing_range.to_anchors(&snapshot.buffer_snapshot),
             ],
-            |theme| theme.editor_document_highlight_bracket_background,
+            |theme| theme.colors().editor_document_highlight_bracket_background,
             cx,
         )
     }

--- a/crates/editor/src/hover_links.rs
+++ b/crates/editor/src/hover_links.rs
@@ -635,7 +635,7 @@ pub fn show_link_definition(
 
                         match highlight_range {
                             RangeInEditor::Text(text_range) => editor
-                                .highlight_text::<HoveredLinkState>(vec![text_range], style, cx),
+                                .highlight_text::<HoveredLinkState>(vec![(text_range, style)], cx),
                             RangeInEditor::Inlay(highlight) => editor
                                 .highlight_inlays::<HoveredLinkState>(vec![highlight], style, cx),
                         }
@@ -1403,7 +1403,6 @@ mod tests {
                 let snapshot = editor.snapshot(window, cx);
                 let actual_ranges = snapshot
                     .text_highlight_ranges::<HoveredLinkState>()
-                    .map(|ranges| ranges.as_ref().clone().1)
                     .unwrap_or_default();
 
                 assert!(actual_ranges.is_empty(), "When no cmd is pressed, should have no hint label selected, but got: {actual_ranges:?}");
@@ -1635,7 +1634,6 @@ mod tests {
                     .snapshot(window, cx)
                     .text_highlight_ranges::<HoveredLinkState>()
                     .unwrap_or_default()
-                    .1
                     .is_empty()
             );
         });
@@ -1842,7 +1840,6 @@ mod tests {
                     .snapshot(window, cx)
                     .text_highlight_ranges::<HoveredLinkState>()
                     .unwrap_or_default()
-                    .1
                     .is_empty()
             );
         });

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -520,7 +520,7 @@ fn show_hover(
                     // Highlight the selected symbol using a background highlight
                     editor.highlight_background::<HoverState>(
                         &hover_highlights,
-                        |theme| theme.element_hover, // todo update theme
+                        |theme| theme.colors().element_hover, // todo update theme
                         cx,
                     );
                 }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1432,8 +1432,11 @@ impl SearchableItem for Editor {
     fn get_matches(&self, _window: &mut Window, _: &mut App) -> Vec<Range<Anchor>> {
         self.background_highlights
             .get(&TypeId::of::<BufferSearchHighlights>())
-            .map_or(Vec::new(), |(_color, ranges)| {
-                ranges.iter().cloned().collect()
+            .map_or(Vec::new(), |highlights| {
+                highlights
+                    .iter()
+                    .map(|highlight| highlight.range.clone())
+                    .collect()
             })
     }
 
@@ -1452,14 +1455,14 @@ impl SearchableItem for Editor {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let existing_range = self
+        let existing_ranges = self
             .background_highlights
             .get(&TypeId::of::<BufferSearchHighlights>())
-            .map(|(_, range)| range.as_ref());
-        let updated = existing_range != Some(matches);
+            .map(|highlights| highlights.iter().map(|highlight| &highlight.range));
+        let updated = !existing_ranges.is_some_and(|existing_ranges| existing_ranges.eq(matches));
         self.highlight_background::<BufferSearchHighlights>(
             matches,
-            |theme| theme.search_match_background,
+            |theme| theme.colors().search_match_background,
             cx,
         );
         if updated {
@@ -1480,7 +1483,12 @@ impl SearchableItem for Editor {
         if self.has_filtered_search_ranges() {
             self.previous_search_ranges = self
                 .clear_background_highlights::<SearchWithinRange>(cx)
-                .map(|(_, ranges)| ranges)
+                .map(|highlights| {
+                    highlights
+                        .iter()
+                        .map(|highlight| highlight.range.clone())
+                        .collect()
+                })
         }
 
         if !enabled {
@@ -1702,8 +1710,11 @@ impl SearchableItem for Editor {
         let search_within_ranges = self
             .background_highlights
             .get(&TypeId::of::<SearchWithinRange>())
-            .map_or(vec![], |(_color, ranges)| {
-                ranges.iter().cloned().collect::<Vec<_>>()
+            .map_or(vec![], |highlights| {
+                highlights
+                    .iter()
+                    .map(|highlight| highlight.range.clone())
+                    .collect::<Vec<_>>()
             });
 
         cx.background_spawn(async move {

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -510,10 +510,9 @@ impl EditorTestContext {
             editor
                 .background_highlights
                 .get(&TypeId::of::<Tag>())
-                .map(|h| h.1.clone())
-                .unwrap_or_default()
-                .iter()
-                .map(|range| range.to_offset(&snapshot.buffer_snapshot))
+                .into_iter()
+                .flat_map(|highlights| highlights.as_slice())
+                .map(|highlight| highlight.range.to_offset(&snapshot.buffer_snapshot))
                 .collect()
         });
         assert_set_eq!(actual_ranges, expected_ranges);

--- a/crates/editor/src/test/editor_test_context.rs
+++ b/crates/editor/src/test/editor_test_context.rs
@@ -525,7 +525,12 @@ impl EditorTestContext {
         let snapshot = self.update_editor(|editor, window, cx| editor.snapshot(window, cx));
         let actual_ranges: Vec<Range<usize>> = snapshot
             .text_highlight_ranges::<Tag>()
-            .map(|ranges| ranges.as_ref().clone().1)
+            .map(|ranges| {
+                ranges
+                    .iter()
+                    .map(|(range, _)| range.clone())
+                    .collect::<Vec<_>>()
+            })
             .unwrap_or_default()
             .into_iter()
             .map(|range| range.to_offset(&snapshot.buffer_snapshot))

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -358,7 +358,7 @@ impl Render for SyntaxTreeView {
                                                 editor.clear_background_highlights::<Self>( cx);
                                                 editor.highlight_background::<Self>(
                                                     &[range],
-                                                    |theme| theme.editor_document_highlight_write_background,
+                                                    |theme| theme.colors().editor_document_highlight_write_background,
                                                      cx,
                                                 );
                                             });

--- a/crates/project/src/debugger/dap_command.rs
+++ b/crates/project/src/debugger/dap_command.rs
@@ -1547,7 +1547,7 @@ fn dap_client_capabilities(adapter_id: String) -> InitializeRequestArguments {
         supports_memory_event: Some(false),
         supports_args_can_be_interpreted_by_shell: Some(false),
         supports_start_debugging_request: Some(true),
-        supports_ansistyling: Some(false),
+        supports_ansistyling: Some(true),
     }
 }
 

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1377,7 +1377,7 @@ impl ProjectSearchView {
                 }
                 editor.highlight_background::<Self>(
                     &match_ranges,
-                    |theme| theme.search_match_background,
+                    |theme| theme.colors().search_match_background,
                     cx,
                 );
             });

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1346,7 +1346,6 @@ fn to_highlighted_range_lines(
     Some((start_y, highlighted_range_lines))
 }
 
-// FIXME
 /// Converts a 2, 8, or 24 bit color ANSI color to the GPUI equivalent.
 pub fn convert_color(fg: &terminal::alacritty_terminal::vte::ansi::Color, theme: &Theme) -> Hsla {
     let colors = theme.colors();

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1346,6 +1346,7 @@ fn to_highlighted_range_lines(
     Some((start_y, highlighted_range_lines))
 }
 
+// FIXME
 /// Converts a 2, 8, or 24 bit color ANSI color to the GPUI equivalent.
 pub fn convert_color(fg: &terminal::alacritty_terminal::vte::ansi::Color, theme: &Theme) -> Hsla {
     let colors = theme.colors();

--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -222,7 +222,7 @@ impl Vim {
 
         editor.highlight_background::<HighlightOnYank>(
             &ranges_to_highlight,
-            |colors| colors.editor_document_highlight_read_background,
+            |theme| theme.colors().editor_document_highlight_read_background,
             cx,
         );
         cx.spawn(async move |this, cx| {

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -217,8 +217,8 @@ impl Vim {
         window: &mut Window,
         cx: &mut Context<Editor>,
     ) {
-        if let Some((_, ranges)) = editor.clear_background_highlights::<VimExchange>(cx) {
-            let previous_range = ranges[0].clone();
+        if let Some(highlights) = editor.clear_background_highlights::<VimExchange>(cx) {
+            let previous_range = highlights[0].range.clone();
 
             let new_range_start = new_range.start.to_offset(&snapshot.buffer_snapshot);
             let new_range_end = new_range.end.to_offset(&snapshot.buffer_snapshot);
@@ -261,7 +261,7 @@ impl Vim {
             let ranges = [new_range];
             editor.highlight_background::<VimExchange>(
                 &ranges,
-                |theme| theme.editor_document_highlight_read_background,
+                |theme| theme.colors().editor_document_highlight_read_background,
                 cx,
             );
         }

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -864,16 +864,13 @@ async fn test_jk(cx: &mut gpui::TestAppContext) {
 fn assert_pending_input(cx: &mut VimTestContext, expected: &str) {
     cx.update_editor(|editor, window, cx| {
         let snapshot = editor.snapshot(window, cx);
-        let highlights = editor
-            .text_highlights::<editor::PendingInput>(cx)
-            .unwrap()
-            .1;
+        let highlights = editor.text_highlights::<editor::PendingInput>(cx).unwrap();
         let (_, ranges) = marked_text_ranges(expected, false);
 
         assert_eq!(
             highlights
                 .iter()
-                .map(|highlight| highlight.to_offset(&snapshot.buffer_snapshot))
+                .map(|(highlight, _)| highlight.to_offset(&snapshot.buffer_snapshot))
                 .collect::<Vec<_>>(),
             ranges
         )
@@ -923,15 +920,12 @@ async fn test_jk_delay(cx: &mut gpui::TestAppContext) {
     cx.assert_state("ˇjhello", Mode::Insert);
     cx.update_editor(|editor, window, cx| {
         let snapshot = editor.snapshot(window, cx);
-        let highlights = editor
-            .text_highlights::<editor::PendingInput>(cx)
-            .unwrap()
-            .1;
+        let highlights = editor.text_highlights::<editor::PendingInput>(cx).unwrap();
 
         assert_eq!(
             highlights
                 .iter()
-                .map(|highlight| highlight.to_offset(&snapshot.buffer_snapshot))
+                .map(|(highlight, _)| highlight.to_offset(&snapshot.buffer_snapshot))
                 .collect::<Vec<_>>(),
             vec![0..1]
         )


### PR DESCRIPTION
- [x] foreground highlights
- [x] background highlights
- [x] advertise support in DAP capabilities

Closes #31372

Release Notes:

- Debugger Beta: added basic support for highlighting in the console based on ANSI escape codes.