### PR TITLE
docs: Add note about extension submodules needing to use HTTPS URLS

### DIFF
--- a/docs/src/extensions/developing-extensions.md
+++ b/docs/src/extensions/developing-extensions.md
@@ -120,6 +120,8 @@ git submodule add https://github.com/your-username/foobar-zed.git extensions/foo
 git add extensions/foobar
 ```
 
+> All extension submodules must use HTTPS URLs and not SSH URLS (`git@github.com`).
+
 2. Add a new entry to the top-level `extensions.toml` file containing your extension:
 
 ```toml


### PR DESCRIPTION
This PR adds a note to the extension publishing docs about extension submodules needing to use HTTPS URLs.

Release Notes:

- N/A
