### PR TITLE
helix: Enable case converting

### DIFF
--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -13,7 +13,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 }
 
 impl Vim {
-    fn normal_before(
+    pub fn normal_before(
         &mut self,
         action: &NormalBefore,
         window: &mut Window,

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -13,7 +13,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 }
 
 impl Vim {
-    pub fn normal_before(
+    fn normal_before(
         &mut self,
         action: &NormalBefore,
         window: &mut Window,

--- a/crates/vim/src/normal/convert.rs
+++ b/crates/vim/src/normal/convert.rs
@@ -1,5 +1,5 @@
 use collections::HashMap;
-use editor::{SelectionEffects, display_map::ToDisplayPoint, movement};
+use editor::{SelectionEffects, display_map::ToDisplayPoint};
 use gpui::{Context, Window};
 use language::{Bias, Point, SelectionGoal};
 use multi_buffer::MultiBufferRow;

--- a/crates/vim/src/normal/convert.rs
+++ b/crates/vim/src/normal/convert.rs
@@ -212,7 +212,9 @@ impl Vim {
                         }
                     }
 
-                    Mode::HelixNormal => {}
+                    Mode::HelixNormal => {
+                        ranges.push(selection.start..selection.end);
+                    }
                     Mode::Insert | Mode::Normal | Mode::Replace => {
                         let start = selection.start;
                         let mut end = start;
@@ -240,9 +242,11 @@ impl Vim {
                         .collect::<String>();
                     editor.edit([(range, text)], cx)
                 }
-                editor.change_selections(Default::default(), window, cx, |s| {
-                    s.select_ranges(cursor_positions)
-                })
+                if !cursor_positions.is_empty() {
+                    editor.change_selections(Default::default(), window, cx, |s| {
+                        s.select_ranges(cursor_positions)
+                    })
+                }
             });
         });
         self.switch_mode(Mode::Normal, true, window, cx)

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1008,6 +1008,21 @@ impl Vim {
         });
     }
 
+    pub fn switch_to_normal_mode(
+        &mut self,
+        leave_selections: bool,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let mode = if HelixModeSetting::get_global(cx).0 {
+            Mode::HelixNormal
+        } else {
+            Mode::Normal
+        };
+
+        self.switch_mode(mode, leave_selections, window, cx);
+    }
+
     pub fn take_count(cx: &mut App) -> Option<usize> {
         let global_state = cx.global_mut::<VimGlobals>();
         if global_state.dot_replaying {


### PR DESCRIPTION
Closes #33750

Convert motions in helix mode link to a placeholder, which leads to a crash. This adds them just like they work in helix.

Release Notes:

- helix: Added text manipulation (like case converting)
