### PR TITLE
Automatically adjust ANSI color contrast

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1350,7 +1350,7 @@
       // 5. Never show the scrollbar:
       //    "never"
       "show": null
-    }
+    },
     // Set the terminal's font size. If this option is not included,
     // the terminal will default to matching the buffer's font size.
     // "font_size": 15,
@@ -1367,6 +1367,13 @@
     // Default: 10_000, maximum: 100_000 (all bigger values set will be treated as 100_000), 0 disables the scrolling.
     // Existing terminals will not pick up this change until they are recreated.
     // "max_scroll_history_lines": 10000,
+    // The minimum contrast ratio between foreground and background colors.
+    // The contrast ratio is a value between 1 and 21. A value of 1 allows for no
+    // contrast (e.g. black on black). Higher values ensure greater legibility.
+    // If the contrast between text and background is below this threshold,
+    // the text color will be adjusted to either black or white, whichever
+    // provides better contrast.
+    "minimum_contrast": 1.1
   },
   "code_actions_on_format": {},
   // Settings related to running tasks.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1367,13 +1367,17 @@
     // Default: 10_000, maximum: 100_000 (all bigger values set will be treated as 100_000), 0 disables the scrolling.
     // Existing terminals will not pick up this change until they are recreated.
     // "max_scroll_history_lines": 10000,
-    // The minimum contrast ratio between foreground and background colors.
-    // The contrast ratio is a value between 1 and 21. A value of 1 allows for no
-    // contrast (e.g. black on black). Higher values ensure greater legibility.
-    // If the contrast between text and background is below this threshold,
-    // the text color will be adjusted to either black or white, whichever
-    // provides better contrast.
-    "minimum_contrast": 1.1
+    // The minimum APCA perceptual contrast between foreground and background colors.
+    // APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
+    // especially for dark mode. Values range from 0 to 106.
+    // - 0: No contrast adjustment
+    // - 15: Minimum for large text
+    // - 30: Minimum for incidental text
+    // - 45: Minimum for placeholders
+    // - 60: Minimum for body text (WCAG 2.x AA equivalent)
+    // - 75: Recommended for body text
+    // - 90: Enhanced contrast
+    "minimum_contrast": 0
   },
   "code_actions_on_format": {},
   // Settings related to running tasks.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1370,16 +1370,17 @@
     // The minimum APCA perceptual contrast between foreground and background colors.
     // APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
     // especially for dark mode. Values range from 0 to 106.
-    // - 0: No contrast adjustment
-    // - 15: Minimum for non-text elements
-    // - 30: Minimum for large text (24px+)
-    // - 45: Minimum for medium text (18px+)
-    // - 60: Minimum for body text (similar to WCAG 3:1)
-    // - 75: Enhanced contrast (similar to WCAG 4.5:1)
-    // - 90: High contrast (similar to WCAG 7:1)
     //
-    // Most terminal themes use colors with APCA values of 40-70.
-    // A value of 45 provides good legibility while preserving colors.
+    // Based on APCA Readability Criterion (ARC) Bronze Simple Mode:
+    // https://readtech.org/ARC/tests/bronze-simple-mode/
+    // - 0: No contrast adjustment
+    // - 45: Minimum for large fluent text (36px+)
+    // - 60: Minimum for other content text
+    // - 75: Minimum for body text
+    // - 90: Preferred for body text
+    //
+    // Most terminal themes have APCA values of 40-70.
+    // A value of 45 preserves colorful themes while ensuring legibility.
     "minimum_contrast": 45
   },
   "code_actions_on_format": {},

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1371,13 +1371,16 @@
     // APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
     // especially for dark mode. Values range from 0 to 106.
     // - 0: No contrast adjustment
-    // - 15: Minimum for large text
-    // - 30: Minimum for incidental text
-    // - 45: Minimum for placeholders
-    // - 60: Minimum for body text (WCAG 2.x AA equivalent)
-    // - 75: Recommended for body text
-    // - 90: Enhanced contrast
-    "minimum_contrast": 0
+    // - 15: Minimum for non-text elements
+    // - 30: Minimum for large text (24px+)
+    // - 45: Minimum for medium text (18px+)
+    // - 60: Minimum for body text (similar to WCAG 3:1)
+    // - 75: Enhanced contrast (similar to WCAG 4.5:1)
+    // - 90: High contrast (similar to WCAG 7:1)
+    //
+    // Most terminal themes use colors with APCA values of 40-70.
+    // A value of 45 provides good legibility while preserving colors.
+    "minimum_contrast": 45
   },
   "code_actions_on_format": {},
   // Settings related to running tasks.

