### PR TITLE
debugger: Add a tooltip to the session picker with the session ID

### DIFF
--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -11,7 +11,7 @@ use project::worktree_store::WorktreeStore;
 use rpc::proto;
 use running::RunningState;
 use std::{cell::OnceCell, sync::OnceLock};
-use ui::{Indicator, prelude::*};
+use ui::{Indicator, Tooltip, prelude::*};
 use workspace::{
     CollaboratorId, FollowableItem, ViewId, Workspace,
     item::{self, Item},
@@ -153,6 +153,8 @@ impl DebugSession {
         };
 
         h_flex()
+            .id("session-label")
+            .tooltip(Tooltip::text(format!("Session {}", self.session_id(cx).0,)))
             .ml(depth * px(16.0))
             .gap_2()
             .when_some(icon, |this, indicator| this.child(indicator))


### PR DESCRIPTION
This helps correlate sessions in the picker with entries in the debug adapter logs view.

Release Notes:

- N/A