### PR TITLE
Update documentation for tailwindcss language server now that HTML/ERB is it's own file.

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -255,7 +255,7 @@ In order to do that, you need to configure the language server so that it knows 
     "tailwindcss-language-server": {
       "settings": {
         "includeLanguages": {
-          "erb": "html",
+          "html/erb": "html",
           "ruby": "html"
         },
         "experimental": {


### PR DESCRIPTION
Hello,

Recently my tailwind auto completion broke in ERB files. I noticed  that HTML/ERB is it's own file type now. It used to be ERB. This broke the previous tailwindcss ERB configuration. I made the attached change to my configuration and it works now.