### PR TITLE
agent: Move focus to the panel after sending a user message edit

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -1618,6 +1618,14 @@ impl ActiveThread {
                     })
                     .log_err();
             }));
+
+        if let Some(workspace) = self.workspace.upgrade() {
+            workspace.update(cx, |workspace, cx| {
+                if let Some(panel) = workspace.panel::<AgentPanel>(cx) {
+                    panel.focus_handle(cx).focus(window);
+                }
+            });
+        }
     }
 
     fn messages_after(&self, message_id: MessageId) -> &[MessageId] {


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/31611.
Closes https://github.com/zed-industries/zed/issues/33005.

Release Notes:

- agent: Fixed a bug where, after confirming editing a previous user message while zoomed in, the focus went to the buffer and the panel got closed.
