### PR TITLE
Use /usr/bin/env to run bash restart script

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -201,7 +201,8 @@ impl<P: LinuxClient + 'static> Platform for P {
         );
 
         // execute the script using /bin/bash
-        let restart_process = Command::new("/bin/bash")
+        let restart_process = Command::new("/usr/bin/env")
+            .arg("bash")
             .arg("-c")
             .arg(script)
             .process_group(0)

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -200,7 +200,6 @@ impl<P: LinuxClient + 'static> Platform for P {
             app_path = app_path.display()
         );
 
-        // execute the script using /bin/bash
         let restart_process = Command::new("/usr/bin/env")
             .arg("bash")
             .arg("-c")


### PR DESCRIPTION
Closes #33935

Release Notes:

- Use `/usr/bin/env` to launch the bash restart script
