### PR TITLE
lsp: Allow signature help to show while completions menu is visible

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -11805,8 +11805,8 @@ async fn test_completion(cx: &mut TestAppContext) {
     cx.run_until_parked();
     cx.update_editor(|editor, _, _| {
         assert!(
-            !editor.signature_help_state.is_shown(),
-            "No signature help should be shown when completions menu is open"
+            editor.signature_help_state.is_shown(),
+            "Signature help can be shown alongside completions menu"
         );
     });
 

--- a/crates/editor/src/signature_help.rs
+++ b/crates/editor/src/signature_help.rs
@@ -156,7 +156,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if self.pending_rename.is_some() || self.has_visible_completions_menu() {
+        if self.pending_rename.is_some() {
             return;
         }
 


### PR DESCRIPTION
Remove the check that prevented signature help from displaying when the completions menu is visible. There's no fundamental reason why these two features can't work simultaneously - they serve complementary purposes and typically appear in different locations in the UI.
This behavior is also consistent with how other editors like VSCode handles those two LSP features.