### PR TITLE
languages: Fix `(` wouldn’t autocomplete when `.` is preceded by it in Markdown

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -3,7 +3,7 @@ grammar = "markdown"
 path_suffixes = ["md", "mdx", "mdwn", "markdown", "MD"]
 completion_query_characters = ["-"]
 block_comment = ["<!-- ", " -->"]
-autoclose_before = "}])>"
+autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
Closes #5092

Release Notes:

- Fixed issue where `(` wouldn’t autocomplete when `.` is preceded by it in Markdown.
