### PR TITLE
terminal: Expose `selection` in context and add `keep_selection_on_copy` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1292,6 +1292,8 @@
     // Whether or not selecting text in the terminal will automatically
     // copy to the system clipboard.
     "copy_on_select": false,
+    // Whether to keep the text selection after copying it to the clipboard
+    "keep_selection_on_copy": true,
     // Whether to show the terminal button in the status bar
     "button": true,
     // Any key-value pairs added to this list will be added to the terminal's

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1293,7 +1293,7 @@
     // copy to the system clipboard.
     "copy_on_select": false,
     // Whether to keep the text selection after copying it to the clipboard
-    "keep_selection_on_copy": true,
+    "keep_selection_on_copy": false,
     // Whether to show the terminal button in the status bar
     "button": true,
     // Any key-value pairs added to this list will be added to the terminal's

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -880,7 +880,13 @@ impl Terminal {
 
             InternalEvent::Copy => {
                 if let Some(txt) = term.selection_to_string() {
-                    cx.write_to_clipboard(ClipboardItem::new_string(txt))
+                    cx.write_to_clipboard(ClipboardItem::new_string(txt));
+
+                    let settings = TerminalSettings::get_global(cx);
+
+                    if !settings.keep_selection_on_copy {
+                        self.events.push_back(InternalEvent::SetSelection(None));
+                    }
                 }
             }
             InternalEvent::ScrollToAlacPoint(point) => {

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -195,7 +195,7 @@ pub struct TerminalSettingsContent {
     pub copy_on_select: Option<bool>,
     /// Whether to keep the text selection after copying it to the clipboard.
     ///
-    /// Default: true
+    /// Default: false
     pub keep_selection_on_copy: Option<bool>,
     /// Whether to show the terminal button in the status bar.
     ///
@@ -291,9 +291,6 @@ impl settings::Settings for TerminalSettings {
         {
             current.line_height = Some(TerminalLineHeight::Custom(height as f32))
         }
-
-        // in vscode the text selection is always removed after copying
-        current.keep_selection_on_copy = Some(false);
 
         #[cfg(target_os = "windows")]
         let platform = "windows";

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -40,6 +40,7 @@ pub struct TerminalSettings {
     pub alternate_scroll: AlternateScroll,
     pub option_as_meta: bool,
     pub copy_on_select: bool,
+    pub keep_selection_on_copy: bool,
     pub button: bool,
     pub dock: TerminalDockPosition,
     pub default_width: Pixels,
@@ -192,6 +193,10 @@ pub struct TerminalSettingsContent {
     ///
     /// Default: false
     pub copy_on_select: Option<bool>,
+    /// Whether to keep the text selection after copying it to the clipboard.
+    ///
+    /// Default: true
+    pub keep_selection_on_copy: Option<bool>,
     /// Whether to show the terminal button in the status bar.
     ///
     /// Default: true
@@ -286,6 +291,9 @@ impl settings::Settings for TerminalSettings {
         {
             current.line_height = Some(TerminalLineHeight::Custom(height as f32))
         }
+
+        // in vscode the text selection is always removed after copying
+        current.keep_selection_on_copy = Some(false);
 
         #[cfg(target_os = "windows")]
         let platform = "windows";

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -815,6 +815,11 @@ impl TerminalView {
             };
             dispatch_context.set("mouse_format", format);
         };
+
+        if self.terminal.read(cx).last_content.selection.is_some() {
+            dispatch_context.add("selection");
+        }
+
         dispatch_context
     }
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2562,7 +2562,7 @@ List of `integer` column numbers
     "alternate_scroll": "off",
     "blinking": "terminal_controlled",
     "copy_on_select": false,
-    "keep_selection_on_copy": true,
+    "keep_selection_on_copy": false,
     "dock": "bottom",
     "default_width": 640,
     "default_height": 320,
@@ -2691,7 +2691,7 @@ List of `integer` column numbers
 
 - Description: Whether or not to keep the selection in the terminal after copying text.
 - Setting: `keep_selection_on_copy`
-- Default: `true`
+- Default: `false`
 
 **Options**
 
@@ -2702,7 +2702,7 @@ List of `integer` column numbers
 ```json
 {
   "terminal": {
-    "keep_selection_on_copy": false
+    "keep_selection_on_copy": true
   }
 }
 ```

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2562,6 +2562,7 @@ List of `integer` column numbers
     "alternate_scroll": "off",
     "blinking": "terminal_controlled",
     "copy_on_select": false,
+    "keep_selection_on_copy": true,
     "dock": "bottom",
     "default_width": 640,
     "default_height": 320,
@@ -2682,6 +2683,26 @@ List of `integer` column numbers
 {
   "terminal": {
     "copy_on_select": true
+  }
+}
+```
+
+### Terminal: Keep Selection On Copy
+
+- Description: Whether or not to keep the selection in the terminal after copying text.
+- Setting: `keep_selection_on_copy`
+- Default: `true`
+
+**Options**
+
+`boolean` values
+
+**Example**
+
+```json
+{
+  "terminal": {
+    "keep_selection_on_copy": false
   }
 }
 ```


### PR DESCRIPTION
Closes #21262

Introduces a new setting `keep_selection_on_copy`, which controls whether the current text selection is preserved after copying in the terminal. The default behavior remains the same (`true`), but setting it to `false` will clear the selection after the copy operation,  matching VSCode's behavior.

Additionally, the terminal context now exposes a `selection` flag whenever text is selected.

This allows users to match VSCode and other terminal's smart copy behavior.

Release Notes:

- Add `keep_selection_on_copy` terminal setting (default: `false`). Set `true` to preserve text selection after copying text. 
- Add `Terminal && selection` as keybind context for when there is text selected in the terminal.

**settings.json:**
```json
  "terminal": {
    "keep_selection_on_copy": true
  },
```
**keymap.json:**
```json
  {
    "context": "Terminal && selection",
    "bindings": {
      "ctrl-c": "terminal::Copy"
    }
  }
```