### PR TITLE
Remove web-style hand pointers

### DIFF
--- a/crates/gpui_macros/src/styles.rs
+++ b/crates/gpui_macros/src/styles.rs
@@ -176,7 +176,7 @@ pub fn cursor_style_methods(input: TokenStream) -> TokenStream {
         /// Sets the cursor style when hovering an element to `pointer`.
         /// [Docs](https://tailwindcss.com/docs/cursor)
         #visibility fn cursor_pointer(mut self) -> Self {
-            self.style().mouse_cursor = Some(gpui::CursorStyle::PointingHand);
+            //self.style().mouse_cursor = Some(gpui::CursorStyle::PointingHand);
             self
         }
 

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -381,7 +381,7 @@ impl ButtonLike {
             rounding: Some(ButtonLikeRounding::All),
             tooltip: None,
             children: SmallVec::new(),
-            cursor_style: CursorStyle::PointingHand,
+            cursor_style: CursorStyle::default(),
             on_click: None,
             on_right_click: None,
             layer: None,


### PR DESCRIPTION
Hand cursor on clickable elements is an old web convension. I think it is confusing to have it inside a desktop UI and the UI looks cleaner without it.

It is just an illustration of how it behave. I don't exepect it to be merged as it is.

Could you guide me about what could I do to have such a customization possible for people who whant it ? ? 

https://github.com/user-attachments/assets/3803fb38-1dc2-4f20-9742-848852eb5417

