### PR TITLE
agent: Avoid layout shift due to the "waiting for confirmation" label

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -3088,6 +3088,7 @@ impl ActiveThread {
                                 .pr_1()
                                 .gap_1()
                                 .justify_between()
+                                .flex_wrap()
                                 .bg(cx.theme().colors().editor_background)
                                 .border_t_1()
                                 .border_color(self.tool_card_border_color(cx))


### PR DESCRIPTION
Just a tiny, one-line change to avoid the "Waiting for Confirmation" animated label pushing the "allow" buttons to the side.

Release Notes:

- agent: Fixed layout shift in "waiting for confirmation" state in the terminal card.
