### PR TITLE
Fix path parsing for goto syntax provided by Haskell language server

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -170,10 +170,10 @@ impl<T: AsRef<Path>> From<T> for SanitizedPath {
 pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
 const ROW_COL_CAPTURE_REGEX: &str = r"(?xs)
-    ([^\(]+)(?:
-        \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column)
+    ([^\(:]+)\:?(?:
+        \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column), filename:(row,column), filename:(row:column)
         |
-        \((\d+)\)()     # filename(row)
+        \((\d+)\)()     # filename(row), filename:(row)
     )
     |
     (.+?)(?:
@@ -672,6 +672,15 @@ mod tests {
                 path: PathBuf::from("👋\nab"),
                 row: None,
                 column: None
+            }
+        );
+
+        assert_eq!(
+            PathWithPosition::parse_str("Types.hs:(617,9)-(670,28):"),
+            PathWithPosition {
+                path: PathBuf::from("Types.hs"),
+                row: Some(617),
+                column: Some(9),
             }
         );
     }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -170,10 +170,16 @@ impl<T: AsRef<Path>> From<T> for SanitizedPath {
 pub const FILE_ROW_COLUMN_DELIMITER: char = ':';
 
 const ROW_COL_CAPTURE_REGEX: &str = r"(?xs)
-    ([^\(:]+)\:?(?:
-        \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column), filename:(row,column), filename:(row:column)
+    ([^\(]+)\:(?:
+        \((\d+)[,:](\d+)\) # filename:(row,column), filename:(row:column)
         |
-        \((\d+)\)()     # filename(row), filename:(row)
+        \((\d+)\)()     # filename:(row)
+    )
+    |
+    ([^\(]+)(?:
+        \((\d+)[,:](\d+)\) # filename(row,column), filename(row:column)
+        |
+        \((\d+)\)()     # filename(row)
     )
     |
     (.+?)(?:


### PR DESCRIPTION
path parsing for multiline errors provided by haskell language server where not working correctly 

<img width="875" alt="image" src="https://github.com/user-attachments/assets/967d2e03-e167-4055-9c8e-31531cca1471" />

while its being parsed correctly in vscode

<img width="934" alt="image" src="https://github.com/user-attachments/assets/a881cf0e-f06e-4b44-8363-6295bcc825fd" />

Release Notes:

- Fixed path parsing paths in the format of the Haskell language server 
