### PR TITLE
bedrock: Add Sonnet 4 to cross-region model list (eu/apac)

### DIFF
--- a/crates/bedrock/src/models.rs
+++ b/crates/bedrock/src/models.rs
@@ -483,6 +483,8 @@ impl Model {
                 Model::Claude3_5Sonnet
                 | Model::Claude3_7Sonnet
                 | Model::Claude3_7SonnetThinking
+                | Model::ClaudeSonnet4
+                | Model::ClaudeSonnet4Thinking
                 | Model::Claude3Haiku
                 | Model::Claude3Sonnet
                 | Model::MetaLlama321BInstructV1
@@ -496,7 +498,9 @@ impl Model {
                 Model::Claude3_5Sonnet
                 | Model::Claude3_5SonnetV2
                 | Model::Claude3Haiku
-                | Model::Claude3Sonnet,
+                | Model::Claude3Sonnet
+                | Model::ClaudeSonnet4
+                | Model::ClaudeSonnet4Thinking,
                 "apac",
             ) => Ok(format!("{}.{}", region_group, model_id)),
 
@@ -531,6 +535,10 @@ mod tests {
     #[test]
     fn test_eu_region_inference_ids() -> anyhow::Result<()> {
         // Test European regions
+        assert_eq!(
+            Model::ClaudeSonnet4.cross_region_inference_id("eu-west-1")?,
+            "eu.anthropic.claude-sonnet-4-20250514-v1:0"
+        );
         assert_eq!(
             Model::Claude3Sonnet.cross_region_inference_id("eu-west-1")?,
             "eu.anthropic.claude-3-sonnet-20240229-v1:0"


### PR DESCRIPTION
Closes #31946

Sonnet 4 is [now available](https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-support.html) via Bedrock in EU aws regions. 

Release Notes:

- bedrock: Add cross-region usage of Sonnet 4 in EU/APAC AWS regions