### PR TITLE
Fix document colors issues with other inlays and multi buffers

### DIFF
--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -327,9 +327,9 @@ impl<'a> Iterator for InlayChunks<'a> {
                     InlayId::DebuggerValue(_) => self.highlight_styles.inlay_hint,
                     InlayId::Color(_) => match inlay.color {
                         Some(color) => {
-                            let style = self.highlight_styles.inlay_hint.get_or_insert_default();
+                            let mut style = self.highlight_styles.inlay_hint.unwrap_or_default();
                             style.color = Some(color);
-                            Some(*style)
+                            Some(style)
                         }
                         None => self.highlight_styles.inlay_hint,
                     },

--- a/crates/editor/src/inlay_hint_cache.rs
+++ b/crates/editor/src/inlay_hint_cache.rs
@@ -956,7 +956,7 @@ fn fetch_and_update_hints(
             .update(cx, |editor, cx| {
                 if got_throttled {
                     let query_not_around_visible_range = match editor
-                        .excerpts_for_inlay_hints_query(None, cx)
+                        .visible_excerpts(None, cx)
                         .remove(&query.excerpt_id)
                     {
                         Some((_, _, current_visible_range)) => {
@@ -2525,9 +2525,7 @@ pub mod tests {
         cx: &mut gpui::TestAppContext,
     ) -> Range<Point> {
         let ranges = editor
-            .update(cx, |editor, _window, cx| {
-                editor.excerpts_for_inlay_hints_query(None, cx)
-            })
+            .update(cx, |editor, _window, cx| editor.visible_excerpts(None, cx))
             .unwrap();
         assert_eq!(
             ranges.len(),

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -487,8 +487,9 @@ impl Editor {
         if opened_first_time {
             cx.spawn_in(window, async move |editor, cx| {
                 editor
-                    .update(cx, |editor, cx| {
-                        editor.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx)
+                    .update_in(cx, |editor, window, cx| {
+                        editor.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
+                        editor.refresh_colors(false, None, window, cx);
                     })
                     .ok()
             })
@@ -599,6 +600,7 @@ impl Editor {
         );
 
         self.refresh_inlay_hints(InlayHintRefreshReason::NewLinesShown, cx);
+        self.refresh_colors(false, None, window, cx);
     }
 
     pub fn scroll_position(&self, cx: &mut Context<Self>) -> gpui::Point<f32> {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -795,7 +795,7 @@ impl std::hash::Hash for DocumentColor {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ColorPresentation {
-    pub label: String,
+    pub label: SharedString,
     pub text_edit: Option<lsp::TextEdit>,
     pub additional_text_edits: Vec<lsp::TextEdit>,
 }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33575

* Fixes inlay colors spoiled after document color displayed
* Optimizes the query pattern for large multi buffers

Release Notes:

- Fixed document colors issues with other inlays and multi buffers
