### PR TITLE
copilot: Fix config dir logic to support Flatpak environments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,6 +3346,7 @@ dependencies = [
  "collections",
  "command_palette_hooks",
  "ctor",
+ "dirs 4.0.0",
  "editor",
  "fs",
  "futures 0.3.31",

--- a/crates/copilot/Cargo.toml
+++ b/crates/copilot/Cargo.toml
@@ -29,6 +29,7 @@ chrono.workspace = true
 client.workspace = true
 collections.workspace = true
 command_palette_hooks.workspace = true
+dirs.workspace = true
 fs.workspace = true
 futures.workspace = true
 gpui.workspace = true

--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -424,18 +424,12 @@ pub fn copilot_chat_config_dir() -> &'static PathBuf {
     static COPILOT_CHAT_CONFIG_DIR: OnceLock<PathBuf> = OnceLock::new();
 
     COPILOT_CHAT_CONFIG_DIR.get_or_init(|| {
-        let config_dir = if cfg!(any(target_os = "linux", target_os = "freebsd")) {
-            std::env::var("FLATPAK_XDG_CONFIG_HOME")
-                .map(PathBuf::from)
-                .unwrap_or_else(|_| {
-                    dirs::config_dir().expect(
-                        "failed to determine XDG_CONFIG_HOME or FLATPAK_XDG_CONFIG_HOME directory",
-                    )
-                })
-        } else if cfg!(target_os = "windows") {
-            dirs::config_dir().expect("failed to determine RoamingAppData directory")
+        let config_dir = if cfg!(target_os = "windows") {
+            dirs::data_local_dir().expect("failed to determine LocalAppData directory")
         } else {
-            home_dir().join(".config")
+            std::env::var("XDG_CONFIG_HOME")
+                .map(PathBuf::from)
+                .unwrap_or_else(|_| home_dir().join(".config"))
         };
 
         config_dir.join("github-copilot")


### PR DESCRIPTION
Closes #30784

In github copilot we were not handling the config path correctly for FLATPAK.

* Only tested on mac don't have access to other platform. But this should work on other platform as well. It follows the similar pattern seen in zed config path resolution.
- [x] Macos
- [ ] Linux
- [ ] Linux with Flatpak
- [ ] Windows

Release Notes:

- Fix copilot config detection for flatpack
