### PR TITLE
debugger: Fix treatment of node-terminal scenarios

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4119,6 +4119,7 @@ dependencies = [
  "paths",
  "serde",
  "serde_json",
+ "shlex",
  "task",
  "util",
  "workspace-hack",

--- a/crates/dap_adapters/Cargo.toml
+++ b/crates/dap_adapters/Cargo.toml
@@ -33,6 +33,7 @@ log.workspace = true
 paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+shlex.workspace = true
 task.workspace = true
 util.workspace = true
 workspace-hack.workspace = true


### PR DESCRIPTION
- Normalize `node-terminal` to `pwa-node` before sending to DAP
- Split `command` into `program` and `args`
- Run in external console

Release Notes:

- debugger: Fixed debugging JavaScript tasks that used `"type": "node-terminal"`.