--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -25,6 +25,7 @@ use alacritty_terminal::{
 use gpui::{Bounds, ClipboardItem, Entity, FontStyle, TextStyle, WhiteSpace, canvas, size};
 use language::Buffer;
 use settings::Settings as _;
+use terminal::terminal_settings::TerminalSettings;
 use terminal_view::terminal_element::TerminalElement;
 use theme::ThemeSettings;
 use ui::{IntoElement, prelude::*};
@@ -257,8 +258,17 @@ impl Render for TerminalOutput {
                 point: ic.point,
                 cell: ic.cell.clone(),
             });
-        let (cells, rects) =
-            TerminalElement::layout_grid(grid, 0, &text_style, text_system, None, window, cx);
+        let minimum_contrast = TerminalSettings::get_global(cx).minimum_contrast;
+        let (cells, rects) = TerminalElement::layout_grid(
+            grid,
+            0,
+            &text_style,
+            text_system,
+            None,
+            minimum_contrast,
+            window,
+            cx,
+        );
 
         // lines are 0-indexed, so we must add 1 to get the number of lines
         let text_line_height = text_style.line_height_in_pixels(window.rem_size());

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -230,15 +230,19 @@ pub struct TerminalSettingsContent {
     pub toolbar: Option<ToolbarContent>,
     /// Scrollbar-related settings
     pub scrollbar: Option<ScrollbarSettingsContent>,
-    /// The minimum contrast ratio between foreground and background colors.
+    /// The minimum APCA perceptual contrast between foreground and background colors.
     ///
-    /// The contrast ratio is a value between 1 and 21. A value of 1 allows for no
-    /// contrast (e.g. black on black). Higher values ensure greater legibility.
-    /// If the contrast between text and background is below this threshold,
-    /// the text color will be adjusted to either black or white, whichever
-    /// provides better contrast.
+    /// APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
+    /// especially for dark mode. Values range from 0 to 106.
+    /// - 0: No contrast adjustment
+    /// - 15: Minimum for large text
+    /// - 30: Minimum for incidental text
+    /// - 45: Minimum for placeholders
+    /// - 60: Minimum for body text (WCAG 2.x AA equivalent)
+    /// - 75: Recommended for body text
+    /// - 90: Enhanced contrast
     ///
-    /// Default: 1.0 (no adjustment)
+    /// Default: 0 (no adjustment)
     pub minimum_contrast: Option<f32>,
 }
 
