### PR TITLE
Move the cursor on search in Terminal if ViMode is active

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1854,7 +1854,7 @@ impl SearchableItem for TerminalView {
 
     /// Clear stored matches
     fn clear_matches(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        self.terminal().update(cx, |term, _| term.matches.clear())
+        self.terminal().update(cx, |term, _| term.clear_matches())
     }
 
     /// Store matches returned from find_matches somewhere for rendering


### PR DESCRIPTION
Currently, the terminal search function doesn't work well with ViMode. It matches the search terms, scrolls the active match in the view, but it doesn't move the cursor to the match, which makes it useless for navigating the scrollback in vimode.

With this improvement, if a user activates ViMode before the search Zed moves the cursor to the active search terms. So, when the search dialog is dismissed the cursor is places on the latest active search term and it's possible to navigate the scrollback via ViMode using this place as the starting point.

https://github.com/user-attachments/assets/63325405-ed93-4bf8-a00f-28ded5511f31

Release Notes:

- Improved the search function in the terminal when ViMode is activated
