### PR TITLE
TOML formating with taplo : add config & ci

### DIFF
--- a/.github/actions/toml_fmt/action.yml
+++ b/.github/actions/toml_fmt/action.yml
@@ -1,0 +1,17 @@
+name: "Check TOML formatting"
+description: "Checks toml  formatting use taplo"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Install Taplo
+      env:
+        version: "0.10.0"
+      run: |
+        curl -Ls "https://github.com/tamasfe/taplo/releases/download/${{ env.version }}/taplo-full-linux-x86_64.gz" | \
+        gzip -d > taplo && \
+        chmod +x taplo && \
+        sudo mv taplo /usr/local/bin/taplo
+    - name: run taplo
+      shell: bash -euxo pipefail {0}
+      run: taplo format --check --colors never

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,9 @@ jobs:
       - name: Run style checks
         uses: ./.github/actions/check_style
 
+      - name: Run TOML fmt checks
+        uses: ./.github/actions/toml_fmt
+
       - name: Check for typos
         uses: crate-ci/typos@8e6a4285bcbde632c5d79900a7779746e8b7ea3f # v1.24.6
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -480,7 +480,7 @@ json_dotpath = "1.1"
 jsonschema = "0.30.0"
 jsonwebtoken = "9.3"
 jupyter-protocol = { git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734" }
-jupyter-websocket-client = {  git = "https://github.com/ConradIrwin/runtimed" ,rev = "7130c804216b6914355d15d0b91ea91f6babd734" }
+jupyter-websocket-client = { git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734" }
 libc = "0.2"
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
 linkify = "0.10.0"
@@ -491,7 +491,7 @@ metal = "0.29"
 moka = { version = "0.12.10", features = ["sync"] }
 naga = { version = "25.0", features = ["wgsl-in"] }
 nanoid = "0.4"
-nbformat = {  git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734" }
+nbformat = { git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734" }
 nix = "0.29"
 num-format = "0.4.4"
 objc = "0.2"
@@ -531,7 +531,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "951c77
     "stream",
 ] }
 rsa = "0.9.6"
-runtimelib = {  git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734", default-features = false, features = [
+runtimelib = { git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734", default-features = false, features = [
     "async-dispatcher-runtime",
 ] }
 rust-embed = { version = "8.4", features = ["include-exclude"] }

--- a/crates/assistant_tools/Cargo.toml
+++ b/crates/assistant_tools/Cargo.toml
@@ -81,7 +81,7 @@ pretty_assertions.workspace = true
 reqwest_client.workspace = true
 settings = { workspace = true, features = ["test-support"] }
 smol.workspace = true
-task = { workspace = true, features = ["test-support"]}
+task = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true
 theme.workspace = true
 tree-sitter-rust.workspace = true

--- a/crates/bedrock/Cargo.toml
+++ b/crates/bedrock/Cargo.toml
@@ -17,8 +17,10 @@ schemars = ["dep:schemars"]
 
 [dependencies]
 anyhow.workspace = true
-aws-sdk-bedrockruntime = { workspace = true, features = ["behavior-version-latest"] }
-aws-smithy-types = {workspace = true}
+aws-sdk-bedrockruntime = { workspace = true, features = [
+    "behavior-version-latest",
+] }
+aws-smithy-types = { workspace = true }
 futures.workspace = true
 schemars = { workspace = true, optional = true }
 serde.workspace = true

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -19,7 +19,7 @@ test-support = [
     "gpui/test-support",
     "livekit_client/test-support",
     "project/test-support",
-    "util/test-support"
+    "util/test-support",
 ]
 
 [dependencies]

--- a/crates/channel/Cargo.toml
+++ b/crates/channel/Cargo.toml
@@ -13,7 +13,11 @@ path = "src/channel.rs"
 doctest = false
 
 [features]
-test-support = ["collections/test-support", "gpui/test-support", "rpc/test-support"]
+test-support = [
+    "collections/test-support",
+    "gpui/test-support",
+    "rpc/test-support",
+]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -13,12 +13,20 @@ path = "src/client.rs"
 doctest = false
 
 [features]
-test-support = ["clock/test-support", "collections/test-support", "gpui/test-support", "rpc/test-support"]
+test-support = [
+    "clock/test-support",
+    "collections/test-support",
+    "gpui/test-support",
+    "rpc/test-support",
+]
 
 [dependencies]
 anyhow.workspace = true
 async-recursion = "0.3"
-async-tungstenite = { workspace = true, features = ["tokio", "tokio-rustls-manual-roots"] }
+async-tungstenite = { workspace = true, features = [
+    "tokio",
+    "tokio-rustls-manual-roots",
+] }
 base64.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 clock.workspace = true
@@ -51,7 +59,9 @@ text.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tiny_http.workspace = true
-tokio-socks = { version = "0.5.2", default-features = false, features = ["futures-io"] }
+tokio-socks = { version = "0.5.2", default-features = false, features = [
+    "futures-io",
+] }
 url.workspace = true
 util.workspace = true
 worktree.workspace = true
@@ -81,4 +91,7 @@ tokio-native-tls = "0.3"
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos")))'.dependencies]
 rustls-pki-types = "1.12"
-tokio-rustls = { version = "0.26", features = ["tls12", "ring"], default-features = false }
+tokio-rustls = { version = "0.26", features = [
+    "tls12",
+    "ring",
+], default-features = false }

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -50,14 +50,26 @@ reqwest_client.workspace = true
 rpc.workspace = true
 rustc-demangle.workspace = true
 scrypt = "0.11"
-sea-orm = { version = "1.1.0-rc.1", features = ["sqlx-postgres", "postgres-array", "runtime-tokio-rustls", "with-uuid"] }
+sea-orm = { version = "1.1.0-rc.1", features = [
+    "sqlx-postgres",
+    "postgres-array",
+    "runtime-tokio-rustls",
+    "with-uuid",
+] }
 semantic_version.workspace = true
 semver.workspace = true
 serde.workspace = true
 serde_derive.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "any"] }
+sqlx = { version = "0.8", features = [
+    "runtime-tokio-rustls",
+    "postgres",
+    "json",
+    "time",
+    "uuid",
+    "any",
+] }
 strum.workspace = true
 subtle.workspace = true
 supermaven_api.workspace = true
@@ -70,7 +82,12 @@ toml.workspace = true
 tower = "0.4"
 tower-http = { workspace = true, features = ["trace"] }
 tracing = "0.1.40"
-tracing-subscriber = { version = "0.3.18", features = ["env-filter", "json", "registry", "tracing-log"] } # workaround for https://github.com/tokio-rs/tracing/issues/2927
+tracing-subscriber = { version = "0.3.18", features = [
+    "env-filter",
+    "json",
+    "registry",
+    "tracing-log",
+] } # workaround for https://github.com/tokio-rs/tracing/issues/2927
 util.workspace = true
 uuid.workspace = true
 workspace-hack.workspace = true
@@ -107,7 +124,7 @@ hyper.workspace = true
 indoc.workspace = true
 language = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
-livekit_client =  { workspace = true, features = ["test-support"] }
+livekit_client = { workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features = ["test-support"] }
 menu.workspace = true
 multi_buffer = { workspace = true, features = ["test-support"] }

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -22,7 +22,7 @@ test-support = [
     "util/test-support",
     "workspace/test-support",
     "unindent",
-    "debugger_tools"
+    "debugger_tools",
 ]
 
 [dependencies]

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -43,7 +43,7 @@ editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
 markdown = { workspace = true, features = ["test-support"] }
