### PR TITLE
Fix agent panel unexpectedly closing in zoom mode during scrolling

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2942,10 +2942,6 @@ impl Workspace {
             }
         });
 
-        if reveal_dock {
-            self.dismiss_zoomed_items_to_reveal(Some(dock_side), window, cx);
-        }
-
         if focus_center {
             self.active_pane
                 .update(cx, |pane, cx| window.focus(&pane.focus_handle(cx)))
@@ -3847,14 +3843,19 @@ impl Workspace {
             self.last_active_center_pane = Some(pane.downgrade());
         }
 
-        self.dismiss_zoomed_items_to_reveal(None, window, cx);
+        // Handle zoom state changes
         if pane.read(cx).is_zoomed() {
+            // This pane is zoomed, dismiss other zoomed items
+            self.dismiss_zoomed_items_to_reveal(None, window, cx);
             self.zoomed = Some(pane.downgrade().into());
-        } else {
+            self.zoomed_position = None;
+            cx.emit(Event::ZoomChanged);
+        }  else {
+            // No zoomed items
             self.zoomed = None;
+            self.zoomed_position = None;
         }
-        self.zoomed_position = None;
-        cx.emit(Event::ZoomChanged);
+
         self.update_active_view_for_followers(window, cx);
         pane.update(cx, |pane, _| {
             pane.track_alternate_file_items();


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33430

Release Notes:

- Fixed agent panel unexpectedly closing in zoom mode during scrolling

---

When the AI panel is zoomed and the user scrolls through content, the panel would unexpectedly close after a short delay. This was particularly disruptive during active AI conversations when users needed to scroll through responses.

## Root Cause Analysis

Through debugging with logging, i discovered that the issue occurred due to overly aggressive zoom dismissal logic:

1. When scrolling causes content updates in the AI panel, focus temporarily shifts between components
2. The workspace's focus handling code in `workspace.rs` was dismissing ALL zoomed panels whenever:
   - Center pane gained focus
   - A dock was revealed for any reason

The specific issue was that `dismiss_zoomed_items_to_reveal()` was being called unconditionally in these scenarios, which would hide any zoomed panel regardless of whether the user intended to change the zoom state.

### What we couldn't figure out

I tried to track down why the AI panel loses focus during scrolling but couldn't nail down the exact cause. The focus seems to jump to a center pane during scroll operations. I initially thought it might be related to lazy loading or virtual list updates - specifically that the virtual list might become empty during updates and the center panel would get focus "through" it, but debugging showed this wasn't the case. The only clue I found was that during this focus loss, the arena allocator in gpui tried to allocate more memory, suggesting some kind of component reconstruction or reallocation might be happening during scroll operations. This fix basically works around this focus issue instead of addressing the root cause.

## Solution

Since I couldn't prevent the focus loss during scrolling, I modified the zoom handling logic in `workspace.rs` to be more conservative and user-intent focused:

### 1. Center pane focus handling
- **Before**: When any center pane gained focus, it would dismiss all zoomed panels unconditionally
- **After**: Only dismiss other zoomed panels when the focused pane is itself zoomed, preserving zoomed dock state when focusing a non-zoomed center pane. I have no idea if this is possible, but defensive strategy sounds reasonable.

### 2. Dock reveal handling
- **Before**: Revealing any dock would dismiss all zoomed panels via `dismiss_zoomed_items_to_reveal()`
- **After**: Simply revealing a dock no longer affects zoom state - removed the dismiss call entirely

## Implementation Details

The key insight was to distinguish between intentional zoom changes (user explicitly zooming a panel) and incidental focus changes (temporary focus shifts during scrolling/updates). The fix ensures zoomed panels remain stable unless the user explicitly:
- Toggles zoom on another panel
- Unzooms the current panel
- Closes the zoomed panel

While this doesn't solve the underlying focus loss issue, it prevents that focus loss from having user-visible consequences.

## Testing

The fix was verified by:
1. Zooming the AI panel
2. Scrolling through content to trigger lazy loading and focus changes
3. Confirming the panel remains zoomed and visible
4. Verifying that explicitly zooming another panel still correctly dismisses the previously zoomed panel
