### PR TITLE
vim: Non-interactive shell

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -148,7 +148,7 @@ impl Project {
         let ssh_details = self.ssh_details(cx);
         let settings = self.terminal_settings(&path, cx).clone();
 
-        let builder = ShellBuilder::new(ssh_details.is_none(), &settings.shell);
+        let builder = ShellBuilder::new(ssh_details.is_none(), &settings.shell).non_interactive();
         let (command, args) = builder.build(command, &Vec::new());
 
         let mut env = self


### PR DESCRIPTION
Closes #33144

Release Notes:

- vim: Run r! in a non-interactive shell
