### PR TITLE
Scroll pane with keyboard focus instead of mouse focus

### DIFF
--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -77,7 +77,7 @@ impl Deref for ModifiersChangedEvent {
 
 /// The phase of a touch motion event.
 /// Based on the winit enum of the same name.
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum TouchPhase {
     /// The touch started.
     Started,
@@ -243,7 +243,7 @@ impl MouseMoveEvent {
 }
 
 /// A mouse wheel event from the platform
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct ScrollWheelEvent {
     /// The position of the mouse on the window.
     pub position: Point<Pixels>,
@@ -275,7 +275,7 @@ impl Deref for ScrollWheelEvent {
 }
 
 /// The scroll delta for a scroll wheel event.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ScrollDelta {
     /// An exact scroll delta in pixels.
     Pixels(Point<Pixels>),


### PR DESCRIPTION
Hey, I'd like to get some feedback one this.

My usecase is that I have a rotary encoder on my keyboard, and with mouse focus I have to reposition the mouse often to use it, which is quite unergonomic. In my vim config, I've solved it like this:

```lua
map("n", "<ScrollWheelUp>", "3<c-y>", { silent = true })
map("n", "<ScrollWheelDown>", "3<c-e>", { silent = true })
```

Mapping scroll wheel doesn't seem possible right now, and I think in general it would be better to directly use the scroll events instead of going to a binding and back like in my neovim config.

---

I'm not sure if using actions is the way to go here, since from my understanding they are mainly used for keyboard shortcuts. It would probably also be possible to get the active pane and then downcast it, but I feel like dispatching an action from the workspace  works better since individual elements could still choose to override it, and views have to actively decide to listen to the event. See the comments I've added in my changes.

If the proposed method is okay with you, I'd implement the listener for all other scrollables views and add a setting. I'd imagine either of these would work fine:

```json5
{
  "scroll_target": "mouse" // or "keyboard",
  "scroll_keyboard_focused_pane": true //or false
}
```

Release Notes:

- Allow scrolling by keyboard focus instead of mouse focus
