### PR TITLE
Stop showing diagnostics in the diff-related editors

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -993,6 +993,7 @@ pub struct Editor {
     show_inline_diagnostics: bool,
     inline_diagnostics_update: Task<()>,
     inline_diagnostics_enabled: bool,
+    diagnostics_enabled: bool,
     inline_diagnostics: Vec<(Anchor, InlineDiagnostic)>,
     soft_wrap_mode_override: Option<language_settings::SoftWrap>,
     hard_wrap: Option<usize>,
@@ -2063,6 +2064,7 @@ impl Editor {
                 released_too_fast: false,
             },
             inline_diagnostics_enabled: mode.is_full(),
+            diagnostics_enabled: mode.is_full(),
             inline_value_cache: InlineValueCache::new(inlay_hint_settings.show_value_hints),
             inlay_hint_cache: InlayHintCache::new(inlay_hint_settings),
 
@@ -14639,6 +14641,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.diagnostics_enabled() {
+            return;
+        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.go_to_diagnostic_impl(Direction::Next, window, cx)
     }
@@ -14649,6 +14654,9 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if !self.diagnostics_enabled() {
+            return;
+        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.go_to_diagnostic_impl(Direction::Prev, window, cx)
     }
@@ -16070,7 +16078,7 @@ impl Editor {
     }
 
     fn refresh_active_diagnostics(&mut self, cx: &mut Context<Editor>) {
-        if self.mode.is_minimap() {
+        if !self.diagnostics_enabled() {
             return;
         }
 
@@ -16101,6 +16109,9 @@ impl Editor {
     }
 
     pub fn set_all_diagnostics_active(&mut self, cx: &mut Context<Self>) {
+        if !self.diagnostics_enabled() {
+            return;
+        }
         self.dismiss_diagnostics(cx);
         self.active_diagnostics = ActiveDiagnostic::All;
     }
@@ -16112,7 +16123,7 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if matches!(self.active_diagnostics, ActiveDiagnostic::All) {
+        if !self.diagnostics_enabled() || matches!(self.active_diagnostics, ActiveDiagnostic::All) {
             return;
         }
         self.dismiss_diagnostics(cx);
@@ -16163,12 +16174,19 @@ impl Editor {
         self.inline_diagnostics.clear();
     }
 
+    pub fn disable_diagnostics(&mut self, cx: &mut Context<Self>) {
+        self.diagnostics_enabled = false;
+        self.dismiss_diagnostics(cx);
+        self.inline_diagnostics_update = Task::ready(());
+        self.inline_diagnostics.clear();
+    }
+
     pub fn diagnostics_enabled(&self) -> bool {
-        self.mode.is_full()
+        self.diagnostics_enabled && self.mode.is_full()
     }
 
     pub fn inline_diagnostics_enabled(&self) -> bool {
-        self.diagnostics_enabled() && self.inline_diagnostics_enabled
+        self.inline_diagnostics_enabled && self.diagnostics_enabled()
     }
 
     pub fn show_inline_diagnostics(&self) -> bool {
@@ -19391,6 +19409,9 @@ impl Editor {
     }
 
     fn update_diagnostics_state(&mut self, window: &mut Window, cx: &mut Context<'_, Editor>) {
+        if !self.diagnostics_enabled() {
+            return;
+        }
         self.refresh_active_diagnostics(cx);
         self.refresh_inline_diagnostics(true, window, cx);
         self.scrollbar_marker_state.dirty = true;
@@ -22097,7 +22118,7 @@ impl Render for Editor {
                 inlay_hints_style: make_inlay_hints_style(cx),
                 inline_completion_styles: make_suggestion_styles(cx),
                 unnecessary_code_fade: ThemeSettings::get_global(cx).unnecessary_code_fade,
-                show_underlines: !self.mode.is_minimap(),
+                show_underlines: self.diagnostics_enabled(),
             },
         )
     }

--- a/crates/git_ui/src/diff_view.rs
+++ b/crates/git_ui/src/diff_view.rs
@@ -94,7 +94,7 @@ impl DiffView {
             let mut editor =
                 Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
             editor.start_temporary_diff_override();
-            editor.disable_inline_diagnostics();
+            editor.disable_diagnostics(cx);
             editor.set_expand_all_diff_hunks(cx);
             editor.set_render_diff_hunk_controls(
                 Arc::new(|_, _, _, _, _, _, _, _| gpui::Empty.into_any_element()),

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -141,7 +141,7 @@ impl ProjectDiff {
         let editor = cx.new(|cx| {
             let mut diff_display_editor =
                 Editor::for_multibuffer(multibuffer.clone(), Some(project.clone()), window, cx);
-            diff_display_editor.disable_inline_diagnostics();
+            diff_display_editor.disable_diagnostics(cx);
             diff_display_editor.set_expand_all_diff_hunks(cx);
             diff_display_editor.register_addon(GitPanelAddon {
                 workspace: workspace.downgrade(),


### PR DESCRIPTION
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/a63925a7-8e13-4d48-bd31-33f434209ea6" />

Diagnostics UI elements (underlines, popovers, hovers) are quite noisy by themselves and get even more so with the git background colors.

Release Notes:

- Stopped showing diagnostics in the diff-related editors
