### PR TITLE
agent: Make stalled files notifications permanent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -64,6 +64,7 @@ dependencies = [
  "buffer_diff",
  "chrono",
  "client",
+ "clock",
  "collections",
  "component",
  "context_server",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -33,6 +33,7 @@ collections.workspace = true
 component.workspace = true
 context_server.workspace = true
 convert_case.workspace = true
+clock.workspace = true
 db.workspace = true
 editor.workspace = true
 extension.workspace = true


### PR DESCRIPTION
## Context

_Stalled files_ are files that the user has edited while the agent is running. This only applies to files that have been added to the thread context, either explicitly or when the agent calls `read_file`.

_Stalled files notification_ -- a feature that informs the agent when tracked files have changed.


## History of stalled files notifications

1. Temporary notification at the end of the thread
   - Insert a temporary message at the end of the thread each time a file changes, until the agent re-reads the modified file(s).
   - Pros: The agent is always aware of file changes.
   - Cons: Too distracting for the agent; the notification isn't visible in a serialized  thread.

2. Temporary notification before the last message:
   - Place a temporary notification message close to the most recent activity in the thread, but not at the very end.
   - Pros: Less distracting for the agent.
   - Cons: Hurts prompt caching performance; still not visible in a serialized thread.

3. Permanent notification before the last message (this change):
   - Same as in (2), but make this a permanent message.
   - Pros: Avoids distracting the agent; caching efficiency; notification is visible in a serialized thread.
   - Cons: Consumes a small number of extra tokens.


Release Notes:

- N/A

