### PR TITLE
linux: Fix KeePassXC integration via org.freedesktop.Secrets

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -491,6 +491,7 @@ impl<P: LinuxClient + 'static> Platform for P {
                     let username = attributes
                         .get("username")
                         .context("Cannot find username in stored credentials")?;
+                    item.unlock().await?;
                     let secret = item.secret().await?;
 
                     // we lose the zeroizing capabilities at this boundary,


### PR DESCRIPTION
Closes #29956

Unlike GNOME Keyring, KeePassXC locks individual secrets in addition to the entire database when configured to ask for confirmation for access requests by DBus clients. As such, before the secret is read it should be unlocked by the client.

Tested against both KeePassXC and GNOME Keyring, and with this patch Zed successfully logs in and fetches the API keys from the Secret Service.

Release Notes:

- Fixed KeePassXC integration via org.freedesktop.Secrets