### PR TITLE
linux: Fix blurry rendering on Wayland when using fractional scaling

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -1593,8 +1593,8 @@ impl Size<Pixels> {
     /// Converts the size from physical to logical pixels.
     pub(crate) fn to_device_pixels(self, scale_factor: f32) -> Size<DevicePixels> {
         size(
-            DevicePixels((self.width.0 * scale_factor) as i32),
-            DevicePixels((self.height.0 * scale_factor) as i32),
+            DevicePixels((self.width.0 * scale_factor).round() as i32),
+            DevicePixels((self.height.0 * scale_factor).round() as i32),
         )
     }
 }
@@ -1641,8 +1641,8 @@ impl Bounds<Pixels> {
     pub fn to_device_pixels(&self, factor: f32) -> Bounds<DevicePixels> {
         Bounds {
             origin: point(
-                DevicePixels((self.origin.x.0 * factor) as i32),
-                DevicePixels((self.origin.y.0 * factor) as i32),
+                DevicePixels((self.origin.x.0 * factor).round() as i32),
+                DevicePixels((self.origin.y.0 * factor).round() as i32),
             ),
             size: self.size.to_device_pixels(factor),
         }

--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -1590,7 +1590,7 @@ impl Size<DevicePixels> {
 }
 
 impl Size<Pixels> {
-    /// Converts the size from physical to logical pixels.
+    /// Converts the size from logical to physical pixels.
     pub(crate) fn to_device_pixels(self, scale_factor: f32) -> Size<DevicePixels> {
         size(
             DevicePixels((self.width.0 * scale_factor).round() as i32),


### PR DESCRIPTION
Partially Closes #25195

In Wayland, To create buffer size (`renderer.update_drawable_size`), we convert logical pixels to device pixels by taking the scale factor into account. Later, we also let the compositor know the logical pixels we want to use for our app (`viewport.set_destination`). Then, the compositor takes our buffer and tries to scale it to fit the viewport size we provided. If this is accurate, we see perfect rendering. If our buffer size is not accurate (off by 1px in this case), the compositor scales our buffer to fit the viewport size. This causes blur.

To make sure we set correct buffer size for renderer as same as what compositor is going to use, we needs to use rounding instead of truncate when converting logical pixels to device pixels. It's not super clear from docs, what exact algorithm it uses but it says it uses rounding and seems to fix issue for me if we follow that for our buffer.

From https://wayland.app/protocols/fractional-scale-v1:
> If a surface has a surface-local size of 100 px by 50 px and wishes to submit buffers with a scale of 1.5, then a buffer of 150px by 75 px should be used and the wp_viewport destination rectangle should be 100 px by 50 px.
>
> For toplevel surfaces, the size is **rounded halfway away from zero**. The rounding algorithm for subsurface position and size is not defined.

Tested on:
- [x] Gnome
- [x] KDE
- [x] Sway

Release Notes:

- Fixed blurry rendering on Wayland when using fractional scaling for Gnome and KDE.
