### PR TITLE
lsp: Complete overloaded signature help implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12260,6 +12260,7 @@ dependencies = [
  "language",
  "log",
  "lsp",
+ "markdown",
  "node_runtime",
  "parking_lot",
  "pathdiff",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -686,6 +686,13 @@
       "pagedown": "editor::ContextMenuLast"
     }
   },
+  {
+    "context": "Editor && can_scroll_signature_help && !showing_completions",
+    "bindings": {
+      "up": "editor::SignatureHelpPrevious",
+      "down": "editor::SignatureHelpNext"
+    }
+  },
   // Custom bindings
   {
     "bindings": {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -687,7 +687,7 @@
     }
   },
   {
-    "context": "Editor && showing_signature_helps && !showing_completions",
+    "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
       "down": "editor::SignatureHelpNext"

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -687,7 +687,7 @@
     }
   },
   {
-    "context": "Editor && can_scroll_signature_help && !showing_completions",
+    "context": "Editor && showing_signature_helps && !showing_completions",
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
       "down": "editor::SignatureHelpNext"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -751,7 +751,7 @@
     }
   },
   {
-    "context": "Editor && showing_signature_helps && !showing_completions",
+    "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
       "down": "editor::SignatureHelpNext"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -751,7 +751,7 @@
     }
   },
   {
-    "context": "Editor && can_scroll_signature_help && !showing_completions",
+    "context": "Editor && showing_signature_helps && !showing_completions",
     "bindings": {
       "up": "editor::SignatureHelpPrevious",
       "down": "editor::SignatureHelpNext"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -750,6 +750,13 @@
       "pagedown": "editor::ContextMenuLast"
     }
   },
