### PR TITLE
ci: Block PRs on Nix build failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,7 @@ jobs:
       run_tests: ${{ steps.filter.outputs.run_tests }}
       run_license: ${{ steps.filter.outputs.run_license }}
       run_docs: ${{ steps.filter.outputs.run_docs }}
+      run_nix: ${{ steps.filter.outputs.run_nix }}
     runs-on:
       - ubuntu-latest
     steps:
@@ -68,6 +69,12 @@ jobs:
             echo "run_license=true" >> $GITHUB_OUTPUT
           else
             echo "run_license=false" >> $GITHUB_OUTPUT
+          fi
+          NIX_REGEX='^(nix/|flake\.|Cargo\.|rust-toolchain.toml|\.cargo/config.toml)'
+          if [[ $(git diff --name-only $COMPARE_REV ${{ github.sha }} | grep "$NIX_REGEX" ]]; then
+            echo "run_nix=true" >> $GITHUB_OUTPUT
+          else
+            echo "run_nix=false" >> $GITHUB_OUTPUT
           fi
 
   migration_checks:
@@ -746,7 +753,10 @@ jobs:
   nix-build:
     name: Build with Nix
     uses: ./.github/workflows/nix.yml
-    if: github.repository_owner == 'zed-industries' && contains(github.event.pull_request.labels.*.name, 'run-nix')
+    needs: [job_spec]
+    if: github.repository_owner == 'zed-industries' &&
+      (contains(github.event.pull_request.labels.*.name, 'run-nix') ||
+      needs.job_spec.outputs.run_nix == 'true')
     secrets: inherit
     with:
       flake-output: debug

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             echo "run_license=false" >> $GITHUB_OUTPUT
           fi
           NIX_REGEX='^(nix/|flake\.|Cargo\.|rust-toolchain.toml|\.cargo/config.toml)'
-          if [[ $(git diff --name-only $COMPARE_REV ${{ github.sha }} | grep "$NIX_REGEX" ]]; then
+          if [[ $(git diff --name-only $COMPARE_REV ${{ github.sha }} | grep "$NIX_REGEX") ]]; then
             echo "run_nix=true" >> $GITHUB_OUTPUT
           else
             echo "run_nix=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Closes #17458

For now we're being conservative and only running CI on changes to the following files:
- `flake.{nix,lock}`
- `Cargo.{lock,toml}`
- `nix/*`
- `.cargo/config.toml`
- `rust-toolchain.toml`

Release Notes:

- N/A
