### PR TITLE
debugger: Show child sessions as indented and ensure they're next to the parent session

### DIFF
--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -125,7 +125,7 @@ impl DebugSession {
         &self.running_state
     }
 
-    pub(crate) fn label_element(&self, cx: &App) -> AnyElement {
+    pub(crate) fn label_element(&self, depth: usize, cx: &App) -> AnyElement {
         let label = self.label(cx);
 
         let is_terminated = self
@@ -153,6 +153,7 @@ impl DebugSession {
         };
 
         h_flex()
+            .ml(depth * px(16.0))
             .gap_2()
             .when_some(icon, |this, indicator| this.child(indicator))
             .justify_between()


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- debugger: Tweaked how child sessions are shown in the session list.
