### PR TITLE
lsp: Implement proper LSP-based signature help trigger characters

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4156,7 +4156,14 @@ impl Editor {
             }
 
             let editor_settings = EditorSettings::get_global(cx);
-            if bracket_inserted
+
+            let should_trigger_signature_help = if this.has_lsp_signature_help_triggers(cx) {
+                this.should_trigger_signature_help(&text, cx)
+            } else {
+                bracket_inserted // check if the bracket has been inserted as a fallback
+            };
+
+            if should_trigger_signature_help
                 && (editor_settings.auto_signature_help
                     || editor_settings.show_signature_help_after_edits)
             {


### PR DESCRIPTION
This completes the fix for #31846. The signature help now properly respects language server configuration instead of using hardcoded trigger strategy.

Closes #31846

Release Notes:

- Fixed the logic for triggering signature help, and the `triggerCharacters` setting configured by the server is now used. The `retriggerCharacters` configuration is also now respected.
