### PR TITLE
debugger: Don't take JS adapter's suggested child session name if it's empty

### DIFF
--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -522,7 +522,11 @@ impl DebugAdapter for JsDebugAdapter {
     }
 
     fn label_for_child_session(&self, args: &StartDebuggingRequestArguments) -> Option<String> {
-        let label = args.configuration.get("name")?.as_str()?;
+        let label = args
+            .configuration
+            .get("name")?
+            .as_str()
+            .filter(|name| !name.is_empty())?;
         Some(label.to_owned())
     }
 }


### PR DESCRIPTION
Related to #33072 

We use the JS adapter's suggested names for child sessions, but sometimes it sends us `""`, so don't use that one.

Release Notes:

- debugger: Fixed nameless child sessions appearing with the JavaScript adapter.