### PR TITLE
helix: Prevent cursor move on entering insert mode

### DIFF
--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -29,15 +29,20 @@ impl Vim {
         self.stop_recording_immediately(action.boxed_clone(), cx);
         if count <= 1 || Vim::globals(cx).dot_replaying {
             self.create_mark("^".into(), window, cx);
+
             self.update_editor(window, cx, |_, editor, window, cx| {
                 editor.dismiss_menus_and_popups(false, window, cx);
-                editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
-                    s.move_cursors_with(|map, mut cursor, _| {
-                        *cursor.column_mut() = cursor.column().saturating_sub(1);
-                        (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
+
+                if !HelixModeSetting::get_global(cx).0 {
+                    editor.change_selections(Some(Autoscroll::fit()), window, cx, |s| {
+                        s.move_cursors_with(|map, mut cursor, _| {
+                            *cursor.column_mut() = cursor.column().saturating_sub(1);
+                            (map.clip_point(cursor, Bias::Left), SelectionGoal::None)
+                        });
                     });
-                });
+                }
             });
+
             if HelixModeSetting::get_global(cx).0 {
                 self.switch_mode(Mode::HelixNormal, false, window, cx);
             } else {


### PR DESCRIPTION
Closes #33061

https://github.com/user-attachments/assets/3b3e146e-7c12-412e-b4dd-c70411891b9e

Release Notes:

- Fixed cursor unexpectedly moving when entering/exiting insert mode in Helix mode, making the behavior consistent with the Helix editor.
