### PR TITLE
Wait for source maps when setting TypeScript breakpoints

### DIFF
--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -99,6 +99,14 @@ impl JsDebugAdapter {
             configuration
                 .entry("console")
                 .or_insert("externalTerminal".into());
+
+            configuration.entry("sourceMaps").or_insert(true.into());
+            configuration
+                .entry("pauseForSourceMap")
+                .or_insert(true.into());
+            configuration
+                .entry("sourceMapRenames")
+                .or_insert(true.into());
         }
 
         Ok(DebugAdapterBinary {

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -277,6 +277,16 @@ impl DebugAdapter for JsDebugAdapter {
                                     "description": "Use JavaScript source maps if they exist",
                                     "default": true
                                 },
+                                "pauseForSourceMap": {
+                                    "type": "boolean",
+                                    "description": "Wait for source maps to load before setting breakpoints.",
+                                    "default": true
+                                },
+                                "sourceMapRenames": {
+                                    "type": "boolean",
+                                    "description": "Whether to use the \"names\" mapping in sourcemaps.",
+                                    "default": true
+                                },
                                 "sourceMapPathOverrides": {
                                     "type": "object",
                                     "description": "Rewrites the locations of source files from what the sourcemap says to their locations on disk",


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- debugger: Fix setting breakpoints in typescript code when debugging compiled javascript
