### PR TITLE
Support multiple windows open per-project

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -542,6 +542,7 @@
       "ctrl-n": "workspace::NewFile",
       "shift-new": "workspace::NewWindow",
       "ctrl-shift-n": "workspace::NewWindow",
+      "ctrl-alt-shift-n": "workspace::NewWindowForWorkspace",
       "ctrl-`": "terminal_panel::ToggleFocus",
       "f10": ["app_menu::OpenApplicationMenu", "Zed"],
       "alt-1": ["workspace::ActivatePane", 0],

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -542,7 +542,7 @@
       "ctrl-n": "workspace::NewFile",
       "shift-new": "workspace::NewWindow",
       "ctrl-shift-n": "workspace::NewWindow",
-      "ctrl-alt-shift-n": "workspace::NewWindowForWorkspace",
+      "ctrl-alt-shift-n": "workspace::NewProjectWindow",
       "ctrl-`": "terminal_panel::ToggleFocus",
       "f10": ["app_menu::OpenApplicationMenu", "Zed"],
       "alt-1": ["workspace::ActivatePane", 0],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -609,6 +609,7 @@
       "alt-shift-enter": "toast::RunAction",
       "cmd-shift-s": "workspace::SaveAs",
       "cmd-shift-n": "workspace::NewWindow",
+      "cmd-alt-shift-n": "workspace::NewWindowForWorkspace",
       "ctrl-`": "terminal_panel::ToggleFocus",
       "cmd-1": ["workspace::ActivatePane", 0],
       "cmd-2": ["workspace::ActivatePane", 1],

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -609,7 +609,7 @@
       "alt-shift-enter": "toast::RunAction",
       "cmd-shift-s": "workspace::SaveAs",
       "cmd-shift-n": "workspace::NewWindow",
-      "cmd-alt-shift-n": "workspace::NewWindowForWorkspace",
+      "cmd-alt-shift-n": "workspace::NewProjectWindow",
       "ctrl-`": "terminal_panel::ToggleFocus",
       "cmd-1": ["workspace::ActivatePane", 0],
       "cmd-2": ["workspace::ActivatePane", 1],

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2085,9 +2085,7 @@ impl Workspace {
             }
 
             // Create new window with shared project
