### PR TITLE
agent: Make `AgentSettings::default_model` optional

### DIFF
--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -50,7 +50,7 @@ pub struct AgentSettings {
     pub dock: AgentDockPosition,
     pub default_width: Pixels,
     pub default_height: Pixels,
-    pub default_model: LanguageModelSelection,
+    pub default_model: Option<LanguageModelSelection>,
     pub inline_assistant_model: Option<LanguageModelSelection>,
     pub commit_message_model: Option<LanguageModelSelection>,
     pub thread_summary_model: Option<LanguageModelSelection>,
@@ -357,15 +357,6 @@ impl From<&str> for LanguageModelProviderSetting {
     }
 }
 
-impl Default for LanguageModelSelection {
-    fn default() -> Self {
-        Self {
-            provider: LanguageModelProviderSetting("openai".to_string()),
-            model: "gpt-4".to_string(),
-        }
-    }
-}
-
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize, JsonSchema)]
 pub struct AgentProfileContent {
     pub name: Arc<str>,
@@ -409,7 +400,10 @@ impl Settings for AgentSettings {
                 &mut settings.default_height,
                 value.default_height.map(Into::into),
             );
-            merge(&mut settings.default_model, value.default_model.clone());
+            settings.default_model = value
+                .default_model
+                .clone()
+                .or(settings.default_model.take());
             settings.inline_assistant_model = value
                 .inline_assistant_model
                 .clone()

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -211,7 +211,7 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         }
     }
 
-    let default = to_selected_model(&settings.default_model);
+    let default = settings.default_model.as_ref().map(to_selected_model);
     let inline_assistant = settings
         .inline_assistant_model
         .as_ref()
@@ -231,7 +231,7 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         .collect::<Vec<_>>();
 
     LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
-        registry.select_default_model(Some(&default), cx);
+        registry.select_default_model(default.as_ref(), cx);
         registry.select_inline_assistant_model(inline_assistant.as_ref(), cx);
         registry.select_commit_message_model(commit_message.as_ref(), cx);
         registry.select_thread_summary_model(thread_summary.as_ref(), cx);


### PR DESCRIPTION
It's already effectively optional and the the old default of gpt-4 doesn't really get used in practice

Release Notes:

- N/A