### PR TITLE
Explicitly associate files as JSONC

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -40,6 +40,7 @@
   },
   "file_types": {
     "Dockerfile": ["Dockerfile*[!dockerignore]"],
+    "JSONC": ["assets/**/*.json", "renovate.json"],
     "Git Ignore": ["dockerignore"]
   },
   "hard_tabs": false,


### PR DESCRIPTION
Fixes an issue when the zed repo was checked out to folder other than `zed` (e.g. `zed2`) files were incorrectly identified as JSON instead of JSONC.

Release Notes:

- N/A
