### PR TITLE
Fix handling of `--diff` flag

### DIFF
--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -296,7 +296,7 @@ pub async fn handle_cli_connection(
                 env,
                 user_data_dir: _,
             } => {
-                if !urls.is_empty() || !diff_paths.is_empty() {
+                if !urls.is_empty() {
                     cx.update(|cx| {
                         match OpenRequest::parse(RawOpenRequest { urls, diff_paths }, cx) {
                             Ok(open_request) => {
@@ -346,7 +346,7 @@ async fn open_workspaces(
     env: Option<collections::HashMap<String, String>>,
     cx: &mut AsyncApp,
 ) -> Result<()> {
-    let grouped_locations = if paths.is_empty() {
+    let grouped_locations = if paths.is_empty() && diff_paths.is_empty() {
         // If no paths are provided, restore from previous workspaces unless a new workspace is requested with -n
         if open_new_workspace == Some(true) {
             Vec::new()


### PR DESCRIPTION
* Restore the ability to combine --diff with other path arguments
* Restore combining --diff with --wait

There is still one defect in the current handling of `--diff`: when Zed is already open, we'll open the diff view in your current active zed window. It would be better to search all of the open zed windows for any window containing the diffed paths, but implementing that is a bit complex. Currently, the logic for *picking* an existing zed window is coupled to the logic for opening buffers in that window. I'd like to decouple it, but I wanted to keep this change small, so that we hotfix it to stable without too much risk.

Release Notes:

- Fixed a bug where the `--diff` CLI flag did not work with `--wait`
