### PR TITLE
languages: Fix ESLint diagnostics not getting shown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9657,12 +9657,11 @@ dependencies = [
 [[package]]
 name = "lsp-types"
 version = "0.95.1"
-source = "git+https://github.com/zed-industries/lsp-types?rev=c9c189f1c5dd53c624a419ce35bc77ad6a908d18#c9c189f1c5dd53c624a419ce35bc77ad6a908d18"
+source = "git+https://github.com/zed-industries/lsp-types?rev=6add7052b598ea1f40f7e8913622c3958b009b60#6add7052b598ea1f40f7e8913622c3958b009b60"
 dependencies = [
  "bitflags 1.3.2",
  "serde",
  "serde_json",
- "serde_repr",
  "url",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -492,7 +492,7 @@ libc = "0.2"
 libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
 linkify = "0.10.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
-lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "c9c189f1c5dd53c624a419ce35bc77ad6a908d18" }
+lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "6add7052b598ea1f40f7e8913622c3958b009b60" }
 markup5ever_rcdom = "0.3.0"
 metal = "0.29"
 moka = { version = "0.12.10", features = ["sync"] }

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -782,8 +782,8 @@ pub struct EsLintLspAdapter {
 }
 
 impl EsLintLspAdapter {
-    const CURRENT_VERSION: &'static str = "3.0.10";
-    const CURRENT_VERSION_TAG_NAME: &'static str = "release/3.0.10";
+    const CURRENT_VERSION: &'static str = "2.4.4";
+    const CURRENT_VERSION_TAG_NAME: &'static str = "release/2.4.4";
 
     #[cfg(not(windows))]
     const GITHUB_ASSET_KIND: AssetKind = AssetKind::TarGz;
@@ -867,8 +867,7 @@ impl LspAdapter for EsLintLspAdapter {
             },
             "experimental": {
                 "useFlatConfig": use_flat_config,
-            },
-            "useFlatConfig": use_flat_config,
+            }
         });
 
         let override_options = cx.update(|cx| {

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -3822,7 +3822,7 @@ impl GetDocumentDiagnostics {
             code,
             code_description: match diagnostic.code_description {
                 Some(code_description) => Some(CodeDescription {
-                    href: lsp::Url::parse(&code_description).unwrap(),
+                    href: Some(lsp::Url::parse(&code_description).unwrap()),
                 }),
                 None => None,
             },
@@ -3898,7 +3898,7 @@ impl GetDocumentDiagnostics {
             tags,
             code_description: diagnostic
                 .code_description
-                .map(|desc| desc.href.to_string()),
+                .and_then(|desc| desc.href.map(|url| url.to_string())),
             message: diagnostic.message,
             data: diagnostic.data.as_ref().map(|data| data.to_string()),
         })

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -9130,7 +9130,13 @@ impl LspStore {
             }
         };
 
-        let lsp::ProgressParamsValue::WorkDone(progress) = progress.value;
+        let progress = match progress.value {
+            lsp::ProgressParamsValue::WorkDone(progress) => progress,
+            lsp::ProgressParamsValue::WorkspaceDiagnostic(_) => {
+                return;
+            }
+        };
+
         let language_server_status =
             if let Some(status) = self.language_server_statuses.get_mut(&language_server_id) {
                 status
@@ -10503,7 +10509,7 @@ impl LspStore {
                         code_description: diagnostic
                             .code_description
                             .as_ref()
-                            .map(|d| d.href.clone()),
+                            .and_then(|d| d.href.clone()),
                         severity: diagnostic.severity.unwrap_or(DiagnosticSeverity::ERROR),
                         markdown: adapter.as_ref().and_then(|adapter| {
                             adapter.diagnostic_message_to_markdown(&diagnostic.message)
@@ -10530,7 +10536,7 @@ impl LspStore {
                                     code_description: diagnostic
                                         .code_description
                                         .as_ref()
-                                        .map(|c| c.href.clone()),
+                                        .and_then(|d| d.href.clone()),
                                     severity: DiagnosticSeverity::INFORMATION,
                                     markdown: adapter.as_ref().and_then(|adapter| {
                                         adapter.diagnostic_message_to_markdown(&info.message)


### PR DESCRIPTION
Closes #33442

Release Notes:

- Resolved an issue where the ESLint language server returned an empty string for the CodeDescription.href field in diagnostics, leading to missing diagnostics in editor.