### PR TITLE
Add $ZED_CURRENT_TEXT var for spawning task with current buffer

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -982,6 +982,7 @@ impl ContextProvider for BasicContextProvider {
         let selected_text = buffer
             .chars_for_range(location.range.clone())
             .collect::<String>();
+        let current_text = buffer.chars().collect::<String>();
 
         let mut task_variables = TaskVariables::from_iter([
             (VariableName::Row, row.to_string()),
@@ -993,6 +994,9 @@ impl ContextProvider for BasicContextProvider {
         }
         if !selected_text.trim().is_empty() {
             task_variables.insert(VariableName::SelectedText, selected_text);
+        }
+        if !current_text.trim().is_empty() {
+            task_variables.insert(VariableName::CurrentText, current_text);
         }
         let worktree_root_dir =
             buffer

--- a/crates/task/src/lib.rs
+++ b/crates/task/src/lib.rs
@@ -169,6 +169,8 @@ pub enum VariableName {
     Column,
     /// Text from the latest selection.
     SelectedText,
+    /// The currently opened buffer, and it's not a real file.
+    CurrentText,
     /// The symbol selected by the symbol tagging system, specifically the @run capture in a runnables.scm
     RunnableSymbol,
     /// Custom variable, provided by the plugin or other external source.
@@ -203,6 +205,7 @@ impl FromStr for VariableName {
             "SYMBOL" => Self::Symbol,
             "RUNNABLE_SYMBOL" => Self::RunnableSymbol,
             "SELECTED_TEXT" => Self::SelectedText,
+            "CURRENT_TEXT" => Self::CurrentText,
             "ROW" => Self::Row,
             "COLUMN" => Self::Column,
             _ => {
@@ -237,6 +240,7 @@ impl std::fmt::Display for VariableName {
             Self::Row => write!(f, "{ZED_VARIABLE_NAME_PREFIX}ROW"),
             Self::Column => write!(f, "{ZED_VARIABLE_NAME_PREFIX}COLUMN"),
             Self::SelectedText => write!(f, "{ZED_VARIABLE_NAME_PREFIX}SELECTED_TEXT"),
+            Self::CurrentText => write!(f, "{ZED_VARIABLE_NAME_PREFIX}CURRENT_TEXT"),
             Self::RunnableSymbol => write!(f, "{ZED_VARIABLE_NAME_PREFIX}RUNNABLE_SYMBOL"),
             Self::Custom(s) => write!(
                 f,

--- a/crates/task/src/task_template.rs
+++ b/crates/task/src/task_template.rs
@@ -542,6 +542,7 @@ mod tests {
             (VariableName::Column, "5678".to_string()),
             (VariableName::File, "test_file".to_string()),
             (VariableName::SelectedText, "test_selected_text".to_string()),
+            (VariableName::CurrentText, "test_current_text".to_string()),
             (VariableName::Symbol, long_value.clone()),
             (VariableName::WorktreeRoot, "/test_root/".to_string()),
             (
@@ -569,6 +570,7 @@ mod tests {
                 format!("arg1 {}", VariableName::SelectedText.template_value()),
                 format!("arg2 {}", VariableName::Column.template_value()),
                 format!("arg3 {}", VariableName::Symbol.template_value()),
+                format!("arg4 {}", VariableName::CurrentText.template_value()),
             ],
             env: HashMap::from_iter([
                 ("test_env_key".to_string(), "test_env_var".to_string()),
@@ -645,13 +647,14 @@ mod tests {
                     "arg1 $ZED_SELECTED_TEXT",
                     "arg2 $ZED_COLUMN",
                     "arg3 $ZED_SYMBOL",
+                    "arg4 $ZED_CURRENT_TEXT",
                 ],
                 "Args should not be substituted with variables"
             );
             assert_eq!(
                 spawn_in_terminal.command_label,
                 format!(
-                    "{} arg1 test_selected_text arg2 5678 arg3 {long_value}",
+                    "{} arg1 test_selected_text arg2 5678 arg3 {long_value} arg4 test_current_text",
                     spawn_in_terminal.command
                 ),
                 "Command label args should be substituted with variables and those should not be shortened"

--- a/crates/task/src/vscode_format.rs
+++ b/crates/task/src/vscode_format.rs
@@ -101,6 +101,10 @@ impl TryFrom<VsCodeTaskFile> for TaskTemplates {
                 "selectedText".to_owned(),
                 VariableName::SelectedText.to_string(),
             ),
+            (
+                "currentText".to_owned(),
+                VariableName::CurrentText.to_string(),
+            ),
         ]));
         let templates = value
             .tasks

--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -522,6 +522,10 @@ mod tests {
             &TaskContext {
                 cwd: Some(path!("/dir").into()),
                 task_variables: TaskVariables::from_iter([
+                    (
+                        VariableName::CurrentText,
+                        "use std; fn this_is_a_rust_file() { }".into()
+                    ),
                     (VariableName::File, path!("/dir/rust/b.rs").into()),
                     (VariableName::Filename, "b.rs".into()),
                     (VariableName::RelativeFile, path!("rust/b.rs").into()),
@@ -564,6 +568,10 @@ mod tests {
                     (VariableName::Row, "1".into()),
                     (VariableName::Column, "15".into()),
                     (VariableName::SelectedText, "is_i".into()),
+                    (
+                        VariableName::CurrentText,
+                        "use std; fn this_is_a_rust_file() { }".into()
+                    ),
                     (VariableName::Symbol, "this_is_a_rust_file".into()),
                 ]),
                 project_env: HashMap::default(),
@@ -583,6 +591,10 @@ mod tests {
             &TaskContext {
                 cwd: Some(path!("/dir").into()),
                 task_variables: TaskVariables::from_iter([
+                    (
+                        VariableName::CurrentText,
+                        "function this_is_a_test() { }".into()
+                    ),
                     (VariableName::File, path!("/dir/a.ts").into()),
                     (VariableName::Filename, "a.ts".into()),
                     (VariableName::RelativeFile, "a.ts".into()),

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -84,6 +84,7 @@ These variables allow you to pull information from the current editor and use it
 - `ZED_STEM`: stem (filename without extension) of the currently opened file (e.g. `main`)
 - `ZED_SYMBOL`: currently selected symbol; should match the last symbol shown in a symbol breadcrumb (e.g. `mod tests > fn test_task_contexts`)
 - `ZED_SELECTED_TEXT`: currently selected text
+- `ZED_CURRENT_TEXT`: current buffer text, it's not needed to be a real file
 - `ZED_WORKTREE_ROOT`: absolute path to the root of the current worktree. (e.g. `/Users/my-user/path/to/project`)
 - `ZED_CUSTOM_RUST_PACKAGE`: (Rust-specific) name of the parent package of $ZED_FILE source file.
 


### PR DESCRIPTION
Sometime, I just don't want to do a task with a real file but quickly testing on temporary tabs like for small scripts.
I would like to add $ZED_CURRENT_TEXT var to support reading all chars from buffer.
~~Also added some tasks in places that already have $ZED_SELECTED_TEXT~~

Related to this issue: https://github.com/zed-industries/zed/issues/32662
Here is a VSCode extension which does the same thing: https://marketplace.visualstudio.com/items?itemName=formulahendry.code-runner

An example of running Go code without creating a file
```json
{
    "label": "Run go",
    "command": "mktemp ~/hey-$(date +%s).go | { read temple; echo '$ZED_CURRENT_TEXT' > $tmpfile && go run $tmpfile && rm $tmpfile; }"
}
```

Screenshot:
![image](https://github.com/user-attachments/assets/c20fc5b1-7ac7-4525-adfd-5eaf7bd1ab80)

Release Notes:

- Add $ZED_CURRENT_TEXT var for spawning task with current buffer