### PR TITLE
Fix being unable to input a whitespace character in collab channels filter

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -1645,6 +1645,10 @@ impl CollabPanel {
             self.channel_name_editor.update(cx, |editor, cx| {
                 editor.insert(" ", window, cx);
             });
+        } else if self.filter_editor.focus_handle(cx).is_focused(window) {
+            self.filter_editor.update(cx, |editor, cx| {
+                editor.insert(" ", window, cx);
+            });
         }
     }
 
@@ -2045,7 +2049,9 @@ impl CollabPanel {
         dispatch_context.add("CollabPanel");
         dispatch_context.add("menu");
 
-        let identifier = if self.channel_name_editor.focus_handle(cx).is_focused(window) {
+        let identifier = if self.channel_name_editor.focus_handle(cx).is_focused(window)
+            || self.filter_editor.focus_handle(cx).is_focused(window)
+        {
             "editing"
         } else {
             "not_editing"
@@ -3031,7 +3037,7 @@ impl Render for CollabPanel {
             .on_action(cx.listener(CollabPanel::start_move_selected_channel))
             .on_action(cx.listener(CollabPanel::move_channel_up))
             .on_action(cx.listener(CollabPanel::move_channel_down))
-            .track_focus(&self.focus_handle(cx))
+            .track_focus(&self.focus_handle)
             .size_full()
             .child(if self.user_store.read(cx).current_user().is_none() {
                 self.render_signed_out(cx)


### PR DESCRIPTION
Before, `space` was always causing a channel join.
Now it's less fluent, one has to press `ESC` to get the focus out of the filter editor and then `space` starts joining the channel.

Release Notes:

- Fixed being unable to input a whitespace character in collab channels filter
