### PR TITLE
helix: Stay in helix normal mode after helix delete

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -368,40 +368,40 @@ mod test {
         cx.assert_state("aa\n«ˇ  »bb", Mode::HelixNormal);
     }
 
-    // #[gpui::test]
-    // async fn test_delete(cx: &mut gpui::TestAppContext) {
-    //     let mut cx = VimTestContext::new(cx, true).await;
+    #[gpui::test]
+    async fn test_delete(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
 
-    //     // test delete a selection
-    //     cx.set_state(
-    //         indoc! {"
-    //         The qu«ick ˇ»brown
-    //         fox jumps over
-    //         the lazy dog."},
-    //         Mode::HelixNormal,
-    //     );
+        // test delete a selection
+        cx.set_state(
+            indoc! {"
+            The qu«ick ˇ»brown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
 
-    //     cx.simulate_keystrokes("d");
+        cx.simulate_keystrokes("d");
 
-    //     cx.assert_state(
-    //         indoc! {"
-    //         The quˇbrown
-    //         fox jumps over
-    //         the lazy dog."},
-    //         Mode::HelixNormal,
-    //     );
+        cx.assert_state(
+            indoc! {"
+            The quˇbrown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
 
-    //     // test deleting a single character
-    //     cx.simulate_keystrokes("d");
+        // test deleting a single character
+        cx.simulate_keystrokes("d");
 
-    //     cx.assert_state(
-    //         indoc! {"
-    //         The quˇrown
-    //         fox jumps over
-    //         the lazy dog."},
-    //         Mode::HelixNormal,
-    //     );
-    // }
+        cx.assert_state(
+            indoc! {"
+            The quˇrown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
+    }
 
     // #[gpui::test]
     // async fn test_delete_character_end_of_line(cx: &mut gpui::TestAppContext) {

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -138,6 +138,7 @@ pub(crate) fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
             })
         });
         vim.visual_delete(false, window, cx);
+        vim.switch_mode(Mode::HelixNormal, true, window, cx);
     });
 
     Vim::action(editor, cx, |vim, _: &ChangeToEndOfLine, window, cx| {


### PR DESCRIPTION
Currently, the HelixDelete action switches to (vim) Normal mode instead of HelixNormal mode. This adds a line to the helix delete action to stay in helix normal mode.

There was already a commented-out test for this. I've uncommented it and it now passes.

Release Notes:

- helix: Fixed switching to vim NORMAL mode instead of HELIX_NORMAL mode after deletion
