### PR TITLE
Make `script/generate-license` fail on WARN too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,7 +64,7 @@ jobs:
           else
             echo "run_docs=false" >> $GITHUB_OUTPUT
           fi
-          if [[ $(git diff --name-only $COMPARE_REV ${{ github.sha }} | grep '^Cargo.lock') ]]; then
+          if [[ $(git diff --name-only $COMPARE_REV ${{ github.sha }} | grep -P '^(Cargo.lock|script/.*licenses)') ]]; then
             echo "run_license=true" >> $GITHUB_OUTPUT
           else
             echo "run_license=false" >> $GITHUB_OUTPUT

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -7,8 +7,13 @@ OUTPUT_FILE="${1:-$(pwd)/assets/licenses.md}"
 TEMPLATE_FILE="script/licenses/template.md.hbs"
 
 fail_on_stderr() {
-    ! "$@" 2>&1 1>&3 | grep . >&2
-} 3>&1
+    local tmpfile=$(mktemp)
+    "$@" 2> >(tee "$tmpfile" >&2)
+    local rc=$?
+    [ -s "$tmpfile" ] && rc=1
+    rm "$tmpfile"
+    return $rc
+}
 
 echo -n "" >"$OUTPUT_FILE"
 

--- a/script/generate-licenses
+++ b/script/generate-licenses
@@ -6,6 +6,10 @@ CARGO_ABOUT_VERSION="0.7"
 OUTPUT_FILE="${1:-$(pwd)/assets/licenses.md}"
 TEMPLATE_FILE="script/licenses/template.md.hbs"
 
+fail_on_stderr() {
+    ! "$@" 2>&1 1>&3 | grep . >&2
+} 3>&1
+
 echo -n "" >"$OUTPUT_FILE"
 
 {
@@ -28,7 +32,7 @@ fi
 echo "Generating cargo licenses"
 if [ -z "${ALLOW_MISSING_LICENSES-}" ]; then FAIL_FLAG=--fail; else FAIL_FLAG=""; fi
 set -x
-cargo about generate \
+fail_on_stderr cargo about generate \
     $FAIL_FLAG \
     -c script/licenses/zed-licenses.toml \
     "$TEMPLATE_FILE" >>"$OUTPUT_FILE"

--- a/script/licenses/zed-licenses.toml
+++ b/script/licenses/zed-licenses.toml
@@ -177,9 +177,3 @@ license = "MIT"
 [[pet-windows-store.clarify.files]]
 path = '../../LICENSE'
 checksum = 'c2cfccb812fe482101a8f04597dfc5a9991a6b2748266c47ac91b6a5aae15383'
-
-[ring.clarify]
-license = "ISC AND OpenSSL"
-[[ring.clarify.files]]
-path = 'LICENSE'
-checksum = '76b39f9b371688eac9d8323f96ee80b3aef5ecbc2217f25377bd4e4a615296a9'


### PR DESCRIPTION
Current main shows this on `script/generate-licenses`:
```
[WARN] failed to validate all files specified in clarification for crate ring 0.17.14: checksum mismatch, expected '76b39f9b371688eac9d8323f96ee80b3aef5ecbc2217f25377bd4e4a615296a9'
```

Ring fixed it's licenses ambiguity upstream.  This warning was identifying that their license text (multiple licenses concatenated) had changed (sha mismatch) and thus our license clarification was invalid.

Tested the script to confirm this [now fails](https://github.com/zed-industries/zed/actions/runs/16118890720/job/45479355992?pr=34008) under CI and then removed the ring clarification because it is no longer required and now passes.

Release Notes:

- N/A
