### PR TITLE
debugger: Prevent port collision when attaching to existing node debugger

### DIFF
--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -96,6 +96,9 @@ impl JsDebugAdapter {
                 .or_insert(delegate.worktree_root_path().to_string_lossy().into());
 
             configuration.entry("type").and_modify(normalize_task_type);
+            configuration
+                .entry("console")
+                .or_insert("externalTerminal".into());
         }
 
         Ok(DebugAdapterBinary {

--- a/crates/task/src/vscode_debug_format.rs
+++ b/crates/task/src/vscode_debug_format.rs
@@ -154,11 +154,7 @@ mod tests {
                     "type": "node",
                     "port": 17,
                 }),
-                tcp_connection: Some(TcpArgumentsTemplate {
-                    port: Some(17),
-                    host: None,
-                    timeout: None,
-                }),
+                tcp_connection: None,
                 build: None
             }])
         );

--- a/crates/task/src/vscode_debug_format.rs
+++ b/crates/task/src/vscode_debug_format.rs
@@ -26,14 +26,14 @@ struct VsCodeDebugTaskDefinition {
 }
 
 impl VsCodeDebugTaskDefinition {
-    fn try_to_zed(self, replacer: &EnvVariableReplacer) -> anyhow::Result<DebugScenario> {
+    fn try_to_zed(mut self, replacer: &EnvVariableReplacer) -> anyhow::Result<DebugScenario> {
         let label = replacer.replace(&self.name);
         let mut config = replacer.replace_value(self.other_attributes);
         let adapter = task_type_to_adapter_name(&self.r#type);
         if let Some(config) = config.as_object_mut() {
             if adapter == "JavaScript" {
                 config.insert("type".to_owned(), self.r#type.clone().into());
-                if let Some(port) = self.port {
+                if let Some(port) = self.port.take() {
                     config.insert("port".to_owned(), port.into());
                 }
             }

--- a/crates/task/src/vscode_debug_format.rs
+++ b/crates/task/src/vscode_debug_format.rs
@@ -103,7 +103,7 @@ fn task_type_to_adapter_name(task_type: &str) -> String {
 mod tests {
     use serde_json::json;
 
-    use crate::{DebugScenario, DebugTaskFile, TcpArgumentsTemplate};
+    use crate::{DebugScenario, DebugTaskFile};
 
     use super::VsCodeDebugTaskFile;
 


### PR DESCRIPTION
We were translating port configuration incorrectly, using it for both attach target and debugger port.
This however meant that we were spawning a 2nd process that'd listen on the same port as the existing debugger.

Closes #32836

Release Notes:

- debugger: Fixed issues with auto-translated Visual Studio Code debug configs for attaching to existing node debugger instances.
