### PR TITLE
debugger_ui: Fix variable completion accept in console appends the whole word

### DIFF
--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -646,8 +646,23 @@ impl ConsoleQueryBarCompletionProvider {
             (variables, string_matches)
         });
 
-        let query = buffer.read(cx).text();
-
+        let snapshot = buffer.read(cx).text_snapshot();
+        let query = snapshot.text();
+        let replace_range = {
+            let buffer_offset = buffer_position.to_offset(&snapshot);
+            let reversed_chars = snapshot.reversed_chars_for_range(0..buffer_offset);
+            let mut word_len = 0;
+            for ch in reversed_chars {
+                if ch.is_alphanumeric() || ch == '_' {
+                    word_len += 1;
+                } else {
+                    break;
+                }
+            }
+            let word_start_offset = buffer_offset - word_len;
+            let start_anchor = snapshot.anchor_at(word_start_offset, Bias::Left);
+            start_anchor..buffer_position
+        };
         cx.spawn(async move |_, cx| {
             const LIMIT: usize = 10;
             let matches = fuzzy::match_strings(
@@ -667,7 +682,7 @@ impl ConsoleQueryBarCompletionProvider {
                     let variable_value = variables.get(&string_match.string)?;
 
                     Some(project::Completion {
-                        replace_range: buffer_position..buffer_position,
+                        replace_range: replace_range.clone(),
                         new_text: string_match.string.clone(),
                         label: CodeLabel {
                             filter_range: 0..string_match.string.len(),


### PR DESCRIPTION
Closes #32959

Release Notes:

- Fixed the issue where accepting variable completion in the Debugger would append the entire variable name instead of the remaining part.
