### PR TITLE
agent: Improve MCP with no config editor empty state

### DIFF
--- a/crates/agent/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent/src/agent_configuration/configure_context_server_modal.rs
@@ -503,10 +503,7 @@ impl ConfigureContextServerModal {
             ConfigurationSource::Existing { editor } => editor,
             ConfigurationSource::Extension { editor, .. } => {
                 let Some(editor) = editor else {
-                    return Label::new(
-                        "No configuration options available for this context server. Visit the Repository for any further instructions.",
-                    )
-                    .color(Color::Muted).into_any_element();
+                    return div().into_any_element();
                 };
                 editor
             }


### PR DESCRIPTION
Removed an additional label from the modal empty state as I figured we don't need it, given we already have a version of the description in place for when the extension itself doesn't return any. So, ultimately, having both the label and the description was redundant.

Release Notes:

- N/A
