### PR TITLE
ruby: Add basic documentation about debugging

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -340,3 +340,41 @@ Plain minitest does not support running tests by line number, only by name, so w
 ```
 
 Similar task syntax can be used for other test frameworks such as `quickdraw` or `tldr`.
+
+## Debugging
+
+The Ruby extension provides a debug adapter for debugging Ruby code. Zed's name for the adapter (in the UI and `debug.json`) is `rdbg`, and under the hood, it uses the [`debug`](https://github.com/ruby/debug) gem. The extension uses the [same activation logic](#language-server-activation) as the language servers.
+
+### Examples
+
+#### Debug a Ruby script
+
+```jsonc
+[
+  {
+    "label": "Debug current file",
+    "adapter": "rdbg",
+    "request": "launch",
+    "script": "$ZED_FILE",
+    "cwd": "$ZED_WORKTREE_ROOT",
+  },
+]
+```
+
+#### Debug Rails server
+
+```jsonc
+[
+  {
+    "label": "Debug Rails server",
+    "adapter": "rdbg",
+    "request": "launch",
+    "command": "$ZED_WORKTREE_ROOT/bin/rails",
+    "args": ["server"],
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "env": {
+      "RUBY_DEBUG_OPEN": "true",
+    },
+  },
+]
+```


### PR DESCRIPTION
Hi, this pull request adds basic documentation about debugging feature available in the Ruby extension.


Release Notes:

- N/A
