### PR TITLE
docs: Add FreeBSD build instructions and current status

### DIFF
--- a/docs/src/development/freebsd.md
+++ b/docs/src/development/freebsd.md
@@ -40,11 +40,9 @@ cargo run -p cli
 
 ### WebRTC Notice
 
-Currently, building `webrtc-sys` on FreeBSD fails due to missing upstream support and unavailable prebuilt binaries. As a result, some collaboration features that depend on WebRTC are temporarily disabled.
+Currently, building `webrtc-sys` on FreeBSD fails due to missing upstream support and unavailable prebuilt binaries. As a result, some collaboration features (audio calls and screensharing) that depend on WebRTC are temporarily disabled.
 
-This workaround has been merged via PR #33162, which temporarily disables LiveKit/WebRTC support to allow Zed to build successfully on FreeBSD.
-
-More progress and discussion can be found in #15309 , #29500 .
+See [Issue #15309: FreeBSD Support] and [Discussion #29550: Unofficial FreeBSD port for Zed] for more.
 
 ## Troubleshooting
 

--- a/docs/src/development/freebsd.md
+++ b/docs/src/development/freebsd.md
@@ -16,15 +16,38 @@ Clone the [Zed repository](https://github.com/zed-industries/zed).
 
   If preferred, you can inspect [`script/freebsd`](https://github.com/zed-industries/zed/blob/main/script/freebsd) and perform the steps manually.
 
----
+## Building from source
 
-### ⚠️ WebRTC Notice
+Once the dependencies are installed, you can build Zed using [Cargo](https://doc.rust-lang.org/cargo/).
 
-Currently, building `webrtc-sys` on FreeBSD fails due to missing upstream support and unavailable prebuilt binaries.
-This is actively being worked on.
+For a debug build of the editor:
 
-More progress and discussion can be found in [Zed’s GitHub Discussions](https://github.com/zed-industries/zed/discussions/29550).
+```sh
+cargo run
+```
 
-_Environment:
-FreeBSD 14.2-RELEASE
-Architecture: amd64 (x86_64)_
+And to run the tests:
+
+```sh
+cargo test --workspace
+```
+
+In release mode, the primary user interface is the `cli` crate. You can run it in development with:
+
+```sh
+cargo run -p cli
+```
+
+### WebRTC Notice
+
+Currently, building `webrtc-sys` on FreeBSD fails due to missing upstream support and unavailable prebuilt binaries. As a result, some collaboration features that depend on WebRTC are temporarily disabled.
+
+This workaround has been merged via PR #33162, which temporarily disables LiveKit/WebRTC support to allow Zed to build successfully on FreeBSD.
+
+More progress and discussion can be found in #15309 , #29500 .
+
+## Troubleshooting
+
+### Cargo errors claiming that a dependency is using unstable features
+
+Try `cargo clean` and `cargo build`.


### PR DESCRIPTION
This adds documentation for building Zed on FreeBSD.
Notice WebRTC/LiveKit remains unsupported on this platform for now.

Follow-up to:
- #33162
- #30981

Release Notes:

- N/A