### PR TITLE
agent: Fix an issue with messages containing trailing whitespace

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1343,6 +1343,7 @@ impl Thread {
             for segment in &message.segments {
                 match segment {
                     MessageSegment::Text(text) => {
+                        let text = text.trim_end();
                         if !text.is_empty() {
                             request_message
                                 .content

--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -528,6 +528,11 @@ pub fn into_anthropic(
                     .into_iter()
                     .filter_map(|content| match content {
                         MessageContent::Text(text) => {
+                            let text = if text.chars().last().map_or(false, |c| c.is_whitespace()) {
+                                text.trim_end().to_string()
+                            } else {
+                                text
+                            };
                             if !text.is_empty() {
                                 Some(anthropic::RequestContent::Text {
                                     text,


### PR DESCRIPTION
Seeing this come up in our server logs when sending requests to Anthropic: `final assistant content cannot end with trailing whitespace`.


Release Notes:

- agent: Fixed an issue where Anthropic requests would sometimes fail because of malformed assistant messages