### PR TITLE
keymap_ui: Syntax highlight context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14590,6 +14590,7 @@ dependencies = [
  "settings",
  "theme",
  "tree-sitter-json",
+ "tree-sitter-rust",
  "ui",
  "util",
  "workspace",

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -34,6 +34,7 @@ serde.workspace = true
 settings.workspace = true
 theme.workspace = true
 tree-sitter-json.workspace = true
+tree-sitter-rust.workspace = true
 ui.workspace = true
 util.workspace = true
 workspace-hack.workspace = true

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -249,6 +249,7 @@ impl KeymapEditor {
 
     fn process_bindings(
         json_language: Arc<Language>,
+        rust_language: Arc<Language>,
         cx: &mut App,
     ) -> (Vec<ProcessedKeybinding>, Vec<StringMatchCandidate>) {
         let key_bindings_ptr = cx.key_bindings();
@@ -270,7 +271,9 @@ impl KeymapEditor {
 
             let context = key_binding
                 .predicate()
-                .map(|predicate| KeybindContextString::Local(predicate.to_string().into()))
+                .map(|predicate| {
+                    KeybindContextString::Local(predicate.to_string().into(), rust_language.clone())
+                })
                 .unwrap_or(KeybindContextString::Global);
 
             let source = source.map(|source| (source, source.name().into()));
@@ -315,11 +318,12 @@ impl KeymapEditor {
     fn update_keybindings(&mut self, cx: &mut Context<KeymapEditor>) {
         let workspace = self.workspace.clone();
         cx.spawn(async move |this, cx| {
-            let json_language = Self::load_json_language(workspace, cx).await;
+            let json_language = Self::load_json_language(workspace.clone(), cx).await;
+            let rust_language = Self::load_rust_language(workspace.clone(), cx).await;
 
             let query = this.update(cx, |this, cx| {
                 let (key_bindings, string_match_candidates) =
-                    Self::process_bindings(json_language.clone(), cx);
+                    Self::process_bindings(json_language, rust_language, cx);
                 this.keybindings = key_bindings;
                 this.string_match_candidates = Arc::new(string_match_candidates);
                 this.matches = this
@@ -366,6 +370,35 @@ impl KeymapEditor {
                     ..Default::default()
                 },
                 Some(tree_sitter_json::LANGUAGE.into()),
+            ))
+        });
+    }
+
+    async fn load_rust_language(
+        workspace: WeakEntity<Workspace>,
+        cx: &mut AsyncApp,
+    ) -> Arc<Language> {
+        let rust_language_task = workspace
+            .read_with(cx, |workspace, cx| {
+                workspace
+                    .project()
+                    .read(cx)
+                    .languages()
+                    .language_for_name("Rust")
+            })
+            .context("Failed to load Rust language")
+            .log_err();
+        let rust_language = match rust_language_task {
+            Some(task) => task.await.context("Failed to load Rust language").log_err(),
+            None => None,
+        };
+        return rust_language.unwrap_or_else(|| {
+            Arc::new(Language::new(
+                LanguageConfig {
+                    name: "Rust".into(),
+                    ..Default::default()
+                },
+                Some(tree_sitter_rust::LANGUAGE.into()),
             ))
         });
     }
@@ -544,7 +577,7 @@ struct ProcessedKeybinding {
 #[derive(Clone, Debug, IntoElement)]
 enum KeybindContextString {
     Global,
-    Local(SharedString),
+    Local(SharedString, Arc<Language>),
 }
 
 impl KeybindContextString {
@@ -553,14 +586,14 @@ impl KeybindContextString {
     pub fn local(&self) -> Option<&SharedString> {
         match self {
             KeybindContextString::Global => None,
-            KeybindContextString::Local(name) => Some(name),
+            KeybindContextString::Local(name, _) => Some(name),
         }
     }
 
     pub fn local_str(&self) -> Option<&str> {
         match self {
             KeybindContextString::Global => None,
-            KeybindContextString::Local(name) => Some(name),
+            KeybindContextString::Local(name, _) => Some(name),
         }
     }
 }
@@ -568,8 +601,15 @@ impl KeybindContextString {
 impl RenderOnce for KeybindContextString {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         match self {
-            KeybindContextString::Global => KeybindContextString::GLOBAL.clone(),
-            KeybindContextString::Local(name) => name,
+            KeybindContextString::Global => StyledText::new(KeybindContextString::GLOBAL.clone())
+                .with_highlights([(
+                    0..KeybindContextString::GLOBAL.len(),
+                    gpui::HighlightStyle::color(_cx.theme().colors().text_muted),
+                )])
+                .into_any_element(),
+            KeybindContextString::Local(name, language) => {
+                SyntaxHighlightedText::new(name, language).into_any_element()
+            }
         }
     }
 }


### PR DESCRIPTION
Closes #ISSUE

Uses Rust for syntax highlighting of context in the keymap editor. Future pass will improve color choice to make colors less abrasive 

Release Notes:

- N/A *or* Added/Fixed/Improved ...
