### PR TITLE
Fix border and minimap flickering on pane split

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3842,11 +3842,13 @@ impl Workspace {
                 if *local {
                     self.unfollow_in_pane(&pane, window, cx);
                 }
+                serialize_workspace = *focus_changed || pane != self.active_pane();
                 if pane == self.active_pane() {
                     self.active_item_path_changed(window, cx);
                     self.update_active_view_for_followers(window, cx);
+                } else if *local {
+                    self.set_active_pane(&pane, window, cx);
                 }
-                serialize_workspace = *focus_changed || pane != self.active_pane();
             }
             pane::Event::UserSavedItem { item, save_intent } => {
                 cx.emit(Event::UserSavedItem {


### PR DESCRIPTION
Closes #33972

As noted on https://github.com/zed-industries/zed/pull/31390#discussion_r2147473526, when splitting panes and having a border size set for the active pane, or the minimap visibility configured to the active editor only, zed will shortly show a flicker of the border or the minimap on the pane that's being deactivated. 

Release Notes:

-  Fixed an issue where pane activations would sometimes have a brief delay, causing a flicker in the process.
