### PR TITLE
agent: Fix token limit callout to show burn mode only for zed provider

### DIFF
--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -1225,16 +1225,17 @@ impl MessageEditor {
             })
     }
 
-    fn render_usage_callout(&self, line_height: Pixels, cx: &mut Context<Self>) -> Option<Div> {
-        let is_using_zed_provider = self
-            .thread
+    fn is_using_zed_provider(&self, cx: &App) -> bool {
+        self.thread
             .read(cx)
             .configured_model()
             .map_or(false, |model| {
                 model.provider.id().0 == ZED_CLOUD_PROVIDER_ID
-            });
+            })
+    }
 
-        if !is_using_zed_provider {
+    fn render_usage_callout(&self, line_height: Pixels, cx: &mut Context<Self>) -> Option<Div> {
+        if !self.is_using_zed_provider(cx) {
             return None;
         }
 
@@ -1288,15 +1289,7 @@ impl MessageEditor {
             "Thread reaching the token limit soon"
         };
 
-        let is_using_zed_provider = self
-            .thread
-            .read(cx)
-            .configured_model()
-            .map_or(false, |model| {
-                model.provider.id().0 == ZED_CLOUD_PROVIDER_ID
-            });
-
-        let description = if is_using_zed_provider {
+        let description = if self.is_using_zed_provider(cx) {
             "To continue, start a new thread from a summary or turn burn mode on."
         } else {
             "To continue, start a new thread from a summary."
@@ -1316,7 +1309,7 @@ impl MessageEditor {
                     })),
             );
 
-        if is_using_zed_provider {
+        if self.is_using_zed_provider(cx) {
             callout = callout.secondary_action(
                 IconButton::new("burn-mode-callout", IconName::ZedBurnMode)
                     .icon_size(IconSize::XSmall)


### PR DESCRIPTION
The token limit reached callout was shown for all the providers and it included the burn mode toggle and description. I have made that conditional to only show for zed provider.

Before this changes
<img width="413" alt="image" src="https://github.com/user-attachments/assets/b7e177fc-d2e6-4942-8934-39ac8c844649" />

After this change:
<img width="404" alt="image" src="https://github.com/user-attachments/assets/0e091b99-c8e3-4960-8b4d-47170883d224" />


Release Notes:

- agent: Fix token limit callout to show burn mode only for zed provider
