### PR TITLE
keymap_ui: Add context menu for table rows

### DIFF
--- a/crates/editor/src/mouse_context_menu.rs
+++ b/crates/editor/src/mouse_context_menu.rs
@@ -233,31 +233,25 @@ pub fn deploy_context_menu(
                 .action("Copy and Trim", Box::new(CopyAndTrim))
                 .action("Paste", Box::new(Paste))
                 .separator()
-                .map(|builder| {
-                    let reveal_in_finder_label = if cfg!(target_os = "macos") {
+                .action_disabled_when(
+                    !has_reveal_target,
+                    if cfg!(target_os = "macos") {
                         "Reveal in Finder"
                     } else {
                         "Reveal in File Manager"
-                    };
-                    const OPEN_IN_TERMINAL_LABEL: &str = "Open in Terminal";
-                    if has_reveal_target {
-                        builder
-                            .action(reveal_in_finder_label, Box::new(RevealInFileManager))
-                            .action(OPEN_IN_TERMINAL_LABEL, Box::new(OpenInTerminal))
-                    } else {
-                        builder
-                            .disabled_action(reveal_in_finder_label, Box::new(RevealInFileManager))
-                            .disabled_action(OPEN_IN_TERMINAL_LABEL, Box::new(OpenInTerminal))
-                    }
-                })
-                .map(|builder| {
-                    const COPY_PERMALINK_LABEL: &str = "Copy Permalink";
-                    if has_git_repo {
-                        builder.action(COPY_PERMALINK_LABEL, Box::new(CopyPermalinkToLine))
-                    } else {
-                        builder.disabled_action(COPY_PERMALINK_LABEL, Box::new(CopyPermalinkToLine))
-                    }
-                });
+                    },
+                    Box::new(RevealInFileManager),
+                )
+                .action_disabled_when(
+                    !has_reveal_target,
+                    "Open in Terminal",
+                    Box::new(OpenInTerminal),
+                )
+                .action_disabled_when(
+                    !has_git_repo,
+                    "Copy Permalink",
+                    Box::new(CopyPermalinkToLine),
+                );
             match focus {
                 Some(focus) => builder.context(focus),
                 None => builder,

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -122,40 +122,29 @@ fn git_panel_context_menu(
     ContextMenu::build(window, cx, move |context_menu, _, _| {
         context_menu
             .context(focus_handle)
-            .map(|menu| {
-                if state.has_unstaged_changes {
-                    menu.action("Stage All", StageAll.boxed_clone())
-                } else {
-                    menu.disabled_action("Stage All", StageAll.boxed_clone())
-                }
-            })
-            .map(|menu| {
-                if state.has_staged_changes {
-                    menu.action("Unstage All", UnstageAll.boxed_clone())
-                } else {
-                    menu.disabled_action("Unstage All", UnstageAll.boxed_clone())
-                }
-            })
+            .action_disabled_when(
+                !state.has_unstaged_changes,
+                "Stage All",
+                StageAll.boxed_clone(),
+            )
+            .action_disabled_when(
+                !state.has_staged_changes,
+                "Unstage All",
+                UnstageAll.boxed_clone(),
+            )
             .separator()
             .action("Open Diff", project_diff::Diff.boxed_clone())
             .separator()
-            .map(|menu| {
-                if state.has_tracked_changes {
-                    menu.action("Discard Tracked Changes", RestoreTrackedFiles.boxed_clone())
-                } else {
-                    menu.disabled_action(
-                        "Discard Tracked Changes",
-                        RestoreTrackedFiles.boxed_clone(),
-                    )
-                }
-            })
-            .map(|menu| {
-                if state.has_new_changes {
-                    menu.action("Trash Untracked Files", TrashUntrackedFiles.boxed_clone())
-                } else {
-                    menu.disabled_action("Trash Untracked Files", TrashUntrackedFiles.boxed_clone())
-                }
-            })
+            .action_disabled_when(
+                !state.has_tracked_changes,
+                "Discard Tracked Changes",
+                RestoreTrackedFiles.boxed_clone(),
+            )
+            .action_disabled_when(
+                !state.has_new_changes,
+                "Trash Untracked Files",
+                TrashUntrackedFiles.boxed_clone(),
+            )
     })
 }
 

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -820,13 +820,11 @@ impl ProjectPanel {
                             .action("Copy", Box::new(Copy))
                             .action("Duplicate", Box::new(Duplicate))
                             // TODO: Paste should always be visible, cbut disabled when clipboard is empty
-                            .map(|menu| {
-                                if self.clipboard.as_ref().is_some() {
-                                    menu.action("Paste", Box::new(Paste))
-                                } else {
-                                    menu.disabled_action("Paste", Box::new(Paste))
-                                }
-                            })
+                            .action_disabled_when(
+                                self.clipboard.as_ref().is_none(),
+                                "Paste",
+                                Box::new(Paste),
+                            )
                             .separator()
                             .action("Copy Path", Box::new(zed_actions::workspace::CopyPath))
                             .action(

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -9,7 +9,7 @@ use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     AppContext as _, AsyncApp, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
     FontWeight, Global, KeyContext, Keystroke, ModifiersChangedEvent, ScrollStrategy, StyledText,
-    Subscription, WeakEntity, actions, div,
+    Subscription, WeakEntity, actions, div, transparent_black,
 };
 use language::{Language, LanguageConfig};
 use settings::KeybindSource;
@@ -514,10 +514,21 @@ impl Render for KeymapEditor {
                     .striped()
                     .column_widths([rems(16.), rems(16.), rems(16.), rems(32.), rems(8.)])
                     .header(["Action", "Arguments", "Keystrokes", "Context", "Source"])
-                    .selected_item_index(self.selected_index)
-                    .on_click_row(cx.processor(|this, row_index, _window, _cx| {
-                        this.selected_index = Some(row_index);
-                    }))
+                    .map_row(
+                        cx.processor(|this, (row_index, row): (usize, Div), _window, cx| {
+                            let is_selected = this.selected_index == Some(row_index);
+                            row.id(("keymap-table-row", row_index))
+                                .on_click(cx.listener(move |this, _event, _window, _cx| {
+                                    this.selected_index = Some(row_index);
+                                }))
+                                .border_2()
+                                .border_color(transparent_black())
+                                .when(is_selected, |row| {
+                                    row.border_color(cx.theme().colors().panel_focused_border)
+                                })
+                                .into_any_element()
+                        }),
+                    )
                     .uniform_list(
                         "keymap-editor-table",
                         row_count,

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -30,6 +30,7 @@ use crate::{
 
 actions!(zed, [OpenKeymapEditor]);
 
+const KEYMAP_EDITOR_NAMESPACE: &'static str = "keymap_editor";
 actions!(keymap_editor, [EditBinding, CopyAction, CopyContext]);
 
 pub fn init(cx: &mut App) {
@@ -61,6 +62,7 @@ pub fn init(cx: &mut App) {
 
         command_palette_hooks::CommandPaletteFilter::update_global(cx, |filter, _cx| {
             filter.hide_action_types(&keymap_ui_actions);
+            filter.hide_namespace(KEYMAP_EDITOR_NAMESPACE);
         });
 
         cx.observe_flag::<SettingsUiFeatureFlag, _>(
@@ -71,6 +73,7 @@ pub fn init(cx: &mut App) {
                         cx,
                         |filter, _cx| {
                             filter.show_action_types(keymap_ui_actions.iter());
+                            filter.show_namespace(KEYMAP_EDITOR_NAMESPACE);
                         },
                     );
                 } else {
@@ -78,6 +81,7 @@ pub fn init(cx: &mut App) {
                         cx,
                         |filter, _cx| {
                             filter.hide_action_types(&keymap_ui_actions);
+                            filter.hide_namespace(KEYMAP_EDITOR_NAMESPACE);
                         },
                     );
                 }

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -562,7 +562,17 @@ impl Render for KeymapEditor {
 
                             let this = cx.entity();
                             right_click_menu(("keymap-table-row-menu", row_index))
-                                .trigger(|_| row)
+                                .trigger(move |is_menu_open: bool, _window, cx| {
+                                    if is_menu_open {
+                                        this.update(cx, |this, cx| {
+                                            if this.selected_index != Some(row_index) {
+                                                this.selected_index = Some(row_index);
+                                                cx.notify();
+                                            }
+                                        });
+                                    }
+                                    row
+                                })
                                 .menu(|window, cx| {
                                     ContextMenu::build(window, cx, |menu, _window, _cx| {
                                         menu.header("Context Menu")

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -17,8 +17,8 @@ use settings::KeybindSource;
 use util::ResultExt;
 
 use ui::{
-    ActiveTheme as _, App, BorrowAppContext, ParentElement as _, Render, SharedString, Styled as _,
-    Window, prelude::*,
+    ActiveTheme as _, App, BorrowAppContext, ContextMenu, ParentElement as _, Render, SharedString,
+    Styled as _, Window, prelude::*, right_click_menu,
 };
 use workspace::{Item, ModalView, SerializableItem, Workspace, register_serializable_item};
 
@@ -514,21 +514,6 @@ impl Render for KeymapEditor {
                     .striped()
                     .column_widths([rems(16.), rems(16.), rems(16.), rems(32.), rems(8.)])
                     .header(["Action", "Arguments", "Keystrokes", "Context", "Source"])
-                    .map_row(
-                        cx.processor(|this, (row_index, row): (usize, Div), _window, cx| {
-                            let is_selected = this.selected_index == Some(row_index);
-                            row.id(("keymap-table-row", row_index))
-                                .on_click(cx.listener(move |this, _event, _window, _cx| {
-                                    this.selected_index = Some(row_index);
-                                }))
-                                .border_2()
-                                .border_color(transparent_black())
-                                .when(is_selected, |row| {
-                                    row.border_color(cx.theme().colors().panel_focused_border)
-                                })
-                                .into_any_element()
-                        }),
-                    )
                     .uniform_list(
                         "keymap-editor-table",
                         row_count,
@@ -559,6 +544,31 @@ impl Render for KeymapEditor {
                                     Some([action, action_input, keystrokes, context, source])
                                 })
                                 .collect()
+                        }),
+                    )
+                    .map_row(
+                        cx.processor(|this, (row_index, row): (usize, Div), _window, cx| {
+                            let is_selected = this.selected_index == Some(row_index);
+                            let row = row
+                                .id(("keymap-table-row", row_index))
+                                .on_click(cx.listener(move |this, _event, _window, _cx| {
+                                    this.selected_index = Some(row_index);
+                                }))
+                                .border_2()
+                                .border_color(transparent_black())
+                                .when(is_selected, |row| {
+                                    row.border_color(cx.theme().colors().panel_focused_border)
+                                });
+
+                            let this = cx.entity();
+                            right_click_menu(("keymap-table-row-menu", row_index))
+                                .trigger(|_| row)
+                                .menu(|window, cx| {
+                                    ContextMenu::build(window, cx, |menu, _window, _cx| {
+                                        menu.header("Context Menu")
+                                    })
+                                })
+                                .into_any_element()
                         }),
                     ),
             )

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -503,8 +503,9 @@ impl ContextMenu {
         self
     }
 
-    pub fn disabled_action(
+    pub fn action_disabled_when(
         mut self,
+        disabled: bool,
         label: impl Into<SharedString>,
         action: Box<dyn Action>,
     ) -> Self {
@@ -522,7 +523,7 @@ impl ContextMenu {
             icon_size: IconSize::Small,
             icon_position: IconPosition::End,
             icon_color: None,
-            disabled: true,
+            disabled,
             documentation_aside: None,
             end_slot_icon: None,
             end_slot_title: None,

--- a/crates/ui/src/components/stories/context_menu.rs
+++ b/crates/ui/src/components/stories/context_menu.rs
@@ -47,12 +47,12 @@ impl Render for ContextMenuStory {
                     .justify_between()
                     .child(
                         right_click_menu("test2")
-                            .trigger(|_| Label::new("TOP LEFT"))
+                            .trigger(|_, _, _| Label::new("TOP LEFT"))
                             .menu(move |window, cx| build_menu(window, cx, "top left")),
                     )
                     .child(
                         right_click_menu("test1")
-                            .trigger(|_| Label::new("BOTTOM LEFT"))
+                            .trigger(|_, _, _| Label::new("BOTTOM LEFT"))
                             .anchor(Corner::BottomLeft)
                             .attach(Corner::TopLeft)
                             .menu(move |window, cx| build_menu(window, cx, "bottom left")),
@@ -65,13 +65,13 @@ impl Render for ContextMenuStory {
                     .justify_between()
                     .child(
                         right_click_menu("test3")
-                            .trigger(|_| Label::new("TOP RIGHT"))
+                            .trigger(|_, _, _| Label::new("TOP RIGHT"))
                             .anchor(Corner::TopRight)
                             .menu(move |window, cx| build_menu(window, cx, "top right")),
                     )
                     .child(
                         right_click_menu("test4")
-                            .trigger(|_| Label::new("BOTTOM RIGHT"))
+                            .trigger(|_, _, _| Label::new("BOTTOM RIGHT"))
                             .anchor(Corner::BottomRight)
                             .attach(Corner::TopRight)
                             .menu(move |window, cx| build_menu(window, cx, "bottom right")),

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -902,7 +902,7 @@ impl Render for PanelButtons {
                         })
                         .anchor(menu_anchor)
                         .attach(menu_attach)
-                        .trigger(move |is_active| {
+                        .trigger(move |is_active, _window, _cx| {
                             IconButton::new(name, icon)
                                 .icon_size(IconSize::Small)
                                 .toggle_state(is_active_button)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2521,7 +2521,7 @@ impl Pane {
         let pane = cx.entity().downgrade();
         let menu_context = item.item_focus_handle(cx);
         right_click_menu(ix)
-            .trigger(|_| tab)
+            .trigger(|_, _, _| tab)
             .menu(move |window, cx| {
                 let pane = pane.clone();
                 let menu_context = menu_context.clone();

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4311,6 +4311,7 @@ mod tests {
                 "icon_theme_selector",
                 "jj",
                 "journal",
+                "keymap_editor",
                 "language_selector",
                 "lsp_tool",
                 "markdown",

--- a/crates/zed/src/zed/quick_action_bar.rs
+++ b/crates/zed/src/zed/quick_action_bar.rs
@@ -258,18 +258,12 @@ impl Render for QuickActionBar {
                             .action("Next Problem", Box::new(GoToDiagnostic))
                             .action("Previous Problem", Box::new(GoToPreviousDiagnostic))
                             .separator()
-                            .map(|menu| {
-                                if has_diff_hunks {
-                                    menu.action("Next Hunk", Box::new(GoToHunk))
-                                        .action("Previous Hunk", Box::new(GoToPreviousHunk))
-                                } else {
-                                    menu.disabled_action("Next Hunk", Box::new(GoToHunk))
-                                        .disabled_action(
-                                            "Previous Hunk",
-                                            Box::new(GoToPreviousHunk),
-                                        )
-                                }
-                            })
+                            .action_disabled_when(!has_diff_hunks, "Next Hunk", Box::new(GoToHunk))
+                            .action_disabled_when(
+                                !has_diff_hunks,
+                                "Previous Hunk",
+                                Box::new(GoToPreviousHunk),
+                            )
                             .separator()
                             .action("Move Line Up", Box::new(MoveLineUp))
                             .action("Move Line Down", Box::new(MoveLineDown))


### PR DESCRIPTION
Closes #ISSUE

Adds a right click context menu to table rows, refactoring the table API to support more general row rendering in the process, and creating actions for the couple of operations available in the context menu.

Additionally includes an only partially related change to the context menu API, which makes it easier to have actions that are disabled based on a boolean value.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