-            let _window = cx.open_window(options, {
-                let app_state = app_state.clone();
-                let project = project.clone();
+            cx.open_window(options, {
                 move |window, cx| {
                     cx.new(|cx| Workspace::new(workspace_id, project, app_state, window, cx))
                 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -187,7 +187,7 @@ actions!(
         NewSearch,
         NewTerminal,
         NewWindow,
-        NewWindowForWorkspace,
+        NewProjectWindow,
         Open,
         OpenFiles,
         OpenInTerminal,
@@ -2062,7 +2062,7 @@ impl Workspace {
 
     pub fn new_project_window(
         &mut self,
-        _: &NewWindowForWorkspace,
+        _: &NewProjectWindow,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -10405,9 +10405,9 @@ mod tests {
         let initial_bounds =
             workspace.update_in(cx, |_, window, _| window.window_bounds().get_bounds());
 
-        // Dispatch NewWindowForWorkspace action
+        // Dispatch NewProjectWindow action
         workspace.update_in(cx, |workspace, window, cx| {
-            workspace.new_project_window(&NewWindowForWorkspace, window, cx);
+            workspace.new_project_window(&NewProjectWindow, window, cx);
         });
 
         // Allow async task to complete
@@ -10471,7 +10471,7 @@ mod tests {
         // Create multiple new windows
         for _ in 0..3 {
             workspace.update_in(cx, |workspace, window, cx| {
-                workspace.new_project_window(&NewWindowForWorkspace, window, cx);
+                workspace.new_project_window(&NewProjectWindow, window, cx);
             });
         }
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -65,9 +65,9 @@ use vim_mode_setting::VimModeSetting;
 use welcome::{BaseKeymap, DOCS_URL, MultibufferHint};
 use workspace::notifications::{NotificationId, dismiss_app_notification, show_app_notification};
 use workspace::{
-    AppState, NewFile, NewWindow, OpenLog, Toast, Workspace, WorkspaceSettings,
-    create_and_open_local_file, notifications::simple_message_notification::MessageNotification,
-    open_new,
+    AppState, NewFile, NewWindow, NewWindowForWorkspace, OpenLog, Toast, Workspace,
+    WorkspaceSettings, create_and_open_local_file,
+    notifications::simple_message_notification::MessageNotification, open_new,
 };
 use workspace::{CloseIntent, CloseWindow, RestoreBanner, with_active_or_new_workspace};
 use workspace::{Pane, notifications::DetachAndPromptErr};
@@ -616,6 +616,9 @@ fn register_actions(
                 }
             })
             .detach()
+        })
+        .register_action(|workspace, _: &NewWindowForWorkspace, window, cx| {
+            workspace.new_window_for_workspace(&NewWindowForWorkspace, window, cx);
         })
         .register_action(|workspace, action: &zed_actions::OpenRemote, window, cx| {
             if !action.from_existing_connection {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -65,7 +65,7 @@ use vim_mode_setting::VimModeSetting;
 use welcome::{BaseKeymap, DOCS_URL, MultibufferHint};
 use workspace::notifications::{NotificationId, dismiss_app_notification, show_app_notification};
 use workspace::{
-    AppState, NewFile, NewWindow, NewWindowForWorkspace, OpenLog, Toast, Workspace,
+    AppState, NewFile, NewWindow, NewProjectWindow, OpenLog, Toast, Workspace,
     WorkspaceSettings, create_and_open_local_file,
     notifications::simple_message_notification::MessageNotification, open_new,
 };
@@ -617,8 +617,8 @@ fn register_actions(
             })
             .detach()
         })
-        .register_action(|workspace, _: &NewWindowForWorkspace, window, cx| {
-            workspace.new_project_window(&NewWindowForWorkspace, window, cx);
+        .register_action(|workspace, _: &NewProjectWindow, window, cx| {
+            workspace.new_project_window(&NewProjectWindow, window, cx);
         })
         .register_action(|workspace, action: &zed_actions::OpenRemote, window, cx| {
             if !action.from_existing_connection {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -618,7 +618,7 @@ fn register_actions(
             .detach()
         })
         .register_action(|workspace, _: &NewWindowForWorkspace, window, cx| {
-            workspace.new_window_for_workspace(&NewWindowForWorkspace, window, cx);
+            workspace.new_project_window(&NewWindowForWorkspace, window, cx);
         })
         .register_action(|workspace, action: &zed_actions::OpenRemote, window, cx| {
             if !action.from_existing_connection {

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -233,6 +233,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Minimize", super::Minimize),
                 MenuItem::action("Zoom", super::Zoom),
                 MenuItem::separator(),
+                MenuItem::action("New Window for Workspace", workspace::NewWindowForWorkspace),
             ],
         },
         Menu {

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -233,7 +233,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Minimize", super::Minimize),
                 MenuItem::action("Zoom", super::Zoom),
                 MenuItem::separator(),
-                MenuItem::action("New Window for Workspace", workspace::NewWindowForWorkspace),
+                MenuItem::action("New Project Window", workspace::NewProjectWindow),
             ],
         },
         Menu {


### PR DESCRIPTION
Closes #9662

**Status:** Implementation is functional, but some components (e.g. agent diff) don't have the standard UI.

Adds `workspace::NewProjectWindow` command that opens a new workspace window with shared project state.

## Editing files
https://github.com/user-attachments/assets/eb09f74b-d6af-4376-9236-ef73770dd2ef

## Using agent

https://github.com/user-attachments/assets/543e4af8-a57f-45aa-84d1-91d2f3ac4083



Release Notes:

- Added `workspace::NewProjectWindow` command that opens a new workspace window with shared project state