### PR TITLE
agent: Improve error handling and retry for zed-provided models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20128,9 +20128,9 @@ dependencies = [
 
 [[package]]
 name = "zed_llm_client"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de7d9523255f4e00ee3d0918e5407bd252d798a4a8e71f6d37f23317a1588203"
+checksum = "c740e29260b8797ad252c202ea09a255b3cbc13f30faaf92fb6b2490336106e0"
 dependencies = [
  "anyhow",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8945,7 +8945,6 @@ dependencies = [
  "aws-credential-types",
  "aws_http_client",
  "bedrock",
- "chrono",
  "client",
  "collections",
  "copilot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8945,6 +8945,7 @@ dependencies = [
  "aws-credential-types",
  "aws_http_client",
  "bedrock",
+ "chrono",
  "client",
  "collections",
  "copilot",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -625,7 +625,7 @@ wasmtime = { version = "29", default-features = false, features = [
 wasmtime-wasi = "29"
 which = "6.0.0"
 workspace-hack = "0.1.0"
-zed_llm_client = "0.8.4"
+zed_llm_client = "0.8.5"
 zstd = "0.11"
 
 [workspace.dependencies.async-stripe]

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1536,13 +1536,28 @@ impl Thread {
                             Err(error) => {
                                 match error {
                                     LanguageModelCompletionError::RateLimitExceeded { retry_after } => {
-                                        anyhow::bail!(LanguageModelKnownError::RateLimitExceeded { retry_after });
+                                        let provider_name = if model.is_zed() {
+                                            None
+                                        } else {
+                                            Some(model.provider_name().0.as_ref())
+                                        };
+                                        anyhow::bail!(LanguageModelKnownError::rate_limit_exceeded(provider_name, retry_after));
                                     }
                                     LanguageModelCompletionError::Overloaded => {
-                                        anyhow::bail!(LanguageModelKnownError::Overloaded);
+                                        let provider_name = if model.is_zed() {
+                                            None
+                                        } else {
+                                            Some(model.provider_name().0.as_ref())
+                                        };
+                                        anyhow::bail!(LanguageModelKnownError::overloaded(provider_name));
                                     }
                                     LanguageModelCompletionError::ApiInternalServerError =>{
-                                        anyhow::bail!(LanguageModelKnownError::ApiInternalServerError);
+                                        let provider_name = if model.is_zed() {
+                                            None
+                                        } else {
+                                            Some(model.provider_name().0.as_ref())
+                                        };
+                                        anyhow::bail!(LanguageModelKnownError::api_internal_server_error(provider_name));
                                     }
                                     LanguageModelCompletionError::PromptTooLarge { tokens } => {
                                         let tokens = tokens.unwrap_or_else(|| {
@@ -1564,7 +1579,12 @@ impl Thread {
                                         anyhow::bail!(LanguageModelKnownError::UnknownResponseFormat(error));
                                     }
                                     LanguageModelCompletionError::HttpResponseError { status, ref body } => {
-                                        if let Some(known_error) = LanguageModelKnownError::from_http_response(status, body) {
+                                        let provider_name = if model.is_zed() {
+                                            None
+                                        } else {
+                                            Some(model.provider_name().0.as_ref())
+                                        };
+                                        if let Some(known_error) = LanguageModelKnownError::from_http_response(status, body, provider_name) {
                                             anyhow::bail!(known_error);
                                         } else {
                                             return Err(error.into());
@@ -1894,15 +1914,9 @@ impl Thread {
                                         });
                                         cx.notify();
                                     }
-                                    LanguageModelKnownError::RateLimitExceeded { retry_after } => {
-                                        let provider_name = model.provider_name();
-                                        let error_message = format!(
-                                            "{}'s API rate limit exceeded",
-                                            provider_name.0.as_ref()
-                                        );
-
+                                    LanguageModelKnownError::RateLimitExceeded(message, retry_after) => {
                                         thread.handle_rate_limit_error(
-                                            &error_message,
+                                            message,
                                             *retry_after,
                                             model.clone(),
                                             intent,
@@ -1911,15 +1925,9 @@ impl Thread {
                                         );
                                         retry_scheduled = true;
                                     }
-                                    LanguageModelKnownError::Overloaded => {
-                                        let provider_name = model.provider_name();
-                                        let error_message = format!(
-                                            "{}'s API servers are overloaded right now",
-                                            provider_name.0.as_ref()
-                                        );
-
+                                    LanguageModelKnownError::Overloaded(message) => {
                                         retry_scheduled = thread.handle_retryable_error(
-                                            &error_message,
+                                            message,
                                             model.clone(),
                                             intent,
                                             window,
@@ -1929,15 +1937,9 @@ impl Thread {
                                             emit_generic_error(error, cx);
                                         }
                                     }
-                                    LanguageModelKnownError::ApiInternalServerError => {
-                                        let provider_name = model.provider_name();
-                                        let error_message = format!(
-                                            "{}'s API server reported an internal server error",
-                                            provider_name.0.as_ref()
-                                        );
-
+                                    LanguageModelKnownError::ApiInternalServerError(message) => {
                                         retry_scheduled = thread.handle_retryable_error(
-                                            &error_message,
+                                            message,
                                             model.clone(),
                                             intent,
                                             window,

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1694,7 +1694,7 @@ impl Thread {
                                         } => {
                                             return Err(
                                                 LanguageModelCompletionError::from_cloud_failure(
-                                                    model.provider_name(),
+                                                    model.upstream_provider_name(),
                                                     code,
                                                     message,
                                                     retry_after.map(Duration::from_secs_f64),

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1691,6 +1691,8 @@ impl Thread {
                                         CompletionRequestStatus::Failed {
                                             code, message, request_id
                                         } => {
+                                            // todo! This is where HTTP errors from cloud models actually get reported.
+                                            // Should add `retry_after` to failed and clarify upstream vs internal errors.
                                             anyhow::bail!("completion request failed. request_id: {request_id}, code: {code}, message: {message}");
                                         }
                                         CompletionRequestStatus::UsageUpdated {
@@ -4070,6 +4072,7 @@ fn main() {{
                 TestError::InternalServerError => {
                     LanguageModelCompletionError::ApiInternalServerError {
                         provider: self.provider_name(),
+                        message: "I'm a teapot orbiting the sun".to_string(),
                     }
                 }
             };

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2048,6 +2048,10 @@ impl Thread {
     ) {
         // For rate limit errors, we only retry once with the specified duration
         let retry_message = format!("{error}. Retrying in {} seconds…", retry_after.as_secs());
+        log::warn!(
+            "Retrying completion request in {} seconds: {error:?}",
+            retry_after.as_secs(),
+        );
 
         // Add a UI-only message instead of a regular message
         let id = self.next_message_id.post_inc();
@@ -2120,8 +2124,12 @@ impl Thread {
             // Add a transient message to inform the user
             let delay_secs = delay.as_secs();
             let retry_message = format!(
-                "{}. Retrying (attempt {} of {}) in {} seconds...",
-                error, attempt, max_attempts, delay_secs
+                "{error}. Retrying (attempt {attempt} of {max_attempts}) \
+                in {delay_secs} seconds..."
+            );
+            log::warn!(
+                "Retrying completion request (attempt {attempt} of {max_attempts}) \
+                in {delay_secs} seconds: {error:?}",
             );
 
             // Add a UI-only message instead of a regular message

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2025,9 +2025,7 @@ impl AgentPanel {
                     .thread()
                     .read(cx)
                     .configured_model()
-                    .map_or(false, |model| {
-                        model.provider.id().0 == ZED_CLOUD_PROVIDER_ID
-                    });
+                    .map_or(false, |model| model.provider.id() == ZED_CLOUD_PROVIDER_ID);
 
                 if !is_using_zed_provider {
                     return false;

--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1250,9 +1250,7 @@ impl MessageEditor {
         self.thread
             .read(cx)
             .configured_model()
-            .map_or(false, |model| {
-                model.provider.id().0 == ZED_CLOUD_PROVIDER_ID
-            })
+            .map_or(false, |model| model.provider.id() == ZED_CLOUD_PROVIDER_ID)
     }
 
     fn render_usage_callout(&self, line_height: Pixels, cx: &mut Context<Self>) -> Option<Div> {

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -520,6 +520,10 @@ pub async fn stream_completion_with_rate_limit_info(
             })
             .boxed();
         Ok((stream, Some(rate_limits)))
+    } else if response.status().as_u16() == 529 {
+        Err(AnthropicError::ServerOverloaded {
+            retry_after: rate_limits.retry_after,
+        })
     } else if let Some(retry_after) = rate_limits.retry_after {
         Err(AnthropicError::RateLimit { retry_after })
     } else {
@@ -805,6 +809,9 @@ pub enum AnthropicError {
 
     /// Rate limit exceeded
     RateLimit { retry_after: Duration },
+
+    /// Server overloaded
+    ServerOverloaded { retry_after: Option<Duration> },
 
     /// API returned an error response
     ApiError(ApiError),

--- a/crates/anthropic/src/anthropic.rs
+++ b/crates/anthropic/src/anthropic.rs
@@ -536,8 +536,7 @@ pub async fn stream_completion_with_rate_limit_info(
 
         match serde_json::from_str::<Event>(&body) {
             Ok(Event::Error { error }) => Err(AnthropicError::ApiError(error)),
-            Ok(_) => Err(AnthropicError::UnexpectedResponseFormat(body)),
-            Err(_) => Err(AnthropicError::HttpResponseError {
+            Ok(_) | Err(_) => Err(AnthropicError::HttpResponseError {
                 status: response.status().as_u16(),
                 body: body,
             }),
@@ -815,9 +814,6 @@ pub enum AnthropicError {
 
     /// API returned an error response
     ApiError(ApiError),
-
-    /// Unexpected response format
-    UnexpectedResponseFormat(String),
 }
 
 #[derive(Debug, Serialize, Deserialize, Error)]

--- a/crates/assistant_context/src/assistant_context.rs
+++ b/crates/assistant_context/src/assistant_context.rs
@@ -2140,7 +2140,8 @@ impl AssistantContext {
                                         );
                                     }
                                     LanguageModelCompletionEvent::ToolUse(_) |
-                                    LanguageModelCompletionEvent::UsageUpdate(_)  => {}
+                                    LanguageModelCompletionEvent::ToolUseJsonParseError { .. } |
+                                    LanguageModelCompletionEvent::UsageUpdate(_) => {}
                                 }
                             });
 

--- a/crates/assistant_tools/src/edit_agent/evals.rs
+++ b/crates/assistant_tools/src/edit_agent/evals.rs
@@ -29,6 +29,7 @@ use std::{
     path::Path,
     str::FromStr,
     sync::mpsc,
+    time::Duration,
 };
 use util::path;
 
@@ -1658,12 +1659,14 @@ async fn retry_on_rate_limit<R>(mut request: impl AsyncFnMut() -> Result<R>) -> 
         match request().await {
             Ok(result) => return Ok(result),
             Err(err) => match err.downcast::<LanguageModelCompletionError>() {
-                Ok(err) => match err {
-                    LanguageModelCompletionError::RateLimitExceeded { retry_after } => {
+                Ok(err) => match &err {
+                    LanguageModelCompletionError::RateLimitExceeded { retry_after, .. }
+                    | LanguageModelCompletionError::ServerOverloaded { retry_after, .. } => {
+                        let retry_after = retry_after.unwrap_or(Duration::from_secs(5));
                         // Wait for the duration supplied, with some jitter to avoid all requests being made at the same time.
                         let jitter = retry_after.mul_f64(rand::thread_rng().gen_range(0.0..1.0));
                         eprintln!(
-                            "Attempt #{attempt}: Rate limit exceeded. Retry after {retry_after:?} + jitter of {jitter:?}"
+                            "Attempt #{attempt}: {err}. Retry after {retry_after:?} + jitter of {jitter:?}"
                         );
                         Timer::after(retry_after + jitter).await;
                         continue;

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -1054,6 +1054,15 @@ pub fn response_events_to_markdown(
                 | LanguageModelCompletionEvent::StartMessage { .. }
                 | LanguageModelCompletionEvent::StatusUpdate { .. },
             ) => {}
+            Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                json_parse_error, ..
+            }) => {
+                flush_buffers(&mut response, &mut text_buffer, &mut thinking_buffer);
+                response.push_str(&format!(
+                    "**Error**: parse error in tool use JSON: {}\n\n",
+                    json_parse_error
+                ));
+            }
             Err(error) => {
                 flush_buffers(&mut response, &mut text_buffer, &mut thinking_buffer);
                 response.push_str(&format!("**Error**: {}\n\n", error));
@@ -1131,6 +1140,17 @@ impl ThreadDialog {
                 | Ok(LanguageModelCompletionEvent::StatusUpdate { .. })
                 | Ok(LanguageModelCompletionEvent::StartMessage { .. })
                 | Ok(LanguageModelCompletionEvent::Stop(_)) => {}
+
+                Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                    json_parse_error,
+                    ..
+                }) => {
+                    flush_text(&mut current_text, &mut content);
+                    content.push(MessageContent::Text(format!(
+                        "ERROR: parse error in tool use JSON: {}",
+                        json_parse_error
+                    )));
+                }
 
                 Err(error) => {
                     flush_text(&mut current_text, &mut content);

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -128,35 +128,35 @@ pub enum LanguageModelCompletionError {
     PermissionError { provider: LanguageModelProviderName },
     #[error("language model provider API endpoint not found")]
     ApiEndpointNotFound { provider: LanguageModelProviderName },
-    #[error("I/O error reading response from {provider}'s API: {error:?}")]
+    #[error("I/O error reading response from {provider}'s API")]
     ApiReadResponseError {
         provider: LanguageModelProviderName,
+        #[source]
         error: io::Error,
     },
-    #[error("error serializing request to {provider} API: {error}")]
+    #[error("error serializing request to {provider} API")]
     SerializeRequest {
         provider: LanguageModelProviderName,
+        #[source]
         error: serde_json::Error,
     },
-    #[error("error building request body to {provider} API: {error}")]
+    #[error("error building request body to {provider} API")]
     BuildRequestBody {
         provider: LanguageModelProviderName,
+        #[source]
         error: http::Error,
     },
-    #[error("error sending HTTP request to {provider} API: {error}")]
+    #[error("error sending HTTP request to {provider} API")]
     HttpSend {
         provider: LanguageModelProviderName,
+        #[source]
         error: anyhow::Error,
     },
-    #[error("error deserializing {provider} API response: {error}")]
+    #[error("error deserializing {provider} API response")]
     DeserializeResponse {
         provider: LanguageModelProviderName,
+        #[source]
         error: serde_json::Error,
-    },
-    #[error("unexpected {provider} API response format: {error}")]
-    UnknownResponseFormat {
-        provider: LanguageModelProviderName,
-        error: String,
     },
 
     /// Error from cloud provider - message is used directly rather than converting it to one of the
@@ -199,9 +199,6 @@ impl From<AnthropicError> for LanguageModelCompletionError {
                 retry_after: retry_after,
             },
             AnthropicError::ApiError(api_error) => api_error.into(),
-            AnthropicError::UnexpectedResponseFormat(error) => {
-                Self::UnknownResponseFormat { provider, error }
-            }
         }
     }
 }

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -556,7 +556,7 @@ pub struct LanguageModelProviderId(pub SharedString);
 
 impl LanguageModelProviderId {
     pub fn is_zed(&self) -> bool {
-        self.0 == language_model::ZED_CLOUD_PROVIDER_ID
+        self.0 == ZED_CLOUD_PROVIDER_ID
     }
 }
 

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -124,8 +124,6 @@ pub enum LanguageModelCompletionError {
     },
 
     // Client errors
-    //
-    // todo! which of these should be retriable?
     #[error("invalid request format to {provider}'s API: {message}")]
     BadRequestFormat {
         provider: LanguageModelProviderName,
@@ -174,7 +172,7 @@ pub enum LanguageModelCompletionError {
         error: serde_json::Error,
     },
 
-    // todo! remove - having From<anyhow::Error> discourages using proper error values
+    // TODO: Ideally this would be removed in favor of having a comprehensive list of errors.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -190,7 +190,7 @@ impl LanguageModelCompletionError {
         {
             Self::from_http_status(upstream_provider, status_code, message, retry_after)
         } else if let Some(status_code) = code
-            .strip_prefix("upstream_http_")
+            .strip_prefix("http_")
             .and_then(|code| StatusCode::from_str(code).ok())
         {
             Self::from_http_status(ZED_CLOUD_PROVIDER_NAME, status_code, message, retry_after)
@@ -219,6 +219,10 @@ impl LanguageModelCompletionError {
             },
             StatusCode::INTERNAL_SERVER_ERROR => Self::ApiInternalServerError { provider, message },
             StatusCode::SERVICE_UNAVAILABLE => Self::ServerOverloaded {
+                provider,
+                retry_after,
+            },
+            _ if status_code.as_u16() == 529 => Self::ServerOverloaded {
                 provider,
                 retry_after,
             },

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -184,7 +184,14 @@ impl LanguageModelCompletionError {
         message: String,
         retry_after: Option<Duration>,
     ) -> Self {
-        if let Some(status_code) = code
+        if let Some(tokens) = parse_prompt_too_long(&message) {
+            // TODO: currently Anthropic PAYLOAD_TOO_LARGE response may cause INTERNAL_SERVER_ERROR
+            // to be reported. This is a temporary workaround to handle this in the case where the
+            // token limit has been exceeded.
+            Self::PromptTooLarge {
+                tokens: Some(tokens),
+            }
+        } else if let Some(status_code) = code
             .strip_prefix("upstream_http_")
             .and_then(|code| StatusCode::from_str(code).ok())
         {

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -98,7 +98,7 @@ impl ConfiguredModel {
     }
 
     pub fn is_provided_by_zed(&self) -> bool {
-        self.provider.id().0 == crate::ZED_CLOUD_PROVIDER_ID
+        self.provider.id() == crate::ZED_CLOUD_PROVIDER_ID
     }
 }
 

--- a/crates/language_model/src/telemetry.rs
+++ b/crates/language_model/src/telemetry.rs
@@ -1,3 +1,4 @@
+use crate::ANTHROPIC_PROVIDER_ID;
 use anthropic::ANTHROPIC_API_URL;
 use anyhow::{Context as _, anyhow};
 use client::telemetry::Telemetry;
@@ -8,8 +9,6 @@ use std::sync::Arc;
 use telemetry_events::{AssistantEventData, AssistantKind, AssistantPhase};
 use util::ResultExt;
 
-pub const ANTHROPIC_PROVIDER_ID: &str = "anthropic";
-
 pub fn report_assistant_event(
     event: AssistantEventData,
     telemetry: Option<Arc<Telemetry>>,
@@ -19,7 +18,7 @@ pub fn report_assistant_event(
 ) {
     if let Some(telemetry) = telemetry.as_ref() {
         telemetry.report_assistant_event(event.clone());
-        if telemetry.metrics_enabled() && event.model_provider == ANTHROPIC_PROVIDER_ID {
+        if telemetry.metrics_enabled() && event.model_provider == ANTHROPIC_PROVIDER_ID.0 {
             if let Some(api_key) = model_api_key {
                 executor
                     .spawn(async move {

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -20,6 +20,7 @@ aws-credential-types = { workspace = true, features = [
 ] }
 aws_http_client.workspace = true
 bedrock.workspace = true
+chrono.workspace = true
 client.workspace = true
 collections.workspace = true
 credentials_provider.workspace = true

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -20,7 +20,6 @@ aws-credential-types = { workspace = true, features = [
 ] }
 aws_http_client.workspace = true
 bedrock.workspace = true
-chrono.workspace = true
 client.workspace = true
 collections.workspace = true
 credentials_provider.workspace = true

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -34,7 +34,7 @@ use ui::{Icon, IconName, List, Tooltip, prelude::*};
 use util::ResultExt;
 
 const PROVIDER_ID: LanguageModelProviderId = language_model::ANTHROPIC_PROVIDER_ID;
-pub const PROVIDER_NAME: LanguageModelProviderName = language_model::ANTHROPIC_PROVIDER_NAME;
+const PROVIDER_NAME: LanguageModelProviderName = language_model::ANTHROPIC_PROVIDER_NAME;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct AnthropicSettings {

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -406,8 +406,7 @@ impl AnthropicModel {
             let Some(api_key) = api_key else {
                 return Err(LanguageModelCompletionError::NoApiKey {
                     provider: PROVIDER_NAME,
-                }
-                .into());
+                });
             };
             let request =
                 anthropic::stream_completion(http_client.as_ref(), &api_url, &api_key, request);

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -33,8 +33,8 @@ use theme::ThemeSettings;
 use ui::{Icon, IconName, List, Tooltip, prelude::*};
 use util::ResultExt;
 
-const PROVIDER_ID: &str = language_model::ANTHROPIC_PROVIDER_ID;
-const PROVIDER_NAME: &str = "Anthropic";
+const PROVIDER_ID: LanguageModelProviderId = language_model::ANTHROPIC_PROVIDER_ID;
+pub const PROVIDER_NAME: LanguageModelProviderName = language_model::ANTHROPIC_PROVIDER_NAME;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct AnthropicSettings {
@@ -218,11 +218,11 @@ impl LanguageModelProviderState for AnthropicLanguageModelProvider {
 
 impl LanguageModelProvider for AnthropicLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -403,7 +403,12 @@ impl AnthropicModel {
         };
 
         async move {
-            let api_key = api_key.context("Missing Anthropic API Key")?;
+            let Some(api_key) = api_key else {
+                return Err(LanguageModelCompletionError::NoApiKey {
+                    provider: PROVIDER_NAME,
+                }
+                .into());
+            };
             let request =
                 anthropic::stream_completion(http_client.as_ref(), &api_url, &api_key, request);
             request.await.map_err(Into::into)
@@ -422,11 +427,11 @@ impl LanguageModel for AnthropicModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -806,12 +811,14 @@ impl AnthropicEventMapper {
                                 raw_input: tool_use.input_json.clone(),
                             },
                         )),
-                        Err(json_parse_err) => Err(LanguageModelCompletionError::BadInputJson {
-                            id: tool_use.id.into(),
-                            tool_name: tool_use.name.into(),
-                            raw_input: input_json.into(),
-                            json_parse_error: json_parse_err.to_string(),
-                        }),
+                        Err(json_parse_err) => {
+                            Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                                id: tool_use.id.into(),
+                                tool_name: tool_use.name.into(),
+                                raw_input: input_json.into(),
+                                json_parse_error: json_parse_err.to_string(),
+                            })
+                        }
                     };
 
                     vec![event_result]

--- a/crates/language_models/src/provider/bedrock.rs
+++ b/crates/language_models/src/provider/bedrock.rs
@@ -52,8 +52,8 @@ use util::ResultExt;
 
 use crate::AllLanguageModelSettings;
 
-const PROVIDER_ID: &str = "amazon-bedrock";
-const PROVIDER_NAME: &str = "Amazon Bedrock";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("amazon-bedrock");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Amazon Bedrock");
 
 #[derive(Default, Clone, Deserialize, Serialize, PartialEq, Debug)]
 pub struct BedrockCredentials {
@@ -285,11 +285,11 @@ impl BedrockLanguageModelProvider {
 
 impl LanguageModelProvider for BedrockLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -489,11 +489,11 @@ impl LanguageModel for BedrockModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -1000,9 +1000,7 @@ where
         .flat_map(move |event| {
             futures::stream::iter(match event {
                 Err(error) => {
-                    vec![Err(LanguageModelCompletionError::from(
-                        LanguageModelCompletionError::Other(error),
-                    ))]
+                    vec![Err(LanguageModelCompletionError::from(error))]
                 }
                 Ok(CloudCompletionEvent::Status(event)) => {
                     vec![Ok(LanguageModelCompletionEvent::StatusUpdate(event))]

--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -35,8 +35,9 @@ use super::anthropic::count_anthropic_tokens;
 use super::google::count_google_tokens;
 use super::open_ai::count_open_ai_tokens;
 
-const PROVIDER_ID: &str = "copilot_chat";
-const PROVIDER_NAME: &str = "GitHub Copilot Chat";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("copilot_chat");
+const PROVIDER_NAME: LanguageModelProviderName =
+    LanguageModelProviderName::new("GitHub Copilot Chat");
 
 pub struct CopilotChatLanguageModelProvider {
     state: Entity<State>,
@@ -102,11 +103,11 @@ impl LanguageModelProviderState for CopilotChatLanguageModelProvider {
 
 impl LanguageModelProvider for CopilotChatLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -201,11 +202,11 @@ impl LanguageModel for CopilotChatLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -391,24 +392,24 @@ pub fn map_to_language_model_completion_events(
                                             serde_json::Value::from_str(&tool_call.arguments)
                                         };
                                         match arguments {
-                                            Ok(input) => Ok(LanguageModelCompletionEvent::ToolUse(
-                                                LanguageModelToolUse {
-                                                    id: tool_call.id.clone().into(),
-                                                    name: tool_call.name.as_str().into(),
-                                                    is_input_complete: true,
-                                                    input,
-                                                    raw_input: tool_call.arguments.clone(),
-                                                },
-                                            )),
-                                            Err(error) => {
-                                                Err(LanguageModelCompletionError::BadInputJson {
-                                                    id: tool_call.id.into(),
-                                                    tool_name: tool_call.name.as_str().into(),
-                                                    raw_input: tool_call.arguments.into(),
-                                                    json_parse_error: error.to_string(),
-                                                })
-                                            }
-                                        }
+                                        Ok(input) => Ok(LanguageModelCompletionEvent::ToolUse(
+                                            LanguageModelToolUse {
+                                                id: tool_call.id.clone().into(),
+                                                name: tool_call.name.as_str().into(),
+                                                is_input_complete: true,
+                                                input,
+                                                raw_input: tool_call.arguments.clone(),
+                                            },
+                                        )),
+                                        Err(error) => Ok(
+                                            LanguageModelCompletionEvent::ToolUseJsonParseError {
+                                                id: tool_call.id.into(),
+                                                tool_name: tool_call.name.as_str().into(),
+                                                raw_input: tool_call.arguments.into(),
+                                                json_parse_error: error.to_string(),
+                                            },
+                                        ),
+                                    }
                                     },
                                 ));
 

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -28,8 +28,8 @@ use util::ResultExt;
 
 use crate::{AllLanguageModelSettings, ui::InstructionListItem};
 
-const PROVIDER_ID: &str = "deepseek";
-const PROVIDER_NAME: &str = "DeepSeek";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("deepseek");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("DeepSeek");
 const DEEPSEEK_API_KEY_VAR: &str = "DEEPSEEK_API_KEY";
 
 #[derive(Default)]
@@ -174,11 +174,11 @@ impl LanguageModelProviderState for DeepSeekLanguageModelProvider {
 
 impl LanguageModelProvider for DeepSeekLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -283,11 +283,11 @@ impl LanguageModel for DeepSeekLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -466,7 +466,9 @@ impl DeepSeekEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::Other(anyhow!(error)))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(
+                    LanguageModelCompletionError::Other(anyhow!(error)),
+                ))],
             })
         })
     }
@@ -476,9 +478,9 @@ impl DeepSeekEventMapper {
         event: deepseek::StreamResponse,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::Other(anyhow!(
-                "Response contained no choices"
-            )))];
+            return vec![Err(LanguageModelCompletionError::from(
+                LanguageModelCompletionError::Other(anyhow!("Response contained no choices")),
+            ))];
         };
 
         let mut events = Vec::new();
@@ -538,8 +540,8 @@ impl DeepSeekEventMapper {
                                 raw_input: tool_call.arguments.clone(),
                             },
                         )),
-                        Err(error) => Err(LanguageModelCompletionError::BadInputJson {
-                            id: tool_call.id.into(),
+                        Err(error) => Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                            id: tool_call.id.clone().into(),
                             tool_name: tool_call.name.as_str().into(),
                             raw_input: tool_call.arguments.into(),
                             json_parse_error: error.to_string(),

--- a/crates/language_models/src/provider/deepseek.rs
+++ b/crates/language_models/src/provider/deepseek.rs
@@ -466,9 +466,7 @@ impl DeepSeekEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::from(
-                    LanguageModelCompletionError::Other(anyhow!(error)),
-                ))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(error))],
             })
         })
     }
@@ -478,9 +476,9 @@ impl DeepSeekEventMapper {
         event: deepseek::StreamResponse,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::from(
-                LanguageModelCompletionError::Other(anyhow!("Response contained no choices")),
-            ))];
+            return vec![Err(LanguageModelCompletionError::from(anyhow!(
+                "Response contained no choices"
+            )))];
         };
 
         let mut events = Vec::new();

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -423,9 +423,7 @@ impl LanguageModel for GoogleLanguageModel {
         );
         let request = self.stream_completion(request, cx);
         let future = self.request_limiter.stream(async move {
-            let response = request
-                .await
-                .map_err(|err| LanguageModelCompletionError::from(err))?;
+            let response = request.await.map_err(LanguageModelCompletionError::from)?;
             Ok(GoogleEventMapper::new().map_stream(response))
         });
         async move { Ok(future.await?.boxed()) }.boxed()

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -37,8 +37,8 @@ use util::ResultExt;
 use crate::AllLanguageModelSettings;
 use crate::ui::InstructionListItem;
 
-const PROVIDER_ID: &str = "google";
-const PROVIDER_NAME: &str = "Google AI";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("google");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Google AI");
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct GoogleSettings {
@@ -207,11 +207,11 @@ impl LanguageModelProviderState for GoogleLanguageModelProvider {
 
 impl LanguageModelProvider for GoogleLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -334,11 +334,11 @@ impl LanguageModel for GoogleLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -37,8 +37,8 @@ use util::ResultExt;
 use crate::AllLanguageModelSettings;
 use crate::ui::InstructionListItem;
 
-const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("google");
-const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Google AI");
+const PROVIDER_ID: LanguageModelProviderId = language_model::GOOGLE_PROVIDER_ID;
+const PROVIDER_NAME: LanguageModelProviderName = language_model::GOOGLE_PROVIDER_NAME;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct GoogleSettings {

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -425,7 +425,7 @@ impl LanguageModel for GoogleLanguageModel {
         let future = self.request_limiter.stream(async move {
             let response = request
                 .await
-                .map_err(|err| LanguageModelCompletionError::Other(anyhow!(err)))?;
+                .map_err(|err| LanguageModelCompletionError::from(err))?;
             Ok(GoogleEventMapper::new().map_stream(response))
         });
         async move { Ok(future.await?.boxed()) }.boxed()
@@ -622,7 +622,7 @@ impl GoogleEventMapper {
                 futures::stream::iter(match event {
                     Some(Ok(event)) => self.map_event(event),
                     Some(Err(error)) => {
-                        vec![Err(LanguageModelCompletionError::Other(anyhow!(error)))]
+                        vec![Err(LanguageModelCompletionError::from(error))]
                     }
                     None => vec![Ok(LanguageModelCompletionEvent::Stop(self.stop_reason))],
                 })

--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -474,7 +474,7 @@ impl LmStudioEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::Other(anyhow!(error)))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(error))],
             })
         })
     }
@@ -484,7 +484,7 @@ impl LmStudioEventMapper {
         event: lmstudio::ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.into_iter().next() else {
-            return vec![Err(LanguageModelCompletionError::Other(anyhow!(
+            return vec![Err(LanguageModelCompletionError::from(anyhow!(
                 "Response contained no choices"
             )))];
         };

--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -31,8 +31,8 @@ const LMSTUDIO_DOWNLOAD_URL: &str = "https://lmstudio.ai/download";
 const LMSTUDIO_CATALOG_URL: &str = "https://lmstudio.ai/models";
 const LMSTUDIO_SITE: &str = "https://lmstudio.ai/";
 
-const PROVIDER_ID: &str = "lmstudio";
-const PROVIDER_NAME: &str = "LM Studio";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("lmstudio");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("LM Studio");
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct LmStudioSettings {
@@ -156,11 +156,11 @@ impl LanguageModelProviderState for LmStudioLanguageModelProvider {
 
 impl LanguageModelProvider for LmStudioLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -386,11 +386,11 @@ impl LanguageModel for LmStudioLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -553,7 +553,7 @@ impl LmStudioEventMapper {
                                 raw_input: tool_call.arguments,
                             },
                         )),
-                        Err(error) => Err(LanguageModelCompletionError::BadInputJson {
+                        Err(error) => Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
                             id: tool_call.id.into(),
                             tool_name: tool_call.name.into(),
                             raw_input: tool_call.arguments.into(),

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -2,8 +2,7 @@ use anyhow::{Context as _, Result, anyhow};
 use collections::BTreeMap;
 use credentials_provider::CredentialsProvider;
 use editor::{Editor, EditorElement, EditorStyle};
-use futures::stream::BoxStream;
-use futures::{FutureExt, StreamExt, future::BoxFuture};
+use futures::{FutureExt, Stream, StreamExt, future::BoxFuture, stream::BoxStream};
 use gpui::{
     AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
 };
@@ -15,6 +14,7 @@ use language_model::{
     LanguageModelToolChoice, LanguageModelToolResultContent, LanguageModelToolUse, MessageContent,
     RateLimiter, Role, StopReason, TokenUsage,
 };
+use mistral::StreamResponse;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsStore};
@@ -29,8 +29,8 @@ use util::ResultExt;
 
 use crate::{AllLanguageModelSettings, ui::InstructionListItem};
 
-const PROVIDER_ID: &str = "mistral";
-const PROVIDER_NAME: &str = "Mistral";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("mistral");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Mistral");
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct MistralSettings {
@@ -171,11 +171,11 @@ impl LanguageModelProviderState for MistralLanguageModelProvider {
 
 impl LanguageModelProvider for MistralLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -298,11 +298,11 @@ impl LanguageModel for MistralLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -579,8 +579,8 @@ impl MistralEventMapper {
 
     pub fn map_stream(
         mut self,
-        events: Pin<Box<dyn Send + futures::Stream<Item = Result<mistral::StreamResponse>>>>,
-    ) -> impl futures::Stream<Item = Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>
+        events: Pin<Box<dyn Send + Stream<Item = Result<StreamResponse>>>>,
+    ) -> impl Stream<Item = Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>
     {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
@@ -595,9 +595,9 @@ impl MistralEventMapper {
         event: mistral::StreamResponse,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::Other(anyhow!(
-                "Response contained no choices"
-            )))];
+            return vec![Err(LanguageModelCompletionError::from(
+                LanguageModelCompletionError::Other(anyhow!("Response contained no choices")),
+            ))];
         };
 
         let mut events = Vec::new();
@@ -660,9 +660,11 @@ impl MistralEventMapper {
 
         for (_, tool_call) in self.tool_calls_by_index.drain() {
             if tool_call.id.is_empty() || tool_call.name.is_empty() {
-                results.push(Err(LanguageModelCompletionError::Other(anyhow!(
-                    "Received incomplete tool call: missing id or name"
-                ))));
+                results.push(Err(LanguageModelCompletionError::from(
+                    LanguageModelCompletionError::Other(anyhow!(
+                        "Received incomplete tool call: missing id or name"
+                    )),
+                )));
                 continue;
             }
 
@@ -676,12 +678,14 @@ impl MistralEventMapper {
                         raw_input: tool_call.arguments,
                     },
                 ))),
-                Err(error) => results.push(Err(LanguageModelCompletionError::BadInputJson {
-                    id: tool_call.id.into(),
-                    tool_name: tool_call.name.into(),
-                    raw_input: tool_call.arguments.into(),
-                    json_parse_error: error.to_string(),
-                })),
+                Err(error) => {
+                    results.push(Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                        id: tool_call.id.into(),
+                        tool_name: tool_call.name.into(),
+                        raw_input: tool_call.arguments.into(),
+                        json_parse_error: error.to_string(),
+                    }))
+                }
             }
         }
 

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -585,7 +585,7 @@ impl MistralEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::Other(anyhow!(error)))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(error))],
             })
         })
     }
@@ -596,7 +596,7 @@ impl MistralEventMapper {
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
             return vec![Err(LanguageModelCompletionError::from(
-                LanguageModelCompletionError::Other(anyhow!("Response contained no choices")),
+                LanguageModelCompletionError::from(anyhow!("Response contained no choices")),
             ))];
         };
 
@@ -661,7 +661,7 @@ impl MistralEventMapper {
         for (_, tool_call) in self.tool_calls_by_index.drain() {
             if tool_call.id.is_empty() || tool_call.name.is_empty() {
                 results.push(Err(LanguageModelCompletionError::from(
-                    LanguageModelCompletionError::Other(anyhow!(
+                    LanguageModelCompletionError::from(anyhow!(
                         "Received incomplete tool call: missing id or name"
                     )),
                 )));

--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -595,9 +595,9 @@ impl MistralEventMapper {
         event: mistral::StreamResponse,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::from(
-                LanguageModelCompletionError::from(anyhow!("Response contained no choices")),
-            ))];
+            return vec![Err(LanguageModelCompletionError::from(anyhow!(
+                "Response contained no choices"
+            )))];
         };
 
         let mut events = Vec::new();
@@ -660,11 +660,9 @@ impl MistralEventMapper {
 
         for (_, tool_call) in self.tool_calls_by_index.drain() {
             if tool_call.id.is_empty() || tool_call.name.is_empty() {
-                results.push(Err(LanguageModelCompletionError::from(
-                    LanguageModelCompletionError::from(anyhow!(
-                        "Received incomplete tool call: missing id or name"
-                    )),
-                )));
+                results.push(Err(LanguageModelCompletionError::from(anyhow!(
+                    "Received incomplete tool call: missing id or name"
+                ))));
                 continue;
             }
 

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -454,7 +454,7 @@ fn map_to_language_model_completion_events(
                 Ok(delta) => delta,
                 Err(e) => {
                     let event = Err(LanguageModelCompletionError::from(
-                        LanguageModelCompletionError::Other(anyhow!(e)),
+                        LanguageModelCompletionError::from(anyhow!(e)),
                     ));
                     return Some((vec![event], state));
                 }

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -30,8 +30,8 @@ const OLLAMA_DOWNLOAD_URL: &str = "https://ollama.com/download";
 const OLLAMA_LIBRARY_URL: &str = "https://ollama.com/library";
 const OLLAMA_SITE: &str = "https://ollama.com/";
 
-const PROVIDER_ID: &str = "ollama";
-const PROVIDER_NAME: &str = "Ollama";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("ollama");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Ollama");
 
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct OllamaSettings {
@@ -181,11 +181,11 @@ impl LanguageModelProviderState for OllamaLanguageModelProvider {
 
 impl LanguageModelProvider for OllamaLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -350,11 +350,11 @@ impl LanguageModel for OllamaLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -453,7 +453,9 @@ fn map_to_language_model_completion_events(
             let delta = match response {
                 Ok(delta) => delta,
                 Err(e) => {
-                    let event = Err(LanguageModelCompletionError::Other(anyhow!(e)));
+                    let event = Err(LanguageModelCompletionError::from(
+                        LanguageModelCompletionError::Other(anyhow!(e)),
+                    ));
                     return Some((vec![event], state));
                 }
             };

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -453,9 +453,7 @@ fn map_to_language_model_completion_events(
             let delta = match response {
                 Ok(delta) => delta,
                 Err(e) => {
-                    let event = Err(LanguageModelCompletionError::from(
-                        LanguageModelCompletionError::from(anyhow!(e)),
-                    ));
+                    let event = Err(LanguageModelCompletionError::from(anyhow!(e)));
                     return Some((vec![event], state));
                 }
             };

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -31,8 +31,8 @@ use util::ResultExt;
 use crate::OpenAiSettingsContent;
 use crate::{AllLanguageModelSettings, ui::InstructionListItem};
 
-const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openai");
-const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("OpenAI");
+const PROVIDER_ID: LanguageModelProviderId = language_model::OPEN_AI_PROVIDER_ID;
+const PROVIDER_NAME: LanguageModelProviderName = language_model::OPEN_AI_PROVIDER_NAME;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct OpenAiSettings {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -263,16 +263,14 @@ impl OpenAiLanguageModel {
             let settings = &AllLanguageModelSettings::get_global(cx).openai;
             (state.api_key.clone(), settings.api_url.clone())
         }) else {
-            return futures::future::ready(Err(anyhow!("App state dropped").into())).boxed();
+            return futures::future::ready(Err(anyhow!("App state dropped"))).boxed();
         };
 
         let future = self.request_limiter.stream(async move {
             let Some(api_key) = api_key else {
-                return Err(LanguageModelCompletionError::from(
-                    LanguageModelCompletionError::NoApiKey {
-                        provider: PROVIDER_NAME,
-                    },
-                ));
+                return Err(LanguageModelCompletionError::NoApiKey {
+                    provider: PROVIDER_NAME,
+                });
             };
             let request = stream_completion(http_client.as_ref(), &api_url, &api_key, request);
             let response = request.await?;

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -531,9 +531,7 @@ impl OpenAiEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::from(
-                    LanguageModelCompletionError::Other(anyhow!(error)),
-                ))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(anyhow!(error)))],
             })
         })
     }

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -29,8 +29,8 @@ use util::ResultExt;
 
 use crate::{AllLanguageModelSettings, ui::InstructionListItem};
 
-const PROVIDER_ID: &str = "openrouter";
-const PROVIDER_NAME: &str = "OpenRouter";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openrouter");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("OpenRouter");
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct OpenRouterSettings {
@@ -244,11 +244,11 @@ impl LanguageModelProviderState for OpenRouterLanguageModelProvider {
 
 impl LanguageModelProvider for OpenRouterLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -363,11 +363,11 @@ impl LanguageModel for OpenRouterLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {
@@ -607,7 +607,9 @@ impl OpenRouterEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::Other(anyhow!(error)))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(
+                    LanguageModelCompletionError::Other(anyhow!(error)),
+                ))],
             })
         })
     }
@@ -617,9 +619,9 @@ impl OpenRouterEventMapper {
         event: ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::Other(anyhow!(
-                "Response contained no choices"
-            )))];
+            return vec![Err(LanguageModelCompletionError::from(
+                LanguageModelCompletionError::Other(anyhow!("Response contained no choices")),
+            ))];
         };
 
         let mut events = Vec::new();
@@ -683,10 +685,10 @@ impl OpenRouterEventMapper {
                                 raw_input: tool_call.arguments.clone(),
                             },
                         )),
-                        Err(error) => Err(LanguageModelCompletionError::BadInputJson {
-                            id: tool_call.id.into(),
+                        Err(error) => Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                            id: tool_call.id.clone().into(),
                             tool_name: tool_call.name.as_str().into(),
-                            raw_input: tool_call.arguments.into(),
+                            raw_input: tool_call.arguments.clone().into(),
                             json_parse_error: error.to_string(),
                         }),
                     }

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -607,9 +607,7 @@ impl OpenRouterEventMapper {
         events.flat_map(move |event| {
             futures::stream::iter(match event {
                 Ok(event) => self.map_event(event),
-                Err(error) => vec![Err(LanguageModelCompletionError::from(
-                    LanguageModelCompletionError::Other(anyhow!(error)),
-                ))],
+                Err(error) => vec![Err(LanguageModelCompletionError::from(anyhow!(error)))],
             })
         })
     }
@@ -619,9 +617,9 @@ impl OpenRouterEventMapper {
         event: ResponseStreamEvent,
     ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
         let Some(choice) = event.choices.first() else {
-            return vec![Err(LanguageModelCompletionError::from(
-                LanguageModelCompletionError::Other(anyhow!("Response contained no choices")),
-            ))];
+            return vec![Err(LanguageModelCompletionError::from(anyhow!(
+                "Response contained no choices"
+            )))];
         };
 
         let mut events = Vec::new();

--- a/crates/language_models/src/provider/vercel.rs
+++ b/crates/language_models/src/provider/vercel.rs
@@ -25,8 +25,8 @@ use util::ResultExt;
 
 use crate::{AllLanguageModelSettings, ui::InstructionListItem};
 
-const PROVIDER_ID: &str = "vercel";
-const PROVIDER_NAME: &str = "Vercel";
+const PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("vercel");
+const PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Vercel");
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct VercelSettings {
@@ -172,11 +172,11 @@ impl LanguageModelProviderState for VercelLanguageModelProvider {
 
 impl LanguageModelProvider for VercelLanguageModelProvider {
     fn id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn icon(&self) -> IconName {
@@ -269,7 +269,11 @@ impl VercelLanguageModel {
         };
 
         let future = self.request_limiter.stream(async move {
-            let api_key = api_key.context("Missing Vercel API Key")?;
+            let Some(api_key) = api_key else {
+                return Err(LanguageModelCompletionError::NoApiKey {
+                    provider: PROVIDER_NAME,
+                });
+            };
             let request =
                 open_ai::stream_completion(http_client.as_ref(), &api_url, &api_key, request);
             let response = request.await?;
@@ -290,11 +294,11 @@ impl LanguageModel for VercelLanguageModel {
     }
 
     fn provider_id(&self) -> LanguageModelProviderId {
-        LanguageModelProviderId(PROVIDER_ID.into())
+        PROVIDER_ID
     }
 
     fn provider_name(&self) -> LanguageModelProviderName {
-        LanguageModelProviderName(PROVIDER_NAME.into())
+        PROVIDER_NAME
     }
 
     fn supports_tools(&self) -> bool {

--- a/crates/web_search_providers/src/cloud.rs
+++ b/crates/web_search_providers/src/cloud.rs
@@ -7,10 +7,7 @@ use gpui::{App, AppContext, Context, Entity, Subscription, Task};
 use http_client::{HttpClient, Method};
 use language_model::{LlmApiToken, RefreshLlmTokenListener};
 use web_search::{WebSearchProvider, WebSearchProviderId};
-use zed_llm_client::{
-    CLIENT_SUPPORTS_EXA_WEB_SEARCH_PROVIDER_HEADER_NAME, EXPIRED_LLM_TOKEN_HEADER_NAME,
-    WebSearchBody, WebSearchResponse,
-};
+use zed_llm_client::{EXPIRED_LLM_TOKEN_HEADER_NAME, WebSearchBody, WebSearchResponse};
 
 pub struct CloudWebSearchProvider {
     state: Entity<State>,
@@ -92,7 +89,6 @@ async fn perform_web_search(
             .uri(http_client.build_zed_llm_url("/web_search", &[])?.as_ref())
             .header("Content-Type", "application/json")
             .header("Authorization", format!("Bearer {token}"))
-            .header(CLIENT_SUPPORTS_EXA_WEB_SEARCH_PROVIDER_HEADER_NAME, "true")
             .body(serde_json::to_string(&body)?.into())?;
         let mut response = http_client
             .send(request)


### PR DESCRIPTION

* Updates to `zed_llm_client-0.8.5` which adds support for `retry_after` when anthropic provides it.
* Distinguishes upstream provider errors and rate limits from errors that originate from zed's servers
* Moves `LanguageModelCompletionError::BadInputJson` to `LanguageModelCompletionEvent::ToolUseJsonParseError`.  While arguably this is an error case, the logic in thread is cleaner with this move.  There is also precedent for inclusion of errors in the event type - `CompletionRequestStatus::Failed` is how cloud errors arrive. 
* Updates `PROVIDER_ID` / `PROVIDER_NAME` constants to use proper types instead of `&str`, since they can be constructed in a const fashion.
* Removes use of `CLIENT_SUPPORTS_EXA_WEB_SEARCH_PROVIDER_HEADER_NAME` as the server no longer reads this header and just defaults to that behavior.

Release notes for this is covered by:
- #33275

See also: 
- https://github.com/zed-industries/zed/issues/31531


Release Notes:

- N/A