### PR TITLE
Move the `LoadingLabel` component to the UI crate

### DIFF
--- a/crates/agent_ui/src/active_thread.rs
+++ b/crates/agent_ui/src/active_thread.rs
@@ -1,9 +1,7 @@
 use crate::context_picker::{ContextPicker, MentionLink};
 use crate::context_strip::{ContextStrip, ContextStripEvent, SuggestContextKind};
 use crate::message_editor::{extract_message_creases, insert_message_creases};
-use crate::ui::{
-    AddedContext, AgentNotification, AgentNotificationEvent, AnimatedLabel, ContextPill,
-};
+use crate::ui::{AddedContext, AgentNotification, AgentNotificationEvent, ContextPill};
 use crate::{AgentPanel, ModelUsageContext};
 use agent::{
     ContextStore, LastRestoreCheckpoint, MessageCrease, MessageId, MessageSegment, TextThreadStore,
@@ -1820,7 +1818,7 @@ impl ActiveThread {
                 .my_3()
                 .mx_5()
                 .when(is_generating_stale || message.is_hidden, |this| {
-                    this.child(AnimatedLabel::new("").size(LabelSize::Small))
+                    this.child(LoadingLabel::new("").size(LabelSize::Small))
                 })
         });
 
@@ -2586,7 +2584,7 @@ impl ActiveThread {
                                             .size(IconSize::XSmall)
                                             .color(Color::Muted),
                                     )
-                                    .child(AnimatedLabel::new("Thinking").size(LabelSize::Small)),
+                                    .child(LoadingLabel::new("Thinking").size(LabelSize::Small)),
                             )
                             .child(
                                 h_flex()
@@ -3155,7 +3153,7 @@ impl ActiveThread {
                                 .border_color(self.tool_card_border_color(cx))
                                 .rounded_b_lg()
                                 .child(
-                                    AnimatedLabel::new("Waiting for Confirmation").size(LabelSize::Small)
+                                    LoadingLabel::new("Waiting for Confirmation").size(LabelSize::Small)
                                 )
                                 .child(
                                     h_flex()

--- a/crates/agent_ui/src/ui.rs
+++ b/crates/agent_ui/src/ui.rs
@@ -1,5 +1,4 @@
 mod agent_notification;
-mod animated_label;
 mod burn_mode_tooltip;
 mod context_pill;
 mod onboarding_modal;
@@ -7,7 +6,6 @@ pub mod preview;
 mod upsell;
 
 pub use agent_notification::*;
-pub use animated_label::*;
 pub use burn_mode_tooltip::*;
 pub use context_pill::*;
 pub use onboarding_modal::*;

--- a/crates/ui/src/components/label.rs
+++ b/crates/ui/src/components/label.rs
@@ -1,7 +1,9 @@
 mod highlighted_label;
 mod label;
 mod label_like;
+mod loading_label;
 
 pub use highlighted_label::*;
 pub use label::*;
 pub use label_like::*;
+pub use loading_label::*;

--- a/crates/ui/src/components/label/loading_label.rs
+++ b/crates/ui/src/components/label/loading_label.rs
@@ -1,24 +1,24 @@
+use crate::prelude::*;
 use gpui::{Animation, AnimationExt, FontWeight, pulsating_between};
 use std::time::Duration;
-use ui::prelude::*;
 
 #[derive(IntoElement)]
-pub struct AnimatedLabel {
+pub struct LoadingLabel {
     base: Label,
     text: SharedString,
 }
 
-impl AnimatedLabel {
+impl LoadingLabel {
     pub fn new(text: impl Into<SharedString>) -> Self {
         let text = text.into();
-        AnimatedLabel {
+        LoadingLabel {
             base: Label::new(text.clone()),
             text,
         }
     }
 }
 
-impl LabelCommon for AnimatedLabel {
+impl LabelCommon for LoadingLabel {
     fn size(mut self, size: LabelSize) -> Self {
         self.base = self.base.size(size);
         self
@@ -80,14 +80,14 @@ impl LabelCommon for AnimatedLabel {
     }
 }
 
-impl RenderOnce for AnimatedLabel {
+impl RenderOnce for LoadingLabel {
     fn render(self, _window: &mut Window, _cx: &mut App) -> impl IntoElement {
         let text = self.text.clone();
 
         self.base
             .color(Color::Muted)
             .with_animations(
-                "animated-label",
+                "loading_label",
                 vec![
                     Animation::new(Duration::from_secs(1)),
                     Animation::new(Duration::from_secs(1)).repeat(),

--- a/crates/ui/src/prelude.rs
+++ b/crates/ui/src/prelude.rs
@@ -25,7 +25,7 @@ pub use crate::{Button, ButtonSize, ButtonStyle, IconButton, SelectableButton};
 pub use crate::{ButtonCommon, Color};
 pub use crate::{Headline, HeadlineSize};
 pub use crate::{Icon, IconName, IconPosition, IconSize};
-pub use crate::{Label, LabelCommon, LabelSize, LineHeightStyle};
+pub use crate::{Label, LabelCommon, LabelSize, LineHeightStyle, LoadingLabel};
 pub use crate::{h_container, h_flex, v_container, v_flex};
 pub use crate::{
     h_group, h_group_lg, h_group_sm, h_group_xl, v_group, v_group_lg, v_group_sm, v_group_xl,


### PR DESCRIPTION
So we can use it in other places and don't require them to depend on the `agent_ui`. This PR also renames it from `AnimatedLabel` to `LoadingLabel`.

Release Notes:

- N/A
