### PR TITLE
Add support for passing toolchain to the LSP server extension

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4281,6 +4281,7 @@ dependencies = [
  "dap",
  "extension",
  "gpui",
+ "language",
  "serde_json",
  "task",
  "util",

--- a/crates/assistant_slash_command/src/extension_slash_command.rs
+++ b/crates/assistant_slash_command/src/extension_slash_command.rs
@@ -5,6 +5,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use extension::{Extension, ExtensionHostProxy, ExtensionSlashCommandProxy, WorktreeDelegate};
 use gpui::{App, Task, WeakEntity, Window};
+use language::Toolchain;
 use language::{BufferSnapshot, LspAdapterDelegate};
 use ui::prelude::*;
 use workspace::Workspace;
@@ -62,6 +63,10 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
 
     async fn shell_env(&self) -> Vec<(String, String)> {
         self.0.shell_env().await.into_iter().collect()
+    }
+
+    async fn active_toolchain(&self) -> Option<Toolchain> {
+        None
     }
 }
 

--- a/crates/debug_adapter_extension/Cargo.toml
+++ b/crates/debug_adapter_extension/Cargo.toml
@@ -14,6 +14,7 @@ gpui.workspace = true
 serde_json.workspace = true
 util.workspace = true
 task.workspace = true
+language.workspace = true
 workspace-hack = { version = "0.1", path = "../../tooling/workspace-hack" }
 
 [lints]

--- a/crates/debug_adapter_extension/src/extension_dap_adapter.rs
+++ b/crates/debug_adapter_extension/src/extension_dap_adapter.rs
@@ -14,6 +14,7 @@ use dap::{
 };
 use extension::{Extension, WorktreeDelegate};
 use gpui::AsyncApp;
+use language::Toolchain;
 use task::{DebugScenario, ZedDebugConfig};
 
 pub(crate) struct ExtensionDapAdapter {
@@ -66,6 +67,10 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
             .which(binary_name.as_ref())
             .await
             .map(|path| path.to_string_lossy().to_string())
+    }
+
+    async fn active_toolchain(&self) -> Option<Toolchain> {
+        None
     }
 
     async fn shell_env(&self) -> Vec<(String, String)> {

--- a/crates/extension/src/extension.rs
+++ b/crates/extension/src/extension.rs
@@ -12,7 +12,7 @@ use anyhow::{Context as _, Result, bail};
 use async_trait::async_trait;
 use fs::normalize_path;
 use gpui::{App, Task};
-use language::LanguageName;
+use language::{LanguageName, Toolchain};
 use semantic_version::SemanticVersion;
 use task::{SpawnInTerminal, ZedDebugConfig};
 
@@ -34,6 +34,7 @@ pub trait WorktreeDelegate: Send + Sync + 'static {
     async fn read_text_file(&self, path: PathBuf) -> Result<String>;
     async fn which(&self, binary_name: String) -> Option<String>;
     async fn shell_env(&self) -> Vec<(String, String)>;
+    async fn active_toolchain(&self) -> Option<Toolchain>;
 }
 
 pub trait ProjectDelegate: Send + Sync + 'static {

--- a/crates/extension_api/wit/since_v0.6.0/extension.wit
+++ b/crates/extension_api/wit/since_v0.6.0/extension.wit
@@ -12,7 +12,7 @@ world extension {
     use common.{env-vars, range};
     use context-server.{context-server-configuration};
     use dap.{attach-request, build-task-template, debug-config, debug-adapter-binary, debug-task-definition, debug-request, debug-scenario, launch-request, resolved-task, start-debugging-request-arguments-request};
-    use lsp.{completion, symbol};
+    use lsp.{completion, symbol, toolchain};
     use process.{command};
     use slash-command.{slash-command, slash-command-argument-completion, slash-command-output};
 
@@ -74,6 +74,8 @@ world extension {
         which: func(binary-name: string) -> option<string>;
         /// Returns the current shell environment.
         shell-env: func() -> env-vars;
+        /// Returns the activate toolchain for the worktree.
+        active-toolchain: func() -> option<toolchain>;
     }
 
     /// A Zed project.

--- a/crates/extension_api/wit/since_v0.6.0/lsp.wit
+++ b/crates/extension_api/wit/since_v0.6.0/lsp.wit
@@ -87,4 +87,12 @@ interface lsp {
         type-parameter,
         other(s32),
     }
+
+    /// An LSP toolchain.
+    record toolchain {
+        name: string,
+        path: string,
+        language-name: string,
+        as-json: string
+    }
 }

--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -575,6 +575,24 @@ impl HostWorktree for WasmState {
         Ok(delegate.which(binary_name).await)
     }
 
+    async fn active_toolchain(
+        &mut self,
+        delegate: Resource<Arc<dyn WorktreeDelegate>>,
+    ) -> wasmtime::Result<Option<Toolchain>> {
+        let delegate = self.table.get(&delegate)?;
+        let toolchain = delegate.active_toolchain().await;
+        if let Some(toolchain) = toolchain {
+            Ok(Some(Toolchain {
+                name: toolchain.name.to_string(),
+                path: toolchain.path.to_string(),
+                language_name: toolchain.language_name.to_string(),
+                as_json: toolchain.as_json.to_string(),
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
     async fn drop(&mut self, _worktree: Resource<Worktree>) -> Result<()> {
         // We only ever hand out borrows of worktrees.
         Ok(())


### PR DESCRIPTION
This PR passes language toolchain information to the `language_server_workspace_configuration` and `language_server_command` interfaces' worktree in LSP server extensions. This allows LSP server extensions to make modifications based on the selected language toolchain, which is particularly helpful for Python environment selection and enables the LSP to switch Python interpreters according to the selected interpreter.

As I primarily work on Python development using virtual environments like conda, and use the basedpyright extension for LSP, the LSP cannot update to recognize the Python interpreter I need when switching environments, which prevents it from providing correct syntax hints. Therefore, I added this functionality.

This issue has also been mentioned in the following issues:
#29807 
#20402 

This is my first PR submission, and I'm also a Rust beginner, so please feel free to point out any shortcomings and I will do my best to make improvements.

demo:
before:

https://github.com/user-attachments/assets/abe03ced-33ae-4d8a-8f9f-0fbf76d17653


after:

https://github.com/user-attachments/assets/024adc4b-a28a-4a30-b907-8ef00dac4aff



Release Notes:

- N/A
