### PR TITLE
WIP: Add Zed task runnables

### DIFF
--- a/crates/languages/src/json/runnables.scm
+++ b/crates/languages/src/json/runnables.scm
@@ -19,3 +19,14 @@
     (#set! tag package-script)
     (#set! tag composer-script)
 )
+
+; Runnables from our `debug.json` and `tasks.json`
+
+(
+    (document
+        (array
+            (object) @config
+        )
+    )
+    (#set! tag task)
+)


### PR DESCRIPTION
Release Notes:

- Add runnables for Zed custom tasks and debug tasks to launch straight from the `debug.json` or `tasks.json`