### PR TITLE
pane: Update pinned tab count when it exceeds actual tab count

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2793,7 +2793,7 @@ impl Pane {
                 tab_count
             );
             self.pinned_tab_count = tab_count;
-        };
+        }
         let unpinned_tabs = tab_items.split_off(self.pinned_tab_count);
         let pinned_tabs = tab_items;
         TabBar::new("tab_bar")

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2792,6 +2792,7 @@ impl Pane {
                 self.pinned_tab_count,
                 tab_count
             );
+            self.pinned_tab_count = tab_count;
             tab_count
         } else {
             self.pinned_tab_count

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2784,7 +2784,7 @@ impl Pane {
             })
             .collect::<Vec<_>>();
         let tab_count = tab_items.len();
-        let safe_pinned_count = if self.pinned_tab_count > tab_count {
+        if self.pinned_tab_count > tab_count {
             log::warn!(
                 "Pinned tab count ({}) exceeds actual tab count ({}). \
                 This should not happen. If possible, add reproduction steps, \
@@ -2793,11 +2793,8 @@ impl Pane {
                 tab_count
             );
             self.pinned_tab_count = tab_count;
-            tab_count
-        } else {
-            self.pinned_tab_count
         };
-        let unpinned_tabs = tab_items.split_off(safe_pinned_count);
+        let unpinned_tabs = tab_items.split_off(self.pinned_tab_count);
         let pinned_tabs = tab_items;
         TabBar::new("tab_bar")
             .when(


### PR DESCRIPTION
## Summary

This PR improves the workaround introduced in #33335 that handles cases where the pinned tab count exceeds the actual tab count during workspace deserialization.

## Problem

The original workaround in #33335 successfully prevented the panic but had two issues:
1. **Console spam**: The warning message was logged repeatedly because `self.pinned_tab_count` wasn't updated to match the actual tab count
2. **Auto-pinning behavior**: New tabs up until you exceed the old safe tab count were automatically pinned after the workaround was triggered.

## Solution

Updates the defensive code to set `self.pinned_tab_count = tab_count` when the mismatch is detected, ensuring:
- The warning is only logged once when encountered.
- New tabs behave normally (aren't auto-pinned)
- The workspace remains in a consistent state

This is an immediate fix for the workaround. I'll attempt to open up a follow-up PR when i get the chance that will address the root cause by implementing serialization for empty untitled tabs, as discussed in #33342.

Release Notes:

- N/A