### PR TITLE
ci: Prevent multiple danger runs

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -9,13 +9,14 @@ on:
       - reopened
       - edited
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   danger:
     if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
-    concurrency:
-      group: danger-${{ github.event.pull_request.number }}
-      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -13,6 +13,9 @@ jobs:
   danger:
     if: github.repository_owner == 'zed-industries'
     runs-on: ubuntu-latest
+    concurrency:
+      group: danger-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
Setup a cancel key at the workflow level for danger.

| Before | After |
| - | - |
| <img width="361" alt="Screenshot 2025-06-26 at 11 08 53" src="https://github.com/user-attachments/assets/611261d6-93b5-45f6-9287-274d6d9bf030" /> | |

Release Notes:

- N/A