### PR TITLE
ci: Fix duplicated/failed eval jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -460,8 +460,10 @@ jobs:
           RET_CODE=0
           # Always check style
           [[ "${{ needs.style.result }}"      != 'success' ]] && { RET_CODE=1; echo "style tests failed"; }
-          [[ "${{ needs.check_docs.result }}" != 'success' ]] && { RET_CODE=1; echo "docs checks failed"; }
 
+          if [[ "${{ needs.job_spec.outputs.run_docs }}" == "true" ]]; then
+            [[ "${{ needs.check_docs.result }}" != 'success' ]] && { RET_CODE=1; echo "docs checks failed"; }
+          fi
           # Only check test jobs if they were supposed to run
           if [[ "${{ needs.job_spec.outputs.run_tests }}" == "true" ]]; then
             [[ "${{ needs.workspace_hack.result }}"       != 'success' ]] && { RET_CODE=1; echo "Workspace Hack failed"; }

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     branches:
       - "**"
-    types: [opened, synchronize, reopened, labeled]
+    types: [synchronize, reopened, labeled]
 
   workflow_dispatch:
 
@@ -25,16 +25,6 @@ env:
   ZED_EVAL_TELEMETRY: 1
 
 jobs:
-  # This is a no-op job that we run to prevent GitHub from marking the workflow
-  # as failed for PRs that don't have the `run-eval` label.
-  noop:
-    name: No-op
-    runs-on: ubuntu-latest
-    if: github.repository_owner == 'zed-industries'
-    steps:
-      - name: No-op
-        run: echo "Nothing to do"
-
   run_eval:
     timeout-minutes: 60
     name: Run Agent Eval


### PR DESCRIPTION
I think this should fix the CI issues with Eval jobs:

1. Duplicated workflows because `synchronize` / `opened` were triggering distinct runs.  This caused failed job entries because the duplicated workflows had a shared concurrency group and so one would pre-empt the other.

3. Removes the no-op job, introduced as an attempted workaround in
   https://github.com/zed-industries/zed/pull/29420.

These should correctly show as "Skipped" now:

| Before | After |
| - | - |
| <img width="359" alt="Screenshot 2025-06-26 at 9 57 04" src="https://github.com/user-attachments/assets/6ddd4f46-27c7-4d82-98ba-0f1166fc55e7" /> | <img width="355" alt="Screenshot 2025-06-26 at 10 09 54" src="https://github.com/user-attachments/assets/5faade2c-f17c-447a-9af9-6396f9e53016" /> |

Release Notes:

- N/A
