### PR TITLE
gpui: Fix drawing rotated SVGs

### DIFF
--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 use anyhow::Result;
 use gpui::{
     Animation, AnimationExt as _, App, Application, AssetSource, Bounds, Context, SharedString,
-    Transformation, Window, WindowBounds, WindowOptions, black, bounce, div, ease_in_out,
-    percentage, prelude::*, px, rgb, size, svg,
+    Transformation, Window, WindowBounds, WindowOptions, bounce, div, ease_in_out, percentage,
+    prelude::*, px, size, svg,
 };
 
 struct Assets {}
@@ -37,37 +37,65 @@ struct AnimationExample {}
 
 impl Render for AnimationExample {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().flex().flex_col().size_full().justify_around().child(
-            div().flex().flex_row().w_full().justify_around().child(
+        div()
+            .flex()
+            .flex_col()
+            .size_full()
+            .bg(gpui::white())
+            .text_color(gpui::black())
+            .justify_around()
+            .child(
                 div()
                     .flex()
-                    .bg(rgb(0x2e7d32))
-                    .size(px(300.0))
-                    .justify_center()
-                    .items_center()
-                    .shadow_lg()
-                    .text_xl()
-                    .text_color(black())
-                    .child("hello")
+                    .flex_col()
+                    .size_full()
+                    .justify_around()
                     .child(
-                        svg()
-                            .size_8()
-                            .path(ARROW_CIRCLE_SVG)
-                            .text_color(black())
-                            .with_animation(
-                                "image_circle",
-                                Animation::new(Duration::from_secs(2))
-                                    .repeat()
-                                    .with_easing(bounce(ease_in_out)),
-                                |svg, delta| {
-                                    svg.with_transformation(Transformation::rotate(percentage(
-                                        delta,
-                                    )))
-                                },
+                        div()
+                            .id("content")
+                            .flex()
+                            .flex_col()
+                            .h(px(150.))
+                            .overflow_y_scroll()
+                            .w_full()
+                            .flex_1()
+                            .justify_center()
+                            .items_center()
+                            .text_xl()
+                            .gap_4()
+                            .child("Hello Animation")
+                            .child(
+                                svg()
+                                    .size_20()
+                                    .path(ARROW_CIRCLE_SVG)
+                                    .text_color(gpui::black())
+                                    .with_animation(
+                                        "image_circle",
+                                        Animation::new(Duration::from_secs(2))
+                                            .repeat()
+                                            .with_easing(bounce(ease_in_out)),
+                                        |svg, delta| {
+                                            svg.with_transformation(Transformation::rotate(
+                                                percentage(delta),
+                                            ))
+                                        },
+                                    ),
                             ),
+                    )
+                    .child(
+                        div()
+                            .flex()
+                            .h(px(64.))
+                            .w_full()
+                            .p_2()
+                            .justify_center()
+                            .items_center()
+                            .border_t_1()
+                            .border_color(gpui::black().opacity(0.1))
+                            .bg(gpui::black().opacity(0.05))
+                            .child("Other Panel"),
                     ),
-            ),
-        )
+            )
     }
 }
 

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -67,6 +67,7 @@ impl Render for AnimationExample {
                             .child(
                                 svg()
                                     .size_20()
+                                    .overflow_hidden()
                                     .path(ARROW_CIRCLE_SVG)
                                     .text_color(gpui::black())
                                     .with_animation(

--- a/crates/gpui/src/platform/blade/shaders.wgsl
+++ b/crates/gpui/src/platform/blade/shaders.wgsl
@@ -172,6 +172,12 @@ fn distance_from_clip_rect(unit_vertex: vec2<f32>, bounds: Bounds, clip_bounds: 
     return distance_from_clip_rect_impl(position, clip_bounds);
 }
 
+fn distance_from_clip_rect_transformed(unit_vertex: vec2<f32>, bounds: Bounds, clip_bounds: Bounds, transform: TransformationMatrix) -> vec4<f32> {
+    let position = unit_vertex * vec2<f32>(bounds.size) + bounds.origin;
+    let transformed = transpose(transform.rotation_scale) * position + transform.translation;
+    return distance_from_clip_rect_impl(transformed, clip_bounds);
+}
+
 // https://gamedev.stackexchange.com/questions/92015/optimized-linear-to-srgb-glsl
 fn srgb_to_linear(srgb: vec3<f32>) -> vec3<f32> {
     let cutoff = srgb < vec3<f32>(0.04045);
@@ -1150,7 +1156,7 @@ fn vs_mono_sprite(@builtin(vertex_index) vertex_id: u32, @builtin(instance_index
 
     out.tile_position = to_tile_position(unit_vertex, sprite.tile);
     out.color = hsla_to_rgba(sprite.color);
-    out.clip_distances = distance_from_clip_rect(unit_vertex, sprite.bounds, sprite.content_mask);
+    out.clip_distances = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
     return out;
 }
 

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -107,6 +107,12 @@ float4 distance_from_clip_rect(float2 unit_vertex, Bounds bounds, Bounds clip_bo
     return distance_from_clip_rect_impl(position, clip_bounds);
 }
 
+float4 distance_from_clip_rect_transformed(float2 unit_vertex, Bounds bounds, Bounds clip_bounds, TransformationMatrix transformation) {
+    float2 position = unit_vertex * bounds.size + bounds.origin;
+    float2 transformed = mul(position, transformation.rotation_scale) + transformation.translation;
+    return distance_from_clip_rect_impl(transformed, clip_bounds);
+}
+
 // Convert linear RGB to sRGB
 float3 linear_to_srgb(float3 color) {
     return pow(color, float3(2.2, 2.2, 2.2));
@@ -1088,7 +1094,7 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
     MonochromeSprite sprite = mono_sprites[sprite_id];
     float4 device_position =
         to_device_position_transformed(unit_vertex, sprite.bounds, sprite.transformation);
-    float4 clip_distance = distance_from_clip_rect(unit_vertex, sprite.bounds, sprite.content_mask);
+    float4 clip_distance = distance_from_clip_rect_transformed(unit_vertex, sprite.bounds, sprite.content_mask, sprite.transformation);
     float2 tile_position = to_tile_position(unit_vertex, sprite.tile);
     float4 color = hsla_to_rgba(sprite.color);
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3082,22 +3082,31 @@ impl Window {
         let Some(tile) =
             self.sprite_atlas
                 .get_or_insert_with(&params.clone().into(), &mut || {
-                    let Some(bytes) = cx.svg_renderer.render(&params)? else {
+                    let Some((size, bytes)) = cx.svg_renderer.render(&params)? else {
                         return Ok(None);
                     };
-                    Ok(Some((params.size, Cow::Owned(bytes))))
+                    Ok(Some((size, Cow::Owned(bytes))))
                 })?
         else {
             return Ok(());
         };
         let content_mask = self.content_mask().scale(scale_factor);
+        let svg_bounds = Bounds {
+            origin: bounds.center()
+                - Point::new(
+                    ScaledPixels(tile.bounds.size.width.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
+                    ScaledPixels(tile.bounds.size.height.0 as f32 / SMOOTH_SVG_SCALE_FACTOR / 2.),
+                ),
+            size: tile
+                .bounds
+                .size
+                .map(|value| ScaledPixels(value.0 as f32 / SMOOTH_SVG_SCALE_FACTOR)),
+        };
 
         self.next_frame.scene.insert_primitive(MonochromeSprite {
             order: 0,
             pad: 0,
-            bounds: bounds
-                .map_origin(|origin| origin.floor())
-                .map_size(|size| size.ceil()),
+            bounds: svg_bounds,
             content_mask,
             color: color.opacity(element_opacity),
             tile,


### PR DESCRIPTION
Fixes: https://github.com/longbridge/gpui-component/issues/994

1. When SVG is rotated, incorrect graphics are drawn.

For example: the original aspect ratio of the SVG is 1:1, if the bounds used to render the SVG are 400x200 (aspect ratio 2:1), [here](https://github.com/zed-industries/zed/blob/21f985a018f7cca9c0fb7f5b7a87555486ab9db5/crates/gpui/src/svg_renderer.rs#L91) the width is used as the scaling factor, causing the rendered SVG to only have half the height. This PR ensures the complete SVG image is always rendered.

2. The clipping region has no transformation applied, I added a function called `distance_from_clip_rect_transformed` in the shader.

3. Fixed `monochrome_sprite_fragment` in `shader.metal` not applying clipping region.

### Before:

https://github.com/user-attachments/assets/8f93ac36-281e-4837-96cd-c308bfbf92d1

### After:

https://github.com/user-attachments/assets/f52b67a6-4cb9-4d6c-b759-bbb91b59c1cf

Release Notes:

- N/A
