### PR TITLE
Show conflicts in the keymap editor

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -387,6 +387,10 @@ impl KeymapEditor {
                     .flatten()
                     .collect();
 
+                if this.conflicts.is_empty() {
+                    this.filter_state = FilterState::All;
+                }
+
                 this.keybindings = key_bindings;
                 this.string_match_candidates = Arc::new(string_match_candidates);
                 this.matches = this

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -12,7 +12,7 @@ use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     AppContext as _, AsyncApp, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
     Global, KeyContext, Keystroke, ModifiersChangedEvent, ScrollStrategy, StyledText, Subscription,
-    WeakEntity, actions, div, transparent_black,
+    WeakEntity, actions, div,
 };
 use language::{Language, LanguageConfig, ToOffset as _};
 use settings::{BaseKeymap, KeybindSource, KeymapFile, SettingsAssets};
@@ -683,7 +683,11 @@ impl Render for KeymapEditor {
                     .when(!self.conflicts.is_empty(), |this| {
                         this.child(
                             IconButton::new("KeymapEditorConflictIcon", IconName::Warning)
-                                .selected_icon_color(Color::Warning)
+                                .tooltip(Tooltip::text(match self.filter_state {
+                                    FilterState::All => "Show conflicts",
+                                    FilterState::Conflicts => "Hide conflicts",
+                                }))
+                                .selected_icon_color(Color::Error)
                                 .toggle_state(matches!(self.filter_state, FilterState::Conflicts))
                                 .on_click(cx.listener(|this, _, _, cx| {
                                     this.filter_state = this.filter_state.invert();
@@ -769,10 +773,8 @@ impl Render for KeymapEditor {
                                     this.selected_index = Some(row_index);
                                 }))
                                 .border_2()
-                                .border_color(if is_conflict {
-                                    cx.theme().colors().terminal_ansi_red
-                                } else {
-                                    transparent_black()
+                                .when(is_conflict, |row| {
+                                    row.bg(cx.theme().status().error_background)
                                 })
                                 .when(is_selected, |row| {
                                     row.border_color(cx.theme().colors().panel_focused_border)


### PR DESCRIPTION
This PR shows conflicts in a user's keymap editor by adding an error background to a conflicting row and allows users to filter the keymap editor by conflicts.

A key binding is determined to have a conflict if any other binding has the same context and key strokes. In the future, this could be further improved upon by normalizing bindings’ context so it's not just a string comparison. 


Release Notes:

- N/A
