### PR TITLE
Reduce segment cloning when rendering messages

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -198,6 +198,13 @@ impl MessageSegment {
             Self::RedactedThinking(_) => false,
         }
     }
+
+    pub fn text(&self) -> Option<&str> {
+        match self {
+            MessageSegment::Text(text) => Some(text),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]


### PR DESCRIPTION
While working on retries, I discovered some opportunities to reduce cloning of message segments. These segments have full `String`s (not `SharedString`s), so cloning them means copying cloning all the bytes of all the strings in the message, which would be nice to avoid!

Release Notes:

- N/A