### PR TITLE
agent: Improve layout shift on previous message editor

### DIFF
--- a/crates/agent/src/active_thread.rs
+++ b/crates/agent/src/active_thread.rs
@@ -57,6 +57,10 @@ use workspace::{CollaboratorId, Workspace};
 use zed_actions::assistant::OpenRulesLibrary;
 use zed_llm_client::CompletionIntent;
 
+const CODEBLOCK_CONTAINER_GROUP: &str = "codeblock_container";
+const EDIT_PREVIOUS_MESSAGE_MIN_LINES: usize = 1;
+const EDIT_PREVIOUS_MESSAGE_MAX_LINES: usize = 6;
+
 pub struct ActiveThread {
     context_store: Entity<ContextStore>,
     language_registry: Arc<LanguageRegistry>,
@@ -333,8 +337,6 @@ fn tool_use_markdown_style(window: &Window, cx: &mut App) -> MarkdownStyle {
         ..Default::default()
     }
 }
-
-const CODEBLOCK_CONTAINER_GROUP: &str = "codeblock_container";
 
 fn render_markdown_code_block(
     message_id: MessageId,
@@ -1327,6 +1329,8 @@ impl ActiveThread {
             self.context_store.downgrade(),
             self.thread_store.downgrade(),
             self.text_thread_store.downgrade(),
+            EDIT_PREVIOUS_MESSAGE_MIN_LINES,
+            EDIT_PREVIOUS_MESSAGE_MAX_LINES,
             window,
             cx,
         );

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -89,6 +89,8 @@ pub(crate) fn create_editor(
     context_store: WeakEntity<ContextStore>,
     thread_store: WeakEntity<ThreadStore>,
     text_thread_store: WeakEntity<TextThreadStore>,
+    min_lines: usize,
+    max_lines: usize,
     window: &mut Window,
     cx: &mut App,
 ) -> Entity<Editor> {
@@ -105,8 +107,8 @@ pub(crate) fn create_editor(
         let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
         let mut editor = Editor::new(
             editor::EditorMode::AutoHeight {
-                min_lines: MIN_EDITOR_LINES,
-                max_lines: MAX_EDITOR_LINES,
+                min_lines,
+                max_lines,
             },
             buffer,
             None,
@@ -161,6 +163,8 @@ impl MessageEditor {
             context_store.downgrade(),
             thread_store.clone(),
             text_thread_store.clone(),
+            MIN_EDITOR_LINES,
+            MAX_EDITOR_LINES,
             window,
             cx,
         );


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/32765.

This PR creates a slot for the `message_editor::create_editor` to allow using different values for min and max lines. In practice, the panel's main editor now has a minimum of 4 lines, whereas the previous message editor has just one. This makes the layout shift when clicking on a previous message to edit it much smaller.

Release Notes:

- agent: Improved layout shift when clicking to edit a previous sent message.
