### PR TITLE
One Light Theme: Change constant color

### DIFF
--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -601,7 +601,7 @@
             "font_weight": null
           },
           "constant": {
-            "color": "#669f59ff",
+            "color": "#c18401ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/4617
Closes: https://github.com/zed-industries/zed/issues/25709

Changes the One Light syntax highlight for `constant` to be a distinct from `comment`:

| Before | After |
| - | - |
| <img width="424" alt="Screenshot 2025-06-21 at 11 59 22" src="https://github.com/user-attachments/assets/8780918f-7701-4780-809a-f95951970c90" /> | <img width="430" alt="Screenshot 2025-06-21 at 11 59 17" src="https://github.com/user-attachments/assets/d7efaa16-f95a-4076-a0b2-b1170e2ffe68" /> |

I picked a color which was present in the palette from the original One Light theme from Atom.

@failable: Sorry this took so long, does this look ok to you?

Release Notes:

- N/A
