### PR TITLE
editor: Reapply fix for wrap guide positioning

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -5238,8 +5238,8 @@ impl EditorElement {
                     paint_highlight(range.start, range.end, color, edges);
                 }
 
-                let scroll_left =
-                    layout.position_map.snapshot.scroll_position().x * layout.position_map.em_width;
+                let scroll_left = layout.position_map.snapshot.scroll_position().x
+                    * layout.position_map.em_advance;
 
                 for (wrap_position, active) in layout.wrap_guides.iter() {
                     let x = (layout.position_map.text_hitbox.origin.x
@@ -6676,7 +6676,7 @@ impl EditorElement {
                         let position_map: &PositionMap = &position_map;
 
                         let line_height = position_map.line_height;
-                        let max_glyph_width = position_map.em_width;
+                        let max_glyph_advance = position_map.em_advance;
                         let (delta, axis) = match delta {
                             gpui::ScrollDelta::Pixels(mut pixels) => {
                                 //Trackpad
@@ -6687,15 +6687,15 @@ impl EditorElement {
                             gpui::ScrollDelta::Lines(lines) => {
                                 //Not trackpad
                                 let pixels =
-                                    point(lines.x * max_glyph_width, lines.y * line_height);
+                                    point(lines.x * max_glyph_advance, lines.y * line_height);
                                 (pixels, None)
                             }
                         };
 
                         let current_scroll_position = position_map.snapshot.scroll_position();
-                        let x = (current_scroll_position.x * max_glyph_width
+                        let x = (current_scroll_position.x * max_glyph_advance
                             - (delta.x * scroll_sensitivity))
-                            / max_glyph_width;
+                            / max_glyph_advance;
                         let y = (current_scroll_position.y * line_height
                             - (delta.y * scroll_sensitivity))
                             / line_height;
@@ -8591,7 +8591,7 @@ impl Element for EditorElement {
                                 start_row,
                                 editor_content_width,
                                 scroll_width,
-                                em_width,
+                                em_advance,
                                 &line_layouts,
                                 cx,
                             )

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -2657,18 +2657,18 @@ impl EditorElement {
 
     fn layout_wrap_guides(
         &self,
-        em_width: Pixels,
         em_advance: Pixels,
         scroll_position: gpui::Point<f32>,
+        content_origin: gpui::Point<Pixels>,
         scrollbar_layout: Option<&EditorScrollbars>,
         vertical_scrollbar_width: Pixels,
-        text_hitbox: &Hitbox,
         hitbox: &Hitbox,
         window: &Window,
         cx: &App,
     ) -> SmallVec<[(Pixels, bool); 2]> {
         let scroll_left = scroll_position.x * em_advance;
-        let horizontal_offset = text_hitbox.origin.x + em_width / 2. - scroll_left;
+        let content_origin = content_origin.x;
+        let horizontal_offset = content_origin - scroll_left;
         let vertical_scrollbar_width = scrollbar_layout
             .and_then(|layout| layout.visible.then_some(vertical_scrollbar_width))
             .unwrap_or_default();
@@ -2680,7 +2680,7 @@ impl EditorElement {
             .flat_map(|(guide, active)| {
                 let wrap_position = self.column_pixels(guide, window);
                 let wrap_guide_x = wrap_position + horizontal_offset;
-                let display_wrap_guide = wrap_guide_x >= text_hitbox.origin.x
+                let display_wrap_guide = wrap_guide_x >= content_origin
                     && wrap_guide_x <= hitbox.bounds.right() - vertical_scrollbar_width;
 
                 display_wrap_guide.then_some((wrap_guide_x, active))
@@ -8793,12 +8793,11 @@ impl Element for EditorElement {
                     });
 
                     let wrap_guides = self.layout_wrap_guides(
-                        em_width,
                         em_advance,
                         scroll_position,
+                        content_origin,
                         scrollbars_layout.as_ref(),
                         vertical_scrollbar_width,
-                        &text_hitbox,
                         &hitbox,
                         window,
                         cx,


### PR DESCRIPTION
Reapplies the fix from #33514 which was removed in #33554. Wrap guides are currently drifting again due to this on main.

Slightly changed the approach here so that we now actually only save the wrap guides in the `EditorLayout` that will actually be painted. Also ensures that we paint indent guides that were previously hidden behind the vertical scrollbar once it auto-hides.

I wanted to add tests for this, however, I am rather sure this depends on the work/fixes in #33590 and thus I'd prefer to add these later so we can have this fix in the next release.

Release Notes:

- N/A