### PR TITLE
debugger: Fix spec violation with threads request being issued before debug session is initialized

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -868,7 +868,7 @@ impl DebugPanel {
                                         let threads =
                                             running_state.update(cx, |running_state, cx| {
                                                 let session = running_state.session();
-                                                session.read(cx).is_running().then(|| {
+                                                session.read(cx).is_started().then(|| {
                                                     session.update(cx, |session, cx| {
                                                         session.threads(cx)
                                                     })

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -114,7 +114,7 @@ impl Console {
     }
 
     fn is_running(&self, cx: &Context<Self>) -> bool {
-        self.session.read(cx).is_running()
+        self.session.read(cx).is_started()
     }
 
     fn handle_stack_frame_list_events(

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -1037,10 +1037,6 @@ impl Session {
         matches!(self.mode, Mode::Building)
     }
 
-    pub fn is_running(&self) -> bool {
-        matches!(self.mode, Mode::Running(_))
-    }
-
     pub fn as_running_mut(&mut self) -> Option<&mut RunningMode> {
         match &mut self.mode {
             Mode::Running(local_mode) => Some(local_mode),


### PR DESCRIPTION
Follow-up to #32852. This time we'll check if the debug session is initialized before querying threads.

Release Notes:

- Fix Zed's debugger issuing threads request before it is allowed to do so per DAP specification.
