### PR TITLE
Terminal detect venv support CMD in Windows

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -476,6 +476,7 @@ impl Project {
             },
             terminal_settings::ActivateScript::Nushell => "overlay use",
             terminal_settings::ActivateScript::PowerShell => ".",
+            terminal_settings::ActivateScript::Cmd => "",
             _ => "source",
         };
         let activate_script_name = match venv_settings.activate_script {
@@ -484,6 +485,12 @@ impl Project {
             terminal_settings::ActivateScript::Fish => "activate.fish",
             terminal_settings::ActivateScript::Nushell => "activate.nu",
             terminal_settings::ActivateScript::PowerShell => "activate.ps1",
+            terminal_settings::ActivateScript::Cmd => "activate.bat",
+        };
+
+        let clear_cmd = match venv_settings.activate_script {
+            terminal_settings::ActivateScript::Cmd => "cls",
+            _ => "clear",
         };
         let path = venv_base_directory
             .join(match std::env::consts::OS {
@@ -503,8 +510,8 @@ impl Project {
             .flatten()?;
 
         Some(format!(
-            "{} {} ; clear{}",
-            activate_keyword, quoted, line_ending
+            "{} {} ; {}{}",
+            activate_keyword, quoted, clear_cmd, line_ending
         ))
     }
 

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -509,9 +509,14 @@ impl Project {
             .ok()
             .flatten()?;
 
+        let joiner = match venv_settings.activate_script {
+            terminal_settings::ActivateScript::Cmd => "&&",
+            _ => ";"
+        };
+
         Some(format!(
-            "{} {} ; {}{}",
-            activate_keyword, quoted, clear_cmd, line_ending
+            "{} {} {} {}{}",
+            activate_keyword, quoted, joiner, clear_cmd, line_ending
         ))
     }
 

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -126,6 +126,7 @@ pub enum ActivateScript {
     Fish,
     Nushell,
     PowerShell,
+    Cmd,
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]


### PR DESCRIPTION
Closes [#33083](https://github.com/zed-industries/zed/discussions/33083)

Release Notes:

- Terminal detect venv support CMD in Windows
