### PR TITLE
open_ai: Make OpenAI error message generic

### DIFF
--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -565,7 +565,7 @@ impl LmStudioEventMapper {
                 events.push(Ok(LanguageModelCompletionEvent::Stop(StopReason::ToolUse)));
             }
             Some(stop_reason) => {
-                log::error!("Unexpected OpenAI stop_reason: {stop_reason:?}",);
+                log::error!("Unexpected LMStudio stop_reason: {stop_reason:?}",);
                 events.push(Ok(LanguageModelCompletionEvent::Stop(StopReason::EndTurn)));
             }
             None => {}

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -445,15 +445,11 @@ pub async fn stream_completion(
 
         match serde_json::from_str::<OpenAiResponse>(&body) {
             Ok(response) if !response.error.message.is_empty() => Err(anyhow!(
-                "Failed to connect to OpenAI API: {}",
+                "Failed to connect to API: {}",
                 response.error.message,
             )),
 
-            _ => anyhow::bail!(
-                "Failed to connect to OpenAI API: {} {}",
-                response.status(),
-                body,
-            ),
+            _ => anyhow::bail!("Failed to connect to API: {} {}", response.status(), body,),
         }
     }
 }

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -445,11 +445,17 @@ pub async fn stream_completion(
 
         match serde_json::from_str::<OpenAiResponse>(&body) {
             Ok(response) if !response.error.message.is_empty() => Err(anyhow!(
-                "Failed to connect to API: {}",
+                "API request to {} failed: {}",
+                api_url,
                 response.error.message,
             )),
 
-            _ => anyhow::bail!("Failed to connect to API: {} {}", response.status(), body,),
+            _ => anyhow::bail!(
+                "API request to {} failed with status {}: {}",
+                api_url,
+                response.status(),
+                body,
+            ),
         }
     }
 }


### PR DESCRIPTION
Context: In this PR: https://github.com/zed-industries/zed/pull/33362, we started to use underlying open_ai crate for making api calls for vercel as well. Now whenever we get the error we get something like the below. Where on part of the error mentions OpenAI but the rest of the error returns the actual error from provider. This PR tries to make the error generic for now so that people don't get confused seeing OpenAI in their v0 integration.

```
Error interacting with language model
Failed to connect to OpenAI API: 403 Forbidden {"success":false,"error":"Premium or Team plan required to access the v0 API: https://v0.dev/chat/settings/billing"}
```

Release Notes:

- N/A
