### PR TITLE
helix: Change word motions

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -192,8 +192,8 @@ impl Vim {
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
                     let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found =
-                        (left_kind != right_kind && right_kind != CharKind::Whitespace) || at_newline;
+                    let found = (left_kind != right_kind && right_kind != CharKind::Whitespace)
+                        || at_newline;
 
                     found
                 })
@@ -204,8 +204,8 @@ impl Vim {
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
                     let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found = (left_kind != right_kind
-                        && left_kind != CharKind::Whitespace) || at_newline;
+                    let found = (left_kind != right_kind && left_kind != CharKind::Whitespace)
+                        || at_newline;
 
                     found
                 })
@@ -216,8 +216,8 @@ impl Vim {
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
                     let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found = (left_kind != right_kind
-                        && left_kind != CharKind::Whitespace) || at_newline;
+                    let found = (left_kind != right_kind && left_kind != CharKind::Whitespace)
+                        || at_newline;
 
                     found
                 })
@@ -228,8 +228,8 @@ impl Vim {
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
                     let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found = (left_kind != right_kind
-                        && right_kind != CharKind::Whitespace) || at_newline;
+                    let found = (left_kind != right_kind && right_kind != CharKind::Whitespace)
+                        || at_newline;
 
                     found
                 })

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -190,10 +190,10 @@ impl Vim {
                 self.helix_find_range_forward(times, window, cx, |left, right, classifier| {
                     let left_kind = classifier.kind_with(left, ignore_punctuation);
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = right == '\n';
+                    let at_newline = (left == '\n') ^ (right == '\n');
 
                     let found =
-                        left_kind != right_kind && right_kind != CharKind::Whitespace || at_newline;
+                        (left_kind != right_kind && right_kind != CharKind::Whitespace) || at_newline;
 
                     found
                 })
@@ -202,10 +202,10 @@ impl Vim {
                 self.helix_find_range_forward(times, window, cx, |left, right, classifier| {
                     let left_kind = classifier.kind_with(left, ignore_punctuation);
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = right == '\n';
+                    let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found = left_kind != right_kind
-                        && (left_kind != CharKind::Whitespace || at_newline);
+                    let found = (left_kind != right_kind
+                        && left_kind != CharKind::Whitespace) || at_newline;
 
                     found
                 })
@@ -214,10 +214,10 @@ impl Vim {
                 self.helix_find_range_backward(times, window, cx, |left, right, classifier| {
                     let left_kind = classifier.kind_with(left, ignore_punctuation);
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = right == '\n';
+                    let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found = left_kind != right_kind
-                        && (left_kind != CharKind::Whitespace || at_newline);
+                    let found = (left_kind != right_kind
+                        && left_kind != CharKind::Whitespace) || at_newline;
 
                     found
                 })
@@ -226,11 +226,10 @@ impl Vim {
                 self.helix_find_range_backward(times, window, cx, |left, right, classifier| {
                     let left_kind = classifier.kind_with(left, ignore_punctuation);
                     let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = right == '\n';
+                    let at_newline = (left == '\n') ^ (right == '\n');
 
-                    let found = left_kind != right_kind
-                        && right_kind != CharKind::Whitespace
-                        && !at_newline;
+                    let found = (left_kind != right_kind
+                        && right_kind != CharKind::Whitespace) || at_newline;
 
                     found
                 })


### PR DESCRIPTION
When starting on the newline character at the end of a line the helix word motions select that character, unlike in helix itself. This makes it easy to accidentaly join two lines together.
Also, word motions that go backwards should stop at the start of a line. I added that.

Release Notes:

- helix: Fix edge-cases with word motions and newlines
