### PR TITLE
Support vim-mode in git commit editor

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -850,6 +850,18 @@
     }
   },
   {
+    "context": "(CommitEditor || GitCommit) > Editor && VimControl",
+    "bindings": {
+      // TODO: Implement search on commit editor
+      "/": null,
+      "?": null,
+      "#": null,
+      "*": null,
+      "n": null,
+      "shift-n": null
+    }
+  },
+  {
     "context": "Editor && edit_prediction",
     "bindings": {
       // This is identical to the binding in the base keymap, but the vim bindings above to

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -850,15 +850,22 @@
     }
   },
   {
-    "context": "(CommitEditor || GitCommit) > Editor && VimControl",
+    "context": "Editor && mode == auto_height && VimControl",
     "bindings": {
-      // TODO: Implement search on commit editor
+      // TODO: Implement search
       "/": null,
       "?": null,
       "#": null,
       "*": null,
       "n": null,
       "shift-n": null
+    }
+  },
+  {
+    "context": "GitCommit > Editor && VimControl && vim_mode == normal",
+    "bindings": {
+      "ctrl-c": "menu::Cancel",
+      "escape": "menu::Cancel"
     }
   },
   {
@@ -872,14 +879,7 @@
   {
     "context": "MessageEditor > Editor && VimControl",
     "bindings": {
-      "enter": "agent::Chat",
-      // TODO: Implement search
-      "/": null,
-      "?": null,
-      "#": null,
-      "*": null,
-      "n": null,
-      "shift-n": null
+      "enter": "agent::Chat"
     }
   },
   {

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -388,6 +388,7 @@ pub(crate) fn commit_message_editor(
     commit_editor.set_collaboration_hub(Box::new(project));
     commit_editor.set_use_autoclose(false);
     commit_editor.set_show_gutter(false, cx);
+    commit_editor.set_use_modal_editing(true);
     commit_editor.set_show_wrap_guides(false, cx);
     commit_editor.set_show_indent_guides(false, cx);
     let placeholder = placeholder.unwrap_or("Enter commit message".into());


### PR DESCRIPTION
Release Notes:

- Added support for vim-mode on git commit editor (modal included)

Side notes: 
- Maybe in the future (or even on this PR) a config could be added to let the user choose whether to enable vim-mode on this editor or not? And on the agent message editor as well. 