### PR TITLE
worktree: Correctly display and handle broken symbolic links

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -98,6 +98,7 @@ CREATE TABLE "worktree_entries" (
     "is_deleted" BOOL NOT NULL,
     "git_status" INTEGER,
     "is_fifo" BOOL NOT NULL,
+    "is_symlink_broken" BOOL NOT NULL,
     PRIMARY KEY (project_id, worktree_id, id),
     FOREIGN KEY (project_id, worktree_id) REFERENCES worktrees (project_id, id) ON DELETE CASCADE
 );

--- a/crates/collab/migrations/20250630080559_add_is_symlink_broken_field_to_worktree_entries.sql
+++ b/crates/collab/migrations/20250630080559_add_is_symlink_broken_field_to_worktree_entries.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "worktree_entries"
+ADD "is_symlink_broken" BOOL NOT NULL DEFAULT FALSE;

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -282,6 +282,7 @@ impl Database {
                         is_deleted: ActiveValue::set(false),
                         scan_id: ActiveValue::set(update.scan_id as i64),
                         is_fifo: ActiveValue::set(entry.is_fifo),
+                        is_symlink_broken: ActiveValue::set(entry.is_symlink_broken),
                     }
                 }))
                 .on_conflict(
@@ -901,6 +902,7 @@ impl Database {
                         // on number of files only. That shouldn't be a huge deal in practice.
                         size: None,
                         is_fifo: db_entry.is_fifo,
+                        is_symlink_broken: db_entry.is_symlink_broken,
                     });
                 }
             }

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -677,6 +677,7 @@ impl Database {
                             // on number of files only. That shouldn't be a huge deal in practice.
                             size: None,
                             is_fifo: db_entry.is_fifo,
+                            is_symlink_broken: db_entry.is_symlink_broken,
                         });
                     }
                 }

