### PR TITLE
debuggers: Mark processId as optional field in Delve Attach configurations

### DIFF
--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -343,7 +343,7 @@ impl DebugAdapter for GoDebugAdapter {
                         },
                         {
                             "type": "object",
-                            "required": ["processId", "mode"],
+                            "required": ["mode"],
                             "properties": attach_properties
                         }
                     ]


### PR DESCRIPTION
Closes #32849

Release Notes:

- Fixed overly strict validation of Go debugging configurations.
