### PR TITLE
Redact command environment variables from log output

### DIFF
--- a/crates/extension/src/types.rs
+++ b/crates/extension/src/types.rs
@@ -5,6 +5,8 @@ mod slash_command;
 
 use std::ops::Range;
 
+use util::redact::should_redact;
+
 pub use context_server::*;
 pub use dap::*;
 pub use lsp::*;
@@ -14,7 +16,6 @@ pub use slash_command::*;
 pub type EnvVars = Vec<(String, String)>;
 
 /// A command.
-#[derive(Debug)]
 pub struct Command {
     /// The command to execute.
     pub command: String,
@@ -22,6 +23,22 @@ pub struct Command {
     pub args: Vec<String>,
     /// The environment variables to set for the command.
     pub env: EnvVars,
+}
+
+impl std::fmt::Debug for Command {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let filtered_env = self
+            .env
+            .iter()
+            .map(|(k, v)| (k, if should_redact(k) { "[REDACTED]" } else { v }))
+            .collect::<Vec<_>>();
+
+        f.debug_struct("Command")
+            .field("command", &self.command)
+            .field("args", &self.args)
+            .field("env", &filtered_env)
+            .finish()
+    }
 }
 
 /// A label containing some code.

--- a/crates/util/src/redact.rs
+++ b/crates/util/src/redact.rs
@@ -1,0 +1,8 @@
+/// Whether a given environment variable name should have its value redacted
+pub fn should_redact(env_var_name: &str) -> bool {
+    const REDACTED_SUFFIXES: &[&str] =
+        &["KEY", "TOKEN", "PASSWORD", "SECRET", "PASS", "CREDENTIALS"];
+    REDACTED_SUFFIXES
+        .iter()
+        .any(|suffix| env_var_name.ends_with(suffix))
+}

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -4,6 +4,7 @@ pub mod command;
 pub mod fs;
 pub mod markdown;
 pub mod paths;
+pub mod redact;
 pub mod serde;
 pub mod shell_env;
 pub mod size;


### PR DESCRIPTION
Before/After (linebreaks added for readability)
```log 
# before
INFO  [project::context_server_store::extension]
loaded command for context server mcp-server-github:
Command { 
  command: "/Users/peter/Library/Application Support/Zed/extensions/work/mcp-server-github/github-mcp-server-v0.5.0/github-mcp-server", 
  args: ["stdio"], 
  env: [("GITHUB_PERSONAL_ACCESS_TOKEN", "gho_WOOOOOOOOOOOOOOO")] 
}

#after
INFO  [project::context_server_store::extension]
loaded command for context server mcp-server-github:
Command {
  command: "/Users/peter/Library/Application Support/Zed/extensions/work/mcp-server-github/github-mcp-server-v0.5.0/github-mcp-server",
  args: ["stdio"],
  env: [("GITHUB_PERSONAL_ACCESS_TOKEN", "[REDACTED]")]
}
```

Release Notes:

- Redact sensitive environment variables from MCP logs
 