### PR TITLE
git: Intercept signing prompt from GPG when committing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -542,6 +542,7 @@ dependencies = [
  "parking_lot",
  "smol",
  "tempfile",
+ "unindent",
  "util",
  "workspace-hack",
 ]

--- a/crates/askpass/Cargo.toml
+++ b/crates/askpass/Cargo.toml
@@ -11,6 +11,9 @@ workspace = true
 [lib]
 path = "src/askpass.rs"
 
+[features]
+test-support = []
+
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true
@@ -19,5 +22,6 @@ net.workspace = true
 parking_lot.workspace = true
 smol.workspace = true
 tempfile.workspace = true
+unindent.workspace = true
 util.workspace = true
 workspace-hack.workspace = true

--- a/crates/askpass/Cargo.toml
+++ b/crates/askpass/Cargo.toml
@@ -11,9 +11,6 @@ workspace = true
 [lib]
 path = "src/askpass.rs"
 
-[features]
-test-support = []
-
 [dependencies]
 anyhow.workspace = true
 futures.workspace = true

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -311,10 +311,10 @@ fn generate_gpg_script() -> String {
         unset GIT_CONFIG_PARAMETERS
         GPG_PROGRAM=$(git config gpg.program || echo 'gpg')
         PROMPT="Enter passphrase to unlock GPG key"
-        PASSPHRASE=$(${{GIT_ASKPASS}} "${{PROMPT}}")
+        PASSPHRASE=$(${GIT_ASKPASS} "${PROMPT}")
 
-        exec "${{GPG_PROGRAM}}" --batch --no-tty --yes --passphrase-fd 3 --pinentry-mode loopback "$@" 3<<EOF
-        ${{PASSPHRASE}}
+        exec "${GPG_PROGRAM}" --batch --no-tty --yes --passphrase-fd 3 --pinentry-mode loopback "$@" 3<<EOF
+        ${PASSPHRASE}
         EOF
     "#.unindent()
 }

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -71,8 +71,6 @@ const ASKPASS_SCRIPT_NAME: &str = "askpass.ps1";
 
 #[cfg(not(target_os = "windows"))]
 const GPG_SCRIPT_NAME: &str = "gpg.sh";
