### PR TITLE
ui: Don't render separators at start/end or with nothing in between

### DIFF
--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -762,6 +762,17 @@ impl ContextMenu {
         self
     }
 
+    fn should_render_menu_item(&self, ix: usize, item: &ContextMenuItem) -> bool {
+        match item {
+            ContextMenuItem::Separator => {
+                ix > 0
+                    && ix < self.items.len() - 1
+                    && !matches!(self.items.get(ix - 1), Some(ContextMenuItem::Separator))
+            }
+            _ => true,
+        }
+    }
+
     fn render_menu_item(
         &self,
         ix: usize,
@@ -1136,11 +1147,15 @@ impl Render for ContextMenu {
                                 el
                             })
                             .child(
-                                List::new().children(
-                                    self.items.iter().enumerate().map(|(ix, item)| {
-                                        self.render_menu_item(ix, item, window, cx)
-                                    }),
-                                ),
+                                List::new().children(self.items.iter().enumerate().filter_map(
+                                    |(ix, item)| {
+                                        if self.should_render_menu_item(ix, item) {
+                                            Some(self.render_menu_item(ix, item, window, cx))
+                                        } else {
+                                            None
+                                        }
+                                    },
+                                )),
                             ),
                     ),
             )


### PR DESCRIPTION
When using `"root_hide": True`, `Rename` is hidden and we end up with two separators
![Screenshot 2025-06-29 at 10 36 28 AM](https://github.com/user-attachments/assets/0b399b3c-5066-4b27-8ab7-fa38a9cadca3)

Instead of trying to deal with just that case, I decided to do it a bit more generally by avoiding adding a separator if it's at the start, at the end or with another separator right before it.

![Screenshot 2025-06-29 at 10 36 36 AM](https://github.com/user-attachments/assets/64cc96c3-6e10-4869-97f8-d4cf2bd504a1)

Release Notes:

- Improved handling of separators in menu
