### PR TITLE
script: Fix license symlink and path in `new-crate.sh`

### DIFF
--- a/script/new-crate
+++ b/script/new-crate
@@ -27,7 +27,7 @@ elif [[ "$LICENSE_FLAG" == *"agpl"* ]]; then
     LICENSE_FILE="LICENSE-AGPL"
 else
     LICENSE_MODE="GPL-3.0-or-later"
-    LICENSE_FILE="LICENSE"
+    LICENSE_FILE="LICENSE-GPL"
 fi
 
 if [[ ! "$CRATE_NAME" =~ ^[a-z0-9_]+$ ]]; then
@@ -39,7 +39,7 @@ CRATE_PATH="crates/$CRATE_NAME"
 mkdir -p "$CRATE_PATH/src"
 
 # Symlink the license
-ln -sf "../../../$LICENSE_FILE" "$CRATE_PATH/LICENSE"
+ln -sf "../../../$LICENSE_FILE" "$CRATE_PATH/$LICENSE_FILE"
 
 CARGO_TOML_TEMPLATE=$(cat << 'EOF'
 [package]


### PR DESCRIPTION
While creating a new crate I realised the License symlink and path are broken. The symlink was broken for LICENSE-GPL. Also the file created in the new crate was not using the expected file name as per the check-license script which was failing due to wrong filename in the new crate. I fixed that as well. 

Release Notes:

- N/A
