### PR TITLE
Fix edit prediction provider in the project settings not being respected

### DIFF
--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -51,6 +51,7 @@ pub struct InlineCompletionButton {
     language: Option<Arc<Language>>,
     file: Option<Arc<dyn File>>,
     edit_prediction_provider: Option<Arc<dyn inline_completion::InlineCompletionProviderHandle>>,
+    provider_kind: EditPredictionProvider,
     fs: Arc<dyn Fs>,
     user_store: Entity<UserStore>,
     popover_menu_handle: PopoverMenuHandle<ContextMenu>,
@@ -65,9 +66,7 @@ enum SupermavenButtonStatus {
 
 impl Render for InlineCompletionButton {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let all_language_settings = all_language_settings(None, cx);
-
-        match all_language_settings.edit_predictions.provider {
+        match self.provider_kind {
             EditPredictionProvider::None => div(),
 
             EditPredictionProvider::Copilot => {
@@ -384,6 +383,7 @@ impl InlineCompletionButton {
             language: None,
             file: None,
             edit_prediction_provider: None,
+            provider_kind: EditPredictionProvider::None,
             popover_menu_handle,
             fs,
             user_store,
@@ -823,6 +823,9 @@ impl InlineCompletionButton {
         };
         self.editor_show_predictions = editor.edit_predictions_enabled();
         self.edit_prediction_provider = editor.edit_prediction_provider();
+        self.provider_kind = all_language_settings(self.file.as_ref(), cx)
+            .edit_predictions
+            .provider;
         self.language = language.cloned();
         self.file = file;
         self.editor_focus_handle = Some(editor.focus_handle(cx));
@@ -851,6 +854,7 @@ impl StatusItemView for InlineCompletionButton {
         } else {
             self.language = None;
             self.editor_subscription = None;
+            self.provider_kind = EditPredictionProvider::None;
             self.editor_enabled = None;
         }
         cx.notify();

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -48,9 +48,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
                 .read(cx)
                 .as_singleton()
                 .and_then(|buffer| buffer.read(cx).file());
-            let provider = all_language_settings(file, cx)
-                .edit_predictions
-                .provider;
+            let provider = all_language_settings(file, cx).edit_predictions.provider;
             assign_edit_prediction_provider(
                 editor,
                 provider,
@@ -75,12 +73,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
             let mut status = client.status();
             while let Some(_status) = status.next().await {
                 cx.update(|cx| {
-                    assign_edit_prediction_providers(
-                        &editors,
-                        &client,
-                        user_store.clone(),
-                        cx,
-                    );
+                    assign_edit_prediction_providers(&editors, &client, user_store.clone(), cx);
                 })
                 .log_err();
             }
@@ -93,12 +86,7 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
         let client = client.clone();
         let user_store = user_store.clone();
         move |cx| {
-            assign_edit_prediction_providers(
-                &editors,
-                &client,
-                user_store.clone(),
-                cx,
-            );
+            assign_edit_prediction_providers(&editors, &client, user_store.clone(), cx);
 
             let new_provider = all_language_settings(None, cx).edit_predictions.provider;
 
@@ -110,8 +98,6 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
                 .unwrap_or(false);
 
             if provider_changed {
-
-
                 telemetry::event!(
                     "Edit Prediction Provider Changed",
                     from = provider,
@@ -120,34 +106,27 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
                 );
 
                 provider = new_provider;
-                assign_edit_prediction_providers(
-                    &editors,
-                    &client,
-                    user_store.clone(),
-                    cx,
-                );
+                assign_edit_prediction_providers(&editors, &client, user_store.clone(), cx);
 
-            if provider_changed {
-                    match provider {
-                        EditPredictionProvider::Zed => {
-                            let Some(window) = cx.active_window() else {
-                                return;
-                            };
+                match provider {
+                    EditPredictionProvider::Zed => {
+                        let Some(window) = cx.active_window() else {
+                            return;
+                        };
 
-                            window
-                                .update(cx, |_, window, cx| {
-                                    window.dispatch_action(
-                                        Box::new(zed_actions::OpenZedPredictOnboarding),
-                                        cx,
-                                    );
-                                })
-                                .ok();
-                        }
-                        EditPredictionProvider::None
-                        | EditPredictionProvider::Copilot
-                        | EditPredictionProvider::Supermaven => {}
+                        window
+                            .update(cx, |_, window, cx| {
+                                window.dispatch_action(
+                                    Box::new(zed_actions::OpenZedPredictOnboarding),
+                                    cx,
+                                );
+                            })
+                            .ok();
                     }
-                }
+                    EditPredictionProvider::None
+                    | EditPredictionProvider::Copilot
+                    | EditPredictionProvider::Supermaven => {}
+                };
             }
         }
     })
@@ -175,12 +154,10 @@ fn assign_edit_prediction_providers(
                     .read(cx)
                     .as_singleton()
                     .and_then(|buffer| buffer.read(cx).file());
-                let provider = all_language_settings(file, cx)
-                    .edit_predictions
-                    .provider;
+                let provider = all_language_settings(file, cx).edit_predictions.provider;
 
                 // Apply provider; Editor will ignore if unchanged internally
-                    assign_edit_prediction_provider(
+                assign_edit_prediction_provider(
                     editor,
                     provider,
                     &client,

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -110,18 +110,18 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
 
                 match provider {
                     EditPredictionProvider::Zed => {
-                        let Some(window) = cx.active_window() else {
-                            return;
-                        };
-
-                        window
-                            .update(cx, |_, window, cx| {
-                                window.dispatch_action(
-                                    Box::new(zed_actions::OpenZedPredictOnboarding),
-                                    cx,
-                                );
-                            })
-                            .ok();
+                        if !tos_accepted {
+                            if let Some(window) = cx.active_window() {
+                                window
+                                    .update(cx, |_, window, cx| {
+                                        window.dispatch_action(
+                                            Box::new(zed_actions::OpenZedPredictOnboarding),
+                                            cx,
+                                        );
+                                    })
+                                    .ok();
+                            }
+                        }
                     }
                     EditPredictionProvider::None
                     | EditPredictionProvider::Copilot

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -1,6 +1,6 @@
 use client::{Client, UserStore};
 use collections::HashMap;
-use copilot::{Copilot, CopilotCompletionProvider};
+use copilot::{Copilot, CopilotCompletionProvider, Status};
 use editor::Editor;
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{EditPredictionProvider, all_language_settings};
@@ -234,6 +234,17 @@ fn assign_edit_prediction_provider(
                         });
                     }
                 }
+
+                if matches!(
+                    copilot.read(cx).status(),
+                    Status::Disabled
+                        | Status::SignedOut {
+                            awaiting_signing_in: false
+                        }
+                ) {
+                    copilot::initiate_sign_in(window, cx);
+                }
+
                 let provider = cx.new(|_| CopilotCompletionProvider::new(copilot));
                 editor.set_edit_prediction_provider(Some(provider), window, cx);
             }

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -43,7 +43,14 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
             editors
                 .borrow_mut()
                 .insert(editor_handle, window.window_handle());
-            let provider = all_language_settings(None, cx).edit_predictions.provider;
+            let file = editor
+                .buffer()
+                .read(cx)
+                .as_singleton()
+                .and_then(|buffer| buffer.read(cx).file());
+            let provider = all_language_settings(file, cx)
+                .edit_predictions
+                .provider;
             assign_edit_prediction_provider(
                 editor,
                 provider,
@@ -70,7 +77,6 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
                 cx.update(|cx| {
                     assign_edit_prediction_providers(
                         &editors,
-                        provider,
                         &client,
                         user_store.clone(),
                         cx,
@@ -105,7 +111,6 @@ pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
                 provider = new_provider;
                 assign_edit_prediction_providers(
                     &editors,
-                    provider,
                     &client,
                     user_store.clone(),
                     cx,
@@ -146,7 +151,6 @@ fn clear_zeta_edit_history(_: &zeta::ClearHistory, cx: &mut App) {
 
 fn assign_edit_prediction_providers(
     editors: &Rc<RefCell<HashMap<WeakEntity<Editor>, AnyWindowHandle>>>,
-    provider: EditPredictionProvider,
     client: &Arc<Client>,
     user_store: Entity<UserStore>,
     cx: &mut App,
@@ -154,6 +158,15 @@ fn assign_edit_prediction_providers(
     for (editor, window) in editors.borrow().iter() {
         _ = window.update(cx, |_window, window, cx| {
             _ = editor.update(cx, |editor, cx| {
+                let file = editor
+                    .buffer()
+                    .read(cx)
+                    .as_singleton()
+                    .and_then(|buffer| buffer.read(cx).file());
+                let provider = all_language_settings(file, cx)
+                    .edit_predictions
+                    .provider;
+
                 assign_edit_prediction_provider(
                     editor,
                     provider,


### PR DESCRIPTION
Closes #33120 

Zed will now accordingly switch between the edit prediction provider that the user has defined for the file that is currently open, either in the global or project settings. 

Release Notes:

- Fix edit prediction provider value in the project settings not being respected