### PR TITLE
agent: Add ability to change the API base URL for OpenAI via the UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9007,6 +9007,7 @@ dependencies = [
  "tiktoken-rs",
  "tokio",
  "ui",
+ "ui_input",
  "util",
  "workspace-hack",
  "zed_llm_client",

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -55,6 +55,7 @@ thiserror.workspace = true
 tiktoken-rs.workspace = true
 tokio = { workspace = true, features = ["rt", "rt-multi-thread"] }
 ui.workspace = true
+ui_input.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
 zed_llm_client.workspace = true

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -802,16 +802,18 @@ impl ConfigurationView {
                         ),
                     ));
                 } else {
-                    settings.openai.as_mut().map(|openai| match openai {
-                        OpenAiSettingsContent::Versioned(versioned) => match versioned {
-                            VersionedOpenAiSettingsContent::V1(v1) => {
-                                v1.api_url = Some(api_url.clone());
+                    if let Some(openai) = settings.openai.as_mut() {
+                        match openai {
+                            OpenAiSettingsContent::Versioned(versioned) => match versioned {
+                                VersionedOpenAiSettingsContent::V1(v1) => {
+                                    v1.api_url = Some(api_url.clone());
+                                }
+                            },
+                            OpenAiSettingsContent::Legacy(legacy) => {
+                                legacy.api_url = Some(api_url.clone());
                             }
-                        },
-                        OpenAiSettingsContent::Legacy(legacy) => {
-                            legacy.api_url = Some(api_url.clone());
                         }
-                    });
+                    }
                 }
             });
         }

--- a/crates/ui_input/src/ui_input.rs
+++ b/crates/ui_input/src/ui_input.rs
@@ -138,18 +138,18 @@ impl Render for SingleLineInput {
             .when_some(self.label.clone(), |this, label| {
                 this.child(
                     Label::new(label)
-                        .size(LabelSize::Default)
+                        .size(LabelSize::Small)
                         .color(if self.disabled {
                             Color::Disabled
                         } else {
-                            Color::Muted
+                            Color::Default
                         }),
                 )
             })
             .child(
                 h_flex()
                     .px_2()
-                    .py_1()
+                    .py_1p5()
                     .bg(style.background_color)
                     .text_color(style.text_color)
                     .rounded_md()


### PR DESCRIPTION
The `api_url` setting is one that most providers already support and can be changed via the `settings.json`. We're adding the ability to change it via the UI for OpenAI specifically so it can be more easily connected to v0.

Release Notes:

- agent: Added ability to change the API base URL for OpenAI via the UI
