### PR TITLE
remote_server: Improve error reporting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13560,6 +13560,7 @@ dependencies = [
  "smol",
  "sysinfo",
  "telemetry_events",
+ "thiserror 2.0.12",
  "toml 0.8.20",
  "unindent",
  "util",

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -65,6 +65,7 @@ telemetry_events.workspace = true
 util.workspace = true
 watch.workspace = true
 worktree.workspace = true
+thiserror.workspace = true
 
 [target.'cfg(not(windows))'.dependencies]
 crashes.workspace = true

--- a/crates/remote_server/src/main.rs
+++ b/crates/remote_server/src/main.rs
@@ -1,6 +1,7 @@
 #![cfg_attr(target_os = "windows", allow(unused, dead_code))]
 
-use clap::{Parser, Subcommand};
+use clap::Parser;
+use remote_server::Commands;
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -21,29 +22,6 @@ struct Cli {
     printenv: bool,
 }
 
-#[derive(Subcommand)]
-enum Commands {
-    Run {
-        #[arg(long)]
-        log_file: PathBuf,
-        #[arg(long)]
-        pid_file: PathBuf,
-        #[arg(long)]
-        stdin_socket: PathBuf,
-        #[arg(long)]
-        stdout_socket: PathBuf,
-        #[arg(long)]
-        stderr_socket: PathBuf,
-    },
-    Proxy {
-        #[arg(long)]
-        reconnect: bool,
-        #[arg(long)]
-        identifier: String,
-    },
-    Version,
-}
-
 #[cfg(windows)]
 fn main() {
     unimplemented!()
@@ -51,11 +29,6 @@ fn main() {
 
 #[cfg(not(windows))]
 fn main() -> anyhow::Result<()> {
-    use anyhow::Context;
-    use release_channel::{RELEASE_CHANNEL, ReleaseChannel};
-    use remote::proxy::ProxyLaunchError;
-    use remote_server::unix::{execute_proxy, execute_run};
-
     let cli = Cli::parse();
 
     if let Some(socket_path) = &cli.askpass {
@@ -73,51 +46,9 @@ fn main() -> anyhow::Result<()> {
         return Ok(());
     }
 
-    match cli.command {
-        Some(Commands::Run {
-            log_file,
-            pid_file,
-            stdin_socket,
-            stdout_socket,
-            stderr_socket,
-        }) => execute_run(
-            log_file,
-            pid_file,
-            stdin_socket,
-            stdout_socket,
-            stderr_socket,
-        ),
-        Some(Commands::Proxy {
-            identifier,
-            reconnect,
-        }) => match execute_proxy(identifier, reconnect) {
-            Ok(_) => Ok(()),
-            Err(err) => {
-                if let Some(err) = err.downcast_ref::<ProxyLaunchError>() {
-                    std::process::exit(err.to_exit_code());
-                }
-                Err(err)
-            }
-        },
-        Some(Commands::Version) => {
-            let release_channel = *RELEASE_CHANNEL;
-            match release_channel {
-                ReleaseChannel::Stable | ReleaseChannel::Preview => {
-                    println!("{}", env!("ZED_PKG_VERSION"))
-                }
-                ReleaseChannel::Nightly | ReleaseChannel::Dev => {
-                    println!(
-                        "{}",
-                        option_env!("ZED_COMMIT_SHA").unwrap_or(release_channel.dev_name())
-                    )
-                }
-            };
-            std::process::exit(0);
-        }
-        None => {
-            eprintln!("usage: remote <run|proxy|version>");
-            std::process::exit(1);
-        }
+    if let Some(command) = cli.command {
+        remote_server::run(command)
+    } else {
+        Err(anyhow::anyhow!("usage: remote <run|proxy|version>"))
     }
-    .context("exiting remote server due to error")
 }

--- a/crates/remote_server/src/main.rs
+++ b/crates/remote_server/src/main.rs
@@ -49,6 +49,7 @@ fn main() -> anyhow::Result<()> {
     if let Some(command) = cli.command {
         remote_server::run(command)
     } else {
-        Err(anyhow::anyhow!("usage: remote <run|proxy|version>"))
+        eprintln!("usage: remote <run|proxy|version>");
+        std::process::exit(1);
     }
 }

--- a/crates/remote_server/src/remote_server.rs
+++ b/crates/remote_server/src/remote_server.rs
@@ -6,4 +6,79 @@ pub mod unix;
 #[cfg(test)]
 mod remote_editing_tests;
 
+use clap::Subcommand;
+use std::path::PathBuf;
+
 pub use headless_project::{HeadlessAppState, HeadlessProject};
+
+#[derive(Subcommand)]
+pub enum Commands {
+    Run {
+        #[arg(long)]
+        log_file: PathBuf,
+        #[arg(long)]
+        pid_file: PathBuf,
+        #[arg(long)]
+        stdin_socket: PathBuf,
+        #[arg(long)]
+        stdout_socket: PathBuf,
+        #[arg(long)]
+        stderr_socket: PathBuf,
+    },
+    Proxy {
+        #[arg(long)]
+        reconnect: bool,
+        #[arg(long)]
+        identifier: String,
+    },
+    Version,
+}
+
+#[cfg(not(windows))]
+pub fn run(command: Commands) -> anyhow::Result<()> {
+    use anyhow::Context;
+    use release_channel::{RELEASE_CHANNEL, ReleaseChannel};
+    use remote::proxy::ProxyLaunchError;
+    use unix::{execute_proxy, execute_run};
+
+    match command {
+        Commands::Run {
+            log_file,
+            pid_file,
+            stdin_socket,
+            stdout_socket,
+            stderr_socket,
+        } => execute_run(
+            log_file,
+            pid_file,
+            stdin_socket,
+            stdout_socket,
+            stderr_socket,
+        ),
+        Commands::Proxy {
+            identifier,
+            reconnect,
+        } => execute_proxy(identifier, reconnect)
+            .inspect_err(|err| {
+                if let Some(err) = err.downcast_ref::<ProxyLaunchError>() {
+                    std::process::exit(err.to_exit_code());
+                }
+            })
+            .context("running proxy on the remote server"),
+        Commands::Version => {
+            let release_channel = *RELEASE_CHANNEL;
+            match release_channel {
+                ReleaseChannel::Stable | ReleaseChannel::Preview => {
+                    println!("{}", env!("ZED_PKG_VERSION"))
+                }
+                ReleaseChannel::Nightly | ReleaseChannel::Dev => {
+                    println!(
+                        "{}",
+                        option_env!("ZED_COMMIT_SHA").unwrap_or(release_channel.dev_name())
+                    )
+                }
+            };
+            Ok(())
+        }
+    }
+}

--- a/crates/remote_server/src/remote_server.rs
+++ b/crates/remote_server/src/remote_server.rs
@@ -38,8 +38,7 @@ pub enum Commands {
 pub fn run(command: Commands) -> anyhow::Result<()> {
     use anyhow::Context;
     use release_channel::{RELEASE_CHANNEL, ReleaseChannel};
-    use remote::proxy::ProxyLaunchError;
-    use unix::{execute_proxy, execute_run};
+    use unix::{ExecuteProxyError, execute_proxy, execute_run};
 
     match command {
         Commands::Run {
@@ -60,7 +59,7 @@ pub fn run(command: Commands) -> anyhow::Result<()> {
             reconnect,
         } => execute_proxy(identifier, reconnect)
             .inspect_err(|err| {
-                if let Some(err) = err.downcast_ref::<ProxyLaunchError>() {
+                if let ExecuteProxyError::ServerNotRunning(err) = err {
                     std::process::exit(err.to_exit_code());
                 }
             })

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -789,9 +789,8 @@ fn spawn_server(paths: &ServerPaths) -> Result<(), SpawnServerError> {
         return Err(SpawnServerError::LaunchStatus {
             status,
             paths: format!(
-                "log file: {}, pid file: {}",
-                paths.log_file.display(),
-                paths.pid_file.display()
+                "log file: {:?}, pid file: {:?}",
+                paths.log_file, paths.pid_file,
             ),
         });
     }

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -526,7 +526,7 @@ pub fn execute_run(
     Ok(())
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct ServerPaths {
     log_file: PathBuf,
     pid_file: PathBuf,


### PR DESCRIPTION
Closes #33736

Use `thiserror` to implement error stack and `anyhow` to report is to user.
Also move some code from main to remote_server to have better crate isolation.

Release Notes:

- N/A
