### PR TITLE
Fix windows manifest inclusion

### DIFF
--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -63,7 +63,12 @@ git.workspace = true
 git_hosting_providers.workspace = true
 git_ui.workspace = true
 go_to_line.workspace = true
-gpui = { workspace = true, features = ["wayland", "x11", "font-kit"] }
+gpui = { workspace = true, features = [
+    "wayland",
+    "x11",
+    "font-kit",
+    "windows-manifest",
+] }
 gpui_tokio.workspace = true
 
 http_client.workspace = true


### PR DESCRIPTION
Fixes a regression which prevented zed from starting on windows due to the lack of the embedded manifest. Caused by #bff5d85

Release Notes:

- N/A