### PR TITLE
Fix remote binary bundling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -276,7 +276,6 @@ go_to_line = { path = "crates/go_to_line" }
 google_ai = { path = "crates/google_ai" }
 gpui = { path = "crates/gpui", default-features = false, features = [
     "http_client",
-    "screen-capture",
 ] }
 gpui_macros = { path = "crates/gpui_macros" }
 gpui_tokio = { path = "crates/gpui_tokio" }

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -29,7 +29,7 @@ client.workspace = true
 collections.workspace = true
 fs.workspace = true
 futures.workspace = true
-gpui.workspace = true
+gpui = { workspace = true, features = ["screen-capture"] }
 language.workspace = true
 log.workspace = true
 postage.workspace = true

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -35,6 +35,7 @@ dashmap.workspace = true
 derive_more.workspace = true
 envy = "0.4.2"
 futures.workspace = true
+gpui = { workspace = true, features = ["screen-capture"] }
 hex.workspace = true
 http_client.workspace = true
 jsonwebtoken.workspace = true

--- a/crates/livekit_client/Cargo.toml
+++ b/crates/livekit_client/Cargo.toml
@@ -25,7 +25,7 @@ async-trait.workspace = true
 collections.workspace = true
 cpal.workspace = true
 futures.workspace = true
-gpui = { workspace = true, features = ["x11", "wayland"] }
+gpui = { workspace = true, features = ["screen-capture", "x11", "wayland"] }
 gpui_tokio.workspace = true
 http_client_tls.workspace = true
 image.workspace = true

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -32,7 +32,7 @@ call.workspace = true
 chrono.workspace = true
 client.workspace = true
 db.workspace = true
-gpui.workspace = true
+gpui = { workspace = true, features = ["screen-capture"] }
 notifications.workspace = true
 project.workspace = true
 remote.workspace = true


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/32937
Fixes remote server bundling: https://github.com/zed-industries/zed/actions/runs/16043840539/job/45271137215#step:6:2079

Excludes `screen-capture` feature from Zed's default, use it only in the components that need it.

Release Notes:

- N/A 
