### PR TITLE
Add configurable timeout for context server tool calls

### DIFF
--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -2475,7 +2475,7 @@ fn setup_context_server(
                     path: "somebinary".into(),
                     args: Vec::new(),
                     env: None,
-                    tool_call_timeout_millis: None,
+                    timeout: None,
                 },
             },
         );

--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -2475,6 +2475,7 @@ fn setup_context_server(
                     path: "somebinary".into(),
                     args: Vec::new(),
                     env: None,
+                    tool_call_timeout_millis: None,
                 },
             },
         );

--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -144,7 +144,7 @@ pub struct ModelContextServerBinary {
     pub executable: PathBuf,
     pub args: Vec<String>,
     pub env: Option<HashMap<String, String>>,
-    pub tool_call_timeout_millis: Option<u64>,
+    pub timeout: Option<u64>,
 }
 
 impl Client {
@@ -171,7 +171,7 @@ impl Client {
             .map(|name| name.to_string_lossy().to_string())
             .unwrap_or_else(String::new);
 
-        let timeout = binary.tool_call_timeout_millis.map(Duration::from_millis);
+        let timeout = binary.timeout.map(Duration::from_millis);
         let transport = Arc::new(StdioTransport::new(binary, working_directory, &cx)?);
         Self::new(server_id, server_name.into(), transport, timeout, cx)
     }

--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -25,7 +25,7 @@ use crate::{
 };
 
 const JSON_RPC_VERSION: &str = "2.0";
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
+const DEFAULT_REQUEST_TIMEOUT: Duration = Duration::from_secs(60);
 
 // Standard JSON-RPC error codes
 pub const PARSE_ERROR: i32 = -32700;
@@ -60,6 +60,7 @@ pub(crate) struct Client {
     executor: BackgroundExecutor,
     #[allow(dead_code)]
     transport: Arc<dyn Transport>,
+    request_timeout: Option<Duration>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -143,6 +144,7 @@ pub struct ModelContextServerBinary {
     pub executable: PathBuf,
     pub args: Vec<String>,
     pub env: Option<HashMap<String, String>>,
+    pub tool_call_timeout_millis: Option<u64>,
 }
 
 impl Client {
@@ -169,8 +171,9 @@ impl Client {
             .map(|name| name.to_string_lossy().to_string())
             .unwrap_or_else(String::new);
 
+        let timeout = binary.tool_call_timeout_millis.map(Duration::from_millis);
         let transport = Arc::new(StdioTransport::new(binary, working_directory, &cx)?);
-        Self::new(server_id, server_name.into(), transport, cx)
+        Self::new(server_id, server_name.into(), transport, timeout, cx)
     }
 
     /// Creates a new Client instance for a context server.
@@ -178,6 +181,7 @@ impl Client {
         server_id: ContextServerId,
         server_name: Arc<str>,
         transport: Arc<dyn Transport>,
+        request_timeout: Option<Duration>,
         cx: AsyncApp,
     ) -> Result<Self> {
         let (outbound_tx, outbound_rx) = channel::unbounded::<String>();
@@ -237,6 +241,7 @@ impl Client {
             io_tasks: Mutex::new(Some((input_task, output_task))),
             output_done_rx: Mutex::new(Some(output_done_rx)),
             transport,
+            request_timeout,
         })
     }
 
@@ -327,8 +332,13 @@ impl Client {
         method: &str,
         params: impl Serialize,
     ) -> Result<T> {
-        self.request_with(method, params, None, Some(REQUEST_TIMEOUT))
-            .await
+        self.request_with(
+            method,
+            params,
+            None,
+            self.request_timeout.or(Some(DEFAULT_REQUEST_TIMEOUT)),
+        )
+        .await
     }
 
     pub async fn request_with<T: DeserializeOwned>(

--- a/crates/context_server/src/context_server.rs
+++ b/crates/context_server/src/context_server.rs
@@ -34,6 +34,8 @@ pub struct ContextServerCommand {
     pub path: PathBuf,
     pub args: Vec<String>,
     pub env: Option<HashMap<String, String>>,
+    /// Timeout for tool calls in milliseconds. Defaults to 60000 (60 seconds) if not specified.
+    pub tool_call_timeout_millis: Option<u64>,
 }
 
 impl std::fmt::Debug for ContextServerCommand {
@@ -123,6 +125,7 @@ impl ContextServer {
                     executable: Path::new(&command.path).to_path_buf(),
                     args: command.args.clone(),
                     env: command.env.clone(),
+                    tool_call_timeout_millis: command.tool_call_timeout_millis,
                 },
                 working_directory,
                 cx.clone(),
@@ -131,6 +134,7 @@ impl ContextServer {
                 client::ContextServerId(self.id.0.clone()),
                 self.id().0,
                 transport.clone(),
+                None,
                 cx.clone(),
             )?,
         })

--- a/crates/context_server/src/context_server.rs
+++ b/crates/context_server/src/context_server.rs
@@ -35,7 +35,7 @@ pub struct ContextServerCommand {
     pub args: Vec<String>,
     pub env: Option<HashMap<String, String>>,
     /// Timeout for tool calls in milliseconds. Defaults to 60000 (60 seconds) if not specified.
-    pub tool_call_timeout_millis: Option<u64>,
+    pub timeout: Option<u64>,
 }
 
 impl std::fmt::Debug for ContextServerCommand {
@@ -125,7 +125,7 @@ impl ContextServer {
                     executable: Path::new(&command.path).to_path_buf(),
                     args: command.args.clone(),
                     env: command.env.clone(),
-                    tool_call_timeout_millis: command.tool_call_timeout_millis,
+                    timeout: command.timeout,
                 },
                 working_directory,
                 cx.clone(),

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -1153,6 +1153,7 @@ mod tests {
                             path: "somebinary".into(),
                             args: vec!["arg".to_string()],
                             env: None,
+                            tool_call_timeout_millis: None,
                         },
                     },
                 )],
