### PR TITLE
project panel: Add indent guides for sticky items

### DIFF
--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -506,35 +506,6 @@ pub trait UniformListDecoration {
     ) -> AnyElement;
 }
 
-/// A trait for implementing top slots in a [`UniformList`].
-/// Top slots are elements that appear at the top of the list and can adjust
-/// the visible range of list items.
-pub trait UniformListTopSlot {
-    /// Returns elements to render at the top slot for the given visible range.
-    fn compute(
-        &mut self,
-        visible_range: Range<usize>,
-        window: &mut Window,
-        cx: &mut App,
-    ) -> SmallVec<[AnyElement; 8]>;
-
-    /// Layout and prepaint the top slot elements.
-    fn prepaint(
-        &self,
-        elements: &mut SmallVec<[AnyElement; 8]>,
-        bounds: Bounds<Pixels>,
-        item_height: Pixels,
-        scroll_offset: Point<Pixels>,
-        padding: crate::Edges<Pixels>,
-        can_scroll_horizontally: bool,
-        window: &mut Window,
-        cx: &mut App,
-    );
-
-    /// Paint the top slot elements.
-    fn paint(&self, elements: &mut SmallVec<[AnyElement; 8]>, window: &mut Window, cx: &mut App);
-}
-
 impl UniformList {
     /// Selects a specific list item for measurement.
     pub fn with_width_from_item(mut self, item_index: Option<usize>) -> Self {

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -8,7 +8,7 @@ use crate::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId,
     Hitbox, InspectorElementId, InteractiveElement, Interactivity, IntoElement, IsZero, LayoutId,
     ListSizingBehavior, Overflow, Pixels, Point, ScrollHandle, Size, StyleRefinement, Styled,
-    Window, point, size,
+    Window, point, px, size,
 };
 use smallvec::SmallVec;
 use std::{cell::RefCell, cmp, ops::Range, rc::Rc};
@@ -358,7 +358,7 @@ impl Element for UniformList {
                             }
                             ScrollStrategy::ToPosition(sticky_index) => {
                                 let target_y_in_viewport = item_height * sticky_index;
-                                let target_scroll_top = item_top - target_y_in_viewport;
+                                let target_scroll_top = item_top - target_y_in_viewport - px(1.0);
                                 let max_scroll_top =
                                     (content_height - list_height).max(Pixels::ZERO);
                                 let new_scroll_top =

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -8,7 +8,7 @@ use crate::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, Element, ElementId, GlobalElementId,
     Hitbox, InspectorElementId, InteractiveElement, Interactivity, IntoElement, IsZero, LayoutId,
     ListSizingBehavior, Overflow, Pixels, Point, ScrollHandle, Size, StyleRefinement, Styled,
-    Window, point, px, size,
+    Window, point, size,
 };
 use smallvec::SmallVec;
 use std::{cell::RefCell, cmp, ops::Range, rc::Rc};
@@ -358,7 +358,7 @@ impl Element for UniformList {
                             }
                             ScrollStrategy::ToPosition(sticky_index) => {
                                 let target_y_in_viewport = item_height * sticky_index;
-                                let target_scroll_top = item_top - target_y_in_viewport - px(1.0);
+                                let target_scroll_top = item_top - target_y_in_viewport;
                                 let max_scroll_top =
                                     (content_height - list_height).max(Pixels::ZERO);
                                 let new_scroll_top =

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -4584,53 +4584,52 @@ impl OutlinePanel {
                 .track_scroll(self.scroll_handle.clone())
                 .when(show_indent_guides, |list| {
                     list.with_decoration(
-                        ui::indent_guides(
-                            cx.entity().clone(),
-                            px(indent_size),
-                            IndentGuideColors::panel(cx),
-                            |outline_panel, range, _, _| {
-                                let entries = outline_panel.cached_entries.get(range);
-                                if let Some(entries) = entries {
-                                    entries.into_iter().map(|item| item.depth).collect()
-                                } else {
-                                    smallvec::SmallVec::new()
-                                }
-                            },
-                        )
-                        .with_render_fn(
-                            cx.entity().clone(),
-                            move |outline_panel, params, _, _| {
-                                const LEFT_OFFSET: Pixels = px(14.);
+                        ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
+                            .with_compute_indents_fn(
+                                cx.entity().clone(),
+                                |outline_panel, range, _, _| {
+                                    let entries = outline_panel.cached_entries.get(range);
+                                    if let Some(entries) = entries {
+                                        entries.into_iter().map(|item| item.depth).collect()
+                                    } else {
+                                        smallvec::SmallVec::new()
+                                    }
+                                },
+                            )
+                            .with_render_fn(
+                                cx.entity().clone(),
+                                move |outline_panel, params, _, _| {
+                                    const LEFT_OFFSET: Pixels = px(14.);
 
-                                let indent_size = params.indent_size;
-                                let item_height = params.item_height;
-                                let active_indent_guide_ix = find_active_indent_guide_ix(
-                                    outline_panel,
-                                    &params.indent_guides,
-                                );
+                                    let indent_size = params.indent_size;
+                                    let item_height = params.item_height;
+                                    let active_indent_guide_ix = find_active_indent_guide_ix(
+                                        outline_panel,
+                                        &params.indent_guides,
+                                    );
 
-                                params
-                                    .indent_guides
-                                    .into_iter()
-                                    .enumerate()
-                                    .map(|(ix, layout)| {
-                                        let bounds = Bounds::new(
-                                            point(
-                                                layout.offset.x * indent_size + LEFT_OFFSET,
-                                                layout.offset.y * item_height,
-                                            ),
-                                            size(px(1.), layout.length * item_height),
-                                        );
-                                        ui::RenderedIndentGuide {
-                                            bounds,
-                                            layout,
-                                            is_active: active_indent_guide_ix == Some(ix),
-                                            hitbox: None,
-                                        }
-                                    })
-                                    .collect()
-                            },
-                        ),
+                                    params
+                                        .indent_guides
+                                        .into_iter()
+                                        .enumerate()
+                                        .map(|(ix, layout)| {
+                                            let bounds = Bounds::new(
+                                                point(
+                                                    layout.offset.x * indent_size + LEFT_OFFSET,
+                                                    layout.offset.y * item_height,
+                                                ),
+                                                size(px(1.), layout.length * item_height),
+                                            );
+                                            ui::RenderedIndentGuide {
+                                                bounds,
+                                                layout,
+                                                is_active: active_indent_guide_ix == Some(ix),
+                                                hitbox: None,
+                                            }
+                                        })
+                                        .collect()
+                                },
+                            ),
                     )
                 })
             };

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5289,44 +5289,32 @@ impl Render for ProjectPanel {
                         list.with_decoration(if show_indent_guides {
                             sticky_items.with_decoration(
                                 ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
-                                    .with_render_fn(
-                                        cx.entity().clone(),
-                                        move |this, params, _, cx| {
-                                            const LEFT_OFFSET: Pixels = px(14.);
+                                    .with_render_fn(cx.entity().clone(), move |_, params, _, _| {
+                                        const LEFT_OFFSET: Pixels = px(14.);
 
-                                            let active_indent_guide_index = this
-                                                .find_active_indent_guide(
-                                                    &params.indent_guides,
-                                                    cx,
+                                        let indent_size = params.indent_size;
+                                        let item_height = params.item_height;
+
+                                        params
+                                            .indent_guides
+                                            .into_iter()
+                                            .map(|layout| {
+                                                let bounds = Bounds::new(
+                                                    point(
+                                                        layout.offset.x * indent_size + LEFT_OFFSET,
+                                                        layout.offset.y * item_height,
+                                                    ),
+                                                    size(px(1.), layout.length * item_height),
                                                 );
-
-                                            let indent_size = params.indent_size;
-                                            let item_height = params.item_height;
-
-                                            params
-                                                .indent_guides
-                                                .into_iter()
-                                                .enumerate()
-                                                .map(|(idx, layout)| {
-                                                    let bounds = Bounds::new(
-                                                        point(
-                                                            layout.offset.x * indent_size
-                                                                + LEFT_OFFSET,
-                                                            layout.offset.y * item_height,
-                                                        ),
-                                                        size(px(1.), layout.length * item_height),
-                                                    );
-                                                    ui::RenderedIndentGuide {
-                                                        bounds,
-                                                        layout,
-                                                        is_active: Some(idx)
-                                                            == active_indent_guide_index,
-                                                        hitbox: None,
-                                                    }
-                                                })
-                                                .collect()
-                                        },
-                                    ),
+                                                ui::RenderedIndentGuide {
+                                                    bounds,
+                                                    layout,
+                                                    is_active: false,
+                                                    hitbox: None,
+                                                }
+                                            })
+                                            .collect()
+                                    }),
                             )
                         } else {
                             sticky_items

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4941,50 +4941,6 @@ impl ProjectPanel {
             })
             .collect()
     }
-
-    fn render_indent_guides(
-        &self,
-        params: RenderIndentGuideParams,
-        cx: &mut App,
-    ) -> SmallVec<[RenderedIndentGuide; 12]> {
-        const LEFT_OFFSET: Pixels = px(14.);
-        const PADDING_Y: Pixels = px(4.);
-        const HITBOX_OVERDRAW: Pixels = px(3.);
-
-        let active_indent_guide_index = self.find_active_indent_guide(&params.indent_guides, cx);
-
-        let indent_size = params.indent_size;
-        let item_height = params.item_height;
-
-        params
-            .indent_guides
-            .into_iter()
-            .enumerate()
-            .map(|(idx, layout)| {
-                let offset = if layout.continues_offscreen {
-                    px(0.)
-                } else {
-                    PADDING_Y
-                };
-                let bounds = Bounds::new(
-                    point(
-                        layout.offset.x * indent_size + LEFT_OFFSET,
-                        layout.offset.y * item_height + offset,
-                    ),
-                    size(px(1.), layout.length * item_height - offset * 2.),
-                );
-                ui::RenderedIndentGuide {
-                    bounds,
-                    layout,
-                    is_active: Some(idx) == active_indent_guide_index,
-                    hitbox: Some(Bounds::new(
-                        point(bounds.origin.x - HITBOX_OVERDRAW, bounds.origin.y),
-                        size(bounds.size.width + HITBOX_OVERDRAW * 2., bounds.size.height),
-                    )),
-                }
-            })
-            .collect()
-    }
 }
 
 #[derive(Clone)]
@@ -5257,7 +5213,53 @@ impl Render for ProjectPanel {
                                     },
                                 ))
                                 .with_render_fn(cx.entity().clone(), move |this, params, _, cx| {
-                                    this.render_indent_guides(params, cx)
+                                    const LEFT_OFFSET: Pixels = px(14.);
+                                    const PADDING_Y: Pixels = px(4.);
+                                    const HITBOX_OVERDRAW: Pixels = px(3.);
+
+                                    let active_indent_guide_index =
+                                        this.find_active_indent_guide(&params.indent_guides, cx);
+
+                                    let indent_size = params.indent_size;
+                                    let item_height = params.item_height;
+
+                                    params
+                                        .indent_guides
+                                        .into_iter()
+                                        .enumerate()
+                                        .map(|(idx, layout)| {
+                                            let offset = if layout.continues_offscreen {
+                                                px(0.)
+                                            } else {
+                                                PADDING_Y
+                                            };
+                                            let bounds = Bounds::new(
+                                                point(
+                                                    layout.offset.x * indent_size + LEFT_OFFSET,
+                                                    layout.offset.y * item_height + offset,
+                                                ),
+                                                size(
+                                                    px(1.),
+                                                    layout.length * item_height - offset * 2.,
+                                                ),
+                                            );
+                                            ui::RenderedIndentGuide {
+                                                bounds,
+                                                layout,
+                                                is_active: Some(idx) == active_indent_guide_index,
+                                                hitbox: Some(Bounds::new(
+                                                    point(
+                                                        bounds.origin.x - HITBOX_OVERDRAW,
+                                                        bounds.origin.y,
+                                                    ),
+                                                    size(
+                                                        bounds.size.width + HITBOX_OVERDRAW * 2.,
+                                                        bounds.size.height,
+                                                    ),
+                                                )),
+                                            }
+                                        })
+                                        .collect()
                                 }),
                         )
                     })
