### PR TITLE
gpui: Store action documentation 

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -31,7 +31,13 @@ use workspace::{StatusItemView, Workspace, item::ItemHandle};
 
 const GIT_OPERATION_DELAY: Duration = Duration::from_millis(0);
 
-actions!(activity_indicator, [ShowErrorMessage]);
+actions!(
+    activity_indicator,
+    [
+        /// Display error messages from language servers in the status bar
+        ShowErrorMessage
+    ]
+);
 
 pub enum Event {
     ShowStatus {

--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -34,7 +34,7 @@ const GIT_OPERATION_DELAY: Duration = Duration::from_millis(0);
 actions!(
     activity_indicator,
     [
-        /// Display error messages from language servers in the status bar
+        /// Displays error messages from language servers in the status bar.
         ShowErrorMessage
     ]
 );

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -54,38 +54,71 @@ pub use ui::preview::{all_agent_previews, get_agent_preview};
 actions!(
     agent,
     [
+        /// Create a new text-based conversation thread
         NewTextThread,
+        /// Toggle the context picker interface for adding files, symbols, or other context
         ToggleContextPicker,
+        /// Toggle the navigation menu for switching between threads and views
         ToggleNavigationMenu,
+        /// Toggle the options menu for agent settings and preferences
         ToggleOptionsMenu,
+        /// Delete the recently opened thread from history
         DeleteRecentlyOpenThread,
+        /// Toggle the profile selector for switching between agent profiles
         ToggleProfileSelector,
+        /// Remove all added context from the current conversation
         RemoveAllContext,
+        /// Expand the message editor to full size
         ExpandMessageEditor,
+        /// Open the conversation history view
         OpenHistory,
+        /// Add a context server to the configuration
         AddContextServer,
+        /// Remove the currently selected thread
         RemoveSelectedThread,
+        /// Start a chat conversation with the agent
         Chat,
+        /// Start a chat conversation with follow-up enabled
         ChatWithFollow,
+        /// Cycle to the next inline assist suggestion
         CycleNextInlineAssist,
+        /// Cycle to the previous inline assist suggestion
         CyclePreviousInlineAssist,
+        /// Move focus up in the interface
         FocusUp,
+        /// Move focus down in the interface
         FocusDown,
+        /// Move focus left in the interface
         FocusLeft,
+        /// Move focus right in the interface
         FocusRight,
+        /// Remove the currently focused context item
         RemoveFocusedContext,
+        /// Accept the suggested context item
         AcceptSuggestedContext,
+        /// Open the active thread as a markdown file
         OpenActiveThreadAsMarkdown,
+        /// Open the agent diff view to review changes
         OpenAgentDiff,
+        /// Keep the current suggestion or change
         Keep,
+        /// Reject the current suggestion or change
         Reject,
+        /// Reject all suggestions or changes
         RejectAll,
+        /// Keep all suggestions or changes
         KeepAll,
+        /// Follow the agent's suggestions
         Follow,
+        /// Reset the trial upsell notification
         ResetTrialUpsell,
+        /// Reset the trial end upsell notification
         ResetTrialEndUpsell,
+        /// Continue the current thread
         ContinueThread,
+        /// Continue the thread with burn mode enabled
         ContinueWithBurnMode,
+        /// Toggle burn mode for faster responses
         ToggleBurnMode,
     ]
 );

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -54,71 +54,71 @@ pub use ui::preview::{all_agent_previews, get_agent_preview};
 actions!(
     agent,
     [
-        /// Create a new text-based conversation thread
+        /// Creates a new text-based conversation thread.
         NewTextThread,
-        /// Toggle the context picker interface for adding files, symbols, or other context
+        /// Toggles the context picker interface for adding files, symbols, or other context.
         ToggleContextPicker,
-        /// Toggle the navigation menu for switching between threads and views
+        /// Toggles the navigation menu for switching between threads and views.
         ToggleNavigationMenu,
-        /// Toggle the options menu for agent settings and preferences
+        /// Toggles the options menu for agent settings and preferences.
         ToggleOptionsMenu,
-        /// Delete the recently opened thread from history
+        /// Deletes the recently opened thread from history.
         DeleteRecentlyOpenThread,
-        /// Toggle the profile selector for switching between agent profiles
+        /// Toggles the profile selector for switching between agent profiles.
         ToggleProfileSelector,
-        /// Remove all added context from the current conversation
+        /// Removes all added context from the current conversation.
         RemoveAllContext,
-        /// Expand the message editor to full size
+        /// Expands the message editor to full size.
         ExpandMessageEditor,
-        /// Open the conversation history view
+        /// Opens the conversation history view.
         OpenHistory,
-        /// Add a context server to the configuration
+        /// Adds a context server to the configuration.
         AddContextServer,
-        /// Remove the currently selected thread
+        /// Removes the currently selected thread.
         RemoveSelectedThread,
-        /// Start a chat conversation with the agent
+        /// Starts a chat conversation with the agent.
         Chat,
-        /// Start a chat conversation with follow-up enabled
+        /// Starts a chat conversation with follow-up enabled.
         ChatWithFollow,
-        /// Cycle to the next inline assist suggestion
+        /// Cycles to the next inline assist suggestion.
         CycleNextInlineAssist,
-        /// Cycle to the previous inline assist suggestion
+        /// Cycles to the previous inline assist suggestion.
         CyclePreviousInlineAssist,
-        /// Move focus up in the interface
+        /// Moves focus up in the interface.
         FocusUp,
-        /// Move focus down in the interface
+        /// Moves focus down in the interface.
         FocusDown,
-        /// Move focus left in the interface
+        /// Moves focus left in the interface.
         FocusLeft,
-        /// Move focus right in the interface
+        /// Moves focus right in the interface.
         FocusRight,
-        /// Remove the currently focused context item
+        /// Removes the currently focused context item.
         RemoveFocusedContext,
-        /// Accept the suggested context item
+        /// Accepts the suggested context item.
         AcceptSuggestedContext,
-        /// Open the active thread as a markdown file
+        /// Opens the active thread as a markdown file.
         OpenActiveThreadAsMarkdown,
-        /// Open the agent diff view to review changes
+        /// Opens the agent diff view to review changes.
         OpenAgentDiff,
-        /// Keep the current suggestion or change
+        /// Keeps the current suggestion or change.
         Keep,
-        /// Reject the current suggestion or change
+        /// Rejects the current suggestion or change.
         Reject,
-        /// Reject all suggestions or changes
+        /// Rejects all suggestions or changes.
         RejectAll,
-        /// Keep all suggestions or changes
+        /// Keeps all suggestions or changes.
         KeepAll,
-        /// Follow the agent's suggestions
+        /// Follows the agent's suggestions.
         Follow,
-        /// Reset the trial upsell notification
+        /// Resets the trial upsell notification.
         ResetTrialUpsell,
-        /// Reset the trial end upsell notification
+        /// Resets the trial end upsell notification.
         ResetTrialEndUpsell,
-        /// Continue the current thread
+        /// Continues the current thread.
         ContinueThread,
-        /// Continue the thread with burn mode enabled
+        /// Continues the thread with burn mode enabled.
         ContinueWithBurnMode,
-        /// Toggle burn mode for faster responses
+        /// Toggles burn mode for faster responses.
         ToggleBurnMode,
     ]
 );

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -123,6 +123,7 @@ actions!(
     ]
 );
 
+/// Creates a new conversation thread, optionally based on an existing thread.
 #[derive(Default, Clone, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = agent)]
 #[serde(deny_unknown_fields)]
@@ -131,6 +132,7 @@ pub struct NewThread {
     from_thread_id: Option<ThreadId>,
 }
 
+/// Opens the profile management interface for configuring agent tools and settings.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = agent)]
 #[serde(deny_unknown_fields)]

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -18,6 +18,7 @@ use ui::{ListItem, ListItemSpacing, prelude::*};
 actions!(
     agent,
     [
+        /// Toggle the language model selector dropdown
         #[action(deprecated_aliases = ["assistant::ToggleModelSelector", "assistant2::ToggleModelSelector"])]
         ToggleModelSelector
     ]

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -18,7 +18,7 @@ use ui::{ListItem, ListItemSpacing, prelude::*};
 actions!(
     agent,
     [
-        /// Toggle the language model selector dropdown
+        /// Toggles the language model selector dropdown.
         #[action(deprecated_aliases = ["assistant::ToggleModelSelector", "assistant2::ToggleModelSelector"])]
         ToggleModelSelector
     ]

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -85,19 +85,19 @@ use assistant_context::{
 actions!(
     assistant,
     [
-        /// Send the current message to the assistant
+        /// Sends the current message to the assistant.
         Assist,
-        /// Confirm and execute the entered slash command
+        /// Confirms and executes the entered slash command.
         ConfirmCommand,
-        /// Copy code from the assistant's response to the clipboard
+        /// Copies code from the assistant's response to the clipboard.
         CopyCode,
-        /// Cycle between user and assistant message roles
+        /// Cycles between user and assistant message roles.
         CycleMessageRole,
-        /// Insert the selected text into the active editor
+        /// Inserts the selected text into the active editor.
         InsertIntoEditor,
-        /// Quote the current selection in the assistant conversation
+        /// Quotes the current selection in the assistant conversation.
         QuoteSelection,
-        /// Split the conversation at the current cursor position
+        /// Splits the conversation at the current cursor position.
         Split,
     ]
 );

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -85,12 +85,19 @@ use assistant_context::{
 actions!(
     assistant,
     [
+        /// Send the current message to the assistant
         Assist,
+        /// Confirm and execute the entered slash command
         ConfirmCommand,
+        /// Copy code from the assistant's response to the clipboard
         CopyCode,
+        /// Cycle between user and assistant message roles
         CycleMessageRole,
+        /// Insert the selected text into the active editor
         InsertIntoEditor,
+        /// Quote the current selection in the assistant conversation
         QuoteSelection,
+        /// Split the conversation at the current cursor position
         Split,
     ]
 );

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -102,6 +102,7 @@ actions!(
     ]
 );
 
+/// Inserts files that were dragged and dropped into the assistant conversation.
 #[derive(PartialEq, Clone, Action)]
 #[action(namespace = assistant, no_json, no_register)]
 pub enum InsertDraggedFiles {

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -28,7 +28,17 @@ use workspace::Workspace;
 const SHOULD_SHOW_UPDATE_NOTIFICATION_KEY: &str = "auto-updater-should-show-updated-notification";
 const POLL_INTERVAL: Duration = Duration::from_secs(60 * 60);
 
-actions!(auto_update, [Check, DismissErrorMessage, ViewReleaseNotes,]);
+actions!(
+    auto_update,
+    [
+        /// Check for available updates
+        Check,
+        /// Dismiss the update error message
+        DismissErrorMessage,
+        /// Open the release notes for the current version
+        ViewReleaseNotes,
+    ]
+);
 
 #[derive(Serialize)]
 struct UpdateRequestBody {

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -31,11 +31,11 @@ const POLL_INTERVAL: Duration = Duration::from_secs(60 * 60);
 actions!(
     auto_update,
     [
-        /// Check for available updates
+        /// Checks for available updates.
         Check,
-        /// Dismiss the update error message
+        /// Dismisses the update error message.
         DismissErrorMessage,
-        /// Open the release notes for the current version
+        /// Opens the release notes for the current version.
         ViewReleaseNotes,
     ]
 );

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -12,7 +12,13 @@ use workspace::Workspace;
 use workspace::notifications::simple_message_notification::MessageNotification;
 use workspace::notifications::{NotificationId, show_app_notification};
 
-actions!(auto_update, [ViewReleaseNotesLocally]);
+actions!(
+    auto_update,
+    [
+        /// Open release notes in the browser for the current version
+        ViewReleaseNotesLocally
+    ]
+);
 
 pub fn init(cx: &mut App) {
     notify_if_app_was_updated(cx);

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -15,7 +15,7 @@ use workspace::notifications::{NotificationId, show_app_notification};
 actions!(
     auto_update,
     [
-        /// Open release notes in the browser for the current version
+        /// Opens release notes in the browser for the current version.
         ViewReleaseNotesLocally
     ]
 );

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -84,11 +84,11 @@ pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
 actions!(
     client,
     [
-        /// Sign in to Zed account
+        /// Signs in to Zed account.
         SignIn,
-        /// Sign out of Zed account
+        /// Signs out of Zed account.
         SignOut,
-        /// Reconnect to the collaboration server
+        /// Reconnects to the collaboration server.
         Reconnect
     ]
 );

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -81,7 +81,17 @@ pub const INITIAL_RECONNECTION_DELAY: Duration = Duration::from_millis(500);
 pub const MAX_RECONNECTION_DELAY: Duration = Duration::from_secs(10);
 pub const CONNECTION_TIMEOUT: Duration = Duration::from_secs(20);
 
-actions!(client, [SignIn, SignOut, Reconnect]);
+actions!(
+    client,
+    [
+        /// Sign in to Zed account
+        SignIn,
+        /// Sign out of Zed account
+        SignOut,
+        /// Reconnect to the collaboration server
+        Reconnect
+    ]
+);
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
 pub struct ClientSettingsContent {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -30,7 +30,13 @@ use workspace::{
 };
 use workspace::{item::Dedup, notifications::NotificationId};
 
-actions!(collab, [CopyLink]);
+actions!(
+    collab,
+    [
+        /// Copy a link to the current position in the channel buffer
+        CopyLink
+    ]
+);
 
 pub fn init(cx: &mut App) {
     workspace::FollowableViewRegistry::register::<ChannelView>(cx)

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -33,7 +33,7 @@ use workspace::{item::Dedup, notifications::NotificationId};
 actions!(
     collab,
     [
-        /// Copy a link to the current position in the channel buffer
+        /// Copies a link to the current position in the channel buffer.
         CopyLink
     ]
 );

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -71,7 +71,13 @@ struct SerializedChatPanel {
     width: Option<Pixels>,
 }
 
-actions!(chat_panel, [ToggleFocus]);
+actions!(
+    chat_panel,
+    [
+        /// Toggle focus on the chat panel
+        ToggleFocus
+    ]
+);
 
 impl ChatPanel {
     pub fn new(

--- a/crates/collab_ui/src/chat_panel.rs
+++ b/crates/collab_ui/src/chat_panel.rs
@@ -74,7 +74,7 @@ struct SerializedChatPanel {
 actions!(
     chat_panel,
     [
-        /// Toggle focus on the chat panel
+        /// Toggles focus on the chat panel.
         ToggleFocus
     ]
 );

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -44,15 +44,25 @@ use workspace::{
 actions!(
     collab_panel,
     [
+        /// Toggle focus on the collaboration panel
         ToggleFocus,
+        /// Remove the selected channel or contact
         Remove,
+        /// Open the context menu for the selected item
         Secondary,
+        /// Collapse the selected channel in the tree view
         CollapseSelectedChannel,
+        /// Expand the selected channel in the tree view
         ExpandSelectedChannel,
+        /// Start moving a channel to a new location
         StartMoveChannel,
+        /// Move the selected item to the current location
         MoveSelected,
+        /// Insert a space character in the filter input
         InsertSpace,
+        /// Move the selected channel up in the list
         MoveChannelUp,
+        /// Move the selected channel down in the list
         MoveChannelDown,
     ]
 );

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -44,25 +44,25 @@ use workspace::{
 actions!(
     collab_panel,
     [
-        /// Toggle focus on the collaboration panel
+        /// Toggles focus on the collaboration panel.
         ToggleFocus,
-        /// Remove the selected channel or contact
+        /// Removes the selected channel or contact.
         Remove,
-        /// Open the context menu for the selected item
+        /// Opens the context menu for the selected item.
         Secondary,
-        /// Collapse the selected channel in the tree view
+        /// Collapses the selected channel in the tree view.
         CollapseSelectedChannel,
-        /// Expand the selected channel in the tree view
+        /// Expands the selected channel in the tree view.
         ExpandSelectedChannel,
-        /// Start moving a channel to a new location
+        /// Starts moving a channel to a new location.
         StartMoveChannel,
-        /// Move the selected item to the current location
+        /// Moves the selected item to the current location.
         MoveSelected,
-        /// Insert a space character in the filter input
+        /// Inserts a space character in the filter input.
         InsertSpace,
-        /// Move the selected channel up in the list
+        /// Moves the selected channel up in the list.
         MoveChannelUp,
-        /// Move the selected channel down in the list
+        /// Moves the selected channel down in the list.
         MoveChannelDown,
     ]
 );

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -17,13 +17,13 @@ use workspace::{ModalView, notifications::DetachAndPromptErr};
 actions!(
     channel_modal,
     [
-        /// Select the next control in the channel modal
+        /// Selects the next control in the channel modal.
         SelectNextControl,
-        /// Toggle between invite members and manage members mode
+        /// Toggles between invite members and manage members mode.
         ToggleMode,
-        /// Toggle admin status for the selected member
+        /// Toggles admin status for the selected member.
         ToggleMemberAdmin,
-        /// Remove the selected member from the channel
+        /// Removes the selected member from the channel.
         RemoveMember
     ]
 );

--- a/crates/collab_ui/src/collab_panel/channel_modal.rs
+++ b/crates/collab_ui/src/collab_panel/channel_modal.rs
@@ -17,9 +17,13 @@ use workspace::{ModalView, notifications::DetachAndPromptErr};
 actions!(
     channel_modal,
     [
+        /// Select the next control in the channel modal
         SelectNextControl,
+        /// Toggle between invite members and manage members mode
         ToggleMode,
+        /// Toggle admin status for the selected member
         ToggleMemberAdmin,
+        /// Remove the selected member from the channel
         RemoveMember
     ]
 );

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -77,7 +77,7 @@ pub struct NotificationPresenter {
 actions!(
     notification_panel,
     [
-        /// Toggle focus on the notification panel
+        /// Toggles focus on the notification panel.
         ToggleFocus
     ]
 );

--- a/crates/collab_ui/src/notification_panel.rs
+++ b/crates/collab_ui/src/notification_panel.rs
@@ -74,7 +74,13 @@ pub struct NotificationPresenter {
     pub can_navigate: bool,
 }
 
-actions!(notification_panel, [ToggleFocus]);
+actions!(
+    notification_panel,
+    [
+        /// Toggle focus on the notification panel
+        ToggleFocus
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -46,17 +46,17 @@ pub use crate::sign_in::{CopilotCodeVerification, initiate_sign_in, reinstall_an
 actions!(
     copilot,
     [
-        /// Request a code completion suggestion from Copilot
+        /// Requests a code completion suggestion from Copilot.
         Suggest,
-        /// Cycle to the next Copilot suggestion
+        /// Cycles to the next Copilot suggestion.
         NextSuggestion,
-        /// Cycle to the previous Copilot suggestion
+        /// Cycles to the previous Copilot suggestion.
         PreviousSuggestion,
-        /// Reinstall the Copilot language server
+        /// Reinstalls the Copilot language server.
         Reinstall,
-        /// Sign in to GitHub Copilot
+        /// Signs in to GitHub Copilot.
         SignIn,
-        /// Sign out of GitHub Copilot
+        /// Signs out of GitHub Copilot.
         SignOut
     ]
 );

--- a/crates/copilot/src/copilot.rs
+++ b/crates/copilot/src/copilot.rs
@@ -46,11 +46,17 @@ pub use crate::sign_in::{CopilotCodeVerification, initiate_sign_in, reinstall_an
 actions!(
     copilot,
     [
+        /// Request a code completion suggestion from Copilot
         Suggest,
+        /// Cycle to the next Copilot suggestion
         NextSuggestion,
+        /// Cycle to the previous Copilot suggestion
         PreviousSuggestion,
+        /// Reinstall the Copilot language server
         Reinstall,
+        /// Sign in to GitHub Copilot
         SignIn,
+        /// Sign out of GitHub Copilot
         SignOut
     ]
 );

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -918,7 +918,13 @@ impl Render for DapLogView {
     }
 }
 
-actions!(dev, [OpenDebugAdapterLogs]);
+actions!(
+    dev,
+    [
+        /// Open the debug adapter protocol logs viewer
+        OpenDebugAdapterLogs
+    ]
+);
 
 pub fn init(cx: &mut App) {
     let log_store = cx.new(|cx| LogStore::new(cx));

--- a/crates/debugger_tools/src/dap_log.rs
+++ b/crates/debugger_tools/src/dap_log.rs
@@ -921,7 +921,7 @@ impl Render for DapLogView {
 actions!(
     dev,
     [
-        /// Open the debug adapter protocol logs viewer
+        /// Opens the debug adapter protocol logs viewer.
         OpenDebugAdapterLogs
     ]
 );

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -32,56 +32,56 @@ pub mod tests;
 actions!(
     debugger,
     [
-        /// Start a new debugging session
+        /// Starts a new debugging session.
         Start,
-        /// Continue execution until the next breakpoint
+        /// Continues execution until the next breakpoint.
         Continue,
-        /// Detach the debugger from the running process
+        /// Detaches the debugger from the running process.
         Detach,
-        /// Pause the currently running program
+        /// Pauses the currently running program.
         Pause,
-        /// Restart the current debugging session
+        /// Restarts the current debugging session.
         Restart,
-        /// Rerun the current debugging session with the same configuration
+        /// Reruns the current debugging session with the same configuration.
         RerunSession,
-        /// Step into the next function call
+        /// Steps into the next function call.
         StepInto,
-        /// Step over the current line
+        /// Steps over the current line.
         StepOver,
-        /// Step out of the current function
+        /// Steps out of the current function.
         StepOut,
-        /// Step back to the previous statement
+        /// Steps back to the previous statement.
         StepBack,
-        /// Stop the debugging session
+        /// Stops the debugging session.
         Stop,
-        /// Toggle whether to ignore all breakpoints
+        /// Toggles whether to ignore all breakpoints.
         ToggleIgnoreBreakpoints,
-        /// Clear all breakpoints in the project
+        /// Clears all breakpoints in the project.
         ClearAllBreakpoints,
-        /// Focus on the debugger console panel
+        /// Focuses on the debugger console panel.
         FocusConsole,
-        /// Focus on the variables panel
+        /// Focuses on the variables panel.
         FocusVariables,
-        /// Focus on the breakpoint list panel
+        /// Focuses on the breakpoint list panel.
         FocusBreakpointList,
-        /// Focus on the call stack frames panel
+        /// Focuses on the call stack frames panel.
         FocusFrames,
-        /// Focus on the loaded modules panel
+        /// Focuses on the loaded modules panel.
         FocusModules,
-        /// Focus on the loaded sources panel
+        /// Focuses on the loaded sources panel.
         FocusLoadedSources,
-        /// Focus on the terminal panel
+        /// Focuses on the terminal panel.
         FocusTerminal,
-        /// Show the stack trace for the current thread
+        /// Shows the stack trace for the current thread.
         ShowStackTrace,
-        /// Toggle the thread picker dropdown
+        /// Toggles the thread picker dropdown.
         ToggleThreadPicker,
-        /// Toggle the session picker dropdown
+        /// Toggles the session picker dropdown.
         ToggleSessionPicker,
-        /// Rerun the last debugging session
+        /// Reruns the last debugging session.
         #[action(deprecated_aliases = ["debugger::RerunLastSession"])]
         Rerun,
-        /// Toggle expansion of the selected item in the debugger UI
+        /// Toggles expansion of the selected item in the debugger UI.
         ToggleExpandItem,
     ]
 );
@@ -89,7 +89,7 @@ actions!(
 actions!(
     dev,
     [
-        /// Copy debug adapter launch arguments to clipboard
+        /// Copies debug adapter launch arguments to clipboard.
         CopyDebugAdapterArguments
     ]
 );

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -32,36 +32,67 @@ pub mod tests;
 actions!(
     debugger,
     [
+        /// Start a new debugging session
         Start,
+        /// Continue execution until the next breakpoint
         Continue,
+        /// Detach the debugger from the running process
         Detach,
+        /// Pause the currently running program
         Pause,
+        /// Restart the current debugging session
         Restart,
+        /// Rerun the current debugging session with the same configuration
         RerunSession,
+        /// Step into the next function call
         StepInto,
+        /// Step over the current line
         StepOver,
+        /// Step out of the current function
         StepOut,
+        /// Step back to the previous statement
         StepBack,
+        /// Stop the debugging session
         Stop,
+        /// Toggle whether to ignore all breakpoints
         ToggleIgnoreBreakpoints,
+        /// Clear all breakpoints in the project
         ClearAllBreakpoints,
+        /// Focus on the debugger console panel
         FocusConsole,
+        /// Focus on the variables panel
         FocusVariables,
+        /// Focus on the breakpoint list panel
         FocusBreakpointList,
+        /// Focus on the call stack frames panel
         FocusFrames,
+        /// Focus on the loaded modules panel
         FocusModules,
+        /// Focus on the loaded sources panel
         FocusLoadedSources,
+        /// Focus on the terminal panel
         FocusTerminal,
+        /// Show the stack trace for the current thread
         ShowStackTrace,
+        /// Toggle the thread picker dropdown
         ToggleThreadPicker,
+        /// Toggle the session picker dropdown
         ToggleSessionPicker,
+        /// Rerun the last debugging session
         #[action(deprecated_aliases = ["debugger::RerunLastSession"])]
         Rerun,
+        /// Toggle expansion of the selected item in the debugger UI
         ToggleExpandItem,
     ]
 );
 
-actions!(dev, [CopyDebugAdapterArguments]);
+actions!(
+    dev,
+    [
+        /// Copy debug adapter launch arguments to clipboard
+        CopyDebugAdapterArguments
+    ]
+);
 
 pub fn init(cx: &mut App) {
     DebuggerSettings::register(cx);

--- a/crates/debugger_ui/src/session/running/breakpoint_list.rs
+++ b/crates/debugger_ui/src/session/running/breakpoint_list.rs
@@ -33,7 +33,12 @@ use zed_actions::{ToggleEnableBreakpoint, UnsetBreakpoint};
 
 actions!(
     debugger,
-    [PreviousBreakpointProperty, NextBreakpointProperty]
+    [
+        /// Navigate to the previous breakpoint property in the list
+        PreviousBreakpointProperty,
+        /// Navigate to the next breakpoint property in the list
+        NextBreakpointProperty
+    ]
 );
 #[derive(Clone, Copy, PartialEq)]
 pub(crate) enum SelectedBreakpointKind {

--- a/crates/debugger_ui/src/session/running/breakpoint_list.rs
+++ b/crates/debugger_ui/src/session/running/breakpoint_list.rs
@@ -34,9 +34,9 @@ use zed_actions::{ToggleEnableBreakpoint, UnsetBreakpoint};
 actions!(
     debugger,
     [
-        /// Navigate to the previous breakpoint property in the list
+        /// Navigates to the previous breakpoint property in the list.
         PreviousBreakpointProperty,
-        /// Navigate to the next breakpoint property in the list
+        /// Navigates to the next breakpoint property in the list.
         NextBreakpointProperty
     ]
 );

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -26,7 +26,7 @@ use ui::{ContextMenu, Divider, PopoverMenu, SplitButton, Tooltip, prelude::*};
 actions!(
     console,
     [
-        /// Add an expression to the watch list
+        /// Adds an expression to the watch list.
         WatchExpression
     ]
 );

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -23,7 +23,13 @@ use std::{cell::RefCell, ops::Range, rc::Rc, usize};
 use theme::{Theme, ThemeSettings};
 use ui::{ContextMenu, Divider, PopoverMenu, SplitButton, Tooltip, prelude::*};
 
-actions!(console, [WatchExpression]);
+actions!(
+    console,
+    [
+        /// Add an expression to the watch list
+        WatchExpression
+    ]
+);
 
 pub struct Console {
     console: Entity<Editor>,

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -18,19 +18,19 @@ use util::debug_panic;
 actions!(
     variable_list,
     [
-        /// Expand the selected variable entry to show its children
+        /// Expands the selected variable entry to show its children.
         ExpandSelectedEntry,
-        /// Collapse the selected variable entry to hide its children
+        /// Collapses the selected variable entry to hide its children.
         CollapseSelectedEntry,
-        /// Copy the variable name to the clipboard
+        /// Copies the variable name to the clipboard.
         CopyVariableName,
-        /// Copy the variable value to the clipboard
+        /// Copies the variable value to the clipboard.
         CopyVariableValue,
-        /// Edit the value of the selected variable
+        /// Edits the value of the selected variable.
         EditVariable,
-        /// Add the selected variable to the watch list
+        /// Adds the selected variable to the watch list.
         AddWatch,
-        /// Remove the selected variable from the watch list
+        /// Removes the selected variable from the watch list.
         RemoveWatch,
     ]
 );

--- a/crates/debugger_ui/src/session/running/variable_list.rs
+++ b/crates/debugger_ui/src/session/running/variable_list.rs
@@ -18,12 +18,19 @@ use util::debug_panic;
 actions!(
     variable_list,
     [
+        /// Expand the selected variable entry to show its children
         ExpandSelectedEntry,
+        /// Collapse the selected variable entry to hide its children
         CollapseSelectedEntry,
+        /// Copy the variable name to the clipboard
         CopyVariableName,
+        /// Copy the variable value to the clipboard
         CopyVariableValue,
+        /// Edit the value of the selected variable
         EditVariable,
+        /// Add the selected variable to the watch list
         AddWatch,
+        /// Remove the selected variable from the watch list
         RemoveWatch,
     ]
 );

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -49,11 +49,11 @@ use workspace::{
 actions!(
     diagnostics,
     [
-        /// Open the project diagnostics view
+        /// Opens the project diagnostics view.
         Deploy,
-        /// Toggle the display of warning-level diagnostics
+        /// Toggles the display of warning-level diagnostics.
         ToggleWarnings,
-        /// Toggle automatic refresh of diagnostics
+        /// Toggles automatic refresh of diagnostics.
         ToggleDiagnosticsRefresh
     ]
 );

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -48,7 +48,14 @@ use workspace::{
 
 actions!(
     diagnostics,
-    [Deploy, ToggleWarnings, ToggleDiagnosticsRefresh]
+    [
+        /// Open the project diagnostics view
+        Deploy,
+        /// Toggle the display of warning-level diagnostics
+        ToggleWarnings,
+        /// Toggle automatic refresh of diagnostics
+        ToggleDiagnosticsRefresh
+    ]
 );
 
 #[derive(Default)]

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -238,11 +238,20 @@ pub enum UuidVersion {
     V7,
 }
 
-actions!(debugger, [RunToCursor, EvaluateSelectedText]);
+actions!(
+    debugger,
+    [
+        /// Run program execution to the current cursor position
+        RunToCursor,
+        /// Evaluate the selected text in the debugger context
+        EvaluateSelectedText
+    ]
+);
 
 actions!(
     go_to_line,
     [
+        /// Toggle the go to line dialog
         #[action(name = "Toggle")]
         ToggleGoToLine
     ]
@@ -251,219 +260,428 @@ actions!(
 actions!(
     editor,
     [
+        /// Accept the full edit prediction
         AcceptEditPrediction,
+        /// Accept a partial Copilot suggestion
         AcceptPartialCopilotSuggestion,
+        /// Accept a partial edit prediction
         AcceptPartialEditPrediction,
+        /// Add a cursor above the current selection
         AddSelectionAbove,
+        /// Add a cursor below the current selection
         AddSelectionBelow,
+        /// Apply all diff hunks in the editor
         ApplyAllDiffHunks,
+        /// Apply the diff hunk at the current position
         ApplyDiffHunk,
+        /// Delete the character before the cursor
         Backspace,
+        /// Cancel the current operation
         Cancel,
+        /// Cancel the running flycheck operation
         CancelFlycheck,
+        /// Cancel pending language server work
         CancelLanguageServerWork,
+        /// Clear flycheck results
         ClearFlycheck,
+        /// Confirm the rename operation
         ConfirmRename,
+        /// Confirm completion by inserting at cursor
         ConfirmCompletionInsert,
+        /// Confirm completion by replacing existing text
         ConfirmCompletionReplace,
+        /// Navigate to the first item in the context menu
         ContextMenuFirst,
+        /// Navigate to the last item in the context menu
         ContextMenuLast,
+        /// Navigate to the next item in the context menu
         ContextMenuNext,
+        /// Navigate to the previous item in the context menu
         ContextMenuPrevious,
+        /// Convert indentation from tabs to spaces
         ConvertIndentationToSpaces,
+        /// Convert indentation from spaces to tabs
         ConvertIndentationToTabs,
+        /// Convert selected text to kebab-case
         ConvertToKebabCase,
+        /// Convert selected text to lowerCamelCase
         ConvertToLowerCamelCase,
+        /// Convert selected text to lowercase
         ConvertToLowerCase,
+        /// Toggle the case of selected text
         ConvertToOppositeCase,
+        /// Convert selected text to snake_case
         ConvertToSnakeCase,
+        /// Convert selected text to Title Case
         ConvertToTitleCase,
+        /// Convert selected text to UpperCamelCase
         ConvertToUpperCamelCase,
+        /// Convert selected text to UPPERCASE
         ConvertToUpperCase,
+        /// Apply ROT13 cipher to selected text
         ConvertToRot13,
+        /// Apply ROT47 cipher to selected text
         ConvertToRot47,
+        /// Copy selected text to the clipboard
         Copy,
+        /// Copy selected text to the clipboard with leading/trailing whitespace trimmed
         CopyAndTrim,
+        /// Copy the current file location to the clipboard
         CopyFileLocation,
+        /// Copy the highlighted text as JSON
         CopyHighlightJson,
+        /// Copy the current file name to the clipboard
         CopyFileName,
+        /// Copy the file name without extension to the clipboard
         CopyFileNameWithoutExtension,
+        /// Copy a permalink to the current line
         CopyPermalinkToLine,
+        /// Cut selected text to the clipboard
         Cut,
+        /// Cut from cursor to end of line
         CutToEndOfLine,
+        /// Delete the character after the cursor
         Delete,
+        /// Delete the current line
         DeleteLine,
+        /// Delete from cursor to end of line
         DeleteToEndOfLine,
+        /// Delete to the end of the next subword
         DeleteToNextSubwordEnd,
+        /// Delete to the start of the previous subword
         DeleteToPreviousSubwordStart,
+        /// Display names of all active cursors
         DisplayCursorNames,
+        /// Duplicate the current line below
         DuplicateLineDown,
+        /// Duplicate the current line above
         DuplicateLineUp,
+        /// Duplicate the current selection
         DuplicateSelection,
+        /// Expand all diff hunks in the editor
         #[action(deprecated_aliases = ["editor::ExpandAllHunkDiffs"])]
         ExpandAllDiffHunks,
+        /// Expand macros recursively at cursor position
         ExpandMacroRecursively,
+        /// Find all references to the symbol at cursor
         FindAllReferences,
+        /// Find the next match in the search
         FindNextMatch,
+        /// Find the previous match in the search
         FindPreviousMatch,
+        /// Fold the current code block
         Fold,
+        /// Fold all foldable regions in the editor
         FoldAll,
+        /// Fold all function bodies in the editor
         FoldFunctionBodies,
+        /// Fold the current code block and all its children
         FoldRecursive,
+        /// Fold the selected ranges
         FoldSelectedRanges,
+        /// Toggle folding at the current position
         ToggleFold,
+        /// Toggle recursive folding at the current position
         ToggleFoldRecursive,
+        /// Format the entire document
         Format,
+        /// Format only the selected text
         FormatSelections,
+        /// Go to the declaration of the symbol at cursor
         GoToDeclaration,
+        /// Go to declaration in a split pane
         GoToDeclarationSplit,
+        /// Go to the definition of the symbol at cursor
         GoToDefinition,
+        /// Go to definition in a split pane
         GoToDefinitionSplit,
+        /// Go to the next diagnostic in the file
         GoToDiagnostic,
+        /// Go to the next diff hunk
         GoToHunk,
+        /// Go to the previous diff hunk
         GoToPreviousHunk,
+        /// Go to the implementation of the symbol at cursor
         GoToImplementation,
+        /// Go to implementation in a split pane
         GoToImplementationSplit,
+        /// Go to the next change in the file
         GoToNextChange,
+        /// Go to the parent module of the current file
         GoToParentModule,
+        /// Go to the previous change in the file
         GoToPreviousChange,
+        /// Go to the previous diagnostic in the file
         GoToPreviousDiagnostic,
+        /// Go to the type definition of the symbol at cursor
         GoToTypeDefinition,
+        /// Go to type definition in a split pane
         GoToTypeDefinitionSplit,
+        /// Scroll down by half a page
         HalfPageDown,
+        /// Scroll up by half a page
         HalfPageUp,
+        /// Show hover information for the symbol at cursor
         Hover,
+        /// Increase indentation of selected lines
         Indent,
+        /// Insert a UUID v4 at cursor position
         InsertUuidV4,
+        /// Insert a UUID v7 at cursor position
         InsertUuidV7,
+        /// Join the current line with the next line
         JoinLines,
+        /// Cut to kill ring (Emacs-style)
         KillRingCut,
+        /// Yank from kill ring (Emacs-style)
         KillRingYank,
+        /// Move cursor down one line
         LineDown,
+        /// Move cursor up one line
         LineUp,
+        /// Move cursor down
         MoveDown,
+        /// Move cursor left
         MoveLeft,
+        /// Move the current line down
         MoveLineDown,
+        /// Move the current line up
         MoveLineUp,
+        /// Move cursor right
         MoveRight,
+        /// Move cursor to the beginning of the document
         MoveToBeginning,
+        /// Move cursor to the enclosing bracket
         MoveToEnclosingBracket,
+        /// Move cursor to the end of the document
         MoveToEnd,
+        /// Move cursor to the end of the paragraph
         MoveToEndOfParagraph,
+        /// Move cursor to the end of the next subword
         MoveToNextSubwordEnd,
+        /// Move cursor to the end of the next word
         MoveToNextWordEnd,
+        /// Move cursor to the start of the previous subword
         MoveToPreviousSubwordStart,
+        /// Move cursor to the start of the previous word
         MoveToPreviousWordStart,
+        /// Move cursor to the start of the paragraph
         MoveToStartOfParagraph,
+        /// Move cursor to the start of the current excerpt
         MoveToStartOfExcerpt,
+        /// Move cursor to the start of the next excerpt
         MoveToStartOfNextExcerpt,
+        /// Move cursor to the end of the current excerpt
         MoveToEndOfExcerpt,
+        /// Move cursor to the end of the previous excerpt
         MoveToEndOfPreviousExcerpt,
+        /// Move cursor up
         MoveUp,
+        /// Insert a new line and move cursor to it
         Newline,
+        /// Insert a new line above the current line
         NewlineAbove,
+        /// Insert a new line below the current line
         NewlineBelow,
+        /// Navigate to the next edit prediction
         NextEditPrediction,
+        /// Scroll to the next screen
         NextScreen,
+        /// Open the context menu at cursor position
         OpenContextMenu,
+        /// Open excerpts from the current file
         OpenExcerpts,
+        /// Open excerpts in a split pane
         OpenExcerptsSplit,
+        /// Open the proposed changes editor
         OpenProposedChangesEditor,
+        /// Open documentation for the symbol at cursor
         OpenDocs,
+        /// Open a permalink to the current line
         OpenPermalinkToLine,
+        /// Open the file whose name is selected in the editor
         #[action(deprecated_aliases = ["editor::OpenFile"])]
         OpenSelectedFilename,
+        /// Open all selections in a multibuffer
         OpenSelectionsInMultibuffer,
+        /// Open the URL at cursor position
         OpenUrl,
+        /// Organize import statements
         OrganizeImports,
+        /// Decrease indentation of selected lines
         Outdent,
+        /// Automatically adjust indentation based on context
         AutoIndent,
+        /// Scroll down by one page
         PageDown,
+        /// Scroll up by one page
         PageUp,
+        /// Paste from clipboard
         Paste,
+        /// Navigate to the previous edit prediction
         PreviousEditPrediction,
+        /// Redo the last undone edit
         Redo,
+        /// Redo the last selection change
         RedoSelection,
+        /// Rename the symbol at cursor
         Rename,
+        /// Restart the language server for the current file
         RestartLanguageServer,
+        /// Reveal the current file in the system file manager
         RevealInFileManager,
+        /// Reverse the order of selected lines
         ReverseLines,
+        /// Reload the file from disk
         ReloadFile,
+        /// Rewrap text to fit within the preferred line length
         Rewrap,
+        /// Run flycheck diagnostics
         RunFlycheck,
+        /// Scroll the cursor to the bottom of the viewport
         ScrollCursorBottom,
+        /// Scroll the cursor to the center of the viewport
         ScrollCursorCenter,
+        /// Cycle cursor position between center, top, and bottom
         ScrollCursorCenterTopBottom,
+        /// Scroll the cursor to the top of the viewport
         ScrollCursorTop,
+        /// Select all text in the editor
         SelectAll,
+        /// Select all matches of the current selection
         SelectAllMatches,
+        /// Select to the start of the current excerpt
         SelectToStartOfExcerpt,
+        /// Select to the start of the next excerpt
         SelectToStartOfNextExcerpt,
+        /// Select to the end of the current excerpt
         SelectToEndOfExcerpt,
+        /// Select to the end of the previous excerpt
         SelectToEndOfPreviousExcerpt,
+        /// Extend selection down
         SelectDown,
+        /// Select the enclosing symbol
         SelectEnclosingSymbol,
+        /// Select the next larger syntax node
         SelectLargerSyntaxNode,
+        /// Extend selection left
         SelectLeft,
+        /// Select the current line
         SelectLine,
+        /// Extend selection down by one page
         SelectPageDown,
+        /// Extend selection up by one page
         SelectPageUp,
+        /// Extend selection right
         SelectRight,
+        /// Select the next smaller syntax node
         SelectSmallerSyntaxNode,
+        /// Select to the beginning of the document
         SelectToBeginning,
+        /// Select to the end of the document
         SelectToEnd,
+        /// Select to the end of the paragraph
         SelectToEndOfParagraph,
+        /// Select to the end of the next subword
         SelectToNextSubwordEnd,
+        /// Select to the end of the next word
         SelectToNextWordEnd,
+        /// Select to the start of the previous subword
         SelectToPreviousSubwordStart,
+        /// Select to the start of the previous word
         SelectToPreviousWordStart,
+        /// Select to the start of the paragraph
         SelectToStartOfParagraph,
+        /// Extend selection up
         SelectUp,
+        /// Show the system character palette
         ShowCharacterPalette,
+        /// Show edit prediction at cursor
         ShowEditPrediction,
+        /// Show signature help for the current function
         ShowSignatureHelp,
+        /// Show word completions
         ShowWordCompletions,
+        /// Randomly shuffle selected lines
         ShuffleLines,
         SignatureHelpNext,
         SignatureHelpPrevious,
+        /// Sort selected lines case-insensitively
         SortLinesCaseInsensitive,
+        /// Sort selected lines case-sensitively
         SortLinesCaseSensitive,
+        /// Split selection into individual lines
         SplitSelectionIntoLines,
+        /// Stop the language server for the current file
         StopLanguageServer,
+        /// Switch between source and header files
         SwitchSourceHeader,
+        /// Insert a tab character or indent
         Tab,
+        /// Remove a tab character or outdent
         Backtab,
+        /// Toggle a breakpoint at the current line
         ToggleBreakpoint,
+        /// Toggle the case of selected text
         ToggleCase,
+        /// Disable the breakpoint at the current line
         DisableBreakpoint,
+        /// Enable the breakpoint at the current line
         EnableBreakpoint,
+        /// Edit the log message for a breakpoint
         EditLogBreakpoint,
+        /// Toggle automatic signature help
         ToggleAutoSignatureHelp,
+        /// Toggle inline git blame display
         ToggleGitBlameInline,
+        /// Open the git commit for the blame at cursor
         OpenGitBlameCommit,
+        /// Toggle the diagnostics panel
         ToggleDiagnostics,
+        /// Toggle indent guides display
         ToggleIndentGuides,
+        /// Toggle inlay hints display
         ToggleInlayHints,
+        /// Toggle inline values display
         ToggleInlineValues,
+        /// Toggle inline diagnostics display
         ToggleInlineDiagnostics,
+        /// Toggle edit prediction feature
         ToggleEditPrediction,
+        /// Toggle line numbers display
         ToggleLineNumbers,
+        /// Toggle the minimap display
         ToggleMinimap,
+        /// Swap the start and end of the current selection
         SwapSelectionEnds,
+        /// Set a mark at the current position
         SetMark,
+        /// Toggle relative line numbers display
         ToggleRelativeLineNumbers,
+        /// Toggle diff display for selected hunks
         #[action(deprecated_aliases = ["editor::ToggleHunkDiff"])]
         ToggleSelectedDiffHunks,
+        /// Toggle the selection menu
         ToggleSelectionMenu,
+        /// Toggle soft wrap mode
         ToggleSoftWrap,
+        /// Toggle the tab bar display
         ToggleTabBar,
+        /// Transpose characters around cursor
         Transpose,
+        /// Undo the last edit
         Undo,
+        /// Undo the last selection change
         UndoSelection,
+        /// Unfold all folded regions
         UnfoldAll,
+        /// Unfold lines at cursor
         UnfoldLines,
+        /// Unfold recursively at cursor
         UnfoldRecursive,
+        /// Remove duplicate lines (case-insensitive)
         UniqueLinesCaseInsensitive,
+        /// Remove duplicate lines (case-sensitive)
         UniqueLinesCaseSensitive,
     ]
 );

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -241,9 +241,9 @@ pub enum UuidVersion {
 actions!(
     debugger,
     [
-        /// Run program execution to the current cursor position
+        /// Runs program execution to the current cursor position.
         RunToCursor,
-        /// Evaluate the selected text in the debugger context
+        /// Evaluates the selected text in the debugger context.
         EvaluateSelectedText
     ]
 );
@@ -251,7 +251,7 @@ actions!(
 actions!(
     go_to_line,
     [
-        /// Toggle the go to line dialog
+        /// Toggles the go to line dialog.
         #[action(name = "Toggle")]
         ToggleGoToLine
     ]
@@ -260,428 +260,428 @@ actions!(
 actions!(
     editor,
     [
-        /// Accept the full edit prediction
+        /// Accepts the full edit prediction.
         AcceptEditPrediction,
-        /// Accept a partial Copilot suggestion
+        /// Accepts a partial Copilot suggestion.
         AcceptPartialCopilotSuggestion,
-        /// Accept a partial edit prediction
+        /// Accepts a partial edit prediction.
         AcceptPartialEditPrediction,
-        /// Add a cursor above the current selection
+        /// Adds a cursor above the current selection.
         AddSelectionAbove,
-        /// Add a cursor below the current selection
+        /// Adds a cursor below the current selection.
         AddSelectionBelow,
-        /// Apply all diff hunks in the editor
+        /// Applies all diff hunks in the editor.
         ApplyAllDiffHunks,
-        /// Apply the diff hunk at the current position
+        /// Applies the diff hunk at the current position.
         ApplyDiffHunk,
-        /// Delete the character before the cursor
+        /// Deletes the character before the cursor.
         Backspace,
-        /// Cancel the current operation
+        /// Cancels the current operation.
         Cancel,
-        /// Cancel the running flycheck operation
+        /// Cancels the running flycheck operation.
         CancelFlycheck,
-        /// Cancel pending language server work
+        /// Cancels pending language server work.
         CancelLanguageServerWork,
-        /// Clear flycheck results
+        /// Clears flycheck results.
         ClearFlycheck,
-        /// Confirm the rename operation
+        /// Confirms the rename operation.
         ConfirmRename,
-        /// Confirm completion by inserting at cursor
+        /// Confirms completion by inserting at cursor.
         ConfirmCompletionInsert,
-        /// Confirm completion by replacing existing text
+        /// Confirms completion by replacing existing text.
         ConfirmCompletionReplace,
-        /// Navigate to the first item in the context menu
+        /// Navigates to the first item in the context menu.
         ContextMenuFirst,
-        /// Navigate to the last item in the context menu
+        /// Navigates to the last item in the context menu.
         ContextMenuLast,
-        /// Navigate to the next item in the context menu
+        /// Navigates to the next item in the context menu.
         ContextMenuNext,
-        /// Navigate to the previous item in the context menu
+        /// Navigates to the previous item in the context menu.
         ContextMenuPrevious,
-        /// Convert indentation from tabs to spaces
+        /// Converts indentation from tabs to spaces.
         ConvertIndentationToSpaces,
-        /// Convert indentation from spaces to tabs
+        /// Converts indentation from spaces to tabs.
         ConvertIndentationToTabs,
-        /// Convert selected text to kebab-case
+        /// Converts selected text to kebab-case.
         ConvertToKebabCase,
-        /// Convert selected text to lowerCamelCase
+        /// Converts selected text to lowerCamelCase.
         ConvertToLowerCamelCase,
-        /// Convert selected text to lowercase
+        /// Converts selected text to lowercase.
         ConvertToLowerCase,
-        /// Toggle the case of selected text
+        /// Toggles the case of selected text.
         ConvertToOppositeCase,
-        /// Convert selected text to snake_case
+        /// Converts selected text to snake_case.
         ConvertToSnakeCase,
-        /// Convert selected text to Title Case
+        /// Converts selected text to Title Case.
         ConvertToTitleCase,
-        /// Convert selected text to UpperCamelCase
+        /// Converts selected text to UpperCamelCase.
         ConvertToUpperCamelCase,
-        /// Convert selected text to UPPERCASE
+        /// Converts selected text to UPPERCASE.
         ConvertToUpperCase,
-        /// Apply ROT13 cipher to selected text
+        /// Applies ROT13 cipher to selected text.
         ConvertToRot13,
-        /// Apply ROT47 cipher to selected text
+        /// Applies ROT47 cipher to selected text.
         ConvertToRot47,
-        /// Copy selected text to the clipboard
+        /// Copies selected text to the clipboard.
         Copy,
-        /// Copy selected text to the clipboard with leading/trailing whitespace trimmed
+        /// Copies selected text to the clipboard with leading/trailing whitespace trimmed.
         CopyAndTrim,
-        /// Copy the current file location to the clipboard
+        /// Copies the current file location to the clipboard.
         CopyFileLocation,
-        /// Copy the highlighted text as JSON
+        /// Copies the highlighted text as JSON.
         CopyHighlightJson,
-        /// Copy the current file name to the clipboard
+        /// Copies the current file name to the clipboard.
         CopyFileName,
-        /// Copy the file name without extension to the clipboard
+        /// Copies the file name without extension to the clipboard.
         CopyFileNameWithoutExtension,
-        /// Copy a permalink to the current line
+        /// Copies a permalink to the current line.
         CopyPermalinkToLine,
-        /// Cut selected text to the clipboard
+        /// Cuts selected text to the clipboard.
         Cut,
-        /// Cut from cursor to end of line
+        /// Cuts from cursor to end of line.
         CutToEndOfLine,
-        /// Delete the character after the cursor
+        /// Deletes the character after the cursor.
         Delete,
-        /// Delete the current line
+        /// Deletes the current line.
         DeleteLine,
-        /// Delete from cursor to end of line
+        /// Deletes from cursor to end of line.
         DeleteToEndOfLine,
-        /// Delete to the end of the next subword
+        /// Deletes to the end of the next subword.
         DeleteToNextSubwordEnd,
-        /// Delete to the start of the previous subword
+        /// Deletes to the start of the previous subword.
         DeleteToPreviousSubwordStart,
-        /// Display names of all active cursors
+        /// Displays names of all active cursors.
         DisplayCursorNames,
-        /// Duplicate the current line below
+        /// Duplicates the current line below.
         DuplicateLineDown,
-        /// Duplicate the current line above
+        /// Duplicates the current line above.
         DuplicateLineUp,
-        /// Duplicate the current selection
+        /// Duplicates the current selection.
         DuplicateSelection,
-        /// Expand all diff hunks in the editor
+        /// Expands all diff hunks in the editor.
         #[action(deprecated_aliases = ["editor::ExpandAllHunkDiffs"])]
         ExpandAllDiffHunks,
-        /// Expand macros recursively at cursor position
+        /// Expands macros recursively at cursor position.
         ExpandMacroRecursively,
-        /// Find all references to the symbol at cursor
+        /// Finds all references to the symbol at cursor.
         FindAllReferences,
-        /// Find the next match in the search
+        /// Finds the next match in the search.
         FindNextMatch,
-        /// Find the previous match in the search
+        /// Finds the previous match in the search.
         FindPreviousMatch,
-        /// Fold the current code block
+        /// Folds the current code block.
         Fold,
-        /// Fold all foldable regions in the editor
+        /// Folds all foldable regions in the editor.
         FoldAll,
-        /// Fold all function bodies in the editor
+        /// Folds all function bodies in the editor.
         FoldFunctionBodies,
-        /// Fold the current code block and all its children
+        /// Folds the current code block and all its children.
         FoldRecursive,
-        /// Fold the selected ranges
+        /// Folds the selected ranges.
         FoldSelectedRanges,
-        /// Toggle folding at the current position
+        /// Toggles folding at the current position.
         ToggleFold,
-        /// Toggle recursive folding at the current position
+        /// Toggles recursive folding at the current position.
         ToggleFoldRecursive,
-        /// Format the entire document
+        /// Formats the entire document.
         Format,
-        /// Format only the selected text
+        /// Formats only the selected text.
         FormatSelections,
-        /// Go to the declaration of the symbol at cursor
+        /// Goes to the declaration of the symbol at cursor.
         GoToDeclaration,
-        /// Go to declaration in a split pane
+        /// Goes to declaration in a split pane.
         GoToDeclarationSplit,
-        /// Go to the definition of the symbol at cursor
+        /// Goes to the definition of the symbol at cursor.
         GoToDefinition,
-        /// Go to definition in a split pane
+        /// Goes to definition in a split pane.
         GoToDefinitionSplit,
-        /// Go to the next diagnostic in the file
+        /// Goes to the next diagnostic in the file.
         GoToDiagnostic,
-        /// Go to the next diff hunk
+        /// Goes to the next diff hunk.
         GoToHunk,
-        /// Go to the previous diff hunk
+        /// Goes to the previous diff hunk.
         GoToPreviousHunk,
-        /// Go to the implementation of the symbol at cursor
+        /// Goes to the implementation of the symbol at cursor.
         GoToImplementation,
-        /// Go to implementation in a split pane
+        /// Goes to implementation in a split pane.
         GoToImplementationSplit,
-        /// Go to the next change in the file
+        /// Goes to the next change in the file.
         GoToNextChange,
-        /// Go to the parent module of the current file
+        /// Goes to the parent module of the current file.
         GoToParentModule,
-        /// Go to the previous change in the file
+        /// Goes to the previous change in the file.
         GoToPreviousChange,
-        /// Go to the previous diagnostic in the file
+        /// Goes to the previous diagnostic in the file.
         GoToPreviousDiagnostic,
-        /// Go to the type definition of the symbol at cursor
+        /// Goes to the type definition of the symbol at cursor.
         GoToTypeDefinition,
-        /// Go to type definition in a split pane
+        /// Goes to type definition in a split pane.
         GoToTypeDefinitionSplit,
-        /// Scroll down by half a page
+        /// Scrolls down by half a page.
         HalfPageDown,
-        /// Scroll up by half a page
+        /// Scrolls up by half a page.
         HalfPageUp,
-        /// Show hover information for the symbol at cursor
+        /// Shows hover information for the symbol at cursor.
         Hover,
-        /// Increase indentation of selected lines
+        /// Increases indentation of selected lines.
         Indent,
-        /// Insert a UUID v4 at cursor position
+        /// Inserts a UUID v4 at cursor position.
         InsertUuidV4,
-        /// Insert a UUID v7 at cursor position
+        /// Inserts a UUID v7 at cursor position.
         InsertUuidV7,
-        /// Join the current line with the next line
+        /// Joins the current line with the next line.
         JoinLines,
-        /// Cut to kill ring (Emacs-style)
+        /// Cuts to kill ring (Emacs-style).
         KillRingCut,
-        /// Yank from kill ring (Emacs-style)
+        /// Yanks from kill ring (Emacs-style).
         KillRingYank,
-        /// Move cursor down one line
+        /// Moves cursor down one line.
         LineDown,
-        /// Move cursor up one line
+        /// Moves cursor up one line.
         LineUp,
-        /// Move cursor down
+        /// Moves cursor down.
         MoveDown,
-        /// Move cursor left
+        /// Moves cursor left.
         MoveLeft,
-        /// Move the current line down
+        /// Moves the current line down.
         MoveLineDown,
-        /// Move the current line up
+        /// Moves the current line up.
         MoveLineUp,
-        /// Move cursor right
+        /// Moves cursor right.
         MoveRight,
-        /// Move cursor to the beginning of the document
+        /// Moves cursor to the beginning of the document.
         MoveToBeginning,
-        /// Move cursor to the enclosing bracket
+        /// Moves cursor to the enclosing bracket.
         MoveToEnclosingBracket,
-        /// Move cursor to the end of the document
+        /// Moves cursor to the end of the document.
         MoveToEnd,
-        /// Move cursor to the end of the paragraph
+        /// Moves cursor to the end of the paragraph.
         MoveToEndOfParagraph,
-        /// Move cursor to the end of the next subword
+        /// Moves cursor to the end of the next subword.
         MoveToNextSubwordEnd,
-        /// Move cursor to the end of the next word
+        /// Moves cursor to the end of the next word.
         MoveToNextWordEnd,
-        /// Move cursor to the start of the previous subword
+        /// Moves cursor to the start of the previous subword.
         MoveToPreviousSubwordStart,
-        /// Move cursor to the start of the previous word
+        /// Moves cursor to the start of the previous word.
         MoveToPreviousWordStart,
-        /// Move cursor to the start of the paragraph
+        /// Moves cursor to the start of the paragraph.
         MoveToStartOfParagraph,
-        /// Move cursor to the start of the current excerpt
+        /// Moves cursor to the start of the current excerpt.
         MoveToStartOfExcerpt,
-        /// Move cursor to the start of the next excerpt
+        /// Moves cursor to the start of the next excerpt.
         MoveToStartOfNextExcerpt,
-        /// Move cursor to the end of the current excerpt
+        /// Moves cursor to the end of the current excerpt.
         MoveToEndOfExcerpt,
-        /// Move cursor to the end of the previous excerpt
+        /// Moves cursor to the end of the previous excerpt.
         MoveToEndOfPreviousExcerpt,
-        /// Move cursor up
+        /// Moves cursor up.
         MoveUp,
-        /// Insert a new line and move cursor to it
+        /// Inserts a new line and moves cursor to it.
         Newline,
-        /// Insert a new line above the current line
+        /// Inserts a new line above the current line.
         NewlineAbove,
-        /// Insert a new line below the current line
+        /// Inserts a new line below the current line.
         NewlineBelow,
-        /// Navigate to the next edit prediction
+        /// Navigates to the next edit prediction.
         NextEditPrediction,
-        /// Scroll to the next screen
+        /// Scrolls to the next screen.
         NextScreen,
-        /// Open the context menu at cursor position
+        /// Opens the context menu at cursor position.
         OpenContextMenu,
-        /// Open excerpts from the current file
+        /// Opens excerpts from the current file.
         OpenExcerpts,
-        /// Open excerpts in a split pane
+        /// Opens excerpts in a split pane.
         OpenExcerptsSplit,
-        /// Open the proposed changes editor
+        /// Opens the proposed changes editor.
         OpenProposedChangesEditor,
-        /// Open documentation for the symbol at cursor
+        /// Opens documentation for the symbol at cursor.
         OpenDocs,
-        /// Open a permalink to the current line
+        /// Opens a permalink to the current line.
         OpenPermalinkToLine,
-        /// Open the file whose name is selected in the editor
+        /// Opens the file whose name is selected in the editor.
         #[action(deprecated_aliases = ["editor::OpenFile"])]
         OpenSelectedFilename,
-        /// Open all selections in a multibuffer
+        /// Opens all selections in a multibuffer.
         OpenSelectionsInMultibuffer,
-        /// Open the URL at cursor position
+        /// Opens the URL at cursor position.
         OpenUrl,
-        /// Organize import statements
+        /// Organizes import statements.
         OrganizeImports,
-        /// Decrease indentation of selected lines
+        /// Decreases indentation of selected lines.
         Outdent,
-        /// Automatically adjust indentation based on context
+        /// Automatically adjusts indentation based on context.
         AutoIndent,
-        /// Scroll down by one page
+        /// Scrolls down by one page.
         PageDown,
-        /// Scroll up by one page
+        /// Scrolls up by one page.
         PageUp,
-        /// Paste from clipboard
+        /// Pastes from clipboard.
         Paste,
-        /// Navigate to the previous edit prediction
+        /// Navigates to the previous edit prediction.
         PreviousEditPrediction,
-        /// Redo the last undone edit
+        /// Redoes the last undone edit.
         Redo,
-        /// Redo the last selection change
+        /// Redoes the last selection change.
         RedoSelection,
-        /// Rename the symbol at cursor
+        /// Renames the symbol at cursor.
         Rename,
-        /// Restart the language server for the current file
+        /// Restarts the language server for the current file.
         RestartLanguageServer,
-        /// Reveal the current file in the system file manager
+        /// Reveals the current file in the system file manager.
         RevealInFileManager,
-        /// Reverse the order of selected lines
+        /// Reverses the order of selected lines.
         ReverseLines,
-        /// Reload the file from disk
+        /// Reloads the file from disk.
         ReloadFile,
-        /// Rewrap text to fit within the preferred line length
+        /// Rewraps text to fit within the preferred line length.
         Rewrap,
-        /// Run flycheck diagnostics
+        /// Runs flycheck diagnostics.
         RunFlycheck,
-        /// Scroll the cursor to the bottom of the viewport
+        /// Scrolls the cursor to the bottom of the viewport.
         ScrollCursorBottom,
-        /// Scroll the cursor to the center of the viewport
+        /// Scrolls the cursor to the center of the viewport.
         ScrollCursorCenter,
-        /// Cycle cursor position between center, top, and bottom
+        /// Cycles cursor position between center, top, and bottom.
         ScrollCursorCenterTopBottom,
-        /// Scroll the cursor to the top of the viewport
+        /// Scrolls the cursor to the top of the viewport.
         ScrollCursorTop,
-        /// Select all text in the editor
+        /// Selects all text in the editor.
         SelectAll,
-        /// Select all matches of the current selection
+        /// Selects all matches of the current selection.
         SelectAllMatches,
-        /// Select to the start of the current excerpt
+        /// Selects to the start of the current excerpt.
         SelectToStartOfExcerpt,
-        /// Select to the start of the next excerpt
+        /// Selects to the start of the next excerpt.
         SelectToStartOfNextExcerpt,
-        /// Select to the end of the current excerpt
+        /// Selects to the end of the current excerpt.
         SelectToEndOfExcerpt,
-        /// Select to the end of the previous excerpt
+        /// Selects to the end of the previous excerpt.
         SelectToEndOfPreviousExcerpt,
-        /// Extend selection down
+        /// Extends selection down.
         SelectDown,
-        /// Select the enclosing symbol
+        /// Selects the enclosing symbol.
         SelectEnclosingSymbol,
-        /// Select the next larger syntax node
+        /// Selects the next larger syntax node.
         SelectLargerSyntaxNode,
-        /// Extend selection left
+        /// Extends selection left.
         SelectLeft,
-        /// Select the current line
+        /// Selects the current line.
         SelectLine,
-        /// Extend selection down by one page
+        /// Extends selection down by one page.
         SelectPageDown,
-        /// Extend selection up by one page
+        /// Extends selection up by one page.
         SelectPageUp,
-        /// Extend selection right
+        /// Extends selection right.
         SelectRight,
-        /// Select the next smaller syntax node
+        /// Selects the next smaller syntax node.
         SelectSmallerSyntaxNode,
-        /// Select to the beginning of the document
+        /// Selects to the beginning of the document.
         SelectToBeginning,
-        /// Select to the end of the document
+        /// Selects to the end of the document.
         SelectToEnd,
-        /// Select to the end of the paragraph
+        /// Selects to the end of the paragraph.
         SelectToEndOfParagraph,
-        /// Select to the end of the next subword
+        /// Selects to the end of the next subword.
         SelectToNextSubwordEnd,
-        /// Select to the end of the next word
+        /// Selects to the end of the next word.
         SelectToNextWordEnd,
-        /// Select to the start of the previous subword
+        /// Selects to the start of the previous subword.
         SelectToPreviousSubwordStart,
-        /// Select to the start of the previous word
+        /// Selects to the start of the previous word.
         SelectToPreviousWordStart,
-        /// Select to the start of the paragraph
+        /// Selects to the start of the paragraph.
         SelectToStartOfParagraph,
-        /// Extend selection up
+        /// Extends selection up.
         SelectUp,
-        /// Show the system character palette
+        /// Shows the system character palette.
         ShowCharacterPalette,
-        /// Show edit prediction at cursor
+        /// Shows edit prediction at cursor.
         ShowEditPrediction,
-        /// Show signature help for the current function
+        /// Shows signature help for the current function.
         ShowSignatureHelp,
-        /// Show word completions
+        /// Shows word completions.
         ShowWordCompletions,
-        /// Randomly shuffle selected lines
+        /// Randomly shuffles selected lines.
         ShuffleLines,
         SignatureHelpNext,
         SignatureHelpPrevious,
-        /// Sort selected lines case-insensitively
+        /// Sorts selected lines case-insensitively.
         SortLinesCaseInsensitive,
-        /// Sort selected lines case-sensitively
+        /// Sorts selected lines case-sensitively.
         SortLinesCaseSensitive,
-        /// Split selection into individual lines
+        /// Splits selection into individual lines.
         SplitSelectionIntoLines,
-        /// Stop the language server for the current file
+        /// Stops the language server for the current file.
         StopLanguageServer,
-        /// Switch between source and header files
+        /// Switches between source and header files.
         SwitchSourceHeader,
-        /// Insert a tab character or indent
+        /// Inserts a tab character or indents.
         Tab,
-        /// Remove a tab character or outdent
+        /// Removes a tab character or outdents.
         Backtab,
-        /// Toggle a breakpoint at the current line
+        /// Toggles a breakpoint at the current line.
         ToggleBreakpoint,
-        /// Toggle the case of selected text
+        /// Toggles the case of selected text.
         ToggleCase,
-        /// Disable the breakpoint at the current line
+        /// Disables the breakpoint at the current line.
         DisableBreakpoint,
-        /// Enable the breakpoint at the current line
+        /// Enables the breakpoint at the current line.
         EnableBreakpoint,
-        /// Edit the log message for a breakpoint
+        /// Edits the log message for a breakpoint.
         EditLogBreakpoint,
-        /// Toggle automatic signature help
+        /// Toggles automatic signature help.
         ToggleAutoSignatureHelp,
-        /// Toggle inline git blame display
+        /// Toggles inline git blame display.
         ToggleGitBlameInline,
-        /// Open the git commit for the blame at cursor
+        /// Opens the git commit for the blame at cursor.
         OpenGitBlameCommit,
-        /// Toggle the diagnostics panel
+        /// Toggles the diagnostics panel.
         ToggleDiagnostics,
-        /// Toggle indent guides display
+        /// Toggles indent guides display.
         ToggleIndentGuides,
-        /// Toggle inlay hints display
+        /// Toggles inlay hints display.
         ToggleInlayHints,
-        /// Toggle inline values display
+        /// Toggles inline values display.
         ToggleInlineValues,
-        /// Toggle inline diagnostics display
+        /// Toggles inline diagnostics display.
         ToggleInlineDiagnostics,
-        /// Toggle edit prediction feature
+        /// Toggles edit prediction feature.
         ToggleEditPrediction,
-        /// Toggle line numbers display
+        /// Toggles line numbers display.
         ToggleLineNumbers,
-        /// Toggle the minimap display
+        /// Toggles the minimap display.
         ToggleMinimap,
-        /// Swap the start and end of the current selection
+        /// Swaps the start and end of the current selection.
         SwapSelectionEnds,
-        /// Set a mark at the current position
+        /// Sets a mark at the current position.
         SetMark,
-        /// Toggle relative line numbers display
+        /// Toggles relative line numbers display.
         ToggleRelativeLineNumbers,
-        /// Toggle diff display for selected hunks
+        /// Toggles diff display for selected hunks.
         #[action(deprecated_aliases = ["editor::ToggleHunkDiff"])]
         ToggleSelectedDiffHunks,
-        /// Toggle the selection menu
+        /// Toggles the selection menu.
         ToggleSelectionMenu,
-        /// Toggle soft wrap mode
+        /// Toggles soft wrap mode.
         ToggleSoftWrap,
-        /// Toggle the tab bar display
+        /// Toggles the tab bar display.
         ToggleTabBar,
-        /// Transpose characters around cursor
+        /// Transposes characters around cursor.
         Transpose,
-        /// Undo the last edit
+        /// Undoes the last edit.
         Undo,
-        /// Undo the last selection change
+        /// Undoes the last selection change.
         UndoSelection,
-        /// Unfold all folded regions
+        /// Unfolds all folded regions.
         UnfoldAll,
-        /// Unfold lines at cursor
+        /// Unfolds lines at cursor.
         UnfoldLines,
-        /// Unfold recursively at cursor
+        /// Unfolds recursively at cursor.
         UnfoldRecursive,
-        /// Remove duplicate lines (case-insensitive)
+        /// Removes duplicate lines (case-insensitive).
         UniqueLinesCaseInsensitive,
-        /// Remove duplicate lines (case-sensitive)
+        /// Removes duplicate lines (case-sensitive).
         UniqueLinesCaseSensitive,
     ]
 );

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -4,6 +4,7 @@ use gpui::{Action, actions};
 use schemars::JsonSchema;
 use util::serde::default_true;
 
+/// Selects the next occurrence of the current selection.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -12,6 +13,7 @@ pub struct SelectNext {
     pub replace_newest: bool,
 }
 
+/// Selects the previous occurrence of the current selection.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -20,6 +22,7 @@ pub struct SelectPrevious {
     pub replace_newest: bool,
 }
 
+/// Moves the cursor to the beginning of the current line.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -30,6 +33,7 @@ pub struct MoveToBeginningOfLine {
     pub stop_at_indent: bool,
 }
 
+/// Selects from the cursor to the beginning of the current line.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -40,6 +44,7 @@ pub struct SelectToBeginningOfLine {
     pub stop_at_indent: bool,
 }
 
+/// Deletes from the cursor to the beginning of the current line.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -48,6 +53,7 @@ pub struct DeleteToBeginningOfLine {
     pub(super) stop_at_indent: bool,
 }
 
+/// Moves the cursor up by one page.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -56,6 +62,7 @@ pub struct MovePageUp {
     pub(super) center_cursor: bool,
 }
 
+/// Moves the cursor down by one page.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -64,6 +71,7 @@ pub struct MovePageDown {
     pub(super) center_cursor: bool,
 }
 
+/// Moves the cursor to the end of the current line.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -72,6 +80,7 @@ pub struct MoveToEndOfLine {
     pub stop_at_soft_wraps: bool,
 }
 
+/// Selects from the cursor to the end of the current line.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -80,6 +89,7 @@ pub struct SelectToEndOfLine {
     pub(super) stop_at_soft_wraps: bool,
 }
 
+/// Toggles the display of available code actions at the cursor position.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -101,6 +111,7 @@ pub enum CodeActionSource {
     QuickActionBar,
 }
 
+/// Confirms and accepts the currently selected completion suggestion.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -109,6 +120,7 @@ pub struct ConfirmCompletion {
     pub item_ix: Option<usize>,
 }
 
+/// Composes multiple completion suggestions into a single completion.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -117,6 +129,7 @@ pub struct ComposeCompletion {
     pub item_ix: Option<usize>,
 }
 
+/// Confirms and applies the currently selected code action.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -125,6 +138,7 @@ pub struct ConfirmCodeAction {
     pub item_ix: Option<usize>,
 }
 
+/// Toggles comment markers for the selected lines.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -135,6 +149,7 @@ pub struct ToggleComments {
     pub ignore_indent: bool,
 }
 
+/// Moves the cursor up by a specified number of lines.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -143,6 +158,7 @@ pub struct MoveUpByLines {
     pub(super) lines: u32,
 }
 
+/// Moves the cursor down by a specified number of lines.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -151,6 +167,7 @@ pub struct MoveDownByLines {
     pub(super) lines: u32,
 }
 
+/// Extends selection up by a specified number of lines.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -159,6 +176,7 @@ pub struct SelectUpByLines {
     pub(super) lines: u32,
 }
 
+/// Extends selection down by a specified number of lines.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -167,6 +185,7 @@ pub struct SelectDownByLines {
     pub(super) lines: u32,
 }
 
+/// Expands all excerpts in the editor.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -175,6 +194,7 @@ pub struct ExpandExcerpts {
     pub(super) lines: u32,
 }
 
+/// Expands excerpts above the current position.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -183,6 +203,7 @@ pub struct ExpandExcerptsUp {
     pub(super) lines: u32,
 }
 
+/// Expands excerpts below the current position.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -191,6 +212,7 @@ pub struct ExpandExcerptsDown {
     pub(super) lines: u32,
 }
 
+/// Shows code completion suggestions at the cursor position.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -199,10 +221,12 @@ pub struct ShowCompletions {
     pub(super) trigger: Option<String>,
 }
 
+/// Handles text input in the editor.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 pub struct HandleInput(pub String);
 
+/// Deletes from the cursor to the end of the next word.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -211,6 +235,7 @@ pub struct DeleteToNextWordEnd {
     pub ignore_newlines: bool,
 }
 
+/// Deletes from the cursor to the start of the previous word.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -219,10 +244,12 @@ pub struct DeleteToPreviousWordStart {
     pub ignore_newlines: bool,
 }
 
+/// Folds all code blocks at the specified indentation level.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 pub struct FoldAtLevel(pub u32);
 
+/// Spawns the nearest available task from the current cursor position.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = editor)]
 #[serde(deny_unknown_fields)]
@@ -604,7 +631,9 @@ actions!(
         ShowWordCompletions,
         /// Randomly shuffles selected lines.
         ShuffleLines,
+        /// Navigates to the next signature in the signature help popup.
         SignatureHelpNext,
+        /// Navigates to the previous signature in the signature help popup.
         SignatureHelpPrevious,
         /// Sorts selected lines case-insensitively.
         SortLinesCaseInsensitive,

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -178,7 +178,13 @@ pub struct ExtensionIndexLanguageEntry {
     pub grammar: Option<Arc<str>>,
 }
 
-actions!(zed, [ReloadExtensions]);
+actions!(
+    zed,
+    [
+        /// Reload all installed extensions
+        ReloadExtensions
+    ]
+);
 
 pub fn init(
     extension_host_proxy: Arc<ExtensionHostProxy>,

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -181,7 +181,7 @@ pub struct ExtensionIndexLanguageEntry {
 actions!(
     zed,
     [
-        /// Reload all installed extensions
+        /// Reloads all installed extensions.
         ReloadExtensions
     ]
 );

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -38,7 +38,13 @@ use crate::extension_version_selector::{
     ExtensionVersionSelector, ExtensionVersionSelectorDelegate,
 };
 
-actions!(zed, [InstallDevExtension]);
+actions!(
+    zed,
+    [
+        /// Install an extension from a local directory for development
+        InstallDevExtension
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(move |workspace: &mut Workspace, window, cx| {

--- a/crates/extensions_ui/src/extensions_ui.rs
+++ b/crates/extensions_ui/src/extensions_ui.rs
@@ -41,7 +41,7 @@ use crate::extension_version_selector::{
 actions!(
     zed,
     [
-        /// Install an extension from a local directory for development
+        /// Installs an extension from a local directory for development.
         InstallDevExtension
     ]
 );

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -11,9 +11,13 @@ pub mod system_specs;
 actions!(
     zed,
     [
+        /// Copy system specifications to the clipboard for bug reports
         CopySystemSpecsIntoClipboard,
+        /// Open email client to send feedback to Zed support
         EmailZed,
+        /// Open the Zed repository on GitHub
         OpenZedRepo,
+        /// Open the feature request form
         RequestFeature,
     ]
 );

--- a/crates/feedback/src/feedback.rs
+++ b/crates/feedback/src/feedback.rs
@@ -11,13 +11,13 @@ pub mod system_specs;
 actions!(
     zed,
     [
-        /// Copy system specifications to the clipboard for bug reports
+        /// Copies system specifications to the clipboard for bug reports.
         CopySystemSpecsIntoClipboard,
-        /// Open email client to send feedback to Zed support
+        /// Opens email client to send feedback to Zed support.
         EmailZed,
-        /// Open the Zed repository on GitHub
+        /// Opens the Zed repository on GitHub.
         OpenZedRepo,
-        /// Open the feature request form
+        /// Opens the feature request form.
         RequestFeature,
     ]
 );

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -48,11 +48,11 @@ use workspace::{
 actions!(
     file_finder,
     [
-        /// Select the previous item in the file finder
+        /// Selects the previous item in the file finder.
         SelectPrevious,
-        /// Toggle the file filter menu
+        /// Toggles the file filter menu.
         ToggleFilterMenu,
-        /// Toggle the split direction menu
+        /// Toggles the split direction menu.
         ToggleSplitMenu
     ]
 );

--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -47,7 +47,14 @@ use workspace::{
 
 actions!(
     file_finder,
-    [SelectPrevious, ToggleFilterMenu, ToggleSplitMenu]
+    [
+        /// Select the previous item in the file finder
+        SelectPrevious,
+        /// Toggle the file filter menu
+        ToggleFilterMenu,
+        /// Toggle the split direction menu
+        ToggleSplitMenu
+    ]
 );
 
 impl ModalView for FileFinder {

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -31,34 +31,59 @@ actions!(
     git,
     [
         // per-hunk
+        /// Toggle the staged state of the hunk at cursor
         ToggleStaged,
+        /// Stage the current hunk and move to the next one
         StageAndNext,
+        /// Unstage the current hunk and move to the next one
         UnstageAndNext,
+        /// Restore the selected hunks to their original state
         #[action(deprecated_aliases = ["editor::RevertSelectedHunks"])]
         Restore,
         // per-file
+        /// Show git blame information for the current file
         #[action(deprecated_aliases = ["editor::ToggleGitBlame"])]
         Blame,
+        /// Stage the current file
         StageFile,
+        /// Unstage the current file
         UnstageFile,
         // repo-wide
+        /// Stage all changes in the repository
         StageAll,
+        /// Unstage all changes in the repository
         UnstageAll,
+        /// Restore all tracked files to their last committed state
         RestoreTrackedFiles,
+        /// Move all untracked files to trash
         TrashUntrackedFiles,
+        /// Undo the last commit, keeping changes in the working directory
         Uncommit,
+        /// Push commits to the remote repository
         Push,
+        /// Push commits to a specific remote branch
         PushTo,
+        /// Force push commits to the remote repository
         ForcePush,
+        /// Pull changes from the remote repository
         Pull,
+        /// Fetch changes from the remote repository
         Fetch,
+        /// Fetch changes from a specific remote
         FetchFrom,
+        /// Create a new commit with staged changes
         Commit,
+        /// Amend the last commit with staged changes
         Amend,
+        /// Cancel the current git operation
         Cancel,
+        /// Expand the commit message editor
         ExpandCommitEditor,
+        /// Generate a commit message using AI
         GenerateCommitMessage,
+        /// Initialize a new git repository
         Init,
+        /// Open all modified files in the editor
         OpenModifiedFiles,
     ]
 );

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -88,6 +88,7 @@ actions!(
     ]
 );
 
+/// Restores a file to its last committed state, discarding local changes.
 #[derive(Clone, Debug, Default, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = git, deprecated_aliases = ["editor::RevertFile"])]
 #[serde(deny_unknown_fields)]

--- a/crates/git/src/git.rs
+++ b/crates/git/src/git.rs
@@ -31,59 +31,59 @@ actions!(
     git,
     [
         // per-hunk
-        /// Toggle the staged state of the hunk at cursor
+        /// Toggles the staged state of the hunk at cursor.
         ToggleStaged,
-        /// Stage the current hunk and move to the next one
+        /// Stages the current hunk and moves to the next one.
         StageAndNext,
-        /// Unstage the current hunk and move to the next one
+        /// Unstages the current hunk and moves to the next one.
         UnstageAndNext,
-        /// Restore the selected hunks to their original state
+        /// Restores the selected hunks to their original state.
         #[action(deprecated_aliases = ["editor::RevertSelectedHunks"])]
         Restore,
         // per-file
-        /// Show git blame information for the current file
+        /// Shows git blame information for the current file.
         #[action(deprecated_aliases = ["editor::ToggleGitBlame"])]
         Blame,
-        /// Stage the current file
+        /// Stages the current file.
         StageFile,
-        /// Unstage the current file
+        /// Unstages the current file.
         UnstageFile,
         // repo-wide
-        /// Stage all changes in the repository
+        /// Stages all changes in the repository.
         StageAll,
-        /// Unstage all changes in the repository
+        /// Unstages all changes in the repository.
         UnstageAll,
-        /// Restore all tracked files to their last committed state
+        /// Restores all tracked files to their last committed state.
         RestoreTrackedFiles,
-        /// Move all untracked files to trash
+        /// Moves all untracked files to trash.
         TrashUntrackedFiles,
-        /// Undo the last commit, keeping changes in the working directory
+        /// Undoes the last commit, keeping changes in the working directory.
         Uncommit,
-        /// Push commits to the remote repository
+        /// Pushes commits to the remote repository.
         Push,
-        /// Push commits to a specific remote branch
+        /// Pushes commits to a specific remote branch.
         PushTo,
-        /// Force push commits to the remote repository
+        /// Force pushes commits to the remote repository.
         ForcePush,
-        /// Pull changes from the remote repository
+        /// Pulls changes from the remote repository.
         Pull,
-        /// Fetch changes from the remote repository
+        /// Fetches changes from the remote repository.
         Fetch,
-        /// Fetch changes from a specific remote
+        /// Fetches changes from a specific remote.
         FetchFrom,
-        /// Create a new commit with staged changes
+        /// Creates a new commit with staged changes.
         Commit,
-        /// Amend the last commit with staged changes
+        /// Amends the last commit with staged changes.
         Amend,
-        /// Cancel the current git operation
+        /// Cancels the current git operation.
         Cancel,
-        /// Expand the commit message editor
+        /// Expands the commit message editor.
         ExpandCommitEditor,
-        /// Generate a commit message using AI
+        /// Generates a commit message using AI.
         GenerateCommitMessage,
-        /// Initialize a new git repository
+        /// Initializes a new git repository.
         Init,
-        /// Open all modified files in the editor
+        /// Opens all modified files in the editor.
         OpenModifiedFiles,
     ]
 );

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -77,11 +77,17 @@ use zed_llm_client::CompletionIntent;
 actions!(
     git_panel,
     [
+        /// Close the git panel
         Close,
+        /// Toggle focus on the git panel
         ToggleFocus,
+        /// Open the git panel menu
         OpenMenu,
+        /// Focus on the commit message editor
         FocusEditor,
+        /// Focus on the changes list
         FocusChanges,
+        /// Toggle automatic co-author suggestions
         ToggleFillCoAuthors,
     ]
 );

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -77,17 +77,17 @@ use zed_llm_client::CompletionIntent;
 actions!(
     git_panel,
     [
-        /// Close the git panel
+        /// Closes the git panel.
         Close,
-        /// Toggle focus on the git panel
+        /// Toggles focus on the git panel.
         ToggleFocus,
-        /// Open the git panel menu
+        /// Opens the git panel menu.
         OpenMenu,
-        /// Focus on the commit message editor
+        /// Focuses on the commit message editor.
         FocusEditor,
-        /// Focus on the changes list
+        /// Focuses on the changes list.
         FocusChanges,
-        /// Toggle automatic co-author suggestions
+        /// Toggles automatic co-author suggestions.
         ToggleFillCoAuthors,
     ]
 );

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -31,7 +31,13 @@ pub mod project_diff;
 pub(crate) mod remote_output;
 pub mod repository_selector;
 
-actions!(git, [ResetOnboarding]);
+actions!(
+    git,
+    [
+        /// Reset the git onboarding state to show the tutorial again
+        ResetOnboarding
+    ]
+);
 
 pub fn init(cx: &mut App) {
     GitPanelSettings::register(cx);

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -34,7 +34,7 @@ pub mod repository_selector;
 actions!(
     git,
     [
-        /// Reset the git onboarding state to show the tutorial again
+        /// Resets the git onboarding state to show the tutorial again.
         ResetOnboarding
     ]
 );

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -41,7 +41,15 @@ use workspace::{
     searchable::SearchableItemHandle,
 };
 
-actions!(git, [Diff, Add]);
+actions!(
+    git,
+    [
+        /// Show the diff between the working directory and the index
+        Diff,
+        /// Add files to the git staging area
+        Add
+    ]
+);
 
 pub struct ProjectDiff {
     project: Entity<Project>,

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -44,9 +44,9 @@ use workspace::{
 actions!(
     git,
     [
-        /// Show the diff between the working directory and the index
+        /// Shows the diff between the working directory and the index.
         Diff,
-        /// Add files to the git staging area
+        /// Adds files to the git staging area.
         Add
     ]
 );

--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -150,6 +150,15 @@ pub trait Action: Any + Send {
     {
         None
     }
+
+    /// The documentation for this action, if any. When using the derive macro for actions
+    /// this will be automatically generated from the doc comments on the action struct.
+    fn documentation() -> Option<&'static str>
+    where
+        Self: Sized,
+    {
+        None
+    }
 }
 
 impl std::fmt::Debug for dyn Action {
@@ -254,6 +263,7 @@ pub struct MacroActionData {
     pub json_schema: fn(&mut schemars::SchemaGenerator) -> Option<schemars::Schema>,
     pub deprecated_aliases: &'static [&'static str],
     pub deprecation_message: Option<&'static str>,
+    pub documentation: Option<&'static str>,
 }
 
 inventory::collect!(MacroActionBuilder);
@@ -276,6 +286,7 @@ impl ActionRegistry {
             json_schema: A::action_json_schema,
             deprecated_aliases: A::deprecated_aliases(),
             deprecation_message: A::deprecation_message(),
+            documentation: A::documentation(),
         });
     }
 

--- a/crates/gpui_macros/src/derive_action.rs
+++ b/crates/gpui_macros/src/derive_action.rs
@@ -14,6 +14,7 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
     let mut no_register = false;
     let mut namespace = None;
     let mut deprecated = None;
+    let mut doc_str: Option<String> = None;
 
     for attr in &input.attrs {
         if attr.path().is_ident("action") {
@@ -74,6 +75,22 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
                 Ok(())
             })
             .unwrap_or_else(|e| panic!("in #[action] attribute: {}", e));
+        } else if attr.path().is_ident("doc") {
+            use syn::{Expr::Lit, ExprLit, Lit::Str, Meta, MetaNameValue};
+            if let Meta::NameValue(MetaNameValue {
+                value:
+                    Lit(ExprLit {
+                        lit: Str(ref lit_str),
+                        ..
+                    }),
+                ..
+            }) = attr.meta
+            {
+                let doc = lit_str.value();
+                let doc_str = doc_str.get_or_insert_default();
+                doc_str.push_str(doc.trim());
+                doc_str.push('\n');
+            }
         }
     }
 
@@ -118,6 +135,13 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
 
     let deprecation_fn_body = if let Some(message) = deprecated {
         quote! { Some(#message) }
+    } else {
+        quote! { None }
+    };
+
+    let documentation_fn_body = if let Some(doc) = doc_str {
+        let doc = doc.trim();
+        quote! { Some(#doc) }
     } else {
         quote! { None }
     };
@@ -170,6 +194,10 @@ pub(crate) fn derive_action(input: TokenStream) -> TokenStream {
 
             fn deprecation_message() -> Option<&'static str> {
                 #deprecation_fn_body
+            }
+
+            fn documentation() -> Option<&'static str> {
+                #documentation_fn_body
             }
         }
     })

--- a/crates/gpui_macros/src/register_action.rs
+++ b/crates/gpui_macros/src/register_action.rs
@@ -34,6 +34,7 @@ pub(crate) fn generate_register_action(type_name: &Ident) -> TokenStream2 {
                         json_schema: <#type_name as gpui::Action>::action_json_schema,
                         deprecated_aliases: <#type_name as gpui::Action>::deprecated_aliases(),
                         deprecation_message: <#type_name as gpui::Action>::deprecation_message(),
+                        documentation: <#type_name as gpui::Action>::documentation(),
                     }
                 }
 

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -40,7 +40,7 @@ use zeta::RateCompletions;
 actions!(
     edit_prediction,
     [
-        /// Toggle the inline completion menu
+        /// Toggles the inline completion menu.
         ToggleMenu
     ]
 );

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -37,7 +37,13 @@ use zed_actions::OpenBrowser;
 use zed_llm_client::UsageLimit;
 use zeta::RateCompletions;
 
-actions!(edit_prediction, [ToggleMenu]);
+actions!(
+    edit_prediction,
+    [
+        /// Toggle the inline completion menu
+        ToggleMenu
+    ]
+);
 
 const COPILOT_SETTINGS_URL: &str = "https://github.com/settings/copilot";
 

--- a/crates/install_cli/src/install_cli.rs
+++ b/crates/install_cli/src/install_cli.rs
@@ -8,7 +8,15 @@ use util::ResultExt;
 use workspace::notifications::{DetachAndPromptErr, NotificationId};
 use workspace::{Toast, Workspace};
 
-actions!(cli, [Install, RegisterZedScheme]);
+actions!(
+    cli,
+    [
+        /// Install the Zed CLI tool to the system PATH
+        Install,
+        /// Register the zed:// URL scheme handler
+        RegisterZedScheme
+    ]
+);
 
 async fn install_script(cx: &AsyncApp) -> Result<PathBuf> {
     let cli_path = cx.update(|cx| cx.path_for_auxiliary_executable("cli"))??;

--- a/crates/install_cli/src/install_cli.rs
+++ b/crates/install_cli/src/install_cli.rs
@@ -11,9 +11,9 @@ use workspace::{Toast, Workspace};
 actions!(
     cli,
     [
-        /// Install the Zed CLI tool to the system PATH
+        /// Installs the Zed CLI tool to the system PATH.
         Install,
-        /// Register the zed:// URL scheme handler
+        /// Registers the zed:// URL scheme handler.
         RegisterZedScheme
     ]
 );

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -16,7 +16,7 @@ use workspace::{AppState, OpenVisible, Workspace};
 actions!(
     journal,
     [
-        /// Create a new journal entry for today
+        /// Creates a new journal entry for today.
         NewJournalEntry
     ]
 );

--- a/crates/journal/src/journal.rs
+++ b/crates/journal/src/journal.rs
@@ -13,7 +13,13 @@ use std::{
 };
 use workspace::{AppState, OpenVisible, Workspace};
 
-actions!(journal, [NewJournalEntry]);
+actions!(
+    journal,
+    [
+        /// Create a new journal entry for today
+        NewJournalEntry
+    ]
+);
 
 /// Settings specific to journaling
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -19,7 +19,13 @@ use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
 use workspace::{ModalView, Workspace};
 
-actions!(language_selector, [Toggle]);
+actions!(
+    language_selector,
+    [
+        /// Toggle the language selector modal
+        Toggle
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(LanguageSelector::register).detach();

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -22,7 +22,7 @@ use workspace::{ModalView, Workspace};
 actions!(
     language_selector,
     [
-        /// Toggle the language selector modal
+        /// Toggles the language selector modal.
         Toggle
     ]
 );

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -13,7 +13,13 @@ use ui::{
 };
 use workspace::{Item, SplitDirection, Workspace};
 
-actions!(dev, [OpenKeyContextView]);
+actions!(
+    dev,
+    [
+        /// Open the key context view for debugging keybindings
+        OpenKeyContextView
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/language_tools/src/key_context_view.rs
+++ b/crates/language_tools/src/key_context_view.rs
@@ -16,7 +16,7 @@ use workspace::{Item, SplitDirection, Workspace};
 actions!(
     dev,
     [
-        /// Open the key context view for debugging keybindings
+        /// Opens the key context view for debugging keybindings.
         OpenKeyContextView
     ]
 );

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -204,7 +204,13 @@ pub(crate) struct LogMenuItem {
     pub server_kind: LanguageServerKind,
 }
 
-actions!(dev, [OpenLanguageServerLogs]);
+actions!(
+    dev,
+    [
+        /// Open the language server protocol logs viewer
+        OpenLanguageServerLogs
+    ]
+);
 
 pub(super) struct GlobalLogStore(pub WeakEntity<LogStore>);
 

--- a/crates/language_tools/src/lsp_log.rs
+++ b/crates/language_tools/src/lsp_log.rs
@@ -207,7 +207,7 @@ pub(crate) struct LogMenuItem {
 actions!(
     dev,
     [
-        /// Open the language server protocol logs viewer
+        /// Opens the language server protocol logs viewer.
         OpenLanguageServerLogs
     ]
 );

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -22,7 +22,7 @@ use crate::lsp_log::GlobalLogStore;
 actions!(
     lsp_tool,
     [
-        /// Toggle the language server tool menu
+        /// Toggles the language server tool menu.
         ToggleMenu
     ]
 );

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -19,7 +19,13 @@ use workspace::{StatusItemView, Workspace};
 
 use crate::lsp_log::GlobalLogStore;
 
-actions!(lsp_tool, [ToggleMenu]);
+actions!(
+    lsp_tool,
+    [
+        /// Toggle the language server tool menu
+        ToggleMenu
+    ]
+);
 
 pub struct LspTool {
     state: Entity<PickerState>,

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -15,7 +15,13 @@ use workspace::{
     item::{Item, ItemHandle},
 };
 
-actions!(dev, [OpenSyntaxTreeView]);
+actions!(
+    dev,
+    [
+        /// Open the syntax tree view for the current file
+        OpenSyntaxTreeView
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/language_tools/src/syntax_tree_view.rs
+++ b/crates/language_tools/src/syntax_tree_view.rs
@@ -18,7 +18,7 @@ use workspace::{
 actions!(
     dev,
     [
-        /// Open the syntax tree view for the current file
+        /// Opens the syntax tree view for the current file.
         OpenSyntaxTreeView
     ]
 );

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -141,7 +141,15 @@ pub type CodeBlockRenderFn = Arc<
 pub type CodeBlockTransformFn =
     Arc<dyn Fn(AnyDiv, Range<usize>, CodeBlockMetadata, &mut Window, &App) -> AnyDiv>;
 
-actions!(markdown, [Copy, CopyAsMarkdown]);
+actions!(
+    markdown,
+    [
+        /// Copy the selected text to the clipboard
+        Copy,
+        /// Copy the selected text as markdown to the clipboard
+        CopyAsMarkdown
+    ]
+);
 
 impl Markdown {
     pub fn new(

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -144,9 +144,9 @@ pub type CodeBlockTransformFn =
 actions!(
     markdown,
     [
-        /// Copy the selected text to the clipboard
+        /// Copies the selected text to the clipboard.
         Copy,
-        /// Copy the selected text as markdown to the clipboard
+        /// Copies the selected text as markdown to the clipboard.
         CopyAsMarkdown
     ]
 );

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -9,10 +9,15 @@ pub mod markdown_renderer;
 actions!(
     markdown,
     [
+        /// Scroll up by one page in the markdown preview
         MovePageUp,
+        /// Scroll down by one page in the markdown preview
         MovePageDown,
+        /// Open a markdown preview for the current file
         OpenPreview,
+        /// Open a markdown preview in a split pane
         OpenPreviewToTheSide,
+        /// Open a following markdown preview that syncs with the editor
         OpenFollowingPreview
     ]
 );

--- a/crates/markdown_preview/src/markdown_preview.rs
+++ b/crates/markdown_preview/src/markdown_preview.rs
@@ -9,15 +9,15 @@ pub mod markdown_renderer;
 actions!(
     markdown,
     [
-        /// Scroll up by one page in the markdown preview
+        /// Scrolls up by one page in the markdown preview.
         MovePageUp,
-        /// Scroll down by one page in the markdown preview
+        /// Scrolls down by one page in the markdown preview.
         MovePageDown,
-        /// Open a markdown preview for the current file
+        /// Opens a markdown preview for the current file.
         OpenPreview,
-        /// Open a markdown preview in a split pane
+        /// Opens a markdown preview in a split pane.
         OpenPreviewToTheSide,
-        /// Open a following markdown preview that syncs with the editor
+        /// Opens a following markdown preview that syncs with the editor.
         OpenFollowingPreview
     ]
 );

--- a/crates/menu/src/menu.rs
+++ b/crates/menu/src/menu.rs
@@ -12,13 +12,21 @@ pub fn init() {}
 actions!(
     menu,
     [
+        /// Cancel the current menu operation
         Cancel,
+        /// Confirm the selected menu item
         Confirm,
+        /// Perform secondary confirmation action
         SecondaryConfirm,
+        /// Select the previous item in the menu
         SelectPrevious,
+        /// Select the next item in the menu
         SelectNext,
+        /// Select the first item in the menu
         SelectFirst,
+        /// Select the last item in the menu
         SelectLast,
+        /// Restart the menu from the beginning
         Restart,
         EndSlot,
     ]

--- a/crates/menu/src/menu.rs
+++ b/crates/menu/src/menu.rs
@@ -12,21 +12,21 @@ pub fn init() {}
 actions!(
     menu,
     [
-        /// Cancel the current menu operation
+        /// Cancels the current menu operation.
         Cancel,
-        /// Confirm the selected menu item
+        /// Confirms the selected menu item.
         Confirm,
-        /// Perform secondary confirmation action
+        /// Performs secondary confirmation action.
         SecondaryConfirm,
-        /// Select the previous item in the menu
+        /// Selects the previous item in the menu.
         SelectPrevious,
-        /// Select the next item in the menu
+        /// Selects the next item in the menu.
         SelectNext,
-        /// Select the first item in the menu
+        /// Selects the first item in the menu.
         SelectFirst,
-        /// Select the last item in the menu
+        /// Selects the last item in the menu.
         SelectLast,
-        /// Restart the menu from the beginning
+        /// Restarts the menu from the beginning.
         Restart,
         EndSlot,
     ]

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -65,25 +65,27 @@ use worktree::{Entry, ProjectEntryId, WorktreeId};
 actions!(
     outline_panel,
     [
-        /// Collapse all entries in the outline tree
+        /// Collapses all entries in the outline tree.
         CollapseAllEntries,
-        /// Collapse the currently selected entry
+        /// Collapses the currently selected entry.
         CollapseSelectedEntry,
-        /// Expand all entries in the outline tree
+        /// Expands all entries in the outline tree.
         ExpandAllEntries,
-        /// Expand the currently selected entry
+        /// Expands the currently selected entry.
         ExpandSelectedEntry,
-        /// Fold the selected directory
+        /// Folds the selected directory.
         FoldDirectory,
-        /// Open the selected entry in the editor
+        /// Opens the selected entry in the editor.
         OpenSelectedEntry,
-        /// Reveal the selected item in the system file manager
+        /// Reveals the selected item in the system file manager.
         RevealInFileManager,
-        /// Select the parent of the current entry
+        /// Selects the parent of the current entry.
         SelectParent,
-        /// Unfold the selected directory
+        /// Toggles the pin status of the active editor.
+        ToggleActiveEditorPin,
+        /// Unfolds the selected directory.
         UnfoldDirectory,
-        /// Toggle focus on the outline panel
+        /// Toggles focus on the outline panel.
         ToggleFocus,
     ]
 );

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -65,17 +65,26 @@ use worktree::{Entry, ProjectEntryId, WorktreeId};
 actions!(
     outline_panel,
     [
+        /// Collapse all entries in the outline tree
         CollapseAllEntries,
+        /// Collapse the currently selected entry
         CollapseSelectedEntry,
+        /// Expand all entries in the outline tree
         ExpandAllEntries,
+        /// Expand the currently selected entry
         ExpandSelectedEntry,
+        /// Fold the selected directory
         FoldDirectory,
+        /// Open the selected entry in the editor
         OpenSelectedEntry,
+        /// Reveal the selected item in the system file manager
         RevealInFileManager,
+        /// Select the parent of the current entry
         SelectParent,
-        ToggleActiveEditorPin,
-        ToggleFocus,
+        /// Unfold the selected directory
         UnfoldDirectory,
+        /// Toggle focus on the outline panel
+        ToggleFocus,
     ]
 );
 

--- a/crates/panel/src/panel.rs
+++ b/crates/panel/src/panel.rs
@@ -5,7 +5,15 @@ use settings::Settings;
 use theme::ThemeSettings;
 use ui::{Tab, prelude::*};
 
-actions!(panel, [NextPanelTab, PreviousPanelTab]);
+actions!(
+    panel,
+    [
+        /// Navigate to the next tab in the panel
+        NextPanelTab,
+        /// Navigate to the previous tab in the panel
+        PreviousPanelTab
+    ]
+);
 
 pub trait PanelHeader: workspace::Panel {
     fn header_height(&self, cx: &mut App) -> Pixels {

--- a/crates/panel/src/panel.rs
+++ b/crates/panel/src/panel.rs
@@ -8,9 +8,9 @@ use ui::{Tab, prelude::*};
 actions!(
     panel,
     [
-        /// Navigate to the next tab in the panel
+        /// Navigates to the next tab in the panel.
         NextPanelTab,
-        /// Navigate to the previous tab in the panel
+        /// Navigates to the previous tab in the panel.
         PreviousPanelTab
     ]
 );

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -34,7 +34,13 @@ pub enum Direction {
     Down,
 }
 
-actions!(picker, [ConfirmCompletion]);
+actions!(
+    picker,
+    [
+        /// Confirm the selected completion in the picker
+        ConfirmCompletion
+    ]
+);
 
 /// ConfirmInput is an alternative editor action which - instead of selecting active picker entry - treats pickers editor input literally,
 /// performing some kind of action on it.

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -37,7 +37,7 @@ pub enum Direction {
 actions!(
     picker,
     [
-        /// Confirm the selected completion in the picker
+        /// Confirms the selected completion in the picker.
         ConfirmCompletion
     ]
 );

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -24,7 +24,7 @@ pub fn init(cx: &mut App) {
 actions!(
     context_server,
     [
-        /// Restart the context server
+        /// Restarts the context server.
         Restart
     ]
 );

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -21,7 +21,13 @@ pub fn init(cx: &mut App) {
     extension::init(cx);
 }
 
-actions!(context_server, [Restart]);
+actions!(
+    context_server,
+    [
+        /// Restart the context server
+        Restart
+    ]
+);
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum ContextServerStatus {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -181,6 +181,7 @@ struct EntryDetails {
     canonical_path: Option<Arc<Path>>,
 }
 
+/// Permanently deletes the selected file or directory.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = project_panel)]
 #[serde(deny_unknown_fields)]
@@ -189,6 +190,7 @@ struct Delete {
     pub skip_prompt: bool,
 }
 
+/// Moves the selected file or directory to the system trash.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = project_panel)]
 #[serde(deny_unknown_fields)]

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -200,32 +200,59 @@ struct Trash {
 actions!(
     project_panel,
     [
+        /// Expand the selected entry in the project tree
         ExpandSelectedEntry,
+        /// Collapse the selected entry in the project tree
         CollapseSelectedEntry,
+        /// Collapse all entries in the project tree
         CollapseAllEntries,
+        /// Create a new directory
         NewDirectory,
+        /// Create a new file
         NewFile,
+        /// Copy the selected file or directory
         Copy,
+        /// Duplicate the selected file or directory
         Duplicate,
+        /// Reveal the selected item in the system file manager
         RevealInFileManager,
+        /// Remove the selected folder from the project
         RemoveFromProject,
+        /// Open the selected file with the system's default application
         OpenWithSystem,
+        /// Cut the selected file or directory
         Cut,
+        /// Paste the previously cut or copied item
         Paste,
+        /// Rename the selected file or directory
         Rename,
+        /// Open the selected file in the editor
         Open,
+        /// Open the selected file in a permanent tab
         OpenPermanent,
+        /// Toggle focus on the project panel
         ToggleFocus,
+        /// Toggle visibility of git-ignored files
         ToggleHideGitIgnore,
+        /// Start a new search in the selected directory
         NewSearchInDirectory,
+        /// Unfold the selected directory
         UnfoldDirectory,
+        /// Fold the selected directory
         FoldDirectory,
+        /// Select the parent directory
         SelectParent,
+        /// Select the next entry with git changes
         SelectNextGitEntry,
+        /// Select the previous entry with git changes
         SelectPrevGitEntry,
+        /// Select the next entry with diagnostics
         SelectNextDiagnostic,
+        /// Select the previous entry with diagnostics
         SelectPrevDiagnostic,
+        /// Select the next directory
         SelectNextDirectory,
+        /// Select the previous directory
         SelectPrevDirectory,
     ]
 );

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -200,59 +200,59 @@ struct Trash {
 actions!(
     project_panel,
     [
-        /// Expand the selected entry in the project tree
+        /// Expands the selected entry in the project tree.
         ExpandSelectedEntry,
-        /// Collapse the selected entry in the project tree
+        /// Collapses the selected entry in the project tree.
         CollapseSelectedEntry,
-        /// Collapse all entries in the project tree
+        /// Collapses all entries in the project tree.
         CollapseAllEntries,
-        /// Create a new directory
+        /// Creates a new directory.
         NewDirectory,
-        /// Create a new file
+        /// Creates a new file.
         NewFile,
-        /// Copy the selected file or directory
+        /// Copies the selected file or directory.
         Copy,
-        /// Duplicate the selected file or directory
+        /// Duplicates the selected file or directory.
         Duplicate,
-        /// Reveal the selected item in the system file manager
+        /// Reveals the selected item in the system file manager.
         RevealInFileManager,
-        /// Remove the selected folder from the project
+        /// Removes the selected folder from the project.
         RemoveFromProject,
-        /// Open the selected file with the system's default application
+        /// Opens the selected file with the system's default application.
         OpenWithSystem,
-        /// Cut the selected file or directory
+        /// Cuts the selected file or directory.
         Cut,
-        /// Paste the previously cut or copied item
+        /// Pastes the previously cut or copied item.
         Paste,
-        /// Rename the selected file or directory
+        /// Renames the selected file or directory.
         Rename,
-        /// Open the selected file in the editor
+        /// Opens the selected file in the editor.
         Open,
-        /// Open the selected file in a permanent tab
+        /// Opens the selected file in a permanent tab.
         OpenPermanent,
-        /// Toggle focus on the project panel
+        /// Toggles focus on the project panel.
         ToggleFocus,
-        /// Toggle visibility of git-ignored files
+        /// Toggles visibility of git-ignored files.
         ToggleHideGitIgnore,
-        /// Start a new search in the selected directory
+        /// Starts a new search in the selected directory.
         NewSearchInDirectory,
-        /// Unfold the selected directory
+        /// Unfolds the selected directory.
         UnfoldDirectory,
-        /// Fold the selected directory
+        /// Folds the selected directory.
         FoldDirectory,
-        /// Select the parent directory
+        /// Selects the parent directory.
         SelectParent,
-        /// Select the next entry with git changes
+        /// Selects the next entry with git changes.
         SelectNextGitEntry,
-        /// Select the previous entry with git changes
+        /// Selects the previous entry with git changes.
         SelectPrevGitEntry,
-        /// Select the next entry with diagnostics
+        /// Selects the next entry with diagnostics.
         SelectNextDiagnostic,
-        /// Select the previous entry with diagnostics
+        /// Selects the previous entry with diagnostics.
         SelectPrevDiagnostic,
-        /// Select the next directory
+        /// Selects the next directory.
         SelectNextDirectory,
-        /// Select the previous directory
+        /// Selects the previous directory.
         SelectPrevDirectory,
     ]
 );

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -28,19 +28,19 @@ use nbformat::v4::Metadata as NotebookMetadata;
 actions!(
     notebook,
     [
-        /// Open a Jupyter notebook file
+        /// Opens a Jupyter notebook file.
         OpenNotebook,
-        /// Run all cells in the notebook
+        /// Runs all cells in the notebook.
         RunAll,
-        /// Clear all cell outputs
+        /// Clears all cell outputs.
         ClearOutputs,
-        /// Move the current cell up
+        /// Moves the current cell up.
         MoveCellUp,
-        /// Move the current cell down
+        /// Moves the current cell down.
         MoveCellDown,
-        /// Add a new markdown cell
+        /// Adds a new markdown cell.
         AddMarkdownBlock,
-        /// Add a new code cell
+        /// Adds a new code cell.
         AddCodeBlock,
     ]
 );

--- a/crates/repl/src/notebook/notebook_ui.rs
+++ b/crates/repl/src/notebook/notebook_ui.rs
@@ -28,12 +28,19 @@ use nbformat::v4::Metadata as NotebookMetadata;
 actions!(
     notebook,
     [
+        /// Open a Jupyter notebook file
         OpenNotebook,
+        /// Run all cells in the notebook
         RunAll,
+        /// Clear all cell outputs
         ClearOutputs,
+        /// Move the current cell up
         MoveCellUp,
+        /// Move the current cell down
         MoveCellDown,
+        /// Add a new markdown cell
         AddMarkdownBlock,
+        /// Add a new code cell
         AddCodeBlock,
     ]
 );

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -16,21 +16,21 @@ use crate::repl_store::ReplStore;
 actions!(
     repl,
     [
-        /// Run the current cell and advance to the next one
+        /// Runs the current cell and advances to the next one.
         Run,
-        /// Run the current cell without advancing
+        /// Runs the current cell without advancing.
         RunInPlace,
-        /// Clear all outputs in the REPL
+        /// Clears all outputs in the REPL.
         ClearOutputs,
-        /// Open the REPL sessions panel
+        /// Opens the REPL sessions panel.
         Sessions,
-        /// Interrupt the currently running kernel
+        /// Interrupts the currently running kernel.
         Interrupt,
-        /// Shutdown the current kernel
+        /// Shuts down the current kernel.
         Shutdown,
-        /// Restart the current kernel
+        /// Restarts the current kernel.
         Restart,
-        /// Refresh the list of available kernelspecs
+        /// Refreshes the list of available kernelspecs.
         RefreshKernelspecs
     ]
 );

--- a/crates/repl/src/repl_sessions_ui.rs
+++ b/crates/repl/src/repl_sessions_ui.rs
@@ -16,13 +16,21 @@ use crate::repl_store::ReplStore;
 actions!(
     repl,
     [
+        /// Run the current cell and advance to the next one
         Run,
+        /// Run the current cell without advancing
         RunInPlace,
+        /// Clear all outputs in the REPL
         ClearOutputs,
+        /// Open the REPL sessions panel
         Sessions,
+        /// Interrupt the currently running kernel
         Interrupt,
+        /// Shutdown the current kernel
         Shutdown,
+        /// Restart the current kernel
         Restart,
+        /// Refresh the list of available kernelspecs
         RefreshKernelspecs
     ]
 );

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -37,7 +37,16 @@ pub fn init(cx: &mut App) {
 
 actions!(
     rules_library,
-    [NewRule, DeleteRule, DuplicateRule, ToggleDefaultRule]
+    [
+        /// Create a new rule in the rules library
+        NewRule,
+        /// Delete the selected rule
+        DeleteRule,
+        /// Duplicate the selected rule
+        DuplicateRule,
+        /// Toggle whether the selected rule is a default rule
+        ToggleDefaultRule
+    ]
 );
 
 const BUILT_IN_TOOLTIP_TEXT: &'static str = concat!(

--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -38,13 +38,13 @@ pub fn init(cx: &mut App) {
 actions!(
     rules_library,
     [
-        /// Create a new rule in the rules library
+        /// Creates a new rule in the rules library.
         NewRule,
-        /// Delete the selected rule
+        /// Deletes the selected rule.
         DeleteRule,
-        /// Duplicate the selected rule
+        /// Duplicates the selected rule.
         DuplicateRule,
-        /// Toggle whether the selected rule is a default rule
+        /// Toggles whether the selected rule is a default rule.
         ToggleDefaultRule
     ]
 );

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -58,7 +58,17 @@ pub struct Deploy {
     pub selection_search_enabled: bool,
 }
 
-actions!(buffer_search, [DeployReplace, Dismiss, FocusEditor]);
+actions!(
+    buffer_search,
+    [
+        /// Deploy the search and replace interface
+        DeployReplace,
+        /// Dismiss the search bar
+        Dismiss,
+        /// Focus back on the editor
+        FocusEditor
+    ]
+);
 
 impl Deploy {
     pub fn find() -> Self {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -46,6 +46,7 @@ use registrar::{ForDeployed, ForDismissed, SearchActionsRegistrar, WithResults};
 
 const MAX_BUFFER_SEARCH_HISTORY_SIZE: usize = 50;
 
+/// Opens the buffer search interface with the specified configuration.
 #[derive(PartialEq, Clone, Deserialize, JsonSchema, Action)]
 #[action(namespace = buffer_search)]
 #[serde(deny_unknown_fields)]

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -61,11 +61,11 @@ pub struct Deploy {
 actions!(
     buffer_search,
     [
-        /// Deploy the search and replace interface
+        /// Deploys the search and replace interface.
         DeployReplace,
-        /// Dismiss the search bar
+        /// Dismisses the search bar.
         Dismiss,
-        /// Focus back on the editor
+        /// Focuses back on the editor.
         FocusEditor
     ]
 );

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -48,13 +48,13 @@ use workspace::{
 actions!(
     project_search,
     [
-        /// Search in a new project search tab
+        /// Searches in a new project search tab.
         SearchInNew,
-        /// Toggle focus between the search bar and the search results
+        /// Toggles focus between the search bar and the search results.
         ToggleFocus,
-        /// Move to the next input field
+        /// Moves to the next input field.
         NextField,
-        /// Toggle the search filters panel
+        /// Toggles the search filters panel.
         ToggleFilters
     ]
 );

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -50,7 +50,7 @@ actions!(
     [
         /// Search in a new project search tab
         SearchInNew,
-        /// Toggle focus on the project search panel
+        /// Toggle focus between the search bar and the search results
         ToggleFocus,
         /// Move to the next input field
         NextField,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -47,7 +47,16 @@ use workspace::{
 
 actions!(
     project_search,
-    [SearchInNew, ToggleFocus, NextField, ToggleFilters]
+    [
+        /// Search in a new project search tab
+        SearchInNew,
+        /// Toggle focus on the project search panel
+        ToggleFocus,
+        /// Move to the next input field
+        NextField,
+        /// Toggle the search filters panel
+        ToggleFilters
+    ]
 );
 
 #[derive(Default)]

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -23,35 +23,35 @@ pub fn init(cx: &mut App) {
 actions!(
     search,
     [
-        /// Focus on the search input field
+        /// Focuses on the search input field.
         FocusSearch,
-        /// Toggle whole word matching
+        /// Toggles whole word matching.
         ToggleWholeWord,
-        /// Toggle case-sensitive search
+        /// Toggles case-sensitive search.
         ToggleCaseSensitive,
-        /// Toggle searching in ignored files
+        /// Toggles searching in ignored files.
         ToggleIncludeIgnored,
-        /// Toggle regular expression mode
+        /// Toggles regular expression mode.
         ToggleRegex,
-        /// Toggle the replace interface
+        /// Toggles the replace interface.
         ToggleReplace,
-        /// Toggle searching within selection only
+        /// Toggles searching within selection only.
         ToggleSelection,
-        /// Select the next search match
+        /// Selects the next search match.
         SelectNextMatch,
-        /// Select the previous search match
+        /// Selects the previous search match.
         SelectPreviousMatch,
-        /// Select all search matches
+        /// Selects all search matches.
         SelectAllMatches,
-        /// Cycle through search modes
+        /// Cycles through search modes.
         CycleMode,
-        /// Navigate to the next query in search history
+        /// Navigates to the next query in search history.
         NextHistoryQuery,
-        /// Navigate to the previous query in search history
+        /// Navigates to the previous query in search history.
         PreviousHistoryQuery,
-        /// Replace all matches
+        /// Replaces all matches.
         ReplaceAll,
-        /// Replace the next match
+        /// Replaces the next match.
         ReplaceNext,
     ]
 );

--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -23,19 +23,35 @@ pub fn init(cx: &mut App) {
 actions!(
     search,
     [
+        /// Focus on the search input field
         FocusSearch,
+        /// Toggle whole word matching
         ToggleWholeWord,
+        /// Toggle case-sensitive search
         ToggleCaseSensitive,
+        /// Toggle searching in ignored files
         ToggleIncludeIgnored,
+        /// Toggle regular expression mode
         ToggleRegex,
+        /// Toggle the replace interface
         ToggleReplace,
+        /// Toggle searching within selection only
         ToggleSelection,
+        /// Select the next search match
         SelectNextMatch,
+        /// Select the previous search match
         SelectPreviousMatch,
+        /// Select all search matches
         SelectAllMatches,
+        /// Cycle through search modes
+        CycleMode,
+        /// Navigate to the next query in search history
         NextHistoryQuery,
+        /// Navigate to the previous query in search history
         PreviousHistoryQuery,
+        /// Replace all matches
         ReplaceAll,
+        /// Replace the next match
         ReplaceNext,
     ]
 );

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -31,7 +31,7 @@ use crate::{
 actions!(
     zed,
     [
-        /// Open the keymap editor
+        /// Opens the keymap editor.
         OpenKeymapEditor
     ]
 );
@@ -40,11 +40,11 @@ const KEYMAP_EDITOR_NAMESPACE: &'static str = "keymap_editor";
 actions!(
     keymap_editor,
     [
-        /// Edit the selected key binding
+        /// Edits the selected key binding.
         EditBinding,
-        /// Copy the action name to clipboard
+        /// Copies the action name to clipboard.
         CopyAction,
-        /// Copy the context predicate to clipboard
+        /// Copies the context predicate to clipboard.
         CopyContext
     ]
 );

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -28,10 +28,26 @@ use crate::{
     ui_components::table::{Table, TableInteractionState},
 };
 
-actions!(zed, [OpenKeymapEditor]);
+actions!(
+    zed,
+    [
+        /// Open the keymap editor
+        OpenKeymapEditor
+    ]
+);
 
 const KEYMAP_EDITOR_NAMESPACE: &'static str = "keymap_editor";
-actions!(keymap_editor, [EditBinding, CopyAction, CopyContext]);
+actions!(
+    keymap_editor,
+    [
+        /// Edit the selected key binding
+        EditBinding,
+        /// Copy the action name to clipboard
+        CopyAction,
+        /// Copy the context predicate to clipboard
+        CopyContext
+    ]
+);
 
 pub fn init(cx: &mut App) {
     let keymap_event_channel = KeymapEventChannel::new();

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -44,7 +44,13 @@ pub struct ImportCursorSettings {
     #[serde(default)]
     pub skip_prompt: bool,
 }
-actions!(zed, [OpenSettingsEditor]);
+actions!(
+    zed,
+    [
+        /// Open the settings editor
+        OpenSettingsEditor
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.on_action(|_: &OpenSettingsEditor, cx| {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -29,6 +29,7 @@ impl FeatureFlag for SettingsUiFeatureFlag {
     const NAME: &'static str = "settings-ui";
 }
 
+/// Imports settings from Visual Studio Code.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -37,6 +38,7 @@ pub struct ImportVsCodeSettings {
     pub skip_prompt: bool,
 }
 
+/// Imports settings from Cursor editor.
 #[derive(Copy, Clone, Debug, Default, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -47,7 +47,7 @@ pub struct ImportCursorSettings {
 actions!(
     zed,
     [
-        /// Open the settings editor
+        /// Opens the settings editor.
         OpenSettingsEditor
     ]
 );

--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -54,7 +54,15 @@ impl From<ScopeFileName> for ScopeName {
     }
 }
 
-actions!(snippets, [ConfigureSnippets, OpenFolder]);
+actions!(
+    snippets,
+    [
+        /// Open the snippets configuration file
+        ConfigureSnippets,
+        /// Open the snippets folder in the file manager
+        OpenFolder
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(register).detach();

--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -57,9 +57,9 @@ impl From<ScopeFileName> for ScopeName {
 actions!(
     snippets,
     [
-        /// Open the snippets configuration file
+        /// Opens the snippets configuration file.
         ConfigureSnippets,
-        /// Open the snippets folder in the file manager
+        /// Opens the snippets folder in the file manager.
         OpenFolder
     ]
 );

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -28,7 +28,7 @@ use util::ResultExt;
 actions!(
     supermaven,
     [
-        /// Sign out of Supermaven
+        /// Signs out of Supermaven.
         SignOut
     ]
 );

--- a/crates/supermaven/src/supermaven.rs
+++ b/crates/supermaven/src/supermaven.rs
@@ -25,7 +25,13 @@ use std::{path::PathBuf, process::Stdio, sync::Arc};
 use ui::prelude::*;
 use util::ResultExt;
 
-actions!(supermaven, [SignOut]);
+actions!(
+    supermaven,
+    [
+        /// Sign out of Supermaven
+        SignOut
+    ]
+);
 
 pub fn init(client: Arc<Client>, cx: &mut App) {
     let supermaven = cx.new(|_| Supermaven::Starting);

--- a/crates/svg_preview/src/svg_preview.rs
+++ b/crates/svg_preview/src/svg_preview.rs
@@ -5,7 +5,14 @@ pub mod svg_preview_view;
 
 actions!(
     svg,
-    [OpenPreview, OpenPreviewToTheSide, OpenFollowingPreview]
+    [
+        /// Open an SVG preview for the current file
+        OpenPreview,
+        /// Open an SVG preview in a split pane
+        OpenPreviewToTheSide,
+        /// Open a following SVG preview that syncs with the editor
+        OpenFollowingPreview
+    ]
 );
 
 pub fn init(cx: &mut App) {

--- a/crates/svg_preview/src/svg_preview.rs
+++ b/crates/svg_preview/src/svg_preview.rs
@@ -6,11 +6,11 @@ pub mod svg_preview_view;
 actions!(
     svg,
     [
-        /// Open an SVG preview for the current file
+        /// Opens an SVG preview for the current file.
         OpenPreview,
-        /// Open an SVG preview in a split pane
+        /// Opens an SVG preview in a split pane.
         OpenPreviewToTheSide,
-        /// Open a following SVG preview that syncs with the editor
+        /// Opens a following SVG preview that syncs with the editor.
         OpenFollowingPreview
     ]
 );

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -32,7 +32,15 @@ pub struct Toggle {
     #[serde(default)]
     pub select_last: bool,
 }
-actions!(tab_switcher, [CloseSelectedItem, ToggleAll]);
+actions!(
+    tab_switcher,
+    [
+        /// Close the selected item in the tab switcher
+        CloseSelectedItem,
+        /// Toggle between showing all tabs or just the current pane's tabs
+        ToggleAll
+    ]
+);
 
 pub struct TabSwitcher {
     picker: Entity<Picker<TabSwitcherDelegate>>,

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -25,6 +25,7 @@ use workspace::{
 
 const PANEL_WIDTH_REMS: f32 = 28.;
 
+/// Toggles the tab switcher interface.
 #[derive(PartialEq, Clone, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = tab_switcher)]
 #[serde(deny_unknown_fields)]

--- a/crates/tab_switcher/src/tab_switcher.rs
+++ b/crates/tab_switcher/src/tab_switcher.rs
@@ -35,9 +35,9 @@ pub struct Toggle {
 actions!(
     tab_switcher,
     [
-        /// Close the selected item in the tab switcher
+        /// Closes the selected item in the tab switcher.
         CloseSelectedItem,
-        /// Toggle between showing all tabs or just the current pane's tabs
+        /// Toggles between showing all tabs or just the current pane's tabs.
         ToggleAll
     ]
 );

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -73,18 +73,34 @@ use crate::mappings::{colors::to_alac_rgb, keys::to_esc_str};
 actions!(
     terminal,
     [
+        /// Clear the terminal screen
         Clear,
+        /// Copy selected text to the clipboard
         Copy,
+        /// Paste from the clipboard
         Paste,
+        /// Show the character palette for special characters
         ShowCharacterPalette,
+        /// Search for text in the terminal
         SearchTest,
+        /// Scroll up by one line
         ScrollLineUp,
+        /// Scroll down by one line
         ScrollLineDown,
+        /// Scroll up by one page
         ScrollPageUp,
+        /// Scroll down by one page
         ScrollPageDown,
+        /// Scroll up by half a page
+        ScrollHalfPageUp,
+        /// Scroll down by half a page
+        ScrollHalfPageDown,
+        /// Scroll to the top of the terminal buffer
         ScrollToTop,
+        /// Scroll to the bottom of the terminal buffer
         ScrollToBottom,
-        ToggleViMode,
+        /// Select all text in the terminal
+        SelectAll,
     ]
 );
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -73,33 +73,35 @@ use crate::mappings::{colors::to_alac_rgb, keys::to_esc_str};
 actions!(
     terminal,
     [
-        /// Clear the terminal screen
+        /// Clears the terminal screen.
         Clear,
-        /// Copy selected text to the clipboard
+        /// Copies selected text to the clipboard.
         Copy,
-        /// Paste from the clipboard
+        /// Pastes from the clipboard.
         Paste,
-        /// Show the character palette for special characters
+        /// Shows the character palette for special characters.
         ShowCharacterPalette,
-        /// Search for text in the terminal
+        /// Searches for text in the terminal.
         SearchTest,
-        /// Scroll up by one line
+        /// Scrolls up by one line.
         ScrollLineUp,
-        /// Scroll down by one line
+        /// Scrolls down by one line.
         ScrollLineDown,
-        /// Scroll up by one page
+        /// Scrolls up by one page.
         ScrollPageUp,
-        /// Scroll down by one page
+        /// Scrolls down by one page.
         ScrollPageDown,
-        /// Scroll up by half a page
+        /// Scrolls up by half a page.
         ScrollHalfPageUp,
-        /// Scroll down by half a page
+        /// Scrolls down by half a page.
         ScrollHalfPageDown,
-        /// Scroll to the top of the terminal buffer
+        /// Scrolls to the top of the terminal buffer.
         ScrollToTop,
-        /// Scroll to the bottom of the terminal buffer
+        /// Scrolls to the bottom of the terminal buffer.
         ScrollToBottom,
-        /// Select all text in the terminal
+        /// Toggles vi mode in the terminal.
+        ToggleViMode,
+        /// Selects all text in the terminal.
         SelectAll,
     ]
 );

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -49,7 +49,7 @@ const TERMINAL_PANEL_KEY: &str = "TerminalPanel";
 actions!(
     terminal_panel,
     [
-        /// Toggle focus on the terminal panel
+        /// Toggles focus on the terminal panel.
         ToggleFocus
     ]
 );

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -46,7 +46,13 @@ use zed_actions::assistant::InlineAssist;
 
 const TERMINAL_PANEL_KEY: &str = "TerminalPanel";
 
-actions!(terminal_panel, [ToggleFocus]);
+actions!(
+    terminal_panel,
+    [
+        /// Toggle focus on the terminal panel
+        ToggleFocus
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -78,7 +78,13 @@ pub struct SendText(String);
 #[action(namespace = terminal)]
 pub struct SendKeystroke(String);
 
-actions!(terminal, [RerunTask]);
+actions!(
+    terminal,
+    [
+        /// Rerun the last executed task in the terminal
+        RerunTask
+    ]
+);
 
 pub fn init(cx: &mut App) {
     assistant_slash_command::init(cx);

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -81,7 +81,7 @@ pub struct SendKeystroke(String);
 actions!(
     terminal,
     [
-        /// Rerun the last executed task in the terminal
+        /// Reruns the last executed task in the terminal.
         RerunTask
     ]
 );

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -70,10 +70,12 @@ const GIT_DIFF_PATH_PREFIXES: &[&str] = &["a", "b"];
 #[derive(Clone, Debug, PartialEq)]
 pub struct ScrollTerminal(pub i32);
 
+/// Sends the specified text directly to the terminal.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = terminal)]
 pub struct SendText(String);
 
+/// Sends a keystroke sequence to the terminal.
 #[derive(Clone, Debug, Default, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = terminal)]
 pub struct SendKeystroke(String);

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -20,7 +20,7 @@ use crate::icon_theme_selector::{IconThemeSelector, IconThemeSelectorDelegate};
 actions!(
     theme_selector,
     [
-        /// Reload all themes from disk
+        /// Reloads all themes from disk.
         Reload
     ]
 );

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -17,7 +17,13 @@ use zed_actions::{ExtensionCategoryFilter, Extensions};
 
 use crate::icon_theme_selector::{IconThemeSelector, IconThemeSelectorDelegate};
 
-actions!(theme_selector, [Reload]);
+actions!(
+    theme_selector,
+    [
+        /// Reload all themes from disk
+        Reload
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.on_action(|action: &zed_actions::theme_selector::Toggle, cx| {

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -15,9 +15,9 @@ use ui::{ContextMenu, PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*};
 actions!(
     app_menu,
     [
-        /// Navigate to the menu item on the right
+        /// Navigates to the menu item on the right.
         ActivateMenuRight,
-        /// Navigate to the menu item on the left
+        /// Navigates to the menu item on the left.
         ActivateMenuLeft
     ]
 );

--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -12,7 +12,15 @@ use smallvec::SmallVec;
 use ui::{ContextMenu, PopoverMenu, PopoverMenuHandle, Tooltip, prelude::*};
 
 #[cfg(not(target_os = "macos"))]
-actions!(app_menu, [ActivateMenuRight, ActivateMenuLeft]);
+actions!(
+    app_menu,
+    [
+        /// Navigate to the menu item on the right
+        ActivateMenuRight,
+        /// Navigate to the menu item on the left
+        ActivateMenuLeft
+    ]
+);
 
 #[cfg(not(target_os = "macos"))]
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Default, Action)]

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -14,11 +14,11 @@ use crate::TitleBar;
 actions!(
     collab,
     [
-        /// Toggle screen sharing on or off
+        /// Toggles screen sharing on or off.
         ToggleScreenSharing,
-        /// Toggle microphone mute
+        /// Toggles microphone mute.
         ToggleMute,
-        /// Toggle deafen mode (mute both microphone and speakers)
+        /// Toggles deafen mode (mute both microphone and speakers).
         ToggleDeafen
     ]
 );

--- a/crates/title_bar/src/collab.rs
+++ b/crates/title_bar/src/collab.rs
@@ -11,7 +11,17 @@ use workspace::notifications::DetachAndPromptErr;
 
 use crate::TitleBar;
 
-actions!(collab, [ToggleScreenSharing, ToggleMute, ToggleDeafen]);
+actions!(
+    collab,
+    [
+        /// Toggle screen sharing on or off
+        ToggleScreenSharing,
+        /// Toggle microphone mute
+        ToggleMute,
+        /// Toggle deafen mode (mute both microphone and speakers)
+        ToggleDeafen
+    ]
+);
 
 fn toggle_screen_sharing(_: &ToggleScreenSharing, window: &mut Window, cx: &mut App) {
     let call = ActiveCall::global(cx).read(cx);

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -47,7 +47,17 @@ const MAX_PROJECT_NAME_LENGTH: usize = 40;
 const MAX_BRANCH_NAME_LENGTH: usize = 40;
 const MAX_SHORT_SHA_LENGTH: usize = 8;
 
-actions!(collab, [ToggleUserMenu, ToggleProjectMenu, SwitchBranch]);
+actions!(
+    collab,
+    [
+        /// Toggle the user menu dropdown
+        ToggleUserMenu,
+        /// Toggle the project menu dropdown
+        ToggleProjectMenu,
+        /// Switch to a different git branch
+        SwitchBranch
+    ]
+);
 
 pub fn init(cx: &mut App) {
     TitleBarSettings::register(cx);

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -50,11 +50,11 @@ const MAX_SHORT_SHA_LENGTH: usize = 8;
 actions!(
     collab,
     [
-        /// Toggle the user menu dropdown
+        /// Toggles the user menu dropdown.
         ToggleUserMenu,
-        /// Toggle the project menu dropdown
+        /// Toggles the project menu dropdown.
         ToggleProjectMenu,
-        /// Switch to a different git branch
+        /// Switches to a different git branch.
         SwitchBranch
     ]
 );

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -18,7 +18,7 @@ use workspace::{ModalView, Workspace};
 actions!(
     toolchain,
     [
-        /// Select a toolchain for the current project
+        /// Selects a toolchain for the current project.
         Select
     ]
 );

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -15,7 +15,13 @@ use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
 use workspace::{ModalView, Workspace};
 
-actions!(toolchain, [Select]);
+actions!(
+    toolchain,
+    [
+        /// Select a toolchain for the current project
+        Select
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(ToolchainSelector::register).detach();

--- a/crates/vim/src/change_list.rs
+++ b/crates/vim/src/change_list.rs
@@ -6,9 +6,9 @@ use crate::{Vim, state::Mode};
 actions!(
     vim,
     [
-        /// Navigate to an older position in the change list
+        /// Navigates to an older position in the change list.
         ChangeListOlder,
-        /// Navigate to a newer position in the change list
+        /// Navigates to a newer position in the change list.
         ChangeListNewer
     ]
 );

--- a/crates/vim/src/change_list.rs
+++ b/crates/vim/src/change_list.rs
@@ -3,7 +3,15 @@ use gpui::{Context, Window, actions};
 
 use crate::{Vim, state::Mode};
 
-actions!(vim, [ChangeListOlder, ChangeListNewer]);
+actions!(
+    vim,
+    [
+        /// Navigate to an older position in the change list
+        ChangeListOlder,
+        /// Navigate to a newer position in the change list
+        ChangeListNewer
+    ]
+);
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &ChangeListOlder, window, cx| {

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -177,7 +177,16 @@ enum DeleteMarks {
 
 actions!(
     vim,
-    [VisualCommand, CountCommand, ShellCommand, ArgumentRequired]
+    [
+        /// Execute a command in visual mode
+        VisualCommand,
+        /// Execute a command with a count prefix
+        CountCommand,
+        /// Execute a shell command
+        ShellCommand,
+        /// Indicates that an argument is required for the command
+        ArgumentRequired
+    ]
 );
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -178,13 +178,13 @@ enum DeleteMarks {
 actions!(
     vim,
     [
-        /// Execute a command in visual mode
+        /// Executes a command in visual mode.
         VisualCommand,
-        /// Execute a command with a count prefix
+        /// Executes a command with a count prefix.
         CountCommand,
-        /// Execute a shell command
+        /// Executes a shell command.
         ShellCommand,
-        /// Indicates that an argument is required for the command
+        /// Indicates that an argument is required for the command.
         ArgumentRequired
     ]
 );

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -44,18 +44,21 @@ use crate::{
     visual::VisualDeleteLine,
 };
 
+/// Goes to the specified line number in the editor.
 #[derive(Clone, Debug, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct GoToLine {
     range: CommandRange,
 }
 
+/// Yanks (copies) text based on the specified range.
 #[derive(Clone, Debug, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct YankCommand {
     range: CommandRange,
 }
 
+/// Executes a command with the specified range.
 #[derive(Clone, Debug, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct WithRange {
@@ -64,6 +67,7 @@ pub struct WithRange {
     action: WrappedAction,
 }
 
+/// Executes a command with the specified count.
 #[derive(Clone, Debug, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct WithCount {
@@ -155,12 +159,14 @@ impl VimOption {
     }
 }
 
+/// Sets vim options and configuration values.
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct VimSet {
     options: Vec<VimOption>,
 }
 
+/// Saves the current file with optional save intent.
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 struct VimSave {
@@ -168,6 +174,7 @@ struct VimSave {
     pub filename: String,
 }
 
+/// Deletes the specified marks from the editor.
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 enum DeleteMarks {
@@ -188,6 +195,7 @@ actions!(
         ArgumentRequired
     ]
 );
+/// Opens the specified file for editing.
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 struct VimEdit {
@@ -1291,6 +1299,7 @@ fn generate_positions(string: &str, query: &str) -> Vec<usize> {
     positions
 }
 
+/// Applies a command to all lines matching a pattern.
 #[derive(Debug, PartialEq, Clone, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub(crate) struct OnMatchingLines {
@@ -1489,6 +1498,7 @@ impl OnMatchingLines {
     }
 }
 
+/// Executes a shell command and returns the output.
 #[derive(Clone, Debug, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct ShellExec {

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -6,7 +6,13 @@ use text::SelectionGoal;
 
 use crate::{Vim, motion::Motion, state::Mode};
 
-actions!(vim, [HelixNormalAfter]);
+actions!(
+    vim,
+    [
+        /// Switch to normal mode after the cursor (Helix-style)
+        HelixNormalAfter
+    ]
+);
 
 pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::helix_normal_after);

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -9,7 +9,7 @@ use crate::{Vim, motion::Motion, state::Mode};
 actions!(
     vim,
     [
-        /// Switch to normal mode after the cursor (Helix-style)
+        /// Switches to normal mode after the cursor (Helix-style).
         HelixNormalAfter
     ]
 );

--- a/crates/vim/src/indent.rs
+++ b/crates/vim/src/indent.rs
@@ -13,7 +13,17 @@ pub(crate) enum IndentDirection {
     Auto,
 }
 
-actions!(vim, [Indent, Outdent, AutoIndent]);
+actions!(
+    vim,
+    [
+        /// Increase indentation of selected lines
+        Indent,
+        /// Decrease indentation of selected lines
+        Outdent,
+        /// Automatically adjust indentation based on syntax
+        AutoIndent
+    ]
+);
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &Indent, window, cx| {

--- a/crates/vim/src/indent.rs
+++ b/crates/vim/src/indent.rs
@@ -16,11 +16,11 @@ pub(crate) enum IndentDirection {
 actions!(
     vim,
     [
-        /// Increase indentation of selected lines
+        /// Increases indentation of selected lines.
         Indent,
-        /// Decrease indentation of selected lines
+        /// Decreases indentation of selected lines.
         Outdent,
-        /// Automatically adjust indentation based on syntax
+        /// Automatically adjusts indentation based on syntax.
         AutoIndent
     ]
 );

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -5,7 +5,15 @@ use language::SelectionGoal;
 use settings::Settings;
 use vim_mode_setting::HelixModeSetting;
 
-actions!(vim, [NormalBefore, TemporaryNormal]);
+actions!(
+    vim,
+    [
+        /// Switch to normal mode with cursor positioned before the current character
+        NormalBefore,
+        /// Temporarily switch to normal mode for one command
+        TemporaryNormal
+    ]
+);
 
 pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::normal_before);

--- a/crates/vim/src/insert.rs
+++ b/crates/vim/src/insert.rs
@@ -8,9 +8,9 @@ use vim_mode_setting::HelixModeSetting;
 actions!(
     vim,
     [
-        /// Switch to normal mode with cursor positioned before the current character
+        /// Switches to normal mode with cursor positioned before the current character.
         NormalBefore,
-        /// Temporarily switch to normal mode for one command
+        /// Temporarily switches to normal mode for one command.
         TemporaryNormal
     ]
 );

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -176,6 +176,7 @@ enum IndentType {
     Same,
 }
 
+/// Moves to the start of the next word.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -184,6 +185,7 @@ struct NextWordStart {
     ignore_punctuation: bool,
 }
 
+/// Moves to the end of the next word.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -192,6 +194,7 @@ struct NextWordEnd {
     ignore_punctuation: bool,
 }
 
+/// Moves to the start of the previous word.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -200,6 +203,7 @@ struct PreviousWordStart {
     ignore_punctuation: bool,
 }
 
+/// Moves to the end of the previous word.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -208,6 +212,7 @@ struct PreviousWordEnd {
     ignore_punctuation: bool,
 }
 
+/// Moves to the start of the next subword.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -216,6 +221,7 @@ pub(crate) struct NextSubwordStart {
     pub(crate) ignore_punctuation: bool,
 }
 
+/// Moves to the end of the next subword.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -224,6 +230,7 @@ pub(crate) struct NextSubwordEnd {
     pub(crate) ignore_punctuation: bool,
 }
 
+/// Moves to the start of the previous subword.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -232,6 +239,7 @@ pub(crate) struct PreviousSubwordStart {
     pub(crate) ignore_punctuation: bool,
 }
 
+/// Moves to the end of the previous subword.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -240,6 +248,7 @@ pub(crate) struct PreviousSubwordEnd {
     pub(crate) ignore_punctuation: bool,
 }
 
+/// Moves cursor up by the specified number of lines.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -248,6 +257,7 @@ pub(crate) struct Up {
     pub(crate) display_lines: bool,
 }
 
+/// Moves cursor down by the specified number of lines.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -256,6 +266,7 @@ pub(crate) struct Down {
     pub(crate) display_lines: bool,
 }
 
+/// Moves to the first non-whitespace character on the current line.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -264,6 +275,7 @@ struct FirstNonWhitespace {
     display_lines: bool,
 }
 
+/// Moves to the end of the current line.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -272,6 +284,7 @@ struct EndOfLine {
     display_lines: bool,
 }
 
+/// Moves to the start of the current line.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -280,6 +293,7 @@ pub struct StartOfLine {
     pub(crate) display_lines: bool,
 }
 
+/// Moves to the middle of the current line.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -288,6 +302,7 @@ struct MiddleOfLine {
     display_lines: bool,
 }
 
+/// Finds the next unmatched bracket or delimiter.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -296,6 +311,7 @@ struct UnmatchedForward {
     char: char,
 }
 
+/// Finds the previous unmatched bracket or delimiter.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -307,85 +307,85 @@ struct UnmatchedBackward {
 actions!(
     vim,
     [
-        /// Move cursor left one character
+        /// Moves cursor left one character.
         Left,
-        /// Move cursor left one character, wrapping to previous line
+        /// Moves cursor left one character, wrapping to previous line.
         #[action(deprecated_aliases = ["vim::Backspace"])]
         WrappingLeft,
-        /// Move cursor right one character
+        /// Moves cursor right one character.
         Right,
-        /// Move cursor right one character, wrapping to next line
+        /// Moves cursor right one character, wrapping to next line.
         #[action(deprecated_aliases = ["vim::Space"])]
         WrappingRight,
-        /// Select the current line
+        /// Selects the current line.
         CurrentLine,
-        /// Move to the start of the next sentence
+        /// Moves to the start of the next sentence.
         SentenceForward,
-        /// Move to the start of the previous sentence
+        /// Moves to the start of the previous sentence.
         SentenceBackward,
-        /// Move to the start of the paragraph
+        /// Moves to the start of the paragraph.
         StartOfParagraph,
-        /// Move to the end of the paragraph
+        /// Moves to the end of the paragraph.
         EndOfParagraph,
-        /// Move to the start of the document
+        /// Moves to the start of the document.
         StartOfDocument,
-        /// Move to the end of the document
+        /// Moves to the end of the document.
         EndOfDocument,
-        /// Move to the matching bracket or delimiter
+        /// Moves to the matching bracket or delimiter.
         Matching,
-        /// Go to a percentage position in the file
+        /// Goes to a percentage position in the file.
         GoToPercentage,
-        /// Move to the start of the next line
+        /// Moves to the start of the next line.
         NextLineStart,
-        /// Move to the start of the previous line
+        /// Moves to the start of the previous line.
         PreviousLineStart,
-        /// Move to the start of a line downward
+        /// Moves to the start of a line downward.
         StartOfLineDownward,
-        /// Move to the end of a line downward
+        /// Moves to the end of a line downward.
         EndOfLineDownward,
-        /// Go to a specific column number
+        /// Goes to a specific column number.
         GoToColumn,
-        /// Repeat the last character find
+        /// Repeats the last character find.
         RepeatFind,
-        /// Repeat the last character find in reverse
+        /// Repeats the last character find in reverse.
         RepeatFindReversed,
-        /// Move to the top of the window
+        /// Moves to the top of the window.
         WindowTop,
-        /// Move to the middle of the window
+        /// Moves to the middle of the window.
         WindowMiddle,
-        /// Move to the bottom of the window
+        /// Moves to the bottom of the window.
         WindowBottom,
-        /// Move to the start of the next section
+        /// Moves to the start of the next section.
         NextSectionStart,
-        /// Move to the end of the next section
+        /// Moves to the end of the next section.
         NextSectionEnd,
-        /// Move to the start of the previous section
+        /// Moves to the start of the previous section.
         PreviousSectionStart,
-        /// Move to the end of the previous section
+        /// Moves to the end of the previous section.
         PreviousSectionEnd,
-        /// Move to the start of the next method
+        /// Moves to the start of the next method.
         NextMethodStart,
-        /// Move to the end of the next method
+        /// Moves to the end of the next method.
         NextMethodEnd,
-        /// Move to the start of the previous method
+        /// Moves to the start of the previous method.
         PreviousMethodStart,
-        /// Move to the end of the previous method
+        /// Moves to the end of the previous method.
         PreviousMethodEnd,
-        /// Move to the next comment
+        /// Moves to the next comment.
         NextComment,
-        /// Move to the previous comment
+        /// Moves to the previous comment.
         PreviousComment,
-        /// Move to the previous line with lesser indentation
+        /// Moves to the previous line with lesser indentation.
         PreviousLesserIndent,
-        /// Move to the previous line with greater indentation
+        /// Moves to the previous line with greater indentation.
         PreviousGreaterIndent,
-        /// Move to the previous line with the same indentation
+        /// Moves to the previous line with the same indentation.
         PreviousSameIndent,
-        /// Move to the next line with lesser indentation
+        /// Moves to the next line with lesser indentation.
         NextLesserIndent,
-        /// Move to the next line with greater indentation
+        /// Moves to the next line with greater indentation.
         NextGreaterIndent,
-        /// Move to the next line with the same indentation
+        /// Moves to the next line with the same indentation.
         NextSameIndent,
     ]
 );

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -307,46 +307,85 @@ struct UnmatchedBackward {
 actions!(
     vim,
     [
+        /// Move cursor left one character
         Left,
+        /// Move cursor left one character, wrapping to previous line
         #[action(deprecated_aliases = ["vim::Backspace"])]
         WrappingLeft,
+        /// Move cursor right one character
         Right,
+        /// Move cursor right one character, wrapping to next line
         #[action(deprecated_aliases = ["vim::Space"])]
         WrappingRight,
+        /// Select the current line
         CurrentLine,
+        /// Move to the start of the next sentence
         SentenceForward,
+        /// Move to the start of the previous sentence
         SentenceBackward,
+        /// Move to the start of the paragraph
         StartOfParagraph,
+        /// Move to the end of the paragraph
         EndOfParagraph,
+        /// Move to the start of the document
         StartOfDocument,
+        /// Move to the end of the document
         EndOfDocument,
+        /// Move to the matching bracket or delimiter
         Matching,
+        /// Go to a percentage position in the file
         GoToPercentage,
+        /// Move to the start of the next line
         NextLineStart,
+        /// Move to the start of the previous line
         PreviousLineStart,
+        /// Move to the start of a line downward
         StartOfLineDownward,
+        /// Move to the end of a line downward
         EndOfLineDownward,
+        /// Go to a specific column number
         GoToColumn,
+        /// Repeat the last character find
         RepeatFind,
+        /// Repeat the last character find in reverse
         RepeatFindReversed,
+        /// Move to the top of the window
         WindowTop,
+        /// Move to the middle of the window
         WindowMiddle,
+        /// Move to the bottom of the window
         WindowBottom,
+        /// Move to the start of the next section
         NextSectionStart,
+        /// Move to the end of the next section
         NextSectionEnd,
+        /// Move to the start of the previous section
         PreviousSectionStart,
+        /// Move to the end of the previous section
         PreviousSectionEnd,
+        /// Move to the start of the next method
         NextMethodStart,
+        /// Move to the end of the next method
         NextMethodEnd,
+        /// Move to the start of the previous method
         PreviousMethodStart,
+        /// Move to the end of the previous method
         PreviousMethodEnd,
+        /// Move to the next comment
         NextComment,
+        /// Move to the previous comment
         PreviousComment,
+        /// Move to the previous line with lesser indentation
         PreviousLesserIndent,
+        /// Move to the previous line with greater indentation
         PreviousGreaterIndent,
+        /// Move to the previous line with the same indentation
         PreviousSameIndent,
+        /// Move to the next line with lesser indentation
         NextLesserIndent,
+        /// Move to the next line with greater indentation
         NextGreaterIndent,
+        /// Move to the next line with the same indentation
         NextSameIndent,
     ]
 );

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -36,32 +36,59 @@ use multi_buffer::MultiBufferRow;
 actions!(
     vim,
     [
+        /// Insert text after the cursor
         InsertAfter,
+        /// Insert text before the cursor
         InsertBefore,
+        /// Insert at the first non-whitespace character
         InsertFirstNonWhitespace,
+        /// Insert at the end of the line
         InsertEndOfLine,
+        /// Insert a new line above the current line
         InsertLineAbove,
+        /// Insert a new line below the current line
         InsertLineBelow,
+        /// Insert an empty line above without entering insert mode
         InsertEmptyLineAbove,
+        /// Insert an empty line below without entering insert mode
         InsertEmptyLineBelow,
+        /// Insert at the previous insert position
         InsertAtPrevious,
+        /// Join the current line with the next line
         JoinLines,
+        /// Join lines without adding whitespace
         JoinLinesNoWhitespace,
+        /// Delete character to the left
         DeleteLeft,
+        /// Delete character to the right
         DeleteRight,
+        /// Delete using Helix-style behavior
         HelixDelete,
+        /// Change from cursor to end of line
         ChangeToEndOfLine,
+        /// Delete from cursor to end of line
         DeleteToEndOfLine,
+        /// Yank (copy) the selected text
         Yank,
+        /// Yank the entire line
         YankLine,
+        /// Toggle the case of selected text
         ChangeCase,
+        /// Convert selected text to uppercase
         ConvertToUpperCase,
+        /// Convert selected text to lowercase
         ConvertToLowerCase,
+        /// Apply ROT13 cipher to selected text
         ConvertToRot13,
+        /// Apply ROT47 cipher to selected text
         ConvertToRot47,
+        /// Toggle comments for selected lines
         ToggleComments,
+        /// Show the current location in the file
         ShowLocation,
+        /// Undo the last change
         Undo,
+        /// Redo the last undone change
         Redo,
     ]
 );

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -36,59 +36,59 @@ use multi_buffer::MultiBufferRow;
 actions!(
     vim,
     [
-        /// Insert text after the cursor
+        /// Inserts text after the cursor.
         InsertAfter,
-        /// Insert text before the cursor
+        /// Inserts text before the cursor.
         InsertBefore,
-        /// Insert at the first non-whitespace character
+        /// Inserts at the first non-whitespace character.
         InsertFirstNonWhitespace,
-        /// Insert at the end of the line
+        /// Inserts at the end of the line.
         InsertEndOfLine,
-        /// Insert a new line above the current line
+        /// Inserts a new line above the current line.
         InsertLineAbove,
-        /// Insert a new line below the current line
+        /// Inserts a new line below the current line.
         InsertLineBelow,
-        /// Insert an empty line above without entering insert mode
+        /// Inserts an empty line above without entering insert mode.
         InsertEmptyLineAbove,
-        /// Insert an empty line below without entering insert mode
+        /// Inserts an empty line below without entering insert mode.
         InsertEmptyLineBelow,
-        /// Insert at the previous insert position
+        /// Inserts at the previous insert position.
         InsertAtPrevious,
-        /// Join the current line with the next line
+        /// Joins the current line with the next line.
         JoinLines,
-        /// Join lines without adding whitespace
+        /// Joins lines without adding whitespace.
         JoinLinesNoWhitespace,
-        /// Delete character to the left
+        /// Deletes character to the left.
         DeleteLeft,
-        /// Delete character to the right
+        /// Deletes character to the right.
         DeleteRight,
-        /// Delete using Helix-style behavior
+        /// Deletes using Helix-style behavior.
         HelixDelete,
-        /// Change from cursor to end of line
+        /// Changes from cursor to end of line.
         ChangeToEndOfLine,
-        /// Delete from cursor to end of line
+        /// Deletes from cursor to end of line.
         DeleteToEndOfLine,
-        /// Yank (copy) the selected text
+        /// Yanks (copies) the selected text.
         Yank,
-        /// Yank the entire line
+        /// Yanks the entire line.
         YankLine,
-        /// Toggle the case of selected text
+        /// Toggles the case of selected text.
         ChangeCase,
-        /// Convert selected text to uppercase
+        /// Converts selected text to uppercase.
         ConvertToUpperCase,
-        /// Convert selected text to lowercase
+        /// Converts selected text to lowercase.
         ConvertToLowerCase,
-        /// Apply ROT13 cipher to selected text
+        /// Applies ROT13 cipher to selected text.
         ConvertToRot13,
-        /// Apply ROT47 cipher to selected text
+        /// Applies ROT47 cipher to selected text.
         ConvertToRot47,
-        /// Toggle comments for selected lines
+        /// Toggles comments for selected lines.
         ToggleComments,
-        /// Show the current location in the file
+        /// Shows the current location in the file.
         ShowLocation,
-        /// Undo the last change
+        /// Undoes the last change.
         Undo,
-        /// Redo the last undone change
+        /// Redoes the last undone change.
         Redo,
     ]
 );

--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -9,6 +9,7 @@ use crate::{Vim, state::Mode};
 
 const BOOLEAN_PAIRS: &[(&str, &str)] = &[("true", "false"), ("yes", "no"), ("on", "off")];
 
+/// Increments the number under the cursor or toggles boolean values.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -17,6 +18,7 @@ struct Increment {
     step: bool,
 }
 
+/// Decrements the number under the cursor or toggles boolean values.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]

--- a/crates/vim/src/normal/paste.rs
+++ b/crates/vim/src/normal/paste.rs
@@ -14,6 +14,7 @@ use crate::{
     state::{Mode, Register},
 };
 
+/// Pastes text from the specified register at the cursor position.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -11,7 +11,19 @@ use editor::Editor;
 use gpui::{Action, App, Context, Window, actions};
 use workspace::Workspace;
 
-actions!(vim, [Repeat, EndRepeat, ToggleRecord, ReplayLastRecording]);
+actions!(
+    vim,
+    [
+        /// Repeat the last change
+        Repeat,
+        /// End the repeat recording
+        EndRepeat,
+        /// Toggle macro recording
+        ToggleRecord,
+        /// Replay the last recorded macro
+        ReplayLastRecording
+    ]
+);
 
 fn should_replay(action: &dyn Action) -> bool {
     // skip so that we don't leave the character palette open

--- a/crates/vim/src/normal/repeat.rs
+++ b/crates/vim/src/normal/repeat.rs
@@ -14,13 +14,13 @@ use workspace::Workspace;
 actions!(
     vim,
     [
-        /// Repeat the last change
+        /// Repeats the last change.
         Repeat,
-        /// End the repeat recording
+        /// Ends the repeat recording.
         EndRepeat,
-        /// Toggle macro recording
+        /// Toggles macro recording.
         ToggleRecord,
-        /// Replay the last recorded macro
+        /// Replays the last recorded macro.
         ReplayLastRecording
     ]
 );

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -11,13 +11,21 @@ use settings::Settings;
 actions!(
     vim,
     [
+        /// Scroll up by one line
         LineUp,
+        /// Scroll down by one line
         LineDown,
+        /// Scroll right by one column
         ColumnRight,
+        /// Scroll left by one column
         ColumnLeft,
+        /// Scroll up by half a page
         ScrollUp,
+        /// Scroll down by half a page
         ScrollDown,
+        /// Scroll up by one page
         PageUp,
+        /// Scroll down by one page
         PageDown
     ]
 );

--- a/crates/vim/src/normal/scroll.rs
+++ b/crates/vim/src/normal/scroll.rs
@@ -11,21 +11,21 @@ use settings::Settings;
 actions!(
     vim,
     [
-        /// Scroll up by one line
+        /// Scrolls up by one line.
         LineUp,
-        /// Scroll down by one line
+        /// Scrolls down by one line.
         LineDown,
-        /// Scroll right by one column
+        /// Scrolls right by one column.
         ColumnRight,
-        /// Scroll left by one column
+        /// Scrolls left by one column.
         ColumnLeft,
-        /// Scroll up by half a page
+        /// Scrolls up by half a page.
         ScrollUp,
-        /// Scroll down by half a page
+        /// Scrolls down by half a page.
         ScrollDown,
-        /// Scroll up by one page
+        /// Scrolls up by one page.
         PageUp,
-        /// Scroll down by one page
+        /// Scrolls down by one page.
         PageDown
     ]
 );

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -16,6 +16,7 @@ use crate::{
     state::{Mode, SearchState},
 };
 
+/// Moves to the next search match.
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -28,6 +29,7 @@ pub(crate) struct MoveToNext {
     regex: bool,
 }
 
+/// Moves to the previous search match.
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -40,6 +42,7 @@ pub(crate) struct MoveToPrevious {
     regex: bool,
 }
 
+/// Initiates a search operation with the specified parameters.
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -50,6 +53,7 @@ pub(crate) struct Search {
     regex: bool,
 }
 
+/// Executes a find command to search for patterns in the buffer.
 #[derive(Clone, Debug, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -58,6 +62,7 @@ pub struct FindCommand {
     pub backwards: bool,
 }
 
+/// Executes a search and replace command within the specified range.
 #[derive(Clone, Debug, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 pub struct ReplaceCommand {

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -73,7 +73,17 @@ pub(crate) struct Replacement {
     is_case_sensitive: bool,
 }
 
-actions!(vim, [SearchSubmit, MoveToNextMatch, MoveToPreviousMatch]);
+actions!(
+    vim,
+    [
+        /// Submit the current search query
+        SearchSubmit,
+        /// Move to the next search match
+        MoveToNextMatch,
+        /// Move to the previous search match
+        MoveToPreviousMatch
+    ]
+);
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::move_to_next);

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -76,11 +76,11 @@ pub(crate) struct Replacement {
 actions!(
     vim,
     [
-        /// Submit the current search query
+        /// Submits the current search query.
         SearchSubmit,
-        /// Move to the next search match
+        /// Moves to the next search match.
         MoveToNextMatch,
-        /// Move to the previous search match
+        /// Moves to the previous search match.
         MoveToPreviousMatch
     ]
 );

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -10,9 +10,9 @@ use crate::{
 actions!(
     vim,
     [
-        /// Substitute characters in the current selection
+        /// Substitutes characters in the current selection.
         Substitute,
-        /// Substitute the entire line
+        /// Substitutes the entire line.
         SubstituteLine
     ]
 );

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -7,7 +7,15 @@ use crate::{
     motion::{Motion, MotionKind},
 };
 
-actions!(vim, [Substitute, SubstituteLine]);
+actions!(
+    vim,
+    [
+        /// Substitute characters in the current selection
+        Substitute,
+        /// Substitute the entire line
+        SubstituteLine
+    ]
+);
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &Substitute, window, cx| {

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -258,25 +258,45 @@ fn find_mini_brackets(
 actions!(
     vim,
     [
+        /// Select a sentence text object
         Sentence,
+        /// Select a paragraph text object
         Paragraph,
+        /// Select text within single quotes
         Quotes,
+        /// Select text within backticks
         BackQuotes,
+        /// Select text within the nearest quotes (single or double)
         MiniQuotes,
+        /// Select text within any type of quotes
         AnyQuotes,
+        /// Select text within double quotes
         DoubleQuotes,
+        /// Select text within vertical bars (pipes)
         VerticalBars,
+        /// Select text within parentheses
         Parentheses,
+        /// Select text within the nearest brackets
         MiniBrackets,
+        /// Select text within any type of brackets
         AnyBrackets,
+        /// Select text within square brackets
         SquareBrackets,
+        /// Select text within curly brackets
         CurlyBrackets,
+        /// Select text within angle brackets
         AngleBrackets,
+        /// Select a function argument
         Argument,
+        /// Select an HTML/XML tag
         Tag,
+        /// Select a method or function
         Method,
+        /// Select a class definition
         Class,
+        /// Select a comment block
         Comment,
+        /// Select the entire file
         EntireFile
     ]
 );

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -258,45 +258,45 @@ fn find_mini_brackets(
 actions!(
     vim,
     [
-        /// Select a sentence text object
+        /// Selects a sentence text object.
         Sentence,
-        /// Select a paragraph text object
+        /// Selects a paragraph text object.
         Paragraph,
-        /// Select text within single quotes
+        /// Selects text within single quotes.
         Quotes,
-        /// Select text within backticks
+        /// Selects text within backticks.
         BackQuotes,
-        /// Select text within the nearest quotes (single or double)
+        /// Selects text within the nearest quotes (single or double).
         MiniQuotes,
-        /// Select text within any type of quotes
+        /// Selects text within any type of quotes.
         AnyQuotes,
-        /// Select text within double quotes
+        /// Selects text within double quotes.
         DoubleQuotes,
-        /// Select text within vertical bars (pipes)
+        /// Selects text within vertical bars (pipes).
         VerticalBars,
-        /// Select text within parentheses
+        /// Selects text within parentheses.
         Parentheses,
-        /// Select text within the nearest brackets
+        /// Selects text within the nearest brackets.
         MiniBrackets,
-        /// Select text within any type of brackets
+        /// Selects text within any type of brackets.
         AnyBrackets,
-        /// Select text within square brackets
+        /// Selects text within square brackets.
         SquareBrackets,
-        /// Select text within curly brackets
+        /// Selects text within curly brackets.
         CurlyBrackets,
-        /// Select text within angle brackets
+        /// Selects text within angle brackets.
         AngleBrackets,
-        /// Select a function argument
+        /// Selects a function argument.
         Argument,
-        /// Select an HTML/XML tag
+        /// Selects an HTML/XML tag.
         Tag,
-        /// Select a method or function
+        /// Selects a method or function.
         Method,
-        /// Select a class definition
+        /// Selects a class definition.
         Class,
-        /// Select a comment block
+        /// Selects a comment block.
         Comment,
-        /// Select the entire file
+        /// Selects the entire file.
         EntireFile
     ]
 );

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -46,6 +46,7 @@ pub enum Object {
     EntireFile,
 }
 
+/// Selects a word text object.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -54,6 +55,7 @@ struct Word {
     ignore_punctuation: bool,
 }
 
+/// Selects a subword text object.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]
@@ -61,6 +63,7 @@ struct Subword {
     #[serde(default)]
     ignore_punctuation: bool,
 }
+/// Selects text at the same indentation level.
 #[derive(Clone, Deserialize, JsonSchema, PartialEq, Action)]
 #[action(namespace = vim)]
 #[serde(deny_unknown_fields)]

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -13,7 +13,15 @@ use language::{Point, SelectionGoal};
 use std::ops::Range;
 use std::sync::Arc;
 
-actions!(vim, [ToggleReplace, UndoReplace]);
+actions!(
+    vim,
+    [
+        /// Toggle replace mode
+        ToggleReplace,
+        /// Undo the last replacement
+        UndoReplace
+    ]
+);
 
 pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &ToggleReplace, window, cx| {

--- a/crates/vim/src/replace.rs
+++ b/crates/vim/src/replace.rs
@@ -16,9 +16,9 @@ use std::sync::Arc;
 actions!(
     vim,
     [
-        /// Toggle replace mode
+        /// Toggles replace mode.
         ToggleReplace,
-        /// Undo the last replacement
+        /// Undoes the last replacement.
         UndoReplace
     ]
 );

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -4,7 +4,13 @@ use editor::{Bias, Editor, RewrapOptions, SelectionEffects, display_map::ToDispl
 use gpui::{Context, Window, actions};
 use language::SelectionGoal;
 
-actions!(vim, [Rewrap]);
+actions!(
+    vim,
+    [
+        /// Rewrap the selected text to fit within the line width
+        Rewrap
+    ]
+);
 
 pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, |vim, _: &Rewrap, window, cx| {

--- a/crates/vim/src/rewrap.rs
+++ b/crates/vim/src/rewrap.rs
@@ -7,7 +7,7 @@ use language::SelectionGoal;
 actions!(
     vim,
     [
-        /// Rewrap the selected text to fit within the line width
+        /// Rewraps the selected text to fit within the line width.
         Rewrap
     ]
 );

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -134,93 +134,93 @@ struct PushLiteral {
 actions!(
     vim,
     [
-        /// Switch to normal mode
+        /// Switches to normal mode.
         SwitchToNormalMode,
-        /// Switch to insert mode
+        /// Switches to insert mode.
         SwitchToInsertMode,
-        /// Switch to replace mode
+        /// Switches to replace mode.
         SwitchToReplaceMode,
-        /// Switch to visual mode
+        /// Switches to visual mode.
         SwitchToVisualMode,
-        /// Switch to visual line mode
+        /// Switches to visual line mode.
         SwitchToVisualLineMode,
-        /// Switch to visual block mode
+        /// Switches to visual block mode.
         SwitchToVisualBlockMode,
-        /// Switch to Helix-style normal mode
+        /// Switches to Helix-style normal mode.
         SwitchToHelixNormalMode,
-        /// Clear any pending operators
+        /// Clears any pending operators.
         ClearOperators,
-        /// Clear the exchange register
+        /// Clears the exchange register.
         ClearExchange,
-        /// Insert a tab character
+        /// Inserts a tab character.
         Tab,
-        /// Insert a newline
+        /// Inserts a newline.
         Enter,
-        /// Select inner text object
+        /// Selects inner text object.
         InnerObject,
-        /// Maximize the current pane
+        /// Maximizes the current pane.
         MaximizePane,
-        /// Open the default keymap file
+        /// Opens the default keymap file.
         OpenDefaultKeymap,
-        /// Reset all pane sizes to default
+        /// Resets all pane sizes to default.
         ResetPaneSizes,
-        /// Resize the pane to the right
+        /// Resizes the pane to the right.
         ResizePaneRight,
-        /// Resize the pane to the left
+        /// Resizes the pane to the left.
         ResizePaneLeft,
-        /// Resize the pane upward
+        /// Resizes the pane upward.
         ResizePaneUp,
-        /// Resize the pane downward
+        /// Resizes the pane downward.
         ResizePaneDown,
-        /// Start a change operation
+        /// Starts a change operation.
         PushChange,
-        /// Start a delete operation
+        /// Starts a delete operation.
         PushDelete,
-        /// Exchange text regions
+        /// Exchanges text regions.
         Exchange,
-        /// Start a yank operation
+        /// Starts a yank operation.
         PushYank,
-        /// Start a replace operation
+        /// Starts a replace operation.
         PushReplace,
-        /// Delete surrounding characters
+        /// Deletes surrounding characters.
         PushDeleteSurrounds,
-        /// Set a mark at the current position
+        /// Sets a mark at the current position.
         PushMark,
-        /// Toggle the marks view
+        /// Toggles the marks view.
         ToggleMarksView,
-        /// Start a forced motion
+        /// Starts a forced motion.
         PushForcedMotion,
-        /// Start an indent operation
+        /// Starts an indent operation.
         PushIndent,
-        /// Start an outdent operation
+        /// Starts an outdent operation.
         PushOutdent,
-        /// Start an auto-indent operation
+        /// Starts an auto-indent operation.
         PushAutoIndent,
-        /// Start a rewrap operation
+        /// Starts a rewrap operation.
         PushRewrap,
-        /// Start a shell command operation
+        /// Starts a shell command operation.
         PushShellCommand,
-        /// Convert to lowercase
+        /// Converts to lowercase.
         PushLowercase,
-        /// Convert to uppercase
+        /// Converts to uppercase.
         PushUppercase,
-        /// Toggle case
+        /// Toggles case.
         PushOppositeCase,
-        /// Apply ROT13 encoding
+        /// Applies ROT13 encoding.
         PushRot13,
-        /// Apply ROT47 encoding
+        /// Applies ROT47 encoding.
         PushRot47,
-        /// Toggle the registers view
+        /// Toggles the registers view.
         ToggleRegistersView,
-        /// Select a register
+        /// Selects a register.
         PushRegister,
-        /// Start recording to a register
+        /// Starts recording to a register.
         PushRecordRegister,
-        /// Replay a register
+        /// Replays a register.
         PushReplayRegister,
-        /// Replace with register contents
+        /// Replaces with register contents.
         PushReplaceWithRegister,
-        /// Toggle comments
+        /// Toggles comments.
         PushToggleComments,
     ]
 );
@@ -229,7 +229,7 @@ actions!(
 actions!(
     workspace,
     [
-        /// Toggle Vim mode on or off
+        /// Toggles Vim mode on or off.
         ToggleVimMode,
     ]
 );

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -134,55 +134,105 @@ struct PushLiteral {
 actions!(
     vim,
     [
+        /// Switch to normal mode
         SwitchToNormalMode,
+        /// Switch to insert mode
         SwitchToInsertMode,
+        /// Switch to replace mode
         SwitchToReplaceMode,
+        /// Switch to visual mode
         SwitchToVisualMode,
+        /// Switch to visual line mode
         SwitchToVisualLineMode,
+        /// Switch to visual block mode
         SwitchToVisualBlockMode,
+        /// Switch to Helix-style normal mode
         SwitchToHelixNormalMode,
+        /// Clear any pending operators
         ClearOperators,
+        /// Clear the exchange register
         ClearExchange,
+        /// Insert a tab character
         Tab,
+        /// Insert a newline
         Enter,
+        /// Select inner text object
         InnerObject,
+        /// Maximize the current pane
         MaximizePane,
+        /// Open the default keymap file
         OpenDefaultKeymap,
+        /// Reset all pane sizes to default
         ResetPaneSizes,
+        /// Resize the pane to the right
         ResizePaneRight,
+        /// Resize the pane to the left
         ResizePaneLeft,
+        /// Resize the pane upward
         ResizePaneUp,
+        /// Resize the pane downward
         ResizePaneDown,
+        /// Start a change operation
         PushChange,
+        /// Start a delete operation
         PushDelete,
+        /// Exchange text regions
         Exchange,
+        /// Start a yank operation
         PushYank,
+        /// Start a replace operation
         PushReplace,
+        /// Delete surrounding characters
         PushDeleteSurrounds,
+        /// Set a mark at the current position
         PushMark,
+        /// Toggle the marks view
         ToggleMarksView,
+        /// Start a forced motion
         PushForcedMotion,
+        /// Start an indent operation
         PushIndent,
+        /// Start an outdent operation
         PushOutdent,
+        /// Start an auto-indent operation
         PushAutoIndent,
+        /// Start a rewrap operation
         PushRewrap,
+        /// Start a shell command operation
         PushShellCommand,
+        /// Convert to lowercase
         PushLowercase,
+        /// Convert to uppercase
         PushUppercase,
+        /// Toggle case
         PushOppositeCase,
+        /// Apply ROT13 encoding
         PushRot13,
+        /// Apply ROT47 encoding
         PushRot47,
+        /// Toggle the registers view
         ToggleRegistersView,
+        /// Select a register
         PushRegister,
+        /// Start recording to a register
         PushRecordRegister,
+        /// Replay a register
         PushReplayRegister,
+        /// Replace with register contents
         PushReplaceWithRegister,
+        /// Toggle comments
         PushToggleComments,
     ]
 );
 
 // in the workspace namespace so it's not filtered out when vim is disabled.
-actions!(workspace, [ToggleVimMode,]);
+actions!(
+    workspace,
+    [
+        /// Toggle Vim mode on or off
+        ToggleVimMode,
+    ]
+);
 
 /// Initializes the `vim` crate.
 pub fn init(cx: &mut App) {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -23,41 +23,41 @@ use crate::{
 actions!(
     vim,
     [
-        /// Toggle visual mode
+        /// Toggles visual mode.
         ToggleVisual,
-        /// Toggle visual line mode
+        /// Toggles visual line mode.
         ToggleVisualLine,
-        /// Toggle visual block mode
+        /// Toggles visual block mode.
         ToggleVisualBlock,
-        /// Delete the visual selection
+        /// Deletes the visual selection.
         VisualDelete,
-        /// Delete entire lines in visual selection
+        /// Deletes entire lines in visual selection.
         VisualDeleteLine,
-        /// Yank (copy) the visual selection
+        /// Yanks (copies) the visual selection.
         VisualYank,
-        /// Yank entire lines in visual selection
+        /// Yanks entire lines in visual selection.
         VisualYankLine,
-        /// Move cursor to the other end of the selection
+        /// Moves cursor to the other end of the selection.
         OtherEnd,
-        /// Move cursor to the other end of the selection (row-aware)
+        /// Moves cursor to the other end of the selection (row-aware).
         OtherEndRowAware,
-        /// Select the next occurrence of the current selection
+        /// Selects the next occurrence of the current selection.
         SelectNext,
-        /// Select the previous occurrence of the current selection
+        /// Selects the previous occurrence of the current selection.
         SelectPrevious,
-        /// Select the next match of the current selection
+        /// Selects the next match of the current selection.
         SelectNextMatch,
-        /// Select the previous match of the current selection
+        /// Selects the previous match of the current selection.
         SelectPreviousMatch,
-        /// Select the next smaller syntax node
+        /// Selects the next smaller syntax node.
         SelectSmallerSyntaxNode,
-        /// Select the next larger syntax node
+        /// Selects the next larger syntax node.
         SelectLargerSyntaxNode,
-        /// Restore the previous visual selection
+        /// Restores the previous visual selection.
         RestoreVisualSelection,
-        /// Insert at the end of each line in visual selection
+        /// Inserts at the end of each line in visual selection.
         VisualInsertEndOfLine,
-        /// Insert at the first non-whitespace character of each line
+        /// Inserts at the first non-whitespace character of each line.
         VisualInsertFirstNonWhiteSpace,
     ]
 );

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -23,23 +23,41 @@ use crate::{
 actions!(
     vim,
     [
+        /// Toggle visual mode
         ToggleVisual,
+        /// Toggle visual line mode
         ToggleVisualLine,
+        /// Toggle visual block mode
         ToggleVisualBlock,
+        /// Delete the visual selection
         VisualDelete,
+        /// Delete entire lines in visual selection
         VisualDeleteLine,
+        /// Yank (copy) the visual selection
         VisualYank,
+        /// Yank entire lines in visual selection
         VisualYankLine,
+        /// Move cursor to the other end of the selection
         OtherEnd,
+        /// Move cursor to the other end of the selection (row-aware)
         OtherEndRowAware,
+        /// Select the next occurrence of the current selection
         SelectNext,
+        /// Select the previous occurrence of the current selection
         SelectPrevious,
+        /// Select the next match of the current selection
         SelectNextMatch,
+        /// Select the previous match of the current selection
         SelectPreviousMatch,
+        /// Select the next smaller syntax node
         SelectSmallerSyntaxNode,
+        /// Select the next larger syntax node
         SelectLargerSyntaxNode,
+        /// Restore the previous visual selection
         RestoreVisualSelection,
+        /// Insert at the end of each line in visual selection
         VisualInsertEndOfLine,
+        /// Insert at the first non-whitespace character of each line
         VisualInsertFirstNonWhiteSpace,
     ]
 );

--- a/crates/welcome/src/base_keymap_picker.rs
+++ b/crates/welcome/src/base_keymap_picker.rs
@@ -12,7 +12,13 @@ use ui::{ListItem, ListItemSpacing, prelude::*};
 use util::ResultExt;
 use workspace::{ModalView, Workspace, ui::HighlightedLabel};
 
-actions!(welcome, [ToggleBaseKeymapSelector]);
+actions!(
+    welcome,
+    [
+        /// Toggle the base keymap selector modal
+        ToggleBaseKeymapSelector
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _window, _cx| {

--- a/crates/welcome/src/base_keymap_picker.rs
+++ b/crates/welcome/src/base_keymap_picker.rs
@@ -15,7 +15,7 @@ use workspace::{ModalView, Workspace, ui::HighlightedLabel};
 actions!(
     welcome,
     [
-        /// Toggle the base keymap selector modal
+        /// Toggles the base keymap selector modal.
         ToggleBaseKeymapSelector
     ]
 );

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -25,7 +25,13 @@ mod base_keymap_setting;
 mod multibuffer_hint;
 mod welcome_ui;
 
-actions!(welcome, [ResetHints]);
+actions!(
+    welcome,
+    [
+        /// Reset the welcome screen hints to their initial state
+        ResetHints
+    ]
+);
 
 pub const FIRST_OPEN: &str = "first_open";
 pub const DOCS_URL: &str = "https://zed.dev/docs/";

--- a/crates/welcome/src/welcome.rs
+++ b/crates/welcome/src/welcome.rs
@@ -28,7 +28,7 @@ mod welcome_ui;
 actions!(
     welcome,
     [
-        /// Reset the welcome screen hints to their initial state
+        /// Resets the welcome screen hints to their initial state.
         ResetHints
     ]
 );

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -95,10 +95,12 @@ pub enum SaveIntent {
     Skip,
 }
 
+/// Activates a specific item in the pane by its index.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 pub struct ActivateItem(pub usize);
 
+/// Closes the currently active item in the pane.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -109,6 +111,7 @@ pub struct CloseActiveItem {
     pub close_pinned: bool,
 }
 
+/// Closes all inactive items in the pane.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -119,6 +122,7 @@ pub struct CloseInactiveItems {
     pub close_pinned: bool,
 }
 
+/// Closes all items in the pane.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -129,6 +133,7 @@ pub struct CloseAllItems {
     pub close_pinned: bool,
 }
 
+/// Closes all items that have no unsaved changes.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -137,6 +142,7 @@ pub struct CloseCleanItems {
     pub close_pinned: bool,
 }
 
+/// Closes all items to the right of the current item.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -145,6 +151,7 @@ pub struct CloseItemsToTheRight {
     pub close_pinned: bool,
 }
 
+/// Closes all items to the left of the current item.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -153,6 +160,7 @@ pub struct CloseItemsToTheLeft {
     pub close_pinned: bool,
 }
 
+/// Reveals the current item in the project panel.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]
@@ -161,6 +169,7 @@ pub struct RevealInProjectPanel {
     pub entry_id: Option<u64>,
 }
 
+/// Opens the search interface with the specified configuration.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Default, Action)]
 #[action(namespace = pane)]
 #[serde(deny_unknown_fields)]

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -176,25 +176,45 @@ pub struct DeploySearch {
 actions!(
     pane,
     [
+        /// Activate the previous item in the pane
         ActivatePreviousItem,
+        /// Activate the next item in the pane
         ActivateNextItem,
+        /// Activate the last item in the pane
         ActivateLastItem,
+        /// Switch to the alternate file
         AlternateFile,
+        /// Navigate back in history
         GoBack,
+        /// Navigate forward in history
         GoForward,
+        /// Join this pane into the next pane
         JoinIntoNext,
+        /// Join all panes into one
         JoinAll,
+        /// Reopen the most recently closed item
         ReopenClosedItem,
+        /// Split the pane to the left
         SplitLeft,
+        /// Split the pane upward
         SplitUp,
+        /// Split the pane to the right
         SplitRight,
+        /// Split the pane downward
         SplitDown,
+        /// Split the pane horizontally
         SplitHorizontal,
+        /// Split the pane vertically
         SplitVertical,
+        /// Swap the current item with the one to the left
         SwapItemLeft,
+        /// Swap the current item with the one to the right
         SwapItemRight,
+        /// Toggle preview mode for the current tab
         TogglePreviewTab,
+        /// Toggle pin status for the current tab
         TogglePinTab,
+        /// Unpin all tabs in the pane
         UnpinAllTabs,
     ]
 );

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -176,45 +176,45 @@ pub struct DeploySearch {
 actions!(
     pane,
     [
-        /// Activate the previous item in the pane
+        /// Activates the previous item in the pane.
         ActivatePreviousItem,
-        /// Activate the next item in the pane
+        /// Activates the next item in the pane.
         ActivateNextItem,
-        /// Activate the last item in the pane
+        /// Activates the last item in the pane.
         ActivateLastItem,
-        /// Switch to the alternate file
+        /// Switches to the alternate file.
         AlternateFile,
-        /// Navigate back in history
+        /// Navigates back in history.
         GoBack,
-        /// Navigate forward in history
+        /// Navigates forward in history.
         GoForward,
-        /// Join this pane into the next pane
+        /// Joins this pane into the next pane.
         JoinIntoNext,
-        /// Join all panes into one
+        /// Joins all panes into one.
         JoinAll,
-        /// Reopen the most recently closed item
+        /// Reopens the most recently closed item.
         ReopenClosedItem,
-        /// Split the pane to the left
+        /// Splits the pane to the left.
         SplitLeft,
-        /// Split the pane upward
+        /// Splits the pane upward.
         SplitUp,
-        /// Split the pane to the right
+        /// Splits the pane to the right.
         SplitRight,
-        /// Split the pane downward
+        /// Splits the pane downward.
         SplitDown,
-        /// Split the pane horizontally
+        /// Splits the pane horizontally.
         SplitHorizontal,
-        /// Split the pane vertically
+        /// Splits the pane vertically.
         SplitVertical,
-        /// Swap the current item with the one to the left
+        /// Swaps the current item with the one to the left.
         SwapItemLeft,
-        /// Swap the current item with the one to the right
+        /// Swaps the current item with the one to the right.
         SwapItemRight,
-        /// Toggle preview mode for the current tab
+        /// Toggles preview mode for the current tab.
         TogglePreviewTab,
-        /// Toggle pin status for the current tab
+        /// Toggles pin status for the current tab.
         TogglePinTab,
-        /// Unpin all tabs in the pane
+        /// Unpins all tabs in the pane.
         UnpinAllTabs,
     ]
 );

--- a/crates/workspace/src/theme_preview.rs
+++ b/crates/workspace/src/theme_preview.rs
@@ -14,7 +14,7 @@ use crate::{Item, Workspace};
 actions!(
     dev,
     [
-        /// Open the theme preview window
+        /// Opens the theme preview window.
         OpenThemePreview
     ]
 );

--- a/crates/workspace/src/theme_preview.rs
+++ b/crates/workspace/src/theme_preview.rs
@@ -11,7 +11,13 @@ use ui::{
 
 use crate::{Item, Workspace};
 
-actions!(dev, [OpenThemePreview]);
+actions!(
+    dev,
+    [
+        /// Open the theme preview window
+        OpenThemePreview
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -255,10 +255,12 @@ pub struct OpenPaths {
     pub paths: Vec<PathBuf>,
 }
 
+/// Activates a specific pane by its index.
 #[derive(Clone, Deserialize, PartialEq, JsonSchema, Action)]
 #[action(namespace = workspace)]
 pub struct ActivatePane(pub usize);
 
+/// Moves an item to a specific pane by index.
 #[derive(Clone, Deserialize, PartialEq, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -275,6 +277,7 @@ fn default_1() -> usize {
     1
 }
 
+/// Moves an item to a pane in the specified direction.
 #[derive(Clone, Deserialize, PartialEq, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -291,6 +294,7 @@ fn default_right() -> SplitDirection {
     SplitDirection::Right
 }
 
+/// Saves all open files in the workspace.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -299,6 +303,7 @@ pub struct SaveAll {
     pub save_intent: Option<SaveIntent>,
 }
 
+/// Saves the current file with the specified options.
 #[derive(Clone, PartialEq, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -307,6 +312,7 @@ pub struct Save {
     pub save_intent: Option<SaveIntent>,
 }
 
+/// Closes all items and panes in the workspace.
 #[derive(Clone, PartialEq, Debug, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -315,6 +321,7 @@ pub struct CloseAllItemsAndPanes {
     pub save_intent: Option<SaveIntent>,
 }
 
+/// Closes all inactive tabs and panes in the workspace.
 #[derive(Clone, PartialEq, Debug, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -323,10 +330,12 @@ pub struct CloseInactiveTabsAndPanes {
     pub save_intent: Option<SaveIntent>,
 }
 
+/// Sends a sequence of keystrokes to the active element.
 #[derive(Clone, Deserialize, PartialEq, JsonSchema, Action)]
 #[action(namespace = workspace)]
 pub struct SendKeystrokes(pub String);
 
+/// Reloads the active item or workspace.
 #[derive(Clone, Deserialize, PartialEq, Default, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]
@@ -343,6 +352,7 @@ actions!(
     ]
 );
 
+/// Toggles the file finder interface.
 #[derive(Default, PartialEq, Eq, Clone, Deserialize, JsonSchema, Action)]
 #[action(namespace = file_finder, name = "Toggle")]
 #[serde(deny_unknown_fields)]
@@ -464,6 +474,7 @@ impl PartialEq for Toast {
     }
 }
 
+/// Opens a new terminal with the specified working directory.
 #[derive(Debug, Default, Clone, Deserialize, PartialEq, JsonSchema, Action)]
 #[action(namespace = workspace)]
 #[serde(deny_unknown_fields)]

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -169,44 +169,83 @@ pub trait DebuggerProvider {
 actions!(
     workspace,
     [
+        /// Activate the next pane in the workspace
         ActivateNextPane,
+        /// Activate the previous pane in the workspace
         ActivatePreviousPane,
+        /// Switch to the next window
         ActivateNextWindow,
+        /// Switch to the previous window
         ActivatePreviousWindow,
+        /// Add a folder to the current project
         AddFolderToProject,
+        /// Clear all notifications
         ClearAllNotifications,
+        /// Close the active dock
         CloseActiveDock,
+        /// Close all docks
         CloseAllDocks,
+        /// Close the current window
         CloseWindow,
+        /// Open the feedback dialog
         Feedback,
+        /// Follow the next collaborator in the session
         FollowNextCollaborator,
+        /// Move the focused panel to the next position
         MoveFocusedPanelToNextPosition,
+        /// Open a new terminal in the center
         NewCenterTerminal,
+        /// Create a new file
         NewFile,
+        /// Create a new file in a vertical split
         NewFileSplitVertical,
+        /// Create a new file in a horizontal split
         NewFileSplitHorizontal,
+        /// Open a new search
         NewSearch,
+        /// Open a new terminal
         NewTerminal,
+        /// Open a new window
         NewWindow,
+        /// Open a file or directory
         Open,
+        /// Open multiple files
         OpenFiles,
+        /// Open the current location in terminal
         OpenInTerminal,
+        /// Open the component preview
         OpenComponentPreview,
+        /// Reload the active item
         ReloadActiveItem,
+        /// Reset the active dock to its default size
         ResetActiveDockSize,
+        /// Reset all open docks to their default sizes
         ResetOpenDocksSize,
+        /// Save the current file with a new name
         SaveAs,
+        /// Save without formatting
         SaveWithoutFormat,
+        /// Shutdown all debug adapters
         ShutdownDebugAdapters,
+        /// Suppress the current notification
         SuppressNotification,
+        /// Toggle the bottom dock
         ToggleBottomDock,
+        /// Toggle centered layout mode
         ToggleCenteredLayout,
+        /// Toggle the left dock
         ToggleLeftDock,
+        /// Toggle the right dock
         ToggleRightDock,
+        /// Toggle zoom on the active pane
         ToggleZoom,
+        /// Stop following a collaborator
         Unfollow,
+        /// Show the welcome screen
         Welcome,
+        /// Restore the banner
         RestoreBanner,
+        /// Toggle expansion of the selected item
         ToggleExpandItem,
     ]
 );
@@ -298,6 +337,7 @@ pub struct Reload {
 actions!(
     project_symbols,
     [
+        /// Toggle the project symbols search
         #[action(name = "Toggle")]
         ToggleProjectSymbols
     ]
@@ -354,13 +394,21 @@ pub struct DecreaseOpenDocksSize {
 actions!(
     workspace,
     [
+        /// Activate the pane to the left
         ActivatePaneLeft,
+        /// Activate the pane to the right
         ActivatePaneRight,
+        /// Activate the pane above
         ActivatePaneUp,
+        /// Activate the pane below
         ActivatePaneDown,
+        /// Swap the current pane with the one to the left
         SwapPaneLeft,
+        /// Swap the current pane with the one to the right
         SwapPaneRight,
+        /// Swap the current pane with the one above
         SwapPaneUp,
+        /// Swap the current pane with the one below
         SwapPaneDown,
     ]
 );
@@ -6677,14 +6725,25 @@ actions!(
         /// can be copied via "Copy link to section" in the context menu of the channel notes
         /// buffer. These URLs look like `https://zed.dev/channel/channel-name-CHANNEL_ID/notes`.
         OpenChannelNotes,
+        /// Mute your microphone
         Mute,
+        /// Deafen yourself (mute both microphone and speakers)
         Deafen,
+        /// Leave the current call
         LeaveCall,
+        /// Share the current project with collaborators
         ShareProject,
+        /// Share your screen with collaborators
         ScreenShare
     ]
 );
-actions!(zed, [OpenLog]);
+actions!(
+    zed,
+    [
+        /// Open the Zed log file
+        OpenLog
+    ]
+);
 
 async fn join_channel_internal(
     channel_id: ChannelId,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -169,83 +169,83 @@ pub trait DebuggerProvider {
 actions!(
     workspace,
     [
-        /// Activate the next pane in the workspace
+        /// Activates the next pane in the workspace.
         ActivateNextPane,
-        /// Activate the previous pane in the workspace
+        /// Activates the previous pane in the workspace.
         ActivatePreviousPane,
-        /// Switch to the next window
+        /// Switches to the next window.
         ActivateNextWindow,
-        /// Switch to the previous window
+        /// Switches to the previous window.
         ActivatePreviousWindow,
-        /// Add a folder to the current project
+        /// Adds a folder to the current project.
         AddFolderToProject,
-        /// Clear all notifications
+        /// Clears all notifications.
         ClearAllNotifications,
-        /// Close the active dock
+        /// Closes the active dock.
         CloseActiveDock,
-        /// Close all docks
+        /// Closes all docks.
         CloseAllDocks,
-        /// Close the current window
+        /// Closes the current window.
         CloseWindow,
-        /// Open the feedback dialog
+        /// Opens the feedback dialog.
         Feedback,
-        /// Follow the next collaborator in the session
+        /// Follows the next collaborator in the session.
         FollowNextCollaborator,
-        /// Move the focused panel to the next position
+        /// Moves the focused panel to the next position.
         MoveFocusedPanelToNextPosition,
-        /// Open a new terminal in the center
+        /// Opens a new terminal in the center.
         NewCenterTerminal,
-        /// Create a new file
+        /// Creates a new file.
         NewFile,
-        /// Create a new file in a vertical split
+        /// Creates a new file in a vertical split.
         NewFileSplitVertical,
-        /// Create a new file in a horizontal split
+        /// Creates a new file in a horizontal split.
         NewFileSplitHorizontal,
-        /// Open a new search
+        /// Opens a new search.
         NewSearch,
-        /// Open a new terminal
+        /// Opens a new terminal.
         NewTerminal,
-        /// Open a new window
+        /// Opens a new window.
         NewWindow,
-        /// Open a file or directory
+        /// Opens a file or directory.
         Open,
-        /// Open multiple files
+        /// Opens multiple files.
         OpenFiles,
-        /// Open the current location in terminal
+        /// Opens the current location in terminal.
         OpenInTerminal,
-        /// Open the component preview
+        /// Opens the component preview.
         OpenComponentPreview,
-        /// Reload the active item
+        /// Reloads the active item.
         ReloadActiveItem,
-        /// Reset the active dock to its default size
+        /// Resets the active dock to its default size.
         ResetActiveDockSize,
-        /// Reset all open docks to their default sizes
+        /// Resets all open docks to their default sizes.
         ResetOpenDocksSize,
-        /// Save the current file with a new name
+        /// Saves the current file with a new name.
         SaveAs,
-        /// Save without formatting
+        /// Saves without formatting.
         SaveWithoutFormat,
-        /// Shutdown all debug adapters
+        /// Shuts down all debug adapters.
         ShutdownDebugAdapters,
-        /// Suppress the current notification
+        /// Suppresses the current notification.
         SuppressNotification,
-        /// Toggle the bottom dock
+        /// Toggles the bottom dock.
         ToggleBottomDock,
-        /// Toggle centered layout mode
+        /// Toggles centered layout mode.
         ToggleCenteredLayout,
-        /// Toggle the left dock
+        /// Toggles the left dock.
         ToggleLeftDock,
-        /// Toggle the right dock
+        /// Toggles the right dock.
         ToggleRightDock,
-        /// Toggle zoom on the active pane
+        /// Toggles zoom on the active pane.
         ToggleZoom,
-        /// Stop following a collaborator
+        /// Stops following a collaborator.
         Unfollow,
-        /// Show the welcome screen
+        /// Shows the welcome screen.
         Welcome,
-        /// Restore the banner
+        /// Restores the banner.
         RestoreBanner,
-        /// Toggle expansion of the selected item
+        /// Toggles expansion of the selected item.
         ToggleExpandItem,
     ]
 );
@@ -337,7 +337,7 @@ pub struct Reload {
 actions!(
     project_symbols,
     [
-        /// Toggle the project symbols search
+        /// Toggles the project symbols search.
         #[action(name = "Toggle")]
         ToggleProjectSymbols
     ]
@@ -394,21 +394,21 @@ pub struct DecreaseOpenDocksSize {
 actions!(
     workspace,
     [
-        /// Activate the pane to the left
+        /// Activates the pane to the left.
         ActivatePaneLeft,
-        /// Activate the pane to the right
+        /// Activates the pane to the right.
         ActivatePaneRight,
-        /// Activate the pane above
+        /// Activates the pane above.
         ActivatePaneUp,
-        /// Activate the pane below
+        /// Activates the pane below.
         ActivatePaneDown,
-        /// Swap the current pane with the one to the left
+        /// Swaps the current pane with the one to the left.
         SwapPaneLeft,
-        /// Swap the current pane with the one to the right
+        /// Swaps the current pane with the one to the right.
         SwapPaneRight,
-        /// Swap the current pane with the one above
+        /// Swaps the current pane with the one above.
         SwapPaneUp,
-        /// Swap the current pane with the one below
+        /// Swaps the current pane with the one below.
         SwapPaneDown,
     ]
 );
@@ -6725,22 +6725,22 @@ actions!(
         /// can be copied via "Copy link to section" in the context menu of the channel notes
         /// buffer. These URLs look like `https://zed.dev/channel/channel-name-CHANNEL_ID/notes`.
         OpenChannelNotes,
-        /// Mute your microphone
+        /// Mutes your microphone.
         Mute,
-        /// Deafen yourself (mute both microphone and speakers)
+        /// Deafens yourself (mute both microphone and speakers).
         Deafen,
-        /// Leave the current call
+        /// Leaves the current call.
         LeaveCall,
-        /// Share the current project with collaborators
+        /// Shares the current project with collaborators.
         ShareProject,
-        /// Share your screen with collaborators
+        /// Shares your screen with collaborators.
         ScreenShare
     ]
 );
 actions!(
     zed,
     [
-        /// Open the Zed log file
+        /// Opens the Zed log file.
         OpenLog
     ]
 );

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1368,6 +1368,7 @@ fn dump_all_gpui_actions() {
         name: &'static str,
         human_name: String,
         aliases: &'static [&'static str],
+        documentation: Option<&'static str>,
     }
     let mut actions = gpui::generate_list_of_all_registered_actions()
         .into_iter()
@@ -1375,6 +1376,7 @@ fn dump_all_gpui_actions() {
             name: action.name,
             human_name: command_palette::humanize_action_name(action.name),
             aliases: action.deprecated_aliases,
+            documentation: action.documentation,
         })
         .collect::<Vec<ActionDef>>();
 

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -78,19 +78,33 @@ use zed_actions::{
 actions!(
     zed,
     [
+        /// Open the element inspector for debugging UI
         DebugElements,
+        /// Hide the application window
         Hide,
+        /// Hide all other application windows
         HideOthers,
+        /// Minimize the current window
         Minimize,
+        /// Open the default settings file
         OpenDefaultSettings,
+        /// Open project-specific settings
         OpenProjectSettings,
+        /// Open the project tasks configuration
         OpenProjectTasks,
+        /// Open the tasks panel
         OpenTasks,
+        /// Open debug tasks configuration
         OpenDebugTasks,
+        /// Reset the application database
         ResetDatabase,
+        /// Show all hidden windows
         ShowAll,
+        /// Toggle fullscreen mode
         ToggleFullScreen,
+        /// Zoom the window
         Zoom,
+        /// Trigger a test panic for debugging
         TestPanic,
     ]
 );

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -78,33 +78,33 @@ use zed_actions::{
 actions!(
     zed,
     [
-        /// Open the element inspector for debugging UI
+        /// Opens the element inspector for debugging UI.
         DebugElements,
-        /// Hide the application window
+        /// Hides the application window.
         Hide,
-        /// Hide all other application windows
+        /// Hides all other application windows.
         HideOthers,
-        /// Minimize the current window
+        /// Minimizes the current window.
         Minimize,
-        /// Open the default settings file
+        /// Opens the default settings file.
         OpenDefaultSettings,
-        /// Open project-specific settings
+        /// Opens project-specific settings.
         OpenProjectSettings,
-        /// Open the project tasks configuration
+        /// Opens the project tasks configuration.
         OpenProjectTasks,
-        /// Open the tasks panel
+        /// Opens the tasks panel.
         OpenTasks,
-        /// Open debug tasks configuration
+        /// Opens debug tasks configuration.
         OpenDebugTasks,
-        /// Reset the application database
+        /// Resets the application database.
         ResetDatabase,
-        /// Show all hidden windows
+        /// Shows all hidden windows.
         ShowAll,
-        /// Toggle fullscreen mode
+        /// Toggles fullscreen mode.
         ToggleFullScreen,
-        /// Zoom the window
+        /// Zooms the window.
         Zoom,
-        /// Trigger a test panic for debugging
+        /// Triggers a test panic for debugging.
         TestPanic,
     ]
 );

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -28,15 +28,25 @@ pub struct OpenZedUrl {
 actions!(
     zed,
     [
+        /// Open the settings editor
         OpenSettings,
+        /// Open the default keymap file
         OpenDefaultKeymap,
+        /// Open account settings
         OpenAccountSettings,
+        /// Open server settings
         OpenServerSettings,
+        /// Quit the application
         Quit,
+        /// Open the user keymap file
         OpenKeymap,
+        /// Show information about Zed
         About,
+        /// Open the documentation website
         OpenDocs,
+        /// View open source licenses
         OpenLicenses,
+        /// Open the telemetry log
         OpenTelemetryLog,
     ]
 );
@@ -116,7 +126,13 @@ pub struct ResetUiFontSize {
 pub mod dev {
     use gpui::actions;
 
-    actions!(dev, [ToggleInspector]);
+    actions!(
+        dev,
+        [
+            /// Toggle the developer inspector for debugging UI elements
+            ToggleInspector
+        ]
+    );
 }
 
 pub mod workspace {
@@ -139,9 +155,13 @@ pub mod git {
     actions!(
         git,
         [
+            /// Checkout a different git branch
             CheckoutBranch,
+            /// Switch to a different git branch
             Switch,
+            /// Select a different repository
             SelectRepo,
+            /// Open the git branch selector
             #[action(deprecated_aliases = ["branches::OpenRecent"])]
             Branch
         ]
@@ -151,25 +171,51 @@ pub mod git {
 pub mod jj {
     use gpui::actions;
 
-    actions!(jj, [BookmarkList]);
+    actions!(
+        jj,
+        [
+            /// Open the Jujutsu bookmark list
+            BookmarkList
+        ]
+    );
 }
 
 pub mod toast {
     use gpui::actions;
 
-    actions!(toast, [RunAction]);
+    actions!(
+        toast,
+        [
+            /// Run the action associated with a toast notification
+            RunAction
+        ]
+    );
 }
 
 pub mod command_palette {
     use gpui::actions;
 
-    actions!(command_palette, [Toggle]);
+    actions!(
+        command_palette,
+        [
+            /// Toggle the command palette
+            Toggle
+        ]
+    );
 }
 
 pub mod feedback {
     use gpui::actions;
 
-    actions!(feedback, [FileBugReport, GiveFeedback]);
+    actions!(
+        feedback,
+        [
+            /// Open the bug report form
+            FileBugReport,
+            /// Open the feedback form
+            GiveFeedback
+        ]
+    );
 }
 
 pub mod theme_selector {
@@ -205,7 +251,14 @@ pub mod agent {
 
     actions!(
         agent,
-        [OpenConfiguration, OpenOnboardingModal, ResetOnboarding]
+        [
+            /// Open the agent configuration panel
+            OpenConfiguration,
+            /// Open the agent onboarding modal
+            OpenOnboardingModal,
+            /// Reset the agent onboarding state
+            ResetOnboarding
+        ]
     );
 }
 
@@ -223,7 +276,13 @@ pub mod assistant {
         ]
     );
 
-    actions!(assistant, [ShowConfiguration]);
+    actions!(
+        assistant,
+        [
+            /// Show the assistant configuration panel
+            ShowConfiguration
+        ]
+    );
 
     #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
     #[action(namespace = agent, deprecated_aliases = ["assistant::OpenRulesLibrary", "assistant::DeployPromptLibrary"])]
@@ -244,7 +303,15 @@ pub mod assistant {
 pub mod debugger {
     use gpui::actions;
 
-    actions!(debugger, [OpenOnboardingModal, ResetOnboarding]);
+    actions!(
+        debugger,
+        [
+            /// Open the debugger onboarding modal
+            OpenOnboardingModal,
+            /// Reset the debugger onboarding state
+            ResetOnboarding
+        ]
+    );
 }
 
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
@@ -350,15 +417,36 @@ pub mod outline {
     pub static TOGGLE_OUTLINE: OnceLock<fn(AnyView, &mut Window, &mut App)> = OnceLock::new();
 }
 
-actions!(zed_predict_onboarding, [OpenZedPredictOnboarding]);
-actions!(git_onboarding, [OpenGitIntegrationOnboarding]);
+actions!(
+    zed_predict_onboarding,
+    [
+        /// Open the Zed Predict onboarding modal
+        OpenZedPredictOnboarding
+    ]
+);
+actions!(
+    git_onboarding,
+    [
+        /// Open the git integration onboarding modal
+        OpenGitIntegrationOnboarding
+    ]
+);
 
-actions!(debug_panel, [ToggleFocus]);
+actions!(
+    debug_panel,
+    [
+        /// Toggle focus on the debug panel
+        ToggleFocus
+    ]
+);
 actions!(
     debugger,
     [
+        /// Toggle the enabled state of a breakpoint
         ToggleEnableBreakpoint,
+        /// Remove a breakpoint
         UnsetBreakpoint,
+        /// Open the project debug tasks configuration
         OpenProjectDebugTasks,
     ]
 );

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 // https://github.com/mmastrac/rust-ctor/issues/280
 pub fn init() {}
 
+/// Opens a URL in the system's default web browser.
 #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -18,6 +19,7 @@ pub struct OpenBrowser {
     pub url: String,
 }
 
+/// Opens a zed:// URL within the application.
 #[derive(Clone, PartialEq, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -66,6 +68,7 @@ pub enum ExtensionCategoryFilter {
     DebugAdapters,
 }
 
+/// Opens the extensions management interface.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -75,6 +78,7 @@ pub struct Extensions {
     pub category_filter: Option<ExtensionCategoryFilter>,
 }
 
+/// Decreases the font size in the editor buffer.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -83,6 +87,7 @@ pub struct DecreaseBufferFontSize {
     pub persist: bool,
 }
 
+/// Increases the font size in the editor buffer.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -91,6 +96,7 @@ pub struct IncreaseBufferFontSize {
     pub persist: bool,
 }
 
+/// Resets the buffer font size to the default value.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -99,6 +105,7 @@ pub struct ResetBufferFontSize {
     pub persist: bool,
 }
 
+/// Decreases the font size of the user interface.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -107,6 +114,7 @@ pub struct DecreaseUiFontSize {
     pub persist: bool,
 }
 
+/// Increases the font size of the user interface.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -115,6 +123,7 @@ pub struct IncreaseUiFontSize {
     pub persist: bool,
 }
 
+/// Resets the UI font size to the default value.
 #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
 #[action(namespace = zed)]
 #[serde(deny_unknown_fields)]
@@ -223,6 +232,7 @@ pub mod theme_selector {
     use schemars::JsonSchema;
     use serde::Deserialize;
 
+    /// Toggles the theme selector interface.
     #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
     #[action(namespace = theme_selector)]
     #[serde(deny_unknown_fields)]
@@ -237,6 +247,7 @@ pub mod icon_theme_selector {
     use schemars::JsonSchema;
     use serde::Deserialize;
 
+    /// Toggles the icon theme selector interface.
     #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
     #[action(namespace = icon_theme_selector)]
     #[serde(deny_unknown_fields)]
@@ -284,6 +295,7 @@ pub mod assistant {
         ]
     );
 
+    /// Opens the rules library for managing agent rules and prompts.
     #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
     #[action(namespace = agent, deprecated_aliases = ["assistant::OpenRulesLibrary", "assistant::DeployPromptLibrary"])]
     #[serde(deny_unknown_fields)]
@@ -292,6 +304,7 @@ pub mod assistant {
         pub prompt_to_select: Option<Uuid>,
     }
 
+    /// Deploys the assistant interface with the specified configuration.
     #[derive(Clone, Default, Deserialize, PartialEq, JsonSchema, Action)]
     #[action(namespace = assistant)]
     #[serde(deny_unknown_fields)]
@@ -314,6 +327,7 @@ pub mod debugger {
     );
 }
 
+/// Opens the recent projects interface.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = projects)]
 #[serde(deny_unknown_fields)]
@@ -322,6 +336,7 @@ pub struct OpenRecent {
     pub create_new_window: bool,
 }
 
+/// Creates a project from a selected template.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = projects)]
 #[serde(deny_unknown_fields)]
@@ -343,7 +358,7 @@ pub enum RevealTarget {
     Dock,
 }
 
-/// Spawn a task with name or open tasks modal.
+/// Spawns a task with name or opens tasks modal.
 #[derive(Debug, PartialEq, Clone, Deserialize, JsonSchema, Action)]
 #[action(namespace = task)]
 #[serde(untagged)]
@@ -376,7 +391,7 @@ impl Spawn {
     }
 }
 
-/// Rerun the last task.
+/// Reruns the last task.
 #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
 #[action(namespace = task)]
 #[serde(deny_unknown_fields)]

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -28,25 +28,25 @@ pub struct OpenZedUrl {
 actions!(
     zed,
     [
-        /// Open the settings editor
+        /// Opens the settings editor.
         OpenSettings,
-        /// Open the default keymap file
+        /// Opens the default keymap file.
         OpenDefaultKeymap,
-        /// Open account settings
+        /// Opens account settings.
         OpenAccountSettings,
-        /// Open server settings
+        /// Opens server settings.
         OpenServerSettings,
-        /// Quit the application
+        /// Quits the application.
         Quit,
-        /// Open the user keymap file
+        /// Opens the user keymap file.
         OpenKeymap,
-        /// Show information about Zed
+        /// Shows information about Zed.
         About,
-        /// Open the documentation website
+        /// Opens the documentation website.
         OpenDocs,
-        /// View open source licenses
+        /// Views open source licenses.
         OpenLicenses,
-        /// Open the telemetry log
+        /// Opens the telemetry log.
         OpenTelemetryLog,
     ]
 );
@@ -129,7 +129,7 @@ pub mod dev {
     actions!(
         dev,
         [
-            /// Toggle the developer inspector for debugging UI elements
+            /// Toggles the developer inspector for debugging UI elements.
             ToggleInspector
         ]
     );
@@ -155,13 +155,13 @@ pub mod git {
     actions!(
         git,
         [
-            /// Checkout a different git branch
+            /// Checks out a different git branch.
             CheckoutBranch,
-            /// Switch to a different git branch
+            /// Switches to a different git branch.
             Switch,
-            /// Select a different repository
+            /// Selects a different repository.
             SelectRepo,
-            /// Open the git branch selector
+            /// Opens the git branch selector.
             #[action(deprecated_aliases = ["branches::OpenRecent"])]
             Branch
         ]
@@ -174,7 +174,7 @@ pub mod jj {
     actions!(
         jj,
         [
-            /// Open the Jujutsu bookmark list
+            /// Opens the Jujutsu bookmark list.
             BookmarkList
         ]
     );
@@ -186,7 +186,7 @@ pub mod toast {
     actions!(
         toast,
         [
-            /// Run the action associated with a toast notification
+            /// Runs the action associated with a toast notification.
             RunAction
         ]
     );
@@ -198,7 +198,7 @@ pub mod command_palette {
     actions!(
         command_palette,
         [
-            /// Toggle the command palette
+            /// Toggles the command palette.
             Toggle
         ]
     );
@@ -210,9 +210,9 @@ pub mod feedback {
     actions!(
         feedback,
         [
-            /// Open the bug report form
+            /// Opens the bug report form.
             FileBugReport,
-            /// Open the feedback form
+            /// Opens the feedback form.
             GiveFeedback
         ]
     );
@@ -252,11 +252,11 @@ pub mod agent {
     actions!(
         agent,
         [
-            /// Open the agent configuration panel
+            /// Opens the agent configuration panel.
             OpenConfiguration,
-            /// Open the agent onboarding modal
+            /// Opens the agent onboarding modal.
             OpenOnboardingModal,
-            /// Reset the agent onboarding state
+            /// Resets the agent onboarding state.
             ResetOnboarding
         ]
     );
@@ -279,7 +279,7 @@ pub mod assistant {
     actions!(
         assistant,
         [
-            /// Show the assistant configuration panel
+            /// Shows the assistant configuration panel.
             ShowConfiguration
         ]
     );
@@ -306,9 +306,9 @@ pub mod debugger {
     actions!(
         debugger,
         [
-            /// Open the debugger onboarding modal
+            /// Opens the debugger onboarding modal.
             OpenOnboardingModal,
-            /// Reset the debugger onboarding state
+            /// Resets the debugger onboarding state.
             ResetOnboarding
         ]
     );
@@ -420,14 +420,14 @@ pub mod outline {
 actions!(
     zed_predict_onboarding,
     [
-        /// Open the Zed Predict onboarding modal
+        /// Opens the Zed Predict onboarding modal.
         OpenZedPredictOnboarding
     ]
 );
 actions!(
     git_onboarding,
     [
-        /// Open the git integration onboarding modal
+        /// Opens the git integration onboarding modal.
         OpenGitIntegrationOnboarding
     ]
 );
@@ -435,18 +435,18 @@ actions!(
 actions!(
     debug_panel,
     [
-        /// Toggle focus on the debug panel
+        /// Toggles focus on the debug panel.
         ToggleFocus
     ]
 );
 actions!(
     debugger,
     [
-        /// Toggle the enabled state of a breakpoint
+        /// Toggles the enabled state of a breakpoint.
         ToggleEnableBreakpoint,
-        /// Remove a breakpoint
+        /// Removes a breakpoint.
         UnsetBreakpoint,
-        /// Open the project debug tasks configuration
+        /// Opens the project debug tasks configuration.
         OpenProjectDebugTasks,
     ]
 );

--- a/crates/zeta/src/init.rs
+++ b/crates/zeta/src/init.rs
@@ -10,7 +10,15 @@ use workspace::Workspace;
 
 use crate::{RateCompletionModal, onboarding_modal::ZedPredictModal};
 
-actions!(edit_prediction, [ResetOnboarding, RateCompletions]);
+actions!(
+    edit_prediction,
+    [
+        /// Reset the edit prediction onboarding state
+        ResetOnboarding,
+        /// Open the rate completions modal
+        RateCompletions
+    ]
+);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(move |workspace: &mut Workspace, _, _cx| {

--- a/crates/zeta/src/init.rs
+++ b/crates/zeta/src/init.rs
@@ -13,9 +13,9 @@ use crate::{RateCompletionModal, onboarding_modal::ZedPredictModal};
 actions!(
     edit_prediction,
     [
-        /// Reset the edit prediction onboarding state
+        /// Resets the edit prediction onboarding state.
         ResetOnboarding,
-        /// Open the rate completions modal
+        /// Opens the rate completions modal.
         RateCompletions
     ]
 );

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -9,17 +9,17 @@ use workspace::{ModalView, Workspace};
 actions!(
     zeta,
     [
-        /// Rate the active completion with a thumbs up
+        /// Rates the active completion with a thumbs up.
         ThumbsUpActiveCompletion,
-        /// Rate the active completion with a thumbs down
+        /// Rates the active completion with a thumbs down.
         ThumbsDownActiveCompletion,
-        /// Navigate to the next edit in the completion history
+        /// Navigates to the next edit in the completion history.
         NextEdit,
-        /// Navigate to the previous edit in the completion history
+        /// Navigates to the previous edit in the completion history.
         PreviousEdit,
-        /// Focus on the completions list
+        /// Focuses on the completions list.
         FocusCompletions,
-        /// Preview the selected completion
+        /// Previews the selected completion.
         PreviewCompletion,
     ]
 );

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -9,11 +9,17 @@ use workspace::{ModalView, Workspace};
 actions!(
     zeta,
     [
+        /// Rate the active completion with a thumbs up
         ThumbsUpActiveCompletion,
+        /// Rate the active completion with a thumbs down
         ThumbsDownActiveCompletion,
+        /// Navigate to the next edit in the completion history
         NextEdit,
+        /// Navigate to the previous edit in the completion history
         PreviousEdit,
+        /// Focus on the completions list
         FocusCompletions,
+        /// Preview the selected completion
         PreviewCompletion,
     ]
 );

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -75,7 +75,7 @@ const MAX_EVENT_COUNT: usize = 16;
 actions!(
     edit_prediction,
     [
-        /// Clear the edit prediction history
+        /// Clears the edit prediction history.
         ClearHistory
     ]
 );

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -72,7 +72,13 @@ const MAX_EVENT_TOKENS: usize = 500;
 /// Maximum number of events to track.
 const MAX_EVENT_COUNT: usize = 16;
 
-actions!(edit_prediction, [ClearHistory]);
+actions!(
+    edit_prediction,
+    [
+        /// Clear the edit prediction history
+        ClearHistory
+    ]
+);
 
 #[derive(Copy, Clone, Default, Debug, PartialEq, Eq, Hash)]
 pub struct InlineCompletionId(Uuid);


### PR DESCRIPTION
Closes #ISSUE

Adds a new `documentation` method to actions, that is extracted from doc comments when using the `actions!` or derive macros. 

Additionally, this PR adds doc comments to as many action definitions in Zed as possible.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
