### PR TITLE
project_panel: Only show sticky item shadow when list is scrolled

### DIFF
--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -142,6 +142,15 @@ impl UniformListScrollHandle {
             .map(|(ix, _)| ix)
             .unwrap_or_else(|| this.base_handle.logical_scroll_top().0)
     }
+
+    /// Checks if the list can be scrolled vertically.
+    pub fn is_scrollable(&self) -> bool {
+        if let Some(size) = self.0.borrow().last_item_size {
+            size.contents.height > size.item.height
+        } else {
+            false
+        }
+    }
 }
 
 impl Styled for UniformList {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3940,10 +3940,7 @@ impl ProjectPanel {
 
         let show_sticky_shadow = details.sticky.as_ref().map_or(false, |item| {
             if item.is_last {
-                let content_width = self.scroll_handle.content_size().width;
-                let viewport_width = self.scroll_handle.viewport().size.width;
-                // We need to check both because offset returns delta values even when the scroll handle is not scrollable
-                let is_scrollable = content_width > viewport_width;
+                let is_scrollable = self.scroll_handle.is_scrollable();
                 let is_scrolled = self.scroll_handle.offset().y < px(0.);
                 is_scrollable && is_scrolled
             } else {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5151,30 +5151,6 @@ impl Render for ProjectPanel {
                             items
                         })
                     })
-                    .when(show_sticky_scroll, |list| {
-                        list.with_decoration(ui::sticky_items(
-                            cx.entity().clone(),
-                            |this, range, window, cx| {
-                                let mut items = SmallVec::with_capacity(range.end - range.start);
-                                this.iter_visible_entries(
-                                    range,
-                                    window,
-                                    cx,
-                                    |entry, index, entries, _, _| {
-                                        let (depth, _) =
-                                            Self::calculate_depth_and_difference(entry, entries);
-                                        let candidate =
-                                            StickyProjectPanelCandidate { index, depth };
-                                        items.push(candidate);
-                                    },
-                                );
-                                items
-                            },
-                            |this, marker_entry, window, cx| {
-                                this.render_sticky_entries(marker_entry, window, cx)
-                            },
-                        ))
-                    })
                     .when(show_indent_guides, |list| {
                         list.with_decoration(
                             ui::indent_guides(
@@ -5273,6 +5249,30 @@ impl Render for ProjectPanel {
                                 },
                             ),
                         )
+                    })
+                    .when(show_sticky_scroll, |list| {
+                        list.with_decoration(ui::sticky_items(
+                            cx.entity().clone(),
+                            |this, range, window, cx| {
+                                let mut items = SmallVec::with_capacity(range.end - range.start);
+                                this.iter_visible_entries(
+                                    range,
+                                    window,
+                                    cx,
+                                    |entry, index, entries, _, _| {
+                                        let (depth, _) =
+                                            Self::calculate_depth_and_difference(entry, entries);
+                                        let candidate =
+                                            StickyProjectPanelCandidate { index, depth };
+                                        items.push(candidate);
+                                    },
+                                );
+                                items
+                            },
+                            |this, marker_entry, window, cx| {
+                                this.render_sticky_entries(marker_entry, window, cx)
+                            },
+                        ))
                     })
                     .size_full()
                     .with_sizing_behavior(ListSizingBehavior::Infer)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5152,7 +5152,7 @@ impl Render for ProjectPanel {
                         })
                     })
                     .when(show_sticky_scroll, |list| {
-                        list.with_top_slot(ui::sticky_items(
+                        list.with_decoration(ui::sticky_items(
                             cx.entity().clone(),
                             |this, range, window, cx| {
                                 let mut items = SmallVec::with_capacity(range.end - range.start);

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -147,6 +147,7 @@ mod uniform_list {
             &self,
             visible_range: Range<usize>,
             bounds: Bounds<Pixels>,
+            _scroll_offset: Point<Pixels>,
             item_height: Pixels,
             item_count: usize,
             window: &mut Window,

--- a/crates/ui/src/components/sticky_items.rs
+++ b/crates/ui/src/components/sticky_items.rs
@@ -1,7 +1,8 @@
-use std::ops::Range;
+use std::{ops::Range, rc::Rc};
 
 use gpui::{
-    AnyElement, App, AvailableSpace, Bounds, Context, Entity, Pixels, Render, UniformListTopSlot,
+    AnyElement, App, AvailableSpace, Bounds, Context, Element, ElementId, Entity, GlobalElementId,
+    InspectorElementId, IntoElement, LayoutId, Pixels, Point, Render, Style, UniformListDecoration,
     Window, point, size,
 };
 use smallvec::SmallVec;
@@ -10,11 +11,10 @@ pub trait StickyCandidate {
     fn depth(&self) -> usize;
 }
 
+#[derive(Clone)]
 pub struct StickyItems<T> {
-    compute_fn: Box<dyn Fn(Range<usize>, &mut Window, &mut App) -> SmallVec<[T; 8]>>,
-    render_fn: Box<dyn Fn(T, &mut Window, &mut App) -> SmallVec<[AnyElement; 8]>>,
-    last_item_is_drifting: bool,
-    anchor_index: Option<usize>,
+    compute_fn: Rc<dyn Fn(Range<usize>, &mut Window, &mut App) -> SmallVec<[T; 8]>>,
+    render_fn: Rc<dyn Fn(T, &mut Window, &mut App) -> SmallVec<[AnyElement; 8]>>,
 }
 
 pub fn sticky_items<V, T>(
@@ -30,37 +30,106 @@ where
     let entity_compute = entity.clone();
     let entity_render = entity.clone();
 
-    let compute_fn = Box::new(
+    let compute_fn = Rc::new(
         move |range: Range<usize>, window: &mut Window, cx: &mut App| -> SmallVec<[T; 8]> {
             entity_compute.update(cx, |view, cx| compute_fn(view, range, window, cx))
         },
     );
-    let render_fn = Box::new(
+    let render_fn = Rc::new(
         move |entry: T, window: &mut Window, cx: &mut App| -> SmallVec<[AnyElement; 8]> {
             entity_render.update(cx, |view, cx| render_fn(view, entry, window, cx))
         },
     );
+
     StickyItems {
         compute_fn,
         render_fn,
-        last_item_is_drifting: false,
-        anchor_index: None,
     }
 }
 
-impl<T> UniformListTopSlot for StickyItems<T>
+struct StickyItemsElement {
+    elements: SmallVec<[AnyElement; 8]>,
+}
+
+impl IntoElement for StickyItemsElement {
+    type Element = Self;
+
+    fn into_element(self) -> Self::Element {
+        self
+    }
+}
+
+impl Element for StickyItemsElement {
+    type RequestLayoutState = ();
+    type PrepaintState = ();
+
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (LayoutId, Self::RequestLayoutState) {
+        (window.request_layout(Style::default(), [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _window: &mut Window,
+        _cx: &mut App,
+    ) -> Self::PrepaintState {
+        ()
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&GlobalElementId>,
+        _inspector_id: Option<&InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        _prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
+        // reverse so that last item is bottom most among sticky items
+        for item in self.elements.iter_mut().rev() {
+            item.paint(window, cx);
+        }
+    }
+}
+
+impl<T> UniformListDecoration for StickyItems<T>
 where
     T: StickyCandidate + Clone + 'static,
 {
     fn compute(
-        &mut self,
+        &self,
         visible_range: Range<usize>,
+        bounds: Bounds<Pixels>,
+        scroll_offset: Point<Pixels>,
+        item_height: Pixels,
+        _item_count: usize,
         window: &mut Window,
         cx: &mut App,
-    ) -> SmallVec<[AnyElement; 8]> {
+    ) -> AnyElement {
         let entries = (self.compute_fn)(visible_range.clone(), window, cx);
+        let mut elements = SmallVec::new();
 
         let mut anchor_entry = None;
+        let mut last_item_is_drifting = false;
+        let mut anchor_index = None;
 
         let mut iter = entries.iter().enumerate().peekable();
         while let Some((ix, current_entry)) = iter.next() {
@@ -76,8 +145,8 @@ where
                 let next_depth = next_entry.depth();
 
                 if next_depth < current_depth && next_depth < index_in_range {
-                    self.last_item_is_drifting = true;
-                    self.anchor_index = Some(visible_range.start + ix);
+                    last_item_is_drifting = true;
+                    anchor_index = Some(visible_range.start + ix);
                     anchor_entry = Some(current_entry.clone());
                     break;
                 }
@@ -85,67 +154,36 @@ where
         }
 
         if let Some(anchor_entry) = anchor_entry {
-            (self.render_fn)(anchor_entry, window, cx)
-        } else {
-            SmallVec::new()
-        }
-    }
+            elements = (self.render_fn)(anchor_entry, window, cx);
+            let items_count = elements.len();
 
-    fn prepaint(
-        &self,
-        items: &mut SmallVec<[AnyElement; 8]>,
-        bounds: Bounds<Pixels>,
-        item_height: Pixels,
-        scroll_offset: gpui::Point<Pixels>,
-        padding: gpui::Edges<Pixels>,
-        can_scroll_horizontally: bool,
-        window: &mut Window,
-        cx: &mut App,
-    ) {
-        let items_count = items.len();
+            for (ix, element) in elements.iter_mut().enumerate() {
+                let mut item_y_offset = None;
+                if ix == items_count - 1 && last_item_is_drifting {
+                    if let Some(anchor_index) = anchor_index {
+                        let scroll_top = -scroll_offset.y;
+                        let anchor_top = item_height * anchor_index;
+                        let sticky_area_height = item_height * items_count;
+                        item_y_offset =
+                            Some((anchor_top - scroll_top - sticky_area_height).min(Pixels::ZERO));
+                    };
+                }
 
-        for (ix, item) in items.iter_mut().enumerate() {
-            let mut item_y_offset = None;
-            if ix == items_count - 1 && self.last_item_is_drifting {
-                if let Some(anchor_index) = self.anchor_index {
-                    let scroll_top = -scroll_offset.y;
-                    let anchor_top = item_height * anchor_index;
-                    let sticky_area_height = item_height * items_count;
-                    item_y_offset =
-                        Some((anchor_top - scroll_top - sticky_area_height).min(Pixels::ZERO));
-                };
-            }
+                let sticky_origin = bounds.origin
+                    + point(
+                        scroll_offset.x,
+                        -scroll_offset.y + item_height * ix + item_y_offset.unwrap_or(Pixels::ZERO),
+                    );
 
-            let sticky_origin = bounds.origin
-                + point(
-                    if can_scroll_horizontally {
-                        scroll_offset.x + padding.left
-                    } else {
-                        scroll_offset.x
-                    },
-                    item_height * ix + padding.top + item_y_offset.unwrap_or(Pixels::ZERO),
+                let available_space = size(
+                    AvailableSpace::Definite(bounds.size.width),
+                    AvailableSpace::Definite(item_height),
                 );
-
-            let available_width = if can_scroll_horizontally {
-                bounds.size.width + scroll_offset.x.abs()
-            } else {
-                bounds.size.width
-            };
-
-            let available_space = size(
-                AvailableSpace::Definite(available_width),
-                AvailableSpace::Definite(item_height),
-            );
-
-            item.layout_as_root(available_space, window, cx);
-            item.prepaint_at(sticky_origin, window, cx);
+                element.layout_as_root(available_space, window, cx);
+                element.prepaint_at(sticky_origin, window, cx);
+            }
         }
-    }
 
-    fn paint(&self, items: &mut SmallVec<[AnyElement; 8]>, window: &mut Window, cx: &mut App) {
-        // reverse so that last item is bottom most among sticky items
-        for item in items.iter_mut().rev() {
-            item.paint(window, cx);
-        }
+        StickyItemsElement { elements }.into_any_element()
     }
 }

--- a/crates/ui/src/components/sticky_items.rs
+++ b/crates/ui/src/components/sticky_items.rs
@@ -11,7 +11,7 @@ pub trait StickyCandidate {
 }
 
 pub struct StickyItems<T> {
-    compute_fn: Box<dyn Fn(Range<usize>, &mut Window, &mut App) -> Vec<T>>,
+    compute_fn: Box<dyn Fn(Range<usize>, &mut Window, &mut App) -> SmallVec<[T; 8]>>,
     render_fn: Box<dyn Fn(T, &mut Window, &mut App) -> SmallVec<[AnyElement; 8]>>,
     last_item_is_drifting: bool,
     anchor_index: Option<usize>,
@@ -19,7 +19,8 @@ pub struct StickyItems<T> {
 
 pub fn sticky_items<V, T>(
     entity: Entity<V>,
-    compute_fn: impl Fn(&mut V, Range<usize>, &mut Window, &mut Context<V>) -> Vec<T> + 'static,
+    compute_fn: impl Fn(&mut V, Range<usize>, &mut Window, &mut Context<V>) -> SmallVec<[T; 8]>
+    + 'static,
     render_fn: impl Fn(&mut V, T, &mut Window, &mut Context<V>) -> SmallVec<[AnyElement; 8]> + 'static,
 ) -> StickyItems<T>
 where
@@ -30,7 +31,7 @@ where
     let entity_render = entity.clone();
 
     let compute_fn = Box::new(
-        move |range: Range<usize>, window: &mut Window, cx: &mut App| -> Vec<T> {
+        move |range: Range<usize>, window: &mut Window, cx: &mut App| -> SmallVec<[T; 8]> {
             entity_compute.update(cx, |view, cx| compute_fn(view, range, window, cx))
         },
     );

--- a/crates/ui/src/components/sticky_items.rs
+++ b/crates/ui/src/components/sticky_items.rs
@@ -171,7 +171,7 @@ where
 
                 let sticky_origin = bounds.origin
                     + point(
-                        scroll_offset.x,
+                        -scroll_offset.x,
                         -scroll_offset.y + item_height * ix + item_y_offset.unwrap_or(Pixels::ZERO),
                     );
 


### PR DESCRIPTION
Follow up: https://github.com/zed-industries/zed/pull/34042

- Removes `top_slot_items` from `uniform_list` in favor of using existing `decorations`
- Add condition to only show shadow for sticky item when list is scrolled and scrollable

Release Notes:

- N/A
