### PR TITLE
Add back default keybindings to Burn Mode and branch picker toggles

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -283,6 +283,7 @@
       "cmd->": "assistant::QuoteSelection",
       "cmd-alt-e": "agent::RemoveAllContext",
       "cmd-shift-e": "project_panel::ToggleFocus",
+      "cmd-ctrl-b": "agent::ToggleBurnMode",
       "cmd-shift-enter": "agent::ContinueThread",
       "alt-enter": "agent::ContinueWithBurnMode"
     }
@@ -587,6 +588,7 @@
       "alt-cmd-o": ["projects::OpenRecent", { "create_new_window": false }],
       "ctrl-cmd-o": ["projects::OpenRemote", { "from_existing_connection": false, "create_new_window": false }],
       "ctrl-cmd-shift-o": ["projects::OpenRemote", { "from_existing_connection": true, "create_new_window": false }],
+      "cmd-ctrl-b": "branches::OpenRecent",
       "ctrl-~": "workspace::NewTerminal",
       "cmd-s": "workspace::Save",
       "cmd-k s": "workspace::SaveWithoutFormat",


### PR DESCRIPTION
Follow up to https://github.com/zed-industries/zed/pull/33190, as they were removed because of conflict with VS Code's usage of those bindings to toggle the right dock. `cmd-ctrl-b` seems like a safe alternative. Note that this PR is macOS only, though. I couldn't find yet any good options for Linux as they were all mostly conflicting with something else.

Release Notes:

- N/A
