### PR TITLE
Add a `Copy` button for `About Zed`

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -944,12 +944,23 @@ fn about(
     let message = format!("{release_channel} {version} {debug}");
     let detail = AppCommitSha::try_global(cx).map(|sha| sha.full());
 
-    let prompt = window.prompt(PromptLevel::Info, &message, detail.as_deref(), &["OK"], cx);
-    cx.foreground_executor()
-        .spawn(async {
-            prompt.await.ok();
-        })
-        .detach();
+    let prompt = window.prompt(
+        PromptLevel::Info,
+        &message,
+        detail.as_deref(),
+        &["Copy", "OK"],
+        cx,
+    );
+    cx.spawn(async move |_, cx| {
+        if let Ok(0) = prompt.await {
+            let content = format!("{}\n{}", message, detail.as_deref().unwrap_or(""),);
+            cx.update(|cx| {
+                cx.write_to_clipboard(gpui::ClipboardItem::new_string(content));
+            })
+            .ok();
+        }
+    })
+    .detach();
 }
 
 fn test_panic(_: &TestPanic, _: &mut App) {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -953,7 +953,7 @@ fn about(
     );
     cx.spawn(async move |_, cx| {
         if let Ok(0) = prompt.await {
-            let content = format!("{}\n{}", message, detail.as_deref().unwrap_or(""),);
+            let content = format!("{}\n{}", message, detail.as_deref().unwrap_or(""));
             cx.update(|cx| {
                 cx.write_to_clipboard(gpui::ClipboardItem::new_string(content));
             })


### PR DESCRIPTION
Closes #33160

Since `TaskDialog` doesn’t allow users to copy its contents directly, VSCode added a `Copy` button so users can easily copy the message.



https://github.com/user-attachments/assets/04090753-226f-44d9-992c-8cc8cb8d7ecb




Release Notes:

- N/A
