### PR TITLE
Add CSS language injections for calls to `styled`

### DIFF
--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -12,6 +12,21 @@
 )
 
 (call_expression
+  function: (member_expression
+    object: (identifier) @_obj (#eq? @_obj "styled")
+    property: (property_identifier))
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
+  function: (call_expression
+    function: (identifier) @_name (#eq? @_name "styled"))
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
   function: (identifier) @_name (#eq? @_name "html")
   arguments: (template_string) @injection.content
                               (#set! injection.language "html")

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -12,6 +12,21 @@
 )
 
 (call_expression
+  function: (member_expression
+    object: (identifier) @_obj (#eq? @_obj "styled")
+    property: (property_identifier))
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
+  function: (call_expression
+    function: (identifier) @_name (#eq? @_name "styled"))
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
   function: (identifier) @_name (#eq? @_name "html")
   arguments: (template_string (string_fragment) @injection.content
                               (#set! injection.language "html"))

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -16,6 +16,21 @@
 )
 
 (call_expression
+  function: (member_expression
+    object: (identifier) @_obj (#eq? @_obj "styled")
+    property: (property_identifier))
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
+  function: (call_expression
+    function: (identifier) @_name (#eq? @_name "styled"))
+  arguments: (template_string (string_fragment) @injection.content
+                              (#set! injection.language "css"))
+)
+
+(call_expression
   function: (identifier) @_name (#eq? @_name "html")
   arguments: (template_string) @injection.content
                               (#set! injection.language "html")


### PR DESCRIPTION
…emotion).

Closes: https://github.com/zed-industries/zed/issues/17026

Release Notes:

- Added CSS language injection support for styled-components and emotion in JavaScript, TypeScript, and TSX files.  
