### PR TITLE
agent: Allow thinking in edit file tool

### DIFF
--- a/crates/assistant_tools/src/edit_agent.rs
+++ b/crates/assistant_tools/src/edit_agent.rs
@@ -719,7 +719,7 @@ impl EditAgent {
             tools,
             stop: Vec::new(),
             temperature: None,
-            thinking_allowed: false,
+            thinking_allowed: true,
         };
 
         Ok(self.model.stream_completion_text(request, cx).await?.stream)


### PR DESCRIPTION
Follow up to #34141. As pointed out by  @maan2003 changing the thinking parameters invalidates the message cache ([Docs](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#what-invalidates-the-cache)).

All the other places where `thinking_allowed ` is set to `false` should be fine since we do not do any caching there.

Release Notes:

- N/A
