### PR TITLE
Remove `git_panel::GenerateCommitMessage` in favor of `git::GenerateCommitMessage`

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -83,7 +83,6 @@ actions!(
         FocusEditor,
         FocusChanges,
         ToggleFillCoAuthors,
-        GenerateCommitMessage
     ]
 );
 


### PR DESCRIPTION
`git_panel::GenerateCommitMessage` has no handler, `git::GenerateCommitMessage` should be preferred. Could add a `#[action(deprecated_aliases = ["git_panel::GenerateCommitMessage"])]`, but decided not to because that action didn't work. So instead uses of it will show up as keymap errors.

Closes #32667

Release Notes:

- N/A