@@ -5290,7 +5292,39 @@ impl Render for ProjectPanel {
                                     .with_render_fn(
                                         cx.entity().clone(),
                                         move |this, params, _, cx| {
-                                            this.render_indent_guides(params, cx)
+                                            const LEFT_OFFSET: Pixels = px(14.);
+
+                                            let active_indent_guide_index = this
+                                                .find_active_indent_guide(
+                                                    &params.indent_guides,
+                                                    cx,
+                                                );
+
+                                            let indent_size = params.indent_size;
+                                            let item_height = params.item_height;
+
+                                            params
+                                                .indent_guides
+                                                .into_iter()
+                                                .enumerate()
+                                                .map(|(idx, layout)| {
+                                                    let bounds = Bounds::new(
+                                                        point(
+                                                            layout.offset.x * indent_size
+                                                                + LEFT_OFFSET,
+                                                            layout.offset.y * item_height,
+                                                        ),
+                                                        size(px(1.), layout.length * item_height),
+                                                    );
+                                                    ui::RenderedIndentGuide {
+                                                        bounds,
+                                                        layout,
+                                                        is_active: Some(idx)
+                                                            == active_indent_guide_index,
+                                                        hitbox: None,
+                                                    }
+                                                })
+                                                .collect()
                                         },
                                     ),
                             )

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -56,9 +56,8 @@ use std::{
 use theme::ThemeSettings;
 use ui::{
     Color, ContextMenu, DecoratedIcon, Icon, IconDecoration, IconDecorationKind, IndentGuideColors,
-    IndentGuideLayout, KeyBinding, Label, LabelSize, ListItem, ListItemSpacing,
-    RenderIndentGuideParams, RenderedIndentGuide, ScrollableHandle, Scrollbar, ScrollbarState,
-    StickyCandidate, Tooltip, prelude::*, v_flex,
+    IndentGuideLayout, KeyBinding, Label, LabelSize, ListItem, ListItemSpacing, ScrollableHandle,
+    Scrollbar, ScrollbarState, StickyCandidate, Tooltip, prelude::*, v_flex,
 };
 use util::{ResultExt, TakeUntilExt, TryFutureExt, maybe, paths::compare_paths};
 use workspace::{
@@ -3948,7 +3947,7 @@ impl ProjectPanel {
                 false
             }
         });
