### PR TITLE
Fix blend alpha colors with editor background in inline preview

### DIFF
--- a/crates/editor/src/display_map.rs
+++ b/crates/editor/src/display_map.rs
@@ -966,10 +966,22 @@ impl DisplaySnapshot {
                 .and_then(|id| id.style(&editor_style.syntax));
 
             if let Some(chunk_highlight) = chunk.highlight_style {
+                // For color inlays, blend the color with the editor background
+                let mut processed_highlight = chunk_highlight;
+                if chunk.is_inlay {
+                    if let Some(inlay_color) = chunk_highlight.color {
+                        // Only blend if the color has transparency (alpha < 1.0)
+                        if inlay_color.a < 1.0 {
+                            let blended_color = editor_style.background.blend(inlay_color);
+                            processed_highlight.color = Some(blended_color);
+                        }
+                    }
+                }
+
                 if let Some(highlight_style) = highlight_style.as_mut() {
-                    highlight_style.highlight(chunk_highlight);
+                    highlight_style.highlight(processed_highlight);
                 } else {
-                    highlight_style = Some(chunk_highlight);
+                    highlight_style = Some(processed_highlight);
                 }
             }
 


### PR DESCRIPTION
Closes #33505

## Before

<img width="434" alt="Screenshot 2025-06-27 at 12 22 57" src="https://github.com/user-attachments/assets/ac215a39-b3fe-4c9e-bd7d-0d7568d5fd1f" />

## After

<img width="441" alt="Screenshot 2025-06-27 at 12 22 47" src="https://github.com/user-attachments/assets/28218ed6-c1aa-4d3f-a268-def2fa9f0340" />

Release Notes:

- Fixed inline color previews not correctly blending alpha/transparency values with the editor background
