### PR TITLE
zed_extension_api: Release v0.6.0

### DIFF
--- a/crates/extension_api/Cargo.toml
+++ b/crates/extension_api/Cargo.toml
@@ -6,8 +6,7 @@ repository = "https://github.com/zed-industries/zed"
 documentation = "https://docs.rs/zed_extension_api"
 keywords = ["zed", "extension"]
 edition.workspace = true
-# Change back to `true` when we're ready to publish v0.6.0.
-publish = false
+publish = true
 license = "Apache-2.0"
 
 [lints]

--- a/crates/extension_api/README.md
+++ b/crates/extension_api/README.md
@@ -65,6 +65,7 @@ Here is the compatibility of the `zed_extension_api` with versions of Zed:
 
 | Zed version | `zed_extension_api` version |
 | ----------- | --------------------------- |
+| `0.192.x`   | `0.0.1` - `0.6.0`           |
 | `0.186.x`   | `0.0.1` - `0.5.0`           |
 | `0.184.x`   | `0.0.1` - `0.4.0`           |
 | `0.178.x`   | `0.0.1` - `0.3.0`           |

--- a/crates/extension_host/src/wasm_host/wit.rs
+++ b/crates/extension_host/src/wasm_host/wit.rs
@@ -69,7 +69,7 @@ pub fn wasm_api_version_range(release_channel: ReleaseChannel) -> RangeInclusive
 
     let max_version = match release_channel {
         ReleaseChannel::Dev | ReleaseChannel::Nightly => latest::MAX_VERSION,
-        ReleaseChannel::Stable | ReleaseChannel::Preview => since_v0_5_0::MAX_VERSION,
+        ReleaseChannel::Stable | ReleaseChannel::Preview => latest::MAX_VERSION,
     };
 
     since_v0_0_1::MIN_VERSION..=max_version
@@ -121,8 +121,6 @@ impl Extension {
         let _ = release_channel;
 
         if version >= latest::MIN_VERSION {
-            authorize_access_to_unreleased_wasm_api_version(release_channel)?;
-
             let extension =
                 latest::Extension::instantiate_async(store, component, latest::linker(executor))
                     .await

--- a/crates/extension_host/src/wasm_host/wit/since_v0_5_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_5_0.rs
@@ -9,7 +9,6 @@ use wasmtime::component::{Linker, Resource};
 use super::latest;
 
 pub const MIN_VERSION: SemanticVersion = SemanticVersion::new(0, 5, 0);
-pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 5, 0);
 
 wasmtime::component::bindgen!({
     async: true,


### PR DESCRIPTION
This PR releases v0.6.0 of the Zed extension API.

Support for this version of the extension API will land in Zed v0.192.x.

Release Notes:

- N/A
