### PR TITLE
docs: Document pull diagnostics support for Ruby

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -127,7 +127,7 @@ Solargraph reads its configuration from a file called `.solargraph.yml` in the r
 
 ## Setting up `ruby-lsp`
 
-Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell Zed to disable it by adding the following to your `settings.json`:
+You can pass Ruby LSP configuration to `initialization_options`, e.g.
 
 ```json
 {
@@ -140,8 +140,7 @@ Ruby LSP uses pull-based diagnostics which Zed doesn't support yet. We can tell 
     "ruby-lsp": {
       "initialization_options": {
         "enabledFeatures": {
-          // This disables diagnostics
-          "diagnostics": false
+          // "someFeature": false
         }
       }
     }


### PR DESCRIPTION
This is now supported.

cc @vitallium 

Release Notes:

- N/A
