### PR TITLE
agent: Allow clicking on the whole edit file row to trigger review

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -1160,7 +1160,7 @@ impl MessageEditor {
                                 })
                                 .child(
                                     h_flex()
-                                        .id("file-name")
+                                        .id(("file-name", index))
                                         .pr_8()
                                         .gap_1p5()
                                         .max_w_full()
@@ -1171,9 +1171,16 @@ impl MessageEditor {
                                                 .gap_0p5()
                                                 .children(file_name)
                                                 .children(file_path),
-                                        ), // TODO: Implement line diff
-                                           // .child(Label::new("+").color(Color::Created))
-                                           // .child(Label::new("-").color(Color::Deleted)),
+                                        )
+                                        .on_click({
+                                            let buffer = buffer.clone();
+                                            cx.listener(move |this, _, window, cx| {
+                                                this.handle_file_click(buffer.clone(), window, cx);
+                                            })
+                                        }), // TODO: Implement line diff
+                                            // .child(Label::new("+").color(Color::Created))
+                                            // .child(Label::new("-").color(Color::Deleted)),
+                                            //
                                 )
                                 .child(
                                     h_flex()


### PR DESCRIPTION
Just a small quality-of-life type of PR that makes clicking anywhere until the "Review" button trigger the action that that button triggers (i.e., opens the review multibuffer).

<img src="https://github.com/user-attachments/assets/8936ed75-50fd-49f9-89ef-b6c4301a8eba" width="600" />

Release Notes:

- agent: Added the ability to click the whole file row in the edits bar to trigger the review multibuffer.
