### PR TITLE
Adjust Go outline query for method definition to avoid pesky whitespace

### DIFF
--- a/crates/languages/src/go/outline.scm
+++ b/crates/languages/src/go/outline.scm
@@ -25,7 +25,7 @@
     receiver: (parameter_list
         "(" @context
         (parameter_declaration
-            name: (_) @name
+            name: (_) @context
             type: (_) @context)
         ")" @context)
     name: (field_identifier) @name


### PR DESCRIPTION
Closes #33951 

There's an adjustment that kicks in to extend `name_ranges` when we capture more than one `@name` for an outline `@item`. That was happening here because we captured both the parameter name for the method receiver and the name of the method as `@name`. It seems like only the second one should have that annotation.

Release Notes:

- Fixed extraneous leading space in `$ZED_SYMBOL` when used with Go methods.