### PR TITLE
editor: Improve rewrap to respect indent and prefix boundaries

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11440,37 +11440,37 @@ impl Editor {
             let language_settings = buffer.language_settings_at(selection.head(), cx);
             let language_scope = buffer.language_scope_at(selection.head());
 
-            let Some(start_row) = (selection.start.row..=selection.end.row)
+            let Some(non_blank_start_row) = (selection.start.row..=selection.end.row)
                 .find(|row| !buffer.is_line_blank(MultiBufferRow(*row)))
             else {
                 return vec![];
             };
-            let Some(end_row) = (selection.start.row..=selection.end.row)
+            let Some(non_blank_end_row) = (selection.start.row..=selection.end.row)
                 .rev()
                 .find(|row| !buffer.is_line_blank(MultiBufferRow(*row)))
             else {
                 return vec![];
             };
 
-            let mut row = start_row;
+            let mut current_non_blank_row = non_blank_start_row;
             let mut ranges = Vec::new();
-            while let Some(blank_row) =
-                (row..end_row).find(|row| buffer.is_line_blank(MultiBufferRow(*row)))
+            while let Some(blank_row) = (current_non_blank_row..non_blank_end_row)
+                .find(|row| buffer.is_line_blank(MultiBufferRow(*row)))
             {
-                let next_paragraph_start = (blank_row + 1..=end_row)
+                let next_paragraph_start = (blank_row + 1..=non_blank_end_row)
                     .find(|row| !buffer.is_line_blank(MultiBufferRow(*row)))
                     .unwrap();
                 ranges.push((
                     language_settings.clone(),
                     language_scope.clone(),
-                    Point::new(row, 0)..Point::new(blank_row - 1, 0),
+                    Point::new(current_non_blank_row, 0)..Point::new(blank_row - 1, 0),
                 ));
-                row = next_paragraph_start;
+                current_non_blank_row = next_paragraph_start;
             }
             ranges.push((
                 language_settings.clone(),
                 language_scope.clone(),
-                Point::new(row, 0)..Point::new(end_row, 0),
+                Point::new(current_non_blank_row, 0)..Point::new(non_blank_end_row, 0),
             ));
 
             ranges

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5224,7 +5224,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test that cursors that expand to the same region are collapsed.
+    // Test that cursors that expand to the same region are not collapsed.
     assert_rewrap(
         indoc! {"
             // ˇLorem ipsum dolor sit amet, consectetur adipiscing elit.
@@ -5408,6 +5408,28 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 }
 
             }
+        "},
+        language_with_doc_comments.clone(),
+        &mut cx,
+    );
+
+    // Test range boundary when there isn't any blank line in between
+    assert_rewrap(
+        indoc! {"
+            «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae.
+            // Praesent semper egestas tellus id dignissim.
+            do_something();
+            // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae.
+            // Praesent semper egestas tellus id dignissim.ˇ»
+        "},
+        indoc! {"
+            «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit
+            // purus, a ornare lacus gravida vitae. Praesent semper egestas tellus id
+            // dignissim.
+            do_something();
+            // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit
+            // purus, a ornare lacus gravida vitae. Praesent semper egestas tellus id
+            // dignissim.ˇ»
         "},
         language_with_doc_comments.clone(),
         &mut cx,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5183,6 +5183,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         None,
     ));
 
+    // Test basic rewrapping of a single long comment line into multiple properly wrapped lines
     assert_rewrap(
         indoc! {"
             // ˇLorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus auctor, eu lacinia sapien scelerisque. Vivamus sit amet neque et quam tincidunt hendrerit. Praesent semper egestas tellus id dignissim. Pellentesque odio lectus, iaculis ac volutpat et, blandit quis urna. Sed vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam, et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis porttitor id. Aliquam id accumsan eros.
@@ -5295,7 +5296,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test that rewrapping is ignored outside of comments in most languages.
+    // Test that rewrapping only affects comments and not regular code, even if code is very long
     assert_rewrap(
         indoc! {"
             /// Adds two numbers.
@@ -5315,7 +5316,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test that rewrapping works in Markdown and Plain Text languages.
+    // Test that rewrapping works in Markdown documents (languages with allow_rewrap=Anywhere)
     assert_rewrap(
         indoc! {"
             # Hello
@@ -5337,6 +5338,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
+    // Test that rewrapping works in Plain Text documents (languages with allow_rewrap=Anywhere)
     assert_rewrap(
         indoc! {"
             Lorem ipsum dolor sit amet, ˇconsectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus auctor, eu lacinia sapien scelerisque. Vivamus sit amet neque et quam tincidunt hendrerit. Praesent semper egestas tellus id dignissim. Pellentesque odio lectus, iaculis ac volutpat et, blandit quis urna. Sed vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam, et porta nunc laoreet in. Integer sit amet scelerisque nisi.
@@ -5354,7 +5356,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test rewrapping unaligned comments in a selection.
+    // Test rewrapping comments that have different indentation levels within a selection
     assert_rewrap(
         indoc! {"
             fn foo() {
@@ -5383,6 +5385,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
+    // Test rewrapping indented comments with selection starting at beginning of line
     assert_rewrap(
         indoc! {"
             fn foo() {
@@ -5413,7 +5416,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test range boundary when there isn't any blank line in between
+    // Test rewrapping preserves separation between comment blocks separated by code
     assert_rewrap(
         indoc! {"
             «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae.
@@ -5435,6 +5438,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
+    // Test rewrapping multiple selections in plain text with blank lines and tabs
     assert_rewrap(
         indoc! {"
             «ˇone one one one one one one one one one one one one one one one one one one one one one one one one
@@ -5473,6 +5477,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
+    // Test rewrapping multiple cursors on different comment lines including empty comment lines
     assert_rewrap(
         indoc! {"
             //ˇ long long long long long long long long long long long long long long long long long long long long long long long long long long long long

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5370,89 +5370,61 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         &mut cx,
     );
 
-    // Test rewrapping preserves separation between comment blocks separated by code
+    // Test that non-commented code acts as a paragraph boundary within a selection
     assert_rewrap(
         indoc! {"
-            «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae.
-            // Praesent semper egestas tellus id dignissim.
-            do_something();
-            // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae.
-            // Praesent semper egestas tellus id dignissim.ˇ»
-        "},
+               «// This is the first long comment block to be wrapped.
+               fn my_func(a: u32);
+               // This is the second long comment block to be wrapped.ˇ»
+           "},
         indoc! {"
-            «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit
-            // purus, a ornare lacus gravida vitae. Praesent semper egestas tellus id
-            // dignissim.
-            do_something();
-            // Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit
-            // purus, a ornare lacus gravida vitae. Praesent semper egestas tellus id
-            // dignissim.ˇ»
-        "},
+               «// This is the first long comment block
+               // to be wrapped.
+               fn my_func(a: u32);
+               // This is the second long comment block
+               // to be wrapped.ˇ»
+           "},
         rust_language.clone(),
         &mut cx,
     );
 
-    // Test rewrapping multiple selections in plain text with blank lines and tabs
+    // Test rewrapping multiple selections, including ones with blank lines or tabs
     assert_rewrap(
         indoc! {"
-            «ˇone one one one one one one one one one one one one one one one one one one one one one one one one
+            «ˇThis is a very long line that will be wrapped.
 
-            two»
+            This is another paragraph in the same selection.»
 
-            three
-
-            «ˇ\t
-
-            four four four four four four four four four four four four four four four four four four four four»
-
-            «ˇfive five five five five five five five five five five five five five five five five five five five
-            \t»
-            six six six six six six six six six six six six six six six six six six six six six six six six six
-        "},
+            «\tThis is a very long indented line that will be wrapped.ˇ»
+         "},
         indoc! {"
-            «ˇone one one one one one one one one one one one one one one one one one one one
-            one one one one one
+            «ˇThis is a very long line that will be
+            wrapped.
 
-            two»
+            This is another paragraph in the same
+            selection.»
 
-            three
-
-            «ˇ\t
-
-            four four four four four four four four four four four four four four four four
-            four four four four»
-
-            «ˇfive five five five five five five five five five five five five five five five
-            five five five five
-            \t»
-            six six six six six six six six six six six six six six six six six six six six six six six six six
-        "},
+            «\tThis is a very long indented line
+            \tthat will be wrapped.ˇ»
+         "},
         plaintext_language.clone(),
         &mut cx,
     );
 
-    // Test rewrapping multiple cursors on different comment lines including empty comment lines
+    // Test that an empty comment line acts as a paragraph boundary
     assert_rewrap(
         indoc! {"
-            //ˇ long long long long long long long long long long long long long long long long long long long long long long long long long long long long
-            //ˇ
-            //ˇ long long long long long long long long long long long long long long long long long long long long long long long long long long long long
-            //ˇ short short short
-            int main(void) {
-                return 17;
-            }
-        "},
+            // ˇThis is a long comment that will be wrapped.
+            //
+            // And this is another long comment that will also be wrapped.ˇ
+         "},
         indoc! {"
-            //ˇ long long long long long long long long long long long long long long long
-            // long long long long long long long long long long long long long
-            //ˇ
-            //ˇ long long long long long long long long long long long long long long long
-            //ˇ long long long long long long long long long long long long long short short
-            // short
-            int main(void) {
-                return 17;
-            }
-        "},
+            // ˇThis is a long comment that will be
+            // wrapped.
+            //
+            // And this is another long comment that
+            // will also be wrapped.ˇ
+         "},
         cpp_language,
         &mut cx,
     );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5131,6 +5131,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 "Markdown".into(),
                 LanguageSettingsContent {
                     allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    preferred_line_length: Some(40),
                     ..Default::default()
                 },
             ),
@@ -5138,6 +5139,31 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 "Plain Text".into(),
                 LanguageSettingsContent {
                     allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    preferred_line_length: Some(40),
+                    ..Default::default()
+                },
+            ),
+            (
+                "C++".into(),
+                LanguageSettingsContent {
+                    allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    preferred_line_length: Some(40),
+                    ..Default::default()
+                },
+            ),
+            (
+                "Python".into(),
+                LanguageSettingsContent {
+                    allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    preferred_line_length: Some(40),
+                    ..Default::default()
+                },
+            ),
+            (
+                "Rust".into(),
+                LanguageSettingsContent {
+                    allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    preferred_line_length: Some(40),
                     ..Default::default()
                 },
             ),
@@ -5148,6 +5174,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
 
     let language_with_c_comments = Arc::new(Language::new(
         LanguageConfig {
+            name: "C++".into(),
             line_comments: vec!["// ".into()],
             ..LanguageConfig::default()
         },
@@ -5155,6 +5182,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     ));
     let language_with_pound_comments = Arc::new(Language::new(
         LanguageConfig {
+            name: "Python".into(),
             line_comments: vec!["# ".into()],
             ..LanguageConfig::default()
         },
@@ -5169,6 +5197,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     ));
     let language_with_doc_comments = Arc::new(Language::new(
         LanguageConfig {
+            name: "Rust".into(),
             line_comments: vec!["// ".into(), "/// ".into()],
             ..LanguageConfig::default()
         },
@@ -5183,68 +5212,44 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         None,
     ));
 
-    // Test basic rewrapping of a single long comment line into multiple properly wrapped lines
+    // Test basic rewrapping of a long line with a cursor
     assert_rewrap(
         indoc! {"
-            // ˇLorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus auctor, eu lacinia sapien scelerisque. Vivamus sit amet neque et quam tincidunt hendrerit. Praesent semper egestas tellus id dignissim. Pellentesque odio lectus, iaculis ac volutpat et, blandit quis urna. Sed vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam, et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis porttitor id. Aliquam id accumsan eros.
+            // ˇThis is a long comment that needs to be wrapped.
         "},
         indoc! {"
-            // ˇLorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit
-            // purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus
-            // auctor, eu lacinia sapien scelerisque. Vivamus sit amet neque et quam
-            // tincidunt hendrerit. Praesent semper egestas tellus id dignissim.
-            // Pellentesque odio lectus, iaculis ac volutpat et, blandit quis urna. Sed
-            // vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam,
-            // et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum
-            // dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu
-            // viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis
-            // porttitor id. Aliquam id accumsan eros.
+            // ˇThis is a long comment that needs to
+            // be wrapped.
         "},
         language_with_c_comments.clone(),
         &mut cx,
     );
 
-    // Test that rewrapping works inside of a selection
+    // Test rewrapping a full selection
     assert_rewrap(
         indoc! {"
-            «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus auctor, eu lacinia sapien scelerisque. Vivamus sit amet neque et quam tincidunt hendrerit. Praesent semper egestas tellus id dignissim. Pellentesque odio lectus, iaculis ac volutpat et, blandit quis urna. Sed vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam, et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis porttitor id. Aliquam id accumsan eros.ˇ»
-        "},
+            «// This selected long comment needs to be wrapped.ˇ»"
+        },
         indoc! {"
-            «// Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mollis elit
-            // purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus
-            // auctor, eu lacinia sapien scelerisque. Vivamus sit amet neque et quam
-            // tincidunt hendrerit. Praesent semper egestas tellus id dignissim.
-            // Pellentesque odio lectus, iaculis ac volutpat et, blandit quis urna. Sed
-            // vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam,
-            // et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum
-            // dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu
-            // viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis
-            // porttitor id. Aliquam id accumsan eros.ˇ»
-        "},
+            «// This selected long comment needs to
+            // be wrapped.ˇ»"
+        },
         language_with_c_comments.clone(),
         &mut cx,
     );
 
-    // Test that cursors that expand to the same region are not collapsed.
+    // Test multiple cursors on different lines within the same paragraph are preserved after rewrapping
     assert_rewrap(
         indoc! {"
-            // ˇLorem ipsum dolor sit amet, consectetur adipiscing elit.
-            // ˇVivamus mollis elit purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus auctor, eu lacinia sapien scelerisque.
-            // ˇVivamus sit amet neque et quam tincidunt hendrerit. Praesent semper egestas tellus id dignissim. Pellentesque odio lectus, iaculis ac volutpat et,
-            // ˇblandit quis urna. Sed vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam, et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis porttitor id. Aliquam id accumsan eros.
-        "},
+            // ˇThis is the first line.
+            // Thisˇ is the second line.
+            // This is the thirdˇ line, all part of one paragraph.
+         "},
         indoc! {"
-            // ˇLorem ipsum dolor sit amet, consectetur adipiscing elit. ˇVivamus mollis elit
-            // purus, a ornare lacus gravida vitae. Proin consectetur felis vel purus
-            // auctor, eu lacinia sapien scelerisque. ˇVivamus sit amet neque et quam
-            // tincidunt hendrerit. Praesent semper egestas tellus id dignissim.
-            // Pellentesque odio lectus, iaculis ac volutpat et, ˇblandit quis urna. Sed
-            // vestibulum nisi sit amet nisl venenatis tempus. Donec molestie blandit quam,
-            // et porta nunc laoreet in. Integer sit amet scelerisque nisi. Lorem ipsum
-            // dolor sit amet, consectetur adipiscing elit. Cras egestas porta metus, eu
-            // viverra ipsum efficitur quis. Donec luctus eros turpis, id vulputate turpis
-            // porttitor id. Aliquam id accumsan eros.
-        "},
+            // ˇThis is the first line. Thisˇ is the
+            // second line. This is the thirdˇ line,
+            // all part of one paragraph.
+         "},
         language_with_c_comments.clone(),
         &mut cx,
     );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5279,14 +5279,14 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     // Test that change in comment prefix (e.g., `//` to `///`) trigger seperate rewraps
     assert_rewrap(
         indoc! {"
-              «// A regular long long comment to be wrapped.
-              /// A documentation long comment to be wrapped.ˇ»
+            «// A regular long long comment to be wrapped.
+            /// A documentation long comment to be wrapped.ˇ»
           "},
         indoc! {"
-              «// A regular long long comment to be
-              // wrapped.
-              /// A documentation long comment to be
-              /// wrapped.ˇ»
+            «// A regular long long comment to be
+            // wrapped.
+            /// A documentation long comment to be
+            /// wrapped.ˇ»
           "},
         language_with_doc_comments.clone(),
         &mut cx,
@@ -5343,25 +5343,27 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     // Test that rewrapping works in Markdown documents where `allow_rewrap` is `Anywhere`
     assert_rewrap(
         indoc! {"
-             # Header
-             A long line of markdown text to wrap.ˇ
+            # Header
+            A long line of markdown text to wrap.ˇ
          "},
         indoc! {"
-             # Header
-             A long line of markdown text to
-             wrap.ˇ
+            # Header
+            A long line of markdown text to
+            wrap.ˇ
          "},
         markdown_language,
         &mut cx,
     );
 
-    // Test: Rewrapping works in plain text where `allow_rewrap` is `Anywhere`
+    // Test that rewrapping works in plain text where `allow_rewrap` is `Anywhere`
     assert_rewrap(
-        "ˇThis is a very long line of plain text that will be wrapped.",
         indoc! {"
-              ˇThis is a very long line of plain
-              text that will be wrapped.
-          "},
+            ˇThis is a very long line of plain text that will be wrapped.,
+        "},
+        indoc! {"
+            ˇThis is a very long line of plain
+            text that will be wrapped.
+        "},
         plaintext_language.clone(),
         &mut cx,
     );

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5146,7 +5146,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             (
                 "C++".into(),
                 LanguageSettingsContent {
-                    allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    allow_rewrap: Some(language_settings::RewrapBehavior::InComments),
                     preferred_line_length: Some(40),
                     ..Default::default()
                 },
@@ -5154,7 +5154,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             (
                 "Python".into(),
                 LanguageSettingsContent {
-                    allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    allow_rewrap: Some(language_settings::RewrapBehavior::InComments),
                     preferred_line_length: Some(40),
                     ..Default::default()
                 },
@@ -5162,7 +5162,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             (
                 "Rust".into(),
                 LanguageSettingsContent {
-                    allow_rewrap: Some(language_settings::RewrapBehavior::Anywhere),
+                    allow_rewrap: Some(language_settings::RewrapBehavior::InComments),
                     preferred_line_length: Some(40),
                     ..Default::default()
                 },
@@ -5172,7 +5172,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
 
     let mut cx = EditorTestContext::new(cx).await;
 
-    let language_with_c_comments = Arc::new(Language::new(
+    let cpp_language = Arc::new(Language::new(
         LanguageConfig {
             name: "C++".into(),
             line_comments: vec!["// ".into()],
@@ -5180,7 +5180,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         },
         None,
     ));
-    let language_with_pound_comments = Arc::new(Language::new(
+    let python_language = Arc::new(Language::new(
         LanguageConfig {
             name: "Python".into(),
             line_comments: vec!["# ".into()],
@@ -5195,7 +5195,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
         },
         None,
     ));
-    let language_with_doc_comments = Arc::new(Language::new(
+    let rust_language = Arc::new(Language::new(
         LanguageConfig {
             name: "Rust".into(),
             line_comments: vec!["// ".into(), "/// ".into()],
@@ -5221,7 +5221,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             // ˇThis is a long comment that needs to
             // be wrapped.
         "},
-        language_with_c_comments.clone(),
+        cpp_language.clone(),
         &mut cx,
     );
 
@@ -5234,7 +5234,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             «// This selected long comment needs to
             // be wrapped.ˇ»"
         },
-        language_with_c_comments.clone(),
+        cpp_language.clone(),
         &mut cx,
     );
 
@@ -5250,7 +5250,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             // second line. This is the thirdˇ line,
             // all part of one paragraph.
          "},
-        language_with_c_comments.clone(),
+        cpp_language.clone(),
         &mut cx,
     );
 
@@ -5272,7 +5272,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             // line. ˇThis is the second paragraph,
             // second line.
         "},
-        language_with_c_comments.clone(),
+        cpp_language.clone(),
         &mut cx,
     );
 
@@ -5288,7 +5288,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             /// A documentation long comment to be
             /// wrapped.ˇ»
           "},
-        language_with_doc_comments.clone(),
+        rust_language.clone(),
         &mut cx,
     );
 
@@ -5308,7 +5308,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                     // next indent.ˇ»
             }
         "},
-        language_with_doc_comments.clone(),
+        rust_language.clone(),
         &mut cx,
     );
 
@@ -5321,7 +5321,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             # ˇThis is a long comment using a pound
             # sign.
         "},
-        language_with_pound_comments.clone(),
+        python_language.clone(),
         &mut cx,
     );
 
@@ -5329,14 +5329,14 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     assert_rewrap(
         indoc! {"
             «/// This doc comment is long and should be wrapped.
-            fn my_func(a: u32, b: u32, c: u32, d: u32) {}ˇ»
+            fn my_func(a: u32, b: u32, c: u32, d: u32, e: u32, f: u32) {}ˇ»
         "},
         indoc! {"
-            «/// This doc comment is long and
-            /// should be wrapped.
-            fn my_func(a: u32, b: u32, c: u32, d: u32) {}ˇ»
+            «/// This doc comment is long and should
+            /// be wrapped.
+            fn my_func(a: u32, b: u32, c: u32, d: u32, e: u32, f: u32) {}ˇ»
         "},
-        language_with_doc_comments.clone(),
+        rust_language.clone(),
         &mut cx,
     );
 
@@ -5344,12 +5344,14 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     assert_rewrap(
         indoc! {"
             # Header
-            A long line of markdown text to wrap.ˇ
+
+            A long long long line of markdown text to wrap.ˇ
          "},
         indoc! {"
             # Header
-            A long line of markdown text to
-            wrap.ˇ
+
+            A long long long line of markdown text
+            to wrap.ˇ
          "},
         markdown_language,
         &mut cx,
@@ -5358,11 +5360,11 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     // Test that rewrapping works in plain text where `allow_rewrap` is `Anywhere`
     assert_rewrap(
         indoc! {"
-            ˇThis is a very long line of plain text that will be wrapped.,
+            ˇThis is a very long line of plain text that will be wrapped.
         "},
         indoc! {"
-            ˇThis is a very long line of plain
-            text that will be wrapped.
+            ˇThis is a very long line of plain text
+            that will be wrapped.
         "},
         plaintext_language.clone(),
         &mut cx,
@@ -5386,7 +5388,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             // purus, a ornare lacus gravida vitae. Praesent semper egestas tellus id
             // dignissim.ˇ»
         "},
-        language_with_doc_comments.clone(),
+        rust_language.clone(),
         &mut cx,
     );
 
@@ -5451,7 +5453,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                 return 17;
             }
         "},
-        language_with_c_comments,
+        cpp_language,
         &mut cx,
     );
 


### PR DESCRIPTION

1. Fixes bug where this would not rewrap:

```rs
// This is the first long comment block to be wrapped.
fn my_func(a: u32);
// This is the second long comment block to be wrapped.
```
2. Comment prefix boundaries (Notice now they don't merge between different comment prefix):

Initial text:
```rs
// A regular long long comment to be wrapped.
// A second regular long comment to be wrapped.
/// A documentation long comment to be wrapped.
```
Upon rewrap:
```rs
// A regular long long comment to be
// wrapped. A second regular long
// comment to be wrapped.
/// A documentation long comment to be
/// wrapped.
```
3. Indent boundaries (Notice now they don't merge between different indentation):

Initial text:
```rs
fn foo() {
      // This is a long comment at the base indent.
      // This is a long comment at the base indent.
                 // This is a long comment at the next indent.
                 // This is a long comment at the next indent.
      // This is a long comment at the base indent.
}
```
Upon rewrap:
```rs
fn foo() {
      // This is a long comment at the base
      // indent. This is a long comment at the
      // base indent.
                 // This is a long comment at the 
                 // next indent. This is a long 
                 // comment at the next indent.
      // This is a long comment at the base
      // indent.
}
```

Release Notes:

- Fixed an issue where rewrap would not work with selection when two comment blocks are separated with line of code.
- Improved rewrap to respect changes in indentation or comment prefix (e.g. `//` vs `///`) as boundaries so that it doesn't merge them into one mangled text.