@@ -250,11 +254,11 @@ impl settings::Settings for TerminalSettings {
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut App) -> anyhow::Result<Self> {
         let settings: Self = sources.json_merge()?;
 
-        // Validate minimum_contrast
-        if settings.minimum_contrast < 1.0 || settings.minimum_contrast > 21.0 {
+        // Validate minimum_contrast for APCA
+        if settings.minimum_contrast < 0.0 || settings.minimum_contrast > 106.0 {
             anyhow::bail!(
-                "terminal.minimum_contrast must be between 1.0 and 21.0, but got {}. \
-                A value of 1.0 means no contrast adjustment, and 21.0 is maximum contrast.",
+                "terminal.minimum_contrast must be between 0 and 106, but got {}. \
+                APCA values: 0 = no adjustment, 75 = recommended for body text, 106 = maximum contrast.",
                 settings.minimum_contrast
             );
         }

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -234,16 +234,14 @@ pub struct TerminalSettingsContent {
     ///
     /// APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
     /// especially for dark mode. Values range from 0 to 106.
-    /// - 0: No contrast adjustment
-    /// - 15: Minimum for non-text elements
-    /// - 30: Minimum for large text (24px+)
-    /// - 45: Minimum for medium text (18px+)
-    /// - 60: Minimum for body text (similar to WCAG 3:1)
-    /// - 75: Enhanced contrast (similar to WCAG 4.5:1)
-    /// - 90: High contrast (similar to WCAG 7:1)
     ///
-    /// Most terminal themes use colors with APCA values of 40-70.
-    /// A value of 45 provides good legibility while preserving colors.
+    /// Based on APCA Readability Criterion (ARC) Bronze Simple Mode:
+    /// https://readtech.org/ARC/tests/bronze-simple-mode/
+    /// - 0: No contrast adjustment
+    /// - 45: Minimum for large fluent text (36px+)
+    /// - 60: Minimum for other content text
+    /// - 75: Minimum for body text
+    /// - 90: Preferred for body text
     ///
     /// Default: 0 (no adjustment)
     pub minimum_contrast: Option<f32>,

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -235,12 +235,15 @@ pub struct TerminalSettingsContent {
     /// APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
     /// especially for dark mode. Values range from 0 to 106.
     /// - 0: No contrast adjustment
-    /// - 15: Minimum for large text
-    /// - 30: Minimum for incidental text
-    /// - 45: Minimum for placeholders
-    /// - 60: Minimum for body text (WCAG 2.x AA equivalent)
-    /// - 75: Recommended for body text
-    /// - 90: Enhanced contrast
+    /// - 15: Minimum for non-text elements
+    /// - 30: Minimum for large text (24px+)
+    /// - 45: Minimum for medium text (18px+)
+    /// - 60: Minimum for body text (similar to WCAG 3:1)
+    /// - 75: Enhanced contrast (similar to WCAG 4.5:1)
+    /// - 90: High contrast (similar to WCAG 7:1)
+    ///
+    /// Most terminal themes use colors with APCA values of 40-70.
+    /// A value of 45 provides good legibility while preserving colors.
     ///
     /// Default: 0 (no adjustment)
     pub minimum_contrast: Option<f32>,

--- a/crates/terminal_view/src/color_contrast.rs
+++ b/crates/terminal_view/src/color_contrast.rs
@@ -1,0 +1,230 @@
+use gpui::Hsla;
+
+/// Calculates the contrast ratio between two colors according to WCAG 2.0.
+/// The contrast ratio is a value between 1 and 21 where 1 is no contrast
+/// and 21 is maximum contrast.
+///
+/// https://www.w3.org/TR/WCAG20/#contrast-ratiodef
+pub fn contrast_ratio(foreground: Hsla, background: Hsla) -> f32 {
+    let fg_luminance = luminance(foreground);
+    let bg_luminance = luminance(background);
+
+    let lighter = fg_luminance.max(bg_luminance);
+    let darker = fg_luminance.min(bg_luminance);
+
+    (lighter + 0.05) / (darker + 0.05)
+}
+
+/// Calculates the relative luminance of a color according to WCAG 2.0.
+/// Returns a value between 0 and 1 where 0 is black and 1 is white.
+///
+/// https://www.w3.org/TR/WCAG20/#relativeluminancedef
+pub fn luminance(color: Hsla) -> f32 {
+    // Convert HSLA to RGB using GPUI's built-in method
+    let rgba = color.to_rgb();
+
+    // Calculate luminance using the WCAG formula
+    let r_linear = srgb_to_linear(rgba.r);
+    let g_linear = srgb_to_linear(rgba.g);
+    let b_linear = srgb_to_linear(rgba.b);
+
+    0.2126 * r_linear + 0.7152 * g_linear + 0.0722 * b_linear
+}
+
+/// Converts a single sRGB color component to linear RGB.
+/// This is part of the WCAG luminance calculation.
+fn srgb_to_linear(component: f32) -> f32 {
+    if component <= 0.03928 {
+        component / 12.92
+    } else {
+        ((component + 0.055) / 1.055).powf(2.4)
+    }
+}
+
+/// Adjusts the foreground color to meet the minimum contrast ratio against the background.
+/// If the current contrast is below the minimum, it returns either black or white,
+/// whichever provides better contrast.
+pub fn ensure_minimum_contrast(foreground: Hsla, background: Hsla, minimum_contrast: f32) -> Hsla {
+    if minimum_contrast <= 1.0 {
+        return foreground;
+    }
+
+    let current_contrast = contrast_ratio(foreground, background);
+
+    if current_contrast >= minimum_contrast {
+        return foreground;
+    }
+
+    // Try black and white to see which provides better contrast
+    let black = Hsla {
+        h: 0.0,
+        s: 0.0,
+        l: 0.0,
+        a: foreground.a, // Preserve alpha
+    };
+
+    let white = Hsla {
+        h: 0.0,
+        s: 0.0,
+        l: 1.0,
+        a: foreground.a, // Preserve alpha
+    };
+
+    let black_contrast = contrast_ratio(black, background);
+    let white_contrast = contrast_ratio(white, background);
+
+    if white_contrast > black_contrast {
+        white
+    } else {
+        black
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hsla(h: f32, s: f32, l: f32, a: f32) -> Hsla {
+        Hsla { h, s, l, a }
+    }
+
+    fn hsla_from_hex(hex: u32) -> Hsla {
+        let r = ((hex >> 16) & 0xFF) as f32 / 255.0;
+        let g = ((hex >> 8) & 0xFF) as f32 / 255.0;
+        let b = (hex & 0xFF) as f32 / 255.0;
+
+        let max = r.max(g).max(b);
+        let min = r.min(g).min(b);
+        let l = (max + min) / 2.0;
+
+        if max == min {
+            // Achromatic
+            Hsla {
+                h: 0.0,
+                s: 0.0,
+                l,
+                a: 1.0,
+            }
+        } else {
+            let d = max - min;
+            let s = if l > 0.5 {
+                d / (2.0 - max - min)
+            } else {
+                d / (max + min)
+            };
+
+            let h = if max == r {
+                (g - b) / d + if g < b { 6.0 } else { 0.0 }
+            } else if max == g {
+                (b - r) / d + 2.0
+            } else {
+                (r - g) / d + 4.0
+            } / 6.0;
+
+            Hsla { h, s, l, a: 1.0 }
+        }
+    }
+
+    #[test]
+    fn test_contrast_ratio() {
+        // Black on white should have maximum contrast (21:1)
+        let black = hsla(0.0, 0.0, 0.0, 1.0);
+        let white = hsla(0.0, 0.0, 1.0, 1.0);
+        let ratio = contrast_ratio(black, white);
+        assert!((ratio - 21.0).abs() < 0.1, "Expected ~21, got {}", ratio);
+
+        // Same color should have minimum contrast (1:1)
+        let gray = hsla(0.0, 0.0, 0.5, 1.0);
+        let ratio = contrast_ratio(gray, gray);
+        assert!((ratio - 1.0).abs() < 0.01, "Expected ~1, got {}", ratio);
+
+        // Test commutative property
+        assert_eq!(contrast_ratio(black, white), contrast_ratio(white, black));
+    }
+
+    #[test]
+    fn test_luminance() {
+        // Test known luminance values
+        let black = hsla(0.0, 0.0, 0.0, 1.0);
+        assert!((luminance(black) - 0.0).abs() < 0.001);
+
+        let white = hsla(0.0, 0.0, 1.0, 1.0);
+        assert!((luminance(white) - 1.0).abs() < 0.001);
+
+        // Middle gray should have luminance around 0.2159
+        // (This is the sRGB middle gray, not perceptual middle gray)
+        let gray = hsla(0.0, 0.0, 0.5, 1.0);
+        let gray_lum = luminance(gray);
+        assert!(
+            (gray_lum - 0.2159).abs() < 0.01,
+            "Expected ~0.2159, got {}",
+            gray_lum
+        );
+    }
+
+    #[test]
+    fn test_ensure_minimum_contrast() {
+        let white_bg = hsla(0.0, 0.0, 1.0, 1.0);
+        let light_gray = hsla(0.0, 0.0, 0.9, 1.0);
+
+        // Light gray on white has poor contrast
+        let initial_contrast = contrast_ratio(light_gray, white_bg);
+        assert!(initial_contrast < 2.0);
+
+        // Should be adjusted to black for better contrast
+        let adjusted = ensure_minimum_contrast(light_gray, white_bg, 3.0);
+        assert_eq!(adjusted.l, 0.0); // Should be black
+        assert_eq!(adjusted.a, light_gray.a); // Alpha preserved
+
+        // Test with dark background
+        let black_bg = hsla(0.0, 0.0, 0.0, 1.0);
+        let dark_gray = hsla(0.0, 0.0, 0.1, 1.0);
+
+        // Dark gray on black has poor contrast
+        let initial_contrast = contrast_ratio(dark_gray, black_bg);
+        assert!(initial_contrast < 2.0);
+
+        // Should be adjusted to white for better contrast
+        let adjusted = ensure_minimum_contrast(dark_gray, black_bg, 3.0);
+        assert_eq!(adjusted.l, 1.0); // Should be white
+
+        // Test when contrast is already sufficient
+        let black = hsla(0.0, 0.0, 0.0, 1.0);
+        let adjusted = ensure_minimum_contrast(black, white_bg, 3.0);
+        assert_eq!(adjusted, black); // Should remain unchanged
+    }
+
+    #[test]
+    fn test_one_light_theme_exact_colors() {
+        // Test with exact colors from One Light theme
+        // terminal.background and terminal.ansi.white are both #fafafaff
+        let fafafa = hsla_from_hex(0xfafafa);
+
+        // They should be identical
+        let bg = fafafa;
+        let fg = fafafa;
+
+        // Contrast ratio should be 1.0 (no contrast)
+        let ratio = contrast_ratio(fg, bg);
+        assert!(
+            (ratio - 1.0).abs() < 0.01,
+            "Same color should have contrast ratio 1.0, got {}",
+            ratio
+        );
+
+        // With minimum contrast 1.1, it should adjust
+        let adjusted = ensure_minimum_contrast(fg, bg, 1.1);
+        assert!(
+            adjusted.l < 0.1 || adjusted.l > 0.9,
+            "Color should be adjusted to black or white"
+        );
+
+        // The adjusted color should have sufficient contrast
+        let new_ratio = contrast_ratio(adjusted, bg);
+        assert!(
+            new_ratio >= 1.1,
+            "Adjusted contrast {} should be >= 1.1",
+            new_ratio
+        );
+    }
+}

--- a/crates/terminal_view/src/color_contrast.rs
+++ b/crates/terminal_view/src/color_contrast.rs
@@ -64,12 +64,14 @@ impl Default for APCAConstants {
 /// - Perceptually uniform across the range
 ///
 /// Common APCA Lc thresholds:
-/// - Lc 15: Minimum for large text
-/// - Lc 30: Minimum for incidental text
-/// - Lc 45: Minimum for placeholders
-/// - Lc 60: Minimum for body text (similar to WCAG 2.x 4.5:1)
-/// - Lc 75: Recommended minimum for body text
-/// - Lc 90: Preferred for body text
+/// - Lc 15: Minimum for non-text elements
+/// - Lc 30: Minimum for large text (24px+)
+/// - Lc 45: Minimum for medium text (18px+)
+/// - Lc 60: Minimum for body text (similar to WCAG 3:1)
+/// - Lc 75: Enhanced contrast (similar to WCAG 4.5:1)
+/// - Lc 90: High contrast (similar to WCAG 7:1)
+///
+/// Most terminal themes use colors with APCA values of 40-70.
 ///
 /// https://github.com/Myndex/apca-w3
 pub fn apca_contrast(text_color: Hsla, background_color: Hsla) -> f32 {
@@ -301,8 +303,8 @@ mod tests {
             initial_contrast
         );
 
-        // Should be adjusted to black for better contrast (using APCA Lc 75 as minimum)
-        let adjusted = ensure_minimum_contrast(light_gray, white_bg, 75.0);
+        // Should be adjusted to black for better contrast (using APCA Lc 45 as minimum)
+        let adjusted = ensure_minimum_contrast(light_gray, white_bg, 45.0);
         assert_eq!(adjusted.l, 0.0); // Should be black
         assert_eq!(adjusted.a, light_gray.a); // Alpha preserved
 
@@ -319,12 +321,12 @@ mod tests {
         );
 
         // Should be adjusted to white for better contrast
-        let adjusted = ensure_minimum_contrast(dark_gray, black_bg, 75.0);
+        let adjusted = ensure_minimum_contrast(dark_gray, black_bg, 45.0);
         assert_eq!(adjusted.l, 1.0); // Should be white
 
         // Test when contrast is already sufficient
         let black = hsla(0.0, 0.0, 0.0, 1.0);
-        let adjusted = ensure_minimum_contrast(black, white_bg, 75.0);
+        let adjusted = ensure_minimum_contrast(black, white_bg, 45.0);
         assert_eq!(adjusted, black); // Should remain unchanged
     }
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1436,8 +1436,8 @@ mod tests {
             actual_contrast
         );
 
-        // After adjustment with minimum APCA contrast of 75, should be dark
-        let adjusted = color_contrast::ensure_minimum_contrast(white_fg, light_gray_bg, 75.0);
+        // After adjustment with minimum APCA contrast of 45, should be dark
+        let adjusted = color_contrast::ensure_minimum_contrast(white_fg, light_gray_bg, 45.0);
         assert!(adjusted.l < 0.1, "Adjusted color should be dark");
 
         // Test case 2: Dark colors (poor contrast)
@@ -1462,12 +1462,12 @@ mod tests {
             actual_contrast
         );
 
-        // After adjustment with minimum APCA contrast of 75, should be light
-        let adjusted = color_contrast::ensure_minimum_contrast(black_fg, dark_gray_bg, 75.0);
+        // After adjustment with minimum APCA contrast of 45, should be light
+        let adjusted = color_contrast::ensure_minimum_contrast(black_fg, dark_gray_bg, 45.0);
         assert!(adjusted.l > 0.9, "Adjusted color should be light");
 
         // Test case 3: Already good contrast
-        let good_contrast = color_contrast::ensure_minimum_contrast(black_fg, white_fg, 75.0);
+        let good_contrast = color_contrast::ensure_minimum_contrast(black_fg, white_fg, 45.0);
         assert_eq!(
             good_contrast, black_fg,
             "Good contrast should not be adjusted"

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1436,9 +1436,14 @@ mod tests {
             actual_contrast
         );
 
-        // After adjustment with minimum APCA contrast of 45, should be dark
+        // After adjustment with minimum APCA contrast of 45, should be darker
         let adjusted = color_contrast::ensure_minimum_contrast(white_fg, light_gray_bg, 45.0);
-        assert!(adjusted.l < 0.1, "Adjusted color should be dark");
+        assert!(
+            adjusted.l < white_fg.l,
+            "Adjusted color should be darker than original"
+        );
+        let adjusted_contrast = color_contrast::apca_contrast(adjusted, light_gray_bg).abs();
+        assert!(adjusted_contrast >= 45.0, "Should meet minimum contrast");
 
         // Test case 2: Dark colors (poor contrast)
         let black_fg = gpui::Hsla {
@@ -1462,9 +1467,14 @@ mod tests {
             actual_contrast
         );
 
-        // After adjustment with minimum APCA contrast of 45, should be light
+        // After adjustment with minimum APCA contrast of 45, should be lighter
         let adjusted = color_contrast::ensure_minimum_contrast(black_fg, dark_gray_bg, 45.0);
-        assert!(adjusted.l > 0.9, "Adjusted color should be light");
+        assert!(
+            adjusted.l > black_fg.l,
+            "Adjusted color should be lighter than original"
+        );
+        let adjusted_contrast = color_contrast::apca_contrast(adjusted, dark_gray_bg).abs();
+        assert!(adjusted_contrast >= 45.0, "Should meet minimum contrast");
 
         // Test case 3: Already good contrast
         let good_contrast = color_contrast::ensure_minimum_contrast(black_fg, white_fg, 45.0);
@@ -1497,11 +1507,11 @@ mod tests {
         let no_adjust = color_contrast::ensure_minimum_contrast(white_fg, white_bg, 0.0);
         assert_eq!(no_adjust, white_fg, "No adjustment with min_contrast 0.0");
 
-        // With minimum APCA contrast of 15, it should adjust to black
+        // With minimum APCA contrast of 15, it should adjust to a darker color
         let adjusted = color_contrast::ensure_minimum_contrast(white_fg, white_bg, 15.0);
         assert!(
-            adjusted.l < 0.1,
-            "White on white with min_contrast 15.0 should become dark, got l={}",
+            adjusted.l < white_fg.l,
+            "White on white should become darker, got l={}",
             adjusted.l
         );
 

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -1429,14 +1429,15 @@ mod tests {
         };
 
         // Should have poor contrast
-        let actual_contrast = color_contrast::contrast_ratio(white_fg, light_gray_bg);
+        let actual_contrast = color_contrast::apca_contrast(white_fg, light_gray_bg).abs();
         assert!(
-            actual_contrast < 2.0,
-            "White on light gray should have poor contrast"
+            actual_contrast < 30.0,
+            "White on light gray should have poor APCA contrast: {}",
+            actual_contrast
         );
 
-        // After adjustment with minimum contrast of 4.5, should be dark
-        let adjusted = color_contrast::ensure_minimum_contrast(white_fg, light_gray_bg, 4.5);
+        // After adjustment with minimum APCA contrast of 75, should be dark
+        let adjusted = color_contrast::ensure_minimum_contrast(white_fg, light_gray_bg, 75.0);
         assert!(adjusted.l < 0.1, "Adjusted color should be dark");
 
         // Test case 2: Dark colors (poor contrast)
@@ -1454,18 +1455,19 @@ mod tests {
         };
 
         // Should have poor contrast
-        let actual_contrast = color_contrast::contrast_ratio(black_fg, dark_gray_bg);
+        let actual_contrast = color_contrast::apca_contrast(black_fg, dark_gray_bg).abs();
         assert!(
-            actual_contrast < 2.0,
-            "Black on dark gray should have poor contrast"
+            actual_contrast < 30.0,
+            "Black on dark gray should have poor APCA contrast: {}",
+            actual_contrast
         );
 
-        // After adjustment with minimum contrast of 4.5, should be light
-        let adjusted = color_contrast::ensure_minimum_contrast(black_fg, dark_gray_bg, 4.5);
+        // After adjustment with minimum APCA contrast of 75, should be light
+        let adjusted = color_contrast::ensure_minimum_contrast(black_fg, dark_gray_bg, 75.0);
         assert!(adjusted.l > 0.9, "Adjusted color should be light");
 
         // Test case 3: Already good contrast
-        let good_contrast = color_contrast::ensure_minimum_contrast(black_fg, white_fg, 4.5);
+        let good_contrast = color_contrast::ensure_minimum_contrast(black_fg, white_fg, 75.0);
         assert_eq!(
             good_contrast, black_fg,
             "Good contrast should not be adjusted"
@@ -1491,23 +1493,23 @@ mod tests {
             a: 1.0,
         };
 
-        // With minimum contrast of 1.0, no adjustment should happen
-        let no_adjust = color_contrast::ensure_minimum_contrast(white_fg, white_bg, 1.0);
-        assert_eq!(no_adjust, white_fg, "No adjustment with min_contrast 1.0");
+        // With minimum contrast of 0.0, no adjustment should happen
+        let no_adjust = color_contrast::ensure_minimum_contrast(white_fg, white_bg, 0.0);
+        assert_eq!(no_adjust, white_fg, "No adjustment with min_contrast 0.0");
 
-        // With minimum contrast of 1.1, it should adjust to black
-        let adjusted = color_contrast::ensure_minimum_contrast(white_fg, white_bg, 1.1);
+        // With minimum APCA contrast of 15, it should adjust to black
+        let adjusted = color_contrast::ensure_minimum_contrast(white_fg, white_bg, 15.0);
         assert!(
             adjusted.l < 0.1,
-            "White on white with min_contrast 1.1 should become dark, got l={}",
+            "White on white with min_contrast 15.0 should become dark, got l={}",
             adjusted.l
         );
 
-        // Verify the contrast ratio is now acceptable
-        let new_contrast = color_contrast::contrast_ratio(adjusted, white_bg);
+        // Verify the contrast is now acceptable
+        let new_contrast = color_contrast::apca_contrast(adjusted, white_bg).abs();
         assert!(
-            new_contrast >= 1.1,
-            "Adjusted contrast {} should be >= 1.1",
+            new_contrast >= 15.0,
+            "Adjusted APCA contrast {} should be >= 15.0",
             new_contrast
         );
     }

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1,3 +1,4 @@
+mod color_contrast;
 mod persistence;
 pub mod terminal_element;
 pub mod terminal_panel;


### PR DESCRIPTION
Closes #33253 in a way that doesn't regress #32175 - namely, automatically adjusts the contrast between the foreground  and background text in the terminal such that it's above a certain threshold. The threshold is configurable in settings, and can be set to 0 to turn off this feature and use exactly the colors the theme specifies even if they are illegible.

## One Light Theme Before
<img width="220" alt="Screenshot 2025-07-07 at 6 00 47 PM" src="https://github.com/user-attachments/assets/096754a6-f79f-4fea-a86e-cb7b8ff45d60" />

(Last row is highlighted because otherwise the text is unreadable; the foreground and background are the same color.)

## One Light Theme After

(This is with the new default contrast adjustment setting.)

<img width="215" alt="Screenshot 2025-07-07 at 6 22 02 PM" src="https://github.com/user-attachments/assets/b082fefe-76f5-4231-b704-ff387983a3cb" />

This approach was inspired by @mitchellh's use of automatic contrast adjustment in [Ghostty](https://ghostty.org/) - thanks, Mitchell! The main difference is that we're using APCA's formula instead of WCAG for [these reasons](https://khan-tw.medium.com/wcag2-are-you-still-using-it-ui-contrast-visibility-standard-readability-contrast-f34eb73e89ee).

Release Notes:

- Added automatic dynamic contrast adjustment for terminal foreground and background colors
