### PR TITLE
Update pathfinder_simd for nightly arm simd fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8160,13 +8160,11 @@ dependencies = [
 name = "inline_completion"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "client",
  "gpui",
  "language",
  "project",
  "workspace-hack",
- "zed_llm_client",
 ]
 
 [[package]]
@@ -11193,9 +11191,9 @@ dependencies = [
 
 [[package]]
 name = "pathfinder_simd"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cf07ef4804cfa9aea3b04a7bbdd5a40031dbb6b4f2cbaf2b011666c80c5b4f2"
+checksum = "bf9027960355bf3afff9841918474a81a5f972ac6d226d518060bba758b5ad57"
 dependencies = [
  "rustc_version",
 ]


### PR DESCRIPTION
`pathfinder_simd` doesn't compile on nightly aarch64 right now, but that was fixed by https://github.com/servo/pathfinder/pull/575 and updated on crates.io by https://github.com/servo/pathfinder/pull/577. This PR simply updates the `pathfinder_simd` dependency to the version that contains these fixes.

I verified that this compiles with nightly on my machine.