### PR TITLE
Add g-w rewrap keybind for vim visual mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -327,6 +327,7 @@
       "g shift-r": ["vim::Paste", { "preserve_clipboard": true }],
       "g c": "vim::ToggleComments",
       "g q": "vim::Rewrap",
+      "g w": "vim::Rewrap",
       "g ?": "vim::ConvertToRot13",
       // "g ?": "vim::ConvertToRot47",
       "\"": "vim::PushRegister",


### PR DESCRIPTION
There are both `g q` and `g w` keybinds for rewrapping in normal mode, but `g w` is missing in visual mode. This PR adds that keybind.

Release Notes:

- Add `g w` rewrap keybind for vim visual mode
