### PR TITLE
Respect NO_PROXY env var

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1784,7 +1784,8 @@
   // `socks5h`. `http` will be used when no scheme is specified.
   //
   // By default no proxy will be used, or Zed will try get proxy settings from
-  // environment variables.
+  // environment variables. If certain hosts should not be proxied,
+  // set the `no_proxy` environment variable and provide a comma-separated list.
   //
   // Examples:
   //   - "proxy": "socks5h://localhost:10808"

--- a/crates/reqwest_client/src/reqwest_client.rs
+++ b/crates/reqwest_client/src/reqwest_client.rs
@@ -61,7 +61,8 @@ impl ReqwestClient {
                 })
                 .ok()
         }) {
-            client = client.proxy(proxy);
+            // Respect NO_PROXY env var
+            client = client.proxy(proxy.no_proxy(reqwest::NoProxy::from_env()));
             client_has_proxy = true;
         } else {
             client_has_proxy = false;

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2212,7 +2212,7 @@ The following URI schemes are supported:
 
 `http` will be used when no scheme is specified.
 
-By default no proxy will be used, or Zed will attempt to retrieve proxy settings from environment variables, such as `http_proxy`, `HTTP_PROXY`, `https_proxy`, `HTTPS_PROXY`, `all_proxy`, `ALL_PROXY`.
+By default no proxy will be used, or Zed will attempt to retrieve proxy settings from environment variables, such as `http_proxy`, `HTTP_PROXY`, `https_proxy`, `HTTPS_PROXY`, `all_proxy`, `ALL_PROXY`, `no_proxy` and `NO_PROXY`.
 
 For example, to set an `http` proxy, add the following to your settings:
 
@@ -2229,6 +2229,8 @@ Or to set a `socks5` proxy:
   "proxy": "socks5h://localhost:10808"
 }
 ```
+
+If you wish to exclude certain hosts from using the proxy, set the `NO_PROXY` environment variable. This accepts a comma-separated list of hostnames, host suffixes, IPv4/IPv6 addresses or blocks that should not use the proxy. For example if your environment included `NO_PROXY="google.com, 192.168.1.0/24"` all hosts in `192.168.1.*`, `google.com` and `*.google.com` would bypass the proxy. See [reqwest NoProxy docs](https://docs.rs/reqwest/latest/reqwest/struct.NoProxy.html#method.from_string) for more.
 
 ## Preview tabs
 


### PR DESCRIPTION
Closes #22991

Release Notes:

- Added support for respecting the NO_PROXY environment variable when any HTTP proxy is configured. For the exact NO_PROXY env var strings that are supported, see [NoProxy in the reqwest docs](https://docs.rs/reqwest/latest/reqwest/struct.NoProxy.html#method.from_env).
