### PR TITLE
New Hide/Show setting for Active Language Button in the Status Bar

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1206,6 +1206,12 @@
     // 2. hour24
     "hour_format": "hour12"
   },
+  // StatusBar-related settings
+  // Many items in the status bar have their own settings.
+  "status_bar": {
+    // Whether to show the active language button in the status bar.
+    "show_active_language_button": true
+  },
   // Settings specific to the terminal
   "terminal": {
     // What shell to use when opening a terminal. May take 3 values:

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -20,6 +20,7 @@ pub struct EditorSettings {
     pub lsp_highlight_debounce: u64,
     pub hover_popover_enabled: bool,
     pub hover_popover_delay: u64,
+    pub status_bar: StatusBar,
     pub toolbar: Toolbar,
     pub scrollbar: Scrollbar,
     pub minimap: Minimap,
@@ -123,6 +124,14 @@ pub struct JupyterContent {
     ///
     /// Default: true
     pub enabled: Option<bool>,
+}
+
+#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct StatusBar {
+    /// Whether to display the active language button in the status bar.
+    ///
+    /// Default: true
+    pub show_active_language_button: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -418,6 +427,8 @@ pub struct EditorSettingsContent {
     ///
     /// Default: 300
     pub hover_popover_delay: Option<u64>,
+    /// Statusbar related settings
+    pub status_bar: Option<StatusBarContent>,
     /// Toolbar related settings
     pub toolbar: Option<ToolbarContent>,
     /// Scrollbar related settings
@@ -545,6 +556,15 @@ pub struct EditorSettingsContent {
     ///
     /// Default: [`DocumentColorsRenderMode::Inlay`]
     pub lsp_document_colors: Option<DocumentColorsRenderMode>,
+}
+
+// StatusBar related settings
+#[derive(Clone, Default, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+pub struct StatusBarContent {
+    /// Whether to display the active language button in the status bar.
+    ///
+    /// Default: true
+    pub show_active_language_button: Option<bool>,
 }
 
 // Toolbar related settings

--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -1,4 +1,6 @@
 use editor::Editor;
+use editor::EditorSettings;
+use settings::Settings as _;
 use gpui::{
     Context, Entity, IntoElement, ParentElement, Render, Subscription, WeakEntity, Window, div,
 };
@@ -39,7 +41,11 @@ impl ActiveBufferLanguage {
 
 impl Render for ActiveBufferLanguage {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        div().when_some(self.active_language.as_ref(), |el, active_language| {
+        let div = div();
+        if !EditorSettings::get_global(cx).status_bar.show_active_language_button {
+            return div;
+        }
+        div.when_some(self.active_language.as_ref(), |el, active_language| {
             let active_language_text = if let Some(active_language_text) = active_language {
                 active_language_text.to_string()
             } else {

--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -1,5 +1,4 @@
-use editor::Editor;
-use editor::EditorSettings;
+use editor::{Editor, EditorSettings};
 use settings::Settings as _;
 use gpui::{
     Context, Entity, IntoElement, ParentElement, Render, Subscription, WeakEntity, Window, div,

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1266,6 +1266,18 @@ Each option controls displaying of a particular toolbar element. If all elements
 
 `boolean` values
 
+## Status Bar
+
+- Description: Control various elements in the status bar. Note that some items in the status bar have their own settings set elsewhere.
+- Setting: `status_bar`
+- Default:
+
+```json
+"status_bar": {
+  "show_active_language_button": true,
+},
+```
+
 ## LSP
 
 - Description: Configuration for language servers.

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -304,6 +304,17 @@ TBD: Centered layout related settings
   }
 ```
 
+### Status Bar
+
+```json
+  "status_bar": {
+    // Show/hide a button that displays the active buffer's language.
+    // Clicking the button brings up the language selector.
+    // Defaults to true.
+    "show_active_language_button": true,
+  },
+```
+
 ### Multibuffer
 
 ```json


### PR DESCRIPTION
### Release Notes:

Added settings

- status_bar.show_active_language_button to show/hide the language button in the status bar.

The motivation for this is visual, I have had zero issues with its functionality.  

The language switcher can still be accessed by the command palette, menu, or a keyboard shortcut.

------

This is my first Zed and first Rust PR, so criticism is very welcome. 

I know there has been discussion around how the status bar settings are structured and named, and I am happy to change it to whatever is best. I was also not sure what order to put it in in the settings default.json. Feedback welcome.

Here is a picture of it in action:

![image](https://github.com/user-attachments/assets/c50131e2-71aa-4fab-8db0-8b2aae586e71)
