### PR TITLE
Allow local build of remote_server dev to be deployed to different linux than local

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13213,6 +13213,7 @@ dependencies = [
  "fs",
  "futures 0.3.31",
  "git",
+ "git2",
  "git_hosting_providers",
  "gpui",
  "gpui_tokio",

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -2089,6 +2089,9 @@ impl SshRemoteConnection {
         if self.ssh_platform.os == "linux" {
             rust_flags.push_str(" -C target-feature=+crt-static");
         }
+        if build_remote_server.contains("mold") {
+            rust_flags.push_str(" -C link-arg=-fuse-ld=mold");
+        }
 
         let bin_path = if self.ssh_platform.arch == std::env::consts::ARCH
             && self.ssh_platform.os == std::env::consts::OS

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -2113,7 +2113,6 @@ impl SshRemoteConnection {
         let Some(triple) = self.ssh_platform.triple() else {
             anyhow::bail!("can't cross compile for: {:?}", self.ssh_platform);
         };
-        smol::fs::create_dir_all("target/remote_server").await?;
 
         if build_remote_server.contains("cross") {
             #[cfg(target_os = "windows")]

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -37,6 +37,7 @@ fs.workspace = true
 futures.workspace = true
 git.workspace = true
 git_hosting_providers.workspace = true
+git2 = { workspace = true, features = ["vendored-libgit2"] }
 gpui.workspace = true
 gpui_tokio.workspace = true
 http_client.workspace = true
@@ -85,7 +86,7 @@ node_runtime = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 remote = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
-lsp = { workspace = true, features=["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 serde_json.workspace = true
 zlog.workspace = true
@@ -95,4 +96,4 @@ cargo_toml.workspace = true
 toml.workspace = true
 
 [package.metadata.cargo-machete]
-ignored = ["rust-embed", "paths"]
+ignored = ["git2", "rust-embed", "paths"]


### PR DESCRIPTION
setup local build of `remote_server` to not depend of the local linux libraries by :
- enable `vendored-libgit2` feature of git2
- setup target triple to `unknown-linux-musl` (mirror bundle-linux script)
- add flag ` -C target-feature=+crt-static` in `RUSTFLAGS` env var (mirror bundle-linux script)

Bonus:
Add an option to setup mold as linker of local build.

Closes #33341

Release Notes:

 - N/A