### PR TITLE
windows: Properly handle surrogates

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1280,6 +1280,10 @@ where
                 capslock: current_capslock(),
             }))
         }
+        VK_PACKET => {
+            translate_message(handle, wparam, lparam);
+            None
+        }
         VK_CAPITAL => {
             let capslock = current_capslock();
             if state

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -88,7 +88,7 @@ pub(crate) fn handle_msg(
         WM_SYSCOMMAND => handle_system_command(wparam, state_ptr),
         WM_KEYDOWN => handle_keydown_msg(handle, wparam, lparam, state_ptr),
         WM_KEYUP => handle_keyup_msg(handle, wparam, lparam, state_ptr),
-        WM_CHAR => handle_char_msg(wparam, state_ptr),
+        WM_CHAR => handle_char_msg(wparam, lparam, state_ptr),
         WM_DEADCHAR => handle_dead_char_msg(wparam, state_ptr),
         WM_IME_STARTCOMPOSITION => handle_ime_position(handle, state_ptr),
         WM_IME_COMPOSITION => handle_ime_composition(handle, lparam, state_ptr),
@@ -404,6 +404,7 @@ fn handle_keydown_msg(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
+    println!("WM_KEYDOWN: wparam: {wparam:?}, lparam: {lparam:?}");
     let mut lock = state_ptr.state.borrow_mut();
     let Some(input) = handle_key_event(handle, wparam, lparam, &mut lock, |keystroke| {
         PlatformInput::KeyDown(KeyDownEvent {
@@ -447,6 +448,7 @@ fn handle_keyup_msg(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
+    println!("WM_KEYUP:   wparam: {wparam:?}, lparam: {lparam:?}");
     let mut lock = state_ptr.state.borrow_mut();
     let Some(input) = handle_key_event(handle, wparam, lparam, &mut lock, |keystroke| {
         PlatformInput::KeyUp(KeyUpEvent { keystroke })
@@ -465,7 +467,15 @@ fn handle_keyup_msg(
     if handled { Some(0) } else { Some(1) }
 }
 
-fn handle_char_msg(wparam: WPARAM, state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
+fn handle_char_msg(
+    wparam: WPARAM,
+    lparam: LPARAM,
+    state_ptr: Rc<WindowsWindowStatePtr>,
+) -> Option<isize> {
+    println!(
+        "=> WM_CHAR: wparam: {wparam:x}, lparam: {lparam:?}",
+        wparam = wparam.0
+    );
     let Some(input) = char::from_u32(wparam.0 as u32)
         .filter(|c| !c.is_control())
         .map(String::from)

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -404,7 +404,6 @@ fn handle_keydown_msg(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
-    println!("WM_KEYDOWN: wparam: {wparam:?}, lparam: {lparam:?}");
     let mut lock = state_ptr.state.borrow_mut();
     let Some(input) = handle_key_event(handle, wparam, lparam, &mut lock, |keystroke| {
         PlatformInput::KeyDown(KeyDownEvent {
@@ -448,7 +447,6 @@ fn handle_keyup_msg(
     lparam: LPARAM,
     state_ptr: Rc<WindowsWindowStatePtr>,
 ) -> Option<isize> {
-    println!("WM_KEYUP:   wparam: {wparam:?}, lparam: {lparam:?}");
     let mut lock = state_ptr.state.borrow_mut();
     let Some(input) = handle_key_event(handle, wparam, lparam, &mut lock, |keystroke| {
         PlatformInput::KeyUp(KeyUpEvent { keystroke })
@@ -468,7 +466,6 @@ fn handle_keyup_msg(
 }
 
 fn handle_char_msg(wparam: WPARAM, state_ptr: Rc<WindowsWindowStatePtr>) -> Option<isize> {
-    println!("=> WM_CHAR: wparam: {wparam:x}", wparam = wparam.0);
     let input = parse_char_message(wparam, &state_ptr)?;
     with_input_handler(&state_ptr, |input_handler| {
         input_handler.replace_text_in_range(None, &input);

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -1248,7 +1248,7 @@ fn parse_char_message(wparam: WPARAM, state_ptr: &Rc<WindowsWindowStatePtr>) -> 
         }
         _ => {
             lock.pending_surrogate = None;
-            char::from_u32(code_point as u32).map(|c| c.to_string())
+            String::from_utf16(&[code_point]).ok()
         }
     }
 }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -43,6 +43,7 @@ pub struct WindowsWindowState {
 
     pub callbacks: Callbacks,
     pub input_handler: Option<PlatformInputHandler>,
+    pub pending_surrogate: Option<u16>,
     pub last_reported_modifiers: Option<Modifiers>,
     pub last_reported_capslock: Option<Capslock>,
     pub system_key_handled: bool,
@@ -105,6 +106,7 @@ impl WindowsWindowState {
         let renderer = windows_renderer::init(gpu_context, hwnd, transparent)?;
         let callbacks = Callbacks::default();
         let input_handler = None;
+        let pending_surrogate = None;
         let last_reported_modifiers = None;
         let last_reported_capslock = None;
         let system_key_handled = false;
@@ -126,6 +128,7 @@ impl WindowsWindowState {
             min_size,
             callbacks,
             input_handler,
+            pending_surrogate,
             last_reported_modifiers,
             last_reported_capslock,
             system_key_handled,


### PR DESCRIPTION
Closes #33791

Surrogate pairs are now handled correctly, so input from tools like `WinCompose` is properly received.

Release Notes:

- N/A