### PR TITLE
git panel: Add some design refinements

### DIFF
--- a/crates/panel/src/panel.rs
+++ b/crates/panel/src/panel.rs
@@ -67,10 +67,10 @@ pub fn panel_filled_button(label: impl Into<SharedString>) -> ui::Button {
 
 pub fn panel_icon_button(id: impl Into<SharedString>, icon: IconName) -> ui::IconButton {
     let id = ElementId::Name(id.into());
-    ui::IconButton::new(id, icon)
+
+    IconButton::new(id, icon)
         // TODO: Change this once we use on_surface_bg in button_like
         .layer(ui::ElevationIndex::ModalSurface)
-        .size(ui::ButtonSize::Compact)
 }
 
 pub fn panel_filled_icon_button(id: impl Into<SharedString>, icon: IconName) -> ui::IconButton {


### PR DESCRIPTION
Things like borders, border colors, which icons are being used, button sizes, and spacing. There is more to do here: polish that we're using a bunch of divs for spacing, arbitrary pixel values for tokens we have in the system, etc. This is just a quick pass!

Release Notes:

- git panel: Polished the panel spacing, border colors, and icons.
