### PR TITLE
Tweak Windows development instructions

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -8,13 +8,12 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ## Dependencies
 
-- Install [rustup](https://www.rust-lang.org/tools/install)
-
 - Install either [Visual Studio](https://visualstudio.microsoft.com/downloads/) with the optional components `MSVC v*** - VS YYYY C++ x64/x86 build tools` and `MSVC v*** - VS YYYY C++ x64/x86 Spectre-mitigated libs (latest)` (`v***` is your VS version and `YYYY` is year when your VS was released. Pay attention to the architecture and change it to yours if needed.)
 - Or, if you prefer to have a slimmer installer of only the MSVC compiler tools, you can install the [build tools](https://visualstudio.microsoft.com/visual-cpp-build-tools/) (+libs as above) and the "Desktop development with C++" workload.
   But beware this installation is not automatically picked up by rustup. You must initialize your environment variables by first launching the "developer" shell (cmd/powershell) this installation places in the start menu or in Windows Terminal and then compile.
+- Install [rustup](https://www.rust-lang.org/tools/install).
 - Install Windows 11 or 10 SDK depending on your system, but ensure that at least `Windows 10 SDK version 2104 (10.0.20348.0)` is installed on your machine. You can download it from the [Windows SDK Archive](https://developer.microsoft.com/windows/downloads/windows-sdk/)
-- Install [CMake](https://cmake.org/download) (required by [a dependency](https://docs.rs/wasmtime-c-api-impl/latest/wasmtime_c_api/)). Or you can install it through Visual Studio Installer, then manually add the `bin` directory to your `PATH`, for example: `C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`.
+- Install [CMake](https://cmake.org/download) (required by [a dependency](https://docs.rs/wasmtime-c-api-impl/latest/wasmtime_c_api/)), if it was not installed by the Visual Studio Installer. (If you used the Visual Studio Installer, you may need to manually add the `bin` directory to your `PATH`, for example: `C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\CMake\CMake\bin`.)
 
 If you can't compile Zed, make sure that you have at least the following components installed in case of a Visual Studio installation:
 


### PR DESCRIPTION
I just went through these on my new machine and found:

- rustup depends on some of the Visual Studio development tools, so we might as well put that step first (I gather rustup can also install those dependencies itself, but it seems like we probably need the Visual Studio Installer step anyway for our own reasons, although I didn't verify this.)
- I was able to install CMake using the Visual Studio Installer, and I didn't need to mess with `$PATH` except by using the "Debugger Powershell" thingy as instructed.

Release Notes:

- N/A