### PR TITLE
Use version equality constraint for `zed_llm_client` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -625,7 +625,7 @@ wasmtime = { version = "29", default-features = false, features = [
 wasmtime-wasi = "29"
 which = "6.0.0"
 workspace-hack = "0.1.0"
-zed_llm_client = "0.8.5"
+zed_llm_client = "= 0.8.5"
 zstd = "0.11"
 
 [workspace.dependencies.async-stripe]


### PR DESCRIPTION
Closes #33578

Release Notes:

- N/A