### PR TITLE
Add editor::DeletePreviousWhitespace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8354,7 +8354,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2285ddfe3054097ef4b2fe909ef8c3bcd1ea52a8f0d274416caebeef39f04a65"
 dependencies = [
  "io-lifetimes",
- "windows-sys 0.59.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -221,6 +221,14 @@ pub struct DeleteToPreviousWordStart {
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
+#[serde(deny_unknown_fields)]
+pub struct DeletePreviousWhitespace {
+    #[serde(default = "default_true")]
+    pub ignore_newlines: bool,
+}
+
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = editor)]
 pub struct FoldAtLevel(pub u32);
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12377,14 +12377,18 @@ impl Editor {
                     } else {
                         FindRange::SingleLine
                     };
-                    let cursor = movement::find_preceding_boundary_display_point(map, selection.head(), range, |c, _| !c.is_whitespace());
+                    let cursor = movement::find_preceding_boundary_display_point(
+                        map,
+                        selection.head(),
+                        range,
+                        |c, _| !c.is_whitespace(),
+                    );
                     selection.set_head(cursor, SelectionGoal::None);
                 });
             });
             this.insert("", window, cx);
         });
     }
-
 
     pub fn move_to_next_word_end(
         &mut self,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -2548,6 +2548,52 @@ fn test_delete_to_next_word_end_or_newline(cx: &mut TestAppContext) {
     });
 }
 
+ #[gpui::test] 
+ fn test_delete_previous_whitespace(cx: &mut TestAppContext) { 
+     init_test(cx, |_| {}); 
+  
+     let editor = cx.add_window(|window, cx| { 
+         let buffer = MultiBuffer::build_simple("one   two  \n three \t four", cx); 
+         build_editor(buffer.clone(), window, cx) 
+     }); 
+  
+     _ = editor.update(cx, |editor, window, cx| { 
+         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| { 
+             s.select_display_ranges([ 
+                 DisplayPoint::new(DisplayRow(1), 1)..DisplayPoint::new(DisplayRow(1), 1),
+                 DisplayPoint::new(DisplayRow(1), 9)..DisplayPoint::new(DisplayRow(1), 9), 
+             ]) 
+         }); 
+         editor.delete_previous_whitespace( 
+             &DeletePreviousWhitespace { 
+                 ignore_newlines: false, 
+             },
+             window, 
+             cx, 
+         ); 
+         assert_eq!(editor.buffer.read(cx).read(cx).text(), "one   two  \nthreefour"); 
+     }); 
+
+     _ = editor.update(cx, |editor, window, cx| { 
+         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| { 
+             s.select_display_ranges([
+                 DisplayPoint::new(DisplayRow(0), 6)..DisplayPoint::new(DisplayRow(0), 6),
+                 DisplayPoint::new(DisplayRow(1), 0)..DisplayPoint::new(DisplayRow(1), 0), 
+             ]) 
+         }); 
+         editor.delete_previous_whitespace( 
+             &DeletePreviousWhitespace { 
+                 ignore_newlines: true, 
+             }, 
+             window, 
+             cx, 
+         );
+         assert_eq!(editor.buffer.read(cx).read(cx).text(), "onetwothreefour"); 
+     });
+
+ } 
+
+
 #[gpui::test]
 fn test_newline(cx: &mut TestAppContext) {
     init_test(cx, |_| {});

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -244,6 +244,8 @@ impl EditorElement {
         register_action(editor, window, Editor::delete_to_previous_subword_start);
         register_action(editor, window, Editor::delete_to_next_word_end);
         register_action(editor, window, Editor::delete_to_next_subword_end);
+        register_action(editor, window, Editor::delete_previous_whitespace);
+        register_action(editor, window, Editor::delete_to_next_word_end);
         register_action(editor, window, Editor::delete_to_beginning_of_line);
         register_action(editor, window, Editor::delete_to_end_of_line);
         register_action(editor, window, Editor::cut_to_end_of_line);


### PR DESCRIPTION
Closes #23016

quirk: if there is no previous whitespace, then a single previous (non-whitespace) char will be deleted.

Release Notes:

- added `editor::DeletePreviousWhitespace` action
