### PR TITLE
bedrock: Support Claude 3.7 in APAC

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -496,7 +496,9 @@ impl Model {
                 Model::Claude3_5Sonnet
                 | Model::Claude3_5SonnetV2
                 | Model::Claude3Haiku
-                | Model::Claude3Sonnet,
+                | Model::Claude3Sonnet
+                | Model::Claude3_7Sonnet
+                | Model::ClaudeSonnet4,
                 "apac",
             ) => Ok(format!("{}.{}", region_group, model_id)),
 

--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -498,7 +498,9 @@ impl Model {
                 | Model::Claude3Haiku
                 | Model::Claude3Sonnet
                 | Model::Claude3_7Sonnet
-                | Model::ClaudeSonnet4,
+                | Model::Claude3_7SonnetThinking
+                | Model::ClaudeSonnet4
+                | Model::ClaudeSonnet4Thinking,
                 "apac",
             ) => Ok(format!("{}.{}", region_group, model_id)),
 


### PR DESCRIPTION
In ap-northeast-1 we have access to 3.7 and 4.0

<img width="251" alt="image" src="https://github.com/user-attachments/assets/4c3703a7-0e7d-4d7e-a1e7-a49383876d55" />

Release Notes:

- N/A