### PR TITLE
ruby: Document how to use `erb-formatter` for ERB files

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -379,3 +379,22 @@ The Ruby extension provides a debug adapter for debugging Ruby code. Zed's name 
   }
 ]
 ```
+
+## Formatters
+
+### `erb-formatter`
+
+To format ERB templates, you can use the `erb-formatter` formatter. This formatter uses the [`erb-formatter`](https://rubygems.org/gems/erb-formatter) gem to format ERB templates.
+
+```jsonc
+{
+  "HTML/ERB": {
+    "formatter": {
+      "external": {
+        "command": "erb-formatter",
+        "arguments": ["--stdin-filename", "{buffer_path}"],
+      },
+    },
+  },
+}
+```


### PR DESCRIPTION
Hi! This is a small pull request that adds a new section about configuring the `erb-formatter` for formatting ERB files. Thanks.

Release Notes:

- N/A