### PR TITLE
Remove a stale TODO

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -877,9 +877,6 @@ impl ExtensionStore {
                 },
             )
             .await?;
-
-            // todo(windows)
-            // Stop the server here.
             this.update(cx, |this, cx| this.reload(None, cx))?.await;
 
             fs.remove_dir(


### PR DESCRIPTION
Based on the testing, language servers are getting stopped without errors now on Windows.

Release Notes:

- N/A