### PR TITLE
lsp: Rename ESLint's workingDirectory to workingDirectories

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -822,9 +822,7 @@ impl LspAdapter for EsLintLspAdapter {
             "rulesCustomizations": [],
             "run": "onType",
             "nodePath": null,
-            "workingDirectory": {
-                "mode": "auto"
-            },
+            "workingDirectories": [{ "mode": "auto" }],
             "workspaceFolder": {
                 "uri": workspace_root,
                 "name": workspace_root.file_name()

--- a/docs/src/languages/javascript.md
+++ b/docs/src/languages/javascript.md
@@ -156,18 +156,16 @@ You can configure ESLint's `rulesCustomizations` setting:
 }
 ```
 
-### Configure ESLint's `workingDirectory`:
+### Configure ESLint's `workingDirectories`:
 
-You can configure ESLint's `workingDirectory` setting:
+You can configure ESLint's `workingDirectories` setting:
 
 ```json
 {
   "lsp": {
     "eslint": {
       "settings": {
-        "workingDirectory": {
-          "mode": "auto"
-        }
+        "workingDirectories": [{ "mode": "auto" }]
       }
     }
   }


### PR DESCRIPTION
As can be seen in https://github.com/microsoft/vscode-eslint/blob/790646388696511b2665a4d119bf0fb713dd990d/package.json#L199, the setting is actually called `workingDirectories` and is an array. Renaming appropriately.

Release Notes:

- Fixed default workingDirectories setting for ESLint
