### PR TITLE
keymap_ui: Hover tooltip for action documentation

### DIFF
--- a/crates/gpui/src/action.rs
+++ b/crates/gpui/src/action.rs
@@ -225,6 +225,7 @@ pub(crate) struct ActionRegistry {
     all_names: Vec<&'static str>, // So we can return a static slice.
     deprecated_aliases: HashMap<&'static str, &'static str>, // deprecated name -> preferred name
     deprecation_messages: HashMap<&'static str, &'static str>, // action name -> deprecation message
+    documentation: HashMap<&'static str, &'static str>, // action name -> documentation
 }
 
 impl Default for ActionRegistry {
@@ -232,6 +233,7 @@ impl Default for ActionRegistry {
         let mut this = ActionRegistry {
             by_name: Default::default(),
             names_by_type_id: Default::default(),
+            documentation: Default::default(),
             all_names: Default::default(),
             deprecated_aliases: Default::default(),
             deprecation_messages: Default::default(),
@@ -327,6 +329,9 @@ impl ActionRegistry {
         if let Some(deprecation_msg) = action.deprecation_message {
             self.deprecation_messages.insert(name, deprecation_msg);
         }
+        if let Some(documentation) = action.documentation {
+            self.documentation.insert(name, documentation);
+        }
     }
 
     /// Construct an action based on its name and optional JSON parameters sourced from the keymap.
@@ -387,6 +392,10 @@ impl ActionRegistry {
 
     pub fn deprecation_messages(&self) -> &HashMap<&'static str, &'static str> {
         &self.deprecation_messages
+    }
+
+    pub fn documentation(&self) -> &HashMap<&'static str, &'static str> {
+        &self.documentation
     }
 }
 

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1403,9 +1403,14 @@ impl App {
         self.actions.deprecated_aliases()
     }
 
-    /// Get a list of all action deprecation messages.
+    /// Get a map from an action name to the deprecation messages.
     pub fn action_deprecation_messages(&self) -> &HashMap<&'static str, &'static str> {
         self.actions.deprecation_messages()
+    }
+
+    /// Get a map from an action name to the documentation.
+    pub fn action_documentation(&self) -> &HashMap<&'static str, &'static str> {
+        self.actions.documentation()
     }
 
     /// Register a callback to be invoked when the application is about to quit.

--- a/crates/settings_ui/src/ui_components/table.rs
+++ b/crates/settings_ui/src/ui_components/table.rs
@@ -12,8 +12,7 @@ use ui::{
     ComponentScope, Div, ElementId, FixedWidth as _, FluentBuilder as _, Indicator,
     InteractiveElement as _, IntoElement, ParentElement, Pixels, RegisterComponent, RenderOnce,
     Scrollbar, ScrollbarState, StatefulInteractiveElement as _, Styled, StyledExt as _,
-    StyledTypography, Tooltip, Window, div, example_group_with_title, h_flex, px, single_example,
-    v_flex,
+    StyledTypography, Window, div, example_group_with_title, h_flex, px, single_example, v_flex,
 };
 
 struct UniformListData<const COLS: usize> {
@@ -474,7 +473,6 @@ pub fn render_row<const COLS: usize>(
     let row = div().w_full().child(
         h_flex()
             .id("table_row")
-            .tooltip(Tooltip::text("Hit enter to edit"))
             .w_full()
             .justify_between()
             .px_1p5()


### PR DESCRIPTION
Closes #ISSUE

Show the documentation for an action when hovered. As a bonus, also show the humanized command palette name!

Release Notes:

- N/A *or* Added/Fixed/Improved ...
