### PR TITLE
Make the preview button the same size as the other buttons

### DIFF
--- a/crates/zed/src/zed/quick_action_bar/preview.rs
+++ b/crates/zed/src/zed/quick_action_bar/preview.rs
@@ -7,7 +7,7 @@ use svg_preview::{
     OpenPreview as SvgOpenPreview, OpenPreviewToTheSide as SvgOpenPreviewToTheSide,
     svg_preview_view::SvgPreviewView,
 };
-use ui::{IconButtonShape, Tooltip, prelude::*, text_for_keystroke};
+use ui::{Tooltip, prelude::*, text_for_keystroke};
 use workspace::Workspace;
 
 use super::QuickActionBar;
@@ -66,7 +66,6 @@ impl QuickActionBar {
         };
 
         let button = IconButton::new(button_id, IconName::Eye)
-            .shape(IconButtonShape::Square)
             .icon_size(IconSize::Small)
             .style(ButtonStyle::Subtle)
             .tooltip(move |window, cx| {


### PR DESCRIPTION
This fixes a tiny visual defect I noticed today. The "Preview" button is slightly smaller and has less padding than the other buttons in the quick action bar.

**Before:**

Note how there is a small gap between the black guides and the button.

https://github.com/user-attachments/assets/04d3d83a-9193-47b1-80d8-94a5d1fbd750

**After:**

https://github.com/user-attachments/assets/98f878cc-c5e3-491c-abe9-9ef0d5cf678a



Release Notes:

- N/A