### PR TITLE
rules_library: Prevent multiline titles in rule editor

### DIFF
--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -613,7 +613,9 @@ impl RulesLibrary {
                         let title_editor = cx.new(|cx| {
                             let mut editor = Editor::auto_width(window, cx);
                             editor.set_placeholder_text("Untitled", cx);
-                            editor.set_text(rule_metadata.title.unwrap_or_default(), window, cx);
+                            let title = rule_metadata.title.unwrap_or_default();
+                            let sanitized_title = title.replace('\n', " ").replace('\r', "");
+                            editor.set_text(sanitized_title, window, cx);
                             if prompt_id.is_built_in() {
                                 editor.set_read_only(true);
                                 editor.set_show_edit_predictions(Some(false), window, cx);


### PR DESCRIPTION
Closes #34195

Release Notes:

- Prevent multiline titles in rule editor
