### PR TITLE
lsp-log: Avoid trimming leading space in language server logs

### DIFF
--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -430,7 +430,7 @@ impl LogStore {
             log_lines,
             id,
             LogMessage {
-                message: message.trim().to_string(),
+                message: message.trim_end().to_string(),
                 typ,
             },
             language_server_state.log_level,


### PR DESCRIPTION
Not sure what the full intention/right fix for this is, but https://github.com/zed-industries/zed/pull/32659 re-introduced trimming of leading spaces. rust-analyzer has [a custom tracing formatter](https://github.com/rust-lang/rust-analyzer/blob/317542c1e4a3ec3467d21d1c25f6a43b80d83e7d/crates/rust-analyzer/src/tracing/hprof.rs) that is _super_ useful for profiling what the heck rust-analyzer is doing. It makes prodigious use of whitespace to delineate to create a tree-shaped structure. This change reintroduces the leading whitespace.

I made a previous change similar to this that removed a `stderr:` in https://github.com/zed-industries/zed/pull/27213/. If this is a direction y'all are happy to go with, I'd be happy to add a test for this!

<details>
<summary>A screenshot of the before</summary>

<img width="1624" alt="Screenshot 2025-06-25 at 2 12 45 PM" src="https://github.com/user-attachments/assets/a714d973-9377-41ca-8087-3b0e82b41620" />

</details>

<details>
<summary>A screenshot of the after</summary>

<img width="1136" alt="Screenshot 2025-06-25 at 2 40 07 PM" src="https://github.com/user-attachments/assets/b798ca13-11fc-4f97-9602-55e782068a5a" />

</details>

cc: @mgsloan.

Release Notes:

- Fixed the removal of leading whitespace in a language server's stderr logs.