-        let shadow_color_top = hsla(0.0, 0.0, 0.0, 0.15);
+        let shadow_color_top = hsla(0.0, 0.0, 0.0, 0.8);
         let shadow_color_bottom = hsla(0.0, 0.0, 0.0, 0.);
         let sticky_shadow = div()
             .absolute()

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4176,6 +4176,16 @@ impl ProjectPanel {
                         }
                     } else if kind.is_dir() {
                         this.marked_entries.clear();
+                        if is_sticky {
+                            if let Some((_, _, index)) = this.index_for_entry(entry_id, worktree_id) {
+                                let strategy = sticky_index
+                                    .map(ScrollStrategy::ToPosition)
+                                    .unwrap_or(ScrollStrategy::Top);
+                                this.scroll_handle.scroll_to_item(index, strategy);
+                                cx.notify();
+                                return;
+                            }
+                        }
                         if event.modifiers().alt {
                             this.toggle_expand_all(entry_id, window, cx);
                         } else {
@@ -4187,16 +4197,6 @@ impl ProjectPanel {
                         let focus_opened_item = !preview_tabs_enabled || click_count > 1;
                         let allow_preview = preview_tabs_enabled && click_count == 1;
                         this.open_entry(entry_id, focus_opened_item, allow_preview, cx);
-                    }
-
-                    if is_sticky {
-                        if let Some((_, _, index)) = this.index_for_entry(entry_id, worktree_id) {
-                            let strategy = sticky_index
-                                .map(ScrollStrategy::ToPosition)
-                                .unwrap_or(ScrollStrategy::Top);
-                            this.scroll_handle.scroll_to_item(index, strategy);
-                            cx.notify();
-                        }
                     }
                 }),
             )

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5212,52 +5212,53 @@ impl Render for ProjectPanel {
                     })
                     .when(show_indent_guides, |list| {
                         list.with_decoration(
-                            ui::indent_guides(
-                                cx.entity().clone(),
-                                px(indent_size),
-                                IndentGuideColors::panel(cx),
-                                |this, range, window, cx| {
-                                    let mut items =
-                                        SmallVec::with_capacity(range.end - range.start);
-                                    this.iter_visible_entries(
-                                        range,
-                                        window,
-                                        cx,
-                                        |entry, _, entries, _, _| {
-                                            let (depth, _) = Self::calculate_depth_and_difference(
-                                                entry, entries,
-                                            );
-                                            items.push(depth);
-                                        },
-                                    );
-                                    items
-                                },
-                            )
-                            .on_click(cx.listener(
-                                |this, active_indent_guide: &IndentGuideLayout, window, cx| {
-                                    if window.modifiers().secondary() {
-                                        let ix = active_indent_guide.offset.y;
-                                        let Some((target_entry, worktree)) = maybe!({
-                                            let (worktree_id, entry) = this.entry_at_index(ix)?;
-                                            let worktree = this
-                                                .project
-                                                .read(cx)
-                                                .worktree_for_id(worktree_id, cx)?;
-                                            let target_entry = worktree
-                                                .read(cx)
-                                                .entry_for_path(&entry.path.parent()?)?;
-                                            Some((target_entry, worktree))
-                                        }) else {
-                                            return;
-                                        };
+                            ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
+                                .with_compute_indents_fn(
+                                    cx.entity().clone(),
+                                    |this, range, window, cx| {
+                                        let mut items =
+                                            SmallVec::with_capacity(range.end - range.start);
+                                        this.iter_visible_entries(
+                                            range,
+                                            window,
+                                            cx,
+                                            |entry, _, entries, _, _| {
+                                                let (depth, _) =
+                                                    Self::calculate_depth_and_difference(
+                                                        entry, entries,
+                                                    );
+                                                items.push(depth);
+                                            },
+                                        );
+                                        items
+                                    },
+                                )
+                                .on_click(cx.listener(
+                                    |this, active_indent_guide: &IndentGuideLayout, window, cx| {
+                                        if window.modifiers().secondary() {
+                                            let ix = active_indent_guide.offset.y;
+                                            let Some((target_entry, worktree)) = maybe!({
+                                                let (worktree_id, entry) =
+                                                    this.entry_at_index(ix)?;
+                                                let worktree = this
+                                                    .project
+                                                    .read(cx)
+                                                    .worktree_for_id(worktree_id, cx)?;
+                                                let target_entry = worktree
+                                                    .read(cx)
+                                                    .entry_for_path(&entry.path.parent()?)?;
+                                                Some((target_entry, worktree))
+                                            }) else {
+                                                return;
+                                            };
 
-                                        this.collapse_entry(target_entry.clone(), worktree, cx);
-                                    }
-                                },
-                            ))
-                            .with_render_fn(cx.entity().clone(), move |this, params, _, cx| {
-                                this.render_indent_guides(params, cx)
-                            }),
+                                            this.collapse_entry(target_entry.clone(), worktree, cx);
+                                        }
+                                    },
+                                ))
+                                .with_render_fn(cx.entity().clone(), move |this, params, _, cx| {
+                                    this.render_indent_guides(params, cx)
+                                }),
                         )
                     })
                     .when(show_sticky_scroll, |list| {
@@ -5285,22 +5286,13 @@ impl Render for ProjectPanel {
                         );
                         list.with_decoration(if show_indent_guides {
                             sticky_items.with_decoration(
-                                ui::indent_guides(
-                                    cx.entity().clone(),
-                                    px(indent_size),
-                                    IndentGuideColors::panel(cx),
-                                    |this, range, window, cx| {
-                                        let mut items =
-                                            SmallVec::with_capacity(range.end - range.start);
-                                        items
-                                    },
-                                )
-                                .with_render_fn(
-                                    cx.entity().clone(),
-                                    move |this, params, _, cx| {
-                                        this.render_indent_guides(params, cx)
-                                    },
-                                ),
+                                ui::indent_guides(px(indent_size), IndentGuideColors::panel(cx))
+                                    .with_render_fn(
+                                        cx.entity().clone(),
+                                        move |this, params, _, cx| {
+                                            this.render_indent_guides(params, cx)
+                                        },
+                                    ),
                             )
                         } else {
                             sticky_items

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5288,8 +5288,27 @@ impl Render for ProjectPanel {
                             },
                         );
                         list.with_decoration(if show_indent_guides {
-                            sticky_items
-                                .with_indent_guides(IndentGuideColors::panel(cx), px(indent_size))
+                            sticky_item.with_decoration(ui::indent_guides(
+                                cx.entity().clone(),
+                                px(indent_size),
+                                IndentGuideColors::panel(cx),
+                                |this, range, window, cx| {
+                                    let mut items =
+                                        SmallVec::with_capacity(range.end - range.start);
+                                    this.iter_visible_entries(
+                                        range,
+                                        window,
+                                        cx,
+                                        |entry, _, entries, _, _| {
+                                            let (depth, _) = Self::calculate_depth_and_difference(
+                                                entry, entries,
+                                            );
+                                            items.push(depth);
+                                        },
+                                    );
+                                    items
+                                },
+                            ))
                         } else {
                             sticky_items
                         })

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5265,7 +5265,7 @@ impl Render for ProjectPanel {
                         )
                     })
                     .when(show_sticky_scroll, |list| {
-                        list.with_decoration(ui::sticky_items(
+                        let sticky_items = ui::sticky_items(
                             cx.entity().clone(),
                             |this, range, window, cx| {
                                 let mut items = SmallVec::with_capacity(range.end - range.start);
@@ -5286,7 +5286,13 @@ impl Render for ProjectPanel {
                             |this, marker_entry, window, cx| {
                                 this.render_sticky_entries(marker_entry, window, cx)
                             },
-                        ))
+                        );
+                        list.with_decoration(if show_indent_guides {
+                            sticky_items
+                                .with_indent_guides(IndentGuideColors::panel(cx), px(indent_size))
+                        } else {
+                            sticky_items
+                        })
                     })
                     .size_full()
                     .with_sizing_behavior(ListSizingBehavior::Infer)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3947,7 +3947,7 @@ impl ProjectPanel {
                 false
             }
         });
-        let shadow_color_top = hsla(0.0, 0.0, 0.0, 0.8);
+        let shadow_color_top = hsla(0.0, 0.0, 0.0, 0.1);
         let shadow_color_bottom = hsla(0.0, 0.0, 0.0, 0.);
         let sticky_shadow = div()
             .absolute()

--- a/crates/storybook/src/stories/indent_guides.rs
+++ b/crates/storybook/src/stories/indent_guides.rs
@@ -55,23 +55,27 @@ impl Render for IndentGuidesStory {
                         }),
                     )
                     .with_sizing_behavior(gpui::ListSizingBehavior::Infer)
