### PR TITLE
linux: Don't insert characters if modifiers other than shift are held

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -699,12 +699,14 @@ impl WaylandWindowStatePtr {
             }
         }
         if let PlatformInput::KeyDown(event) = input {
-            if let Some(key_char) = &event.keystroke.key_char {
-                let mut state = self.state.borrow_mut();
-                if let Some(mut input_handler) = state.input_handler.take() {
-                    drop(state);
-                    input_handler.replace_text_in_range(None, key_char);
-                    self.state.borrow_mut().input_handler = Some(input_handler);
+            if event.keystroke.modifiers.is_subset_of(&Modifiers::shift()) {
+                if let Some(key_char) = &event.keystroke.key_char {
+                    let mut state = self.state.borrow_mut();
+                    if let Some(mut input_handler) = state.input_handler.take() {
+                        drop(state);
+                        input_handler.replace_text_in_range(None, key_char);
+                        self.state.borrow_mut().input_handler = Some(input_handler);
+                    }
                 }
             }
         }

--- a/crates/gpui/src/platform/linux/x11/window.rs
+++ b/crates/gpui/src/platform/linux/x11/window.rs
@@ -982,14 +982,17 @@ impl X11WindowStatePtr {
             }
         }
         if let PlatformInput::KeyDown(event) = input {
-            let mut state = self.state.borrow_mut();
-            if let Some(mut input_handler) = state.input_handler.take() {
-                if let Some(key_char) = &event.keystroke.key_char {
-                    drop(state);
-                    input_handler.replace_text_in_range(None, key_char);
-                    state = self.state.borrow_mut();
+            // only allow shift modifier when inserting text
+            if event.keystroke.modifiers.is_subset_of(&Modifiers::shift()) {
+                let mut state = self.state.borrow_mut();
+                if let Some(mut input_handler) = state.input_handler.take() {
+                    if let Some(key_char) = &event.keystroke.key_char {
+                        drop(state);
+                        input_handler.replace_text_in_range(None, key_char);
+                        state = self.state.borrow_mut();
+                    }
+                    state.input_handler = Some(input_handler);
                 }
-                state.input_handler = Some(input_handler);
             }
         }
     }


### PR DESCRIPTION
Closes #32219 #29666

Release Notes:

- Linux: Now skips insertion of characters when modifiers are held. Before, characters were inserted if there's no match in the keymap.