### PR TITLE
Use `@zed-industries/` fork of `vscode-langservers-extracted` package

### DIFF
--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -17,7 +17,7 @@ use std::{
 use util::{ResultExt, maybe};
 
 const SERVER_PATH: &str =
-    "node_modules/vscode-langservers-extracted/bin/vscode-css-language-server";
+    "node_modules/@zed-industries/vscode-langservers-extracted/bin/vscode-css-language-server";
 
 fn server_binary_arguments(server_path: &Path) -> Vec<OsString> {
     vec![server_path.into(), "--stdio".into()]

--- a/crates/languages/src/css.rs
+++ b/crates/languages/src/css.rs
@@ -28,7 +28,7 @@ pub struct CssLspAdapter {
 }
 
 impl CssLspAdapter {
-    const PACKAGE_NAME: &str = "vscode-langservers-extracted";
+    const PACKAGE_NAME: &str = "@zed-industries/vscode-langservers-extracted";
     pub fn new(node: NodeRuntime) -> Self {
         CssLspAdapter { node }
     }

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -34,7 +34,7 @@ use util::{ResultExt, archive::extract_zip, fs::remove_matching, maybe, merge_js
 use crate::PackageJsonData;
 
 const SERVER_PATH: &str =
-    "node_modules/vscode-langservers-extracted/bin/vscode-json-language-server";
+    "node_modules/@zed-industries/vscode-langservers-extracted/bin/vscode-json-language-server";
 
 // Origin: https://github.com/SchemaStore/schemastore
 const TSCONFIG_SCHEMA: &str = include_str!("json/schemas/tsconfig.json");

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -139,7 +139,7 @@ pub struct JsonLspAdapter {
 }
 
 impl JsonLspAdapter {
-    const PACKAGE_NAME: &str = "vscode-langservers-extracted";
+    const PACKAGE_NAME: &str = "@zed-industries/vscode-langservers-extracted";
 
     pub fn new(node: NodeRuntime, languages: Arc<LanguageRegistry>) -> Self {
         Self {


### PR DESCRIPTION
Update `css.rs` and `json.rs` to refer to the `@zed-industries` fork of the `vscode-langservers-extracted` package, like the `html.rs` one does.

Seems to be an oversight.

Closes: [#34958](https://github.com/zed-industries/zed/issues/36038)

Release Notes:

- N/A