### PR TITLE
copilot: Remove PromptTokensDetails from Usage struct

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -318,13 +318,7 @@ pub struct ResponseEvent {
 pub struct Usage {
     pub completion_tokens: u64,
     pub prompt_tokens: u64,
-    pub prompt_tokens_details: PromptTokensDetails,
     pub total_tokens: u64,
-}
-
-#[derive(Deserialize, Debug)]
-pub struct PromptTokensDetails {
-    pub cached_tokens: u64,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
Closes #33024

During previous changes when we added usage handling for copilot I added PromptTokensDetails as well. Tested this with gpt and claude but missed Gemini. So copilot in case of gemini doesn't return this parameter. As we are not using it it's safe to remove it other option was to make it optional to use it in future but at this time it's better to get rid of it as I don't have any use case in mind.

Release Notes:

- Removed `PromptTokensDetails` from `Usage` as Gemini no longer supplies cached token data for copilot.
