### PR TITLE
agent: Preserve chat box text on 'New From Summary'

### DIFF
--- a/crates/agent/src/agent_panel.rs
+++ b/crates/agent/src/agent_panel.rs
@@ -728,6 +728,12 @@ impl AgentPanel {
     }
 
     fn new_thread(&mut self, action: &NewThread, window: &mut Window, cx: &mut Context<Self>) {
+        // Preserve chat box text when using creating new thread from summary'
+        let preserved_text = action
+            .from_thread_id
+            .is_some()
+            .then(|| self.message_editor.read(cx).get_text(cx).trim().to_string());
+
         let thread = self
             .thread_store
             .update(cx, |this, cx| this.create_thread(cx));
@@ -804,6 +810,13 @@ impl AgentPanel {
                 cx,
             )
         });
+
+        if let Some(text) = preserved_text {
+            self.message_editor.update(cx, |editor, cx| {
+                editor.set_text(text, window, cx);
+            });
+        }
+
         self.message_editor.focus_handle(cx).focus(window);
 
         let message_editor_subscription =

--- a/crates/agent/src/message_editor.rs
+++ b/crates/agent/src/message_editor.rs
@@ -240,6 +240,21 @@ impl MessageEditor {
         &self.context_store
     }
 
+    pub fn get_text(&self, cx: &App) -> String {
+        self.editor.read(cx).text(cx)
+    }
+
+    pub fn set_text(
+        &mut self,
+        text: impl Into<Arc<str>>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.editor.update(cx, |editor, cx| {
+            editor.set_text(text, window, cx);
+        });
+    }
+
     pub fn expand_message_editor(
         &mut self,
         _: &ExpandMessageEditor,


### PR DESCRIPTION
CC: @danilo-leal Do you have thoughts on this?  I found myself typing chat messages after a long thread and then deciding I would be better served by restarting from a summary -- and then "poof" the contents of my chat box was lost.

Release Notes:

- agent: "New From Summary" now preserves any unsent content in the chat box.