### PR TITLE
Allow disabling tools when 'enable_all_context_servers = true'

### DIFF
--- a/crates/agent/src/agent_profile.rs
+++ b/crates/agent/src/agent_profile.rs
@@ -96,16 +96,11 @@ impl AgentProfile {
     fn is_enabled(settings: &AgentProfileSettings, source: ToolSource, name: String) -> bool {
         match source {
             ToolSource::Native => *settings.tools.get(name.as_str()).unwrap_or(&false),
-            ToolSource::ContextServer { id } => {
-                if settings.enable_all_context_servers {
-                    return true;
-                }
-
-                let Some(preset) = settings.context_servers.get(id.as_ref()) else {
-                    return false;
-                };
-                *preset.tools.get(name.as_str()).unwrap_or(&false)
-            }
+            ToolSource::ContextServer { id } => settings
+                .context_servers
+                .get(id.as_ref())
+                .and_then(|preset| preset.tools.get(name.as_str()).copied())
+                .unwrap_or(settings.enable_all_context_servers),
         }
     }
 }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33519

Release Notes:

- agent: Improved support for explicitly disabling individual tools when `enable_all_context_servers` is true. (e.g. enable all tools except XYZ).