### PR TITLE
debugger: Debug sessions rerun build tasks by default when restarting

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -34,7 +34,7 @@
       "ctrl-q": "zed::Quit",
       "f4": "debugger::Start",
       "shift-f5": "debugger::Stop",
-      "ctrl-shift-f5": "debugger::Restart",
+      "ctrl-shift-f5": "debugger::RerunSession",
       "f6": "debugger::Pause",
       "f7": "debugger::StepOver",
       "ctrl-f11": "debugger::StepInto",
@@ -598,7 +598,7 @@
       // "foo-bar": ["task::Spawn", { "task_name": "MyTask", "reveal_target": "dock" }]
       // or by tag:
       // "foo-bar": ["task::Spawn", { "task_tag": "MyTag" }],
-      "f5": "debugger::RerunLastSession"
+      "f5": "debugger::Rerun"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -5,7 +5,7 @@
     "bindings": {
       "f4": "debugger::Start",
       "shift-f5": "debugger::Stop",
-      "shift-cmd-f5": "debugger::Restart",
+      "shift-cmd-f5": "debugger::RerunSession",
       "f6": "debugger::Pause",
       "f7": "debugger::StepOver",
       "f11": "debugger::StepInto",
@@ -652,7 +652,7 @@
       "cmd-k shift-up": "workspace::SwapPaneUp",
       "cmd-k shift-down": "workspace::SwapPaneDown",
       "cmd-shift-x": "zed::Extensions",
-      "f5": "debugger::RerunLastSession"
+      "f5": "debugger::Rerun"
     }
   },
   {

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -23,7 +23,9 @@ use gpui::{
 };
 use itertools::Itertools as _;
 use picker::{Picker, PickerDelegate, highlighted_match_with_paths::HighlightedMatch};
-use project::{ProjectPath, TaskContexts, TaskSourceKind, task_store::TaskStore};
+use project::{
+    DebugScenarioContext, ProjectPath, TaskContexts, TaskSourceKind, task_store::TaskStore,
+};
 use settings::{Settings, initial_local_debug_tasks_content};
 use task::{DebugScenario, RevealTarget, ZedDebugConfig};
 use theme::ThemeSettings;
@@ -92,6 +94,7 @@ impl NewProcessModal {
 
         cx.spawn_in(window, async move |workspace, cx| {
             let task_contexts = workspace.update_in(cx, |workspace, window, cx| {
+                // FIXME get the buffer here (if the active item is an editor) and store it so we can pass it to start_session later
                 tasks_ui::task_contexts(workspace, window, cx)
             })?;
             workspace.update_in(cx, |workspace, window, cx| {
@@ -1110,7 +1113,11 @@ pub(super) struct TaskMode {
 
 pub(super) struct DebugDelegate {
     task_store: Entity<TaskStore>,
-    candidates: Vec<(Option<TaskSourceKind>, DebugScenario)>,
+    candidates: Vec<(
+        Option<TaskSourceKind>,
+        DebugScenario,
+        Option<DebugScenarioContext>,
+    )>,
     selected_index: usize,
     matches: Vec<StringMatch>,
     prompt: String,
@@ -1208,7 +1215,11 @@ impl DebugDelegate {
 
                 this.delegate.candidates = recent
                     .into_iter()
-                    .map(|scenario| Self::get_scenario_kind(&languages, &dap_registry, scenario))
+                    .map(|(scenario, context)| {
+                        let (kind, scenario) =
+                            Self::get_scenario_kind(&languages, &dap_registry, scenario);
+                        (kind, scenario, Some(context))
+                    })
                     .chain(
                         scenarios
                             .into_iter()
@@ -1223,7 +1234,7 @@ impl DebugDelegate {
                             .map(|(kind, scenario)| {
                                 let (language, scenario) =
                                     Self::get_scenario_kind(&languages, &dap_registry, scenario);
-                                (language.or(Some(kind)), scenario)
+                                (language.or(Some(kind)), scenario, None)
                             }),
                     )
                     .collect();
@@ -1269,7 +1280,7 @@ impl PickerDelegate for DebugDelegate {
             let candidates: Vec<_> = candidates
                 .into_iter()
                 .enumerate()
-                .map(|(index, (_, candidate))| {
+                .map(|(index, (_, candidate, _))| {
                     StringMatchCandidate::new(index, candidate.label.as_ref())
                 })
                 .collect();
@@ -1434,25 +1445,40 @@ impl PickerDelegate for DebugDelegate {
             .get(self.selected_index())
             .and_then(|match_candidate| self.candidates.get(match_candidate.candidate_id).cloned());
 
-        let Some((_, debug_scenario)) = debug_scenario else {
+        let Some((_, debug_scenario, context)) = debug_scenario else {
             return;
         };
 
-        let (task_context, worktree_id) = self
-            .task_contexts
-            .as_ref()
-            .and_then(|task_contexts| {
-                Some((
-                    task_contexts.active_context().cloned()?,
-                    task_contexts.worktree(),
-                ))
-            })
-            .unwrap_or_default();
+        let context = context.unwrap_or_else(|| {
+            self.task_contexts
+                .as_ref()
+                .and_then(|task_contexts| {
+                    Some(DebugScenarioContext {
+                        task_context: task_contexts.active_context().cloned()?,
+                        active_buffer: None,
+                        worktree_id: task_contexts.worktree(),
+                    })
+                })
+                .unwrap_or_default()
+        });
+        let DebugScenarioContext {
+            task_context,
+            active_buffer,
+            worktree_id,
+        } = context;
+        let active_buffer = active_buffer.and_then(|buffer| buffer.upgrade());
 
         send_telemetry(&debug_scenario, TelemetrySpawnLocation::ScenarioList, cx);
         self.debug_panel
             .update(cx, |panel, cx| {
-                panel.start_session(debug_scenario, task_context, None, worktree_id, window, cx);
+                panel.start_session(
+                    debug_scenario,
+                    task_context,
+                    active_buffer,
+                    worktree_id,
+                    window,
+                    cx,
+                );
             })
             .ok();
 

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -94,7 +94,7 @@ impl NewProcessModal {
 
         cx.spawn_in(window, async move |workspace, cx| {
             let task_contexts = workspace.update_in(cx, |workspace, window, cx| {
-                // FIXME get the buffer here (if the active item is an editor) and store it so we can pass it to start_session later
+                // todo(debugger): get the buffer here (if the active item is an editor) and store it so we can pass it to start_session later
                 tasks_ui::task_contexts(workspace, window, cx)
             })?;
             workspace.update_in(cx, |workspace, window, cx| {

--- a/crates/debugger_ui/src/tests.rs
+++ b/crates/debugger_ui/src/tests.rs
@@ -115,6 +115,7 @@ pub fn start_debug_session_with<T: Fn(&Arc<DebugAdapterClient>) + 'static>(
             config.to_scenario(),
             TaskContext::default(),
             None,
+            None,
             window,
             cx,
         )

--- a/crates/debugger_ui/src/tests/new_process_modal.rs
+++ b/crates/debugger_ui/src/tests/new_process_modal.rs
@@ -141,7 +141,14 @@ async fn test_debug_session_substitutes_variables_and_relativizes_paths(
 
         workspace
             .update(cx, |workspace, window, cx| {
-                workspace.start_debug_session(scenario, task_context.clone(), None, window, cx)
+                workspace.start_debug_session(
+                    scenario,
+                    task_context.clone(),
+                    None,
+                    None,
+                    window,
+                    cx,
+                )
             })
             .unwrap();
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -6186,7 +6186,14 @@ impl Editor {
 
                 workspace.update(cx, |workspace, cx| {
                     dap::send_telemetry(&scenario, TelemetrySpawnLocation::Gutter, cx);
-                    workspace.start_debug_session(scenario, context, Some(buffer), window, cx);
+                    workspace.start_debug_session(
+                        scenario,
+                        context,
+                        Some(buffer),
+                        None,
+                        window,
+                        cx,
+                    );
                 });
                 Some(Task::ready(Ok(())))
             }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -131,7 +131,8 @@ pub use language::Location;
 #[cfg(any(test, feature = "test-support"))]
 pub use prettier::FORMAT_SUFFIX as TEST_PRETTIER_FORMAT_SUFFIX;
 pub use task_inventory::{
-    BasicContextProvider, ContextProviderWithTasks, Inventory, TaskContexts, TaskSourceKind,
+    BasicContextProvider, ContextProviderWithTasks, DebugScenarioContext, Inventory, TaskContexts,
+    TaskSourceKind,
 };
 
 pub use buffer_store::ProjectTransaction;

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -1399,8 +1399,7 @@ mod tests {
                 })
                 .await
                 .0
-                .first()
-                .is_none(),
+                .is_empty(),
         );
     }
 

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -12,7 +12,7 @@ use anyhow::Result;
 use collections::{HashMap, HashSet, VecDeque};
 use dap::DapRegistry;
 use fs::Fs;
-use gpui::{App, AppContext as _, Context, Entity, SharedString, Task};
+use gpui::{App, AppContext as _, Context, Entity, SharedString, Task, WeakEntity};
 use itertools::Itertools;
 use language::{
     Buffer, ContextLocation, ContextProvider, File, Language, LanguageToolchainStore, Location,
@@ -31,11 +31,18 @@ use worktree::WorktreeId;
 
 use crate::{task_store::TaskSettingsLocation, worktree_store::WorktreeStore};
 
+#[derive(Clone, Debug, Default)]
+pub struct DebugScenarioContext {
+    pub task_context: TaskContext,
+    pub worktree_id: Option<WorktreeId>,
+    pub active_buffer: Option<WeakEntity<Buffer>>,
+}
+
 /// Inventory tracks available tasks for a given project.
 pub struct Inventory {
     fs: Arc<dyn Fs>,
     last_scheduled_tasks: VecDeque<(TaskSourceKind, ResolvedTask)>,
-    last_scheduled_scenarios: VecDeque<DebugScenario>,
+    last_scheduled_scenarios: VecDeque<(DebugScenario, DebugScenarioContext)>,
     templates_from_settings: InventoryFor<TaskTemplate>,
     scenarios_from_settings: InventoryFor<DebugScenario>,
 }
@@ -245,16 +252,29 @@ impl Inventory {
         })
     }
 
-    pub fn scenario_scheduled(&mut self, scenario: DebugScenario) {
+    pub fn scenario_scheduled(
+        &mut self,
+        scenario: DebugScenario,
+        task_context: TaskContext,
+        worktree_id: Option<WorktreeId>,
+        active_buffer: Option<WeakEntity<Buffer>>,
+    ) {
         self.last_scheduled_scenarios
-            .retain(|s| s.label != scenario.label);
-        self.last_scheduled_scenarios.push_back(scenario);
+            .retain(|(s, _)| s.label != scenario.label);
+        self.last_scheduled_scenarios.push_back((
+            scenario,
+            DebugScenarioContext {
+                task_context,
+                worktree_id,
+                active_buffer,
+            },
+        ));
         if self.last_scheduled_scenarios.len() > 5_000 {
             self.last_scheduled_scenarios.pop_front();
         }
     }
 
-    pub fn last_scheduled_scenario(&self) -> Option<&DebugScenario> {
+    pub fn last_scheduled_scenario(&self) -> Option<&(DebugScenario, DebugScenarioContext)> {
         self.last_scheduled_scenarios.back()
     }
 
@@ -265,7 +285,10 @@ impl Inventory {
         current_resolved_tasks: Vec<(TaskSourceKind, task::ResolvedTask)>,
         add_current_language_tasks: bool,
         cx: &mut App,
-    ) -> Task<(Vec<DebugScenario>, Vec<(TaskSourceKind, DebugScenario)>)> {
+    ) -> Task<(
+        Vec<(DebugScenario, DebugScenarioContext)>,
+        Vec<(TaskSourceKind, DebugScenario)>,
+    )> {
         let mut scenarios = Vec::new();
 
         if let Some(worktree_id) = task_contexts
@@ -765,7 +788,7 @@ impl Inventory {
                 }
             }
         }
-        self.last_scheduled_scenarios.retain_mut(|scenario| {
+        self.last_scheduled_scenarios.retain_mut(|(scenario, _)| {
             if !previously_existing_scenarios.contains(&scenario.label) {
                 return true;
             }
@@ -1304,7 +1327,7 @@ mod tests {
             .clone();
 
         inventory.update(cx, |this, _| {
-            this.scenario_scheduled(scenario.clone());
+            this.scenario_scheduled(scenario.clone(), TaskContext::default(), None, None);
         });
 
         assert_eq!(
@@ -1316,7 +1339,8 @@ mod tests {
                 .0
                 .first()
                 .unwrap()
-                .clone(),
+                .clone()
+                .0,
             scenario
         );
 
@@ -1346,6 +1370,7 @@ mod tests {
                 .0
                 .first()
                 .unwrap()
+                .0
                 .adapter,
             "Delve",
         );
@@ -1367,15 +1392,15 @@ mod tests {
             .unwrap();
         });
 
-        assert_eq!(
+        assert!(
             inventory
                 .update(cx, |this, cx| {
                     this.list_debug_scenarios(&TaskContexts::default(), vec![], vec![], false, cx)
                 })
                 .await
                 .0
-                .first(),
-            None
+                .first()
+                .is_none(),
         );
     }
 

--- a/crates/workspace/src/tasks.rs
+++ b/crates/workspace/src/tasks.rs
@@ -3,7 +3,7 @@ use std::process::ExitStatus;
 use anyhow::Result;
 use gpui::{AppContext, Context, Entity, Task};
 use language::Buffer;
-use project::TaskSourceKind;
+use project::{TaskSourceKind, WorktreeId};
 use remote::ConnectionState;
 use task::{DebugScenario, ResolvedTask, SpawnInTerminal, TaskContext, TaskTemplate};
 use ui::Window;
@@ -95,11 +95,19 @@ impl Workspace {
         scenario: DebugScenario,
         task_context: TaskContext,
         active_buffer: Option<Entity<Buffer>>,
+        worktree_id: Option<WorktreeId>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         if let Some(provider) = self.debugger_provider.as_mut() {
-            provider.start_session(scenario, task_context, active_buffer, window, cx)
+            provider.start_session(
+                scenario,
+                task_context,
+                active_buffer,
+                worktree_id,
+                window,
+                cx,
+            )
         }
     }
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -146,6 +146,7 @@ pub trait DebuggerProvider {
         definition: DebugScenario,
         task_context: TaskContext,
         active_buffer: Option<Entity<Buffer>>,
+        worktree_id: Option<WorktreeId>,
         window: &mut Window,
         cx: &mut App,
     );


### PR DESCRIPTION
We reworked the debug modal spawning to use the task context from past debug sessions when spawning a debug scenario based on task inventory history.

We changed restart session keybinding to rerun session too.

Closes #31369

Release Notes:

- Restarting a debug session now reruns build tasks that are associated with the session
