### PR TITLE
Add configurable request timeout for context servers

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1723,6 +1723,12 @@
     // Whether to show the LSP servers button in the status bar.
     "button": true
   },
+  // Common context server settings.
+  "global_context_server_settings": {
+    // Request timeout in seconds for context server operations.
+    // Default: 60
+    // "request_timeout_secs": 60
+  },
   // Jupyter settings
   "jupyter": {
     "enabled": true

--- a/crates/context_server/src/context_server.rs
+++ b/crates/context_server/src/context_server.rs
@@ -87,7 +87,7 @@ impl ContextServer {
         self.client.read().clone()
     }
 
-    pub async fn start(self: Arc<Self>, cx: &AsyncApp) -> Result<()> {
+    pub async fn start(self: Arc<Self>, request_timeout: std::time::Duration, cx: &AsyncApp) -> Result<()> {
         let client = match &self.configuration {
             ContextServerTransport::Stdio(command) => Client::stdio(
                 client::ContextServerId(self.id.0.clone()),
@@ -96,12 +96,14 @@ impl ContextServer {
                     args: command.args.clone(),
                     env: command.env.clone(),
                 },
+                request_timeout,
                 cx.clone(),
             )?,
             ContextServerTransport::Custom(transport) => Client::new(
                 client::ContextServerId(self.id.0.clone()),
                 self.id().0,
                 transport.clone(),
+                request_timeout,
                 cx.clone(),
             )?,
         };

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -60,6 +60,10 @@ pub struct ProjectSettings {
     #[serde(default)]
     pub context_servers: HashMap<Arc<str>, ContextServerSettings>,
 
+    /// Common context server settings.
+    #[serde(default)]
+    pub global_context_server_settings: GlobalContextServerSettings,
+
     /// Configuration for Diagnostics-related features.
     #[serde(default)]
     pub diagnostics: DiagnosticsSettings,
@@ -120,6 +124,20 @@ pub struct GlobalLspSettings {
     /// Default: `true`
     #[serde(default = "default_true")]
     pub button: bool,
+}
+
+/// Common context server settings.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub struct GlobalContextServerSettings {
+    /// Request timeout for context server requests in seconds.
+    ///
+    /// Default: `60`
+    #[serde(default = "default_context_server_request_timeout_secs")]
+    pub request_timeout_secs: u64,
+}
+
+fn default_context_server_request_timeout_secs() -> u64 {
+    60
 }
 
 impl ContextServerSettings {
@@ -287,6 +305,14 @@ impl Default for GlobalLspSettings {
     fn default() -> Self {
         Self {
             button: default_true(),
+        }
+    }
+}
+
+impl Default for GlobalContextServerSettings {
+    fn default() -> Self {
+        Self {
+            request_timeout_secs: default_context_server_request_timeout_secs(),
         }
     }
 }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2440,6 +2440,28 @@ Examples:
 3. `replace_subsequence` - Behaves like `"replace"` if the text that would be replaced is a subsequence of the completion text, and like `"insert"` otherwise
 4. `replace_suffix` - Behaves like `"replace"` if the text after the cursor is a suffix of the completion, and like `"insert"` otherwise
 
+## Global Context Server Settings
+
+- Description: Global configuration settings for Model Context Protocol (MCP) servers.
+- Setting: `global_context_server_settings`
+- Default:
+
+```json
+"global_context_server_settings": {
+  "request_timeout_secs": 60
+}
+```
+
+### Request Timeout (seconds)
+
+- Description: Timeout duration in seconds for requests to context servers. When set to 0, requests will wait indefinitely.
+- Setting: `request_timeout_secs`
+- Default: `60`
+
+**Options**
+
+`integer` values representing seconds
+
 ## Show Completions On Input
 
 - Description: Whether or not to show completions as you type.


### PR DESCRIPTION
Release Notes:

- Added global context server settings with configurable request timeout to use provided timeout instead of hardcoded value