### PR TITLE
agent_ui: Fix disabled context servers not showing in agent setting

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -436,7 +436,7 @@ impl AgentConfiguration {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement {
-        let context_server_ids = self.context_server_store.read(cx).all_server_ids().clone();
+        let context_server_ids = self.context_server_store.read(cx).configured_server_ids();
 
         v_flex()
             .p(DynamicSpacing::Base16.rems(cx))

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -171,6 +171,15 @@ impl ContextServerStore {
         )
     }
 
+    /// Returns all configured context server ids, regardless of enabled state.
+    pub fn configured_server_ids(&self) -> Vec<ContextServerId> {
+        self.context_server_settings
+            .keys()
+            .cloned()
+            .map(ContextServerId)
+            .collect()
+    }
+
     #[cfg(any(test, feature = "test-support"))]
     pub fn test(
         registry: Entity<ContextServerDescriptorRegistry>,


### PR DESCRIPTION
Previously if I set enabled: false for one the context servers in settings.json it will not show up in the settings in agent panel when I start zed. But if I enabled it from settings it properly showed up. We were filtering the configuration to only get the enabled context servers from settings.json. This PR adds fetching all of them.

Release Notes:

- agent: Show context servers which are disabled in agent panel settings.
