### PR TITLE
agent: Store if context server should be enabled/disabled in the settings

### DIFF
--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -20,7 +20,7 @@ use language_model::{LanguageModelProvider, LanguageModelProviderId, LanguageMod
 use notifications::status_toast::{StatusToast, ToastIcon};
 use project::{
     context_server_store::{ContextServerConfiguration, ContextServerStatus, ContextServerStore},
-    project_settings::ProjectSettings,
+    project_settings::{ContextServerSettings, ProjectSettings},
 };
 use settings::{Settings, update_settings_file};
 use ui::{
@@ -771,12 +771,16 @@ impl AgentConfiguration {
                                                         context_server_id.clone();
 
                                                     move |settings, _| {
-                                                        if let Some(context_server) = settings
+                                                        settings
                                                             .context_servers
-                                                            .get_mut(&context_server_id.0)
-                                                        {
-                                                            context_server.set_enabled(is_enabled);
-                                                        }
+                                                            .entry(context_server_id.0)
+                                                            .or_insert_with(|| {
+                                                                ContextServerSettings::Extension {
+                                                                    enabled: is_enabled,
+                                                                    settings: serde_json::json!({}),
+                                                                }
+                                                            })
+                                                            .set_enabled(is_enabled);
                                                     }
                                                 },
                                             );

--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -949,6 +949,7 @@ impl ExtensionImports for WasmState {
 
                         match settings {
                             project::project_settings::ContextServerSettings::Custom {
+                                enabled: _,
                                 command,
                             } => Ok(serde_json::to_string(&settings::ContextServerSettings {
                                 command: Some(settings::CommandSettings {
@@ -959,6 +960,7 @@ impl ExtensionImports for WasmState {
                                 settings: None,
                             })?),
                             project::project_settings::ContextServerSettings::Extension {
+                                enabled: _,
                                 settings,
                             } => Ok(serde_json::to_string(&settings::ContextServerSettings {
                                 command: None,

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -88,18 +88,40 @@ pub struct DapSettings {
 #[serde(tag = "source", rename_all = "snake_case")]
 pub enum ContextServerSettings {
     Custom {
+        /// Whether the context server is enabled.
+        #[serde(default = "default_true")]
+        enabled: bool,
         /// The command to run this context server.
         ///
         /// This will override the command set by an extension.
         command: ContextServerCommand,
     },
     Extension {
+        /// Whether the context server is enabled.
+        #[serde(default = "default_true")]
+        enabled: bool,
         /// The settings for this context server specified by the extension.
         ///
         /// Consult the documentation for the context server to see what settings
         /// are supported.
         settings: serde_json::Value,
     },
+}
+
+impl ContextServerSettings {
+    pub fn enabled(&self) -> bool {
+        match self {
+            ContextServerSettings::Custom { enabled, .. } => *enabled,
+            ContextServerSettings::Extension { enabled, .. } => *enabled,
+        }
+    }
+
+    pub fn set_enabled(&mut self, enabled: bool) {
+        match self {
+            ContextServerSettings::Custom { enabled: e, .. } => *e = enabled,
+            ContextServerSettings::Extension { enabled: e, .. } => *e = enabled,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -478,6 +500,7 @@ impl Settings for ProjectSettings {
                     Some((
                         k.clone().into(),
                         ContextServerSettings::Custom {
+                            enabled: true,
                             command: serde_json::from_value::<VsCodeContextServerCommand>(
                                 v.clone(),
                             )


### PR DESCRIPTION
- [x] Show disabled MCP servers in the list so you can enable them again
- [x] If MCP is not present in the settings, add it

Closes #ISSUE

Release Notes:

- agent: Allow to enable/disable context servers permanently in the agent configuration view
