### PR TITLE
editor: Add CollapseAllDiffHunks docs

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -303,7 +303,7 @@ actions!(
         ApplyDiffHunk,
         /// Deletes the character before the cursor.
         Backspace,
-        /// Cancels the current operation.
+        /// Cancels the current operation. Collapses expanded diff hunks, dismisses menus, and clears selections.
         Cancel,
         /// Cancels the running flycheck operation.
         CancelFlycheck,

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -303,7 +303,7 @@ actions!(
         ApplyDiffHunk,
         /// Deletes the character before the cursor.
         Backspace,
-        /// Cancels the current operation. Collapses expanded diff hunks, dismisses menus, and clears selections.
+        /// Cancels the current operation.
         Cancel,
         /// Cancels the running flycheck operation.
         CancelFlycheck,

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -125,29 +125,29 @@ When viewing files with changes, Zed displays diff hunks that can be expanded or
 
 ## Action Reference
 
-| Action                                 | Keybinding                         |
-| -------------------------------------- | ---------------------------------- |
-| {#action git::Add}                     | {#kb git::Add}                     |
-| {#action git::StageAll}                | {#kb git::StageAll}                |
-| {#action git::UnstageAll}              | {#kb git::UnstageAll}              |
-| {#action git::ToggleStaged}            | {#kb git::ToggleStaged}            |
-| {#action git::StageAndNext}            | {#kb git::StageAndNext}            |
-| {#action git::UnstageAndNext}          | {#kb git::UnstageAndNext}          |
-| {#action git::Commit}                  | {#kb git::Commit}                  |
-| {#action git::ExpandCommitEditor}      | {#kb git::ExpandCommitEditor}      |
-| {#action git::Push}                    | {#kb git::Push}                    |
-| {#action git::ForcePush}               | {#kb git::ForcePush}               |
-| {#action git::Pull}                    | {#kb git::Pull}                    |
-| {#action git::Fetch}                   | {#kb git::Fetch}                   |
-| {#action git::Diff}                    | {#kb git::Diff}                    |
-| {#action git::Restore}                 | {#kb git::Restore}                 |
-| {#action git::RestoreFile}             | {#kb git::RestoreFile}             |
-| {#action git::Branch}                  | {#kb git::Branch}                  |
-| {#action git::Switch}                  | {#kb git::Switch}                  |
-| {#action git::CheckoutBranch}          | {#kb git::CheckoutBranch}          |
-| {#action git::Blame}                   | {#kb git::Blame}                   |
-| {#action editor::ToggleGitBlameInline} | {#kb editor::ToggleGitBlameInline} |
-| {#action editor::ExpandAllDiffHunks}   | {#kb editor::ExpandAllDiffHunks}   |
+| Action                                    | Keybinding                            |
+| ----------------------------------------- | ------------------------------------- |
+| {#action git::Add}                        | {#kb git::Add}                        |
+| {#action git::StageAll}                   | {#kb git::StageAll}                   |
+| {#action git::UnstageAll}                 | {#kb git::UnstageAll}                 |
+| {#action git::ToggleStaged}               | {#kb git::ToggleStaged}               |
+| {#action git::StageAndNext}               | {#kb git::StageAndNext}               |
+| {#action git::UnstageAndNext}             | {#kb git::UnstageAndNext}             |
+| {#action git::Commit}                     | {#kb git::Commit}                     |
+| {#action git::ExpandCommitEditor}         | {#kb git::ExpandCommitEditor}         |
+| {#action git::Push}                       | {#kb git::Push}                       |
+| {#action git::ForcePush}                  | {#kb git::ForcePush}                  |
+| {#action git::Pull}                       | {#kb git::Pull}                       |
+| {#action git::Fetch}                      | {#kb git::Fetch}                      |
+| {#action git::Diff}                       | {#kb git::Diff}                       |
+| {#action git::Restore}                    | {#kb git::Restore}                    |
+| {#action git::RestoreFile}                | {#kb git::RestoreFile}                |
+| {#action git::Branch}                     | {#kb git::Branch}                     |
+| {#action git::Switch}                     | {#kb git::Switch}                     |
+| {#action git::CheckoutBranch}             | {#kb git::CheckoutBranch}             |
+| {#action git::Blame}                      | {#kb git::Blame}                      |
+| {#action editor::ToggleGitBlameInline}    | {#kb editor::ToggleGitBlameInline}    |
+| {#action editor::ExpandAllDiffHunks}      | {#kb editor::ExpandAllDiffHunks}      |
 | {#action editor::ToggleSelectedDiffHunks} | {#kb editor::ToggleSelectedDiffHunks} |
 
 > Not all actions have default keybindings, but can be bound by [customizing your keymap](./key-bindings.md#user-keymaps).

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -112,6 +112,17 @@ by creating a [custom key bindings](key-bindings.md#custom-key-bindings) to the
 `editor::CopyPermalinkToLine` or `editor::OpenPermalinkToLine` actions
 or by simply right clicking and selecting `Copy Permalink` with line(s) selected in your editor.
 
+## Diff Hunk Keyboard Shortcuts
+
+When viewing files with changes, Zed displays diff hunks that can be expanded or collapsed for detailed review:
+
+- **Expand all diff hunks**: {#action editor::ExpandAllDiffHunks} ({#kb editor::ExpandAllDiffHunks})
+- **Collapse all diff hunks**: Press `Escape` (bound to {#action editor::Cancel})
+- **Toggle selected diff hunks**: {#action editor::ToggleSelectedDiffHunks} ({#kb editor::ToggleSelectedDiffHunks})
+- **Navigate between hunks**: {#action editor::GoToHunk} and {#action editor::GoToPreviousHunk}
+
+> **Tip:** The `Escape` key is the quickest way to collapse all expanded diff hunks and return to an overview of your changes.
+
 ## Action Reference
 
 | Action                                 | Keybinding                         |
@@ -136,5 +147,7 @@ or by simply right clicking and selecting `Copy Permalink` with line(s) selected
 | {#action git::CheckoutBranch}          | {#kb git::CheckoutBranch}          |
 | {#action git::Blame}                   | {#kb git::Blame}                   |
 | {#action editor::ToggleGitBlameInline} | {#kb editor::ToggleGitBlameInline} |
+| {#action editor::ExpandAllDiffHunks}   | {#kb editor::ExpandAllDiffHunks}   |
+| {#action editor::ToggleSelectedDiffHunks} | {#kb editor::ToggleSelectedDiffHunks} |
 
 > Not all actions have default keybindings, but can be bound by [customizing your keymap](./key-bindings.md#user-keymaps).


### PR DESCRIPTION
## Summary

This PR improves the documentation for diff hunk keyboard shortcuts to make existing functionality more discoverable to users.

### Problem

Users were unaware that pressing **ESC** already collapses all expanded diff hunks through the existing `Cancel` action. The functionality exists but lacks discoverability:

- The `Cancel` action description was too generic: "Cancels the current operation"
- No documentation existed for diff hunk keyboard shortcuts in the Git docs
- Users would naturally expect a dedicated keybinding for collapsing diff hunks

Release Notes:

- N/A