### PR TITLE
agent: Expand disclosure click area in setting view's provider section

### DIFF
--- a/crates/agent/src/agent_configuration.rs
+++ b/crates/agent/src/agent_configuration.rs
@@ -164,7 +164,6 @@ impl AgentConfiguration {
         v_flex()
             .py_2()
             .gap_1p5()
-            // .debug_bg_blue()
             .border_t_1()
             .border_color(cx.theme().colors().border.opacity(0.6))
             .child(


### PR DESCRIPTION
Previously, you could only expand the provider item in the agent panel settings view by clicking on the little chevron icon button. Now, you can click on the whole title area (minus the button, when present) to do that. Just that little bit more convenient to interact with it.

Release Notes:

- N/A
