### PR TITLE
Diff view

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6215,6 +6215,7 @@ dependencies = [
  "ui",
  "unindent",
  "util",
+ "watch",
  "windows 0.61.1",
  "workspace",
  "workspace-hack",

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -1028,7 +1028,11 @@ impl BufferDiff {
         let (base_text_changed, mut changed_range) =
             match (state.base_text_exists, new_state.base_text_exists) {
                 (false, false) => (true, None),
-                (true, true) if state.base_text.remote_id() == new_state.base_text.remote_id() => {
+                (true, true)
+                    if state.base_text.remote_id() == new_state.base_text.remote_id()
+                        && state.base_text.syntax_update_count()
+                            == new_state.base_text.syntax_update_count() =>
+                {
                     (false, new_state.compare(&state, buffer))
                 }
                 _ => (true, Some(text::Anchor::MIN..text::Anchor::MAX)),

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -17,6 +17,7 @@ pub enum CliRequest {
         open_new_workspace: Option<bool>,
         env: Option<HashMap<String, String>>,
         user_data_dir: Option<String>,
+        diff: bool,
     },
 }
 

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -13,11 +13,11 @@ pub enum CliRequest {
     Open {
         paths: Vec<String>,
         urls: Vec<String>,
+        diff_paths: Vec<[String; 2]>,
         wait: bool,
         open_new_workspace: Option<bool>,
         env: Option<HashMap<String, String>>,
         user_data_dir: Option<String>,
-        diff: bool,
     },
 }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -89,6 +89,9 @@ struct Args {
     /// Will attempt to give the correct command to run
     #[arg(long)]
     system_specs: bool,
+    /// Show a diff of the given paths.
+    #[arg(long)]
+    diff: bool,
     /// Uninstall Zed from user system
     #[cfg(all(
         any(target_os = "linux", target_os = "macos"),
@@ -277,6 +280,7 @@ fn main() -> Result<()> {
                 open_new_workspace,
                 env,
                 user_data_dir: user_data_dir_for_thread,
+                diff: args.diff,
             })?;
 
             while let Ok(response) = rx.recv() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -89,9 +89,9 @@ struct Args {
     /// Will attempt to give the correct command to run
     #[arg(long)]
     system_specs: bool,
-    /// Show a diff of the given paths.
-    #[arg(long)]
-    diff: bool,
+    /// Pairs of file paths to diff. Can be specified multiple times.
+    #[arg(long, action = clap::ArgAction::Append, num_args = 2, value_names = ["OLD_PATH", "NEW_PATH"])]
+    diff: Vec<String>,
     /// Uninstall Zed from user system
     #[cfg(all(
         any(target_os = "linux", target_os = "macos"),
@@ -235,8 +235,13 @@ fn main() -> Result<()> {
     let exit_status = Arc::new(Mutex::new(None));
     let mut paths = vec![];
     let mut urls = vec![];
+    let mut diff_paths = vec![];
     let mut stdin_tmp_file: Option<fs::File> = None;
     let mut anonymous_fd_tmp_files = vec![];
+
+    for path in args.diff.chunks(2) {
+        diff_paths.push([path[0].to_owned(), path[1].to_owned()]);
+    }
 
     for path in args.paths_with_position.iter() {
         if path.starts_with("zed://")
@@ -276,11 +281,11 @@ fn main() -> Result<()> {
             tx.send(CliRequest::Open {
                 paths,
                 urls,
+                diff_paths,
                 wait: args.wait,
                 open_new_workspace,
                 env,
                 user_data_dir: user_data_dir_for_thread,
-                diff: args.diff,
             })?;
 
             while let Ok(response) = rx.recv() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -240,7 +240,10 @@ fn main() -> Result<()> {
     let mut anonymous_fd_tmp_files = vec![];
 
     for path in args.diff.chunks(2) {
-        diff_paths.push([path[0].to_owned(), path[1].to_owned()]);
+        diff_paths.push([
+            parse_path_with_position(&path[0])?,
+            parse_path_with_position(&path[1])?,
+        ]);
     }
 
     for path in args.paths_with_position.iter() {

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -57,6 +57,7 @@ time.workspace = true
 time_format.workspace = true
 ui.workspace = true
 util.workspace = true
+watch.workspace = true
 workspace-hack.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true

--- a/crates/git_ui/src/diff_view.rs
+++ b/crates/git_ui/src/diff_view.rs
@@ -14,6 +14,7 @@ use std::{
     any::{Any, TypeId},
     path::PathBuf,
     pin::pin,
+    sync::Arc,
     time::Duration,
 };
 use ui::{Color, Icon, IconName, Label, LabelCommon as _, SharedString};
@@ -95,6 +96,10 @@ impl DiffView {
             editor.start_temporary_diff_override();
             editor.disable_inline_diagnostics();
             editor.set_expand_all_diff_hunks(cx);
+            editor.set_render_diff_hunk_controls(
+                Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),
+                cx,
+            );
             editor
         });
 

--- a/crates/git_ui/src/diff_view.rs
+++ b/crates/git_ui/src/diff_view.rs
@@ -8,12 +8,11 @@ use gpui::{
     AnyElement, AnyView, App, AppContext as _, AsyncApp, Context, Entity, EventEmitter,
     FocusHandle, Focusable, IntoElement, Render, Task, Window,
 };
-use language::{Buffer, Capability, LanguageRegistry, LineEnding};
+use language::Buffer;
 use project::Project;
 use std::{
     any::{Any, TypeId},
     path::PathBuf,
-    sync::Arc,
 };
 use ui::{Color, Icon, IconName, Label, LabelCommon as _, SharedString};
 use workspace::{
@@ -24,40 +23,41 @@ use workspace::{
 
 pub struct DiffView {
     editor: Entity<Editor>,
+    old_buffer: Entity<Buffer>,
     multibuffer: Entity<MultiBuffer>,
 }
 
 impl DiffView {
     pub fn open(
-        old: PathBuf,
-        new: PathBuf,
+        old_path: PathBuf,
+        new_path: PathBuf,
         workspace: &Workspace,
         window: &mut Window,
         cx: &mut App,
     ) -> Task<Result<Entity<Self>>> {
         let workspace = workspace.weak_handle();
         window.spawn(cx, async move |cx| {
-            let (project, language_registry, fs) = workspace.update(cx, |workspace, cx| {
-                (
-                    workspace.project().clone(),
-                    workspace.project().read(cx).languages().clone(),
-                    workspace.app_state().fs.clone(),
-                )
-            })?;
-            let old_text = fs.load(&old).await?;
-            let new_text = fs.load(&new).await?;
-            let buffer = cx.new(|cx| {
-                let mut b = Buffer::local_normalized(old_text.into(), LineEnding::Unix, cx);
-                b.set_capability(Capability::ReadOnly, cx);
-                b
-            })?;
+            let project = workspace.update(cx, |workspace, _| workspace.project().clone())?;
+            let old_buffer = project
+                .update(cx, |project, cx| project.open_local_buffer(&old_path, cx))?
+                .await?;
+            let new_buffer = project
+                .update(cx, |project, cx| project.open_local_buffer(&new_path, cx))?
+                .await?;
 
-            let buffer_diff =
-                build_buffer_diff(Some(new_text), &buffer, &language_registry, cx).await?;
+            let buffer_diff = build_buffer_diff(&old_buffer, &new_buffer, cx).await?;
 
             workspace.update_in(cx, |workspace, window, cx| {
-                let diff_view =
-                    cx.new(|cx| DiffView::new(buffer, buffer_diff, project.clone(), window, cx));
+                let diff_view = cx.new(|cx| {
+                    DiffView::new(
+                        old_buffer,
+                        new_buffer,
+                        buffer_diff,
+                        project.clone(),
+                        window,
+                        cx,
+                    )
+                });
 
                 let pane = workspace.active_pane();
                 pane.update(cx, |pane, cx| {
@@ -70,20 +70,22 @@ impl DiffView {
     }
 
     pub fn new(
-        buffer: Entity<Buffer>,
+        old_buffer: Entity<Buffer>,
+        new_buffer: Entity<Buffer>,
         diff: Entity<BufferDiff>,
         project: Entity<Project>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Self {
         let multibuffer = cx.new(|cx| {
-            let mut mb = MultiBuffer::singleton(buffer, cx);
-            mb.add_diff(diff, cx);
-            mb
+            let mut multibuffer = MultiBuffer::singleton(new_buffer, cx);
+            multibuffer.add_diff(diff, cx);
+            multibuffer
         });
         let editor = cx.new(|cx| {
             let mut editor =
                 Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
+            editor.start_temporary_diff_override();
             editor.disable_inline_diagnostics();
             editor.set_expand_all_diff_hunks(cx);
             editor
@@ -91,48 +93,34 @@ impl DiffView {
 
         Self {
             editor,
+            old_buffer,
             multibuffer,
         }
     }
 }
 
 async fn build_buffer_diff(
-    mut old_text: Option<String>,
-    buffer: &Entity<Buffer>,
-    language_registry: &Arc<LanguageRegistry>,
+    old_buffer: &Entity<Buffer>,
+    new_buffer: &Entity<Buffer>,
     cx: &mut AsyncApp,
 ) -> Result<Entity<BufferDiff>> {
-    if let Some(old_text) = &mut old_text {
-        LineEnding::normalize(old_text);
-    }
-
-    let buffer_snapshot = cx.update(|cx| buffer.read(cx).snapshot())?;
-
-    let base_buffer = cx
-        .update(|cx| {
-            Buffer::build_snapshot(
-                old_text.as_deref().unwrap_or("").into(),
-                buffer_snapshot.language().cloned(),
-                Some(language_registry.clone()),
-                cx,
-            )
-        })?
-        .await;
+    let old_buffer_snapshot = old_buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
+    let new_buffer_snapshot = new_buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
 
     let diff_snapshot = cx
         .update(|cx| {
             BufferDiffSnapshot::new_with_base_buffer(
-                buffer_snapshot.text.clone(),
-                old_text.map(Arc::new),
-                base_buffer,
+                new_buffer_snapshot.text.clone(),
+                Some(old_buffer_snapshot.text().into()),
+                old_buffer_snapshot,
                 cx,
             )
         })?
         .await;
 
     cx.new(|cx| {
-        let mut diff = BufferDiff::new(&buffer_snapshot.text, cx);
-        diff.set_snapshot(diff_snapshot, &buffer_snapshot.text, cx);
+        let mut diff = BufferDiff::new(&new_buffer_snapshot.text, cx);
+        diff.set_snapshot(diff_snapshot, &new_buffer_snapshot.text, cx);
         diff
     })
 }

--- a/crates/git_ui/src/diff_view.rs
+++ b/crates/git_ui/src/diff_view.rs
@@ -361,6 +361,7 @@ mod tests {
     use settings::{Settings, SettingsStore};
     use std::path::PathBuf;
     use unindent::unindent;
+    use util::path;
     use workspace::Workspace;
 
     fn init_test(cx: &mut TestAppContext) {
@@ -381,7 +382,7 @@ mod tests {
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(
-            "/test",
+            path!("/test"),
             serde_json::json!({
                 "old_file.txt": "old line 1\nline 2\nold line 3\nline 4\n",
                 "new_file.txt": "new line 1\nline 2\nnew line 3\nline 4\n"
@@ -397,8 +398,8 @@ mod tests {
         let diff_view = workspace
             .update_in(cx, |workspace, window, cx| {
                 DiffView::open(
-                    PathBuf::from("/test/old_file.txt"),
-                    PathBuf::from("/test/new_file.txt"),
+                    PathBuf::from(path!("/test/old_file.txt")),
+                    PathBuf::from(path!("/test/new_file.txt")),
                     workspace,
                     window,
                     cx,
@@ -425,7 +426,7 @@ mod tests {
 
         // Modify the new file on disk
         fs.save(
-            &PathBuf::from("/test/new_file.txt"),
+            path!("/test/new_file.txt").as_ref(),
             &unindent(
                 "
                 new line 1
@@ -461,7 +462,7 @@ mod tests {
 
         // Modify the old file on disk
         fs.save(
-            &PathBuf::from("/test/old_file.txt"),
+            path!("/test/old_file.txt").as_ref(),
             &unindent(
                 "
                 new line 1

--- a/crates/git_ui/src/diff_view.rs
+++ b/crates/git_ui/src/diff_view.rs
@@ -202,7 +202,7 @@ impl Item for DiffView {
     type Event = EditorEvent;
 
     fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
-        Some(Icon::new(IconName::GitBranch).color(Color::Muted))
+        Some(Icon::new(IconName::Diff).color(Color::Muted))
     }
 
     fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
@@ -242,7 +242,7 @@ impl Item for DiffView {
                 )
             })
             .unwrap_or_else(|| "untitled".into());
-        format!("Diff: {old_filename} | {new_filename}").into() // todo!()
+        format!("{old_filename} ↔ {new_filename}").into()
     }
 
     fn tab_tooltip_text(&self, cx: &App) -> Option<ui::SharedString> {
@@ -258,7 +258,7 @@ impl Item for DiffView {
             .file()
             .map(|file| file.full_path(cx).compact().to_string_lossy().to_string())
             .unwrap_or_else(|| "untitled".into());
-        Some(format!("Diff: {old_path} | {new_path}").into())
+        Some(format!("{old_path} ↔ {new_path}").into())
     }
 
     fn to_item_events(event: &EditorEvent, f: impl FnMut(ItemEvent)) {

--- a/crates/git_ui/src/diff_view.rs
+++ b/crates/git_ui/src/diff_view.rs
@@ -1,0 +1,265 @@
+//! DiffView provides a UI for displaying differences between two buffers.
+
+use anyhow::Result;
+use buffer_diff::{BufferDiff, BufferDiffSnapshot};
+use editor::{Editor, EditorEvent, MultiBuffer};
+
+use gpui::{
+    AnyElement, AnyView, App, AppContext as _, AsyncApp, Context, Entity, EventEmitter,
+    FocusHandle, Focusable, IntoElement, Render, Window,
+};
+use language::{Buffer, Capability, LanguageRegistry, LineEnding};
+use project::Project;
+use std::{
+    any::{Any, TypeId},
+    path::PathBuf,
+    sync::Arc,
+};
+use ui::{Color, Icon, IconName, Label, LabelCommon as _, SharedString};
+use workspace::{
+    Item, ItemHandle as _, ItemNavHistory, ToolbarItemLocation, Workspace,
+    item::{BreadcrumbText, ItemEvent, TabContentParams},
+    searchable::SearchableItemHandle,
+};
+
+pub struct DiffView {
+    editor: Entity<Editor>,
+    multibuffer: Entity<MultiBuffer>,
+}
+
+const FILE_NAMESPACE: u32 = 1;
+
+impl DiffView {
+    pub fn open(
+        old: PathBuf,
+        new: PathBuf,
+        workspace: &Workspace,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        let workspace = workspace.weak_handle();
+        window
+            .spawn(cx, async move |cx| {
+                let (project, language_registry, fs) = workspace.update(cx, |workspace, cx| {
+                    (
+                        workspace.project().clone(),
+                        workspace.project().read(cx).languages().clone(),
+                        workspace.app_state().fs.clone(),
+                    )
+                })?;
+                dbg!("a");
+                let old_text = fs.load(&old).await?;
+                let new_text = fs.load(&new).await?;
+                let buffer = cx.new(|cx| {
+                    let mut b = Buffer::local_normalized(old_text.into(), LineEnding::Unix, cx);
+                    b.set_capability(Capability::ReadOnly, cx);
+                    b
+                })?;
+
+                let buffer_diff =
+                    build_buffer_diff(Some(new_text), &buffer, &language_registry, cx).await?;
+
+                workspace.update_in(cx, |workspace, window, cx| {
+                    let diff_view = cx
+                        .new(|cx| DiffView::new(buffer, buffer_diff, project.clone(), window, cx));
+
+                    let pane = workspace.active_pane();
+                    pane.update(cx, |pane, cx| {
+                        pane.add_item(Box::new(diff_view), true, true, None, window, cx);
+                    })
+                })
+            })
+            .detach_and_log_err(cx);
+    }
+
+    pub fn new(
+        buffer: Entity<Buffer>,
+        diff: Entity<BufferDiff>,
+        project: Entity<Project>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let multibuffer = cx.new(|cx| {
+            let mut mb = MultiBuffer::singleton(buffer, cx);
+            mb.add_diff(diff, cx);
+            mb
+        });
+        let editor = cx.new(|cx| {
+            let mut editor =
+                Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
+            editor.disable_inline_diagnostics();
+            editor.set_expand_all_diff_hunks(cx);
+            editor
+        });
+
+        Self {
+            editor,
+            multibuffer,
+        }
+    }
+}
+
+async fn build_buffer_diff(
+    mut old_text: Option<String>,
+    buffer: &Entity<Buffer>,
+    language_registry: &Arc<LanguageRegistry>,
+    cx: &mut AsyncApp,
+) -> Result<Entity<BufferDiff>> {
+    if let Some(old_text) = &mut old_text {
+        LineEnding::normalize(old_text);
+    }
+
+    let buffer_snapshot = cx.update(|cx| buffer.read(cx).snapshot())?;
+
+    let base_buffer = cx
+        .update(|cx| {
+            Buffer::build_snapshot(
+                old_text.as_deref().unwrap_or("").into(),
+                buffer_snapshot.language().cloned(),
+                Some(language_registry.clone()),
+                cx,
+            )
+        })?
+        .await;
+
+    let diff_snapshot = cx
+        .update(|cx| {
+            BufferDiffSnapshot::new_with_base_buffer(
+                buffer_snapshot.text.clone(),
+                old_text.map(Arc::new),
+                base_buffer,
+                cx,
+            )
+        })?
+        .await;
+
+    cx.new(|cx| {
+        let mut diff = BufferDiff::new(&buffer_snapshot.text, cx);
+        diff.set_snapshot(diff_snapshot, &buffer_snapshot.text, cx);
+        diff
+    })
+}
+
+impl EventEmitter<EditorEvent> for DiffView {}
+
+impl Focusable for DiffView {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.editor.focus_handle(cx)
+    }
+}
+
+impl Item for DiffView {
+    type Event = EditorEvent;
+
+    fn tab_icon(&self, _window: &Window, _cx: &App) -> Option<Icon> {
+        Some(Icon::new(IconName::GitBranch).color(Color::Muted))
+    }
+
+    fn tab_content(&self, params: TabContentParams, _window: &Window, cx: &App) -> AnyElement {
+        Label::new(self.tab_content_text(params.detail.unwrap_or_default(), cx))
+            .color(if params.selected {
+                Color::Default
+            } else {
+                Color::Muted
+            })
+            .into_any_element()
+    }
+
+    fn tab_content_text(&self, _detail: usize, cx: &App) -> SharedString {
+        "Diff".into() // todo!()
+    }
+
+    fn tab_tooltip_text(&self, cx: &App) -> Option<ui::SharedString> {
+        Some("Diff".into()) // todo!()
+    }
+
+    fn to_item_events(event: &EditorEvent, f: impl FnMut(ItemEvent)) {
+        Editor::to_item_events(event, f)
+    }
+
+    fn telemetry_event_text(&self) -> Option<&'static str> {
+        Some("Diff View Opened")
+    }
+
+    fn deactivated(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.editor
+            .update(cx, |editor, cx| editor.deactivated(window, cx));
+    }
+
+    fn is_singleton(&self, _: &App) -> bool {
+        false
+    }
+
+    fn act_as_type<'a>(
+        &'a self,
+        type_id: TypeId,
+        self_handle: &'a Entity<Self>,
+        _: &'a App,
+    ) -> Option<AnyView> {
+        if type_id == TypeId::of::<Self>() {
+            Some(self_handle.to_any())
+        } else if type_id == TypeId::of::<Editor>() {
+            Some(self.editor.to_any())
+        } else {
+            None
+        }
+    }
+
+    fn as_searchable(&self, _: &Entity<Self>) -> Option<Box<dyn SearchableItemHandle>> {
+        Some(Box::new(self.editor.clone()))
+    }
+
+    fn for_each_project_item(
+        &self,
+        cx: &App,
+        f: &mut dyn FnMut(gpui::EntityId, &dyn project::ProjectItem),
+    ) {
+        self.editor.for_each_project_item(cx, f)
+    }
+
+    fn set_nav_history(
+        &mut self,
+        nav_history: ItemNavHistory,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editor.update(cx, |editor, _| {
+            editor.set_nav_history(Some(nav_history));
+        });
+    }
+
+    fn navigate(
+        &mut self,
+        data: Box<dyn Any>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> bool {
+        self.editor
+            .update(cx, |editor, cx| editor.navigate(data, window, cx))
+    }
+
+    fn breadcrumb_location(&self, _: &App) -> ToolbarItemLocation {
+        ToolbarItemLocation::PrimaryLeft
+    }
+
+    fn breadcrumbs(&self, theme: &theme::Theme, cx: &App) -> Option<Vec<BreadcrumbText>> {
+        self.editor.breadcrumbs(theme, cx)
+    }
+
+    fn added_to_workspace(
+        &mut self,
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editor.update(cx, |editor, cx| {
+            editor.added_to_workspace(workspace, window, cx)
+        });
+    }
+}
+
+impl Render for DiffView {
+    fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
+        self.editor.clone()
+    }
+}

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -22,6 +22,7 @@ mod commit_modal;
 pub mod commit_tooltip;
 mod commit_view;
 mod conflict_view;
+pub mod diff_view;
 pub mod git_panel;
 mod git_panel_settings;
 pub mod onboarding;

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4268,6 +4268,11 @@ impl BufferSnapshot {
         self.non_text_state_update_count
     }
 
+    /// An integer version that changes when the buffer's syntax changes.
+    pub fn syntax_update_count(&self) -> usize {
+        self.syntax.update_count()
+    }
+
     /// Returns a snapshot of underlying file.
     pub fn file(&self) -> Option<&Arc<dyn File>> {
         self.file.as_ref()

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -32,6 +32,7 @@ pub struct SyntaxSnapshot {
     parsed_version: clock::Global,
     interpolated_version: clock::Global,
     language_registry_version: usize,
+    update_count: usize,
 }
 
 #[derive(Default)]
@@ -257,7 +258,9 @@ impl SyntaxMap {
     }
 
     pub fn clear(&mut self, text: &BufferSnapshot) {
+        let update_count = self.snapshot.update_count + 1;
         self.snapshot = SyntaxSnapshot::new(text);
+        self.snapshot.update_count = update_count;
     }
 }
 
@@ -268,11 +271,16 @@ impl SyntaxSnapshot {
             parsed_version: clock::Global::default(),
             interpolated_version: clock::Global::default(),
             language_registry_version: 0,
+            update_count: 0,
         }
     }
 
     pub fn is_empty(&self) -> bool {
         self.layers.is_empty()
+    }
+
+    pub fn update_count(&self) -> usize {
+        self.update_count
     }
 
     pub fn interpolate(&mut self, text: &BufferSnapshot) {
@@ -443,6 +451,8 @@ impl SyntaxSnapshot {
                 self.language_registry_version = registry.version();
             }
         }
+
+        self.update_count += 1;
     }
 
     fn reparse_with_ranges(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2439,11 +2439,14 @@ impl Project {
         abs_path: impl AsRef<Path>,
         cx: &mut Context<Self>,
     ) -> Task<Result<Entity<Buffer>>> {
-        if let Some((worktree, relative_path)) = self.find_worktree(abs_path.as_ref(), cx) {
-            self.open_buffer((worktree.read(cx).id(), relative_path), cx)
-        } else {
-            Task::ready(Err(anyhow!("no such path")))
-        }
+        let worktree_task = self.find_or_create_worktree(abs_path.as_ref(), false, cx);
+        cx.spawn(async move |this, cx| {
+            let (worktree, relative_path) = worktree_task.await?;
+            this.update(cx, |this, cx| {
+                this.open_buffer((worktree.read(cx).id(), relative_path), cx)
+            })?
+            .await
+        })
     }
 
     #[cfg(any(test, feature = "test-support"))]

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -176,8 +176,6 @@ pub fn main() {
 
     let args = Args::parse();
 
-    dbg!(&args);
-
     // `zed --askpass` Makes zed operate in nc/netcat mode for use with askpass
     if let Some(socket) = &args.askpass {
         askpass::main(socket);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -570,7 +570,10 @@ fn register_actions(
             window.toggle_fullscreen();
         })
         .register_action(|_, action: &OpenZedUrl, _, cx| {
-            OpenListener::global(cx).open_urls(vec![action.url.clone()])
+            OpenListener::global(cx).open(RawOpenRequest {
+                urls: vec![action.url.clone()],
+                ..Default::default()
+            })
         })
         .register_action(|_, action: &OpenBrowser, _window, cx| cx.open_url(&action.url))
         .register_action(|workspace, _: &workspace::Open, window, cx| {

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -263,7 +263,8 @@ pub async fn handle_cli_connection(
                 wait,
                 open_new_workspace,
                 env,
-                user_data_dir: _, // Ignore user_data_dir
+                user_data_dir: _,
+                diff,
             } => {
                 if !urls.is_empty() {
                     cx.update(|cx| {
@@ -293,6 +294,7 @@ pub async fn handle_cli_connection(
                     wait,
                     app_state.clone(),
                     env,
+                    diff,
                     cx,
                 )
                 .await;
@@ -311,6 +313,7 @@ async fn open_workspaces(
     wait: bool,
     app_state: Arc<AppState>,
     env: Option<collections::HashMap<String, String>>,
+    diff: bool,
     cx: &mut AsyncApp,
 ) -> Result<()> {
     let grouped_locations = if paths.is_empty() {
@@ -367,6 +370,7 @@ async fn open_workspaces(
                         responses,
                         env.as_ref(),
                         &app_state,
+                        diff,
                         cx,
                     )
                     .await;
@@ -416,6 +420,7 @@ async fn open_local_workspace(
     responses: &IpcSender<CliResponse>,
     env: Option<&HashMap<String, String>>,
     app_state: &Arc<AppState>,
+    diff: bool,
     cx: &mut AsyncApp,
 ) -> bool {
     let mut errored = false;
@@ -428,6 +433,7 @@ async fn open_local_workspace(
         workspace::OpenOptions {
             open_new_workspace,
             env: env.cloned(),
+            // diff,
             ..Default::default()
         },
         cx,

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -174,7 +174,10 @@ pub fn listen_for_cli_connections(opener: OpenListener) -> Result<()> {
     thread::spawn(move || {
         let mut buf = [0u8; 1024];
         while let Ok(len) = listener.recv(&mut buf) {
-            opener.open_urls(vec![String::from_utf8_lossy(&buf[..len]).to_string()]);
+            opener.open(RawOpenRequest {
+                urls: vec![String::from_utf8_lossy(&buf[..len]).to_string()],
+                ..Default::default()
+            });
         }
     });
     Ok(())

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -241,14 +241,10 @@ pub async fn open_paths_with_positions(
         .await?;
 
     for diff_pair in diff_paths {
+        let old_path = Path::new(&diff_pair[0]).canonicalize()?;
+        let new_path = Path::new(&diff_pair[1]).canonicalize()?;
         if let Ok(diff_view) = workspace.update(cx, |workspace, window, cx| {
-            DiffView::open(
-                diff_pair[0].clone().into(),
-                diff_pair[1].clone().into(),
-                workspace,
-                window,
-                cx,
-            )
+            DiffView::open(old_path, new_path, workspace, window, cx)
         }) {
             if let Some(diff_view) = diff_view.await.log_err() {
                 items.push(Some(Ok(Box::new(diff_view))))


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/4523

Todo:

* [x] Open diffed files as regular buffers
* [x] Update diff when buffers change
* [x] Show diffed filenames in the tab title
* [x] Investigate why syntax highlighting isn't reliably handled for old text
* [x] remove unstage/restore buttons

Release Notes:

- Adds `zed --diff A B` to show the diff between the two files
