### PR TITLE
agent: Scroll to bottom after submitting a new message

### DIFF
--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -520,9 +520,14 @@ impl AgentPanel {
         });
 
         let message_editor_subscription =
-            cx.subscribe(&message_editor, |_, _, event, cx| match event {
+            cx.subscribe(&message_editor, |this, _, event, cx| match event {
                 MessageEditorEvent::Changed | MessageEditorEvent::EstimatedTokenCount => {
                     cx.notify();
+                }
+                MessageEditorEvent::ScrollThreadToBottom => {
+                    this.thread.update(cx, |thread, cx| {
+                        thread.scroll_to_bottom(cx);
+                    });
                 }
             });
 
@@ -803,9 +808,14 @@ impl AgentPanel {
         self.message_editor.focus_handle(cx).focus(window);
 
         let message_editor_subscription =
-            cx.subscribe(&self.message_editor, |_, _, event, cx| match event {
+            cx.subscribe(&self.message_editor, |this, _, event, cx| match event {
                 MessageEditorEvent::Changed | MessageEditorEvent::EstimatedTokenCount => {
                     cx.notify();
+                }
+                MessageEditorEvent::ScrollThreadToBottom => {
+                    this.thread.update(cx, |thread, cx| {
+                        thread.scroll_to_bottom(cx);
+                    });
                 }
             });
 
@@ -1018,9 +1028,14 @@ impl AgentPanel {
         self.message_editor.focus_handle(cx).focus(window);
 
         let message_editor_subscription =
-            cx.subscribe(&self.message_editor, |_, _, event, cx| match event {
+            cx.subscribe(&self.message_editor, |this, _, event, cx| match event {
                 MessageEditorEvent::Changed | MessageEditorEvent::EstimatedTokenCount => {
                     cx.notify();
+                }
+                MessageEditorEvent::ScrollThreadToBottom => {
+                    this.thread.update(cx, |thread, cx| {
+                        thread.scroll_to_bottom(cx);
+                    });
                 }
             });
 

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -301,6 +301,7 @@ impl MessageEditor {
         self.set_editor_is_expanded(false, cx);
         self.send_to_model(window, cx);
 
+        cx.emit(MessageEditorEvent::ScrollThreadToBottom);
         cx.notify();
     }
 
@@ -906,7 +907,7 @@ impl MessageEditor {
             )
     }
 
-    fn render_changed_buffers(
+    fn render_edits_bar(
         &self,
         changed_buffers: &BTreeMap<Entity<Buffer>, Entity<BufferDiff>>,
         window: &mut Window,
@@ -1510,6 +1511,7 @@ impl EventEmitter<MessageEditorEvent> for MessageEditor {}
 pub enum MessageEditorEvent {
     EstimatedTokenCount,
     Changed,
+    ScrollThreadToBottom,
 }
 
 impl Focusable for MessageEditor {
@@ -1537,7 +1539,7 @@ impl Render for MessageEditor {
         v_flex()
             .size_full()
             .when(changed_buffers.len() > 0, |parent| {
-                parent.child(self.render_changed_buffers(&changed_buffers, window, cx))
+                parent.child(self.render_edits_bar(&changed_buffers, window, cx))
             })
             .child(self.render_editor(window, cx))
             .children({


### PR DESCRIPTION
This is a follow up to my original attempt https://github.com/zed-industries/zed/pull/30878 and to the PR that eventually reverted parts of it because it broke stuff https://github.com/zed-industries/zed/pull/31295. This new approach attaches the `scroll_to_bottom` feature to the `chat` function, which is triggered when the `Chat` action is dispatched by the "send" icon buttons. With that, and from my testing, the thread doesn't forcefully scroll as new messages are added, which was the regression I had introduced.

Release Notes:

- agent: The panel nows scrolls to the bottom after submitting a new message, allowing to see it more easily.