-                    .with_decoration(ui::indent_guides(
-                        cx.entity().clone(),
-                        px(16.),
-                        ui::IndentGuideColors {
-                            default: Color::Info.color(cx),
-                            hover: Color::Accent.color(cx),
-                            active: Color::Accent.color(cx),
-                        },
-                        |this, range, _cx, _context| {
-                            this.depths
-                                .iter()
-                                .skip(range.start)
-                                .take(range.end - range.start)
-                                .cloned()
-                                .collect()
-                        },
-                    )),
+                    .with_decoration(
+                        ui::indent_guides(
+                            px(16.),
+                            ui::IndentGuideColors {
+                                default: Color::Info.color(cx),
+                                hover: Color::Accent.color(cx),
+                                active: Color::Accent.color(cx),
+                            },
+                        )
+                        .with_compute_indents_fn(
+                            cx.entity().clone(),
+                            |this, range, _cx, _context| {
+                                this.depths
+                                    .iter()
+                                    .skip(range.start)
+                                    .take(range.end - range.start)
+                                    .cloned()
+                                    .collect()
+                            },
+                        ),
+                    ),
                 ),
             )
     }

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -3,6 +3,7 @@ use std::{cmp::Ordering, ops::Range, rc::Rc};
 use gpui::{
     AnyElement, App, Bounds, Entity, Hsla, Point, UniformListDecoration, fill, point, size,
 };
