### PR TITLE
Add toast notifications for regex errors in search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14202,6 +14202,7 @@ dependencies = [
  "gpui",
  "language",
  "menu",
+ "notifications",
  "project",
  "schemars",
  "serde",

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -30,6 +30,7 @@ futures.workspace = true
 gpui.workspace = true
 language.workspace = true
 menu.workspace = true
+notifications.workspace = true
 project.workspace = true
 schemars.workspace = true
 serde.workspace = true


### PR DESCRIPTION
Closes #17223

Surfaces regex errors as toast notifications when using regex search in project search or buffer search. Did not set them to autohide to give users time to read the error. Made sure to cancel the notifications when the search query is updated to a functioning search query.

Release Notes:

- Send toast notifications for regex errors in project and buffer searches.