### PR TITLE
editor: Improve rewrap of markdown lists, todos, and block quotes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4814,6 +4814,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rand 0.8.5",
+ "regex",
  "release_channel",
  "rpc",
  "schemars",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -61,6 +61,7 @@ parking_lot.workspace = true
 pretty_assertions.workspace = true
 project.workspace = true
 rand.workspace = true
+regex.workspace = true
 rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5210,6 +5210,7 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     let markdown_language = Arc::new(Language::new(
         LanguageConfig {
             name: "Markdown".into(),
+            rewrap_prefixes: vec![regex::Regex::new("\\d+\\.\\s+").unwrap()],
             ..LanguageConfig::default()
         },
         None,
@@ -5372,7 +5373,29 @@ async fn test_rewrap(cx: &mut TestAppContext) {
             A long long long line of markdown text
             to wrap.ˇ
          "},
-        markdown_language,
+        markdown_language.clone(),
+        &mut cx,
+    );
+
+    // Test that rewrapping boundary works for Markdown documents
+    assert_rewrap(
+        indoc! {"
+            «1. This is a numbered list item that is very long and needs to be wrapped properly.
+            2. This is a numbered list item that is very long and needs to be wrapped properly.
+            - This is an unordered list item that is also very long and should not merge with the numbered item.ˇ»
+        "},
+        indoc! {"
+            «1. This is a numbered list item that is
+            very long and needs to be wrapped
+            properly.
+            2. This is a numbered list item that is
+            very long and needs to be wrapped
+            properly.
+            - This is an unordered list item that is
+            also very long and should not merge with
+            the numbered item.ˇ»
+        "},
+        markdown_language.clone(),
         &mut cx,
     );
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5383,20 +5383,20 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     // Test that rewrapping boundary works and preserves relative indent for Markdown documents
     assert_rewrap(
         indoc! {"
-            «   1. This is a numbered list item that is very long and needs to be wrapped properly.
-                2. This is a numbered list item that is very long and needs to be wrapped properly.
-                - This is an unordered list item that is also very long and should not merge with the numbered item.ˇ»
+            «1. This is a numbered list item that is very long and needs to be wrapped properly.
+            2. This is a numbered list item that is very long and needs to be wrapped properly.
+            - This is an unordered list item that is also very long and should not merge with the numbered item.ˇ»
         "},
         indoc! {"
-            «   1. This is a numbered list item that is
-                   very long and needs to be wrapped
-                   properly.
-                2. This is a numbered list item that is
-                   very long and needs to be wrapped
-                   properly.
-                - This is an unordered list item that is
-                  also very long and should not merge with
-                  the numbered item.ˇ»
+            «1. This is a numbered list item that is
+               very long and needs to be wrapped
+               properly.
+            2. This is a numbered list item that is
+               very long and needs to be wrapped
+               properly.
+            - This is an unordered list item that is
+              also very long and should not merge
+              with the numbered item.ˇ»
         "},
         markdown_language.clone(),
         &mut cx,
@@ -5405,26 +5405,26 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     // Test that rewrapping add indents for rewrapping boundary if not exists already.
     assert_rewrap(
         indoc! {"
-            «   1. This is a numbered list item that is
-                very long and needs to be wrapped
-                properly.
-                2. This is a numbered list item that is
-                very long and needs to be wrapped
-                properly.
-                - This is an unordered list item that is
-                also very long and should not merge with
-                the numbered item.ˇ»
+            «1. This is a numbered list item that is
+            very long and needs to be wrapped
+            properly.
+            2. This is a numbered list item that is
+            very long and needs to be wrapped
+            properly.
+            - This is an unordered list item that is
+            also very long and should not merge with
+            the numbered item.ˇ»
         "},
         indoc! {"
-            «   1. This is a numbered list item that is
-                   very long and needs to be wrapped
-                   properly.
-                2. This is a numbered list item that is
-                   very long and needs to be wrapped
-                   properly.
-                - This is an unordered list item that is
-                  also very long and should not merge with
-                  the numbered item.ˇ»
+            «1. This is a numbered list item that is
+               very long and needs to be wrapped
+               properly.
+            2. This is a numbered list item that is
+               very long and needs to be wrapped
+               properly.
+            - This is an unordered list item that is
+              also very long and should not merge with
+              the numbered item.ˇ»
         "},
         markdown_language.clone(),
         &mut cx,
@@ -5433,23 +5433,23 @@ async fn test_rewrap(cx: &mut TestAppContext) {
     // Test that rewrapping maintain indents even when they already exists.
     assert_rewrap(
         indoc! {"
-            «   1. This is a numbered list
-                   item that is very long and needs to be wrapped properly.
-                2. This is a numbered list
-                   item that is very long and needs to be wrapped properly.
-                - This is an unordered list item that is also very long and
-                  should not merge with the numbered item.ˇ»
+            «1. This is a numbered list
+               item that is very long and needs to be wrapped properly.
+            2. This is a numbered list
+               item that is very long and needs to be wrapped properly.
+            - This is an unordered list item that is also very long and
+              should not merge with the numbered item.ˇ»
         "},
         indoc! {"
-            «   1. This is a numbered list item that is
-                   very long and needs to be wrapped
-                   properly.
-                2. This is a numbered list item that is
-                   very long and needs to be wrapped
-                   properly.
-                - This is an unordered list item that is
-                  also very long and should not merge with
-                  the numbered item.ˇ»
+            «1. This is a numbered list item that is
+               very long and needs to be wrapped
+               properly.
+            2. This is a numbered list item that is
+               very long and needs to be wrapped
+               properly.
+            - This is an unordered list item that is
+              also very long and should not merge with
+              the numbered item.ˇ»
         "},
         markdown_language.clone(),
         &mut cx,

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5423,8 +5423,8 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                very long and needs to be wrapped
                properly.
             - This is an unordered list item that is
-              also very long and should not merge with
-              the numbered item.ˇ»
+              also very long and should not merge
+              with the numbered item.ˇ»
         "},
         markdown_language.clone(),
         &mut cx,
@@ -5448,8 +5448,8 @@ async fn test_rewrap(cx: &mut TestAppContext) {
                very long and needs to be wrapped
                properly.
             - This is an unordered list item that is
-              also very long and should not merge with
-              the numbered item.ˇ»
+              also very long and should not merge
+              with the numbered item.ˇ»
         "},
         markdown_language.clone(),
         &mut cx,

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -39,7 +39,7 @@ use lsp::{CodeActionKind, InitializeParams, LanguageServerBinary, LanguageServer
 pub use manifest::{ManifestDelegate, ManifestName, ManifestProvider, ManifestQuery};
 use parking_lot::Mutex;
 use regex::Regex;
-use schemars::{JsonSchema, json_schema};
+use schemars::{JsonSchema, SchemaGenerator, json_schema};
 use serde::{Deserialize, Deserializer, Serialize, Serializer, de};
 use serde_json::Value;
 use settings::WorktreeId;
@@ -972,19 +972,10 @@ fn deserialize_regex_vec<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Regex>, 
     Ok(regexes)
 }
 
-fn regex_vec_json_schema(_: &mut SchemaGenerator) -> Schema {
-    Schema::Object(SchemaObject {
-        instance_type: Some(InstanceType::Array.into()),
-        array: Some(Box::new(schemars::schema::ArrayValidation {
-            items: Some(schemars::schema::SingleOrVec::Single(Box::new(
-                Schema::Object(SchemaObject {
-                    instance_type: Some(InstanceType::String.into()),
-                    ..Default::default()
-                }),
-            ))),
-            ..Default::default()
-        })),
-        ..Default::default()
+fn regex_vec_json_schema(_: &mut SchemaGenerator) -> schemars::Schema {
+    json_schema!({
+        "type": "array",
+        "items": { "type": "string" }
     })
 }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -730,6 +730,13 @@ pub struct LanguageConfig {
     /// Starting and closing characters of a block comment.
     #[serde(default)]
     pub block_comment: Option<(Arc<str>, Arc<str>)>,
+    /// A list of additional regex patterns that should be treated as prefixes
+    /// for creating boundaries during rewrapping, ensuring content from one
+    /// prefixed section doesn't merge with another (e.g., markdown list items).
+    /// By default, Zed treats as paragraph and comment prefixes as boundaries.
+    #[serde(default, deserialize_with = "deserialize_regex_vec")]
+    #[schemars(schema_with = "regex_vec_json_schema")]
+    pub rewrap_prefixes: Vec<Regex>,
     /// A list of language servers that are allowed to run on subranges of a given language.
     #[serde(default)]
     pub scope_opt_in_language_servers: Vec<LanguageServerName>,
@@ -909,6 +916,7 @@ impl Default for LanguageConfig {
             autoclose_before: Default::default(),
             line_comments: Default::default(),
             block_comment: Default::default(),
+            rewrap_prefixes: Default::default(),
             scope_opt_in_language_servers: Default::default(),
             overrides: Default::default(),
             word_characters: Default::default(),
@@ -953,6 +961,31 @@ where
         Some(regex) => serializer.serialize_str(regex.as_str()),
         None => serializer.serialize_none(),
     }
+}
+
+fn deserialize_regex_vec<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Regex>, D::Error> {
+    let sources = Vec::<String>::deserialize(d)?;
+    let mut regexes = Vec::new();
+    for source in sources {
+        regexes.push(regex::Regex::new(&source).map_err(de::Error::custom)?);
+    }
+    Ok(regexes)
+}
+
+fn regex_vec_json_schema(_: &mut SchemaGenerator) -> Schema {
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Array.into()),
+        array: Some(Box::new(schemars::schema::ArrayValidation {
+            items: Some(schemars::schema::SingleOrVec::Single(Box::new(
+                Schema::Object(SchemaObject {
+                    instance_type: Some(InstanceType::String.into()),
+                    ..Default::default()
+                }),
+            ))),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })
 }
 
 #[doc(hidden)]
@@ -1829,6 +1862,14 @@ impl LanguageScope {
             self.language.config.block_comment.as_ref(),
         )
         .map(|e| (&e.0, &e.1))
+    }
+
+    /// Returns additional regex patterns that act as prefix markers for creating
+    /// boundaries during rewrapping.
+    ///
+    /// By default, Zed treats as paragraph and comment prefixes as boundaries.
+    pub fn rewrap_prefixes(&self) -> &[Regex] {
+        &self.language.config.rewrap_prefixes
     }
 
     /// Returns a list of language-specific word characters.

--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -13,6 +13,12 @@ brackets = [
     { start = "'", end = "'", close = false, newline = false },
     { start = "`", end = "`", close = false, newline = false },
 ]
+rewrap_prefixes = [
+    "[-*+]\\s+",
+    "\\d+\\.\\s+",
+    ">\\s*",
+    "[-*+]\\s+\\[[\\sx]\\]\\s+"
+]
 
 auto_indent_on_paste = false
 auto_indent_using_last_non_empty_line = false


### PR DESCRIPTION
Closes #19644 #18151

Now, rewrapping markdown lists (unordered, ordered, and to-do lists) and block quotes wrap them separately, without merging them together. Additionally, it correctly indents subsequent lines.

With this input: 

```md
1. This is a list item that is short.
2. This list item is a bit longer because I want to see if it wraps correctly after a rewrap operation in Zed. What do you think?
3. another short item
```

Output would be:

```md
1. This is a list item that is short.
2. This list item is a bit longer because I want to see if it wraps correctly
   after a rewrap operation in Zed. What do you think?
3. another short item
```

Instead of:

```md
1. This is a list item that is short. 2. This list item is a bit longer because 
I want to see if it wraps correctly after a rewrap operation in Zed. What 
do you think? 3. another short item
```

Release Notes:

- Improved rewrap for markdown lists, todos, and block quotes.