-#[cfg(target_os = "windows")]
-const GPG_SCRIPT_NAME: &str = "gpg.ps1";
 
 impl AskPassSession {
     /// This will create a new AskPassSession.

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -310,7 +310,7 @@ fn generate_gpg_script() -> String {
 
         unset GIT_CONFIG_PARAMETERS
         GPG_PROGRAM=$(git config gpg.program || echo 'gpg')
-        PROMPT="Enter passphrase to unlock GPG key"
+        PROMPT="Enter passphrase to unlock GPG key:"
         PASSPHRASE=$(${GIT_ASKPASS} "${PROMPT}")
 
         exec "${GPG_PROGRAM}" --batch --no-tty --yes --passphrase-fd 3 --pinentry-mode loopback "$@" 3<<EOF

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -42,15 +42,8 @@ impl AskPassDelegate {
         Ok(rx.await?)
     }
 
-    #[cfg(any(test, feature = "test-support"))]
-    pub fn fake() -> Self {
-        // FIXME
+    pub fn new_always_failing() -> Self {
         let (tx, _rx) = mpsc::unbounded::<(String, oneshot::Sender<String>)>();
-        // let task = cx.spawn(
-        //     async move |_: &mut AsyncApp| {
-        //         while let Some(_) = rx.next().await {}
-        //     },
-        // );
         Self {
             tx,
             _task: Task::ready(()),

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -6,7 +6,7 @@ use git::{
     blame::Blame,
     repository::{
         AskPassDelegate, Branch, CommitDetails, CommitOptions, FetchOptions, GitRepository,
-        GitRepositoryCheckpoint, PushOptions, Remote, RemoteCommandOutput, RepoPath, ResetMode,
+        GitRepositoryCheckpoint, PushOptions, Remote, RepoPath, ResetMode,
     },
     status::{FileStatus, GitStatus, StatusCode, TrackedStatus, UnmergedStatus},
 };
@@ -378,7 +378,7 @@ impl GitRepository for FakeGitRepository {
         _ask_pass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
         _cx: AsyncApp,
-    ) -> BoxFuture<'static, Result<RemoteCommandOutput>> {
+    ) -> BoxFuture<'static, Result<()>> {
         unimplemented!()
     }
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -6,7 +6,7 @@ use git::{
     blame::Blame,
     repository::{
         AskPassDelegate, Branch, CommitDetails, CommitOptions, FetchOptions, GitRepository,
-        GitRepositoryCheckpoint, PushOptions, Remote, RepoPath, ResetMode,
+        GitRepositoryCheckpoint, PushOptions, Remote, RemoteCommandOutput, RepoPath, ResetMode,
     },
     status::{FileStatus, GitStatus, StatusCode, TrackedStatus, UnmergedStatus},
 };
@@ -375,8 +375,10 @@ impl GitRepository for FakeGitRepository {
         _message: gpui::SharedString,
         _name_and_email: Option<(gpui::SharedString, gpui::SharedString)>,
         _options: CommitOptions,
+        _ask_pass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
-    ) -> BoxFuture<'_, Result<()>> {
+        _cx: AsyncApp,
+    ) -> BoxFuture<'static, Result<RemoteCommandOutput>> {
         unimplemented!()
     }
 

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -41,7 +41,6 @@ futures.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-askpass = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
 serde_json.workspace = true

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -41,9 +41,10 @@ futures.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
+askpass = { workspace = true, features = ["test-support"] }
+gpui = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
 serde_json.workspace = true
+tempfile.workspace = true
 text = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
-gpui = { workspace = true, features = ["test-support"] }
-tempfile.workspace = true

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -391,8 +391,12 @@ pub trait GitRepository: Send + Sync {
         message: SharedString,
         name_and_email: Option<(SharedString, SharedString)>,
         options: CommitOptions,
+        askpass: AskPassDelegate,
         env: Arc<HashMap<String, String>>,
-    ) -> BoxFuture<'_, Result<()>>;
+        // This method takes an AsyncApp to ensure it's invoked on the main thread,
+        // otherwise git-credentials-manager won't work.
+        cx: AsyncApp,
+    ) -> BoxFuture<'static, Result<RemoteCommandOutput>>;
 
     fn push(
         &self,
@@ -1193,36 +1197,66 @@ impl GitRepository for RealGitRepository {
         message: SharedString,
         name_and_email: Option<(SharedString, SharedString)>,
         options: CommitOptions,
+        ask_pass: AskPassDelegate,
         env: Arc<HashMap<String, String>>,
-    ) -> BoxFuture<'_, Result<()>> {
+        cx: AsyncApp,
+    ) -> BoxFuture<'static, Result<RemoteCommandOutput>> {
         let working_directory = self.working_directory();
