### PR TITLE
editor: Fix diagnostic popovers not being scrollable

### DIFF
--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -975,10 +975,6 @@ impl DiagnosticPopover {
         div()
             .id("diagnostic")
             .occlude()
-            .max_h(max_size.height)
-            .overflow_y_scroll()
-            .max_w(max_size.width)
-            .track_scroll(&self.scroll_handle)
             .elevation_2_borderless(cx)
             // Don't draw the background color if the theme
             // allows transparent surfaces.
@@ -999,25 +995,36 @@ impl DiagnosticPopover {
                 div()
                     .py_1()
                     .px_2()
-                    .child(
-                        MarkdownElement::new(
-                            self.markdown.clone(),
-                            diagnostics_markdown_style(window, cx),
-                        )
-                        .on_url_click(move |link, window, cx| {
-                            if let Some(renderer) = GlobalDiagnosticRenderer::global(cx) {
-                                this.update(cx, |this, cx| {
-                                    renderer.as_ref().open_link(this, link, window, cx);
-                                })
-                                .ok();
-                            }
-                        }),
-                    )
-                    .child(self.render_vertical_scrollbar(cx))
                     .bg(self.background_color)
                     .border_1()
                     .border_color(self.border_color)
-                    .rounded_lg(),
+                    .rounded_lg()
+                    .child(
+                        div()
+                            .id("diagnostic-content-container")
+                            .overflow_y_scroll()
+                            .max_w(max_size.width)
+                            .max_h(max_size.height)
+                            .track_scroll(&self.scroll_handle)
+                            .child(
+                                MarkdownElement::new(
+                                    self.markdown.clone(),
+                                    diagnostics_markdown_style(window, cx),
+                                )
+                                .on_url_click(
+                                    move |link, window, cx| {
+                                        if let Some(renderer) = GlobalDiagnosticRenderer::global(cx)
+                                        {
+                                            this.update(cx, |this, cx| {
+                                                renderer.as_ref().open_link(this, link, window, cx);
+                                            })
+                                            .ok();
+                                        }
+                                    },
+                                ),
+                            ),
+                    )
+                    .child(self.render_vertical_scrollbar(cx)),
             )
             .into_any_element()
     }

--- a/crates/editor/src/hover_popover.rs
+++ b/crates/editor/src/hover_popover.rs
@@ -978,6 +978,7 @@ impl DiagnosticPopover {
             .max_h(max_size.height)
             .overflow_y_scroll()
             .max_w(max_size.width)
+            .track_scroll(&self.scroll_handle)
             .elevation_2_borderless(cx)
             // Don't draw the background color if the theme
             // allows transparent surfaces.


### PR DESCRIPTION
Closes #32673

Release Notes:

- Fixed diagnostic popovers not being scrollable
