### PR TITLE
Respect server capabilities on queries

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4335,7 +4335,8 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     cx.update_editor(|e, window, cx| {
         e.convert_indentation_to_spaces(&ConvertIndentationToSpaces, window, cx);
     });
-    cx.assert_editor_state(indoc! {"
+    cx.assert_editor_state(
+        indoc! {"
         «
         abc                 // No indentation
            abc              // 1 tab
@@ -4353,7 +4354,8 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
 
     // Test on just a few lines, the others should remain unchanged
     // Only lines (3, 5, 10, 11) should change
-    cx.set_state(indoc! {"
+    cx.set_state(
+        indoc! {"
 ·
             abc                 // No indentation
             \tabcˇ               // 1 tab
@@ -4371,7 +4373,8 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     cx.update_editor(|e, window, cx| {
         e.convert_indentation_to_spaces(&ConvertIndentationToSpaces, window, cx);
     });
-    cx.assert_editor_state(indoc! {"
+    cx.assert_editor_state(
+        indoc! {"
 ·
         abc                 // No indentation
         «   abc               // 1 tabˇ»
@@ -4405,7 +4408,8 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     cx.update_editor(|e, window, cx| {
         e.convert_indentation_to_spaces(&ConvertIndentationToSpaces, window, cx);
     });
-    cx.assert_editor_state(indoc! {"
+    cx.assert_editor_state(
+        indoc! {"
         «
         abc                 // No indentation
            abc               // 1 tab
@@ -4467,7 +4471,8 @@ async fn test_convert_indentation_to_tabs(cx: &mut TestAppContext) {
 
     // Test on just a few lines, the other should remain unchanged
     // Only lines (4, 8, 11, 12) should change
-    cx.set_state(indoc! {"
+    cx.set_state(
+        indoc! {"
 ·
             abc                 // No indentation
              abc                // 1 space (< 3 so dont convert)
@@ -4488,7 +4493,8 @@ async fn test_convert_indentation_to_tabs(cx: &mut TestAppContext) {
     cx.update_editor(|e, window, cx| {
         e.convert_indentation_to_tabs(&ConvertIndentationToTabs, window, cx);
     });
-    cx.assert_editor_state(indoc! {"
+    cx.assert_editor_state(
+        indoc! {"
 ·
             abc                 // No indentation
              abc                // 1 space (< 3 so dont convert)

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -22669,24 +22669,44 @@ async fn test_mtime_and_document_colors(cx: &mut TestAppContext) {
                     lsp::Url::from_file_path(path!("/a/first.rs")).unwrap()
                 );
                 requests_made.fetch_add(1, atomic::Ordering::Release);
-                Ok(vec![lsp::ColorInformation {
-                    range: lsp::Range {
-                        start: lsp::Position {
-                            line: 0,
-                            character: 0,
+                Ok(vec![
+                    lsp::ColorInformation {
+                        range: lsp::Range {
+                            start: lsp::Position {
+                                line: 0,
+                                character: 0,
+                            },
+                            end: lsp::Position {
+                                line: 0,
+                                character: 1,
+                            },
                         },
-                        end: lsp::Position {
-                            line: 0,
-                            character: 1,
+                        color: lsp::Color {
+                            red: 0.33,
+                            green: 0.33,
+                            blue: 0.33,
+                            alpha: 0.33,
                         },
                     },
-                    color: lsp::Color {
-                        red: 0.33,
-                        green: 0.33,
-                        blue: 0.33,
-                        alpha: 0.33,
+                    lsp::ColorInformation {
+                        range: lsp::Range {
+                            start: lsp::Position {
+                                line: 0,
+                                character: 0,
+                            },
+                            end: lsp::Position {
+                                line: 0,
+                                character: 1,
+                            },
+                        },
+                        color: lsp::Color {
+                            red: 0.33,
+                            green: 0.33,
+                            blue: 0.33,
+                            alpha: 0.33,
+                        },
                     },
-                }])
+                ])
             }
         });
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4337,15 +4337,15 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     });
     cx.assert_editor_state(
         indoc! {"
-        «
-        abc                 // No indentation
-           abc              // 1 tab
-              abc          // 2 tabs
-            abc             // Tab followed by space
-           abc              // Space followed by tab (3 spaces should be the result)
-                       abc   // Mixed indentation (tab conversion depends on the column)
-           abc         // Already space indented
-·
+            «
+            abc                 // No indentation
+               abc              // 1 tab
+                  abc          // 2 tabs
+                abc             // Tab followed by space
+               abc              // Space followed by tab (3 spaces should be the result)
+                           abc   // Mixed indentation (tab conversion depends on the column)
+               abc         // Already space indented
+               ·
                abc\tdef          // Only the leading tab is manipulatedˇ»
         "}
         .replace("·", "")
@@ -4356,7 +4356,7 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     // Only lines (3, 5, 10, 11) should change
     cx.set_state(
         indoc! {"
-·
+            ·
             abc                 // No indentation
             \tabcˇ               // 1 tab
             \t\tabc             // 2 tabs
@@ -4375,15 +4375,15 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     });
     cx.assert_editor_state(
         indoc! {"
-·
-        abc                 // No indentation
-        «   abc               // 1 tabˇ»
-        \t\tabc             // 2 tabs
-        «    abc              // Tab followed by spaceˇ»
-         \tabc              // Space followed by tab (3 spaces should be the result)
-        \t \t  \t   \tabc   // Mixed indentation (tab conversion depends on the column)
-           abc              // Already space indented
-        «·
+            ·
+            abc                 // No indentation
+            «   abc               // 1 tabˇ»
+            \t\tabc             // 2 tabs
+            «    abc              // Tab followed by spaceˇ»
+             \tabc              // Space followed by tab (3 spaces should be the result)
+            \t \t  \t   \tabc   // Mixed indentation (tab conversion depends on the column)
+               abc              // Already space indented
+            «   ·
                abc\tdef          // Only the leading tab is manipulatedˇ»
         "}
         .replace("·", "")
@@ -4410,15 +4410,15 @@ async fn test_convert_indentation_to_spaces(cx: &mut TestAppContext) {
     });
     cx.assert_editor_state(
         indoc! {"
-        «
-        abc                 // No indentation
-           abc               // 1 tab
-              abc             // 2 tabs
-            abc              // Tab followed by space
-           abc              // Space followed by tab (3 spaces should be the result)
-                       abc   // Mixed indentation (tab conversion depends on the column)
-           abc              // Already space indented
-·
+            «
+            abc                 // No indentation
+               abc               // 1 tab
+                  abc             // 2 tabs
+                abc              // Tab followed by space
+               abc              // Space followed by tab (3 spaces should be the result)
+                           abc   // Mixed indentation (tab conversion depends on the column)
+               abc              // Already space indented
+               ·
                abc\tdef          // Only the leading tab is manipulatedˇ»
         "}
         .replace("·", "")
@@ -4473,7 +4473,7 @@ async fn test_convert_indentation_to_tabs(cx: &mut TestAppContext) {
     // Only lines (4, 8, 11, 12) should change
     cx.set_state(
         indoc! {"
-·
+            ·
             abc                 // No indentation
              abc                // 1 space (< 3 so dont convert)
               abc               // 2 spaces (< 3 so dont convert)
@@ -4495,7 +4495,7 @@ async fn test_convert_indentation_to_tabs(cx: &mut TestAppContext) {
     });
     cx.assert_editor_state(
         indoc! {"
-·
+            ·
             abc                 // No indentation
              abc                // 1 space (< 3 so dont convert)
               abc               // 2 spaces (< 3 so dont convert)

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -107,9 +107,7 @@ pub trait LspCommand: 'static + Sized + Send + std::fmt::Debug {
     }
 
     /// When false, `to_lsp_params_or_response` default implementation will return the default response.
-    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool {
-        true
-    }
+    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool;
 
     fn to_lsp(
         &self,
@@ -275,6 +273,16 @@ impl LspCommand for PrepareRename {
 
     fn display_name(&self) -> &str {
         "Prepare rename"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .rename_provider
+            .is_some_and(|capability| match capability {
+                OneOf::Left(enabled) => enabled,
+                OneOf::Right(options) => options.prepare_provider.unwrap_or(false),
+            })
     }
 
     fn to_lsp_params_or_response(
@@ -457,6 +465,16 @@ impl LspCommand for PerformRename {
 
     fn display_name(&self) -> &str {
         "Rename"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .rename_provider
+            .is_some_and(|capability| match capability {
+                OneOf::Left(enabled) => enabled,
+                OneOf::Right(_options) => true,
+            })
     }
 
     fn to_lsp(
@@ -782,6 +800,16 @@ impl LspCommand for GetImplementation {
 
     fn display_name(&self) -> &str {
         "Get implementation"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .implementation_provider
+            .is_some_and(|capability| match capability {
+                lsp::ImplementationProviderCapability::Simple(enabled) => enabled,
+                lsp::ImplementationProviderCapability::Options(_options) => true,
+            })
     }
 
     fn to_lsp(
@@ -2127,6 +2155,13 @@ impl LspCommand for GetCompletions {
 
     fn display_name(&self) -> &str {
         "Get completion"
+    }
+
+    fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
+        capabilities
+            .server_capabilities
+            .completion_provider
+            .is_some()
     }
 
     fn to_lsp(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -583,7 +583,10 @@ impl LspCommand for GetDefinition {
         capabilities
             .server_capabilities
             .definition_provider
-            .is_some()
+            .is_some_and(|capability| match capability {
+                OneOf::Left(supported) => supported,
+                OneOf::Right(_options) => true,
+            })
     }
 
     fn to_lsp(
@@ -682,7 +685,11 @@ impl LspCommand for GetDeclaration {
         capabilities
             .server_capabilities
             .declaration_provider
-            .is_some()
+            .is_some_and(|capability| match capability {
+                lsp::DeclarationCapability::Simple(supported) => supported,
+                lsp::DeclarationCapability::RegistrationOptions(..) => true,
+                lsp::DeclarationCapability::Options(..) => true,
+            })
     }
 
     fn to_lsp(
@@ -1437,7 +1444,10 @@ impl LspCommand for GetDocumentHighlights {
         capabilities
             .server_capabilities
             .document_highlight_provider
-            .is_some()
+            .is_some_and(|capability| match capability {
+                OneOf::Left(supported) => supported,
+                OneOf::Right(_options) => true,
+            })
     }
 
     fn to_lsp(
@@ -1590,7 +1600,10 @@ impl LspCommand for GetDocumentSymbols {
         capabilities
             .server_capabilities
             .document_symbol_provider
-            .is_some()
+            .is_some_and(|capability| match capability {
+                OneOf::Left(supported) => supported,
+                OneOf::Right(_options) => true,
+            })
     }
 
     fn to_lsp(
@@ -4161,7 +4174,11 @@ impl LspCommand for GetDocumentColor {
         server_capabilities
             .server_capabilities
             .color_provider
-            .is_some()
+            .is_some_and(|capability| match capability {
+                lsp::ColorProviderCapability::Simple(supported) => supported,
+                lsp::ColorProviderCapability::ColorProvider(..) => true,
+                lsp::ColorProviderCapability::Options(..) => true,
+            })
     }
 
     fn to_lsp(

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -16,7 +16,7 @@ use language::{
     Buffer, point_to_lsp,
     proto::{deserialize_anchor, serialize_anchor},
 };
-use lsp::{LanguageServer, LanguageServerId};
+use lsp::{AdapterServerCapabilities, LanguageServer, LanguageServerId};
 use rpc::proto::{self, PeerId};
 use serde::{Deserialize, Serialize};
 use std::{
@@ -66,6 +66,10 @@ impl LspCommand for ExpandMacro {
 
     fn display_name(&self) -> &str {
         "Expand macro"
+    }
+
+    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool {
+        true
     }
 
     fn to_lsp(
@@ -194,6 +198,10 @@ impl LspCommand for OpenDocs {
 
     fn display_name(&self) -> &str {
         "Open docs"
+    }
+
+    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool {
+        true
     }
 
     fn to_lsp(
@@ -326,6 +334,10 @@ impl LspCommand for SwitchSourceHeader {
         "Switch source header"
     }
 
+    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool {
+        true
+    }
+
     fn to_lsp(
         &self,
         path: &Path,
@@ -402,6 +414,10 @@ impl LspCommand for GoToParentModule {
 
     fn display_name(&self) -> &str {
         "Go to parent module"
+    }
+
+    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool {
+        true
     }
 
     fn to_lsp(
@@ -576,6 +592,10 @@ impl LspCommand for GetLspRunnables {
 
     fn display_name(&self) -> &str {
         "LSP Runnables"
+    }
+
+    fn check_capabilities(&self, _: AdapterServerCapabilities) -> bool {
+        true
     }
 
     fn to_lsp(

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -779,11 +779,40 @@ pub struct DocumentColor {
     pub color_presentations: Vec<ColorPresentation>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+impl Eq for DocumentColor {}
+
+impl std::hash::Hash for DocumentColor {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.lsp_range.hash(state);
+        self.color.red.to_bits().hash(state);
+        self.color.green.to_bits().hash(state);
+        self.color.blue.to_bits().hash(state);
+        self.color.alpha.to_bits().hash(state);
+        self.resolved.hash(state);
+        self.color_presentations.hash(state);
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ColorPresentation {
     pub label: String,
     pub text_edit: Option<lsp::TextEdit>,
     pub additional_text_edits: Vec<lsp::TextEdit>,
+}
+
+impl std::hash::Hash for ColorPresentation {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.label.hash(state);
+        if let Some(ref edit) = self.text_edit {
+            edit.range.hash(state);
+            edit.new_text.hash(state);
+        }
+        self.additional_text_edits.len().hash(state);
+        for edit in &self.additional_text_edits {
+            edit.range.hash(state);
+            edit.new_text.hash(state);
+        }
+    }
 }
 
 #[derive(Clone)]

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -422,7 +422,12 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
             "Rust",
             FakeLspAdapter {
                 name: "rust-analyzer",
-                ..Default::default()
+                capabilities: lsp::ServerCapabilities {
+                    completion_provider: Some(lsp::CompletionOptions::default()),
+                    rename_provider: Some(lsp::OneOf::Left(true)),
+                    ..lsp::ServerCapabilities::default()
+                },
+                ..FakeLspAdapter::default()
             },
         )
     });
@@ -430,7 +435,11 @@ async fn test_remote_lsp(cx: &mut TestAppContext, server_cx: &mut TestAppContext
     let mut fake_lsp = server_cx.update(|cx| {
         headless.read(cx).languages.register_fake_language_server(
             LanguageServerName("rust-analyzer".into()),
-            Default::default(),
+            lsp::ServerCapabilities {
+                completion_provider: Some(lsp::CompletionOptions::default()),
+                rename_provider: Some(lsp::OneOf::Left(true)),
+                ..lsp::ServerCapabilities::default()
+            },
             None,
         )
     });


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33522

Turns out a bunch of Zed requests were not checking their capabilities correctly, due to odd copy-paste and due to default that assumed that the capabilities are met.

Adjust the code, which includes the document colors, add the test on the colors case.

Release Notes:

- Fixed excessive document colors requests for unrelated files
