### PR TITLE
emmet: Enable in `HTML/ERB` files

### DIFF
--- a/extensions/emmet/extension.toml
+++ b/extensions/emmet/extension.toml
@@ -9,12 +9,13 @@ repository = "https://github.com/zed-industries/zed"
 [language_servers.emmet-language-server]
 name = "Emmet Language Server"
 language = "HTML"
-languages = ["HTML", "PHP", "ERB", "JavaScript", "TSX", "CSS", "HEEX", "Elixir"]
+languages = ["HTML", "PHP", "ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "HEEX", "Elixir"]
 
 [language_servers.emmet-language-server.language_ids]
 "HTML" = "html"
 "PHP" = "php"
 "ERB" = "eruby"
+"HTML/ERB" = "eruby"
 "JavaScript" = "javascriptreact"
 "TSX" = "typescriptreact"
 "CSS" = "css"


### PR DESCRIPTION
Closes [#133](https://github.com/zed-extensions/ruby/issues/133)

This PR enables the Emmet LS in `HTML/ERB` files that we added in the https://github.com/zed-extensions/ruby/pull/113. Let me know if I picked the right approach here.

Thanks!

Release Notes:

- N/A
