### PR TITLE
Switch to `ctrl-f11` for `debugger::StepInto` on macOS

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -8,7 +8,7 @@
       "shift-cmd-f5": "debugger::RerunSession",
       "f6": "debugger::Pause",
       "f7": "debugger::StepOver",
-      "f11": "debugger::StepInto",
+      "ctrl-f11": "debugger::StepInto",
       "shift-f11": "debugger::StepOut",
       "home": "menu::SelectFirst",
       "shift-pageup": "menu::SelectFirst",


### PR DESCRIPTION
Plain `f11` is a system keybinding. We already use `ctrl-f11` for this on Linux.

Release Notes:

- debugger: Switched the macOS keybinding for `debugger::StepInto` from `f11` to `ctrl-f11`.