### PR TITLE
gpui: Defer `App::on_action` listeners

### DIFF
--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3727,102 +3727,104 @@ impl Window {
         cx: &mut App,
     ) {
         let dispatch_path = self.rendered_frame.dispatch_tree.dispatch_path(node_id);
-        let action = action.boxed_clone();
-        let window = self.handle;
 
-        cx.defer(move |cx| {
-            // Capture phase for global actions.
-            cx.propagate_event = true;
-            if let Some(mut global_listeners) = cx
-                .global_action_listeners
-                .remove(&action.as_any().type_id())
+        cx.defer({
+            let action = action.boxed_clone();
+            move |cx| {
+                // Capture phase for global actions.
+                cx.propagate_event = true;
+                if let Some(mut global_listeners) = cx
+                    .global_action_listeners
+                    .remove(&action.as_any().type_id())
+                {
+                    for listener in &global_listeners {
+                        listener(action.as_any(), DispatchPhase::Capture, cx);
+                        if !cx.propagate_event {
+                            break;
+                        }
+                    }
+
+                    global_listeners.extend(
+                        cx.global_action_listeners
+                            .remove(&action.as_any().type_id())
+                            .unwrap_or_default(),
+                    );
+
+                    cx.global_action_listeners
+                        .insert(action.as_any().type_id(), global_listeners);
+                }
+            }
+        });
+
+        if !cx.propagate_event {
+            return;
+        }
+
+        // Capture phase for window actions.
+        for node_id in &dispatch_path {
+            let node = self.rendered_frame.dispatch_tree.node(*node_id);
+            for DispatchActionListener {
+                action_type,
+                listener,
+            } in node.action_listeners.clone()
             {
-                for listener in &global_listeners {
-                    listener(action.as_any(), DispatchPhase::Capture, cx);
+                let any_action = action.as_any();
+                if action_type == any_action.type_id() {
+                    listener(any_action, DispatchPhase::Capture, self, cx);
+
                     if !cx.propagate_event {
-                        break;
+                        return;
                     }
                 }
-
-                global_listeners.extend(
-                    cx.global_action_listeners
-                        .remove(&action.as_any().type_id())
-                        .unwrap_or_default(),
-                );
-
-                cx.global_action_listeners
-                    .insert(action.as_any().type_id(), global_listeners);
             }
+        }
 
-            if !cx.propagate_event {
-                return;
-            }
-
-            window
-                .update(cx, |_, window, cx| {
-                    // Capture phase for window actions.
-                    for node_id in &dispatch_path {
-                        let node = window.rendered_frame.dispatch_tree.node(*node_id);
-                        for DispatchActionListener {
-                            action_type,
-                            listener,
-                        } in node.action_listeners.clone()
-                        {
-                            let any_action = action.as_any();
-                            if action_type == any_action.type_id() {
-                                listener(any_action, DispatchPhase::Capture, window, cx);
-
-                                if !cx.propagate_event {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-
-                    // Bubble phase for window actions.
-                    for node_id in dispatch_path.iter().rev() {
-                        let node = window.rendered_frame.dispatch_tree.node(*node_id);
-                        for DispatchActionListener {
-                            action_type,
-                            listener,
-                        } in node.action_listeners.clone()
-                        {
-                            let any_action = action.as_any();
-                            if action_type == any_action.type_id() {
-                                cx.propagate_event = false; // Actions stop propagation by default during the bubble phase
-                                listener(any_action, DispatchPhase::Bubble, window, cx);
-
-                                if !cx.propagate_event {
-                                    return;
-                                }
-                            }
-                        }
-                    }
-                })
-                .log_err();
-
-            // Bubble phase for global actions.
-            if let Some(mut global_listeners) = cx
-                .global_action_listeners
-                .remove(&action.as_any().type_id())
+        // Bubble phase for window actions.
+        for node_id in dispatch_path.iter().rev() {
+            let node = self.rendered_frame.dispatch_tree.node(*node_id);
+            for DispatchActionListener {
+                action_type,
+                listener,
+            } in node.action_listeners.clone()
             {
-                for listener in global_listeners.iter().rev() {
+                let any_action = action.as_any();
+                if action_type == any_action.type_id() {
                     cx.propagate_event = false; // Actions stop propagation by default during the bubble phase
+                    listener(any_action, DispatchPhase::Bubble, self, cx);
 
-                    listener(action.as_any(), DispatchPhase::Bubble, cx);
                     if !cx.propagate_event {
-                        break;
+                        return;
                     }
                 }
+            }
+        }
 
-                global_listeners.extend(
+        cx.defer({
+            let action = action.boxed_clone();
+            move |cx| {
+                // Bubble phase for global actions.
+                if let Some(mut global_listeners) = cx
+                    .global_action_listeners
+                    .remove(&action.as_any().type_id())
+                {
+                    for listener in global_listeners.iter().rev() {
+                        cx.propagate_event = false; // Actions stop propagation by default during the bubble phase
+
+                        listener(action.as_any(), DispatchPhase::Bubble, cx);
+                        if !cx.propagate_event {
+                            break;
+                        }
+                    }
+
+                    global_listeners.extend(
+                        cx.global_action_listeners
+                            .remove(&action.as_any().type_id())
+                            .unwrap_or_default(),
+                    );
+
                     cx.global_action_listeners
-                        .remove(&action.as_any().type_id())
-                        .unwrap_or_default(),
-                );
-
-                cx.global_action_listeners
-                    .insert(action.as_any().type_id(), global_listeners);
+                        .insert(action.as_any().type_id(), global_listeners);
+                }
             }
         });
     }

--- a/crates/inspector_ui/src/inspector.rs
+++ b/crates/inspector_ui/src/inspector.rs
@@ -16,12 +16,9 @@ pub fn init(app_state: Arc<AppState>, cx: &mut App) {
         else {
             return;
         };
-        // This is deferred to avoid double lease due to window already being updated.
-        cx.defer(move |cx| {
-            active_window
-                .update(cx, |_, window, cx| window.toggle_inspector(cx))
-                .log_err();
-        });
+        active_window
+            .update(cx, |_, window, cx| window.toggle_inspector(cx))
+            .log_err();
     });
 
     // Project used for editor buffers with LSP support

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2027,21 +2027,19 @@ impl Workspace {
     }
 
     pub fn close_global(_: &CloseWindow, cx: &mut App) {
-        cx.defer(|cx| {
-            cx.windows().iter().find(|window| {
-                window
-                    .update(cx, |_, window, _| {
-                        if window.is_window_active() {
-                            //This can only get called when the window's project connection has been lost
-                            //so we don't need to prompt the user for anything and instead just close the window
-                            window.remove_window();
-                            true
-                        } else {
-                            false
-                        }
-                    })
-                    .unwrap_or(false)
-            });
+        cx.windows().iter().find(|window| {
+            window
+                .update(cx, |_, window, _| {
+                    if window.is_window_active() {
+                        //This can only get called when the window's project connection has been lost
+                        //so we don't need to prompt the user for anything and instead just close the window
+                        window.remove_window();
+                        true
+                    } else {
+                        false
+                    }
+                })
+                .unwrap_or(false)
         });
     }
 
@@ -7695,11 +7693,9 @@ pub fn with_active_or_new_workspace(
 ) {
     match cx.active_window().and_then(|w| w.downcast::<Workspace>()) {
         Some(workspace) => {
-            cx.defer(move |cx| {
-                workspace
-                    .update(cx, |workspace, window, cx| f(workspace, window, cx))
-                    .log_err();
-            });
+            workspace
+                .update(cx, |workspace, window, cx| f(workspace, window, cx))
+                .log_err();
         }
         None => {
             let app_state = AppState::global(cx);


### PR DESCRIPTION
Uses defer when calling listeners of `App::on_action`, this prevents a surprise caused by the double lease when trying to update the window in the callback since it is already being updated.

Release Notes:

- N/A