### PR TITLE
windows: Fix wrong glyph index being reported

### DIFF
--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1099,12 +1099,12 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
                     .index_converter
                     .advance_to_utf16_ix(context.utf16_index);
                 context.utf16_index += 1;
-                let glyph_index = cluster_map[index];
+                let glyph_index = cluster_map[index] as usize;
                 if index != 0 && last_glyph_index == glyph_index {
                     last_glyph_index = glyph_index;
                     continue;
                 }
-                let id = GlyphId(glyph_ids[glyph_index as usize] as u32);
+                let id = GlyphId(glyph_ids[glyph_index] as u32);
                 let is_emoji = color_font
                     && is_color_glyph(font_face, id, &context.text_system.components.factory);
                 glyphs.push(ShapedGlyph {
@@ -1113,7 +1113,7 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
                     index: context.index_converter.utf8_ix,
                     is_emoji,
                 });
-                context.width += glyph_advances[index];
+                context.width += glyph_advances[glyph_index];
             }
             context.runs.push(ShapedRun { font_id, glyphs });
         }

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -506,7 +506,6 @@ impl DirectWriteState {
                 ..Default::default()
             });
         }
-        println!("\n\nLayout line: {}", text);
         unsafe {
             let text_renderer = self.components.text_renderer.clone();
             let text_wide = text.encode_utf16().collect_vec();
@@ -609,7 +608,6 @@ impl DirectWriteState {
             )?;
             let width = px(renderer_context.width);
 
-            println!("Runs: {runs:#?}");
             Ok(LineLayout {
                 font_size,
                 width,

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1024,8 +1024,12 @@ impl<'t> ClusterAnalyzer<'t> {
             cluster_map,
         }
     }
+}
 
-    pub fn next(&mut self) -> Option<(usize, usize)> {
+impl Iterator for ClusterAnalyzer<'_> {
+    type Item = (usize, usize);
+
+    fn next(&mut self) -> Option<(usize, usize)> {
         if self.utf16_idx >= self.cluster_map.len() {
             return None; // No more clusters
         }
@@ -1153,7 +1157,7 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
             let mut utf16_idx = 0;
             let mut glyph_idx = 0;
             let mut glyphs = Vec::with_capacity(glyph_count);
-            while let Some((utf16_len, glyph_count)) = cluster_analyzer.next() {
+            for (utf16_len, glyph_count) in cluster_analyzer {
                 context
                     .index_converter
                     .advance_to_utf16_ix(index_offset + utf16_idx);

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -1113,17 +1113,12 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
         unsafe {
             let glyphrun = &*glyphrun;
             let glyph_count = glyphrun.glyphCount as usize;
-            if glyph_count == 0 {
+            if glyph_count == 0 || glyphrun.fontFace.is_none() {
                 return Ok(());
             }
             let desc = &*glyphrundescription;
             let context =
                 &mut *(clientdrawingcontext as *const RendererContext as *mut RendererContext);
-
-            if glyphrun.fontFace.is_none() {
-                return Ok(());
-            }
-
             let font_face = glyphrun.fontFace.as_ref().unwrap();
             // This `cast()` action here should never fail since we are running on Win10+, and
             // `IDWriteFontFace3` requires Win10
@@ -1149,38 +1144,35 @@ impl IDWriteTextRenderer_Impl for TextRenderer_Impl {
             let glyph_offsets = std::slice::from_raw_parts(glyphrun.glyphOffsets, glyph_count);
             let cluster_map =
                 std::slice::from_raw_parts(desc.clusterMap, desc.stringLength as usize);
-            let index_offset = desc.textPosition as usize;
-            println!("glyph advances: {:?}", glyph_advances);
-            println!("glyph offsets: {:?}", glyph_offsets);
 
             let mut cluster_analyzer = ClusterAnalyzer::new(cluster_map, glyph_count);
-            let mut utf16_idx = 0;
+            let mut utf16_idx = desc.textPosition as usize;
             let mut glyph_idx = 0;
             let mut glyphs = Vec::with_capacity(glyph_count);
-            for (utf16_len, glyph_count) in cluster_analyzer {
-                context
-                    .index_converter
-                    .advance_to_utf16_ix(index_offset + utf16_idx);
-                utf16_idx += utf16_len;
-                for (i, glyph_id) in glyph_ids[glyph_idx..(glyph_idx + glyph_count)]
+            for (cluster_utf16_len, cluster_glyph_count) in cluster_analyzer {
+                context.index_converter.advance_to_utf16_ix(utf16_idx);
+                utf16_idx += cluster_utf16_len;
+                for (cluster_glyph_idx, glyph_id) in glyph_ids
+                    [glyph_idx..(glyph_idx + cluster_glyph_count)]
                     .iter()
                     .enumerate()
                 {
                     let id = GlyphId(*glyph_id as u32);
                     let is_emoji = color_font
                         && is_color_glyph(font_face, id, &context.text_system.components.factory);
+                    let this_glyph_idx = glyph_idx + cluster_glyph_idx;
                     glyphs.push(ShapedGlyph {
                         id,
                         position: point(
-                            px(context.width + glyph_offsets[glyph_idx + i].advanceOffset),
+                            px(context.width + glyph_offsets[this_glyph_idx].advanceOffset),
                             px(0.0),
                         ),
                         index: context.index_converter.utf8_ix,
                         is_emoji,
                     });
-                    context.width += glyph_advances[glyph_idx + i];
+                    context.width += glyph_advances[this_glyph_idx];
                 }
-                glyph_idx += glyph_count;
+                glyph_idx += cluster_glyph_count;
             }
             context.runs.push(ShapedRun { font_id, glyphs });
         }


### PR DESCRIPTION
Closes #32424

This PR fixes two bugs:

* In cases like `fi ~~something~~`, the `fi` gets rendered as a ligature, meaning the two characters are combined into a single glyph. The final glyph index didn’t account for this change, which caused issues.
* On Windows, some emojis are composed of multiple glyphs. These composite emojis can now be rendered correctly as well.

![屏幕截图 2025-06-22 161900](https://github.com/user-attachments/assets/e125426b-a15e-41d1-a6e6-403a16924ada)

![屏幕截图 2025-06-22 162005](https://github.com/user-attachments/assets/f5f01022-2404-4e73-89e5-1aaddf7419d9)


Release Notes:

- N/A

