### PR TITLE
docs: Fix `lsp.rust-analyzer.binary` config

### DIFF
--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -78,7 +78,7 @@ If you want to disable Zed looking for a `rust-analyzer` binary, you can set `ig
 }
 ```
 
-If you want to use a binary in a custom location, you can specify a `path` and optional `args`:
+If you want to use a binary in a custom location, you can specify a `path` and optional `arguments`:
 
 ```json
 {
@@ -86,7 +86,7 @@ If you want to use a binary in a custom location, you can specify a `path` and o
     "rust-analyzer": {
       "binary": {
         "path": "/Users/example/bin/rust-analyzer",
-        "args": []
+        "arguments": []
       }
     }
   }


### PR DESCRIPTION
Document the `lsp.rust-analyzer.binary.arguments` setting (currently incorrectly referred to as `args`)

Verify: https://github.com/zed-industries/zed/blob/99215f7660a722461792e49cb920bfda5c801286/crates/extension_api/wit/since_v0.1.0/settings.rs#L24-L29

Question: can such inconsistencies be avoided by automatically documenting the config using a preprocessor?

Release Notes:

- N/A