### PR TITLE
debugger: Fix connections over SSH

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -152,8 +152,7 @@ impl DebugAdapterClient {
             arguments: Some(serialized_arguments),
         };
         self.transport_delegate
-            .add_pending_request(sequence_id, callback_tx)
-            .await;
+            .add_pending_request(sequence_id, callback_tx);
 
         log::debug!(
             "Client {} send `{}` request with sequence_id: {}",

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -46,7 +46,6 @@ impl DebugAdapterClient {
         cx: &mut AsyncApp,
     ) -> Result<Self> {
         let transport_delegate = TransportDelegate::start(&binary, cx).await?;
-        // start handling events/reverse requests
         let this = Self {
             id,
             binary,
@@ -58,8 +57,9 @@ impl DebugAdapterClient {
         Ok(this)
     }
 
-    pub fn can_reconnect(&self) -> bool {
+    pub fn should_reconnect_for_ssh(&self) -> bool {
         self.transport_delegate.tcp_arguments().is_some()
+            && self.binary.command.as_deref() == Some("ssh")
     }
 
     pub async fn connect(

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -8,8 +8,7 @@ use dap_types::{
     requests::Request,
 };
 use futures::channel::oneshot;
-use gpui::{AppContext, AsyncApp};
-use smol::channel::{Receiver, Sender};
+use gpui::{AppContext, AsyncApp, Task};
 use std::{
     hash::Hash,
     sync::atomic::{AtomicU64, Ordering},
@@ -35,6 +34,7 @@ pub struct DebugAdapterClient {
     sequence_count: AtomicU64,
     binary: DebugAdapterBinary,
     transport_delegate: TransportDelegate,
+    connection_task: Option<Task<()>>,
 }
 
 pub type DapMessageHandler = Box<dyn FnMut(Message) + 'static + Send + Sync>;
@@ -44,97 +44,57 @@ impl DebugAdapterClient {
         id: SessionId,
         binary: DebugAdapterBinary,
         message_handler: DapMessageHandler,
-        cx: AsyncApp,
+        cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let ((server_rx, server_tx), transport_delegate) =
-            TransportDelegate::start(&binary, cx.clone()).await?;
-        let this = Self {
+        let transport_delegate = TransportDelegate::start(&binary, cx).await?;
+        // start handling events/reverse requests
+        let mut this = Self {
             id,
             binary,
             transport_delegate,
             sequence_count: AtomicU64::new(1),
+            connection_task: None,
         };
-        log::info!("Successfully connected to debug adapter");
-
-        let client_id = this.id;
-
-        // start handling events/reverse requests
-        cx.background_spawn(Self::handle_receive_messages(
-            client_id,
-            server_rx,
-            server_tx.clone(),
-            message_handler,
-        ))
-        .detach();
+        this.reconnect(message_handler, cx).await?;
 
         Ok(this)
     }
 
     pub async fn reconnect(
         &self,
+        mut message_handler: DapMessageHandler,
+        cx: &mut AsyncApp,
+    ) -> Result<()> {
+        self.transport_delegate.connect(cx, message_handler).await?;
+        let (server_rx, _) = self.transport_delegate.reconnect(cx).await?;
+        self.connection_task = Some(cx.background_spawn(async move {
+            while let Ok(message) = server_rx.recv().await {
+                message_handler(message)
+            }
+        }));
+        Ok(())
+    }
+
+    pub async fn create_child_connection(
+        &self,
         session_id: SessionId,
         binary: DebugAdapterBinary,
-        message_handler: DapMessageHandler,
-        cx: AsyncApp,
+        cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let binary = match self.transport_delegate.transport() {
-            crate::transport::Transport::Tcp(tcp_transport) => DebugAdapterBinary {
-                command: binary.command,
-                arguments: binary.arguments,
-                envs: binary.envs,
-                cwd: binary.cwd,
-                connection: Some(crate::adapters::TcpArguments {
-                    host: tcp_transport.host,
-                    port: tcp_transport.port,
-                    timeout: Some(tcp_transport.timeout),
-                }),
+        let binary = if let Some(connection) = self.transport_delegate.transport.tcp_arguments() {
+            DebugAdapterBinary {
+                command: None,
+                arguments: Default::default(),
+                envs: Default::default(),
+                cwd: Default::default(),
+                connection: Some(connection),
                 request_args: binary.request_args,
-            },
-            _ => self.binary.clone(),
+            }
+        } else {
+            self.binary.clone()
         };
 
         Self::start(session_id, binary, message_handler, cx).await
-    }
-
-    async fn handle_receive_messages(
-        client_id: SessionId,
-        server_rx: Receiver<Message>,
-        client_tx: Sender<Message>,
-        mut message_handler: DapMessageHandler,
-    ) -> Result<()> {
-        let result = loop {
-            let message = match server_rx.recv().await {
-                Ok(message) => message,
-                Err(e) => break Err(e.into()),
-            };
-            match message {
-                Message::Event(ev) => {
-                    log::debug!("Client {} received event `{}`", client_id.0, &ev);
-
-                    message_handler(Message::Event(ev))
-                }
-                Message::Request(req) => {
-                    log::debug!(
-                        "Client {} received reverse request `{}`",
-                        client_id.0,
-                        &req.command
-                    );
-
-                    message_handler(Message::Request(req))
-                }
-                Message::Response(response) => {
-                    log::debug!("Received response after request timeout: {:#?}", response);
-                }
-            }
-
-            smol::future::yield_now().await;
-        };
-
-        drop(client_tx);
-
-        log::debug!("Handle receive messages dropped");
-
-        result
     }
 
     /// Send a request to an adapter and get a response back
@@ -229,7 +189,7 @@ impl DebugAdapterClient {
             + Send
             + FnMut(u64, R::Arguments) -> Result<R::Response, dap_types::ErrorResponse>,
     {
-        let transport = self.transport_delegate.transport().as_fake();
+        let transport = self.transport_delegate.transport.as_fake();
         transport.on_request::<R, F>(handler);
     }
 
@@ -249,7 +209,7 @@ impl DebugAdapterClient {
     where
         F: 'static + Send + Fn(Response),
     {
-        let transport = self.transport_delegate.transport().as_fake();
+        let transport = self.transport_delegate.transport.as_fake();
         transport.on_response::<R, F>(handler).await;
     }
 
@@ -307,7 +267,7 @@ mod tests {
                 },
             },
             Box::new(|_| panic!("Did not expect to hit this code path")),
-            cx.to_async(),
+            &mut cx.to_async(),
         )
         .await
         .unwrap();
@@ -389,7 +349,7 @@ mod tests {
                     );
                 }
             }),
-            cx.to_async(),
+            &mut cx.to_async(),
         )
         .await
         .unwrap();

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -29,6 +29,7 @@ use dap::{
     StartDebuggingRequestArgumentsRequest,
 };
 use futures::SinkExt;
+use futures::channel::mpsc::UnboundedSender;
 use futures::channel::{mpsc, oneshot};
 use futures::{FutureExt, future::Shared};
 use gpui::{
@@ -139,6 +140,7 @@ pub struct RunningMode {
     executor: BackgroundExecutor,
     is_started: bool,
     has_ever_stopped: bool,
+    messages_tx: UnboundedSender<Message>,
 }
 
 fn client_source(abs_path: &Path) -> dap::Source {
@@ -163,34 +165,36 @@ impl RunningMode {
         worktree: WeakEntity<Worktree>,
         binary: DebugAdapterBinary,
         messages_tx: futures::channel::mpsc::UnboundedSender<Message>,
-        cx: AsyncApp,
+        cx: &mut AsyncApp,
     ) -> Result<Self> {
-        let message_handler = Box::new(move |message| {
-            messages_tx.unbounded_send(message).ok();
+        let message_handler = Box::new({
+            let messages_tx = messages_tx.clone();
+            move |message| {
+                messages_tx.unbounded_send(message).ok();
+            }
         });
 
-        let client = Arc::new(
-            if let Some(client) = parent_session
-                .and_then(|session| cx.update(|cx| session.read(cx).adapter_client()).ok())
-                .flatten()
-            {
-                client
-                    .reconnect(session_id, binary.clone(), message_handler, cx.clone())
-                    .await?
-            } else {
-                DebugAdapterClient::start(session_id, binary.clone(), message_handler, cx.clone())
-                    .await?
-            },
-        );
+        let mut client = if let Some(client) = parent_session
+            .and_then(|session| cx.update(|cx| session.read(cx).adapter_client()).ok())
+            .flatten()
+        {
+            client
+                .create_child_connection(session_id, binary.clone(), cx)
+                .await?
+        } else {
+            DebugAdapterClient::start(session_id, binary.clone(), cx).await?
+        };
+        client.connect(message_handler, cx).await?;
 
         Ok(Self {
-            client,
+            client: Arc::new(client),
             worktree,
             tmp_breakpoint: None,
             binary,
             executor: cx.background_executor().clone(),
             is_started: false,
             has_ever_stopped: false,
+            messages_tx,
         })
     }
 
@@ -477,6 +481,18 @@ impl RunningMode {
             .ok();
 
             result?;
+            anyhow::Ok(())
+        })
+    }
+
+    fn reconnect(&self, cx: &mut AsyncApp) -> Task<Result<()>> {
+        let client = self.client.clone();
+        let messages_tx = self.messages_tx.clone();
+        let message_handler = Box::new(move |message| {
+            messages_tx.unbounded_send(message).ok();
+        });
+        cx.spawn(async move |cx| {
+            client.connect(message_handler, cx).await?;
             anyhow::Ok(())
         })
     }
@@ -855,7 +871,7 @@ impl Session {
                 worktree.downgrade(),
                 binary.clone(),
                 message_tx,
-                cx.clone(),
+                cx,
             )
             .await?;
             this.update(cx, |this, cx| {
@@ -1133,27 +1149,37 @@ impl Session {
         let request = Initialize { adapter_id };
         match &self.mode {
             Mode::Running(local_mode) => {
-                let capabilities = local_mode.request(request);
+                let mut response = local_mode.request(request.clone());
 
                 cx.spawn(async move |this, cx| {
-                    let capabilities = capabilities.await?;
-                    this.update(cx, |session, cx| {
-                        session.capabilities = capabilities;
-                        let filters = session
-                            .capabilities
-                            .exception_breakpoint_filters
-                            .clone()
-                            .unwrap_or_default();
-                        for filter in filters {
-                            let default = filter.default.unwrap_or_default();
-                            session
-                                .exception_breakpoints
-                                .entry(filter.filter.clone())
-                                .or_insert_with(|| (filter, default));
+                    loop {
+                        let capabilities = response.await;
+                        match capabilities {
+                            Err(e) => {
+                                local_mode.reconnect(cx).await;
+                                response = local_mode.request(request.clone());
+                            }
+                            Ok(capabilities) => {
+                                this.update(cx, |session, cx| {
+                                    session.capabilities = capabilities;
+                                    let filters = session
+                                        .capabilities
+                                        .exception_breakpoint_filters
+                                        .clone()
+                                        .unwrap_or_default();
+                                    for filter in filters {
+                                        let default = filter.default.unwrap_or_default();
+                                        session
+                                            .exception_breakpoints
+                                            .entry(filter.filter.clone())
+                                            .or_insert_with(|| (filter, default));
+                                    }
+                                    cx.emit(SessionEvent::CapabilitiesLoaded);
+                                })?;
+                                return Ok(());
+                            }
                         }
-                        cx.emit(SessionEvent::CapabilitiesLoaded);
-                    })?;
-                    Ok(())
+                    }
                 })
             }
             Mode::Building => Task::ready(Err(anyhow!(


### PR DESCRIPTION
Before this change, we would see "connection reset" when sending the initialize
request over SSH in the case that the debug adapter was slow to boot.

(Although we'd have successfully created a connection to the local SSH port,
trying to read/write from it would not work until the remote end of the
connection had been established)

Fixes  #32575

Release Notes:

- debugger: Fix connecting to a Python debugger over SSH
