### PR TITLE
Ensure compiled extensions work with older Zed versions

### DIFF
--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -87,9 +87,9 @@ pub struct ExtensionManifest {
     pub snippets: Option<PathBuf>,
     #[serde(default)]
     pub capabilities: Vec<ExtensionCapability>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub debug_adapters: BTreeMap<Arc<str>, DebugAdapterManifestEntry>,
-    #[serde(default)]
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
     pub debug_locators: BTreeMap<Arc<str>, DebugLocatorManifestEntry>,
 }
 


### PR DESCRIPTION
Closes #33039

This PR fixes a bug which causes the newest versions of the Biome and Tombi extensions to not work with older Zed versions.

The bug occurs because in #32822, the type of the debug adapter and debug locators was changed from a Vec to a BTreeMap. However, these fields were already introduced much earlier in Zed, which now causes the de-serialization of the `extension.toml` to fail for older Zed versions. Any extension compiled with the newest extension CLI bumped in https://github.com/zed-industries/extensions/pull/2866 will not work with older Zed versions prior to v0.191.

By adding this change and bumping the extension CLI again, this could be prevented. On de-serialization, we would just fallback to either a Vec for versions prior to v0.190 or a BTreeMap after. Feel free to let me know what you think here.

Release Notes:

- N/A
