### PR TITLE
collab: Lookup avatars by GitHub ID instead of username

### DIFF
--- a/crates/collab/src/db/queries/channels.rs
+++ b/crates/collab/src/db/queries/channels.rs
@@ -734,8 +734,8 @@ impl Database {
                     users.push(proto::User {
                         id: user.id.to_proto(),
                         avatar_url: format!(
-                            "https://github.com/{}.png?size=128",
-                            user.github_login
+                            "https://avatars.githubusercontent.com/u/{}?s=128&v=4",
+                            user.github_user_id
                         ),
                         github_login: user.github_login,
                         name: user.name,


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/19207

This will correctly show Avatars for recently renamed/deleted users and for enterprise users where the username avatar url triggers a redirect to an auth prompt. Also saves a request (302 redirect) per avatar.

Tested locally and avatars loaded as expected.

Release Notes:

- N/A
