### PR TITLE
copilot: Only set Copilot-Vision-Request header for vision requests

### DIFF
--- a/crates/copilot/src/copilot_chat.rs
+++ b/crates/copilot/src/copilot_chat.rs
@@ -698,16 +698,16 @@ async fn stream_completion(
     completion_url: Arc<str>,
     request: Request,
 ) -> Result<BoxStream<'static, Result<ResponseEvent>>> {
-    let is_vision_request = request.messages.last().map_or(false, |message| match message {
-        ChatMessage::User { content }
-        | ChatMessage::Assistant { content, .. }
-        | ChatMessage::Tool { content, .. } => {
-            matches!(content, ChatMessageContent::Multipart(parts) if parts.iter().any(|part| matches!(part, ChatMessagePart::Image { .. })))
-        }
-        _ => false,
-    });
+    let is_vision_request = request.messages.iter().any(|message| match message {
+      ChatMessage::User { content }
+      | ChatMessage::Assistant { content, .. }
+      | ChatMessage::Tool { content, .. } => {
+          matches!(content, ChatMessageContent::Multipart(parts) if parts.iter().any(|part| matches!(part, ChatMessagePart::Image { .. })))
+      }
+      _ => false,
+  });
 
-    let request_builder = HttpRequest::builder()
+    let mut request_builder = HttpRequest::builder()
         .method(Method::POST)
         .uri(completion_url.as_ref())
         .header(
@@ -719,8 +719,12 @@ async fn stream_completion(
         )
         .header("Authorization", format!("Bearer {}", api_key))
         .header("Content-Type", "application/json")
-        .header("Copilot-Integration-Id", "vscode-chat")
-        .header("Copilot-Vision-Request", is_vision_request.to_string());
+        .header("Copilot-Integration-Id", "vscode-chat");
+
+    if is_vision_request {
+        request_builder =
+            request_builder.header("Copilot-Vision-Request", is_vision_request.to_string());
+    }
 
     let is_streaming = request.stream;
 


### PR DESCRIPTION
Closes #31951

The fix is copied and translated from copilot chat actual implementation code: https://github.com/microsoft/vscode-copilot-chat/blob/ad7cbcae9a964e8efb869bf1426999e56ea63cf0/src/platform/openai/node/fetch.ts#L493C1-L495C3

Release Notes:

- Fix copilot failing due to missing `Copilot-Vision-Request` from request.
