### PR TITLE
debugger: Use debugpy's suggested names for child sessions

### DIFF
--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -660,6 +660,15 @@ impl DebugAdapter for PythonDebugAdapter {
         self.get_installed_binary(delegate, &config, None, user_args, toolchain, false)
             .await
     }
+
+    fn label_for_child_session(&self, args: &StartDebuggingRequestArguments) -> Option<String> {
+        let label = args
+            .configuration
+            .get("name")?
+            .as_str()
+            .filter(|label| !label.is_empty())?;
+        Some(label.to_owned())
+    }
 }
 
 async fn fetch_latest_adapter_version_from_github(


### PR DESCRIPTION
Just like vscode-js-debug, debugpy uses the `name` key in StartDebuggingRequestArguments for this:

https://github.com/microsoft/debugpy/blob/0d65353cc6e519292296bf567bdc6dfa5bcd4ffc/src/debugpy/adapter/clients.py#L753

Release Notes:

- debugger: Made the names of Python subprocesses in the session list more helpful.