### PR TITLE
debugger: Fix errors in JavaScript DAP schema

### DIFF
--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -245,7 +245,7 @@ impl DebugAdapter for JsDebugAdapter {
                             "properties": {
                                 "type": {
                                     "type": "string",
-                                    "enum": ["pwa-node", "node", "chrome", "pwa-chrome", "msedge", "pwa-msedge"],
+                                    "enum": ["pwa-node", "node", "chrome", "pwa-chrome", "msedge", "pwa-msedge", "node-terminal"],
                                     "description": "The type of debug session",
                                     "default": "pwa-node"
                                 },
@@ -379,10 +379,6 @@ impl DebugAdapter for JsDebugAdapter {
                                     }
                                 }
                             },
-                            "oneOf": [
-                                { "required": ["program"] },
-                                { "required": ["url"] }
-                            ]
                         }
                     ]
                 },


### PR DESCRIPTION
`program` isn't required, and in fact our built-in `JavaScript debug terminal` configuration doesn't have it.

Also add `node-terminal` to the list of allowed types.

Co-authored-by: Michael <michael@zed.dev>

Release Notes:

- N/A