### PR TITLE
vim: substitute implement c and n flags

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -1466,7 +1466,7 @@ impl BufferSearchBar {
         }
     }
 
-    fn replace_next(&mut self, _: &ReplaceNext, window: &mut Window, cx: &mut Context<Self>) {
+    pub fn replace_next(&mut self, _: &ReplaceNext, window: &mut Window, cx: &mut Context<Self>) {
         let mut should_propagate = true;
         if !self.dismissed && self.active_search.is_some() {
             if let Some(searchable_item) = self.active_searchable_item.as_ref() {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -922,7 +922,7 @@ impl BufferSearchBar {
             .filter(|suggestion| !suggestion.is_empty())
     }
 
-    pub fn set_replacement(&mut self, replacement: Option<&str>, cx: &mut Context<Self>) {
+    pub fn set_replacement(&mut self, replacement: Option<&str>, continue_replacing: bool, window: &mut Window, cx: &mut Context<Self>) {
         if replacement.is_none() {
             self.replace_enabled = false;
             return;
@@ -937,6 +937,11 @@ impl BufferSearchBar {
                         replacement_buffer.edit([(0..len, replacement.unwrap())], None, cx);
                     });
             });
+        if continue_replacing {
+            let handle = self.replacement_editor.focus_handle(cx);
+            self.focus(&handle, window, cx);
+            cx.notify();
+        }
     }
 
     pub fn search(
@@ -1145,7 +1150,7 @@ impl BufferSearchBar {
         }
     }
 
-    fn on_replacement_editor_event(
+    pub fn on_replacement_editor_event(
         &mut self,
         _: Entity<Editor>,
         event: &editor::EditorEvent,

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -513,7 +513,11 @@ impl Vim {
                 search_bar.update_in(cx, |search_bar, window, cx| {
                     search_bar.select_last_match(window, cx);
                     if replacement.replace_any {
-                        search_bar.replace_all(&Default::default(), window, cx);
+                        if replacement.should_replace_all {
+                            search_bar.replace_all(&Default::default(), window, cx);
+                        } else {
+                            search_bar.replace_next(&Default::default(), window, cx);
+                        }
                     }
                     editor.update(cx, |editor, cx| editor.clear_search_within_ranges(cx));
                     let _ = search_bar.search(&search_bar.query(cx), None, window, cx);


### PR DESCRIPTION
Closes #23345 

Release Notes:

- c flag focuses on search bar for consecutive replaces
- n performs a search

lmk if there's anything I should change