### PR TITLE
gpui: Add `cx.intercept_keystrokes` API to intercept keystrokes before action dispatch

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -272,6 +272,7 @@ pub struct App {
     // TypeId is the type of the event that the listener callback expects
     pub(crate) event_listeners: SubscriberSet<EntityId, (TypeId, Listener)>,
     pub(crate) keystroke_observers: SubscriberSet<(), KeystrokeObserver>,
+    pub(crate) keystroke_interceptors: SubscriberSet<(), KeystrokeObserver>,
     pub(crate) keyboard_layout_observers: SubscriberSet<(), Handler>,
     pub(crate) release_listeners: SubscriberSet<EntityId, ReleaseListener>,
     pub(crate) global_observers: SubscriberSet<TypeId, Handler>,
@@ -344,6 +345,7 @@ impl App {
                 event_listeners: SubscriberSet::new(),
                 release_listeners: SubscriberSet::new(),
                 keystroke_observers: SubscriberSet::new(),
+                keystroke_interceptors: SubscriberSet::new(),
                 keyboard_layout_observers: SubscriberSet::new(),
                 global_observers: SubscriberSet::new(),
                 quit_observers: SubscriberSet::new(),
@@ -1315,6 +1317,32 @@ impl App {
 
         inner(
             &mut self.keystroke_observers,
+            Box::new(move |event, window, cx| {
+                f(event, window, cx);
+                true
+            }),
+        )
+    }
+
+    /// Register a callback to be invoked when a keystroke is received by the application
+    /// in any window. Note that this fires _before_ all other action and event mechanisms have resolved
+    /// unlike [`App::observe_keystrokes`] which fires after. This means that `cx.stop_propogation` calls
+    /// within interceptors will prevent action dispatch
+    pub fn intercept_keystrokes(
+        &mut self,
+        mut f: impl FnMut(&KeystrokeEvent, &mut Window, &mut App) + 'static,
+    ) -> Subscription {
+        fn inner(
+            keystroke_interceptors: &SubscriberSet<(), KeystrokeObserver>,
+            handler: KeystrokeObserver,
+        ) -> Subscription {
+            let (subscription, activate) = keystroke_interceptors.insert((), handler);
+            activate();
+            subscription
+        }
+
+        inner(
+            &mut self.keystroke_interceptors,
             Box::new(move |event, window, cx| {
                 f(event, window, cx);
                 true

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1326,7 +1326,7 @@ impl App {
 
     /// Register a callback to be invoked when a keystroke is received by the application
     /// in any window. Note that this fires _before_ all other action and event mechanisms have resolved
-    /// unlike [`App::observe_keystrokes`] which fires after. This means that `cx.stop_propogation` calls
+    /// unlike [`App::observe_keystrokes`] which fires after. This means that `cx.stop_propagation` calls
     /// within interceptors will prevent action dispatch
     pub fn intercept_keystrokes(
         &mut self,

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3547,6 +3547,12 @@ impl Window {
             return;
         };
 
+        self.dispatch_keystroke_interceptors(event, self.context_stack(), cx);
+        if !cx.propagate_event {
+            self.finish_dispatch_key_event(event, dispatch_path, self.context_stack(), cx);
+            return;
+        }
+
         let mut currently_pending = self.pending_input.take().unwrap_or_default();
         if currently_pending.focus.is_some() && currently_pending.focus != self.focus {
             currently_pending = PendingInput::default();
@@ -3596,7 +3602,6 @@ impl Window {
         }
 
         cx.propagate_event = true;
-        self.dispatch_keystroke_interceptors(event, match_result.context_stack.clone(), cx);
         if cx.propagate_event {
             for binding in match_result.bindings {
                 self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3509,10 +3509,6 @@ impl Window {
 
         let mut keystroke: Option<Keystroke> = None;
 
-        dbg!(&event.downcast_ref::<KeyDownEvent>());
-        dbg!(&event.downcast_ref::<crate::KeyUpEvent>());
-        dbg!(&event.downcast_ref::<ModifiersChangedEvent>());
-
         if let Some(event) = event.downcast_ref::<ModifiersChangedEvent>() {
             if event.modifiers.number_of_modifiers() == 0
                 && self.pending_modifier.modifiers.number_of_modifiers() == 1

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3606,20 +3606,17 @@ impl Window {
             return;
         }
 
-        cx.propagate_event = true;
-        if cx.propagate_event {
-            for binding in match_result.bindings {
-                self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
-                if !cx.propagate_event {
-                    self.dispatch_keystroke_observers(
-                        event,
-                        Some(binding.action),
-                        match_result.context_stack.clone(),
-                        cx,
-                    );
-                    self.pending_input_changed(cx);
-                    return;
-                }
+        for binding in match_result.bindings {
+            self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
+            if !cx.propagate_event {
+                self.dispatch_keystroke_observers(
+                    event,
+                    Some(binding.action),
+                    match_result.context_stack.clone(),
+                    cx,
+                );
+                self.pending_input_changed(cx);
+                return;
             }
         }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -1369,6 +1369,31 @@ impl Window {
         });
     }
 
+    pub(crate) fn dispatch_keystroke_interceptors(
+        &mut self,
+        event: &dyn Any,
+        context_stack: Vec<KeyContext>,
+        cx: &mut App,
+    ) {
+        let Some(key_down_event) = event.downcast_ref::<KeyDownEvent>() else {
+            return;
+        };
+
+        cx.keystroke_interceptors
+            .clone()
+            .retain(&(), move |callback| {
+                (callback)(
+                    &KeystrokeEvent {
+                        keystroke: key_down_event.keystroke.clone(),
+                        action: None,
+                        context_stack: context_stack.clone(),
+                    },
+                    self,
+                    cx,
+                )
+            });
+    }
+
     /// Schedules the given function to be run at the end of the current effect cycle, allowing entities
     /// that are currently on the stack to be returned to the app.
     pub fn defer(&self, cx: &mut App, f: impl FnOnce(&mut Window, &mut App) + 'static) {
@@ -3571,17 +3596,20 @@ impl Window {
         }
 
         cx.propagate_event = true;
-        for binding in match_result.bindings {
-            self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
-            if !cx.propagate_event {
-                self.dispatch_keystroke_observers(
-                    event,
-                    Some(binding.action),
-                    match_result.context_stack.clone(),
-                    cx,
-                );
-                self.pending_input_changed(cx);
-                return;
+        self.dispatch_keystroke_interceptors(event, match_result.context_stack.clone(), cx);
+        if cx.propagate_event {
+            for binding in match_result.bindings {
+                self.dispatch_action_on_node(node_id, binding.action.as_ref(), cx);
+                if !cx.propagate_event {
+                    self.dispatch_keystroke_observers(
+                        event,
+                        Some(binding.action),
+                        match_result.context_stack.clone(),
+                        cx,
+                    );
+                    self.pending_input_changed(cx);
+                    return;
+                }
             }
         }
 

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -3509,6 +3509,10 @@ impl Window {
 
         let mut keystroke: Option<Keystroke> = None;
 
+        dbg!(&event.downcast_ref::<KeyDownEvent>());
+        dbg!(&event.downcast_ref::<crate::KeyUpEvent>());
+        dbg!(&event.downcast_ref::<ModifiersChangedEvent>());
+
         if let Some(event) = event.downcast_ref::<ModifiersChangedEvent>() {
             if event.modifiers.number_of_modifiers() == 0
                 && self.pending_modifier.modifiers.number_of_modifiers() == 1
@@ -3547,6 +3551,7 @@ impl Window {
             return;
         };
 
+        cx.propagate_event = true;
         self.dispatch_keystroke_interceptors(event, self.context_stack(), cx);
         if !cx.propagate_event {
             self.finish_dispatch_key_event(event, dispatch_path, self.context_stack(), cx);

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1169,7 +1169,6 @@ impl KeystrokeInput {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        dbg!(("on modifiers changed", &event.modifiers));
         if let Some(last) = self.keystrokes.last_mut()
             && last.key.is_empty()
         {
@@ -1190,16 +1189,13 @@ impl KeystrokeInput {
     }
 
     fn handle_keystroke(&mut self, keystroke: &Keystroke, cx: &mut Context<Self>) {
-        dbg!(("handle keystroke", &keystroke));
         if let Some(last) = self.keystrokes.last_mut()
             && last.key.is_empty()
         {
             *last = keystroke.clone();
-        } else {
-            if Some(keystroke) != self.keystrokes.last() {
+        } else if Some(keystroke) != self.keystrokes.last() {
                 self.keystrokes.push(keystroke.clone());
             }
-        }
         cx.stop_propagation();
         cx.notify();
     }
@@ -1210,7 +1206,6 @@ impl KeystrokeInput {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        dbg!(("on key up", &event.keystroke));
         if let Some(last) = self.keystrokes.last_mut()
             && !last.key.is_empty()
             && last.modifiers == event.keystroke.modifiers

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1169,6 +1169,7 @@ impl KeystrokeInput {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        dbg!(("on modifiers changed", &event.modifiers));
         if let Some(last) = self.keystrokes.last_mut()
             && last.key.is_empty()
         {
@@ -1189,12 +1190,15 @@ impl KeystrokeInput {
     }
 
     fn handle_keystroke(&mut self, keystroke: &Keystroke, cx: &mut Context<Self>) {
+        dbg!(("handle keystroke", &keystroke));
         if let Some(last) = self.keystrokes.last_mut()
             && last.key.is_empty()
         {
             *last = keystroke.clone();
         } else {
-            self.keystrokes.push(keystroke.clone());
+            if Some(keystroke) != self.keystrokes.last() {
+                self.keystrokes.push(keystroke.clone());
+            }
         }
         cx.stop_propagation();
         cx.notify();
@@ -1206,6 +1210,7 @@ impl KeystrokeInput {
         _window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        dbg!(("on key up", &event.keystroke));
         if let Some(last) = self.keystrokes.last_mut()
             && !last.key.is_empty()
             && last.modifiers == event.keystroke.modifiers

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1194,8 +1194,8 @@ impl KeystrokeInput {
         {
             *last = keystroke.clone();
         } else if Some(keystroke) != self.keystrokes.last() {
-                self.keystrokes.push(keystroke.clone());
-            }
+            self.keystrokes.push(keystroke.clone());
+        }
         cx.stop_propagation();
         cx.notify();
     }

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1200,19 +1200,6 @@ impl KeystrokeInput {
         cx.notify();
     }
 
-    fn on_key_down(
-        &mut self,
-        event: &gpui::KeyDownEvent,
-        _window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        dbg!(("on_key_down", &event.keystroke));
-        if event.is_held {
-            return;
-        }
-        self.handle_keystroke(&event.keystroke, cx);
-    }
-
     fn on_key_up(
         &mut self,
         event: &gpui::KeyUpEvent,
@@ -1236,7 +1223,6 @@ impl KeystrokeInput {
     fn on_focus_in(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         if self.intercept_subscription.is_none() {
             let listener = cx.listener(|this, event: &gpui::KeystrokeEvent, _window, cx| {
-                dbg!(("intercept", &event.keystroke));
                 this.handle_keystroke(&event.keystroke, cx);
             });
             self.intercept_subscription = Some(cx.intercept_keystrokes(listener))
@@ -1271,14 +1257,13 @@ impl Focusable for KeystrokeInput {
 }
 
 impl Render for KeystrokeInput {
-    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let colors = cx.theme().colors();
 
         return h_flex()
             .id("keybinding_input")
             .track_focus(&self.focus_handle)
             .on_modifiers_changed(cx.listener(Self::on_modifiers_changed))
-            .on_key_down(cx.listener(Self::on_key_down))
             .on_key_up(cx.listener(Self::on_key_up))
             .focus(|mut style| {
                 style.border_color = Some(colors.border_focused);


### PR DESCRIPTION
Closes #ISSUE

`cx.intercept_keystrokes` functions as a sibling API to `cx.observe_keystrokes`. Under the hood the two API's are basically identical, however, `cx.observe_keystrokes` runs _after_ all event dispatch handling (including action dispatch) while `cx.intercept_keystrokes` runs _before_. This allows for `cx.stop_propogation()` calls within the `cx.intercept_keystrokes` callback to prevent action dispatch. 

The motivating example usage behind this API is also included in this PR. It is used as part of a keystroke input component that needs to intercept keystrokes before action dispatch to display them.

cc: @mikayla-maki 

Release Notes:

- N/A *or* Added/Fixed/Improved ...
