### PR TITLE
open_ai: Fix issues with OpenAI compatible APIs

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -527,9 +527,7 @@ impl OpenAiEventMapper {
         event: ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::Other(anyhow!(
-                "Response contained no choices"
-            )))];
+            return Vec::new();
         };
 
         let mut events = Vec::new();

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -385,7 +385,6 @@ pub enum ResponseStreamResult {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResponseStreamEvent {
-    pub created: u32,
     pub model: String,
     pub choices: Vec<ChoiceDelta>,
     pub usage: Option<Usage>,


### PR DESCRIPTION
Ran into this while adding support for Vercel v0s models:
- The timestamp seems to be returned in Milliseconds instead of seconds so it breaks the bounds of `created: u32`. We did not use this field anywhere so just decided to remove it
- Sometimes the `choices` field can be empty when the last chunk comes in because it only contains `usage`

Release Notes:

- N/A
