### PR TITLE
workspace: Add `file_opening_behavior` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -138,9 +138,9 @@
   "restore_on_file_reopen": true,
   // Whether to automatically close files that have been deleted on disk.
   "close_on_file_delete": false,
-  // Controls which pane files open in when opened from project panel, file finder, etc.
-  // Values: "active_pane", "first_pane"
-  "file_opening_behavior": "active_pane",
+  // Controls which pane new items and tool windows open in
+  // Values: "active_pane", "leftmost_pane"
+  "item_opening_behavior": "active_pane",
   // Relative size of the drop target in the editor that will open dropped file as a split pane (0-0.5)
   // E.g. 0.25 == If you drop onto the top/bottom quarter of the pane a new vertical split will be used
   //              If you drop onto the left/right quarter of the pane a new horizontal split will be used

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -138,6 +138,9 @@
   "restore_on_file_reopen": true,
   // Whether to automatically close files that have been deleted on disk.
   "close_on_file_delete": false,
+  // Controls which pane files open in when opened from project panel, file finder, etc.
+  // Values: "active_pane", "first_pane"
+  "file_opening_behavior": "active_pane",
   // Relative size of the drop target in the editor that will open dropped file as a split pane (0-0.5)
   // E.g. 0.25 == If you drop onto the top/bottom quarter of the pane a new vertical split will be used
   //              If you drop onto the left/right quarter of the pane a new horizontal split will be used

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -115,7 +115,7 @@ impl ProjectDiff {
             let workspace_handle = cx.entity();
             let project_diff =
                 cx.new(|cx| Self::new(workspace.project().clone(), workspace_handle, window, cx));
-            workspace.add_item_to_active_pane(
+            workspace.add_item_to_preferred_pane(
                 Box::new(project_diff.clone()),
                 None,
                 true,

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -906,7 +906,7 @@ impl ProjectSearchView {
 
         let entity = cx.new(|cx| ProjectSearch::new(workspace.project().clone(), cx));
         let search = cx.new(|cx| ProjectSearchView::new(weak_workspace, entity, window, cx, None));
-        workspace.add_item_to_active_pane(Box::new(search.clone()), None, true, window, cx);
+        workspace.add_item_to_preferred_pane(Box::new(search.clone()), None, true, window, cx);
         search.update(cx, |search, cx| {
             search
                 .included_files_editor
@@ -963,7 +963,7 @@ impl ProjectSearchView {
                     entity
                 });
                 let weak_workspace = cx.entity().downgrade();
-                workspace.add_item_to_active_pane(
+                workspace.add_item_to_preferred_pane(
                     Box::new(cx.new(|cx| {
                         ProjectSearchView::new(weak_workspace, entity, window, cx, None)
                     })),
@@ -1021,7 +1021,7 @@ impl ProjectSearchView {
                 ProjectSearchView::new(weak_workspace, project_search, window, cx, settings)
             });
 
-            workspace.add_item_to_active_pane(
+            workspace.add_item_to_preferred_pane(
                 Box::new(project_search_view.clone()),
                 None,
                 true,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -104,7 +104,8 @@ use ui::{Window, prelude::*};
 use util::{ResultExt, TryFutureExt, paths::SanitizedPath, serde::default_true};
 use uuid::Uuid;
 pub use workspace_settings::{
-    AutosaveSetting, BottomDockLayout, RestoreOnStartupBehavior, TabBarSettings, WorkspaceSettings,
+    AutosaveSetting, BottomDockLayout, FileOpeningBehavior, RestoreOnStartupBehavior,
+    TabBarSettings, WorkspaceSettings,
 };
 use zed_actions::{Spawn, feedback::FileBugReport};
 
@@ -3228,7 +3229,12 @@ impl Workspace {
         cx: &mut App,
     ) -> Task<anyhow::Result<Box<dyn ItemHandle>>> {
         let pane = pane.unwrap_or_else(|| {
-            self.last_active_center_pane.clone().unwrap_or_else(|| {
+            let workspace_settings = WorkspaceSettings::get_global(cx);
+            let target_pane = match workspace_settings.file_opening_behavior {
+                FileOpeningBehavior::ActivePane => self.last_active_center_pane.clone(),
+                FileOpeningBehavior::FirstPane => None,
+            };
+            target_pane.unwrap_or_else(|| {
                 self.panes
                     .first()
                     .expect("There must be an active pane")

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3229,8 +3229,7 @@ impl Workspace {
         cx: &mut App,
     ) -> Task<anyhow::Result<Box<dyn ItemHandle>>> {
         let pane = pane.unwrap_or_else(|| {
-            let workspace_settings = WorkspaceSettings::get_global(cx);
-            let target_pane = match workspace_settings.file_opening_behavior {
+            let target_pane = match WorkspaceSettings::get_global(cx).file_opening_behavior {
                 FileOpeningBehavior::ActivePane => self.last_active_center_pane.clone(),
                 FileOpeningBehavior::FirstPane => None,
             };

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -29,6 +29,7 @@ pub struct WorkspaceSettings {
     pub on_last_window_closed: OnLastWindowClosed,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
+    pub file_opening_behavior: FileOpeningBehavior,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -114,6 +115,16 @@ pub enum RestoreOnStartupBehavior {
     /// Restore all workspaces that were open when quitting Zed.
     #[default]
     LastSession,
+}
+
+#[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum FileOpeningBehavior {
+    /// Open files in the last active pane
+    #[default]
+    ActivePane,
+    /// Open files in the first pane
+    FirstPane,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -202,6 +213,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: false
     pub close_on_file_delete: Option<bool>,
+    /// Controls which pane files open in when opened from project panel, file finder, etc.
+    /// Values: active_pane, first_pane
+    ///
+    /// Default: active_pane
+    pub file_opening_behavior: Option<FileOpeningBehavior>,
 }
 
 #[derive(Deserialize)]

--- a/crates/workspace/src/workspace_settings.rs
+++ b/crates/workspace/src/workspace_settings.rs
@@ -29,7 +29,7 @@ pub struct WorkspaceSettings {
     pub on_last_window_closed: OnLastWindowClosed,
     pub resize_all_panels_in_dock: Vec<DockPosition>,
     pub close_on_file_delete: bool,
-    pub file_opening_behavior: FileOpeningBehavior,
+    pub item_opening_behavior: ItemOpeningBehavior,
 }
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -119,12 +119,12 @@ pub enum RestoreOnStartupBehavior {
 
 #[derive(Copy, Clone, Default, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum FileOpeningBehavior {
-    /// Open files in the last active pane
+pub enum ItemOpeningBehavior {
+    /// Open items in the last active pane
     #[default]
     ActivePane,
-    /// Open files in the first pane
-    FirstPane,
+    /// Open items in the leftmost center pane
+    LeftmostPane,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema)]
@@ -213,11 +213,11 @@ pub struct WorkspaceSettingsContent {
     ///
     /// Default: false
     pub close_on_file_delete: Option<bool>,
-    /// Controls which pane files open in when opened from project panel, file finder, etc.
-    /// Values: active_pane, first_pane
+    /// Controls which pane new items and tool windows open in
+    /// Values: active_pane, leftmost_pane
     ///
     /// Default: active_pane
-    pub file_opening_behavior: Option<FileOpeningBehavior>,
+    pub item_opening_behavior: Option<ItemOpeningBehavior>,
 }
 
 #[derive(Deserialize)]

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -290,6 +290,32 @@ Define extensions which should be installed (`true`) or never installed (`false`
 }
 ```
 
+## File Opening Behavior
+
+- Description: Controls which center pane files open in when opened from the project panel, file finder, and other sources
+- Setting: `file_opening_behavior`
+- Default: `"active_pane"`
+
+**Options**
+
+1. Open files in the last active center pane
+
+```json
+{
+  "file_opening_behavior": "active_pane"
+}
+```
+
+2. Open files in the first center pane
+
+```json
+{
+  "file_opening_behavior": "first_pane"
+}
+```
+
+When set to `"first_pane"`, files opened from the project panel, file finder, and other sources will consistently open in the first center pane instead of whichever pane was last active. This prevents files from unexpectedly opening in auxiliary panels that have been moved to the center area.
+
 ## Buffer Font Family
 
 - Description: The name of a font to use for rendering text in the editor.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -290,31 +290,31 @@ Define extensions which should be installed (`true`) or never installed (`false`
 }
 ```
 
-## File Opening Behavior
+## Item Opening Behavior
 
-- Description: Controls which center pane files open in when opened from the project panel, file finder, and other sources
-- Setting: `file_opening_behavior`
+- Description: Controls which center pane new items and tool windows open in
+- Setting: `item_opening_behavior`
 - Default: `"active_pane"`
 
 **Options**
 
-1. Open files in the last active center pane
+1. Open items in the last active center pane
 
 ```json
 {
-  "file_opening_behavior": "active_pane"
+  "item_opening_behavior": "active_pane"
 }
 ```
 
-2. Open files in the first center pane
+2. Open items in the leftmost center pane
 
 ```json
 {
-  "file_opening_behavior": "first_pane"
+  "item_opening_behavior": "leftmost_pane"
 }
 ```
 
-When set to `"first_pane"`, files opened from the project panel, file finder, and other sources will consistently open in the first center pane instead of whichever pane was last active. This prevents files from unexpectedly opening in auxiliary panels that have been moved to the center area.
+When set to `"leftmost_pane"`, new items and tool windows will consistently open in the leftmost center pane instead of whichever pane was last active. This provides predictable behavior regardless of which pane was previously focused.
 
 ## Buffer Font Family
 


### PR DESCRIPTION
Add `file_opening_behavior` workspace setting to control which center pane files open in when opened from the project panel, file finder, and other sources.

  - **`active_pane`** (default): Open files in the last active center pane
  - **`first_pane`**: Open files in the first center pane

This addresses workflows where users must manually click back to the main editor pane after interacting with terminals in center panes before opening files from the project panel. The `first_pane` setting provides predictable file opening behavior regardless of which center pane was last active.

This is useful when the bottom dock is used for running tasks or debugging while having an additional terminal in a center pane for interactive work.