### PR TITLE
windows: More precise handling of `WM_SETTINGCHANGE` and appearance updates

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1206,7 +1206,7 @@ fn handle_system_theme_changed(
                         drop(lock);
                         callback();
                         state_ptr.state.borrow_mut().callbacks.appearance_changed = Some(callback);
-                        configure_dwm_dark_mode(handle);
+                        configure_dwm_dark_mode(handle, new_appearance);
                     }
                 }
                 _ => {}
@@ -1468,7 +1468,7 @@ fn get_frame_thickness(dpi: u32) -> i32 {
     resize_frame_thickness + padding_thickness
 }
 
-pub(crate) fn notify_frame_changed(handle: HWND) {
+fn notify_frame_changed(handle: HWND) {
     unsafe {
         SetWindowPos(
             handle,

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -93,7 +93,7 @@ pub(crate) fn handle_msg(
         WM_IME_STARTCOMPOSITION => handle_ime_position(handle, state_ptr),
         WM_IME_COMPOSITION => handle_ime_composition(handle, lparam, state_ptr),
         WM_SETCURSOR => handle_set_cursor(handle, lparam, state_ptr),
-        WM_SETTINGCHANGE => handle_system_settings_changed(handle, lparam, state_ptr),
+        WM_SETTINGCHANGE => handle_system_settings_changed(handle, wparam, lparam, state_ptr),
         WM_INPUTLANGCHANGE => handle_input_language_changed(lparam, state_ptr),
         WM_GPUI_CURSOR_STYLE_CHANGED => handle_cursor_changed(lparam, state_ptr),
         _ => None,
@@ -1152,15 +1152,18 @@ fn handle_set_cursor(
 
 fn handle_system_settings_changed(
     handle: HWND,
+    wparam: WPARAM,
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
+    println!(
+        "System settings changed: wparam: {}, lparam: {}",
+        wparam.0, lparam.0
+    );
     let mut lock = state_ptr.state.borrow_mut();
     let display = lock.display;
-    // system settings
-    lock.system_settings.update(display);
-    // mouse double click
-    lock.click_state.system_update();
+    lock.system_settings.update(display, wparam.0);
+    lock.click_state.system_update(wparam.0);
     // window border offset
     lock.border_offset.update(handle).log_err();
     drop(lock);

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1159,13 +1159,15 @@ fn handle_system_settings_changed(
     if wparam.0 != 0 {
         let mut lock = state_ptr.state.borrow_mut();
         let display = lock.display;
-        lock.system_settings.update(display, wparam.0, handle);
+        lock.system_settings.update(display, wparam.0);
         lock.click_state.system_update(wparam.0);
         lock.border_offset.update(handle).log_err();
-        drop(lock);
     } else {
         handle_system_theme_changed(handle, lparam, state_ptr)?;
-    }
+    };
+    // Force to trigger WM_NCCALCSIZE event to ensure that we handle auto hide
+    // taskbar correctly.
+    notify_frame_changed(handle);
 
     Some(0)
 }

--- a/crates/gpui/src/platform/windows/system_settings.rs
+++ b/crates/gpui/src/platform/windows/system_settings.rs
@@ -32,12 +32,30 @@ pub(crate) struct MouseWheelSettings {
 impl WindowsSystemSettings {
     pub(crate) fn new(display: WindowsDisplay) -> Self {
         let mut settings = Self::default();
-        settings.update(display);
+        settings.init(display);
         settings
     }
 
-    pub(crate) fn update(&mut self, display: WindowsDisplay) {
+    fn init(&mut self, display: WindowsDisplay) {
         self.mouse_wheel_settings.update();
+        self.auto_hide_taskbar_position = AutoHideTaskbarPosition::new(display).log_err().flatten();
+    }
+
+    pub(crate) fn update(&mut self, display: WindowsDisplay, wparam: usize) {
+        match wparam {
+            // SPI_SETWORKAREA
+            47 => self.update_taskbar_position(display),
+            // SPI_GETWHEELSCROLLLINES, SPI_GETWHEELSCROLLCHARS
+            104 | 108 => self.update_mouse_wheel_settings(),
+            _ => {}
+        }
+    }
+
+    fn update_mouse_wheel_settings(&mut self) {
+        self.mouse_wheel_settings.update();
+    }
+
+    fn update_taskbar_position(&mut self, display: WindowsDisplay) {
         self.auto_hide_taskbar_position = AutoHideTaskbarPosition::new(display).log_err().flatten();
     }
 }

--- a/crates/gpui/src/platform/windows/system_settings.rs
+++ b/crates/gpui/src/platform/windows/system_settings.rs
@@ -41,10 +41,10 @@ impl WindowsSystemSettings {
         self.auto_hide_taskbar_position = AutoHideTaskbarPosition::new(display).log_err().flatten();
     }
 
-    pub(crate) fn update(&mut self, display: WindowsDisplay, wparam: usize, handle: HWND) {
+    pub(crate) fn update(&mut self, display: WindowsDisplay, wparam: usize) {
         match wparam {
             // SPI_SETWORKAREA
-            47 => self.update_taskbar_position(display, handle),
+            47 => self.update_taskbar_position(display),
             // SPI_GETWHEELSCROLLLINES, SPI_GETWHEELSCROLLCHARS
             104 | 108 => self.update_mouse_wheel_settings(),
             _ => {}
@@ -55,11 +55,8 @@ impl WindowsSystemSettings {
         self.mouse_wheel_settings.update();
     }
 
-    fn update_taskbar_position(&mut self, display: WindowsDisplay, handle: HWND) {
+    fn update_taskbar_position(&mut self, display: WindowsDisplay) {
         self.auto_hide_taskbar_position = AutoHideTaskbarPosition::new(display).log_err().flatten();
-        // Force to trigger WM_NCCALCSIZE event to ensure that we handle auto hide
-        // taskbar correctly.
-        notify_frame_changed(handle);
     }
 }
 

--- a/crates/gpui/src/platform/windows/system_settings.rs
+++ b/crates/gpui/src/platform/windows/system_settings.rs
@@ -41,10 +41,10 @@ impl WindowsSystemSettings {
         self.auto_hide_taskbar_position = AutoHideTaskbarPosition::new(display).log_err().flatten();
     }
 
-    pub(crate) fn update(&mut self, display: WindowsDisplay, wparam: usize) {
+    pub(crate) fn update(&mut self, display: WindowsDisplay, wparam: usize, handle: HWND) {
         match wparam {
             // SPI_SETWORKAREA
-            47 => self.update_taskbar_position(display),
+            47 => self.update_taskbar_position(display, handle),
             // SPI_GETWHEELSCROLLLINES, SPI_GETWHEELSCROLLCHARS
             104 | 108 => self.update_mouse_wheel_settings(),
             _ => {}
@@ -55,8 +55,11 @@ impl WindowsSystemSettings {
         self.mouse_wheel_settings.update();
     }
 
-    fn update_taskbar_position(&mut self, display: WindowsDisplay) {
+    fn update_taskbar_position(&mut self, display: WindowsDisplay, handle: HWND) {
         self.auto_hide_taskbar_position = AutoHideTaskbarPosition::new(display).log_err().flatten();
+        // Force to trigger WM_NCCALCSIZE event to ensure that we handle auto hide
+        // taskbar correctly.
+        notify_frame_changed(handle);
     }
 }
 

--- a/crates/gpui/src/platform/windows/util.rs
+++ b/crates/gpui/src/platform/windows/util.rs
@@ -144,8 +144,8 @@ pub(crate) fn load_cursor(style: CursorStyle) -> Option<HCURSOR> {
 }
 
 /// This function is used to configure the dark mode for the window built-in title bar.
-pub(crate) fn configure_dwm_dark_mode(hwnd: HWND) {
-    let dark_mode_enabled: BOOL = match system_appearance().log_err().unwrap_or_default() {
+pub(crate) fn configure_dwm_dark_mode(hwnd: HWND, appearance: WindowAppearance) {
+    let dark_mode_enabled: BOOL = match appearance {
         WindowAppearance::Dark | WindowAppearance::VibrantDark => true.into(),
         WindowAppearance::Light | WindowAppearance::VibrantLight => false.into(),
     };

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -996,10 +996,25 @@ impl ClickState {
         self.current_count
     }
 
-    pub fn system_update(&mut self) {
-        self.double_click_spatial_tolerance_width = unsafe { GetSystemMetrics(SM_CXDOUBLECLK) };
-        self.double_click_spatial_tolerance_height = unsafe { GetSystemMetrics(SM_CYDOUBLECLK) };
-        self.double_click_interval = Duration::from_millis(unsafe { GetDoubleClickTime() } as u64);
+    pub fn system_update(&mut self, wparam: usize) {
+        match wparam {
+            // SPI_SETDOUBLECLKWIDTH
+            29 => {
+                self.double_click_spatial_tolerance_width =
+                    unsafe { GetSystemMetrics(SM_CXDOUBLECLK) }
+            }
+            // SPI_SETDOUBLECLKHEIGHT
+            30 => {
+                self.double_click_spatial_tolerance_height =
+                    unsafe { GetSystemMetrics(SM_CYDOUBLECLK) }
+            }
+            // SPI_SETDOUBLECLICKTIME
+            32 => {
+                self.double_click_interval =
+                    Duration::from_millis(unsafe { GetDoubleClickTime() } as u64)
+            }
+            _ => {}
+        }
     }
 
     #[inline]

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -37,6 +37,7 @@ pub struct WindowsWindowState {
     pub min_size: Option<Size<Pixels>>,
     pub fullscreen_restore_bounds: Bounds<Pixels>,
     pub border_offset: WindowBorderOffset,
+    pub appearance: WindowAppearance,
     pub scale_factor: f32,
     pub restore_from_minimized: Option<Box<dyn FnMut(RequestFrameOptions)>>,
 
@@ -99,6 +100,7 @@ impl WindowsWindowState {
             size: logical_size,
         };
         let border_offset = WindowBorderOffset::default();
+        let appearance = system_appearance().unwrap_or_default();
         let restore_from_minimized = None;
         let renderer = windows_renderer::init(gpu_context, hwnd, transparent)?;
         let callbacks = Callbacks::default();
@@ -118,6 +120,7 @@ impl WindowsWindowState {
             logical_size,
             fullscreen_restore_bounds,
             border_offset,
+            appearance,
             scale_factor,
             restore_from_minimized,
             min_size,

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -546,7 +546,7 @@ impl PlatformWindow for WindowsWindow {
     }
 
     fn appearance(&self) -> WindowAppearance {
-        system_appearance().log_err().unwrap_or_default()
+        self.0.state.borrow().appearance
     }
 
     fn display(&self) -> Option<Rc<dyn PlatformDisplay>> {

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -951,7 +951,7 @@ impl IDropTarget_Impl for WindowsDragDropHandler_Impl {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub(crate) struct ClickState {
     button: MouseButton,
     last_click: Instant,


### PR DESCRIPTION
Closes #33520

This PR adds more fine-grained handling of the `WM_SETTINGCHANGE` message.
Plus, we now only trigger the `appearance_changed` callback when the actual window appearance has changed, rather than calling it every time.


Release Notes:

- N/A