+use gpui::{DispatchPhase, Hitbox, HitboxBehavior, MouseButton, MouseDownEvent, MouseMoveEvent};
 use smallvec::SmallVec;
 
 use crate::prelude::*;
@@ -136,10 +137,6 @@ pub struct IndentGuideLayout {
 
 /// Implements the necessary functionality for rendering indent guides inside a uniform list.
 mod uniform_list {
-    use gpui::{
-        DispatchPhase, Hitbox, HitboxBehavior, MouseButton, MouseDownEvent, MouseMoveEvent,
-    };
-
     use super::*;
 
     impl UniformListDecoration for IndentGuides {
@@ -206,182 +203,237 @@ mod uniform_list {
             indent_guides.into_any_element()
         }
     }
+}
 
-    struct IndentGuidesElement {
-        colors: IndentGuideColors,
-        indent_guides: Rc<SmallVec<[RenderedIndentGuide; 12]>>,
-        on_hovered_indent_guide_click:
-            Option<Rc<dyn Fn(&IndentGuideLayout, &mut Window, &mut App)>>,
-    }
+/// Implements the necessary functionality for rendering indent guides inside a sticky items.
+mod sticky_items {
+    use crate::StickyItemsDecoration;
 
-    enum IndentGuidesElementPrepaintState {
-        Static,
-        Interactive {
-            hitboxes: Rc<SmallVec<[Hitbox; 12]>>,
-            on_hovered_indent_guide_click: Rc<dyn Fn(&IndentGuideLayout, &mut Window, &mut App)>,
-        },
-    }
+    use super::*;
 
-    impl Element for IndentGuidesElement {
-        type RequestLayoutState = ();
-        type PrepaintState = IndentGuidesElementPrepaintState;
-
-        fn id(&self) -> Option<ElementId> {
-            None
-        }
-
-        fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
-            None
-        }
-
-        fn request_layout(
-            &mut self,
-            _id: Option<&gpui::GlobalElementId>,
-            _inspector_id: Option<&gpui::InspectorElementId>,
+    impl StickyItemsDecoration for IndentGuides {
+        fn compute(
+            &self,
+            visible_range: Range<usize>,
+            bounds: Bounds<Pixels>,
+            _scroll_offset: Point<Pixels>,
+            item_height: Pixels,
             window: &mut Window,
             cx: &mut App,
-        ) -> (gpui::LayoutId, Self::RequestLayoutState) {
-            (window.request_layout(gpui::Style::default(), [], cx), ())
-        }
-
-        fn prepaint(
-            &mut self,
-            _id: Option<&gpui::GlobalElementId>,
-            _inspector_id: Option<&gpui::InspectorElementId>,
-            _bounds: Bounds<Pixels>,
-            _request_layout: &mut Self::RequestLayoutState,
-            window: &mut Window,
-            _cx: &mut App,
-        ) -> Self::PrepaintState {
-            if let Some(on_hovered_indent_guide_click) = self.on_hovered_indent_guide_click.clone()
-            {
-                let hitboxes = self
-                    .indent_guides
-                    .as_ref()
-                    .iter()
-                    .map(|guide| {
-                        window.insert_hitbox(
-                            guide.hitbox.unwrap_or(guide.bounds),
-                            HitboxBehavior::Normal,
-                        )
-                    })
-                    .collect();
-                Self::PrepaintState::Interactive {
-                    hitboxes: Rc::new(hitboxes),
-                    on_hovered_indent_guide_click,
-                }
+        ) -> AnyElement {
+            let visible_entries = &(self.compute_indents_fn)(visible_range.clone(), window, cx);
+            let indent_guides = compute_indent_guides(&visible_entries, visible_range.start, false);
+            let mut indent_guides = if let Some(ref custom_render) = self.render_fn {
+                let params = RenderIndentGuideParams {
+                    indent_guides,
+                    indent_size: self.indent_size,
+                    item_height,
+                };
+                custom_render(params, window, cx)
             } else {
-                Self::PrepaintState::Static
-            }
-        }
-
-        fn paint(
-            &mut self,
-            _id: Option<&gpui::GlobalElementId>,
-            _inspector_id: Option<&gpui::InspectorElementId>,
-            _bounds: Bounds<Pixels>,
-            _request_layout: &mut Self::RequestLayoutState,
-            prepaint: &mut Self::PrepaintState,
-            window: &mut Window,
-            _cx: &mut App,
-        ) {
-            let current_view = window.current_view();
-
-            match prepaint {
-                IndentGuidesElementPrepaintState::Static => {
-                    for indent_guide in self.indent_guides.as_ref() {
-                        let fill_color = if indent_guide.is_active {
-                            self.colors.active
-                        } else {
-                            self.colors.default
-                        };
-
-                        window.paint_quad(fill(indent_guide.bounds, fill_color));
-                    }
+                indent_guides
+                    .into_iter()
+                    .map(|layout| RenderedIndentGuide {
+                        bounds: Bounds::new(
+                            point(
+                                layout.offset.x * self.indent_size,
+                                layout.offset.y * item_height,
+                            ),
+                            size(px(1.), layout.length * item_height),
+                        ),
+                        layout,
+                        is_active: false,
+                        hitbox: None,
+                    })
+                    .collect()
+            };
+            for guide in &mut indent_guides {
+                guide.bounds.origin += bounds.origin;
+                if let Some(hitbox) = guide.hitbox.as_mut() {
+                    hitbox.origin += bounds.origin;
                 }
-                IndentGuidesElementPrepaintState::Interactive {
-                    hitboxes,
-                    on_hovered_indent_guide_click,
-                } => {
-                    window.on_mouse_event({
-                        let hitboxes = hitboxes.clone();
-                        let indent_guides = self.indent_guides.clone();
-                        let on_hovered_indent_guide_click = on_hovered_indent_guide_click.clone();
-                        move |event: &MouseDownEvent, phase, window, cx| {
-                            if phase == DispatchPhase::Bubble && event.button == MouseButton::Left {
-                                let mut active_hitbox_ix = None;
-                                for (i, hitbox) in hitboxes.iter().enumerate() {
-                                    if hitbox.is_hovered(window) {
-                                        active_hitbox_ix = Some(i);
-                                        break;
-                                    }
-                                }
+            }
 
-                                let Some(active_hitbox_ix) = active_hitbox_ix else {
-                                    return;
-                                };
+            let indent_guides = IndentGuidesElement {
+                indent_guides: Rc::new(indent_guides),
+                colors: self.colors.clone(),
+                on_hovered_indent_guide_click: self.on_click.clone(),
+            };
+            indent_guides.into_any_element()
+        }
+    }
+}
 
-                                let active_indent_guide = &indent_guides[active_hitbox_ix].layout;
-                                on_hovered_indent_guide_click(active_indent_guide, window, cx);
+struct IndentGuidesElement {
+    colors: IndentGuideColors,
+    indent_guides: Rc<SmallVec<[RenderedIndentGuide; 12]>>,
+    on_hovered_indent_guide_click: Option<Rc<dyn Fn(&IndentGuideLayout, &mut Window, &mut App)>>,
+}
 
-                                cx.stop_propagation();
-                                window.prevent_default();
-                            }
-                        }
-                    });
-                    let mut hovered_hitbox_id = None;
-                    for (i, hitbox) in hitboxes.iter().enumerate() {
-                        window.set_cursor_style(gpui::CursorStyle::PointingHand, hitbox);
-                        let indent_guide = &self.indent_guides[i];
-                        let fill_color = if hitbox.is_hovered(window) {
-                            hovered_hitbox_id = Some(hitbox.id);
-                            self.colors.hover
-                        } else if indent_guide.is_active {
-                            self.colors.active
-                        } else {
-                            self.colors.default
-                        };
+enum IndentGuidesElementPrepaintState {
+    Static,
+    Interactive {
+        hitboxes: Rc<SmallVec<[Hitbox; 12]>>,
+        on_hovered_indent_guide_click: Rc<dyn Fn(&IndentGuideLayout, &mut Window, &mut App)>,
+    },
+}
 
-                        window.paint_quad(fill(indent_guide.bounds, fill_color));
-                    }
+impl Element for IndentGuidesElement {
+    type RequestLayoutState = ();
+    type PrepaintState = IndentGuidesElementPrepaintState;
 
-                    window.on_mouse_event({
-                        let prev_hovered_hitbox_id = hovered_hitbox_id;
-                        let hitboxes = hitboxes.clone();
-                        move |_: &MouseMoveEvent, phase, window, cx| {
-                            let mut hovered_hitbox_id = None;
-                            for hitbox in hitboxes.as_ref() {
+    fn id(&self) -> Option<ElementId> {
+        None
+    }
+
+    fn source_location(&self) -> Option<&'static core::panic::Location<'static>> {
+        None
+    }
+
+    fn request_layout(
+        &mut self,
+        _id: Option<&gpui::GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> (gpui::LayoutId, Self::RequestLayoutState) {
+        (window.request_layout(gpui::Style::default(), [], cx), ())
+    }
+
+    fn prepaint(
+        &mut self,
+        _id: Option<&gpui::GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        window: &mut Window,
+        _cx: &mut App,
+    ) -> Self::PrepaintState {
+        if let Some(on_hovered_indent_guide_click) = self.on_hovered_indent_guide_click.clone() {
+            let hitboxes = self
+                .indent_guides
+                .as_ref()
+                .iter()
+                .map(|guide| {
+                    window
+                        .insert_hitbox(guide.hitbox.unwrap_or(guide.bounds), HitboxBehavior::Normal)
+                })
+                .collect();
+            Self::PrepaintState::Interactive {
+                hitboxes: Rc::new(hitboxes),
+                on_hovered_indent_guide_click,
+            }
+        } else {
+            Self::PrepaintState::Static
+        }
+    }
+
+    fn paint(
+        &mut self,
+        _id: Option<&gpui::GlobalElementId>,
+        _inspector_id: Option<&gpui::InspectorElementId>,
+        _bounds: Bounds<Pixels>,
+        _request_layout: &mut Self::RequestLayoutState,
+        prepaint: &mut Self::PrepaintState,
+        window: &mut Window,
+        _cx: &mut App,
+    ) {
+        let current_view = window.current_view();
+
+        match prepaint {
+            IndentGuidesElementPrepaintState::Static => {
+                for indent_guide in self.indent_guides.as_ref() {
+                    let fill_color = if indent_guide.is_active {
+                        self.colors.active
+                    } else {
+                        self.colors.default
+                    };
+
+                    window.paint_quad(fill(indent_guide.bounds, fill_color));
+                }
+            }
+            IndentGuidesElementPrepaintState::Interactive {
+                hitboxes,
+                on_hovered_indent_guide_click,
+            } => {
+                window.on_mouse_event({
+                    let hitboxes = hitboxes.clone();
+                    let indent_guides = self.indent_guides.clone();
+                    let on_hovered_indent_guide_click = on_hovered_indent_guide_click.clone();
+                    move |event: &MouseDownEvent, phase, window, cx| {
+                        if phase == DispatchPhase::Bubble && event.button == MouseButton::Left {
+                            let mut active_hitbox_ix = None;
+                            for (i, hitbox) in hitboxes.iter().enumerate() {
                                 if hitbox.is_hovered(window) {
-                                    hovered_hitbox_id = Some(hitbox.id);
+                                    active_hitbox_ix = Some(i);
                                     break;
                                 }
                             }
-                            if phase == DispatchPhase::Capture {
-                                // If the hovered hitbox has changed, we need to re-paint the indent guides.
-                                match (prev_hovered_hitbox_id, hovered_hitbox_id) {
-                                    (Some(prev_id), Some(id)) => {
-                                        if prev_id != id {
-                                            cx.notify(current_view)
-                                        }
-                                    }
-                                    (None, Some(_)) => cx.notify(current_view),
-                                    (Some(_), None) => cx.notify(current_view),
-                                    (None, None) => {}
-                                }
+
+                            let Some(active_hitbox_ix) = active_hitbox_ix else {
+                                return;
+                            };
+
+                            let active_indent_guide = &indent_guides[active_hitbox_ix].layout;
+                            on_hovered_indent_guide_click(active_indent_guide, window, cx);
+
+                            cx.stop_propagation();
+                            window.prevent_default();
+                        }
+                    }
+                });
+                let mut hovered_hitbox_id = None;
+                for (i, hitbox) in hitboxes.iter().enumerate() {
+                    window.set_cursor_style(gpui::CursorStyle::PointingHand, hitbox);
+                    let indent_guide = &self.indent_guides[i];
+                    let fill_color = if hitbox.is_hovered(window) {
+                        hovered_hitbox_id = Some(hitbox.id);
+                        self.colors.hover
+                    } else if indent_guide.is_active {
+                        self.colors.active
+                    } else {
+                        self.colors.default
+                    };
+
+                    window.paint_quad(fill(indent_guide.bounds, fill_color));
+                }
+
+                window.on_mouse_event({
+                    let prev_hovered_hitbox_id = hovered_hitbox_id;
+                    let hitboxes = hitboxes.clone();
+                    move |_: &MouseMoveEvent, phase, window, cx| {
+                        let mut hovered_hitbox_id = None;
+                        for hitbox in hitboxes.as_ref() {
+                            if hitbox.is_hovered(window) {
+                                hovered_hitbox_id = Some(hitbox.id);
+                                break;
                             }
                         }
-                    });
-                }
+                        if phase == DispatchPhase::Capture {
+                            // If the hovered hitbox has changed, we need to re-paint the indent guides.
+                            match (prev_hovered_hitbox_id, hovered_hitbox_id) {
+                                (Some(prev_id), Some(id)) => {
+                                    if prev_id != id {
+                                        cx.notify(current_view)
+                                    }
+                                }
+                                (None, Some(_)) => cx.notify(current_view),
+                                (Some(_), None) => cx.notify(current_view),
+                                (None, None) => {}
+                            }
+                        }
+                    }
+                });
             }
         }
     }
+}
 
-    impl IntoElement for IndentGuidesElement {
-        type Element = Self;
+impl IntoElement for IndentGuidesElement {
+    type Element = Self;
 
-        fn into_element(self) -> Self::Element {
-            self
-        }
+    fn into_element(self) -> Self::Element {
+        self
     }
 }
 

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -385,7 +385,7 @@ mod uniform_list {
     }
 }
 
-fn compute_indent_guides(
+pub fn compute_indent_guides(
     indents: &[usize],
     offset: usize,
     includes_trailing_indent: bool,

--- a/crates/ui/src/components/indent_guides.rs
+++ b/crates/ui/src/components/indent_guides.rs
@@ -1,8 +1,6 @@
 use std::{cmp::Ordering, ops::Range, rc::Rc};
 
-use gpui::{
-    AnyElement, App, Bounds, Entity, Hsla, Point, UniformListDecoration, fill, point, size,
-};
+use gpui::{AnyElement, App, Bounds, Entity, Hsla, Point, fill, point, size};
 use gpui::{DispatchPhase, Hitbox, HitboxBehavior, MouseButton, MouseDownEvent, MouseMoveEvent};
 use smallvec::SmallVec;
 
@@ -184,6 +182,8 @@ pub struct IndentGuideLayout {
 
 /// Implements the necessary functionality for rendering indent guides inside a uniform list.
 mod uniform_list {
+    use gpui::UniformListDecoration;
+
     use super::*;
 
     impl UniformListDecoration for IndentGuides {

--- a/crates/ui/src/components/sticky_items.rs
+++ b/crates/ui/src/components/sticky_items.rs
@@ -3,7 +3,7 @@ use std::{ops::Range, rc::Rc};
 use gpui::{
     AnyElement, App, AvailableSpace, Bounds, Context, Element, ElementId, Entity, GlobalElementId,
     InspectorElementId, IntoElement, LayoutId, Pixels, Point, Render, Style, UniformListDecoration,
-    Window, point, size,
+    Window, bounds, point, size,
 };
 use smallvec::SmallVec;
 
@@ -184,9 +184,14 @@ where
                 .collect();
 
             for decoration in &self.decorations {
+                let origin = bounds.origin - scroll_offset;
+                let s = bounds.size;
+
+                let new_bounds = Bounds::new(origin, s);
+
                 let mut decoration = decoration.as_ref().compute(
                     &indents,
-                    bounds,
+                    new_bounds,
                     scroll_offset,
                     item_height,
                     window,

--- a/crates/ui/src/components/sticky_items.rs
+++ b/crates/ui/src/components/sticky_items.rs
@@ -120,7 +120,7 @@ impl Element for StickyItemsElement {
         for item in self.elements.iter_mut().rev() {
             item.paint(window, cx);
         }
-        for item in self.decorations.iter_mut().rev() {
+        for item in self.decorations.iter_mut() {
             item.paint(window, cx);
         }
     }
@@ -178,9 +178,7 @@ where
             let indents: SmallVec<[usize; 8]> = elements
                 .iter()
                 .enumerate()
-                .map(|(ix, _)| {
-                    anchor_depth.saturating_sub(items_count.saturating_sub(1).saturating_sub(ix))
-                })
+                .map(|(ix, _)| anchor_depth.saturating_sub(items_count.saturating_sub(ix)))
                 .collect();
 
             for decoration in &self.decorations {

--- a/crates/ui/src/components/sticky_items.rs
+++ b/crates/ui/src/components/sticky_items.rs
@@ -175,7 +175,7 @@ where
             elements = (self.render_fn)(anchor_entry, window, cx);
             let items_count = elements.len();
 
-            let sticky_depths: SmallVec<[usize; 8]> = elements
+            let indents: SmallVec<[usize; 8]> = elements
                 .iter()
                 .enumerate()
                 .map(|(ix, _)| {
@@ -185,7 +185,7 @@ where
 
             for decoration in &self.decorations {
                 let mut decoration = decoration.as_ref().compute(
-                    sticky_depths,
+                    &indents,
                     bounds,
                     scroll_offset,
                     item_height,
@@ -243,7 +243,7 @@ pub trait StickyItemsDecoration {
     /// the bounds of the list, and the height of each item.
     fn compute(
         &self,
-        visible_range: Range<usize>,
+        indents: &SmallVec<[usize; 8]>,
         bounds: Bounds<Pixels>,
         scroll_offset: Point<Pixels>,
         item_height: Pixels,


### PR DESCRIPTION

- Adds new trait `StickyItemsDecoration` in `sticky_items` which is implemented by `IndentGuides` from `indent_guides`.

<img width="347" alt="image" src="https://github.com/user-attachments/assets/577748bc-13f6-41b8-9266-6a0b72349a18" />

Release Notes:

- N/A