--- a/crates/collab/src/db/tables/worktree_entry.rs
+++ b/crates/collab/src/db/tables/worktree_entry.rs
@@ -22,6 +22,7 @@ pub struct Model {
     pub scan_id: i64,
     pub is_fifo: bool,
     pub canonical_path: Option<String>,
+    pub is_symlink_broken: bool,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -1440,24 +1440,6 @@ impl ProjectPanel {
         allow_preview: bool,
         cx: &mut Context<Self>,
     ) {
-        // if let Some((_, entry)) = self.selected_entry(cx) {
-        //     if entry.is_symlink_broken {
-        //         let answer = window.prompt(
-        //             gpui::PromptLevel::Critical,
-        //             "Cannot open file",
-        //             Some(&format!(
-        //                 "'{}' is a broken symlink and cannot be opened.",
-        //                 entry.path.display()
-        //             )),
-        //             &[gpui::PromptButton::ok("OK")],
-        //             cx,
-        //         );
-        //         // Optionally, you can await the answer if you want to do something after the user closes the dialog.
-        //         // cx.spawn(async move |_| { answer.await.ok(); }).detach();
-        //         return;
-        //     }
-        // }
-
         cx.emit(Event::OpenedEntry {
             entry_id,
             focus_opened_item,

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -539,6 +539,20 @@ impl ProjectPanel {
                             let entry_id = entry.id;
                             let is_via_ssh = project.read(cx).is_via_ssh();
 
+                            if entry.is_symlink_broken {
+                                let _ = window.prompt(
+                                    gpui::PromptLevel::Critical,
+                                    "Broken Symlink",
+                                    Some(&format!(
+                                        "The file '{}' is a symlink that points to a missing or inaccessible target. Please check that the target file exists and you have permission to access it.",
+                                        entry.path.display()
+                                    )),
+                                    &[gpui::PromptButton::ok("OK")],
+                                    cx,
+                                );
+                                return;
+                            }
+
                             workspace
                                 .open_path_preview(
                                     ProjectPath {
@@ -1424,17 +1438,25 @@ impl ProjectPanel {
         entry_id: ProjectEntryId,
         focus_opened_item: bool,
         allow_preview: bool,
-
         cx: &mut Context<Self>,
     ) {
-        if let Some((_, entry)) = self.selected_entry(cx) {
-            eprintln!("Opening entry: {:?}", entry);
-            if entry.is_symlink_broken {
-                // todo!: Raise system error when user tries to open a non symlinked file.
-                eprintln!("Cannot open broken symlink: {}", entry.path.display());
-                return;
-            }
-        }
+        // if let Some((_, entry)) = self.selected_entry(cx) {
+        //     if entry.is_symlink_broken {
+        //         let answer = window.prompt(
+        //             gpui::PromptLevel::Critical,
+        //             "Cannot open file",
+        //             Some(&format!(
+        //                 "'{}' is a broken symlink and cannot be opened.",
+        //                 entry.path.display()
+        //             )),
+        //             &[gpui::PromptButton::ok("OK")],
+        //             cx,
+        //         );
+        //         // Optionally, you can await the answer if you want to do something after the user closes the dialog.
+        //         // cx.spawn(async move |_| { answer.await.ok(); }).detach();
+        //         return;
+        //     }
+        // }
 
         cx.emit(Event::OpenedEntry {
             entry_id,

--- a/crates/proto/proto/worktree.proto
+++ b/crates/proto/proto/worktree.proto
@@ -27,6 +27,7 @@ message Entry {
     bool is_fifo = 10;
     optional uint64 size = 11;
     optional string canonical_path = 12;
+    bool is_symlink_broken = 13;
 }
 
 message AddWorktree {

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4380,6 +4380,7 @@ impl BackgroundScanner {
                     Err(err) => {
                         log::warn!("broken symlink {child_abs_path:?}: {err:#}");
                         child_entry.is_symlink_broken = true;
+                        child_entry.canonical_path = None;
                     }
                 }
             }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4354,8 +4354,9 @@ impl BackgroundScanner {
                 let canonical_path = match self.fs.canonicalize(&child_abs_path).await {
                     Ok(path) => path,
                     Err(err) => {
-                        log::error!("error reading target of symlink {child_abs_path:?}: {err:#}",);
-                        continue;
+                        log::warn!("error reading target of symlink {child_abs_path:?}: {err:#}",);
+                        // Return the original path as a fallback
+                        child_abs_path.to_path_buf()
                     }
                 };
 

--- a/crates/worktree/src/worktree_tests.rs
+++ b/crates/worktree/src/worktree_tests.rs
@@ -210,7 +210,7 @@ async fn test_broken_symlink(cx: &mut TestAppContext) {
     });
 
     // Delete the target file, making the symlink broken
-    fs.remove_file(
+    fs.trash_file(
         "/root/target_dir/file_to_be_symlinked.txt".as_ref(),
         Default::default(),
     )

--- a/script/new-crate
+++ b/script/new-crate
@@ -39,7 +39,7 @@ CRATE_PATH="crates/$CRATE_NAME"
 mkdir -p "$CRATE_PATH/src"
 
 # Symlink the license
-ln -sf "../../../$LICENSE_FILE" "$CRATE_PATH/$LICENSE_FILE"
+ln -sf "../../$LICENSE_FILE" "$CRATE_PATH/$LICENSE_FILE"
 
 CARGO_TOML_TEMPLATE=$(cat << 'EOF'
 [package]


### PR DESCRIPTION
Closes #25181

This addresses two issues related to broken symbolic links (symlinks pointing to non-existent files). First, when a broken symlink is reverted in the Git panel, the UI failed to update and would continue to list the file as a change. Second, broken symlinks were not being displayed in the Project Panel's file tree at all. This change fixes both issues, ensuring that reverting a broken symlink correctly removes it from the Git Panel and that broken symlinks are now visible in the Project Panel. This new behavior is now in line with VS Code's behavior. The root cause appears to be an error when the worktree attempts to read the target of the broken symlink.

The error in the logs is occasionally this.

```
2025-06-30T01:02:18+05:30 ERROR [worktree] error reading target of symlink "/Users/umesh/code/zed/crates/edit_prediction_ui/LICENSE": canonicalizing "/Users/umesh/code/zed/crates/edit_prediction_ui/LICENSE": No such file or directory (os error 2)
```

**1. Bug: Broken symbolic links would persist in the GitPanel after being reverted**

**Before:**
As you can see in this video, a `LICENSE` file is created as a symlink pointing to a non-existent file (`../../LICENSE`). When this change is reverted, the file is not removed from the Git panel UI, which is incorrect.

[https://github.com/user-attachments/assets/22da29d4-584f-472f-b771-c8b81ccb3404](https://github.com/user-attachments/assets/22da29d4-584f-472f-b771-c8b81ccb3404)

**After:**
This video demonstrates the correct behavior. After the fix, reverting the broken symlink properly removes it from the Git panel UI, accurately reflecting the state of the working tree.

[https://github.com/user-attachments/assets/7ef50fdb-d346-4c6f-b1be-914cf9ec496c](https://github.com/user-attachments/assets/7ef50fdb-d346-4c6f-b1be-914cf9ec496c)

**2. Bug: Broken symbolic links would not appear in the Project Panel file tree.**

**Before:**
This video will show that a broken symbolic link created in the file system does not appear in the Project Panel file tree.

https://github.com/user-attachments/assets/0fa6faa2-2b57-4f30-a489-31a8b8469f26

**After:**
This video will show the corrected behavior where the broken symbolic link is now visible in the Project Panel's file tree.

https://github.com/user-attachments/assets/2e853f72-69f6-4e2f-9d68-71bb07866018

P.S: In case this is not a accepted approach would be more than happy to pair get this out.

Release Notes:

  - Fixed a bug where broken symbolic links would persist in the Git Panel after being reverted.
  - Fixed a bug where broken symbolic links would not appear in the Project Panel file tree.