### PR TITLE
vim: Implement `[ e` and `] e` from vim-unimpaired

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -56,6 +56,9 @@
       "[ shift-b": ["pane::ActivateItem", 0],
       "] space": "vim::InsertEmptyLineBelow",
       "[ space": "vim::InsertEmptyLineAbove",
+      "[ e": "editor::MoveLineUp",
+      "] e": "editor::MoveLineDown",
+
       // Word motions
       "w": "vim::NextWordStart",
       "e": "vim::NextWordEnd",


### PR DESCRIPTION
From [this discussion](https://github.com/zed-industries/zed/discussions/30757).

The default vim keymap already implements some of [vim-unimpaired keymaps](https://github.com/tpope/vim-unimpaired). I thought I could add this one as well to move lines up and down.

Since the keymaps are in a plugin and not by default in vim, this might be out of the scope. If you feel like this is the case, just close the PR :)


Release Notes:

- vim: Added `[ e` and `] e` key bindings to move lines up and down.
