### PR TITLE
debugger: Fix issues with restarting sessions

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -2,7 +2,7 @@ use crate::{
     adapters::DebugAdapterBinary,
     transport::{IoKind, LogKind, TransportDelegate},
 };
-use anyhow::Result;
+use anyhow::{Context as _, Result};
 use dap_types::{
     messages::{Message, Response},
     requests::Request,
@@ -108,7 +108,11 @@ impl DebugAdapterClient {
             arguments: Some(serialized_arguments),
         };
         self.transport_delegate
-            .add_pending_request(sequence_id, callback_tx);
+            .pending_requests
+            .lock()
+            .as_mut()
+            .context("client is closed")?
+            .insert(sequence_id, callback_tx);
 
         log::debug!(
             "Client {} send `{}` request with sequence_id: {}",
@@ -166,7 +170,6 @@ impl DebugAdapterClient {
     pub fn kill(&self) {
         log::debug!("Killing DAP process");
         self.transport_delegate.transport.lock().kill();
-        self.transport_delegate.tasks.lock().clear();
     }
 
     pub fn has_adapter_logs(&self) -> bool {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -166,6 +166,7 @@ impl DebugAdapterClient {
     pub fn kill(&self) {
         log::debug!("Killing DAP process");
         self.transport_delegate.transport.lock().kill();
+        self.transport_delegate.tasks.lock().clear();
     }
 
     pub fn has_adapter_logs(&self) -> bool {

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -49,7 +49,6 @@ pub enum IoKind {
     StdErr,
 }
 
-type Requests = Arc<Mutex<HashMap<u64, oneshot::Sender<Result<Response>>>>>;
 type LogHandlers = Arc<Mutex<SmallVec<[(LogKind, IoHandler); 2]>>>;
 
 pub trait Transport: Send + Sync {
@@ -93,10 +92,12 @@ async fn start(
 
 pub(crate) struct TransportDelegate {
     log_handlers: LogHandlers,
-    pub(crate) pending_requests: Requests,
+    // TODO this should really be some kind of associative channel
+    pub(crate) pending_requests:
+        Arc<Mutex<Option<HashMap<u64, oneshot::Sender<Result<Response>>>>>>,
     pub(crate) transport: Mutex<Box<dyn Transport>>,
     pub(crate) server_tx: smol::lock::Mutex<Option<Sender<Message>>>,
-    pub(crate) tasks: Mutex<Vec<Task<()>>>,
+    tasks: Mutex<Vec<Task<()>>>,
 }
 
 impl TransportDelegate {
@@ -107,7 +108,7 @@ impl TransportDelegate {
             transport: Mutex::new(transport),
             log_handlers,
             server_tx: Default::default(),
-            pending_requests: Default::default(),
+            pending_requests: Arc::new(Mutex::new(Some(HashMap::default()))),
             tasks: Default::default(),
         })
     }
@@ -148,16 +149,26 @@ impl TransportDelegate {
                 .await
                 {
                     Ok(()) => {
-                        pending_requests.lock().drain().for_each(|(_, request)| {
-                            request
-                                .send(Err(anyhow!("debugger shutdown unexpectedly")))
-                                .ok();
-                        });
+                        pending_requests
+                            .lock()
+                            .take()
+                            .into_iter()
+                            .flatten()
+                            .for_each(|(_, request)| {
+                                request
+                                    .send(Err(anyhow!("debugger shutdown unexpectedly")))
+                                    .ok();
+                            });
                     }
                     Err(e) => {
-                        pending_requests.lock().drain().for_each(|(_, request)| {
-                            request.send(Err(e.cloned())).ok();
-                        });
+                        pending_requests
+                            .lock()
+                            .take()
+                            .into_iter()
+                            .flatten()
+                            .for_each(|(_, request)| {
+                                request.send(Err(e.cloned())).ok();
+                            });
                     }
                 }
             }));
@@ -180,15 +191,6 @@ impl TransportDelegate {
 
     pub(crate) fn tcp_arguments(&self) -> Option<TcpArguments> {
         self.transport.lock().tcp_arguments()
-    }
-
-    pub(crate) fn add_pending_request(
-        &self,
-        sequence_id: u64,
-        request: oneshot::Sender<Result<Response>>,
-    ) {
-        let mut pending_requests = self.pending_requests.lock();
-        pending_requests.insert(sequence_id, request);
     }
 
     pub(crate) async fn send_message(&self, message: Message) -> Result<()> {
@@ -284,7 +286,7 @@ impl TransportDelegate {
     async fn recv_from_server<Stdout>(
         server_stdout: Stdout,
         mut message_handler: DapMessageHandler,
-        pending_requests: Requests,
+        pending_requests: Arc<Mutex<Option<HashMap<u64, oneshot::Sender<Result<Response>>>>>>,
         log_handlers: Option<LogHandlers>,
     ) -> Result<()>
     where
@@ -294,16 +296,21 @@ impl TransportDelegate {
         let mut reader = BufReader::new(server_stdout);
 
         let result = loop {
-            match Self::receive_server_message(&mut reader, &mut recv_buffer, log_handlers.as_ref())
-                .await
-            {
+            let result =
+                Self::receive_server_message(&mut reader, &mut recv_buffer, log_handlers.as_ref())
+                    .await;
+            match result {
                 ConnectionResult::Timeout => anyhow::bail!("Timed out when connecting to debugger"),
                 ConnectionResult::ConnectionReset => {
                     log::info!("Debugger closed the connection");
-                    return Ok(());
+                    break Ok(());
                 }
                 ConnectionResult::Result(Ok(Message::Response(res))) => {
-                    let tx = pending_requests.lock().remove(&res.request_seq);
+                    let tx = pending_requests
+                        .lock()
+                        .as_mut()
+                        .context("client is closed")?
+                        .remove(&res.request_seq);
                     if let Some(tx) = tx {
                         if let Err(e) = tx.send(Self::process_response(res)) {
                             log::trace!("Did not send response `{:?}` for a cancelled", e);

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -96,7 +96,7 @@ pub(crate) struct TransportDelegate {
     pub(crate) pending_requests: Requests,
     pub(crate) transport: Mutex<Box<dyn Transport>>,
     pub(crate) server_tx: smol::lock::Mutex<Option<Sender<Message>>>,
-    tasks: Mutex<Vec<Task<()>>>,
+    pub(crate) tasks: Mutex<Vec<Task<()>>>,
 }
 
 impl TransportDelegate {

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -99,12 +99,6 @@ pub(crate) struct TransportDelegate {
     tasks: Mutex<Vec<Task<()>>>,
 }
 
-impl Drop for TransportDelegate {
-    fn drop(&mut self) {
-        self.transport.lock().kill()
-    }
-}
-
 impl TransportDelegate {
     pub(crate) async fn start(binary: &DebugAdapterBinary, cx: &mut AsyncApp) -> Result<Self> {
         let log_handlers: LogHandlers = Default::default();

--- a/crates/debugger_ui/src/tests/attach_modal.rs
+++ b/crates/debugger_ui/src/tests/attach_modal.rs
@@ -27,7 +27,7 @@ async fn test_direct_attach_to_process(executor: BackgroundExecutor, cx: &mut Te
     let workspace = init_test_workspace(&project, cx).await;
     let cx = &mut VisualTestContext::from_window(*workspace, cx);
 
-    let session = start_debug_session_with(
+    let _session = start_debug_session_with(
         &workspace,
         cx,
         DebugTaskDefinition {
@@ -59,14 +59,6 @@ async fn test_direct_attach_to_process(executor: BackgroundExecutor, cx: &mut Te
             assert!(workspace.active_modal::<AttachModal>(cx).is_none());
         })
         .unwrap();
-
-    let shutdown_session = project.update(cx, |project, cx| {
-        project.dap_store().update(cx, |dap_store, cx| {
-            dap_store.shutdown_session(session.read(cx).session_id(), cx)
-        })
-    });
-
-    shutdown_session.await.unwrap();
 }
 
 #[gpui::test]

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -660,6 +660,7 @@ pub struct Session {
     ignore_breakpoints: bool,
     exception_breakpoints: BTreeMap<String, (ExceptionBreakpointsFilter, IsEnabled)>,
     background_tasks: Vec<Task<()>>,
+    restart_task: Option<Task<()>>,
     task_context: TaskContext,
 }
 
@@ -821,6 +822,7 @@ impl Session {
                 loaded_sources: Vec::default(),
                 threads: IndexMap::default(),
                 background_tasks: Vec::default(),
+                restart_task: None,
                 locations: Default::default(),
                 is_session_terminated: false,
                 ignore_breakpoints: false,
@@ -1864,18 +1866,30 @@ impl Session {
     }
 
     pub fn restart(&mut self, args: Option<Value>, cx: &mut Context<Self>) {
-        if self.capabilities.supports_restart_request.unwrap_or(false) && !self.is_terminated() {
-            self.request(
-                RestartCommand {
-                    raw: args.unwrap_or(Value::Null),
-                },
-                Self::fallback_to_manual_restart,
-                cx,
-            )
-            .detach();
-        } else {
-            cx.emit(SessionStateEvent::Restart);
+        if self.restart_task.is_some() || self.as_running().is_none() {
+            return;
         }
+
+        let supports_dap_restart =
+            self.capabilities.supports_restart_request.unwrap_or(false) && !self.is_terminated();
+
+        self.restart_task = Some(cx.spawn(async move |this, cx| {
+            let _ = this.update(cx, |session, cx| {
+                if supports_dap_restart {
+                    session
+                        .request(
+                            RestartCommand {
+                                raw: args.unwrap_or(Value::Null),
+                            },
+                            Self::fallback_to_manual_restart,
+                            cx,
+                        )
+                        .detach();
+                } else {
+                    cx.emit(SessionStateEvent::Restart);
+                }
+            });
+        }));
     }
 
     pub fn shutdown(&mut self, cx: &mut Context<Self>) -> Task<()> {
@@ -1913,8 +1927,13 @@ impl Session {
 
         cx.emit(SessionStateEvent::Shutdown);
 
-        cx.spawn(async move |_, _| {
+        cx.spawn(async move |this, cx| {
             task.await;
+            let _ = this.update(cx, |this, _| {
+                if let Some(adapter_client) = this.adapter_client() {
+                    adapter_client.kill();
+                }
+            });
         })
     }
 


### PR DESCRIPTION
Restarting sessions was broken in #33273 when we moved away from calling `kill` in the shutdown sequence. This PR re-adds that `kill` call so that old debug adapter processes will be cleaned up when sessions are restarted within Zed. This doesn't re-introduce the issue that motivated the original changes to the shutdown sequence, because we still send Disconnect/Terminate to debug adapters when quitting Zed without killing the process directly.

We also now remove manually-restarted sessions eagerly from the session list.

Closes #33916 

Release Notes:

- debugger: Fixed not being able to restart sessions for Debugpy and other adapters that communicate over TCP.
- debugger: Fixed debug adapter processes not being cleaned up.