### PR TITLE
languages: Fix detents case line after typing `:` in Python

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -22325,6 +22325,19 @@ async fn test_outdent_after_input_for_python(cx: &mut TestAppContext) {
         def f() -> list[str]:
             aˇ
     "});
+
+    // test does not outdent on typing : after case keyword
+    cx.set_state(indoc! {"
+        match 1:
+            caseˇ
+    "});
+    cx.update_editor(|editor, window, cx| {
+        editor.handle_input(":", window, cx);
+    });
+    cx.assert_editor_state(indoc! {"
+        match 1:
+            case:ˇ
+    "});
 }
 
 #[gpui::test]

--- a/crates/languages/src/python/config.toml
+++ b/crates/languages/src/python/config.toml
@@ -34,5 +34,4 @@ decrease_indent_patterns = [
   { pattern = "^\\s*else\\b.*:",    valid_after = ["if", "elif", "for", "while", "except"] },
   { pattern = "^\\s*except\\b.*:",  valid_after = ["try", "except"] },
   { pattern = "^\\s*finally\\b.*:", valid_after = ["try", "except", "else"] },
-  { pattern = "^\\s*case\\b.*:",    valid_after = ["match", "case"] }
 ]

--- a/crates/languages/src/python/indents.scm
+++ b/crates/languages/src/python/indents.scm
@@ -14,4 +14,4 @@
 (else_clause) @start.else
 (except_clause) @start.except
 (finally_clause) @start.finally
-(case_pattern) @start.case
+(case_clause) @start.case


### PR DESCRIPTION
Closes #34002

`decrease_indent_patterns` should only contain mapping which are at same indent level with each other, which is not true for `match` and `case` mapping.

Caused in https://github.com/zed-industries/zed/pull/33370

Release Notes:

- N/A
