### PR TITLE
Disable word completions by default for plaintext/markdown

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1603,6 +1603,9 @@
       "use_on_type_format": false,
       "allow_rewrap": "anywhere",
       "soft_wrap": "editor_width",
+      "completions": {
+        "words": "disabled"
+      },
       "prettier": {
         "allowed": true
       }
@@ -1616,6 +1619,9 @@
       }
     },
     "Plain Text": {
+      "completions": {
+        "words": "disabled"
+      },
       "allow_rewrap": "anywhere"
     },
     "Python": {


### PR DESCRIPTION
This disables word based completions in Plain Text and Markdown buffers by default.

Word-based completion when typing natural language can be quite disruptive, in particular at the end of a line (e.g. markdown style lists) where `enter` will accept word completions rather than insert a newline (see screenshot).  I think the default, empty buffer experience in Zed should be closer to a zed-mode experience -- just an editor getting out of your way to let you type and not having to mash escape/cmd-z repeatedly to undo a over-aggressive completion.

<img width="265" alt="Screenshot 2025-07-08 at 11 57 26" src="https://github.com/user-attachments/assets/131f73a8-4687-45bf-ad53-f611c0af9387" />

- Context: https://github.com/zed-industries/zed/issues/4957#issuecomment-3049513501
- Follow-up to: https://github.com/zed-industries/zed/pull/26410

Re-enable the existing behavior with:
```json
  "languages": {
    "Plain Text": { "completions": { "words": "fallback" } },
    "Markdown": { "completions": { "words": "fallback" } },
  },
```
Or disable Word based completions everywhere with:
```json
  "completions": { 
    "words": "fallback"
  },
```

Release Notes:

- Disable word-completions by default in Plain Text and Markdown Buffers