### PR TITLE
debugger: Improve debug console autocompletions

### DIFF
--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -706,11 +706,13 @@ impl ConsoleQueryBarCompletionProvider {
                         new_text: string_match.string.clone(),
                         label: CodeLabel {
                             filter_range: 0..string_match.string.len(),
-                            text: format!("{} {}", string_match.string, variable_value),
+                            text: string_match.string.clone(),
                             runs: Vec::new(),
                         },
                         icon_path: None,
-                        documentation: None,
+                        documentation: Some(CompletionDocumentation::MultiLineMarkdown(
+                            variable_value.into(),
+                        )),
                         confirm: None,
                         source: project::CompletionSource::Custom,
                         insert_text_mode: None,

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -5,7 +5,7 @@ use super::{
 use alacritty_terminal::vte::ansi;
 use anyhow::Result;
 use collections::HashMap;
-use dap::OutputEvent;
+use dap::{CompletionItem, CompletionItemType, OutputEvent};
 use editor::{Bias, CompletionProvider, Editor, EditorElement, EditorStyle, ExcerptId};
 use fuzzy::StringMatchCandidate;
 use gpui::{
@@ -17,6 +17,7 @@ use menu::Confirm;
 use project::{
     Completion, CompletionResponse,
     debugger::session::{CompletionsQuery, OutputToken, Session, SessionEvent},
+    lsp_store::CompletionDocumentation,
 };
 use settings::Settings;
 use std::{cell::RefCell, ops::Range, rc::Rc, usize};
@@ -693,6 +694,32 @@ impl ConsoleQueryBarCompletionProvider {
         })
     }
 
+    const fn completion_type_score(completion_type: CompletionItemType) -> usize {
+        match completion_type {
+            CompletionItemType::Field | CompletionItemType::Property => 0,
+            CompletionItemType::Variable | CompletionItemType::Value => 1,
+            CompletionItemType::Method
+            | CompletionItemType::Function
+            | CompletionItemType::Constructor => 2,
+            CompletionItemType::Class
+            | CompletionItemType::Interface
+            | CompletionItemType::Module => 3,
+            _ => 4,
+        }
+    }
+
+    fn completion_item_sort_text(completion_item: &CompletionItem) -> String {
+        completion_item.sort_text.clone().unwrap_or_else(|| {
+            format!(
+                "{:03}_{}",
+                Self::completion_type_score(
+                    completion_item.type_.unwrap_or(CompletionItemType::Text)
+                ),
+                completion_item.label.to_ascii_lowercase()
+            )
+        })
+    }
+
     fn client_completions(
         &self,
         console: &Entity<Console>,
@@ -717,6 +744,7 @@ impl ConsoleQueryBarCompletionProvider {
             let completions = completions
                 .into_iter()
                 .map(|completion| {
+                    let sort_text = Self::completion_item_sort_text(&completion);
                     let new_text = completion
                         .text
                         .as_ref()
@@ -749,12 +777,11 @@ impl ConsoleQueryBarCompletionProvider {
                             runs: Vec::new(),
                         },
                         icon_path: None,
-                        documentation: None,
+                        documentation: completion.detail.map(|detail| {
+                            CompletionDocumentation::MultiLineMarkdown(detail.into())
+                        }),
                         confirm: None,
-                        source: project::CompletionSource::BufferWord {
-                            word_range: buffer_position..language::Anchor::MAX,
-                            resolved: false,
-                        },
+                        source: project::CompletionSource::Dap { sort_text },
                         insert_text_mode: None,
                     }
                 })

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -584,7 +584,7 @@ impl CompletionProvider for ConsoleQueryBarCompletionProvider {
         &self,
         buffer: &Entity<Buffer>,
         position: language::Anchor,
-        text: &str,
+        _text: &str,
         _trigger_in_words: bool,
         menu_is_open: bool,
         cx: &mut Context<Editor>,
@@ -594,19 +594,7 @@ impl CompletionProvider for ConsoleQueryBarCompletionProvider {
             return false;
         }
 
-        self.0
-            .read_with(cx, |console, cx| {
-                console
-                    .session
-                    .read(cx)
-                    .capabilities()
-                    .completion_trigger_characters
-                    .as_ref()
-                    .map(|triggers| triggers.contains(&text.to_string()))
-            })
-            .ok()
-            .flatten()
-            .unwrap_or(true)
+        true
     }
 }
 

--- a/crates/debugger_ui/src/session/running/console.rs
+++ b/crates/debugger_ui/src/session/running/console.rs
@@ -639,21 +639,28 @@ impl ConsoleQueryBarCompletionProvider {
                 variable_list.completion_variables(cx)
             }) {
                 if let Some(evaluate_name) = &variable.evaluate_name {
-                    variables.insert(evaluate_name.clone(), variable.value.clone());
-                    string_matches.push(StringMatchCandidate {
-                        id: 0,
-                        string: evaluate_name.clone(),
-                        char_bag: evaluate_name.chars().collect(),
-                    });
+                    if variables
+                        .insert(evaluate_name.clone(), variable.value.clone())
+                        .is_none()
+                    {
+                        string_matches.push(StringMatchCandidate {
+                            id: 0,
+                            string: evaluate_name.clone(),
+                            char_bag: evaluate_name.chars().collect(),
+                        });
+                    }
                 }
 
-                variables.insert(variable.name.clone(), variable.value.clone());
-
-                string_matches.push(StringMatchCandidate {
-                    id: 0,
-                    string: variable.name.clone(),
-                    char_bag: variable.name.chars().collect(),
-                });
+                if variables
+                    .insert(variable.name.clone(), variable.value.clone())
+                    .is_none()
+                {
+                    string_matches.push(StringMatchCandidate {
+                        id: 0,
+                        string: variable.name.clone(),
+                        char_bag: variable.name.chars().collect(),
+                    });
+                }
             }
 
             (variables, string_matches)

