### PR TITLE
docs: Add GitHub Copilot Enterprise configuration example

### DIFF
--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -214,7 +214,6 @@ You can also modify the `api_url` to use a custom endpoint if needed.
 
 You can use GitHub Copilot Chat with the Zed agent by choosing it via the model dropdown in the Agent Panel.
 
-
 1. Open the settings view (`agent: open configuration`) and go to the GitHub Copilot Chat section
 2. Click on `Sign in to use GitHub Copilot`, follow the steps shown in the modal.
 

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -214,12 +214,15 @@ You can also modify the `api_url` to use a custom endpoint if needed.
 
 You can use GitHub Copilot Chat with the Zed agent by choosing it via the model dropdown in the Agent Panel.
 
+
 1. Open the settings view (`agent: open configuration`) and go to the GitHub Copilot Chat section
 2. Click on `Sign in to use GitHub Copilot`, follow the steps shown in the modal.
 
 Alternatively, you can provide an OAuth token via the `GH_COPILOT_TOKEN` environment variable.
 
 > **Note**: If you don't see specific models in the dropdown, you may need to enable them in your [GitHub Copilot settings](https://github.com/settings/copilot/features).
+
+To use Copilot Enterprise with Zed (for both agent and inline completions), you must configure your enterprise endpoint as described in [Configuring GitHub Copilot Enterprise](./edit-prediction.md#github-copilot-enterprise).
 
 ### Google AI {#google-ai}
 

--- a/docs/src/ai/edit-prediction.md
+++ b/docs/src/ai/edit-prediction.md
@@ -267,6 +267,24 @@ To use GitHub Copilot as your provider, set this within `settings.json`:
 
 You should be able to sign-in to GitHub Copilot by clicking on the Copilot icon in the status bar and following the setup instructions.
 
+### Using GitHub Copilot Enterprise {#github-copilot-enterprise}
+
+If your organization uses GitHub Copilot Enterprise, you can configure Zed to use your enterprise instance by specifying the enterprise URI in your `settings.json`:
+
+```json
+{
+  "edit_predictions": {
+    "copilot": {
+      "enterprise_uri": "https://your.enterprise.domain"
+    }
+  }
+}
+```
+
+Replace `"https://your.enterprise.domain"` with the URL provided by your GitHub Enterprise administrator (e.g., `https://foo.ghe.com`).
+
+Once set, Zed will route Copilot requests through your enterprise endpoint. When you sign in by clicking the Copilot icon in the status bar, you will be redirected to your configured enterprise URL to complete authentication. All other Copilot features and usage remain the same.
+
 Copilot can provide multiple completion alternatives, and these can be navigated with the following actions:
 
 - {#action editor::NextEditPrediction} ({#kb editor::NextEditPrediction}): To cycle to the next edit prediction


### PR DESCRIPTION
### Context

This PR adds documentation for setting up GitHub Copilot Enterprise as an edit prediction provider in Zed.  
There was previously no documentation for this feature, which was implemented in [PR #32296](https://github.com/zed-industries/zed/pull/32296).

This follows up on [my comment](https://github.com/zed-industries/zed/issues/22901#issuecomment-3034817471) and the response from the[ Zed team](https://github.com/zed-industries/zed/issues/22901#issuecomment-3034837282), which clarified the required settings.

### What’s included

- Documents the `enterprise_uri` setting for Copilot Enterprise in `edit-prediction.md`.
- Explains how to configure the setting and what to expect from the sign-in flow.

### Notes

- This is a documentation-only change.
- No code or tests are affected.

Release Notes:

- N/A