### PR TITLE
keymap_ui: Add default sort to keymap table

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -196,7 +196,7 @@ impl KeymapEditor {
             (this.string_match_candidates.clone(), this.keybindings.len())
         })?;
         let executor = cx.background_executor().clone();
-        let matches = fuzzy::match_strings(
+        let mut matches = fuzzy::match_strings(
             &string_match_candidates,
             &query,
             true,
@@ -207,6 +207,21 @@ impl KeymapEditor {
         )
         .await;
         this.update(cx, |this, cx| {
+            if query.is_empty() {
+                matches.sort_by_key(|match_item| {
+                    let keybind = &this.keybindings[match_item.candidate_id];
+                    let source = keybind.source.as_ref().map(|s| s.0);
+                    use KeybindSource::*;
+                    let source_precedence = match source {
+                        Some(User) => 0,
+                        Some(Vim) => 1,
+                        Some(Base) => 2,
+                        Some(Default) => 3,
+                        None => 5,
+                    };
+                    return (source_precedence, keybind.action.as_ref());
+                });
+            }
             this.selected_index.take();
             this.scroll_to_item(0, ScrollStrategy::Top, cx);
             this.matches = matches;
@@ -216,7 +231,7 @@ impl KeymapEditor {
 
     fn process_bindings(
         json_language: Arc<Language>,
-        cx: &mut Context<Self>,
+        cx: &mut App,
     ) -> (Vec<ProcessedKeybinding>, Vec<StringMatchCandidate>) {
         let key_bindings_ptr = cx.key_bindings();
         let lock = key_bindings_ptr.borrow();
@@ -283,6 +298,7 @@ impl KeymapEditor {
         let workspace = self.workspace.clone();
         cx.spawn(async move |this, cx| {
             let json_language = Self::load_json_language(workspace, cx).await;
+
             let query = this.update(cx, |this, cx| {
                 let (key_bindings, string_match_candidates) =
                     Self::process_bindings(json_language.clone(), cx);


### PR DESCRIPTION
Closes #ISSUE

Adds a default sort when no filter query is provided in the keymap editor.

The default sorting algorithm sorts by the source of the binding (roughly in order of precedence)
 
- User
- Vim
- Base
- Default
- None (unbound actions) 

within each source it sorts by action name alphabetically.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
