### PR TITLE
Revert "languages: Bump ESLint LSP server to version 3.0.10 (#32717)"

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -767,8 +767,8 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
-    const CURRENT_VERSION: &'static str = "3.0.10";
-    const CURRENT_VERSION_TAG_NAME: &'static str = "release/3.0.10";
+    const CURRENT_VERSION: &'static str = "2.4.4";
+    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
 
     #[cfg(not(windows))]
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
@@ -846,7 +846,9 @@ impl LspAdapter for EsLintLspAdapter {
                     "enable": true
                 }
             },
-            "useFlatConfig": use_flat_config,
+            "experimental": {
+                "useFlatConfig": use_flat_config,
+            },
         });
 
         let override_options = cx.update(|cx| {


### PR DESCRIPTION
This reverts commit 1edaeebae5b0f1b67cdad1a994b88a3c11f75705.

Based on an elevated number of ESLint-related issues, reverting the upgrade.
Many people upvoted the issues and did not share any repro details, so cannot be certain what's more broken: seems relatively generic as related to *.ts ESLint configs.

Checked the revert on 2 projects from the issues below:

Closes https://github.com/zed-industries/zed/issues/33425

With https://github.com/adamhl8/zed-33425 as an example repo: there, both eslint configurations worked for me when I stopped Zed and opened a project.
Somehow, switching various Zed's with different vscode-eslint package versions, eventually I get
`Error: Cannot find module '~/.local/share/zed/languages/eslint/vscode-eslint-3.0.10/vscode-eslint/server/out/eslintServer.js'`-ish error.

Not very related to issues with newer vscode-eslint integration, but worth mentioning as is related to the package updates.


Closes https://github.com/zed-industries/zed/issues/33648

With a good example of https://github.com/florian-lackner365/zed-eslint-bug monorepo project.
The monorepo part seems not to be related, but somehow, `eslint.config.js` is involved as the newer vscode-eslint fails to find a config.
Works well with the older vscode-eslint.

Release Notes:

- Downgraded to vscode-eslint-2.4.4 as a ESLint language server
