### PR TITLE
Fix panic on inlay split

### DIFF
--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -296,11 +296,10 @@ impl<'a> Iterator for InlayChunks<'a> {
                     *chunk = self.buffer_chunks.next().unwrap();
                 }
 
-                let split_point = utf8_char_boundary(
+                let (prefix, suffix) = chunk.text.split_at(utf8_char_boundary(
                     chunk.text,
                     self.transforms.end(&()).0.0 - self.output_offset.0,
-                );
-                let (prefix, suffix) = chunk.text.split_at(split_point);
+                ));
 
                 chunk.text = suffix;
                 self.output_offset.0 += prefix.len();
@@ -390,9 +389,10 @@ impl<'a> Iterator for InlayChunks<'a> {
                 let inlay_chunk = self
                     .inlay_chunk
                     .get_or_insert_with(|| inlay_chunks.next().unwrap());
-
-                let split_point = utf8_char_boundary(inlay_chunk, next_inlay_highlight_endpoint);
-                let (chunk, remainder) = inlay_chunk.split_at(split_point);
+                let (chunk, remainder) = inlay_chunk.split_at(utf8_char_boundary(
+                    inlay_chunk,
+                    next_inlay_highlight_endpoint,
+                ));
                 *inlay_chunk = remainder;
                 if inlay_chunk.is_empty() {
                     self.inlay_chunk = None;

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -2000,7 +2000,7 @@ mod tests {
     }
 
     #[gpui::test]
-    fn test_inlay_utf8_boundaries_comprehensive(cx: &mut App) {
+    fn test_inlay_utf8_boundaries(cx: &mut App) {
         init_test(cx);
 
         struct TestCase {

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -2043,8 +2043,8 @@ mod tests {
             },
             TestCase {
                 inlay_text: "Hello",
-                highlight_range: 0..3,
-                expected_highlighted: "Hel",
+                highlight_range: 0..2,
+                expected_highlighted: "He",
                 description: "ASCII only - no adjustment needed",
             },
             TestCase {

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -2122,37 +2122,4 @@ mod tests {
             );
         }
     }
-
-    #[test]
-    fn test_utf8_char_boundary() {
-        let hello = "Hello";
-        assert!(hello.is_char_boundary(utf8_char_boundary(hello, 3))); // ASCII boundary
-        assert!(hello.is_char_boundary(utf8_char_boundary(hello, 5))); // At end
-        assert!(hello.is_char_boundary(utf8_char_boundary(hello, 10))); // Past end
-
-        let emoji_str = "👋"; // 4-byte emoji
-        assert!(emoji_str.is_char_boundary(utf8_char_boundary(emoji_str, 0))); // Start
-        assert!(emoji_str.is_char_boundary(utf8_char_boundary(emoji_str, 1))); // Mid-emoji -> next boundary
-        assert!(emoji_str.is_char_boundary(utf8_char_boundary(emoji_str, 2))); // Mid-emoji -> next boundary
-        assert!(emoji_str.is_char_boundary(utf8_char_boundary(emoji_str, 3))); // Mid-emoji -> next boundary
-        assert!(emoji_str.is_char_boundary(utf8_char_boundary(emoji_str, 4))); // Valid boundary
-
-        let mixed = "a→b"; // 'a' (1B), '→' (3B), 'b' (1B)
-        assert!(mixed.is_char_boundary(utf8_char_boundary(mixed, 0))); // Start
-        assert!(mixed.is_char_boundary(utf8_char_boundary(mixed, 1))); // After 'a'
-        assert!(mixed.is_char_boundary(utf8_char_boundary(mixed, 2))); // Mid-arrow -> after arrow
-        assert!(mixed.is_char_boundary(utf8_char_boundary(mixed, 3))); // Mid-arrow -> after arrow
-        assert!(mixed.is_char_boundary(utf8_char_boundary(mixed, 4))); // After arrow
-        assert!(mixed.is_char_boundary(utf8_char_boundary(mixed, 5))); // End
-
-        let complex = "Hello 👋 World! 世界";
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 0))); // Start
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 5))); // Before space
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 6))); // At space
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 7))); // Mid-emoji -> after emoji
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 8))); // Mid-emoji -> after emoji
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 9))); // Mid-emoji -> after emoji
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 10))); // After emoji
-        assert!(complex.is_char_boundary(utf8_char_boundary(complex, 17))); // At '!'
-    }
 }

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1949,6 +1949,8 @@ mod tests {
         // This test verifies that we handle UTF-8 character boundaries correctly
         // when splitting inlay text for highlighting. Previously, this would panic
         // when trying to split at byte 13, which is in the middle of the '…' character.
+        //
+        // See https://github.com/zed-industries/zed/issues/33641
         let buffer = MultiBuffer::build_simple("fn main() {}\n", cx);
         let (mut inlay_map, _) = InlayMap::new(buffer.read(cx).snapshot(cx));
 
@@ -1967,7 +1969,7 @@ mod tests {
         let (inlay_snapshot, _) = inlay_map.splice(&[], vec![inlay]);
 
         // Create highlights that request a split at byte 13, which is in the middle
-        // of the '…' character (bytes 12..14). Our fix should round up to byte 15.
+        // of the '…' character (bytes 12..14). We should round down to byte 12.
         let inlay_highlights = create_inlay_highlights(InlayId::Hint(0), 0..13, position);
 
         let highlights = crate::display_map::Highlights {

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -1155,39 +1155,30 @@ fn next_utf8_char_boundary(text: &str, initial_index: usize) -> usize {
     let bytes = text.as_bytes();
     let mut search_index = initial_index;
 
-    loop {
-        if let Some(&byte) = bytes.get(search_index) {
-            if is_utf8_char_boundary(byte) {
-                return search_index;
-            }
-        } else {
-            // We ran off the end of the string, so try to find a boundary by going in reverse.
-            break;
+    while let Some(&byte) = bytes.get(search_index) {
+        if is_utf8_char_boundary(byte) {
+            return search_index;
         }
 
         search_index += 1;
     }
 
-    // Search in reverse this time.
+    // We ran off the end of the string, so try to find a boundary by going in reverse.
     search_index = initial_index
         .saturating_sub(1)
         .min(text.len().saturating_sub(1));
 
-    loop {
-        if let Some(&byte) = bytes.get(search_index) {
-            if is_utf8_char_boundary(byte) {
-                return search_index;
-            }
-        } else {
-            // The only way .get() could return None when we're decrementing backwards from an index
-            // that is guaranteed to start out as less than or equal to the length is if len was 0.
-            panic!(
-                "next_utf8_char_boundary was called on an empty string, which should never happen."
-            );
+    while let Some(&byte) = bytes.get(search_index) {
+        if is_utf8_char_boundary(byte) {
+            return search_index;
         }
 
         search_index -= 1;
     }
+
+    // The only way .get() could return None when we're decrementing backwards from an index
+    // that is guaranteed to start out as less than or equal to the length is if len was 0.
+    panic!("next_utf8_char_boundary was called on an empty string, which should never happen.");
 }
 
 // Private helper function taken from Rust's core::num module (which is both Apache2 and MIT licensed)


### PR DESCRIPTION
Closes #33641

Release Notes:

- Fixed panic when trying to split on multibyte UTF-8 sequences.
