### PR TITLE
linux: Add StartupWMClass to the .desktop file

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -6,6 +6,7 @@ GenericName=Text Editor
 Comment=A high-performance, multiplayer code editor.
 TryExec=$APP_CLI
 StartupNotify=$DO_STARTUP_NOTIFY
+StartupWMClass=$APP_ID
 Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;


### PR DESCRIPTION
`StartupWMClass` is used by some WMs to identify windows during Startup Notification.

See https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html

Since the build already has the correct APP_ID available during the generation of the `.desktop` file we can simply add to the template.

Release Notes:

- N/A
