### PR TITLE
Change the name of windows CI to reflect what it's doing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -390,7 +390,7 @@ jobs:
 
   windows_tests:
     timeout-minutes: 60
-    name: (Windows) Run Tests
+    name: (Windows) Run Clippy and tests
     needs: [job_spec]
     if: |
       github.repository_owner == 'zed-industries' &&


### PR DESCRIPTION
We're running clippy and tests in our ci

Release Notes:

- N/A
