### PR TITLE
Update Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20086,7 +20086,7 @@ dependencies = [
 
 [[package]]
 name = "zed_emmet"
-version = "0.0.4"
+version = "0.0.3"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]


### PR DESCRIPTION
Followup to: https://github.com/zed-industries/zed/pull/32208

cc @probably-neb I think for some reason the emmet extension version is not reflecting on main. This PR fixes that.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