+  {
+    "context": "Editor && can_scroll_signature_help && !showing_completions",
+    "bindings": {
+      "up": "editor::SignatureHelpPrevious",
+      "down": "editor::SignatureHelpNext"
+    }
+  },
   // Custom bindings
   {
     "use_key_equivalents": true,

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -98,6 +98,13 @@
     }
   },
   {
+    "context": "Editor && showing_signature_help",
+    "bindings": {
+      "ctrl-p": "editor::SignatureHelpPrevious",
+      "ctrl-n": "editor::SignatureHelpNext"
+    }
+  },
+  {
     "context": "Workspace",
     "bindings": {
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal

--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -98,7 +98,7 @@
     }
   },
   {
-    "context": "Editor && showing_signature_help",
+    "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "ctrl-p": "editor::SignatureHelpPrevious",
       "ctrl-n": "editor::SignatureHelpNext"

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -98,6 +98,13 @@
     }
   },
   {
+    "context": "Editor && showing_signature_help",
+    "bindings": {
+      "ctrl-p": "editor::SignatureHelpPrevious",
+      "ctrl-n": "editor::SignatureHelpNext"
+    }
+  },
+  {
     "context": "Workspace",
     "bindings": {
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -98,7 +98,7 @@
     }
   },
   {
-    "context": "Editor && showing_signature_help",
+    "context": "Editor && showing_signature_help && !showing_completions",
     "bindings": {
       "ctrl-p": "editor::SignatureHelpPrevious",
       "ctrl-n": "editor::SignatureHelpNext"

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -478,7 +478,7 @@
     }
   },
   {
-    "context": "vim_mode == insert && showing_signature_help",
+    "context": "vim_mode == insert && showing_signature_help && !showing_completions",
     "bindings": {
       "ctrl-p": "editor::SignatureHelpPrevious",
       "ctrl-n": "editor::SignatureHelpNext"

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -478,6 +478,13 @@
     }
   },
   {
+    "context": "vim_mode == insert && showing_signature_help",
+    "bindings": {
+      "ctrl-p": "editor::SignatureHelpPrevious",
+      "ctrl-n": "editor::SignatureHelpNext"
+    }
+  },
+  {
     "context": "vim_mode == replace",
     "bindings": {
       "ctrl-c": "vim::NormalBefore",

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -423,6 +423,8 @@ actions!(
         ShowSignatureHelp,
         ShowWordCompletions,
         ShuffleLines,
+        SignatureHelpNext,
+        SignatureHelpPrevious,
         SortLinesCaseInsensitive,
         SortLinesCaseSensitive,
         SplitSelectionIntoLines,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2340,7 +2340,7 @@ impl Editor {
         }
 
         if self.signature_help_state.has_multiple_signatures() {
-            key_context.add("showing_signature_helps");
+            key_context.add("showing_signature_help");
         }
 
         // Disable vim contexts when a sub-editor (e.g. rename/inline assistant) is focused.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12259,7 +12259,7 @@ impl Editor {
     ) {
         if let Some(popover) = self.signature_help_state.popover_mut() {
             if popover.current_signature == 0 {
-                popover.current_signature = popover.signature.len() - 1;
+                popover.current_signature = popover.signatures.len() - 1;
             } else {
                 popover.current_signature -= 1;
             }
@@ -12274,7 +12274,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         if let Some(popover) = self.signature_help_state.popover_mut() {
-            if popover.current_signature + 1 == popover.signature.len() {
+            if popover.current_signature + 1 == popover.signatures.len() {
                 popover.current_signature = 0;
             } else {
                 popover.current_signature += 1;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2340,7 +2340,7 @@ impl Editor {
         }
 
         if self.signature_help_state.has_multiple_signatures() {
-            key_context.add("can_scroll_signature_help");
+            key_context.add("showing_signature_helps");
         }
 
         // Disable vim contexts when a sub-editor (e.g. rename/inline assistant) is focused.
@@ -12258,11 +12258,10 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         if let Some(popover) = self.signature_help_state.popover_mut() {
-            let mut current_signature = popover.current_signature.borrow_mut();
-            if *current_signature + 1 == popover.signature.len() {
-                *current_signature = 0;
+            if popover.current_signature == 0 {
+                popover.current_signature = popover.signature.len() - 1;
             } else {
-                *current_signature += 1;
+                popover.current_signature -= 1;
             }
             cx.notify();
         }
@@ -12275,11 +12274,10 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         if let Some(popover) = self.signature_help_state.popover_mut() {
-            let mut current_signature = popover.current_signature.borrow_mut();
-            if *current_signature == 0 {
-                *current_signature = popover.signature.len() - 1;
+            if popover.current_signature + 1 == popover.signature.len() {
+                popover.current_signature = 0;
             } else {
-                *current_signature -= 1;
+                popover.current_signature += 1;
             }
             cx.notify();
         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2339,6 +2339,10 @@ impl Editor {
             None => {}
         }
 
+        if self.signature_help_state.has_multiple_signatures() {
+            key_context.add("can_scroll_signature_help");
+        }
+
         // Disable vim contexts when a sub-editor (e.g. rename/inline assistant) is focused.
         if !self.focus_handle(cx).contains_focused(window, cx)
             || (self.is_focused(window) || self.mouse_menu_is_focused(window, cx))
@@ -12244,6 +12248,40 @@ impl Editor {
     ) {
         if let Some(context_menu) = self.context_menu.borrow_mut().as_mut() {
             context_menu.select_last(self.completion_provider.as_deref(), window, cx);
+        }
+    }
+
+    pub fn signature_help_prev(
+        &mut self,
+        _: &SignatureHelpPrevious,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(popover) = self.signature_help_state.popover_mut() {
+            let mut current_signature = popover.current_signature.borrow_mut();
+            if *current_signature + 1 == popover.signature.len() {
+                *current_signature = 0;
+            } else {
+                *current_signature += 1;
+            }
+            cx.notify();
+        }
+    }
+
+    pub fn signature_help_next(
+        &mut self,
+        _: &SignatureHelpNext,
+        _: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(popover) = self.signature_help_state.popover_mut() {
+            let mut current_signature = popover.current_signature.borrow_mut();
+            if *current_signature == 0 {
+                *current_signature = popover.signature.len() - 1;
+            } else {
+                *current_signature -= 1;
+            }
+            cx.notify();
         }
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11142,7 +11142,10 @@ async fn test_signature_help_multiple_signatures(cx: &mut TestAppContext) {
         assert_eq!(popover.current_signature, 1);
         assert_eq!(popover.signature[0].label, "fn overloaded(x: i32)");
         assert_eq!(popover.signature[1].label, "fn overloaded(x: i32, y: i32)");
-        assert_eq!(popover.signature[2].label, "fn overloaded(x: i32, y: i32, z: i32)");
+        assert_eq!(
+            popover.signature[2].label,
+            "fn overloaded(x: i32, y: i32, z: i32)"
+        );
     });
 
     // Test navigation functionality

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10570,7 +10570,7 @@ async fn test_handle_input_for_show_signature_help_auto_signature_help_true(
         let signature_help_state = editor.signature_help_state.popover().cloned();
         let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature.signature[signature.current_signature].label,
+            signature.signatures[signature.current_signature].label,
             "fn sample(param1: u8, param2: u8)"
         );
     });
@@ -10742,7 +10742,7 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut TestA
         assert!(signature_help_state.is_some());
         let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature.signature[signature.current_signature].label,
+            signature.signatures[signature.current_signature].label,
             "fn sample(param1: u8, param2: u8)"
         );
         editor.signature_help_state = SignatureHelpState::default();
@@ -10784,7 +10784,7 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut TestA
         assert!(signature_help_state.is_some());
         let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature.signature[signature.current_signature].label,
+            signature.signatures[signature.current_signature].label,
             "fn sample(param1: u8, param2: u8)"
         );
     });
@@ -10846,7 +10846,7 @@ async fn test_signature_help(cx: &mut TestAppContext) {
         assert!(signature_help_state.is_some());
         let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature.signature[signature.current_signature].label,
+            signature.signatures[signature.current_signature].label,
             "fn sample(param1: u8, param2: u8)"
         );
     });
@@ -11137,13 +11137,13 @@ async fn test_signature_help_multiple_signatures(cx: &mut TestAppContext) {
     // Verify we have multiple signatures and the right one is selected
     cx.editor(|editor, _, _| {
         let popover = editor.signature_help_state.popover().cloned().unwrap();
-        assert_eq!(popover.signature.len(), 3);
+        assert_eq!(popover.signatures.len(), 3);
         // active_signature was 1, so that should be the current
         assert_eq!(popover.current_signature, 1);
-        assert_eq!(popover.signature[0].label, "fn overloaded(x: i32)");
-        assert_eq!(popover.signature[1].label, "fn overloaded(x: i32, y: i32)");
+        assert_eq!(popover.signatures[0].label, "fn overloaded(x: i32)");
+        assert_eq!(popover.signatures[1].label, "fn overloaded(x: i32, y: i32)");
         assert_eq!(
-            popover.signature[2].label,
+            popover.signatures[2].label,
             "fn overloaded(x: i32, y: i32, z: i32)"
         );
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -10568,9 +10568,10 @@ async fn test_handle_input_for_show_signature_help_auto_signature_help_true(
 
     cx.editor(|editor, _, _| {
         let signature_help_state = editor.signature_help_state.popover().cloned();
+        let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            signature.signature[*signature.current_signature.borrow()].label,
+            "fn sample(param1: u8, param2: u8)"
         );
     });
 }
@@ -10739,9 +10740,10 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut TestA
     cx.update_editor(|editor, _, _| {
         let signature_help_state = editor.signature_help_state.popover().cloned();
         assert!(signature_help_state.is_some());
+        let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            signature.signature[*signature.current_signature.borrow()].label,
+            "fn sample(param1: u8, param2: u8)"
         );
         editor.signature_help_state = SignatureHelpState::default();
     });
@@ -10780,9 +10782,10 @@ async fn test_handle_input_with_different_show_signature_settings(cx: &mut TestA
     cx.editor(|editor, _, _| {
         let signature_help_state = editor.signature_help_state.popover().cloned();
         assert!(signature_help_state.is_some());
+        let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            signature.signature[*signature.current_signature.borrow()].label,
+            "fn sample(param1: u8, param2: u8)"
         );
     });
 }
@@ -10841,9 +10844,10 @@ async fn test_signature_help(cx: &mut TestAppContext) {
     cx.editor(|editor, _, _| {
         let signature_help_state = editor.signature_help_state.popover().cloned();
         assert!(signature_help_state.is_some());
+        let signature = signature_help_state.unwrap();
         assert_eq!(
-            signature_help_state.unwrap().label,
-            "param1: u8, param2: u8"
+            signature.signature[*signature.current_signature.borrow()].label,
+            "fn sample(param1: u8, param2: u8)"
         );
     });
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -551,6 +551,8 @@ impl EditorElement {
         register_action(editor, window, Editor::context_menu_prev);
         register_action(editor, window, Editor::context_menu_next);
         register_action(editor, window, Editor::context_menu_last);
+        register_action(editor, window, Editor::signature_help_prev);
+        register_action(editor, window, Editor::signature_help_next);
         register_action(editor, window, Editor::display_cursor_names);
         register_action(editor, window, Editor::unique_lines_case_insensitive);
         register_action(editor, window, Editor::unique_lines_case_sensitive);
@@ -4983,7 +4985,7 @@ impl EditorElement {
 
         let maybe_element = self.editor.update(cx, |editor, cx| {
             if let Some(popover) = editor.signature_help_state.popover_mut() {
-                let element = popover.render(max_size, cx);
+                let element = popover.render(max_size, window, cx);
                 Some(element)
             } else {
                 None

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -544,6 +544,8 @@ impl EditorElement {
             }
         });
         register_action(editor, window, Editor::show_signature_help);
+        register_action(editor, window, Editor::signature_help_prev);
+        register_action(editor, window, Editor::signature_help_next);
         register_action(editor, window, Editor::next_edit_prediction);
         register_action(editor, window, Editor::previous_edit_prediction);
         register_action(editor, window, Editor::show_inline_completion);
@@ -551,8 +553,6 @@ impl EditorElement {
         register_action(editor, window, Editor::context_menu_prev);
         register_action(editor, window, Editor::context_menu_next);
         register_action(editor, window, Editor::context_menu_last);
-        register_action(editor, window, Editor::signature_help_prev);
-        register_action(editor, window, Editor::signature_help_next);
         register_action(editor, window, Editor::display_cursor_names);
         register_action(editor, window, Editor::unique_lines_case_insensitive);
         register_action(editor, window, Editor::unique_lines_case_sensitive);

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -9,7 +9,11 @@ use language::BufferSnapshot;
 use markdown::{Markdown, MarkdownElement};
 use multi_buffer::{Anchor, ToOffset};
 use settings::Settings;
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
 use std::ops::Range;
+use std::rc::Rc;
 use text::Rope;
 use theme::ThemeSettings;
 use ui::{
@@ -216,89 +220,113 @@ impl Editor {
                             ..Default::default()
                         };
                         let scroll_handle = ScrollHandle::new();
-                        
-                        // Defer the entire popover creation to prevent blinking
-                        let editor_handle = cx.entity();
-                        let languages_clone = languages.clone();
-                        let text_style_clone = text_style.clone();
-                        let scroll_handle_clone = scroll_handle.clone();
-                        
-                        cx.defer(move |cx| {
-                            editor_handle.update(cx, |editor, cx| {
-                                let signatures = signature_help
-                                    .signatures
-                                    .into_iter()
-                                    .map(|s| {
-                                        let parameter_doc = s
-                                            .active_parameter
-                                            .and_then(|idx| s.parameters.get(idx))
-                                            .and_then(|param| param.documentation.clone())
-                                            .map(|documentation| {
-                                                cx.new(|cx| {
-                                                    Markdown::new(
-                                                        documentation.into(),
-                                                        Some(languages_clone.clone()),
-                                                        None,
-                                                        cx,
-                                                    )
-                                                })
-                                            });
+                        let cache = editor.signature_help_state.markdown_cache.clone();
 
-                                        SignatureHelp {
-                                            label: s.label.into(),
-                                            documentation: s.documentation.map(|documentation| {
-                                                cx.new(|cx| {
-                                                    Markdown::new(
-                                                        documentation.into(),
-                                                        Some(languages_clone.clone()),
-                                                        None,
-                                                        cx,
-                                                    )
-                                                })
-                                            }),
-                                            highlights: s.highlights,
-                                            active_parameter: s.active_parameter,
-                                            parameter_documentation: parameter_doc,
-                                        }
-                                    })
-                                    .collect::<Vec<_>>();
-
-                                if signatures.is_empty() {
-                                    editor
-                                        .signature_help_state
-                                        .hide(SignatureHelpHiddenBy::AutoClose);
-                                    return;
+                        // Create signatures with cached or new markdown entities
+                        let signatures: Vec<SignatureHelp> = signature_help
+                            .signatures
+                            .into_iter()
+                            .map(|s| {
+                                let mut hasher = std::collections::hash_map::DefaultHasher::new();
+                                s.label.hash(&mut hasher);
+                                if let Some(ref doc) = s.documentation {
+                                    doc.hash(&mut hasher);
                                 }
+                                if let Some(param_idx) = s.active_parameter {
+                                    if let Some(param) = s.parameters.get(param_idx) {
+                                        if let Some(ref doc) = param.documentation {
+                                            doc.hash(&mut hasher);
+                                        }
+                                    }
+                                }
+                                let hash_key = hasher.finish();
 
-                                let current_signature = signature_help
-                                    .active_signature
-                                    .min(signatures.len().saturating_sub(1));
+                                let mut cache_borrow = cache.borrow_mut();
+                                let (sig_markdown, param_markdown) = if let Some(cached) = cache_borrow.get(&hash_key) {
+                                    cached.clone()
+                                } else {
+                                    // Create markdown entities (parsing happens asynchronously)
+                                    let sig_markdown = s.documentation.map(|doc| {
+                                        let markdown = cx.new(|cx| {
+                                            Markdown::new(
+                                                doc.into(),
+                                                Some(languages.clone()),
+                                                None,
+                                                cx,
+                                            )
+                                        });
+                                        // Observe to trigger redraw when parsing completes
+                                        cx.observe(&markdown, |_, _, cx| cx.notify()).detach();
+                                        markdown
+                                    });
 
-                                let signature_help_popover = SignatureHelpPopover {
-                                    style: text_style_clone,
-                                    signature: signatures,
-                                    current_signature,
-                                    scroll_handle: scroll_handle_clone.clone(),
-                                    scrollbar_state: ScrollbarState::new(scroll_handle_clone),
+                                    let param_markdown = s.active_parameter
+                                        .and_then(|idx| s.parameters.get(idx))
+                                        .and_then(|p| p.documentation.clone())
+                                        .map(|doc| {
+                                            let markdown = cx.new(|cx| {
+                                                Markdown::new(
+                                                    doc.into(),
+                                                    Some(languages.clone()),
+                                                    None,
+                                                    cx,
+                                                )
+                                            });
+                                            cx.observe(&markdown, |_, _, cx| cx.notify()).detach();
+                                            markdown
+                                        });
+
+                                    // Store in cache
+                                    cache_borrow.insert(hash_key, (sig_markdown.clone(), param_markdown.clone()));
+                                    (sig_markdown, param_markdown)
                                 };
-                                
-                                editor
-                                    .signature_help_state
-                                    .set_popover(signature_help_popover);
-                                cx.notify();
-                            });
-                        });
+
+                                SignatureHelp {
+                                    label: s.label.into(),
+                                    documentation: sig_markdown,
+                                    highlights: s.highlights,
+                                    active_parameter: s.active_parameter,
+                                    parameter_documentation: param_markdown,
+                                }
+                            })
+                            .collect();
+
+                        if signatures.is_empty() {
+                            editor
+                                .signature_help_state
+                                .hide(SignatureHelpHiddenBy::AutoClose);
+                            return;
+                        }
+
+                        let current_signature = signature_help
+                            .active_signature
+                            .min(signatures.len().saturating_sub(1));
+
+                        let signature_help_popover = SignatureHelpPopover {
+                            style: text_style.clone(),
+                            signature: signatures,
+                            current_signature,
+                            scroll_handle: scroll_handle.clone(),
+                            scrollbar_state: ScrollbarState::new(scroll_handle.clone()),
+                        };
+
+                        editor
+                            .signature_help_state
+                            .set_popover(signature_help_popover);
+                        cx.notify();
                     })
                     .ok();
             }));
     }
 }
 
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct SignatureHelpState {
     task: Option<Task<()>>,
     popover: Option<SignatureHelpPopover>,
     hidden_by: Option<SignatureHelpHiddenBy>,
+    // Cache for markdown entities
+    markdown_cache: Rc<RefCell<HashMap<u64, (Option<Entity<Markdown>>, Option<Entity<Markdown>>)>>>,
 }
 
 impl SignatureHelpState {
@@ -329,6 +357,7 @@ impl SignatureHelpState {
         if self.hidden_by.is_none() {
             self.popover = None;
             self.hidden_by = Some(hidden_by);
+            self.markdown_cache.borrow_mut().clear();
         }
     }
 

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -226,7 +226,7 @@ impl Editor {
                                     .and_then(|param| param.documentation.clone())
                                     .map(|documentation| {
                                         cx.new(|cx| {
-                                            Markdown::new(
+                                            Markdown::new_simple(
                                                 documentation.into(),
                                                 Some(languages.clone()),
                                                 None,
@@ -239,7 +239,7 @@ impl Editor {
                                     label: s.label.into(),
                                     documentation: s.documentation.map(|documentation| {
                                         cx.new(|cx| {
-                                            Markdown::new(
+                                            Markdown::new_simple(
                                                 documentation.into(),
                                                 Some(languages.clone()),
                                                 None,

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -384,7 +384,7 @@ impl SignatureHelpPopover {
             let prev_button = IconButton::new("signature_help_prev", IconName::ChevronUp)
                 .shape(IconButtonShape::Square)
                 .style(ButtonStyle::Subtle)
-                .icon_size(IconSize::XSmall)
+                .icon_size(IconSize::Small)
                 .tooltip(move |window, cx| {
                     ui::Tooltip::for_action(
                         "Previous Signature",
@@ -400,7 +400,7 @@ impl SignatureHelpPopover {
             let next_button = IconButton::new("signature_help_next", IconName::ChevronDown)
                 .shape(IconButtonShape::Square)
                 .style(ButtonStyle::Subtle)
-                .icon_size(IconSize::XSmall)
+                .icon_size(IconSize::Small)
                 .tooltip(move |window, cx| {
                     ui::Tooltip::for_action("Next Signature", &crate::SignatureHelpNext, window, cx)
                 })

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -2,8 +2,8 @@ use crate::actions::ShowSignatureHelp;
 use crate::hover_popover::open_markdown_url;
 use crate::{Editor, EditorSettings, ToggleAutoSignatureHelp, hover_markdown_style};
 use gpui::{
-    App, AppContext, Context, Entity, HighlightStyle, MouseButton, ScrollHandle, Size,
-    Stateful, StyledText, Task, TextStyle, Window, combine_highlights, Div,
+    App, AppContext, Context, Div, Entity, HighlightStyle, MouseButton, ScrollHandle, Size,
+    Stateful, StyledText, Task, TextStyle, Window, combine_highlights,
 };
 use language::BufferSnapshot;
 use markdown::{Markdown, MarkdownElement};
@@ -13,9 +13,9 @@ use std::ops::Range;
 use text::Rope;
 use theme::ThemeSettings;
 use ui::{
-    ActiveTheme, AnyElement, ButtonCommon, ButtonStyle, Clickable, FluentBuilder,
-    IconButton, IconButtonShape, IconName, IconSize, InteractiveElement, IntoElement, Label,
-    LabelCommon, LabelSize, ParentElement, Pixels, Scrollbar, ScrollbarState, SharedString,
+    ActiveTheme, AnyElement, ButtonCommon, ButtonStyle, Clickable, FluentBuilder, IconButton,
+    IconButtonShape, IconName, IconSize, InteractiveElement, IntoElement, Label, LabelCommon,
+    LabelSize, ParentElement, Pixels, Scrollbar, ScrollbarState, SharedString,
     StatefulInteractiveElement, Styled, StyledExt, div, px, relative,
 };
 
@@ -360,8 +360,12 @@ impl SignatureHelpPopover {
                     .max_w(max_size.width)
                     .max_h(max_size.height)
                     .track_scroll(&self.scroll_handle)
-                    .child(StyledText::new(signature.label.clone())
-                        .with_default_highlights(&self.style, signature.highlights.iter().cloned()))
+                    .child(
+                        StyledText::new(signature.label.clone()).with_default_highlights(
+                            &self.style,
+                            signature.highlights.iter().cloned(),
+                        ),
+                    )
                     .when_some(signature.documentation.clone(), |this, description| {
                         this.child(div().h_px().bg(cx.theme().colors().border_variant).my_1())
                             .child(
@@ -382,7 +386,12 @@ impl SignatureHelpPopover {
                 .style(ButtonStyle::Subtle)
                 .icon_size(IconSize::XSmall)
                 .tooltip(move |window, cx| {
-                    ui::Tooltip::for_action("Previous Signature", &crate::SignatureHelpPrevious, window, cx)
+                    ui::Tooltip::for_action(
+                        "Previous Signature",
+                        &crate::SignatureHelpPrevious,
+                        window,
+                        cx,
+                    )
                 })
                 .on_click(cx.listener(|editor, _, window, cx| {
                     editor.signature_help_prev(&crate::SignatureHelpPrevious, window, cx);

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -216,13 +216,13 @@ impl Editor {
                             ..Default::default()
                         };
                         let scroll_handle = ScrollHandle::new();
-
+                        
                         // Defer the entire popover creation to prevent blinking
                         let editor_handle = cx.entity();
                         let languages_clone = languages.clone();
                         let text_style_clone = text_style.clone();
                         let scroll_handle_clone = scroll_handle.clone();
-
+                        
                         cx.defer(move |cx| {
                             editor_handle.update(cx, |editor, cx| {
                                 let signatures = signature_help
@@ -281,7 +281,7 @@ impl Editor {
                                     scroll_handle: scroll_handle_clone.clone(),
                                     scrollbar_state: ScrollbarState::new(scroll_handle_clone),
                                 };
-
+                                
                                 editor
                                     .signature_help_state
                                     .set_popover(signature_help_popover);

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -441,7 +441,7 @@ impl SignatureHelpPopover {
             .flex_row()
             .when_some(controls, |this, controls| {
                 this.children(vec![
-                    div().flex().items_center().child(controls),
+                    div().flex().items_end().child(controls),
                     div().w_px().bg(cx.theme().colors().border_variant),
                 ])
             })

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -216,13 +216,13 @@ impl Editor {
                             ..Default::default()
                         };
                         let scroll_handle = ScrollHandle::new();
-                        
+
                         // Defer the entire popover creation to prevent blinking
                         let editor_handle = cx.entity();
                         let languages_clone = languages.clone();
                         let text_style_clone = text_style.clone();
                         let scroll_handle_clone = scroll_handle.clone();
-                        
+
                         cx.defer(move |cx| {
                             editor_handle.update(cx, |editor, cx| {
                                 let signatures = signature_help
@@ -281,7 +281,7 @@ impl Editor {
                                     scroll_handle: scroll_handle_clone.clone(),
                                     scrollbar_state: ScrollbarState::new(scroll_handle_clone),
                                 };
-                                
+
                                 editor
                                     .signature_help_state
                                     .set_popover(signature_help_popover);

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -312,7 +312,7 @@ impl SignatureHelpState {
     pub fn has_multiple_signatures(&self) -> bool {
         self.popover
             .as_ref()
-            .map_or(false, |popover| popover.signature.len() > 1)
+            .is_some_and(|popover| popover.signature.len() > 1)
     }
 }
 

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -696,61 +696,6 @@ impl LanguageRegistry {
             .cloned()
     }
 
-    /// Returns a cached language if it's already loaded, otherwise None.
-    /// This is a synchronous method that doesn't trigger language loading.
-    pub fn get_cached_language(self: &Arc<Self>, name: &str) -> Option<Arc<Language>> {
-        let state = self.state.read();
-        let name = UniCase::new(name);
-        state
-            .languages
-            .iter()
-            .find(|l| UniCase::new(&l.config.name) == name)
-            .cloned()
-    }
-
-    /// Returns a cached language by name or extension if it's already loaded, otherwise None.
-    /// This is a synchronous method that doesn't trigger language loading.
-    pub fn get_cached_language_by_name_or_extension(
-        self: &Arc<Self>,
-        string: &str,
-    ) -> Option<Arc<Language>> {
-        let state = self.state.read();
-        let string = UniCase::new(string);
-        state
-            .languages
-            .iter()
-            .find(|l| {
-                UniCase::new(&l.config.name) == string
-                    || l.config
-                        .matcher
-                        .path_suffixes
-                        .iter()
-                        .any(|suffix| UniCase::new(suffix) == string)
-            })
-            .cloned()
-    }
-
-    /// Returns a cached language for a file path if it's already loaded, otherwise None.
-    /// This is a synchronous method that doesn't trigger language loading.
-    pub fn get_cached_language_for_path(self: &Arc<Self>, path: &Path) -> Option<Arc<Language>> {
-        let state = self.state.read();
-
-        // Check both file extension and full file name
-        let extension = path.extension().and_then(OsStr::to_str);
-        let file_name = path.file_name().and_then(OsStr::to_str);
-
-        state
-            .languages
-            .iter()
-            .find(|language| {
-                language.config.matcher.path_suffixes.iter().any(|suffix| {
-                    extension.map_or(false, |ext| suffix == ext)
-                        || file_name.map_or(false, |name| name.ends_with(suffix))
-                })
-            })
-            .cloned()
-    }
-
     pub fn language_for_file(
         self: &Arc<Self>,
         file: &Arc<dyn File>,

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -710,7 +710,10 @@ impl LanguageRegistry {
 
     /// Returns a cached language by name or extension if it's already loaded, otherwise None.
     /// This is a synchronous method that doesn't trigger language loading.
-    pub fn get_cached_language_by_name_or_extension(self: &Arc<Self>, string: &str) -> Option<Arc<Language>> {
+    pub fn get_cached_language_by_name_or_extension(
+        self: &Arc<Self>,
+        string: &str,
+    ) -> Option<Arc<Language>> {
         let state = self.state.read();
         let string = UniCase::new(string);
         state
@@ -731,18 +734,18 @@ impl LanguageRegistry {
     /// This is a synchronous method that doesn't trigger language loading.
     pub fn get_cached_language_for_path(self: &Arc<Self>, path: &Path) -> Option<Arc<Language>> {
         let state = self.state.read();
-        
+
         // Check both file extension and full file name
         let extension = path.extension().and_then(OsStr::to_str);
         let file_name = path.file_name().and_then(OsStr::to_str);
-        
+
         state
             .languages
             .iter()
             .find(|language| {
                 language.config.matcher.path_suffixes.iter().any(|suffix| {
-                    extension.map_or(false, |ext| suffix == ext) ||
-                    file_name.map_or(false, |name| name.ends_with(suffix))
+                    extension.map_or(false, |ext| suffix == ext)
+                        || file_name.map_or(false, |name| name.ends_with(suffix))
                 })
             })
             .cloned()

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -696,6 +696,58 @@ impl LanguageRegistry {
             .cloned()
     }
 
+    /// Returns a cached language if it's already loaded, otherwise None.
+    /// This is a synchronous method that doesn't trigger language loading.
+    pub fn get_cached_language(self: &Arc<Self>, name: &str) -> Option<Arc<Language>> {
+        let state = self.state.read();
+        let name = UniCase::new(name);
+        state
+            .languages
+            .iter()
+            .find(|l| UniCase::new(&l.config.name) == name)
+            .cloned()
+    }
+
+    /// Returns a cached language by name or extension if it's already loaded, otherwise None.
+    /// This is a synchronous method that doesn't trigger language loading.
+    pub fn get_cached_language_by_name_or_extension(self: &Arc<Self>, string: &str) -> Option<Arc<Language>> {
+        let state = self.state.read();
+        let string = UniCase::new(string);
+        state
+            .languages
+            .iter()
+            .find(|l| {
+                UniCase::new(&l.config.name) == string
+                    || l.config
+                        .matcher
+                        .path_suffixes
+                        .iter()
+                        .any(|suffix| UniCase::new(suffix) == string)
+            })
+            .cloned()
+    }
+
+    /// Returns a cached language for a file path if it's already loaded, otherwise None.
+    /// This is a synchronous method that doesn't trigger language loading.
+    pub fn get_cached_language_for_path(self: &Arc<Self>, path: &Path) -> Option<Arc<Language>> {
+        let state = self.state.read();
+        
+        // Check both file extension and full file name
+        let extension = path.extension().and_then(OsStr::to_str);
+        let file_name = path.file_name().and_then(OsStr::to_str);
+        
+        state
+            .languages
+            .iter()
+            .find(|language| {
+                language.config.matcher.path_suffixes.iter().any(|suffix| {
+                    extension.map_or(false, |ext| suffix == ext) ||
+                    file_name.map_or(false, |name| name.ends_with(suffix))
+                })
+            })
+            .cloned()
+    }
+
     pub fn language_for_file(
         self: &Arc<Self>,
         file: &Arc<dyn File>,

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -235,14 +235,19 @@ impl Markdown {
 
             for name in &language_names {
                 if !name.is_empty() {
-                    if let Some(language) = registry.get_cached_language_by_name_or_extension(name) {
-                        this.parsed_markdown.languages_by_name.insert(name.clone(), language);
+                    if let Some(language) = registry.get_cached_language_by_name_or_extension(name)
+                    {
+                        this.parsed_markdown
+                            .languages_by_name
+                            .insert(name.clone(), language);
                     } else {
                         need_async_names.push(name.clone());
                     }
                 } else if let Some(fallback) = &fallback_for_async {
                     if let Some(language) = registry.get_cached_language(fallback.as_ref()) {
-                        this.parsed_markdown.languages_by_name.insert(name.clone(), language);
+                        this.parsed_markdown
+                            .languages_by_name
+                            .insert(name.clone(), language);
                     } else {
                         need_async_names.push(name.clone());
                     }
@@ -251,7 +256,9 @@ impl Markdown {
 
             for path in &paths {
                 if let Some(language) = registry.get_cached_language_for_path(path) {
-                    this.parsed_markdown.languages_by_path.insert(path.clone(), language);
+                    this.parsed_markdown
+                        .languages_by_path
+                        .insert(path.clone(), language);
                 } else {
                     need_async_paths.push(path.clone());
                 }
@@ -293,10 +300,15 @@ impl Markdown {
                 let (languages_by_name, languages_by_path) = async_loading.await;
 
                 this.update(cx, |this, cx| {
-                    this.parsed_markdown.languages_by_name.extend(languages_by_name);
-                    this.parsed_markdown.languages_by_path.extend(languages_by_path);
-                    if !this.parsed_markdown.languages_by_name.is_empty() ||
-                       !this.parsed_markdown.languages_by_path.is_empty() {
+                    this.parsed_markdown
+                        .languages_by_name
+                        .extend(languages_by_name);
+                    this.parsed_markdown
+                        .languages_by_path
+                        .extend(languages_by_path);
+                    if !this.parsed_markdown.languages_by_name.is_empty()
+                        || !this.parsed_markdown.languages_by_path.is_empty()
+                    {
                         cx.notify();
                     }
                 })

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -172,154 +172,6 @@ impl Markdown {
         this
     }
 
-    /// Creates a simple Markdown instance optimized for UI elements like tooltips and popovers.
-    ///
-    /// This method parses the markdown content synchronously and renders it immediately,
-    /// then asynchronously loads language definitions for syntax highlighting. This approach
-    /// prevents flickering that would otherwise occur when using `new()`, which triggers
-    /// a window refresh when parsing completes.
-    ///
-    /// The key insight is that syntax highlighting doesn't affect the overall layout
-    /// calculation - it only changes colors within already-allocated space. By deferring
-    /// only the language loading (not the parsing), we can display the full markdown
-    /// structure immediately while syntax highlighting appears seamlessly once loaded.
-    ///
-    /// This method is particularly suitable for UI elements like tooltips and popovers where
-    /// flickering during initial display would be disruptive to the user experience.
-    ///
-    /// ## Limitations compared to `new()`:
-    /// - Does not decode base64-encoded images from data URLs (not typically needed for popovers)
-    pub fn new_simple(
-        source: SharedString,
-        language_registry: Option<Arc<LanguageRegistry>>,
-        fallback_code_block_language: Option<LanguageName>,
-        cx: &mut Context<Self>,
-    ) -> Self {
-        let focus_handle = cx.focus_handle();
-
-        let (events, language_names, paths) = parse_markdown(&source);
-
-        let parsed_markdown = ParsedMarkdown {
-            source: source.clone(),
-            events: Arc::from(events),
-            languages_by_name: TreeMap::default(),
-            languages_by_path: TreeMap::default(),
-        };
-
-        let fallback_for_async = fallback_code_block_language.clone();
-
-        let mut this = Self {
-            source,
-            selection: Selection::default(),
-            pressed_link: None,
-            autoscroll_request: None,
-            should_reparse: false,
-            images_by_source_offset: Default::default(),
-            parsed_markdown,
-            pending_parse: None,
-            focus_handle,
-            language_registry: language_registry.clone(),
-            fallback_code_block_language,
-            options: Options {
-                parse_links_only: false,
-            },
-            copied_code_blocks: HashSet::new(),
-        };
-
-        // Load languages - try synchronously first, then asynchronously for missing ones
-        if let Some(registry) = language_registry.clone() {
-            let fallback = fallback_for_async.clone();
-
-            let mut need_async_names = Vec::new();
-            let mut need_async_paths = Vec::new();
-
-            for name in &language_names {
-                if !name.is_empty() {
-                    if let Some(language) = registry.get_cached_language_by_name_or_extension(name)
-                    {
-                        this.parsed_markdown
-                            .languages_by_name
-                            .insert(name.clone(), language);
-                    } else {
-                        need_async_names.push(name.clone());
-                    }
-                } else if let Some(fallback) = &fallback_for_async {
-                    if let Some(language) = registry.get_cached_language(fallback.as_ref()) {
-                        this.parsed_markdown
-                            .languages_by_name
-                            .insert(name.clone(), language);
-                    } else {
-                        need_async_names.push(name.clone());
-                    }
-                }
-            }
-
-            for path in &paths {
-                if let Some(language) = registry.get_cached_language_for_path(path) {
-                    this.parsed_markdown
-                        .languages_by_path
-                        .insert(path.clone(), language);
-                } else {
-                    need_async_paths.push(path.clone());
-                }
-            }
-
-            // If all languages were found in cache, we're done
-            if need_async_names.is_empty() && need_async_paths.is_empty() {
-                return this;
-            }
-
-            // Otherwise, load missing languages asynchronously
-            let async_loading = cx.background_spawn(async move {
-                let mut languages_by_name = Vec::new();
-                let mut languages_by_path = Vec::new();
-
-                for name in need_async_names {
-                    let language = if !name.is_empty() {
-                        registry.language_for_name_or_extension(&name).left_future()
-                    } else if let Some(fallback) = &fallback {
-                        registry.language_for_name(fallback.as_ref()).right_future()
-                    } else {
-                        continue;
-                    };
-                    if let Ok(language) = language.await {
-                        languages_by_name.push((name, language));
-                    }
-                }
-
-                for path in need_async_paths {
-                    if let Ok(language) = registry.language_for_file_path(&path).await {
-                        languages_by_path.push((path, language));
-                    }
-                }
-
-                (languages_by_name, languages_by_path)
-            });
-
-            cx.spawn(async move |this, cx| {
-                let (languages_by_name, languages_by_path) = async_loading.await;
-
-                this.update(cx, |this, cx| {
-                    this.parsed_markdown
-                        .languages_by_name
-                        .extend(languages_by_name);
-                    this.parsed_markdown
-                        .languages_by_path
-                        .extend(languages_by_path);
-                    if !this.parsed_markdown.languages_by_name.is_empty()
-                        || !this.parsed_markdown.languages_by_path.is_empty()
-                    {
-                        cx.notify();
-                    }
-                })
-                .ok();
-            })
-            .detach();
-        }
-
-        this
-    }
-
     pub fn new_text(source: SharedString, cx: &mut Context<Self>) -> Self {
         let focus_handle = cx.focus_handle();
         let mut this = Self {
@@ -569,7 +421,7 @@ impl Selection {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct ParsedMarkdown {
     pub source: SharedString,
     pub events: Arc<[(Range<usize>, MarkdownEvent)]>,
@@ -1821,7 +1673,7 @@ struct RenderedText {
     links: Rc<[RenderedLink]>,
 }
 
-#[derive(Clone, Eq, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 struct RenderedLink {
     source_range: Range<usize>,
     destination_url: SharedString,

--- a/crates/project/Cargo.toml
+++ b/crates/project/Cargo.toml
@@ -54,6 +54,7 @@ indexmap.workspace = true
 language.workspace = true
 log.workspace = true
 lsp.workspace = true
+markdown.workspace = true
 node_runtime.workspace = true
 parking_lot.workspace = true
 pathdiff.workspace = true

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -1805,12 +1805,15 @@ impl LspCommand for GetSignatureHelp {
     async fn response_from_lsp(
         self,
         message: Option<lsp::SignatureHelp>,
-        _: Entity<LspStore>,
+        lsp_store: Entity<LspStore>,
         _: Entity<Buffer>,
         _: LanguageServerId,
-        _: AsyncApp,
+        cx: AsyncApp,
     ) -> Result<Self::Response> {
-        Ok(message.and_then(SignatureHelp::new))
+        let Some(message) = message else {
+            return Ok(None);
+        };
+        cx.update(|cx| SignatureHelp::new(message, Some(lsp_store.read(cx).languages.clone()), cx))
     }
 
     fn to_proto(&self, project_id: u64, buffer: &Buffer) -> Self::ProtoRequest {
@@ -1861,14 +1864,18 @@ impl LspCommand for GetSignatureHelp {
     async fn response_from_proto(
         self,
         response: proto::GetSignatureHelpResponse,
-        _: Entity<LspStore>,
+        lsp_store: Entity<LspStore>,
         _: Entity<Buffer>,
-        _: AsyncApp,
+        cx: AsyncApp,
     ) -> Result<Self::Response> {
-        Ok(response
-            .signature_help
-            .map(proto_to_lsp_signature)
-            .and_then(SignatureHelp::new))
+        cx.update(|cx| {
+            response
+                .signature_help
+                .map(proto_to_lsp_signature)
+                .and_then(|signature| {
+                    SignatureHelp::new(signature, Some(lsp_store.read(cx).languages.clone()), cx)
+                })
+        })
     }
 
     fn buffer_id_from_proto(message: &Self::ProtoRequest) -> Result<BufferId> {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -38,6 +38,7 @@ use text::{BufferId, LineEnding};
 use util::{ResultExt as _, debug_panic};
 
 pub use signature_help::SignatureHelp;
+pub use signature_help::SignatureHelpData;
 
 pub fn lsp_formatting_options(settings: &LanguageSettings) -> lsp::FormattingOptions {
     lsp::FormattingOptions {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -38,7 +38,6 @@ use text::{BufferId, LineEnding};
 use util::{ResultExt as _, debug_panic};
 
 pub use signature_help::SignatureHelp;
-pub use signature_help::SignatureHelpData;
 
 pub fn lsp_formatting_options(settings: &LanguageSettings) -> lsp::FormattingOptions {
     lsp::FormattingOptions {

--- a/crates/project/src/lsp_command/signature_help.rs
+++ b/crates/project/src/lsp_command/signature_help.rs
@@ -1,16 +1,7 @@
-use std::collections::HashSet;
 use std::ops::Range;
 
 use gpui::{FontWeight, HighlightStyle};
 use rpc::proto::{self, documentation};
-
-/// Key used for deduplicating signatures based on all content
-#[derive(Hash, Eq, PartialEq)]
-struct SignatureKey {
-    label: String,
-    documentation: Option<String>,
-    parameter_docs: Vec<Option<String>>,
-}
 
 #[derive(Debug)]
 pub struct SignatureHelp {
@@ -39,47 +30,9 @@ impl SignatureHelp {
         if help.signatures.is_empty() {
             return None;
         }
-        let requested_active_signature = help.active_signature.unwrap_or(0) as usize;
+        let active_signature = help.active_signature.unwrap_or(0) as usize;
         let mut signatures = Vec::<SignatureHelpData>::with_capacity(help.signatures.capacity());
-        let mut seen_signatures = HashSet::<SignatureKey>::new();
-        let mut actual_active_signature = 0;
-        let mut original_index = 0;
-
         for signature in &help.signatures {
-            let is_active = original_index == requested_active_signature;
-            original_index += 1;
-
-            let signature_key = SignatureKey {
-                label: signature.label.clone(),
-                documentation: signature.documentation.as_ref().map(|d| match d {
-                    lsp::Documentation::String(s) => s.clone(),
-                    lsp::Documentation::MarkupContent(m) => m.value.clone(),
-                }),
-                parameter_docs: signature
-                    .parameters
-                    .as_ref()
-                    .map(|params| {
-                        params
-                            .iter()
-                            .map(|p| {
-                                p.documentation.as_ref().map(|d| match d {
-                                    lsp::Documentation::String(s) => s.clone(),
-                                    lsp::Documentation::MarkupContent(m) => m.value.clone(),
-                                })
-                            })
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-            };
-
-            if !seen_signatures.insert(signature_key) {
-                continue; // skip duplicated signature
-            }
-
-            if is_active {
-                // If this was the active signature, update our tracked index
-                actual_active_signature = signatures.len();
-            }
             let active_parameter = signature
                 .active_parameter
                 .unwrap_or_else(|| help.active_parameter.unwrap_or(0))
@@ -150,7 +103,7 @@ impl SignatureHelp {
         }
         Some(Self {
             signatures,
-            active_signature: actual_active_signature,
+            active_signature,
             original_data: help,
         })
     }
@@ -736,105 +689,5 @@ mod tests {
 
         // Check that the active parameter is correct
         assert_eq!(signature.active_parameter, Some(0));
-    }
-
-    #[test]
-    fn test_deduplication() {
-        let signature_help = lsp::SignatureHelp {
-            signatures: vec![
-                lsp::SignatureInformation {
-                    label: "fn test(foo: u8)".to_string(),
-                    documentation: Some(Documentation::String("First".to_string())),
-                    parameters: Some(vec![lsp::ParameterInformation {
-                        label: lsp::ParameterLabel::Simple("foo: u8".to_string()),
-                        documentation: Some(Documentation::String("First foo".to_string())),
-                    }]),
-                    active_parameter: None,
-                },
-                lsp::SignatureInformation {
-                    label: "fn test(foo: u8)".to_string(), // Same label, different docs
-                    documentation: Some(Documentation::String("Second".to_string())),
-                    parameters: Some(vec![lsp::ParameterInformation {
-                        label: lsp::ParameterLabel::Simple("foo: u8".to_string()),
-                        documentation: Some(Documentation::String("Second foo".to_string())),
-                    }]),
-                    active_parameter: None,
-                },
-                lsp::SignatureInformation {
-                    label: "fn test(foo: u8)".to_string(), // Exact duplicate of first
-                    documentation: Some(Documentation::String("First".to_string())),
-                    parameters: Some(vec![lsp::ParameterInformation {
-                        label: lsp::ParameterLabel::Simple("foo: u8".to_string()),
-                        documentation: Some(Documentation::String("First foo".to_string())),
-                    }]),
-                    active_parameter: None,
-                },
-                lsp::SignatureInformation {
-                    label: "fn test(foo: u8, bar: &str)".to_string(),
-                    documentation: None,
-                    parameters: None,
-                    active_parameter: None,
-                },
-            ],
-            active_signature: Some(3), // Points to the fourth signature
-            active_parameter: None,
-        };
-
-        let maybe_help = SignatureHelp::new(signature_help);
-        assert!(maybe_help.is_some());
-
-        let help = maybe_help.unwrap();
-        // Should have 3 signatures after deduplication (two different "fn test(foo: u8)" and one "fn test(foo: u8, bar: &str)")
-        assert_eq!(help.signatures.len(), 3);
-        assert_eq!(help.signatures[0].label, "fn test(foo: u8)");
-        assert_eq!(help.signatures[0].documentation, Some("First".to_string()));
-        assert_eq!(help.signatures[1].label, "fn test(foo: u8)");
-        assert_eq!(help.signatures[1].documentation, Some("Second".to_string()));
-        assert_eq!(help.signatures[2].label, "fn test(foo: u8, bar: &str)");
-
-        // Active signature should be adjusted to point to the correct deduplicated index
-        assert_eq!(help.active_signature, 2);
-    }
-
-    #[test]
-    fn test_deduplication_with_markup_content() {
-        let signature_help = lsp::SignatureHelp {
-            signatures: vec![
-                lsp::SignatureInformation {
-                    label: "fn test()".to_string(),
-                    documentation: Some(Documentation::MarkupContent(MarkupContent {
-                        kind: MarkupKind::Markdown,
-                        value: "First doc".to_string(),
-                    })),
-                    parameters: None,
-                    active_parameter: None,
-                },
-                lsp::SignatureInformation {
-                    label: "fn test()".to_string(),
-                    documentation: Some(Documentation::String("First doc".to_string())), // Same content, different format
-                    parameters: None,
-                    active_parameter: None,
-                },
-                lsp::SignatureInformation {
-                    label: "fn test()".to_string(),
-                    documentation: Some(Documentation::MarkupContent(MarkupContent {
-                        kind: MarkupKind::PlainText, // Different kind but same value
-                        value: "First doc".to_string(),
-                    })),
-                    parameters: None,
-                    active_parameter: None,
-                },
-            ],
-            active_signature: Some(1),
-            active_parameter: None,
-        };
-
-        let maybe_help = SignatureHelp::new(signature_help);
-        assert!(maybe_help.is_some());
-
-        let help = maybe_help.unwrap();
-        // All three should be deduplicated as they have same content
-        assert_eq!(help.signatures.len(), 1);
-        assert_eq!(help.active_signature, 0);
     }
 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6381,7 +6381,7 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, actions)| actions)
-                    .filter(|help| !help.label.is_empty())
+                    // .filter(|help| !help.label.is_empty())
                     .collect::<Vec<_>>()
             })
         }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -6381,7 +6381,6 @@ impl LspStore {
                     .await
                     .into_iter()
                     .flat_map(|(_, actions)| actions)
-                    // .filter(|help| !help.label.is_empty())
                     .collect::<Vec<_>>()
             })
         }

--- a/crates/theme/src/styles/accents.rs
+++ b/crates/theme/src/styles/accents.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 
 /// A collection of colors that are used to color indent aware lines in the editor.
-#[derive(Clone, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct AccentColors(pub Vec<Hsla>);
 
 impl Default for AccentColors {

--- a/crates/theme/src/styles/colors.rs
+++ b/crates/theme/src/styles/colors.rs
@@ -533,7 +533,7 @@ pub fn all_theme_colors(cx: &mut App) -> Vec<(Hsla, SharedString)> {
         .collect()
 }
 
-#[derive(Refineable, Clone, PartialEq)]
+#[derive(Refineable, Clone, Debug, PartialEq)]
 pub struct ThemeStyles {
     /// The background appearance of the window.
     pub window_background_appearance: WindowBackgroundAppearance,

--- a/crates/theme/src/styles/players.rs
+++ b/crates/theme/src/styles/players.rs
@@ -20,7 +20,7 @@ pub struct PlayerColor {
 ///
 /// The rest of the default colors crisscross back and forth on the
 /// color wheel so that the colors are as distinct as possible.
-#[derive(Clone, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq)]
 pub struct PlayerColors(pub Vec<PlayerColor>);
 
 impl Default for PlayerColors {

--- a/crates/theme/src/styles/system.rs
+++ b/crates/theme/src/styles/system.rs
@@ -2,7 +2,7 @@
 
 use gpui::{Hsla, hsla};
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct SystemColors {
     pub transparent: Hsla,
     pub mac_os_traffic_light_red: Hsla,

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -265,7 +265,7 @@ pub fn refine_theme_family(theme_family_content: ThemeFamilyContent) -> ThemeFam
 }
 
 /// A theme is the primary mechanism for defining the appearance of the UI.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Theme {
     /// The unique identifier for the theme.
     pub id: String,


### PR DESCRIPTION
This PR revives zed-industries/zed#27818 and aims to complete the partially implemented overloaded signature help feature.

The first commit is a rebase of zed-industries/zed#27818, and the subsequent commit addresses all review feedback from the original PR.

Now the overloaded signature help works like

https://github.com/user-attachments/assets/e253c9a0-e3a5-4bfe-8003-eb75de41f672

Closes #21493

Release Notes:

- Implemented signature help for overloaded items. Additionally, added a support for rendering signature help documentation.