-lsp = { workspace = true, features=["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 serde_json.workspace = true
 theme = { workspace = true, features = ["test-support"] }
 unindent.workspace = true

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -95,7 +95,7 @@ workspace-hack.workspace = true
 ctor.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }
-languages = {workspace = true, features = ["test-support"] }
+languages = { workspace = true, features = ["test-support"] }
 lsp = { workspace = true, features = ["test-support"] }
 markdown = { workspace = true, features = ["test-support"] }
 multi_buffer = { workspace = true, features = ["test-support"] }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -10,7 +10,7 @@ workspace = true
 
 [features]
 test-support = [
-    "load-grammars"
+    "load-grammars",
 ]
 load-grammars = [
     "tree-sitter",

--- a/crates/livekit_client/Cargo.toml
+++ b/crates/livekit_client/Cargo.toml
@@ -42,7 +42,7 @@ workspace-hack.workspace = true
 [target.'cfg(not(any(all(target_os = "windows", target_env = "gnu"), target_os = "freebsd")))'.dependencies]
 libwebrtc = { rev = "d2eade7a6b15d6dbdb38ba12a1ff7bf07fcebba4", git = "https://github.com/zed-industries/livekit-rust-sdks" }
 livekit = { rev = "d2eade7a6b15d6dbdb38ba12a1ff7bf07fcebba4", git = "https://github.com/zed-industries/livekit-rust-sdks", features = [
-    "__rustls-tls"
+    "__rustls-tls",
 ] }
 
 [target.'cfg(any(target_os = "linux", target_os = "freebsd"))'.dependencies]

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -15,7 +15,7 @@ doctest = false
 [features]
 test-support = [
     "gpui/test-support",
-    "util/test-support"
+    "util/test-support",
 ]
 
 [dependencies]

--- a/crates/prettier/Cargo.toml
+++ b/crates/prettier/Cargo.toml
@@ -32,6 +32,6 @@ util.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-fs = { workspace = true,  features = ["test-support"] }
+fs = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 language = { workspace = true, features = ["test-support"] }

--- a/crates/remote/Cargo.toml
+++ b/crates/remote/Cargo.toml
@@ -32,7 +32,7 @@ paths.workspace = true
 prost.workspace = true
 release_channel.workspace = true
 rpc = { workspace = true, features = ["gpui"] }
-schemars.workspace =  true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shlex.workspace = true

--- a/crates/remote_server/Cargo.toml
+++ b/crates/remote_server/Cargo.toml
@@ -85,7 +85,7 @@ node_runtime = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
 remote = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
-lsp = { workspace = true, features=["test-support"] }
+lsp = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 serde_json.workspace = true
 zlog.workspace = true

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -16,7 +16,10 @@ doctest = false
 alacritty_terminal.workspace = true
 anyhow.workspace = true
 async-dispatcher.workspace = true
-async-tungstenite = { workspace = true, features = ["tokio", "tokio-rustls-manual-roots"] }
+async-tungstenite = { workspace = true, features = [
+    "tokio",
+    "tokio-rustls-manual-roots",
+] }
 base64.workspace = true
 client.workspace = true
 collections.workspace = true

--- a/crates/rpc/Cargo.toml
+++ b/crates/rpc/Cargo.toml
@@ -15,7 +15,11 @@ doctest = false
 
 [features]
 gpui = ["dep:gpui"]
-test-support = ["collections/test-support", "gpui/test-support", "proto/test-support"]
+test-support = [
+    "collections/test-support",
+    "gpui/test-support",
+    "proto/test-support",
+]
 
 [dependencies]
 anyhow.workspace = true

--- a/crates/task/Cargo.toml
+++ b/crates/task/Cargo.toml
@@ -8,7 +8,7 @@ license = "GPL-3.0-or-later"
 [features]
 test-support = [
     "gpui/test-support",
-    "util/test-support"
+    "util/test-support",
 ]
 
 [lints]

--- a/crates/theme_importer/Cargo.toml
+++ b/crates/theme_importer/Cargo.toml
@@ -18,7 +18,7 @@ palette.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
-simplelog.workspace= true
+simplelog.workspace = true
 strum = { workspace = true, features = ["derive"] }
 theme.workspace = true
 vscode_theme = "0.2.0"

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -30,7 +30,9 @@ itertools.workspace = true
 language.workspace = true
 log.workspace = true
 multi_buffer.workspace = true
-nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", rev = "764dd270c642f77f10f3e19d05cc178a6cbe69f3", features = ["use_tokio"], optional = true }
+nvim-rs = { git = "https://github.com/KillTheMule/nvim-rs", rev = "764dd270c642f77f10f3e19d05cc178a6cbe69f3", features = [
+    "use_tokio",
+], optional = true }
 picker.workspace = true
 project.workspace = true
 regex.workspace = true

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,7 +1,7 @@
 [toolchain]
 channel = "1.88"
 profile = "minimal"
-components = [ "rustfmt", "clippy" ]
+components = ["rustfmt", "clippy"]
 targets = [
     "x86_64-apple-darwin",
     "aarch64-apple-darwin",

--- a/taplo.toml
+++ b/taplo.toml
@@ -1,0 +1,6 @@
+include = ["**/Cargo.toml", "rust-toolchain.toml"]
+
+[formatting]
+align_comments = false
+array_auto_collapse = false
+indent_string = "    "

--- a/tooling/workspace-hack/Cargo.toml
+++ b/tooling/workspace-hack/Cargo.toml
@@ -19,37 +19,100 @@ ahash = { version = "0.8", features = ["serde"] }
 aho-corasick = { version = "1" }
 anstream = { version = "0.6" }
 arrayvec = { version = "0.7", features = ["serde"] }
-async-compression = { version = "0.4", default-features = false, features = ["deflate", "deflate64", "futures-io", "gzip"] }
+async-compression = { version = "0.4", default-features = false, features = [
+    "deflate",
+    "deflate64",
+    "futures-io",
+    "gzip",
+] }
 async-std = { version = "1", features = ["attributes", "unstable"] }
-async-tungstenite = { version = "0.29", features = ["tokio-rustls-manual-roots"] }
+async-tungstenite = { version = "0.29", features = [
+    "tokio-rustls-manual-roots",
+] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-credential-types = { version = "1", default-features = false, features = ["hardcoded-credentials", "test-util"] }
-aws-runtime = { version = "1", default-features = false, features = ["event-stream", "http-02x", "sigv4a"] }
-aws-sigv4 = { version = "1", features = ["http0-compat", "sign-eventstream", "sigv4a"] }
-aws-smithy-async = { version = "1", default-features = false, features = ["rt-tokio"] }
-aws-smithy-http = { version = "0.62", default-features = false, features = ["event-stream"] }
-aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio", "tls-rustls"] }
-aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "http-auth", "test-util"] }
-aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
+aws-credential-types = { version = "1", default-features = false, features = [
+    "hardcoded-credentials",
+    "test-util",
+] }
+aws-runtime = { version = "1", default-features = false, features = [
+    "event-stream",
+    "http-02x",
+    "sigv4a",
+] }
+aws-sigv4 = { version = "1", features = [
+    "http0-compat",
+    "sign-eventstream",
+    "sigv4a",
+] }
+aws-smithy-async = { version = "1", default-features = false, features = [
+    "rt-tokio",
+] }
+aws-smithy-http = { version = "0.62", default-features = false, features = [
+    "event-stream",
+] }
+aws-smithy-runtime = { version = "1", default-features = false, features = [
+    "client",
+    "default-https-client",
+    "rt-tokio",
+    "tls-rustls",
+] }
+aws-smithy-runtime-api = { version = "1", features = [
+    "client",
+    "http-02x",
+    "http-auth",
+    "test-util",
+] }
+aws-smithy-types = { version = "1", default-features = false, features = [
+    "byte-stream-poll-next",
+    "http-body-0-4-x",
+    "http-body-1-x",
+    "rt-tokio",
+    "test-util",
+] }
 base64 = { version = "0.22" }
 base64ct = { version = "1", default-features = false, features = ["std"] }
 bigdecimal = { version = "0.4", features = ["serde"] }
 bit-set = { version = "0.8", default-features = false, features = ["std"] }
 bit-vec = { version = "0.8", default-features = false, features = ["std"] }
-bitflags = { version = "2", default-features = false, features = ["serde", "std"] }
+bitflags = { version = "2", default-features = false, features = [
+    "serde",
+    "std",
+] }
 bstr = { version = "1" }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc"] }
+bytemuck = { version = "1", default-features = false, features = [
+    "aarch64_simd",
+    "derive",
+    "extern_crate_alloc",
+] }
 byteorder = { version = "1" }
 bytes = { version = "1" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["cargo", "derive", "string", "wrap_help"] }
-clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "std", "string", "suggestions", "usage", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = [
+    "cargo",
+    "color",
+    "std",
+    "string",
+    "suggestions",
+    "usage",
+    "wrap_help",
+] }
 concurrent-queue = { version = "2" }
-cranelift-codegen = { version = "0.116", default-features = false, features = ["host-arch", "incremental-cache", "std", "timing", "unwind"] }
+cranelift-codegen = { version = "0.116", default-features = false, features = [
+    "host-arch",
+    "incremental-cache",
+    "std",
+    "timing",
+    "unwind",
+] }
 crc32fast = { version = "1" }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
-deranged = { version = "0.4", default-features = false, features = ["powerfmt", "serde", "std"] }
+deranged = { version = "0.4", default-features = false, features = [
+    "powerfmt",
+    "serde",
+    "std",
+] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
 either = { version = "1", features = ["serde", "use_std"] }
 euclid = { version = "0.22" }
@@ -64,20 +127,37 @@ futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io-compat", "sink"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "std",
+] }
 half = { version = "2", features = ["num-traits"] }
 handlebars = { version = "4", features = ["rust-embed"] }
-hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = ["serde"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
+hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = [
+    "serde",
+] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = [
+    "raw",
+] }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
-hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
+hyper = { version = "0.14", features = [
+    "client",
+    "http1",
+    "http2",
+    "runtime",
+    "server",
+    "stream",
+] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 jiff = { version = "0.2" }
-lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
+lazy_static = { version = "1", default-features = false, features = [
+    "spin_no_std",
+] }
 libc = { version = "0.2", features = ["extra_traits"] }
 libsqlite3-sys = { version = "0.30", features = ["bundled", "unlock_notify"] }
-log = { version = "0.4", default-features = false, features = ["kv_unstable_serde"] }
+log = { version = "0.4", default-features = false, features = [
+    "kv_unstable_serde",
+] }
 lyon = { version = "1", default-features = false, features = ["extra"] }
 lyon_path = { version = "1" }
 md-5 = { version = "0.10" }
@@ -86,7 +166,10 @@ miniz_oxide = { version = "0.8", features = ["simd"] }
 nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
-num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
+num-iter = { version = "0.1", default-features = false, features = [
+    "i128",
+    "std",
+] }
 num-rational = { version = "0.4", features = ["num-bigint-std"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 once_cell = { version = "1" }
@@ -95,49 +178,141 @@ phf = { version = "0.11", features = ["macros"] }
 phf_shared = { version = "0.11" }
 prost = { version = "0.9" }
 prost-types = { version = "0.9" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = [
+    "small_rng",
+] }
 rand_chacha = { version = "0.3" }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regalloc2 = { version = "0.11", features = ["checker", "enable-serde"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4" }
 regex-syntax = { version = "0.8" }
-rust_decimal = { version = "1", default-features = false, features = ["maths", "serde", "std"] }
+rust_decimal = { version = "1", default-features = false, features = [
+    "maths",
+    "serde",
+    "std",
+] }
 rustc-hash = { version = "1" }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", default-features = false, features = ["fs", "net", "std"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", default-features = false, features = [
+    "fs",
+    "net",
+    "std",
+] }
 rustls = { version = "0.23", features = ["ring"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
-sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres", "sqlx-sqlite"] }
-sea-query-binder = { version = "0.7", default-features = false, features = ["postgres-array", "sqlx-postgres", "sqlx-sqlite", "with-bigdecimal", "with-chrono", "with-json", "with-rust_decimal", "with-time", "with-uuid"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+    "aws-lc-rs",
+    "ring",
+    "std",
+] }
+sea-orm = { version = "1", features = [
+    "runtime-tokio-rustls",
+    "sqlx-postgres",
+    "sqlx-sqlite",
+] }
+sea-query-binder = { version = "0.7", default-features = false, features = [
+    "postgres-array",
+    "sqlx-postgres",
+    "sqlx-sqlite",
+    "with-bigdecimal",
+    "with-chrono",
+    "with-json",
+    "with-rust_decimal",
+    "with-time",
+    "with-uuid",
+] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1", features = [
+    "alloc",
+    "preserve_order",
+    "raw_value",
+    "unbounded_depth",
+] }
 sha1 = { version = "0.10", features = ["compress"] }
 simd-adler32 = { version = "0.3" }
-smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
+smallvec = { version = "1", default-features = false, features = [
+    "const_new",
+    "serde",
+    "union",
+    "write",
+] }
 spin = { version = "0.9" }
-sqlx = { version = "0.8", features = ["bigdecimal", "chrono", "postgres", "runtime-tokio-rustls", "rust_decimal", "sqlite", "time", "uuid"] }
-sqlx-postgres = { version = "0.8", default-features = false, features = ["any", "bigdecimal", "chrono", "json", "migrate", "offline", "rust_decimal", "time", "uuid"] }
-sqlx-sqlite = { version = "0.8", default-features = false, features = ["any", "bundled", "chrono", "json", "migrate", "offline", "time", "uuid"] }
+sqlx = { version = "0.8", features = [
+    "bigdecimal",
+    "chrono",
+    "postgres",
+    "runtime-tokio-rustls",
+    "rust_decimal",
+    "sqlite",
+    "time",
+    "uuid",
+] }
+sqlx-postgres = { version = "0.8", default-features = false, features = [
+    "any",
+    "bigdecimal",
+    "chrono",
+    "json",
+    "migrate",
+    "offline",
+    "rust_decimal",
+    "time",
+    "uuid",
+] }
+sqlx-sqlite = { version = "0.8", default-features = false, features = [
+    "any",
+    "bundled",
+    "chrono",
+    "json",
+    "migrate",
+    "offline",
+    "time",
+    "uuid",
+] }
 strum = { version = "0.26", features = ["derive"] }
 subtle = { version = "2" }
 thiserror = { version = "2" }
-time = { version = "0.3", features = ["local-offset", "macros", "serde-well-known"] }
+time = { version = "0.3", features = [
+    "local-offset",
+    "macros",
+    "serde-well-known",
+] }
 tokio = { version = "1", features = ["full"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "tls12",
+] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_edit = { version = "0.22", features = ["serde"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
-tungstenite = { version = "0.26", default-features = false, features = ["__rustls-tls", "handshake"] }
+tungstenite = { version = "0.26", default-features = false, features = [
+    "__rustls-tls",
+    "handshake",
+] }
 unicode-normalization = { version = "0.1" }
 unicode-properties = { version = "0.1" }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4", "v5", "v7"] }
 wasmparser = { version = "0.221" }
-wasmtime = { version = "29", default-features = false, features = ["async", "component-model", "cranelift", "demangle", "gc-drc", "incremental-cache", "parallel-compilation"] }
-wasmtime-cranelift = { version = "29", default-features = false, features = ["component-model", "gc-drc", "incremental-cache"] }
-wasmtime-environ = { version = "29", default-features = false, features = ["compile", "component-model", "demangle", "gc-drc"] }
+wasmtime = { version = "29", default-features = false, features = [
+    "async",
+    "component-model",
+    "cranelift",
+    "demangle",
+    "gc-drc",
+    "incremental-cache",
+    "parallel-compilation",
+] }
+wasmtime-cranelift = { version = "29", default-features = false, features = [
+    "component-model",
+    "gc-drc",
+    "incremental-cache",
+] }
+wasmtime-environ = { version = "29", default-features = false, features = [
+    "compile",
+    "component-model",
+    "demangle",
+    "gc-drc",
+] }
 winnow = { version = "0.7", features = ["simd"] }
 
 [build-dependencies]
@@ -145,38 +320,101 @@ ahash = { version = "0.8", features = ["serde"] }
 aho-corasick = { version = "1" }
 anstream = { version = "0.6" }
 arrayvec = { version = "0.7", features = ["serde"] }
-async-compression = { version = "0.4", default-features = false, features = ["deflate", "deflate64", "futures-io", "gzip"] }
+async-compression = { version = "0.4", default-features = false, features = [
+    "deflate",
+    "deflate64",
+    "futures-io",
+    "gzip",
+] }
 async-std = { version = "1", features = ["attributes", "unstable"] }
-async-tungstenite = { version = "0.29", features = ["tokio-rustls-manual-roots"] }
+async-tungstenite = { version = "0.29", features = [
+    "tokio-rustls-manual-roots",
+] }
 aws-config = { version = "1", features = ["behavior-version-latest"] }
-aws-credential-types = { version = "1", default-features = false, features = ["hardcoded-credentials", "test-util"] }
-aws-runtime = { version = "1", default-features = false, features = ["event-stream", "http-02x", "sigv4a"] }
-aws-sigv4 = { version = "1", features = ["http0-compat", "sign-eventstream", "sigv4a"] }
-aws-smithy-async = { version = "1", default-features = false, features = ["rt-tokio"] }
-aws-smithy-http = { version = "0.62", default-features = false, features = ["event-stream"] }
-aws-smithy-runtime = { version = "1", default-features = false, features = ["client", "default-https-client", "rt-tokio", "tls-rustls"] }
-aws-smithy-runtime-api = { version = "1", features = ["client", "http-02x", "http-auth", "test-util"] }
-aws-smithy-types = { version = "1", default-features = false, features = ["byte-stream-poll-next", "http-body-0-4-x", "http-body-1-x", "rt-tokio", "test-util"] }
+aws-credential-types = { version = "1", default-features = false, features = [
+    "hardcoded-credentials",
+    "test-util",
+] }
+aws-runtime = { version = "1", default-features = false, features = [
+    "event-stream",
+    "http-02x",
+    "sigv4a",
+] }
+aws-sigv4 = { version = "1", features = [
+    "http0-compat",
+    "sign-eventstream",
+    "sigv4a",
+] }
+aws-smithy-async = { version = "1", default-features = false, features = [
+    "rt-tokio",
+] }
+aws-smithy-http = { version = "0.62", default-features = false, features = [
+    "event-stream",
+] }
+aws-smithy-runtime = { version = "1", default-features = false, features = [
+    "client",
+    "default-https-client",
+    "rt-tokio",
+    "tls-rustls",
+] }
+aws-smithy-runtime-api = { version = "1", features = [
+    "client",
+    "http-02x",
+    "http-auth",
+    "test-util",
+] }
+aws-smithy-types = { version = "1", default-features = false, features = [
+    "byte-stream-poll-next",
+    "http-body-0-4-x",
+    "http-body-1-x",
+    "rt-tokio",
+    "test-util",
+] }
 base64 = { version = "0.22" }
 base64ct = { version = "1", default-features = false, features = ["std"] }
 bigdecimal = { version = "0.4", features = ["serde"] }
 bit-set = { version = "0.8", default-features = false, features = ["std"] }
 bit-vec = { version = "0.8", default-features = false, features = ["std"] }
-bitflags = { version = "2", default-features = false, features = ["serde", "std"] }
+bitflags = { version = "2", default-features = false, features = [
+    "serde",
+    "std",
+] }
 bstr = { version = "1" }
-bytemuck = { version = "1", default-features = false, features = ["aarch64_simd", "derive", "extern_crate_alloc"] }
+bytemuck = { version = "1", default-features = false, features = [
+    "aarch64_simd",
+    "derive",
+    "extern_crate_alloc",
+] }
 byteorder = { version = "1" }
 bytes = { version = "1" }
 cc = { version = "1", default-features = false, features = ["parallel"] }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4", features = ["cargo", "derive", "string", "wrap_help"] }
-clap_builder = { version = "4", default-features = false, features = ["cargo", "color", "std", "string", "suggestions", "usage", "wrap_help"] }
+clap_builder = { version = "4", default-features = false, features = [
+    "cargo",
+    "color",
+    "std",
+    "string",
+    "suggestions",
+    "usage",
+    "wrap_help",
+] }
 concurrent-queue = { version = "2" }
-cranelift-codegen = { version = "0.116", default-features = false, features = ["host-arch", "incremental-cache", "std", "timing", "unwind"] }
+cranelift-codegen = { version = "0.116", default-features = false, features = [
+    "host-arch",
+    "incremental-cache",
+    "std",
+    "timing",
+    "unwind",
+] }
 crc32fast = { version = "1" }
 crossbeam-epoch = { version = "0.9" }
 crossbeam-utils = { version = "0.8" }
-deranged = { version = "0.4", default-features = false, features = ["powerfmt", "serde", "std"] }
+deranged = { version = "0.4", default-features = false, features = [
+    "powerfmt",
+    "serde",
+    "std",
+] }
 digest = { version = "0.10", features = ["mac", "oid", "std"] }
 either = { version = "1", features = ["serde", "use_std"] }
 euclid = { version = "0.22" }
@@ -191,22 +429,39 @@ futures-io = { version = "0.3" }
 futures-sink = { version = "0.3" }
 futures-task = { version = "0.3", default-features = false, features = ["std"] }
 futures-util = { version = "0.3", features = ["channel", "io-compat", "sink"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["std"] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "std",
+] }
 half = { version = "2", features = ["num-traits"] }
 handlebars = { version = "4", features = ["rust-embed"] }
-hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = ["serde"] }
-hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = ["raw"] }
+hashbrown-3575ec1268b04181 = { package = "hashbrown", version = "0.15", features = [
+    "serde",
+] }
+hashbrown-582f2526e08bb6a0 = { package = "hashbrown", version = "0.14", features = [
+    "raw",
+] }
 heck = { version = "0.4", features = ["unicode"] }
 hmac = { version = "0.12", default-features = false, features = ["reset"] }
-hyper = { version = "0.14", features = ["client", "http1", "http2", "runtime", "server", "stream"] }
+hyper = { version = "0.14", features = [
+    "client",
+    "http1",
+    "http2",
+    "runtime",
+    "server",
+    "stream",
+] }
 idna = { version = "1" }
 indexmap = { version = "2", features = ["serde"] }
 itertools-594e8ee84c453af0 = { package = "itertools", version = "0.13" }
 jiff = { version = "0.2" }
-lazy_static = { version = "1", default-features = false, features = ["spin_no_std"] }
+lazy_static = { version = "1", default-features = false, features = [
+    "spin_no_std",
+] }
 libc = { version = "0.2", features = ["extra_traits"] }
 libsqlite3-sys = { version = "0.30", features = ["bundled", "unlock_notify"] }
-log = { version = "0.4", default-features = false, features = ["kv_unstable_serde"] }
+log = { version = "0.4", default-features = false, features = [
+    "kv_unstable_serde",
+] }
 lyon = { version = "1", default-features = false, features = ["extra"] }
 lyon_path = { version = "1" }
 md-5 = { version = "0.10" }
@@ -215,470 +470,1748 @@ miniz_oxide = { version = "0.8", features = ["simd"] }
 nom = { version = "7" }
 num-bigint = { version = "0.4" }
 num-integer = { version = "0.1", features = ["i128"] }
-num-iter = { version = "0.1", default-features = false, features = ["i128", "std"] }
+num-iter = { version = "0.1", default-features = false, features = [
+    "i128",
+    "std",
+] }
 num-rational = { version = "0.4", features = ["num-bigint-std"] }
 num-traits = { version = "0.2", features = ["i128", "libm"] }
 once_cell = { version = "1" }
 percent-encoding = { version = "2" }
 phf = { version = "0.11", features = ["macros"] }
 phf_shared = { version = "0.11" }
-prettyplease = { version = "0.2", default-features = false, features = ["verbatim"] }
+prettyplease = { version = "0.2", default-features = false, features = [
+    "verbatim",
+] }
 proc-macro2 = { version = "1" }
 prost = { version = "0.9" }
 prost-types = { version = "0.9" }
 quote = { version = "1" }
-rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = ["small_rng"] }
+rand-c38e5c1d305a1b54 = { package = "rand", version = "0.8", features = [
+    "small_rng",
+] }
 rand_chacha = { version = "0.3" }
 rand_core = { version = "0.6", default-features = false, features = ["std"] }
 regalloc2 = { version = "0.11", features = ["checker", "enable-serde"] }
 regex = { version = "1" }
 regex-automata = { version = "0.4" }
 regex-syntax = { version = "0.8" }
-rust_decimal = { version = "1", default-features = false, features = ["maths", "serde", "std"] }
+rust_decimal = { version = "1", default-features = false, features = [
+    "maths",
+    "serde",
+    "std",
+] }
 rustc-hash = { version = "1" }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", default-features = false, features = ["fs", "net", "std"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", default-features = false, features = [
+    "fs",
+    "net",
+    "std",
+] }
 rustls = { version = "0.23", features = ["ring"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["aws-lc-rs", "ring", "std"] }
-sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres", "sqlx-sqlite"] }
-sea-query-binder = { version = "0.7", default-features = false, features = ["postgres-array", "sqlx-postgres", "sqlx-sqlite", "with-bigdecimal", "with-chrono", "with-json", "with-rust_decimal", "with-time", "with-uuid"] }
+rustls-webpki = { version = "0.103", default-features = false, features = [
+    "aws-lc-rs",
+    "ring",
+    "std",
+] }
+sea-orm = { version = "1", features = [
+    "runtime-tokio-rustls",
+    "sqlx-postgres",
+    "sqlx-sqlite",
+] }
+sea-query-binder = { version = "0.7", default-features = false, features = [
+    "postgres-array",
+    "sqlx-postgres",
+    "sqlx-sqlite",
+    "with-bigdecimal",
+    "with-chrono",
+    "with-json",
+    "with-rust_decimal",
+    "with-time",
+    "with-uuid",
+] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
 serde_derive = { version = "1", features = ["deserialize_in_place"] }
-serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value", "unbounded_depth"] }
+serde_json = { version = "1", features = [
+    "alloc",
+    "preserve_order",
+    "raw_value",
+    "unbounded_depth",
+] }
 sha1 = { version = "0.10", features = ["compress"] }
 simd-adler32 = { version = "0.3" }
-smallvec = { version = "1", default-features = false, features = ["const_new", "serde", "union", "write"] }
+smallvec = { version = "1", default-features = false, features = [
+    "const_new",
+    "serde",
+    "union",
+    "write",
+] }
 spin = { version = "0.9" }
-sqlx = { version = "0.8", features = ["bigdecimal", "chrono", "postgres", "runtime-tokio-rustls", "rust_decimal", "sqlite", "time", "uuid"] }
-sqlx-macros = { version = "0.8", features = ["_rt-tokio", "_tls-rustls-ring-webpki", "bigdecimal", "chrono", "derive", "json", "macros", "migrate", "postgres", "rust_decimal", "sqlite", "time", "uuid"] }
-sqlx-macros-core = { version = "0.8", features = ["_rt-tokio", "_tls-rustls-ring-webpki", "bigdecimal", "chrono", "derive", "json", "macros", "migrate", "postgres", "rust_decimal", "sqlite", "time", "uuid"] }
-sqlx-postgres = { version = "0.8", default-features = false, features = ["any", "bigdecimal", "chrono", "json", "migrate", "offline", "rust_decimal", "time", "uuid"] }
-sqlx-sqlite = { version = "0.8", default-features = false, features = ["any", "bundled", "chrono", "json", "migrate", "offline", "time", "uuid"] }
+sqlx = { version = "0.8", features = [
+    "bigdecimal",
+    "chrono",
+    "postgres",
+    "runtime-tokio-rustls",
+    "rust_decimal",
+    "sqlite",
+    "time",
+    "uuid",
+] }
+sqlx-macros = { version = "0.8", features = [
+    "_rt-tokio",
+    "_tls-rustls-ring-webpki",
+    "bigdecimal",
+    "chrono",
+    "derive",
+    "json",
+    "macros",
+    "migrate",
+    "postgres",
+    "rust_decimal",
+    "sqlite",
+    "time",
+    "uuid",
+] }
+sqlx-macros-core = { version = "0.8", features = [
+    "_rt-tokio",
+    "_tls-rustls-ring-webpki",
+    "bigdecimal",
+    "chrono",
+    "derive",
+    "json",
+    "macros",
+    "migrate",
+    "postgres",
+    "rust_decimal",
+    "sqlite",
+    "time",
+    "uuid",
+] }
+sqlx-postgres = { version = "0.8", default-features = false, features = [
+    "any",
+    "bigdecimal",
+    "chrono",
+    "json",
+    "migrate",
+    "offline",
+    "rust_decimal",
+    "time",
+    "uuid",
+] }
+sqlx-sqlite = { version = "0.8", default-features = false, features = [
+    "any",
+    "bundled",
+    "chrono",
+    "json",
+    "migrate",
+    "offline",
+    "time",
+    "uuid",
+] }
 strum = { version = "0.26", features = ["derive"] }
 subtle = { version = "2" }
-syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = ["extra-traits", "full"] }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
+syn-dff4ba8e3ae991db = { package = "syn", version = "1", features = [
+    "extra-traits",
+    "full",
+] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = [
+    "extra-traits",
+    "fold",
+    "full",
+    "visit",
+    "visit-mut",
+] }
 thiserror = { version = "2" }
-time = { version = "0.3", features = ["local-offset", "macros", "serde-well-known"] }
-time-macros = { version = "0.2", default-features = false, features = ["formatting", "parsing", "serde"] }
+time = { version = "0.3", features = [
+    "local-offset",
+    "macros",
+    "serde-well-known",
+] }
+time-macros = { version = "0.2", default-features = false, features = [
+    "formatting",
+    "parsing",
+    "serde",
+] }
 tokio = { version = "1", features = ["full"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["tls12"] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "tls12",
+] }
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
 toml_edit = { version = "0.22", features = ["serde"] }
 tracing = { version = "0.1", features = ["log"] }
 tracing-core = { version = "0.1" }
-tungstenite = { version = "0.26", default-features = false, features = ["__rustls-tls", "handshake"] }
+tungstenite = { version = "0.26", default-features = false, features = [
+    "__rustls-tls",
+    "handshake",
+] }
 unicode-normalization = { version = "0.1" }
 unicode-properties = { version = "0.1" }
 url = { version = "2", features = ["serde"] }
 uuid = { version = "1", features = ["serde", "v4", "v5", "v7"] }
 wasmparser = { version = "0.221" }
-wasmtime = { version = "29", default-features = false, features = ["async", "component-model", "cranelift", "demangle", "gc-drc", "incremental-cache", "parallel-compilation"] }
-wasmtime-cranelift = { version = "29", default-features = false, features = ["component-model", "gc-drc", "incremental-cache"] }
-wasmtime-environ = { version = "29", default-features = false, features = ["compile", "component-model", "demangle", "gc-drc"] }
+wasmtime = { version = "29", default-features = false, features = [
+    "async",
+    "component-model",
+    "cranelift",
+    "demangle",
+    "gc-drc",
+    "incremental-cache",
+    "parallel-compilation",
+] }
+wasmtime-cranelift = { version = "29", default-features = false, features = [
+    "component-model",
+    "gc-drc",
+    "incremental-cache",
+] }
+wasmtime-environ = { version = "29", default-features = false, features = [
+    "compile",
+    "component-model",
+    "demangle",
+    "gc-drc",
+] }
 winnow = { version = "0.7", features = ["simd"] }
 
 [target.x86_64-apple-darwin.dependencies]
 codespan-reporting = { version = "0.12" }
 core-foundation = { version = "0.9" }
 core-foundation-sys = { version = "0.8" }
-coreaudio-sys = { version = "0.2", default-features = false, features = ["audio_toolbox", "audio_unit", "core_audio", "core_midi", "open_al"] }
+coreaudio-sys = { version = "0.2", default-features = false, features = [
+    "audio_toolbox",
+    "audio_unit",
+    "core_audio",
+    "core_midi",
+    "open_al",
+] }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 naga = { version = "25", features = ["msl-out", "wgsl-in"] }
 nix = { version = "0.29", features = ["fs", "pthread", "signal", "user"] }
 objc2 = { version = "0.6" }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFCGTypes", "CFData", "CFDate", "CFDictionary", "CFRunLoop", "CFString", "CFURL", "objc2", "std"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSArray", "NSAttributedString", "NSBundle", "NSCoder", "NSData", "NSDate", "NSDictionary", "NSEnumerator", "NSError", "NSGeometry", "NSNotification", "NSNull", "NSObjCRuntime", "NSObject", "NSProcessInfo", "NSRange", "NSRunLoop", "NSString", "NSURL", "NSUndoManager", "NSValue", "objc2-core-foundation", "std"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = [
+    "CFArray",
+    "CFCGTypes",
+    "CFData",
+    "CFDate",
+    "CFDictionary",
+    "CFRunLoop",
+    "CFString",
+    "CFURL",
+    "objc2",
+    "std",
+] }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "NSArray",
+    "NSAttributedString",
+    "NSBundle",
+    "NSCoder",
+    "NSData",
+    "NSDate",
+    "NSDictionary",
+    "NSEnumerator",
+    "NSError",
+    "NSGeometry",
+    "NSNotification",
+    "NSNull",
+    "NSObjCRuntime",
+    "NSObject",
+    "NSProcessInfo",
+    "NSRange",
+    "NSRunLoop",
+    "NSString",
+    "NSURL",
+    "NSUndoManager",
+    "NSValue",
+    "objc2-core-foundation",
+    "std",
+] }
 objc2-metal = { version = "0.3" }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
 security-framework = { version = "3", features = ["OSX_10_14"] }
 security-framework-sys = { version = "2", features = ["OSX_10_14"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 
 [target.x86_64-apple-darwin.build-dependencies]
-clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
+clang-sys = { version = "1", default-features = false, features = [
+    "clang_11_0",
+    "runtime",
+] }
 codespan-reporting = { version = "0.12" }
 core-foundation = { version = "0.9" }
 core-foundation-sys = { version = "0.8" }
-coreaudio-sys = { version = "0.2", default-features = false, features = ["audio_toolbox", "audio_unit", "core_audio", "core_midi", "open_al"] }
+coreaudio-sys = { version = "0.2", default-features = false, features = [
+    "audio_toolbox",
+    "audio_unit",
+    "core_audio",
+    "core_midi",
+    "open_al",
+] }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 naga = { version = "25", features = ["msl-out", "wgsl-in"] }
 nix = { version = "0.29", features = ["fs", "pthread", "signal", "user"] }
 objc2 = { version = "0.6" }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFCGTypes", "CFData", "CFDate", "CFDictionary", "CFRunLoop", "CFString", "CFURL", "objc2", "std"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSArray", "NSAttributedString", "NSBundle", "NSCoder", "NSData", "NSDate", "NSDictionary", "NSEnumerator", "NSError", "NSGeometry", "NSNotification", "NSNull", "NSObjCRuntime", "NSObject", "NSProcessInfo", "NSRange", "NSRunLoop", "NSString", "NSURL", "NSUndoManager", "NSValue", "objc2-core-foundation", "std"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = [
+    "CFArray",
+    "CFCGTypes",
+    "CFData",
+    "CFDate",
+    "CFDictionary",
+    "CFRunLoop",
+    "CFString",
+    "CFURL",
+    "objc2",
+    "std",
+] }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "NSArray",
+    "NSAttributedString",
+    "NSBundle",
+    "NSCoder",
+    "NSData",
+    "NSDate",
+    "NSDictionary",
+    "NSEnumerator",
+    "NSError",
+    "NSGeometry",
+    "NSNotification",
+    "NSNull",
+    "NSObjCRuntime",
+    "NSObject",
+    "NSProcessInfo",
+    "NSRange",
+    "NSRunLoop",
+    "NSString",
+    "NSURL",
+    "NSUndoManager",
+    "NSValue",
+    "objc2-core-foundation",
+    "std",
+] }
 objc2-metal = { version = "0.3" }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
-proc-macro2 = { version = "1", default-features = false, features = ["span-locations"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
+proc-macro2 = { version = "1", default-features = false, features = [
+    "span-locations",
+] }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
 security-framework = { version = "3", features = ["OSX_10_14"] }
 security-framework-sys = { version = "2", features = ["OSX_10_14"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 
 [target.aarch64-apple-darwin.dependencies]
 codespan-reporting = { version = "0.12" }
 core-foundation = { version = "0.9" }
 core-foundation-sys = { version = "0.8" }
-coreaudio-sys = { version = "0.2", default-features = false, features = ["audio_toolbox", "audio_unit", "core_audio", "core_midi", "open_al"] }
+coreaudio-sys = { version = "0.2", default-features = false, features = [
+    "audio_toolbox",
+    "audio_unit",
+    "core_audio",
+    "core_midi",
+    "open_al",
+] }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 naga = { version = "25", features = ["msl-out", "wgsl-in"] }
 nix = { version = "0.29", features = ["fs", "pthread", "signal", "user"] }
 objc2 = { version = "0.6" }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFCGTypes", "CFData", "CFDate", "CFDictionary", "CFRunLoop", "CFString", "CFURL", "objc2", "std"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSArray", "NSAttributedString", "NSBundle", "NSCoder", "NSData", "NSDate", "NSDictionary", "NSEnumerator", "NSError", "NSGeometry", "NSNotification", "NSNull", "NSObjCRuntime", "NSObject", "NSProcessInfo", "NSRange", "NSRunLoop", "NSString", "NSURL", "NSUndoManager", "NSValue", "objc2-core-foundation", "std"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = [
+    "CFArray",
+    "CFCGTypes",
+    "CFData",
+    "CFDate",
+    "CFDictionary",
+    "CFRunLoop",
+    "CFString",
+    "CFURL",
+    "objc2",
+    "std",
+] }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "NSArray",
+    "NSAttributedString",
+    "NSBundle",
+    "NSCoder",
+    "NSData",
+    "NSDate",
+    "NSDictionary",
+    "NSEnumerator",
+    "NSError",
+    "NSGeometry",
+    "NSNotification",
+    "NSNull",
+    "NSObjCRuntime",
+    "NSObject",
+    "NSProcessInfo",
+    "NSRange",
+    "NSRunLoop",
+    "NSString",
+    "NSURL",
+    "NSUndoManager",
+    "NSValue",
+    "objc2-core-foundation",
+    "std",
+] }
 objc2-metal = { version = "0.3" }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
 security-framework = { version = "3", features = ["OSX_10_14"] }
 security-framework-sys = { version = "2", features = ["OSX_10_14"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 
 [target.aarch64-apple-darwin.build-dependencies]
-clang-sys = { version = "1", default-features = false, features = ["clang_11_0", "runtime"] }
+clang-sys = { version = "1", default-features = false, features = [
+    "clang_11_0",
+    "runtime",
+] }
 codespan-reporting = { version = "0.12" }
 core-foundation = { version = "0.9" }
 core-foundation-sys = { version = "0.8" }
-coreaudio-sys = { version = "0.2", default-features = false, features = ["audio_toolbox", "audio_unit", "core_audio", "core_midi", "open_al"] }
+coreaudio-sys = { version = "0.2", default-features = false, features = [
+    "audio_toolbox",
+    "audio_unit",
+    "core_audio",
+    "core_midi",
+    "open_al",
+] }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 naga = { version = "25", features = ["msl-out", "wgsl-in"] }
 nix = { version = "0.29", features = ["fs", "pthread", "signal", "user"] }
 objc2 = { version = "0.6" }
-objc2-core-foundation = { version = "0.3", default-features = false, features = ["CFArray", "CFCGTypes", "CFData", "CFDate", "CFDictionary", "CFRunLoop", "CFString", "CFURL", "objc2", "std"] }
-objc2-foundation = { version = "0.3", default-features = false, features = ["NSArray", "NSAttributedString", "NSBundle", "NSCoder", "NSData", "NSDate", "NSDictionary", "NSEnumerator", "NSError", "NSGeometry", "NSNotification", "NSNull", "NSObjCRuntime", "NSObject", "NSProcessInfo", "NSRange", "NSRunLoop", "NSString", "NSURL", "NSUndoManager", "NSValue", "objc2-core-foundation", "std"] }
+objc2-core-foundation = { version = "0.3", default-features = false, features = [
+    "CFArray",
+    "CFCGTypes",
+    "CFData",
+    "CFDate",
+    "CFDictionary",
+    "CFRunLoop",
+    "CFString",
+    "CFURL",
+    "objc2",
+    "std",
+] }
+objc2-foundation = { version = "0.3", default-features = false, features = [
+    "NSArray",
+    "NSAttributedString",
+    "NSBundle",
+    "NSCoder",
+    "NSData",
+    "NSDate",
+    "NSDictionary",
+    "NSEnumerator",
+    "NSError",
+    "NSGeometry",
+    "NSNotification",
+    "NSNull",
+    "NSObjCRuntime",
+    "NSObject",
+    "NSProcessInfo",
+    "NSRange",
+    "NSRunLoop",
+    "NSString",
+    "NSURL",
+    "NSUndoManager",
+    "NSValue",
+    "objc2-core-foundation",
+    "std",
+] }
 objc2-metal = { version = "0.3" }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
-proc-macro2 = { version = "1", default-features = false, features = ["span-locations"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
+proc-macro2 = { version = "1", default-features = false, features = [
+    "span-locations",
+] }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
 security-framework = { version = "3", features = ["OSX_10_14"] }
 security-framework-sys = { version = "2", features = ["OSX_10_14"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 
 [target.x86_64-unknown-linux-gnu.dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-bytemuck = { version = "1", default-features = false, features = ["min_const_generics"] }
-cipher = { version = "0.4", default-features = false, features = ["block-padding", "rand_core", "zeroize"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
+bytemuck = { version = "1", default-features = false, features = [
+    "min_const_generics",
+] }
+cipher = { version = "0.4", default-features = false, features = [
+    "block-padding",
+    "rand_core",
+    "zeroize",
+] }
 codespan-reporting = { version = "0.12" }
-crypto-common = { version = "0.1", default-features = false, features = ["rand_core", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+    "rand_core",
+    "std",
+] }
 event-listener-strategy = { version = "0.5" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
-inout = { version = "0.1", default-features = false, features = ["block-padding"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+inout = { version = "0.1", default-features = false, features = [
+    "block-padding",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
-linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "xdp"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "xdp",
+] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "system",
+    "xdp",
+] }
 mio = { version = "1", features = ["net", "os-ext"] }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-nix = { version = "0.29", features = ["fs", "pthread", "signal", "socket", "uio", "user"] }
+nix = { version = "0.29", features = [
+    "fs",
+    "pthread",
+    "signal",
+    "socket",
+    "uio",
+    "user",
+] }
 num-bigint-dig = { version = "0.8", features = ["i128", "prime", "zeroize"] }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = { version = "1" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "pty", "shm", "stdio", "system", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "pty",
+    "shm",
+    "stdio",
+    "system",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = [
+    "extra-traits",
+    "fold",
+    "full",
+    "visit",
+    "visit-mut",
+] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+toml_datetime = { version = "0.6", default-features = false, features = [
+    "serde",
+] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5", default-features = false, features = ["enumflags2", "gvariant", "url"] }
+zvariant = { version = "5", default-features = false, features = [
+    "enumflags2",
+    "gvariant",
+    "url",
+] }
 
 [target.x86_64-unknown-linux-gnu.build-dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-bytemuck = { version = "1", default-features = false, features = ["min_const_generics"] }
-cipher = { version = "0.4", default-features = false, features = ["block-padding", "rand_core", "zeroize"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
+bytemuck = { version = "1", default-features = false, features = [
+    "min_const_generics",
+] }
+cipher = { version = "0.4", default-features = false, features = [
+    "block-padding",
+    "rand_core",
+    "zeroize",
+] }
 codespan-reporting = { version = "0.12" }
-crypto-common = { version = "0.1", default-features = false, features = ["rand_core", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+    "rand_core",
+    "std",
+] }
 event-listener-strategy = { version = "0.5" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
-inout = { version = "0.1", default-features = false, features = ["block-padding"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+inout = { version = "0.1", default-features = false, features = [
+    "block-padding",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
-linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "xdp"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "xdp",
+] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "system",
+    "xdp",
+] }
 mio = { version = "1", features = ["net", "os-ext"] }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-nix = { version = "0.29", features = ["fs", "pthread", "signal", "socket", "uio", "user"] }
+nix = { version = "0.29", features = [
+    "fs",
+    "pthread",
+    "signal",
+    "socket",
+    "uio",
+    "user",
+] }
 num-bigint-dig = { version = "0.8", features = ["i128", "prime", "zeroize"] }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
-proc-macro2 = { version = "1", default-features = false, features = ["span-locations"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
+proc-macro2 = { version = "1", default-features = false, features = [
+    "span-locations",
+] }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "pty", "shm", "stdio", "system", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "pty",
+    "shm",
+    "stdio",
+    "system",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+toml_datetime = { version = "0.6", default-features = false, features = [
+    "serde",
+] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5", default-features = false, features = ["enumflags2", "gvariant", "url"] }
+zvariant = { version = "5", default-features = false, features = [
+    "enumflags2",
+    "gvariant",
+    "url",
+] }
 
 [target.aarch64-unknown-linux-gnu.dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-bytemuck = { version = "1", default-features = false, features = ["min_const_generics"] }
-cipher = { version = "0.4", default-features = false, features = ["block-padding", "rand_core", "zeroize"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
+bytemuck = { version = "1", default-features = false, features = [
+    "min_const_generics",
+] }
+cipher = { version = "0.4", default-features = false, features = [
+    "block-padding",
+    "rand_core",
+    "zeroize",
+] }
 codespan-reporting = { version = "0.12" }
-crypto-common = { version = "0.1", default-features = false, features = ["rand_core", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+    "rand_core",
+    "std",
+] }
 event-listener-strategy = { version = "0.5" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
-inout = { version = "0.1", default-features = false, features = ["block-padding"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+inout = { version = "0.1", default-features = false, features = [
+    "block-padding",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
-linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "xdp"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "xdp",
+] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "system",
+    "xdp",
+] }
 mio = { version = "1", features = ["net", "os-ext"] }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-nix = { version = "0.29", features = ["fs", "pthread", "signal", "socket", "uio", "user"] }
+nix = { version = "0.29", features = [
+    "fs",
+    "pthread",
+    "signal",
+    "socket",
+    "uio",
+    "user",
+] }
 num-bigint-dig = { version = "0.8", features = ["i128", "prime", "zeroize"] }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = { version = "1" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "pty", "shm", "stdio", "system", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "pty",
+    "shm",
+    "stdio",
+    "system",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = [
+    "extra-traits",
+    "fold",
+    "full",
+    "visit",
+    "visit-mut",
+] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+toml_datetime = { version = "0.6", default-features = false, features = [
+    "serde",
+] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5", default-features = false, features = ["enumflags2", "gvariant", "url"] }
+zvariant = { version = "5", default-features = false, features = [
+    "enumflags2",
+    "gvariant",
+    "url",
+] }
 
 [target.aarch64-unknown-linux-gnu.build-dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-bytemuck = { version = "1", default-features = false, features = ["min_const_generics"] }
-cipher = { version = "0.4", default-features = false, features = ["block-padding", "rand_core", "zeroize"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
+bytemuck = { version = "1", default-features = false, features = [
+    "min_const_generics",
+] }
+cipher = { version = "0.4", default-features = false, features = [
+    "block-padding",
+    "rand_core",
+    "zeroize",
+] }
 codespan-reporting = { version = "0.12" }
-crypto-common = { version = "0.1", default-features = false, features = ["rand_core", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+    "rand_core",
+    "std",
+] }
 event-listener-strategy = { version = "0.5" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
-inout = { version = "0.1", default-features = false, features = ["block-padding"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+inout = { version = "0.1", default-features = false, features = [
+    "block-padding",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
-linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "xdp"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "xdp",
+] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "system",
+    "xdp",
+] }
 mio = { version = "1", features = ["net", "os-ext"] }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-nix = { version = "0.29", features = ["fs", "pthread", "signal", "socket", "uio", "user"] }
+nix = { version = "0.29", features = [
+    "fs",
+    "pthread",
+    "signal",
+    "socket",
+    "uio",
+    "user",
+] }
 num-bigint-dig = { version = "0.8", features = ["i128", "prime", "zeroize"] }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
-proc-macro2 = { version = "1", default-features = false, features = ["span-locations"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
+proc-macro2 = { version = "1", default-features = false, features = [
+    "span-locations",
+] }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "pty", "shm", "stdio", "system", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "pty",
+    "shm",
+    "stdio",
+    "system",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+toml_datetime = { version = "0.6", default-features = false, features = [
+    "serde",
+] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5", default-features = false, features = ["enumflags2", "gvariant", "url"] }
+zvariant = { version = "5", default-features = false, features = [
+    "enumflags2",
+    "gvariant",
+    "url",
+] }
 
 [target.x86_64-pc-windows-msvc.dependencies]
 codespan-reporting = { version = "0.12" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+] }
 scopeguard = { version = "1" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
-winapi = { version = "0.3", default-features = false, features = ["cfg", "commapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "knownfolders", "minwinbase", "minwindef", "namedpipeapi", "ntsecapi", "objbase", "processenv", "processthreadsapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser"] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
+winapi = { version = "0.3", default-features = false, features = [
+    "cfg",
+    "commapi",
+    "consoleapi",
+    "errhandlingapi",
+    "evntrace",
+    "fileapi",
+    "handleapi",
+    "impl-debug",
+    "impl-default",
+    "in6addr",
+    "inaddr",
+    "ioapiset",
+    "knownfolders",
+    "minwinbase",
+    "minwindef",
+    "namedpipeapi",
+    "ntsecapi",
+    "objbase",
+    "processenv",
+    "processthreadsapi",
+    "shlobj",
+    "std",
+    "synchapi",
+    "sysinfoapi",
+    "timezoneapi",
+    "winbase",
+    "windef",
+    "winerror",
+    "winioctl",
+    "winnt",
+    "winreg",
+    "winsock2",
+    "winuser",
+] }
 windows-core = { version = "0.61" }
 windows-numerics = { version = "0.2" }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_Threading", "Win32_System_Time", "Win32_UI_Shell"] }
+windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_Globalization",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
+    "Win32_Security_Authentication_Identity",
+    "Win32_Security_Credentials",
+    "Win32_Security_Cryptography",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Com",
+    "Win32_System_Console",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
+    "Win32_System_Kernel",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_System_Performance",
+    "Win32_System_Pipes",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_Time",
+    "Win32_System_WindowsProgramming",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Wdk_System_IO",
+    "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_IO",
+    "Win32_System_Memory",
+    "Win32_System_Pipes",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_WindowsProgramming",
+] }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = [
+    "Win32_Foundation",
+    "Win32_Globalization",
+    "Win32_Networking_WinSock",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Com",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Registry",
+    "Win32_System_Threading",
+    "Win32_System_Time",
+    "Win32_UI_Shell",
+] }
 
 [target.x86_64-pc-windows-msvc.build-dependencies]
 codespan-reporting = { version = "0.12" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-proc-macro2 = { version = "1", default-features = false, features = ["span-locations"] }
+proc-macro2 = { version = "1", default-features = false, features = [
+    "span-locations",
+] }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+] }
 scopeguard = { version = "1" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
-winapi = { version = "0.3", default-features = false, features = ["cfg", "commapi", "consoleapi", "errhandlingapi", "evntrace", "fileapi", "handleapi", "impl-debug", "impl-default", "in6addr", "inaddr", "ioapiset", "knownfolders", "minwinbase", "minwindef", "namedpipeapi", "ntsecapi", "objbase", "processenv", "processthreadsapi", "shlobj", "std", "synchapi", "sysinfoapi", "timezoneapi", "winbase", "windef", "winerror", "winioctl", "winnt", "winreg", "winsock2", "winuser"] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
+winapi = { version = "0.3", default-features = false, features = [
+    "cfg",
+    "commapi",
+    "consoleapi",
+    "errhandlingapi",
+    "evntrace",
+    "fileapi",
+    "handleapi",
+    "impl-debug",
+    "impl-default",
+    "in6addr",
+    "inaddr",
+    "ioapiset",
+    "knownfolders",
+    "minwinbase",
+    "minwindef",
+    "namedpipeapi",
+    "ntsecapi",
+    "objbase",
+    "processenv",
+    "processthreadsapi",
+    "shlobj",
+    "std",
+    "synchapi",
+    "sysinfoapi",
+    "timezoneapi",
+    "winbase",
+    "windef",
+    "winerror",
+    "winioctl",
+    "winnt",
+    "winreg",
+    "winsock2",
+    "winuser",
+] }
 windows-core = { version = "0.61" }
 windows-numerics = { version = "0.2" }
-windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Win32_Globalization", "Win32_NetworkManagement_IpHelper", "Win32_Networking_WinSock", "Win32_Security_Authentication_Identity", "Win32_Security_Credentials", "Win32_Security_Cryptography", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Console", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Ioctl", "Win32_System_Kernel", "Win32_System_LibraryLoader", "Win32_System_Memory", "Win32_System_Performance", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_SystemInformation", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_Time", "Win32_System_WindowsProgramming", "Win32_UI_Input_KeyboardAndMouse", "Win32_UI_Shell", "Win32_UI_WindowsAndMessaging"] }
-windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = ["Wdk_Foundation", "Wdk_Storage_FileSystem", "Wdk_System_IO", "Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security_Authorization", "Win32_Storage_FileSystem", "Win32_System_Console", "Win32_System_IO", "Win32_System_Memory", "Win32_System_Pipes", "Win32_System_SystemServices", "Win32_System_Threading", "Win32_System_WindowsProgramming"] }
-windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = ["Win32_Foundation", "Win32_Globalization", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Com", "Win32_System_Diagnostics_Debug", "Win32_System_IO", "Win32_System_Pipes", "Win32_System_Registry", "Win32_System_Threading", "Win32_System_Time", "Win32_UI_Shell"] }
+windows-sys-73dcd821b1037cfd = { package = "windows-sys", version = "0.59", features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Win32_Globalization",
+    "Win32_NetworkManagement_IpHelper",
+    "Win32_Networking_WinSock",
+    "Win32_Security_Authentication_Identity",
+    "Win32_Security_Credentials",
+    "Win32_Security_Cryptography",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Com",
+    "Win32_System_Console",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_IO",
+    "Win32_System_Ioctl",
+    "Win32_System_Kernel",
+    "Win32_System_LibraryLoader",
+    "Win32_System_Memory",
+    "Win32_System_Performance",
+    "Win32_System_Pipes",
+    "Win32_System_Registry",
+    "Win32_System_SystemInformation",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_Time",
+    "Win32_System_WindowsProgramming",
+    "Win32_UI_Input_KeyboardAndMouse",
+    "Win32_UI_Shell",
+    "Win32_UI_WindowsAndMessaging",
+] }
+windows-sys-b21d60becc0929df = { package = "windows-sys", version = "0.52", features = [
+    "Wdk_Foundation",
+    "Wdk_Storage_FileSystem",
+    "Wdk_System_IO",
+    "Win32_Foundation",
+    "Win32_Networking_WinSock",
+    "Win32_Security_Authorization",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Console",
+    "Win32_System_IO",
+    "Win32_System_Memory",
+    "Win32_System_Pipes",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+    "Win32_System_WindowsProgramming",
+] }
+windows-sys-c8eced492e86ede7 = { package = "windows-sys", version = "0.48", features = [
+    "Win32_Foundation",
+    "Win32_Globalization",
+    "Win32_Networking_WinSock",
+    "Win32_Security",
+    "Win32_Storage_FileSystem",
+    "Win32_System_Com",
+    "Win32_System_Diagnostics_Debug",
+    "Win32_System_IO",
+    "Win32_System_Pipes",
+    "Win32_System_Registry",
+    "Win32_System_Threading",
+    "Win32_System_Time",
+    "Win32_UI_Shell",
+] }
 
 [target.x86_64-unknown-linux-musl.dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-bytemuck = { version = "1", default-features = false, features = ["min_const_generics"] }
-cipher = { version = "0.4", default-features = false, features = ["block-padding", "rand_core", "zeroize"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
+bytemuck = { version = "1", default-features = false, features = [
+    "min_const_generics",
+] }
+cipher = { version = "0.4", default-features = false, features = [
+    "block-padding",
+    "rand_core",
+    "zeroize",
+] }
 codespan-reporting = { version = "0.12" }
-crypto-common = { version = "0.1", default-features = false, features = ["rand_core", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+    "rand_core",
+    "std",
+] }
 event-listener-strategy = { version = "0.5" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
-inout = { version = "0.1", default-features = false, features = ["block-padding"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+inout = { version = "0.1", default-features = false, features = [
+    "block-padding",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
-linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "xdp"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "xdp",
+] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "system",
+    "xdp",
+] }
 mio = { version = "1", features = ["net", "os-ext"] }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-nix = { version = "0.29", features = ["fs", "pthread", "signal", "socket", "uio", "user"] }
+nix = { version = "0.29", features = [
+    "fs",
+    "pthread",
+    "signal",
+    "socket",
+    "uio",
+    "user",
+] }
 num-bigint-dig = { version = "0.8", features = ["i128", "prime", "zeroize"] }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
 proc-macro2 = { version = "1", features = ["span-locations"] }
 quote = { version = "1" }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "pty", "shm", "stdio", "system", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "pty",
+    "shm",
+    "stdio",
+    "system",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
-syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = ["extra-traits", "fold", "full", "visit", "visit-mut"] }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+syn-f595c2ba2a3f28df = { package = "syn", version = "2", features = [
+    "extra-traits",
+    "fold",
+    "full",
+    "visit",
+    "visit-mut",
+] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+toml_datetime = { version = "0.6", default-features = false, features = [
+    "serde",
+] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5", default-features = false, features = ["enumflags2", "gvariant", "url"] }
+zvariant = { version = "5", default-features = false, features = [
+    "enumflags2",
+    "gvariant",
+    "url",
+] }
 
 [target.x86_64-unknown-linux-musl.build-dependencies]
 aes = { version = "0.8", default-features = false, features = ["zeroize"] }
-ahash = { version = "0.8", default-features = false, features = ["compile-time-rng"] }
-bytemuck = { version = "1", default-features = false, features = ["min_const_generics"] }
-cipher = { version = "0.4", default-features = false, features = ["block-padding", "rand_core", "zeroize"] }
+ahash = { version = "0.8", default-features = false, features = [
+    "compile-time-rng",
+] }
+bytemuck = { version = "1", default-features = false, features = [
+    "min_const_generics",
+] }
+cipher = { version = "0.4", default-features = false, features = [
+    "block-padding",
+    "rand_core",
+    "zeroize",
+] }
 codespan-reporting = { version = "0.12" }
-crypto-common = { version = "0.1", default-features = false, features = ["rand_core", "std"] }
+crypto-common = { version = "0.1", default-features = false, features = [
+    "rand_core",
+    "std",
+] }
 event-listener-strategy = { version = "0.5" }
 flume = { version = "0.11" }
 foldhash = { version = "0.1", default-features = false, features = ["std"] }
-getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = ["std"] }
-getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = ["js", "rdrand"] }
-gimli = { version = "0.31", default-features = false, features = ["read", "std", "write"] }
-hyper-rustls = { version = "0.27", default-features = false, features = ["http1", "http2", "native-tokio", "ring", "tls12"] }
-inout = { version = "0.1", default-features = false, features = ["block-padding"] }
+getrandom-468e82937335b1c9 = { package = "getrandom", version = "0.3", default-features = false, features = [
+    "std",
+] }
+getrandom-6f8ce4dd05d13bba = { package = "getrandom", version = "0.2", default-features = false, features = [
+    "js",
+    "rdrand",
+] }
+gimli = { version = "0.31", default-features = false, features = [
+    "read",
+    "std",
+    "write",
+] }
+hyper-rustls = { version = "0.27", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "ring",
+    "tls12",
+] }
+inout = { version = "0.1", default-features = false, features = [
+    "block-padding",
+] }
 itertools-5ef9efb8ec2df382 = { package = "itertools", version = "0.12" }
-linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "xdp"] }
-linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = ["elf", "errno", "general", "if_ether", "ioctl", "net", "netlink", "no_std", "prctl", "system", "xdp"] }
+linux-raw-sys-274715c4dabd11b0 = { package = "linux-raw-sys", version = "0.9", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "xdp",
+] }
+linux-raw-sys-9fbad63c4bcf4a8f = { package = "linux-raw-sys", version = "0.4", default-features = false, features = [
+    "elf",
+    "errno",
+    "general",
+    "if_ether",
+    "ioctl",
+    "net",
+    "netlink",
+    "no_std",
+    "prctl",
+    "system",
+    "xdp",
+] }
 mio = { version = "1", features = ["net", "os-ext"] }
 naga = { version = "25", features = ["spv-out", "wgsl-in"] }
-nix = { version = "0.29", features = ["fs", "pthread", "signal", "socket", "uio", "user"] }
+nix = { version = "0.29", features = [
+    "fs",
+    "pthread",
+    "signal",
+    "socket",
+    "uio",
+    "user",
+] }
 num-bigint-dig = { version = "0.8", features = ["i128", "prime", "zeroize"] }
-object = { version = "0.36", default-features = false, features = ["archive", "read_core", "unaligned", "write"] }
-proc-macro2 = { version = "1", default-features = false, features = ["span-locations"] }
+object = { version = "0.36", default-features = false, features = [
+    "archive",
+    "read_core",
+    "unaligned",
+    "write",
+] }
+proc-macro2 = { version = "1", default-features = false, features = [
+    "span-locations",
+] }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 ring = { version = "0.17", features = ["std"] }
-rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = ["event", "mm", "param", "pipe", "process", "pty", "shm", "stdio", "system", "termios", "time"] }
-rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = ["fs", "net", "process", "termios", "time"] }
+rustix-d585fab2519d2d1 = { package = "rustix", version = "0.38", features = [
+    "event",
+    "mm",
+    "param",
+    "pipe",
+    "process",
+    "pty",
+    "shm",
+    "stdio",
+    "system",
+    "termios",
+    "time",
+] }
+rustix-dff4ba8e3ae991db = { package = "rustix", version = "1", features = [
+    "fs",
+    "net",
+    "process",
+    "termios",
+    "time",
+] }
 scopeguard = { version = "1" }
-sync_wrapper = { version = "1", default-features = false, features = ["futures"] }
-tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }
+sync_wrapper = { version = "1", default-features = false, features = [
+    "futures",
+] }
+tokio-rustls = { version = "0.26", default-features = false, features = [
+    "ring",
+] }
 tokio-socks = { version = "0.5", features = ["futures-io"] }
 tokio-stream = { version = "0.1", features = ["fs"] }
-toml_datetime = { version = "0.6", default-features = false, features = ["serde"] }
-tower = { version = "0.5", default-features = false, features = ["timeout", "util"] }
+toml_datetime = { version = "0.6", default-features = false, features = [
+    "serde",
+] }
+tower = { version = "0.5", default-features = false, features = [
+    "timeout",
+    "util",
+] }
 zeroize = { version = "1", features = ["zeroize_derive"] }
-zvariant = { version = "5", default-features = false, features = ["enumflags2", "gvariant", "url"] }
+zvariant = { version = "5", default-features = false, features = [
+    "enumflags2",
+    "gvariant",
+    "url",
+] }
 
 ### END HAKARI SECTION


### PR DESCRIPTION
Closes #33775

TODO: add config and resave of config.toml

Release Notes:

- Added config of [Taplo](https://taplo.tamasfe.dev) for `Cargo.toml` & `rust-toolchain.toml` formatting + check in CI
