### PR TITLE
Do not show update "View Release Notes" notification in nightly builds

### DIFF
--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -132,6 +132,11 @@ pub fn notify_if_app_was_updated(cx: &mut App) {
     let Some(updater) = AutoUpdater::get(cx) else {
         return;
     };
+
+    if let ReleaseChannel::Nightly = ReleaseChannel::global(cx) {
+        return;
+    }
+
     let should_show_notification = updater.read(cx).should_show_update_notification(cx);
     cx.spawn(async move |cx| {
         let should_show_notification = should_show_notification.await?;


### PR DESCRIPTION
These are useless in nightly, as the link within the notification simply directs us to a commit view on GitHub. We update frequently on nightly; dismissing this after every update is annoying.

Release Notes:

- N/A