-        self.executor
-            .spawn(async move {
-                let mut cmd = new_smol_command("git");
-                cmd.current_dir(&working_directory?)
-                    .envs(env.iter())
-                    .args(["commit", "--quiet", "-m"])
-                    .arg(&message.to_string())
-                    .arg("--cleanup=strip");
+        let executor = cx.background_executor().clone();
+        async move {
+            let working_directory = working_directory?;
+            let have_user_git_askpass = env.contains_key("GIT_ASKPASS");
+            let mut command = new_smol_command("git");
+            command.current_dir(&working_directory).envs(env.iter());
 
-                if options.amend {
-                    cmd.arg("--amend");
-                }
+            let ask_pass = if have_user_git_askpass {
+                dbg!("HAVE USER ASKPASS");
+                None
+            } else {
+                dbg!("MAKE AN ASKPASS");
+                Some(AskPassSession::new(&executor, ask_pass).await?)
+            };
 
-                if let Some((name, email)) = name_and_email {
-                    cmd.arg("--author").arg(&format!("{name} <{email}>"));
-                }
+            if let Some(ask_pass) = ask_pass.as_ref() {
+                command.arg("-c").arg(dbg!(format!(
+                    "gpg.program={}",
+                    ask_pass.gpg_script_path().as_ref().to_string_lossy()
+                )));
+            }
 
-                let output = cmd.output().await?;
+            command
+                .args(["commit", "--quiet", "-m"])
+                .arg(&message.to_string())
+                .arg("--cleanup=strip");
 
+            if options.amend {
+                command.arg("--amend");
+            }
+
+            if let Some((name, email)) = name_and_email {
+                command.arg("--author").arg(&format!("{name} <{email}>"));
+            }
+
+            if let Some(ask_pass) = ask_pass {
+                command.env("GIT_ASKPASS", ask_pass.script_path());
+                let git_process = command.spawn()?;
+
+                run_askpass_command(ask_pass, git_process).await
+            } else {
+                let git_process = command.spawn()?;
+                let output = git_process.output().await?;
                 anyhow::ensure!(
                     output.status.success(),
-                    "Failed to commit:\n{}",
+                    "{}",
                     String::from_utf8_lossy(&output.stderr)
                 );
-                Ok(())
-            })
-            .boxed()
+                Ok(RemoteCommandOutput {
+                    stdout: String::from_utf8_lossy(&output.stdout).to_string(),
+                    stderr: String::from_utf8_lossy(&output.stderr).to_string(),
+                })
+            }
+        }
+        .boxed()
     }
 
     fn push(
@@ -2046,12 +2080,16 @@ mod tests {
         )
         .await
         .unwrap();
-        repo.commit(
-            "Initial commit".into(),
-            None,
-            CommitOptions::default(),
-            Arc::new(checkpoint_author_envs()),
-        )
+        cx.spawn(|cx| {
+            repo.commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::fake(),
+                Arc::new(checkpoint_author_envs()),
+                cx,
+            )
+        })
         .await
         .unwrap();
 
@@ -2075,12 +2113,16 @@ mod tests {
         )
         .await
         .unwrap();
-        repo.commit(
-            "Commit after checkpoint".into(),
-            None,
-            CommitOptions::default(),
-            Arc::new(checkpoint_author_envs()),
-        )
+        cx.spawn(|cx| {
+            repo.commit(
+                "Commit after checkpoint".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::fake(),
+                Arc::new(checkpoint_author_envs()),
+                cx,
+            )
+        })
         .await
         .unwrap();
 
@@ -2213,12 +2255,16 @@ mod tests {
         )
         .await
         .unwrap();
-        repo.commit(
-            "Initial commit".into(),
-            None,
-            CommitOptions::default(),
-            Arc::new(checkpoint_author_envs()),
-        )
+        cx.spawn(|cx| {
+            repo.commit(
+                "Initial commit".into(),
+                None,
+                CommitOptions::default(),
+                AskPassDelegate::fake(),
+                Arc::new(checkpoint_author_envs()),
+                cx,
+            )
+        })
         .await
         .unwrap();
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1223,9 +1223,12 @@ impl GitRepository for RealGitRepository {
             }
 
             command
