### PR TITLE
agent_ui: Clear error message callout when message is edited or added in same thread

### DIFF
--- a/crates/agent_ui/src/active_thread.rs
+++ b/crates/agent_ui/src/active_thread.rs
@@ -1026,6 +1026,7 @@ impl ActiveThread {
                 }
             }
             ThreadEvent::MessageAdded(message_id) => {
+                self.clear_last_error();
                 if let Some(rendered_message) = self.thread.update(cx, |thread, cx| {
                     thread.message(*message_id).map(|message| {
                         RenderedMessage::from_segments(
@@ -1042,6 +1043,7 @@ impl ActiveThread {
                 cx.notify();
             }
             ThreadEvent::MessageEdited(message_id) => {
+                self.clear_last_error();
                 if let Some(index) = self.messages.iter().position(|id| id == message_id) {
                     if let Some(rendered_message) = self.thread.update(cx, |thread, cx| {
                         thread.message(*message_id).map(|message| {


### PR DESCRIPTION
Currently if error occurs in the agent thread and user updates the same messages or sends a new message the error callout is still present and is not cleared. In this PR we are clearing the last error in case user sends a new messages or resend the previous message after editing.

Before:

https://github.com/user-attachments/assets/44994004-4cf0-45bc-8b69-88546f037372

After:

https://github.com/user-attachments/assets/993a2a63-8295-47d3-bbda-a2669dee2d5f

Release Notes:

- Fix bug in agent panel error callout not getting removed when a message is edited or new a message is send.