### PR TITLE
file finder: Ensure filter options keybinding is displayed

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -945,7 +945,7 @@
     }
   },
   {
-    "context": "FileFinder",
+    "context": "FileFinder || (FileFinder > Picker > Editor)",
     "bindings": {
       "ctrl-shift-a": "file_finder::ToggleSplitMenu",
       "ctrl-shift-i": "file_finder::ToggleFilterMenu"

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1011,7 +1011,7 @@
     }
   },
   {
-    "context": "FileFinder",
+    "context": "FileFinder || (FileFinder > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-shift-a": "file_finder::ToggleSplitMenu",


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/31777. I could've sworn the filter options keybinding was being displayed in the icon button tooltip, but just realized it actually wasn't. So, this PR fixes that!

Release Notes:

- N/A
