### PR TITLE
languages: Fix string override to match just `string_fragment` part of `template_string`

### DIFF
--- a/crates/languages/src/javascript/overrides.scm
+++ b/crates/languages/src/javascript/overrides.scm
@@ -1,9 +1,8 @@
 (comment) @comment.inclusive
 
-[
-  (string)
-  (template_string)
-] @string
+(string) @string
+
+(template_string (string_fragment) @string)
 
 (jsx_element) @element
 

--- a/crates/languages/src/tsx/overrides.scm
+++ b/crates/languages/src/tsx/overrides.scm
@@ -1,9 +1,8 @@
 (comment) @comment.inclusive
 
-[
-  (string)
-  (template_string)
-] @string
+(string) @string
+
+(template_string (string_fragment) @string)
 
 (jsx_element) @element
 

--- a/crates/languages/src/typescript/overrides.scm
+++ b/crates/languages/src/typescript/overrides.scm
@@ -1,5 +1,8 @@
 (comment) @comment.inclusive
+
 (string) @string
+
+(template_string (string_fragment) @string)
 
 (_ value: (call_expression
   function: (identifier) @function_name_before_type_arguments


### PR DESCRIPTION
Closes #33703

`template_string` consists of `template_substitution` and `string_fragment` chunks. `template_substitution` should not be considered a string.

```ts
const variable = `this is a string_fragment but ${this.is.template_substitution}`;
```

Release Notes:

- Fixed auto-complete not showing on typing `.` character in template literal string in JavaScript and TypeScript files.
