### PR TITLE
emacs: Fix ctrl-p/ctrl-n navigating popover menus

### DIFF
--- a/assets/keymaps/linux/emacs.json
+++ b/assets/keymaps/linux/emacs.json
@@ -91,6 +91,13 @@
     }
   },
   {
+    "context": "Editor && (showing_code_actions || showing_completions)",
+    "bindings": {
+      "ctrl-p": "editor::ContextMenuPrevious",
+      "ctrl-n": "editor::ContextMenuNext"
+    }
+  },
+  {
     "context": "Workspace",
     "bindings": {
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal

--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -91,6 +91,13 @@
     }
   },
   {
+    "context": "Editor && (showing_code_actions || showing_completions)",
+    "bindings": {
+      "ctrl-p": "editor::ContextMenuPrevious",
+      "ctrl-n": "editor::ContextMenuNext"
+    }
+  },
+  {
     "context": "Workspace",
     "bindings": {
       "ctrl-x ctrl-c": "zed::Quit", // save-buffers-kill-terminal


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33200

Release Notes:

- emacs: Fixed ctrl-p/ctrl-n keyboard navigation of autocomplete/code actions menus