### PR TITLE
Fix line indices when using a selection in the context

### DIFF
--- a/crates/agent_ui/src/context_picker.rs
+++ b/crates/agent_ui/src/context_picker.rs
@@ -930,8 +930,8 @@ impl MentionLink {
         format!(
             "[@{} ({}-{})]({}:{}:{}-{})",
             file_name,
-            line_range.start,
-            line_range.end,
+            line_range.start + 1,
+            line_range.end + 1,
             Self::SELECTION,
             full_path,
             line_range.start,


### PR DESCRIPTION
Closes #33152.

The label for a file selection context had an off-by-one error on line indices. This PR adjusts that.

Before:

<img width="1072" alt="Screenshot 2025-06-27 at 20 55 28" src="https://github.com/user-attachments/assets/da0be503-056b-442b-9a79-38cf504d8a44" />

After:

<img width="1090" alt="Screenshot 2025-06-27 at 20 49 35" src="https://github.com/user-attachments/assets/f98df57a-8f07-4ea5-a06b-a4b6fb8c2e4e" />


Release Notes:

- Fixed a off-by-one error on the line indices when using a selection as context for the agent,
