### PR TITLE
debugger: Truncate long session and thread names

### DIFF
--- a/crates/debugger_ui/src/dropdown_menus.rs
+++ b/crates/debugger_ui/src/dropdown_menus.rs
@@ -4,6 +4,7 @@ use collections::HashMap;
 use gpui::{Animation, AnimationExt as _, Entity, Transformation, percentage};
 use project::debugger::session::{ThreadId, ThreadStatus};
 use ui::{ContextMenu, DropdownMenu, DropdownStyle, Indicator, prelude::*};
+use util::truncate_and_trailoff;
 
 use crate::{
     debugger_panel::DebugPanel,
@@ -12,6 +13,8 @@ use crate::{
 
 impl DebugPanel {
     fn dropdown_label(label: impl Into<SharedString>) -> Label {
+        const MAX_LABEL_CHARS: usize = 50;
+        let label = truncate_and_trailoff(&label.into(), MAX_LABEL_CHARS);
         Label::new(label).size(LabelSize::Small)
     }
 
@@ -170,6 +173,8 @@ impl DebugPanel {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Option<DropdownMenu> {
+        const MAX_LABEL_CHARS: usize = 150;
+
         let running_state = running_state.clone();
         let running_state_read = running_state.read(cx);
         let thread_id = running_state_read.thread_id();
@@ -202,6 +207,7 @@ impl DebugPanel {
                                 .is_empty()
                                 .then(|| format!("Tid: {}", thread.id))
                                 .unwrap_or_else(|| thread.name);
+                            let entry_name = truncate_and_trailoff(&entry_name, MAX_LABEL_CHARS);
 
                             this = this.entry(entry_name, None, move |window, cx| {
                                 running_state.update(cx, |running_state, cx| {

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -12,6 +12,7 @@ use rpc::proto;
 use running::RunningState;
 use std::{cell::OnceCell, sync::OnceLock};
 use ui::{Indicator, Tooltip, prelude::*};
+use util::truncate_and_trailoff;
 use workspace::{
     CollaboratorId, FollowableItem, ViewId, Workspace,
     item::{self, Item},
@@ -126,7 +127,10 @@ impl DebugSession {
     }
 
     pub(crate) fn label_element(&self, depth: usize, cx: &App) -> AnyElement {
+        const MAX_LABEL_CHARS: usize = 150;
+
         let label = self.label(cx);
+        let label = truncate_and_trailoff(&label, MAX_LABEL_CHARS);
 
         let is_terminated = self
             .running_state


### PR DESCRIPTION
Related to #33072 

Release Notes:

- debugger: Fixed long session and thread names eating up excessive space in the control strip.