@@ -1180,6 +1181,7 @@ mod tests {
                         command: ContextServerCommand {
                             path: "somebinary".into(),
                             args: vec!["arg".to_string()],
+                            tool_call_timeout_millis: None,
                             env: None,
                         },
                     },

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -976,7 +976,7 @@ mod tests {
                                 path: "somebinary".into(),
                                 args: vec!["arg".to_string()],
                                 env: None,
-                                tool_call_timeout_millis: None,
+                                timeout: None,
                             },
                         },
                     ),
@@ -1017,7 +1017,7 @@ mod tests {
                                 path: "somebinary".into(),
                                 args: vec!["anotherArg".to_string()],
                                 env: None,
-                                tool_call_timeout_millis: None,
+                                timeout: None,
                             },
                         },
                     ),
@@ -1100,7 +1100,7 @@ mod tests {
                         path: "somebinary".into(),
                         args: vec!["arg".to_string()],
                         env: None,
-                        tool_call_timeout_millis: None,
+                        timeout: None,
                     },
                 },
             )],
@@ -1153,7 +1153,7 @@ mod tests {
                             path: "somebinary".into(),
                             args: vec!["arg".to_string()],
                             env: None,
-                            tool_call_timeout_millis: None,
+                            timeout: None,
                         },
                     },
                 )],
@@ -1181,7 +1181,7 @@ mod tests {
                         command: ContextServerCommand {
                             path: "somebinary".into(),
                             args: vec!["arg".to_string()],
-                            tool_call_timeout_millis: None,
+                            timeout: None,
                             env: None,
                         },
                     },
@@ -1235,7 +1235,7 @@ mod tests {
                 path: "somebinary".into(),
                 args: vec!["arg".to_string()],
                 env: None,
-                tool_call_timeout_millis: None,
+                timeout: None,
             },
         }
     }
@@ -1324,7 +1324,7 @@ mod tests {
                 path: self.path.clone(),
                 args: vec!["arg1".to_string(), "arg2".to_string()],
                 env: None,
-                tool_call_timeout_millis: None,
+                timeout: None,
             }))
         }
 

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -976,6 +976,7 @@ mod tests {
                                 path: "somebinary".into(),
                                 args: vec!["arg".to_string()],
                                 env: None,
+                                tool_call_timeout_millis: None,
                             },
                         },
                     ),
@@ -1016,6 +1017,7 @@ mod tests {
                                 path: "somebinary".into(),
                                 args: vec!["anotherArg".to_string()],
                                 env: None,
+                                tool_call_timeout_millis: None,
                             },
                         },
                     ),
@@ -1098,6 +1100,7 @@ mod tests {
                         path: "somebinary".into(),
                         args: vec!["arg".to_string()],
                         env: None,
+                        tool_call_timeout_millis: None,
                     },
                 },
             )],
@@ -1230,6 +1233,7 @@ mod tests {
                 path: "somebinary".into(),
                 args: vec!["arg".to_string()],
                 env: None,
+                tool_call_timeout_millis: None,
             },
         }
     }
@@ -1318,6 +1322,7 @@ mod tests {
                 path: self.path.clone(),
                 args: vec!["arg1".to_string(), "arg2".to_string()],
                 env: None,
+                tool_call_timeout_millis: None,
             }))
         }
 

--- a/crates/project/src/context_server_store/extension.rs
+++ b/crates/project/src/context_server_store/extension.rs
@@ -69,7 +69,7 @@ impl registry::ContextServerDescriptor for ContextServerDescriptor {
                 path: command.command,
                 args: command.args,
                 env: Some(command.env.into_iter().collect()),
-                tool_call_timeout_millis: None,
+                timeout: None,
             })
         })
     }

--- a/crates/project/src/context_server_store/extension.rs
+++ b/crates/project/src/context_server_store/extension.rs
@@ -69,6 +69,7 @@ impl registry::ContextServerDescriptor for ContextServerDescriptor {
                 path: command.command,
                 args: command.args,
                 env: Some(command.env.into_iter().collect()),
+                tool_call_timeout_millis: None,
             })
         })
     }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -604,7 +604,7 @@ impl Settings for ProjectSettings {
                     path: cmd.command,
                     args: cmd.args.unwrap_or_default(),
                     env: cmd.env,
-                    tool_call_timeout_millis: None,
+                    timeout: None,
                 }
             }
         }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -604,6 +604,7 @@ impl Settings for ProjectSettings {
                     path: cmd.command,
                     args: cmd.args.unwrap_or_default(),
                     env: cmd.env,
+                    tool_call_timeout_millis: None,
                 }
             }
         }


### PR DESCRIPTION
Closes: #32668

- Add [tool_call_timeout_millis](https://github.com/cline/cline/pull/1904) field to ContextServerCommand, like in Cline
- Update ModelContextServerBinary to include timeout configuration
- Modify Client to store and use configurable request timeout
- Replace hardcoded REQUEST_TIMEOUT with self.request_timeout
- Rename REQUEST_TIMEOUT to DEFAULT_REQUEST_TIMEOUT for clarity
- Maintain backward compatibility with 60-second default

Release Notes:

- context_server: Add support for configurable timeout for MCP tool calls