### PR TITLE
Fix an interaction between vim's linewise yank and editor's paste

### DIFF
--- a/crates/vim/src/normal/yank.rs
+++ b/crates/vim/src/normal/yank.rs
@@ -195,7 +195,7 @@ impl Vim {
                 }
                 clipboard_selections.push(ClipboardSelection {
                     len: text.len() - initial_len,
-                    is_entire_line: kind.linewise(),
+                    is_entire_line: false,
                     first_line_indent: buffer.indent_size_for_line(MultiBufferRow(start.row)).len,
                 });
             }


### PR DESCRIPTION
Closes #32397

This PR fixes an issue when pasting text with the `editor::Paste` command that was copied with `vim::Yank`'s linewise selection.

The change stops setting the `is_entire_line` setting when copying from with vim linewise selections (<kbd>⇧v</kbd>) and motions (i.e. <kbd>y2j</kbd>).

This flag is used when cutting/copying text without being selected (so, place a cursor on line without selecting anything, and press <kbd>⌘X</kbd>). When cutting/copying text in this manner, [the editor pastes the text above the cursor](https://github.com/afgomez/zed/blob/36941253ee086af3dc7d2b2729a68bebe387d650/crates/editor/src/editor.rs#L11936-L11947). However, this behaviour is not needed when cutting/copying with vim motions.

Pasting with vim operations is not affected by this change. [They are handled elsewhere](https://github.com/afgomez/zed/blob/36941253ee086af3dc7d2b2729a68bebe387d650/crates/vim/src/normal/paste.rs) and they don't consider the `is_entire_line` flag at all.

Note for maintainers: I'm not familiar with this codebase 🙃. This change fixes the issue. I don't see anything breaking... but let me know if it's not the case and a more thorough change is needed.

**Before:**

The text is copied above the first line, before the cursor.

https://github.com/user-attachments/assets/0c2f111a-5da0-4775-a7a0-2e4fb6f78bfc


**After:**
The text is copied at the cursor location:

https://github.com/user-attachments/assets/60a17985-fe8b-4149-a77b-d72bf531bf85


Release Notes:

- Fixed an issue when pasting text that was yanked with vim's linewise selections.
