### PR TITLE
editor: Add action to sort lines by length

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -635,6 +635,8 @@ actions!(
         SignatureHelpNext,
         /// Navigates to the previous signature in the signature help popup.
         SignatureHelpPrevious,
+        /// Sorts selected lines by length.
+        SortLinesByLength,
         /// Sorts selected lines case-insensitively.
         SortLinesCaseInsensitive,
         /// Sorts selected lines case-sensitively.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -195,7 +195,7 @@ use std::{
 };
 pub use sum_tree::Bias;
 use sum_tree::TreeMap;
-use text::{BufferId, FromAnchor, OffsetUtf16, Rope, TextSummary};
+use text::{BufferId, FromAnchor, OffsetUtf16, Rope};
 use theme::{
     ActiveTheme, PlayerColor, StatusColors, SyntaxTheme, Theme, ThemeSettings,
     observe_buffer_font_size_adjustment,
@@ -10211,10 +10211,7 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         self.manipulate_immutable_lines(window, cx, |lines| {
-            lines.sort_by_key(|&line| {
-                let summary: TextSummary = line.into();
-                summary.chars
-            })
+            lines.sort_by_key(|&line| line.chars().count())
         })
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -195,7 +195,7 @@ use std::{
 };
 pub use sum_tree::Bias;
 use sum_tree::TreeMap;
-use text::{BufferId, FromAnchor, OffsetUtf16, Rope};
+use text::{BufferId, FromAnchor, OffsetUtf16, Rope, TextSummary};
 use theme::{
     ActiveTheme, PlayerColor, StatusColors, SyntaxTheme, Theme, ThemeSettings,
     observe_buffer_font_size_adjustment,
@@ -10202,6 +10202,20 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         self.manipulate_immutable_lines(window, cx, |lines| lines.sort())
+    }
+
+    pub fn sort_lines_by_length(
+        &mut self,
+        _: &SortLinesByLength,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.manipulate_immutable_lines(window, cx, |lines| {
+            lines.sort_by_key(|&line| {
+                let summary: TextSummary = line.into();
+                summary.chars
+            })
+        })
     }
 
     pub fn sort_lines_case_insensitive(

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4075,6 +4075,29 @@ async fn test_manipulate_immutable_lines_with_single_selection(cx: &mut TestAppC
         Zˇ»
     "});
 
+    // Test sort_lines_by_length()
+    //
+    // Demonstrates:
+    // - ∞ is 3 bytes UTF-8, but sorted by its char count (1)
+    // - sort is stable
+    cx.set_state(indoc! {"
+        «123
+        æ
+        12
+        ∞
+        1
+        æˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.sort_lines_by_length(&SortLinesByLength, window, cx));
+    cx.assert_editor_state(indoc! {"
+        «æ
+        ∞
+        1
+        æ
+        12
+        123ˇ»
+    "});
+
     // Test reverse_lines()
     cx.set_state(indoc! {"
         «5

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -225,6 +225,7 @@ impl EditorElement {
         register_action(editor, window, Editor::autoindent);
         register_action(editor, window, Editor::delete_line);
         register_action(editor, window, Editor::join_lines);
+        register_action(editor, window, Editor::sort_lines_by_length);
         register_action(editor, window, Editor::sort_lines_case_sensitive);
         register_action(editor, window, Editor::sort_lines_case_insensitive);
         register_action(editor, window, Editor::reverse_lines);


### PR DESCRIPTION
This change introduces a new `Action` implementation to sort lines by their `char`
length. It reuses the same calculation as used for getting the caret column position,
i.e. `TextSummary`. The motivation is to e.g. handle source code where this sort of
order matters ([example](https://github.com/alexpovel/srgn/blob/fdf537c3d3e4c18ebf3426bb34759400552a82c3/tests/readme.rs#L529-L535)).

Tested manually via `cargo build && ./target/debug/zed .`: the new action shows up in the command palette, and testing it on `.mailmap` entries turns those from

```text
Agus Zubiaga <agus@zed.dev>
Agus Zubiaga <agus@zed.dev> <hi@aguz.me>
Alex Viscreanu <alexviscreanu@gmail.com>
Alex Viscreanu <alexviscreanu@gmail.com> <alexandru.viscreanu@kiwi.com>
Alexander Mankuta <alex@pointless.one>
Alexander Mankuta <alex@pointless.one> <alex+github@pointless.one>
amtoaer <amtoaer@gmail.com>
amtoaer <amtoaer@gmail.com> <amtoaer@outlook.com>
Andrei Zvonimir Crnković <andrei@0x7f.dev>
Andrei Zvonimir Crnković <andrei@0x7f.dev> <andreicek@0x7f.dev>
Angelk90 <angelo.k90@hotmail.it>
Angelk90 <angelo.k90@hotmail.it> <20476002+Angelk90@users.noreply.github.com>
Antonio Scandurra <me@as-cii.com>
Antonio Scandurra <me@as-cii.com> <antonio@zed.dev>
Ben Kunkle <ben@zed.dev>
Ben Kunkle <ben@zed.dev> <ben.kunkle@gmail.com>
Bennet Bo Fenner <bennet@zed.dev>
Bennet Bo Fenner <bennet@zed.dev> <53836821+bennetbo@users.noreply.github.com>
Bennet Bo Fenner <bennet@zed.dev> <bennetbo@gmx.de>
Boris Cherny <boris@anthropic.com>
Boris Cherny <boris@anthropic.com> <boris@performancejs.com>
Brian Tan <brian.tan88@gmail.com>
Chris Hayes <chris+git@hayes.software>
Christian Bergschneider <christian.bergschneider@gmx.de>
Christian Bergschneider <christian.bergschneider@gmx.de> <magiclake@gmx.de>
Conrad Irwin <conrad@zed.dev>
Conrad Irwin <conrad@zed.dev> <conrad.irwin@gmail.com>
Dairon Medina <dairon.medina@gmail.com>
Danilo Leal <danilo@zed.dev>
Danilo Leal <danilo@zed.dev> <67129314+danilo-leal@users.noreply.github.com>
Edwin Aronsson <75266237+4teapo@users.noreply.github.com>
Elvis Pranskevichus <elvis@geldata.com>
Elvis Pranskevichus <elvis@geldata.com> <elvis@magic.io>
Evren Sen <nervenes@icloud.com>
Evren Sen <nervenes@icloud.com> <146845123+evrensen467@users.noreply.github.com>
Evren Sen <nervenes@icloud.com> <146845123+evrsen@users.noreply.github.com>
Fernando Tagawa <tagawafernando@gmail.com>
Fernando Tagawa <tagawafernando@gmail.com> <fernando.tagawa.gamail.com@gmail.com>
Finn Evers <dev@bahn.sh>
Finn Evers <dev@bahn.sh> <75036051+MrSubidubi@users.noreply.github.com>
Finn Evers <dev@bahn.sh> <finn.evers@outlook.de>
Gowtham K <73059450+dovakin0007@users.noreply.github.com>
Greg Morenz <greg-morenz@droid.cafe>
Greg Morenz <greg-morenz@droid.cafe> <morenzg@gmail.com>
Ihnat Aŭtuška <autushka.ihnat@gmail.com>
Ivan Žužak <izuzak@gmail.com>
Ivan Žužak <izuzak@gmail.com> <ivan.zuzak@github.com>
Joseph T. Lyons <JosephTLyons@gmail.com>
Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
Julia <floc@unpromptedtirade.com>
Julia <floc@unpromptedtirade.com> <30666851+ForLoveOfCats@users.noreply.github.com>
Kaylee Simmons <kay@the-simmons.net>
Kaylee Simmons <kay@the-simmons.net> <kay@zed.dev>
Kaylee Simmons <kay@the-simmons.net> <keith@the-simmons.net>
Kaylee Simmons <kay@the-simmons.net> <keith@zed.dev>
Kirill Bulatov <kirill@zed.dev>
Kirill Bulatov <kirill@zed.dev> <mail4score@gmail.com>
Kyle Caverly <kylebcaverly@gmail.com>
Kyle Caverly <kylebcaverly@gmail.com> <kyle@zed.dev>
Lilith Iris <itslirissama@gmail.com>
Lilith Iris <itslirissama@gmail.com> <83819417+Irilith@users.noreply.github.com>
LoganDark <contact@logandark.mozmail.com>
LoganDark <contact@logandark.mozmail.com> <git@logandark.mozmail.com>
LoganDark <contact@logandark.mozmail.com> <github@logandark.mozmail.com>
Marko Kungla <marko.kungla@gmail.com>
Marko Kungla <marko.kungla@gmail.com> <marko@mkungla.dev>
Marshall Bowers <git@maxdeviant.com>
Marshall Bowers <git@maxdeviant.com> <elliott.codes@gmail.com>
Marshall Bowers <git@maxdeviant.com> <marshall@zed.dev>
Matt Fellenz <matt@felle.nz>
Matt Fellenz <matt@felle.nz> <matt+github@felle.nz>
Max Brunsfeld <maxbrunsfeld@gmail.com>
Max Brunsfeld <maxbrunsfeld@gmail.com> <max@zed.dev>
Max Linke <maxlinke88@gmail.com>
Max Linke <maxlinke88@gmail.com> <kain88-de@users.noreply.github.com>
Michael Sloan <michael@zed.dev>
Michael Sloan <michael@zed.dev> <mgsloan@gmail.com>
Michael Sloan <michael@zed.dev> <mgsloan@google.com>
Mikayla Maki <mikayla@zed.dev>
Mikayla Maki <mikayla@zed.dev> <mikayla.c.maki@gmail.com>
Mikayla Maki <mikayla@zed.dev> <mikayla.c.maki@icloud.com>
Morgan Krey <morgan@zed.dev>
Muhammad Talal Anwar <mail@talal.io>
Muhammad Talal Anwar <mail@talal.io> <talalanwar@outlook.com>
Nate Butler <iamnbutler@gmail.com>
Nate Butler <iamnbutler@gmail.com> <nate@zed.dev>
Nathan Sobo <nathan@zed.dev>
Nathan Sobo <nathan@zed.dev> <nathan@warp.dev>
Nathan Sobo <nathan@zed.dev> <nathansobo@gmail.com>
Nigel Jose <nigelmjose@gmail.com>
Nigel Jose <nigelmjose@gmail.com> <nigel.jose@student.manchester.ac.uk>
Peter Tripp <peter@zed.dev>
Peter Tripp <peter@zed.dev> <petertripp@gmail.com>
Petros Amoiridis <petros@hey.com>
Petros Amoiridis <petros@hey.com> <petros@zed.dev>
Piotr Osiewicz <piotr@zed.dev>
Piotr Osiewicz <piotr@zed.dev> <24362066+osiewicz@users.noreply.github.com>
Pocæus <github@pocaeus.com>
Pocæus <github@pocaeus.com> <pseudomata@proton.me>
Rashid Almheiri <r.muhairi@pm.me>
Rashid Almheiri <r.muhairi@pm.me> <69181766+huwaireb@users.noreply.github.com>
Richard Feldman <oss@rtfeldman.com>
Richard Feldman <oss@rtfeldman.com> <richard@zed.dev>
Robert Clover <git@clo4.net>
Robert Clover <git@clo4.net> <robert@clover.gdn>
Roy Williams <roy.williams.iii@gmail.com>
Roy Williams <roy.williams.iii@gmail.com> <roy@anthropic.com>
Sebastijan Kelnerič <sebastijan.kelneric@sebba.dev>
Sebastijan Kelnerič <sebastijan.kelneric@sebba.dev> <sebastijan.kelneric@vichava.com>
Sergey Onufrienko <sergey@onufrienko.com>
Shish <webmaster@shishnet.org>
Shish <webmaster@shishnet.org> <shish@shishnet.org>
Smit Barmase <0xtimsb@gmail.com>
Smit Barmase <0xtimsb@gmail.com> <smit@zed.dev>
Thomas <github.thomaub@gmail.com>
Thomas <github.thomaub@gmail.com> <thomas.aubry94@gmail.com>
Thomas <github.thomaub@gmail.com> <thomas.aubry@paylead.fr>
Thomas Heartman <thomasheartman+github@gmail.com>
Thomas Heartman <thomasheartman+github@gmail.com> <thomas@getunleash.io>
Thomas Mickley-Doyle <tmickleydoyle@gmail.com>
Thomas Mickley-Doyle <tmickleydoyle@gmail.com> <thomas@zed.dev>
Thorben Kröger <dev@thorben.net>
Thorben Kröger <dev@thorben.net> <thorben.kroeger@hexagon.com>
Thorsten Ball <mrnugget@gmail.com>
Thorsten Ball <mrnugget@gmail.com> <me@thorstenball.com>
Thorsten Ball <mrnugget@gmail.com> <thorsten@zed.dev>
Tristan Hume <tris.hume@gmail.com>
Tristan Hume <tris.hume@gmail.com> <tristan@anthropic.com>
Uladzislau Kaminski <i@uladkaminski.com>
Uladzislau Kaminski <i@uladkaminski.com> <uladzislau_kaminski@epam.com>
Vitaly Slobodin <vitaliy.slobodin@gmail.com>
Vitaly Slobodin <vitaliy.slobodin@gmail.com> <vitaly_slobodin@fastmail.com>
Will Bradley <williambbradley@gmail.com>
Will Bradley <williambbradley@gmail.com> <will@zed.dev>
WindSoilder <WindSoilder@outlook.com>
张小白 <364772080@qq.com>
````

into

```text
张小白 <364772080@qq.com>
Ben Kunkle <ben@zed.dev>
Finn Evers <dev@bahn.sh>
Agus Zubiaga <agus@zed.dev>
amtoaer <amtoaer@gmail.com>
Peter Tripp <peter@zed.dev>
Pocæus <github@pocaeus.com>
Danilo Leal <danilo@zed.dev>
Matt Fellenz <matt@felle.nz>
Morgan Krey <morgan@zed.dev>
Nathan Sobo <nathan@zed.dev>
Robert Clover <git@clo4.net>
Conrad Irwin <conrad@zed.dev>
Ivan Žužak <izuzak@gmail.com>
Mikayla Maki <mikayla@zed.dev>
Piotr Osiewicz <piotr@zed.dev>
Shish <webmaster@shishnet.org>
Evren Sen <nervenes@icloud.com>
Kirill Bulatov <kirill@zed.dev>
Michael Sloan <michael@zed.dev>
Angelk90 <angelo.k90@hotmail.it>
Max Linke <maxlinke88@gmail.com>
Smit Barmase <0xtimsb@gmail.com>
Thorben Kröger <dev@thorben.net>
Antonio Scandurra <me@as-cii.com>
Bennet Bo Fenner <bennet@zed.dev>
Brian Tan <brian.tan88@gmail.com>
Julia <floc@unpromptedtirade.com>
Nigel Jose <nigelmjose@gmail.com>
Petros Amoiridis <petros@hey.com>
Rashid Almheiri <r.muhairi@pm.me>
Thomas <github.thomaub@gmail.com>
Boris Cherny <boris@anthropic.com>
Nate Butler <iamnbutler@gmail.com>
Thorsten Ball <mrnugget@gmail.com>
Tristan Hume <tris.hume@gmail.com>
Richard Feldman <oss@rtfeldman.com>
Greg Morenz <greg-morenz@droid.cafe>
Kaylee Simmons <kay@the-simmons.net>
Lilith Iris <itslirissama@gmail.com>
Marshall Bowers <git@maxdeviant.com>
Muhammad Talal Anwar <mail@talal.io>
Kyle Caverly <kylebcaverly@gmail.com>
Marko Kungla <marko.kungla@gmail.com>
WindSoilder <WindSoilder@outlook.com>
Alexander Mankuta <alex@pointless.one>
Chris Hayes <chris+git@hayes.software>
Max Brunsfeld <maxbrunsfeld@gmail.com>
Dairon Medina <dairon.medina@gmail.com>
Elvis Pranskevichus <elvis@geldata.com>
Agus Zubiaga <agus@zed.dev> <hi@aguz.me>
Alex Viscreanu <alexviscreanu@gmail.com>
Ihnat Aŭtuška <autushka.ihnat@gmail.com>
Joseph T. Lyons <JosephTLyons@gmail.com>
Uladzislau Kaminski <i@uladkaminski.com>
Will Bradley <williambbradley@gmail.com>
LoganDark <contact@logandark.mozmail.com>
Roy Williams <roy.williams.iii@gmail.com>
Sergey Onufrienko <sergey@onufrienko.com>
Andrei Zvonimir Crnković <andrei@0x7f.dev>
Fernando Tagawa <tagawafernando@gmail.com>
Vitaly Slobodin <vitaliy.slobodin@gmail.com>
Nathan Sobo <nathan@zed.dev> <nathan@warp.dev>
Thomas Mickley-Doyle <tmickleydoyle@gmail.com>
Ben Kunkle <ben@zed.dev> <ben.kunkle@gmail.com>
Smit Barmase <0xtimsb@gmail.com> <smit@zed.dev>
Finn Evers <dev@bahn.sh> <finn.evers@outlook.de>
Robert Clover <git@clo4.net> <robert@clover.gdn>
amtoaer <amtoaer@gmail.com> <amtoaer@outlook.com>
Nate Butler <iamnbutler@gmail.com> <nate@zed.dev>
Thomas Heartman <thomasheartman+github@gmail.com>
Kaylee Simmons <kay@the-simmons.net> <kay@zed.dev>
Peter Tripp <peter@zed.dev> <petertripp@gmail.com>
Petros Amoiridis <petros@hey.com> <petros@zed.dev>
Pocæus <github@pocaeus.com> <pseudomata@proton.me>
Antonio Scandurra <me@as-cii.com> <antonio@zed.dev>
Bennet Bo Fenner <bennet@zed.dev> <bennetbo@gmx.de>
Matt Fellenz <matt@felle.nz> <matt+github@felle.nz>
Michael Sloan <michael@zed.dev> <mgsloan@gmail.com>
Nathan Sobo <nathan@zed.dev> <nathansobo@gmail.com>
Sebastijan Kelnerič <sebastijan.kelneric@sebba.dev>
Shish <webmaster@shishnet.org> <shish@shishnet.org>
Kaylee Simmons <kay@the-simmons.net> <keith@zed.dev>
Kyle Caverly <kylebcaverly@gmail.com> <kyle@zed.dev>
Max Brunsfeld <maxbrunsfeld@gmail.com> <max@zed.dev>
Michael Sloan <michael@zed.dev> <mgsloan@google.com>
Ivan Žužak <izuzak@gmail.com> <ivan.zuzak@github.com>
Richard Feldman <oss@rtfeldman.com> <richard@zed.dev>
Thorsten Ball <mrnugget@gmail.com> <thorsten@zed.dev>
Conrad Irwin <conrad@zed.dev> <conrad.irwin@gmail.com>
Kirill Bulatov <kirill@zed.dev> <mail4score@gmail.com>
Marshall Bowers <git@maxdeviant.com> <marshall@zed.dev>
Will Bradley <williambbradley@gmail.com> <will@zed.dev>
Christian Bergschneider <christian.bergschneider@gmx.de>
Elvis Pranskevichus <elvis@geldata.com> <elvis@magic.io>
Greg Morenz <greg-morenz@droid.cafe> <morenzg@gmail.com>
Thorsten Ball <mrnugget@gmail.com> <me@thorstenball.com>
Edwin Aronsson <75266237+4teapo@users.noreply.github.com>
Gowtham K <73059450+dovakin0007@users.noreply.github.com>
Marko Kungla <marko.kungla@gmail.com> <marko@mkungla.dev>
Mikayla Maki <mikayla@zed.dev> <mikayla.c.maki@gmail.com>
Mikayla Maki <mikayla@zed.dev> <mikayla.c.maki@icloud.com>
Tristan Hume <tris.hume@gmail.com> <tristan@anthropic.com>
Thomas <github.thomaub@gmail.com> <thomas.aubry@paylead.fr>
Boris Cherny <boris@anthropic.com> <boris@performancejs.com>
Kaylee Simmons <kay@the-simmons.net> <keith@the-simmons.net>
Thomas <github.thomaub@gmail.com> <thomas.aubry94@gmail.com>
Muhammad Talal Anwar <mail@talal.io> <talalanwar@outlook.com>
Roy Williams <roy.williams.iii@gmail.com> <roy@anthropic.com>
Marshall Bowers <git@maxdeviant.com> <elliott.codes@gmail.com>
Thorben Kröger <dev@thorben.net> <thorben.kroeger@hexagon.com>
Andrei Zvonimir Crnković <andrei@0x7f.dev> <andreicek@0x7f.dev>
Thomas Mickley-Doyle <tmickleydoyle@gmail.com> <thomas@zed.dev>
Alexander Mankuta <alex@pointless.one> <alex+github@pointless.one>
LoganDark <contact@logandark.mozmail.com> <git@logandark.mozmail.com>
Max Linke <maxlinke88@gmail.com> <kain88-de@users.noreply.github.com>
Alex Viscreanu <alexviscreanu@gmail.com> <alexandru.viscreanu@kiwi.com>
Finn Evers <dev@bahn.sh> <75036051+MrSubidubi@users.noreply.github.com>
Nigel Jose <nigelmjose@gmail.com> <nigel.jose@student.manchester.ac.uk>
Uladzislau Kaminski <i@uladkaminski.com> <uladzislau_kaminski@epam.com>
LoganDark <contact@logandark.mozmail.com> <github@logandark.mozmail.com>
Thomas Heartman <thomasheartman+github@gmail.com> <thomas@getunleash.io>
Christian Bergschneider <christian.bergschneider@gmx.de> <magiclake@gmx.de>
Evren Sen <nervenes@icloud.com> <146845123+evrsen@users.noreply.github.com>
Piotr Osiewicz <piotr@zed.dev> <24362066+osiewicz@users.noreply.github.com>
Vitaly Slobodin <vitaliy.slobodin@gmail.com> <vitaly_slobodin@fastmail.com>
Danilo Leal <danilo@zed.dev> <67129314+danilo-leal@users.noreply.github.com>
Angelk90 <angelo.k90@hotmail.it> <20476002+Angelk90@users.noreply.github.com>
Bennet Bo Fenner <bennet@zed.dev> <53836821+bennetbo@users.noreply.github.com>
Rashid Almheiri <r.muhairi@pm.me> <69181766+huwaireb@users.noreply.github.com>
Evren Sen <nervenes@icloud.com> <146845123+evrensen467@users.noreply.github.com>
Joseph T. Lyons <JosephTLyons@gmail.com> <JosephTLyons@users.noreply.github.com>
Lilith Iris <itslirissama@gmail.com> <83819417+Irilith@users.noreply.github.com>
Fernando Tagawa <tagawafernando@gmail.com> <fernando.tagawa.gamail.com@gmail.com>
Julia <floc@unpromptedtirade.com> <30666851+ForLoveOfCats@users.noreply.github.com>
Sebastijan Kelnerič <sebastijan.kelneric@sebba.dev> <sebastijan.kelneric@vichava.com>
```

which looks good. There's a bit of Unicode in there -- though no grapheme clusters.
Column number calculations do not seem to handle grapheme clusters either (?) so I
thought this is OK.

Open questions are:

- should this be added to vim mode as well?
- is `TextSummary` the way to go here? Is it perhaps too expensive? (it seems fine -- manually counting `char`s seems more brittle -- this way it will stay in sync with column number calculations)

---

Team, I realize you [ask for a discussion to be opened first](https://github.com/zed-industries/zed/blob/86161aa427b9e8b18486272ca436c344224e8ba4/CONTRIBUTING.md#L32), so apologies for not doing that!

It turned out hacking on Zed was much easier than expected (it's really nice!), and this change is small, adding a variation to an existing feature. Hope that's fine.

Release Notes:

- Added feature to sort lines by their length
