### PR TITLE
debugger: Fix a few issues with JS debugging

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -165,6 +165,8 @@ impl PackageJsonData {
                 label: "jest file test".to_owned(),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
                     "jest".to_owned(),
                     "--runInBand".to_owned(),
                     VariableName::File.template_value(),
@@ -176,6 +178,8 @@ impl PackageJsonData {
                 label: format!("jest test {}", VariableName::Symbol.template_value()),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
                     "jest".to_owned(),
                     "--runInBand".to_owned(),
                     "--testNamePattern".to_owned(),
@@ -200,6 +204,8 @@ impl PackageJsonData {
                 label: format!("{} file test", "vitest".to_owned()),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
                     "vitest".to_owned(),
                     "run".to_owned(),
                     "--poolOptions.forks.minForks=0".to_owned(),
@@ -217,6 +223,8 @@ impl PackageJsonData {
                 ),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
                     "vitest".to_owned(),
                     "run".to_owned(),
                     "--poolOptions.forks.minForks=0".to_owned(),
@@ -242,7 +250,12 @@ impl PackageJsonData {
             task_templates.0.push(TaskTemplate {
                 label: format!("{} file test", "mocha".to_owned()),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
-                args: vec!["mocha".to_owned(), VariableName::File.template_value()],
+                args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
+                    "mocha".to_owned(),
+                    VariableName::File.template_value(),
+                ],
                 cwd: Some(TYPESCRIPT_MOCHA_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
@@ -254,6 +267,8 @@ impl PackageJsonData {
                 ),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
                     "mocha".to_owned(),
                     "--grep".to_owned(),
                     format!("\"{}\"", VariableName::Symbol.template_value()),
@@ -273,7 +288,12 @@ impl PackageJsonData {
             task_templates.0.push(TaskTemplate {
                 label: format!("{} file test", "jasmine".to_owned()),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
-                args: vec!["jasmine".to_owned(), VariableName::File.template_value()],
+                args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
+                    "jasmine".to_owned(),
+                    VariableName::File.template_value(),
+                ],
                 cwd: Some(TYPESCRIPT_JASMINE_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
@@ -285,6 +305,8 @@ impl PackageJsonData {
                 ),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
+                    "exec".to_owned(),
+                    "--".to_owned(),
                     "jasmine".to_owned(),
                     format!("--filter={}", VariableName::Symbol.template_value()),
                     VariableName::File.template_value(),

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -164,8 +164,12 @@ impl PackageJsonData {
             task_templates.0.push(TaskTemplate {
                 label: "jest file test".to_owned(),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
-                args: vec!["jest".to_owned(), VariableName::Filename.template_value()],
-                cwd: Some(VariableName::Dirname.template_value()),
+                args: vec![
+                    "jest".to_owned(),
+                    "--runInBand".to_owned(),
+                    VariableName::File.template_value(),
+                ],
+                cwd: Some(TYPESCRIPT_JEST_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
             task_templates.0.push(TaskTemplate {
@@ -173,19 +177,20 @@ impl PackageJsonData {
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
                 args: vec![
                     "jest".to_owned(),
+                    "--runInBand".to_owned(),
                     "--testNamePattern".to_owned(),
                     format!(
                         "\"{}\"",
                         TYPESCRIPT_JEST_TEST_NAME_VARIABLE.template_value()
                     ),
-                    VariableName::Filename.template_value(),
+                    VariableName::File.template_value(),
                 ],
                 tags: vec![
                     "ts-test".to_owned(),
                     "js-test".to_owned(),
                     "tsx-test".to_owned(),
                 ],
-                cwd: Some(VariableName::Dirname.template_value()),
+                cwd: Some(TYPESCRIPT_JEST_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
         }
@@ -197,9 +202,11 @@ impl PackageJsonData {
                 args: vec![
                     "vitest".to_owned(),
                     "run".to_owned(),
-                    VariableName::Filename.template_value(),
+                    "--poolOptions.forks.minForks=0".to_owned(),
+                    "--poolOptions.forks.maxForks=1".to_owned(),
+                    VariableName::File.template_value(),
                 ],
-                cwd: Some(VariableName::Dirname.template_value()),
+                cwd: Some(TYPESCRIPT_VITEST_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
             task_templates.0.push(TaskTemplate {
@@ -212,19 +219,21 @@ impl PackageJsonData {
                 args: vec![
                     "vitest".to_owned(),
                     "run".to_owned(),
+                    "--poolOptions.forks.minForks=0".to_owned(),
+                    "--poolOptions.forks.maxForks=1".to_owned(),
                     "--testNamePattern".to_owned(),
                     format!(
                         "\"{}\"",
                         TYPESCRIPT_VITEST_TEST_NAME_VARIABLE.template_value()
                     ),
-                    VariableName::Filename.template_value(),
+                    VariableName::File.template_value(),
                 ],
                 tags: vec![
                     "ts-test".to_owned(),
                     "js-test".to_owned(),
                     "tsx-test".to_owned(),
                 ],
-                cwd: Some(VariableName::Dirname.template_value()),
+                cwd: Some(TYPESCRIPT_VITEST_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
         }
@@ -233,8 +242,8 @@ impl PackageJsonData {
             task_templates.0.push(TaskTemplate {
                 label: format!("{} file test", "mocha".to_owned()),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
-                args: vec!["mocha".to_owned(), VariableName::Filename.template_value()],
-                cwd: Some(VariableName::Dirname.template_value()),
+                args: vec!["mocha".to_owned(), VariableName::File.template_value()],
+                cwd: Some(TYPESCRIPT_MOCHA_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
             task_templates.0.push(TaskTemplate {
@@ -248,14 +257,14 @@ impl PackageJsonData {
                     "mocha".to_owned(),
                     "--grep".to_owned(),
                     format!("\"{}\"", VariableName::Symbol.template_value()),
-                    VariableName::Filename.template_value(),
+                    VariableName::File.template_value(),
                 ],
                 tags: vec![
                     "ts-test".to_owned(),
                     "js-test".to_owned(),
                     "tsx-test".to_owned(),
                 ],
-                cwd: Some(VariableName::Dirname.template_value()),
+                cwd: Some(TYPESCRIPT_MOCHA_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
         }
@@ -264,11 +273,8 @@ impl PackageJsonData {
             task_templates.0.push(TaskTemplate {
                 label: format!("{} file test", "jasmine".to_owned()),
                 command: TYPESCRIPT_RUNNER_VARIABLE.template_value(),
-                args: vec![
-                    "jasmine".to_owned(),
-                    VariableName::Filename.template_value(),
-                ],
-                cwd: Some(VariableName::Dirname.template_value()),
+                args: vec!["jasmine".to_owned(), VariableName::File.template_value()],
+                cwd: Some(TYPESCRIPT_JASMINE_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
             task_templates.0.push(TaskTemplate {
@@ -281,15 +287,14 @@ impl PackageJsonData {
                 args: vec![
                     "jasmine".to_owned(),
                     format!("--filter={}", VariableName::Symbol.template_value()),
-                    VariableName::Filename.template_value(),
+                    VariableName::File.template_value(),
                 ],
                 tags: vec![
                     "ts-test".to_owned(),
                     "js-test".to_owned(),
                     "tsx-test".to_owned(),
-                    "jasmine-test".to_owned(),
                 ],
-                cwd: Some(VariableName::Dirname.template_value()),
+                cwd: Some(TYPESCRIPT_JASMINE_PACKAGE_PATH_VARIABLE.template_value()),
                 ..TaskTemplate::default()
             });
         }

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -1,4 +1,4 @@
-use std::{borrow::Cow, path::PathBuf};
+use std::borrow::Cow;
 
 use anyhow::{Result, bail};
 use async_trait::async_trait;
@@ -32,34 +32,13 @@ impl DapLocator for NodeLocator {
             return None;
         }
 
-        let test_binary_base = match build_config.args.first()?.as_str() {
-            "jest" => Some("${ZED_CUSTOM_TYPESCRIPT_JEST_PACKAGE_PATH}".to_owned()),
-            "mocha" => Some("${ZED_CUSTOM_TYPESCRIPT_MOCHA_PACKAGE_PATH}".to_owned()),
-            "vitest" => Some("${ZED_CUSTOM_TYPESCRIPT_VITEST_PACKAGE_PATH}".to_owned()),
-            "jasmine" => Some("${ZED_CUSTOM_TYPESCRIPT_JASMINE_PACKAGE_PATH}".to_owned()),
-            _ => None,
-        };
-
-        let (runtime_executable, args) = if let Some(test_binary_base) = test_binary_base {
-            (
-                PathBuf::from(test_binary_base)
-                    .join("node_modules")
-                    .join(".bin")
-                    .join(build_config.args.first()?.as_str())
-                    .to_string_lossy()
-                    .to_string(),
-                build_config.args[1..].iter().cloned().collect::<Vec<_>>(),
-            )
-        } else {
-            (build_config.command.clone(), build_config.args.clone())
-        };
-
         let config = serde_json::json!({
             "request": "launch",
             "type": "pwa-node",
-            "args": args,
+            "args": build_config.args.clone(),
             "cwd": build_config.cwd.clone(),
-            "runtimeExecutable": runtime_executable,
+            "runtimeExecutable": build_config.command.clone(),
+            "env": build_config.env.clone(),
             "runtimeArgs": ["--inspect-brk"],
             "console": "integratedTerminal",
         });

--- a/crates/project/src/debugger/locators/node.rs
+++ b/crates/project/src/debugger/locators/node.rs
@@ -60,7 +60,6 @@ impl DapLocator for NodeLocator {
             "args": args,
             "cwd": build_config.cwd.clone(),
             "runtimeExecutable": runtime_executable,
-            // FIXME
             "runtimeArgs": ["--inspect-brk"],
             "console": "integratedTerminal",
         });


### PR DESCRIPTION
- Don't assume all located tasks come from our test runnables
- Run tests from the right working directory
- Scope forking behavior customization for jest and vitest more tightly, to just our test runnables
- Standardize on `$PACKAGE_MANAGER exec -- $TEST_LIBRARY ...` to fix runnables not working with npm

Release Notes:

- Debugger Beta: Fixed issues with debugging tasks from package.json and test runnables.