### PR TITLE
Fix a bug where --diff wouldn't open the diff

### DIFF
--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -296,7 +296,7 @@ pub async fn handle_cli_connection(
                 env,
                 user_data_dir: _,
             } => {
-                if !urls.is_empty() {
+                if !urls.is_empty() || !diff_paths.is_empty() {
                     cx.update(|cx| {
                         match OpenRequest::parse(RawOpenRequest { urls, diff_paths }, cx) {
                             Ok(open_request) => {


### PR DESCRIPTION
Release Notes:

- Fixed a bug where `zed --diff A B` wouldn't open a diff