### PR TITLE
agent: Add GEMINI.md as a supported rules file name

### DIFF
--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -71,7 +71,7 @@ impl Column for DataType {
     }
 }
 
-const RULES_FILE_NAMES: [&'static str; 8] = [
+const RULES_FILE_NAMES: [&'static str; 9] = [
     ".rules",
     ".cursorrules",
     ".windsurfrules",
@@ -80,6 +80,7 @@ const RULES_FILE_NAMES: [&'static str; 8] = [
     "CLAUDE.md",
     "AGENT.md",
     "AGENTS.md",
+    "GEMINI.md",
 ];
 
 pub fn init(cx: &mut App) {

--- a/docs/src/ai/rules.md
+++ b/docs/src/ai/rules.md
@@ -16,6 +16,7 @@ Other names for this file are also supported for compatibility with other agents
 - `AGENT.md`
 - `AGENTS.md`
 - `CLAUDE.md`
+- `GEMINI.md`
 
 ## Rules Library {#rules-library}
 


### PR DESCRIPTION
Gemini cli creates GEMINI.md file. This PR adds support for it.

Release Notes:

- agent: Add GEMINI.md as a supported rules file name