--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1083,11 +1083,10 @@ impl CompletionsMenu {
                 if lsp_completion.kind == Some(CompletionItemKind::SNIPPET)
             );
 
-            let sort_text = if let CompletionSource::Lsp { lsp_completion, .. } = &completion.source
-            {
-                lsp_completion.sort_text.as_deref()
-            } else {
-                None
+            let sort_text = match &completion.source {
+                CompletionSource::Lsp { lsp_completion, .. } => lsp_completion.sort_text.as_deref(),
+                CompletionSource::Dap { sort_text } => Some(sort_text.as_str()),
+                _ => None,
             };
 
             let (sort_kind, sort_label) = completion.sort_key();

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -5681,7 +5681,9 @@ impl LspStore {
                     );
                     server.request::<lsp::request::ResolveCompletionItem>(*lsp_completion.clone())
                 }
-                CompletionSource::BufferWord { .. } | CompletionSource::Custom => {
+                CompletionSource::BufferWord { .. }
+                | CompletionSource::Dap { .. }
+                | CompletionSource::Custom => {
                     return Ok(());
                 }
             }
@@ -5833,7 +5835,9 @@ impl LspStore {
                     }
                     serde_json::to_string(lsp_completion).unwrap().into_bytes()
                 }
-                CompletionSource::Custom | CompletionSource::BufferWord { .. } => {
+                CompletionSource::Custom
+                | CompletionSource::Dap { .. }
+                | CompletionSource::BufferWord { .. } => {
                     return Ok(());
                 }
             }
@@ -10526,6 +10530,10 @@ impl LspStore {
                 serialized_completion.source = proto::completion::Source::Custom as i32;
                 serialized_completion.resolved = true;
             }
+            CompletionSource::Dap { sort_text } => {
+                serialized_completion.source = proto::completion::Source::Dap as i32;
+                serialized_completion.sort_text = Some(sort_text.clone());
+            }
         }
 
         serialized_completion
@@ -10580,6 +10588,11 @@ impl LspStore {
                         resolved: completion.resolved,
                     }
                 }
+                Some(proto::completion::Source::Dap) => CompletionSource::Dap {
+                    sort_text: completion
+                        .sort_text
+                        .context("expected sort text to exist")?,
+                },
                 _ => anyhow::bail!("Unexpected completion source {}", completion.source),
             },
         })

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -456,6 +456,10 @@ pub enum CompletionSource {
         /// Whether this completion has been resolved, to ensure it happens once per completion.
         resolved: bool,
     },
+    Dap {
+        /// The sort text for this completion.
+        sort_text: String,
+    },
     Custom,
     BufferWord {
         word_range: Range<Anchor>,

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -222,11 +222,13 @@ message Completion {
     optional Anchor buffer_word_end = 10;
     Anchor old_insert_start = 11;
     Anchor old_insert_end = 12;
+    optional string sort_text = 13;
 
     enum Source {
         Lsp = 0;
         Custom = 1;
         BufferWord = 2;
+        Dap = 3;
     }
 }
 


### PR DESCRIPTION
Partially fixes: https://github.com/zed-industries/zed/discussions/33777#discussioncomment-13646294

### Improves debug console autocompletion behavior

This PR fixes a regression in completion trigger support for the debug console, as we only looked if a completion trigger, was in the beginning of the search text, but we also had to check if the current text is a word so we also show completions for variables/input that doesn't start with any of the completion triggers.

We now also leverage DAP provided information to sort completion items more effectively. This results in improved prioritization, showing variable completions above classes and global scope types.

I also added for completion the documentation field, that directly comes from the DAP server. NOTE: I haven't found an adapter that returns this, but it needs to have.

**Before**
<img width="1200" alt="Screenshot 2025-07-03 at 21 00 19" src="https://github.com/user-attachments/assets/611e8d38-e302-4995-a425-ce2c0a1843d4" />

**After**
<img width="1200" alt="Screenshot 2025-07-03 at 20 59 38" src="https://github.com/user-attachments/assets/ab1312db-bbad-49b7-872d-712d6ec708d7" />

Release Notes:

- Debugger: Improve autocompletion sorting for debug console
- Debugger: Fix autocompletion menu now shown when you type
- Debugger: Fix completion item showing up twice for some adapters