-                .args(["commit", "--quiet", "-m"])
-                .arg(&message.to_string())
-                .arg("--cleanup=strip");
+                .args(["commit", "-m"])
+                .arg(message.to_string())
+                .arg("--cleanup=strip")
+                .stdin(smol::process::Stdio::null())
+                .stdout(smol::process::Stdio::piped())
+                .stderr(smol::process::Stdio::piped());
 
             if options.amend {
                 command.arg("--amend");
@@ -1826,7 +1829,6 @@ async fn run_askpass_command(
         }
         output = git_process.output().fuse() => {
             let output = output?;
-            // FIXME git output
             anyhow::ensure!(
                 output.status.success(),
                 "{}",

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1826,6 +1826,7 @@ async fn run_askpass_command(
         }
         output = git_process.output().fuse() => {
             let output = output?;
+            // FIXME git output
             anyhow::ensure!(
                 output.status.success(),
                 "{}",

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1215,10 +1215,13 @@ impl GitRepository for RealGitRepository {
                 Some(AskPassSession::new(&executor, ask_pass).await?)
             };
 
-            if let Some(ask_pass) = ask_pass.as_ref() {
+            if let Some(program) = ask_pass
+                .as_ref()
+                .and_then(|ask_pass| ask_pass.gpg_script_path())
+            {
                 command.arg("-c").arg(format!(
                     "gpg.program={}",
-                    ask_pass.gpg_script_path().as_ref().to_string_lossy()
+                    program.as_ref().to_string_lossy()
                 ));
             }
 

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1574,10 +1574,15 @@ impl GitPanel {
 
         let task = if self.has_staged_changes() {
             // Repository serializes all git operations, so we can just send a commit immediately
-            let commit_task = active_repository.update(cx, |repo, cx| {
-                repo.commit(message.into(), None, options, cx)
-            });
-            cx.background_spawn(async move { commit_task.await? })
+            cx.spawn_in(window, async move |this, cx| {
+                let askpass_delegate = this.update_in(cx, |this, window, cx| {
+                    this.askpass_delegate(format!("git commit"), window, cx)
+                })?;
+                let commit_task = active_repository.update(cx, |repo, cx| {
+                    repo.commit(message.into(), None, options, askpass_delegate, cx)
+                })?;
+                commit_task.await?
+            })
         } else {
             let changed_files = self
                 .entries
@@ -1594,10 +1599,13 @@ impl GitPanel {
 
             let stage_task =
                 active_repository.update(cx, |repo, cx| repo.stage_entries(changed_files, cx));
-            cx.spawn(async move |_, cx| {
+            cx.spawn_in(window, async move |this, cx| {
                 stage_task.await?;
+                let askpass_delegate = this.update_in(cx, |this, window, cx| {
+                    this.askpass_delegate(format!("git commit"), window, cx)
+                })?;
                 let commit_task = active_repository.update(cx, |repo, cx| {
-                    repo.commit(message.into(), None, options, cx)
+                    repo.commit(message.into(), None, options, askpass_delegate, cx)
                 })?;
                 commit_task.await?
             })
@@ -1606,8 +1614,9 @@ impl GitPanel {
             let result = task.await;
             this.update_in(cx, |this, window, cx| {
                 this.pending_commit.take();
+                // FIXME use the output?
                 match result {
-                    Ok(()) => {
+                    Ok(_) => {
                         this.commit_editor
                             .update(cx, |editor, cx| editor.clear(window, cx));
                     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1576,7 +1576,7 @@ impl GitPanel {
             // Repository serializes all git operations, so we can just send a commit immediately
             cx.spawn_in(window, async move |this, cx| {
                 let askpass_delegate = this.update_in(cx, |this, window, cx| {
-                    this.askpass_delegate(format!("git commit"), window, cx)
+                    this.askpass_delegate("git commit", window, cx)
                 })?;
                 let commit_task = active_repository.update(cx, |repo, cx| {
                     repo.commit(message.into(), None, options, askpass_delegate, cx)
@@ -1602,7 +1602,7 @@ impl GitPanel {
             cx.spawn_in(window, async move |this, cx| {
                 stage_task.await?;
                 let askpass_delegate = this.update_in(cx, |this, window, cx| {
-                    this.askpass_delegate(format!("git commit"), window, cx)
+                    this.askpass_delegate("git commit".to_string(), window, cx)
                 })?;
                 let commit_task = active_repository.update(cx, |repo, cx| {
                     repo.commit(message.into(), None, options, askpass_delegate, cx)

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1614,9 +1614,8 @@ impl GitPanel {
             let result = task.await;
             this.update_in(cx, |this, window, cx| {
                 this.pending_commit.take();
-                // FIXME use the output?
                 match result {
-                    Ok(_) => {
+                    Ok(()) => {
                         this.commit_editor
                             .update(cx, |editor, cx| editor.clear(window, cx));
                     }

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -669,25 +669,25 @@ impl DapStore {
             .map(|session_id| self.shutdown_session(*session_id, cx))
             .collect::<Vec<_>>();
 
-        let shutdown_parent_task = if let Some(parent_session) = session
-            .read(cx)
-            .parent_id(cx)
-            .and_then(|session_id| self.session_by_id(session_id))
-        {
-            let shutdown_id = parent_session.update(cx, |parent_session, _| {
-                parent_session.remove_child_session_id(session_id);
+        // let shutdown_parent_task = if let Some(parent_session) = session
+        //     .read(cx)
+        //     .parent_id(cx)
+        //     .and_then(|session_id| self.session_by_id(session_id))
+        // {
+        //     let shutdown_id = parent_session.update(cx, |parent_session, _| {
+        //         parent_session.remove_child_session_id(session_id);
 
-                if parent_session.child_session_ids().len() == 0 {
-                    Some(parent_session.session_id())
-                } else {
-                    None
-                }
-            });
+        //         if parent_session.child_session_ids().len() == 0 {
+        //             Some(parent_session.session_id())
+        //         } else {
+        //             None
+        //         }
+        //     });
 
-            shutdown_id.map(|session_id| self.shutdown_session(session_id, cx))
-        } else {
-            None
-        };
+        //     shutdown_id.map(|session_id| self.shutdown_session(session_id, cx))
+        // } else {
+        //     None
+        // };
 
         let shutdown_task = session.update(cx, |this, cx| this.shutdown(cx));
 
@@ -700,9 +700,9 @@ impl DapStore {
 
             shutdown_task.await;
 
-            if let Some(parent_task) = shutdown_parent_task {
-                parent_task.await?;
-            }
+            // if let Some(parent_task) = shutdown_parent_task {
+            //     parent_task.await?;
+            // }
 
             Ok(())
         })

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3513,7 +3513,6 @@ impl Repository {
                             }),
                             askpass_id: Some(askpass_id),
                         })
-                        // FIXME
                         .await?;
 
                     Ok(())

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3497,8 +3497,7 @@ impl Repository {
                     askpass_delegates.lock().insert(askpass_id, askpass);
                     let _defer = util::defer(|| {
                         let askpass_delegate = askpass_delegates.lock().remove(&askpass_id);
-                        // FIXME
-                        // debug_assert!(askpass_delegate.is_some());
+                        debug_assert!(askpass_delegate.is_some());
                     });
 
                     let (name, email) = name_and_email.unzip();
@@ -3514,8 +3513,8 @@ impl Repository {
                             }),
                             askpass_id: Some(askpass_id),
                         })
-                        .await
-                        .context("sending commit request")?;
+                        // FIXME
+                        .await?;
 
                     Ok(())
                 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -3497,7 +3497,8 @@ impl Repository {
                     askpass_delegates.lock().insert(askpass_id, askpass);
                     let _defer = util::defer(|| {
                         let askpass_delegate = askpass_delegates.lock().remove(&askpass_id);
-                        debug_assert!(askpass_delegate.is_some());
+                        // FIXME
+                        // debug_assert!(askpass_delegate.is_some());
                     });
 
                     let (name, email) = name_and_email.unzip();

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -294,6 +294,7 @@ message Commit {
     optional string email = 5;
     string message = 6;
     optional CommitOptions options = 7;
+    optional uint64 askpass_id = 8;
 
     message CommitOptions {
         bool amend = 1;


### PR DESCRIPTION
Closes #30111 

- [x] basic implementation
- [x] implementation for remote projects
- [x] surface error output from GPG if signing fails
- [ ] ~~Windows~~

Release Notes:

- git: Passphrase prompts from GPG to unlock commit signing keys are now shown in Zed.