### PR TITLE
Handle token usage chunks in OpenAI streamed response

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -13,7 +13,7 @@ use language_model::{
     LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
     LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
     LanguageModelToolChoice, LanguageModelToolResultContent, LanguageModelToolUse, MessageContent,
-    RateLimiter, Role, StopReason,
+    RateLimiter, Role, StopReason, TokenUsage,
 };
 use open_ai::{ImageUrl, Model, ResponseStreamEvent, stream_completion};
 use schemars::JsonSchema;
@@ -526,6 +526,15 @@ impl OpenAiEventMapper {
         &mut self,
         event: ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        if let Some(usage) = event.usage {
+            return vec![Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
+                input_tokens: usage.prompt_tokens,
+                output_tokens: usage.completion_tokens,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+            }))];
+        }
+
         let Some(choice) = event.choices.first() else {
             return vec![Err(LanguageModelCompletionError::Other(anyhow!(
                 "Response contained no choices"

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -526,16 +526,16 @@ impl OpenAiEventMapper {
         &mut self,
         event: ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
-        if let Some(usage) = event.usage {
-            return vec![Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
-                input_tokens: usage.prompt_tokens,
-                output_tokens: usage.completion_tokens,
-                cache_creation_input_tokens: 0,
-                cache_read_input_tokens: 0,
-            }))];
-        }
-
         let Some(choice) = event.choices.first() else {
+            if let Some(usage) = event.usage {
+                return vec![Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
+                    input_tokens: usage.prompt_tokens,
+                    output_tokens: usage.completion_tokens,
+                    cache_creation_input_tokens: 0,
+                    cache_read_input_tokens: 0,
+                }))];
+            }
+
             return vec![Err(LanguageModelCompletionError::Other(anyhow!(
                 "Response contained no choices"
             )))];


### PR DESCRIPTION
 This pull request addresses and resolves a case related to issue #28850.

During chat completion requests streamed from OpenAI models hosted on OpenWebUI, the API can add token usage chunks in the response data.

This update modifies the handling of these responses to account for token usage chunks, preventing potential errors when these are encountered.

Release Notes
- Fixed Open Web UI compatibility with Zed when Open Web UI is sending usage stats chuncks in streamed response.