### PR TITLE
Make remote mkdir shell-independent for compatibility

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1807,7 +1807,7 @@ impl SshRemoteConnection {
             self.socket
                 .run_command(
                     "sh",
-                    &["-c", &format!("mkdir -p {}", parent.to_string_lossy())],
+                    &["-c", &format!("mkdir -p '{}'", parent.to_string_lossy())],
                 )
                 .await?;
         }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1805,7 +1805,7 @@ impl SshRemoteConnection {
     ) -> Result<()> {
         if let Some(parent) = tmp_path_gz.parent() {
             self.socket
-                .run_command("mkdir", &["-p", &parent.to_string_lossy()])
+                .run_command("sh", &["-c", &format!("mkdir -p {}", parent.to_string_lossy())])
                 .await?;
         }
 

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1805,7 +1805,10 @@ impl SshRemoteConnection {
     ) -> Result<()> {
         if let Some(parent) = tmp_path_gz.parent() {
             self.socket
-                .run_command("sh", &["-c", &format!("mkdir -p {}", parent.to_string_lossy())])
+                .run_command(
+                    "sh",
+                    &["-c", &format!("mkdir -p {}", parent.to_string_lossy())],
+                )
                 .await?;
         }
 

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1807,7 +1807,13 @@ impl SshRemoteConnection {
             self.socket
                 .run_command(
                     "sh",
-                    &["-c", &format!("mkdir -p '{}'", parent.to_string_lossy())],
+                    &[
+                        "-c",
+                        &shell_script!(
+                            "mkdir -p {parent}",
+                            parent = parent.to_string_lossy().as_ref()
+                        ),
+                    ],
                 )
                 .await?;
         }
@@ -1880,7 +1886,16 @@ impl SshRemoteConnection {
     ) -> Result<()> {
         if let Some(parent) = tmp_path_gz.parent() {
             self.socket
-                .run_command("mkdir", &["-p", &parent.to_string_lossy()])
+                .run_command(
+                    "sh",
+                    &[
+                        "-c",
+                        &shell_script!(
+                            "mkdir -p {parent}",
+                            parent = parent.to_string_lossy().as_ref()
+                        ),
+                    ],
+                )
                 .await?;
         }
 


### PR DESCRIPTION
- Closes: #30962 

Nushell does not support mkdir -p
So invoke sh -c "mkdir -p" instead which will also work under nushell.

Release Notes:

- Fixed ssh remotes running Nushell (and possibly other non posix-compliant shells)