### PR TITLE
Don't use exclusions for FS events

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4087,13 +4087,6 @@ impl BackgroundScanner {
                     return false;
                 }
 
-                if self.settings.is_path_excluded(&relative_path) {
-                    if !is_git_related {
-                        log::debug!("ignoring FS event for excluded path {relative_path:?}");
-                    }
-                    return false;
-                }
-
                 relative_paths.push(relative_path);
                 true
             }


### PR DESCRIPTION
This optimisation was too hasty, because these events are important for the Git tab, which shows changes for all files, including those in the `file_scan_exclusions` list.

Closes #33167

Release Notes:

- Fixed the Git tab not updating changes to files in the `file_scan_exclusions` list.
