### PR TITLE
Stop extensions' servers and message loops before removing their files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8978,6 +8978,7 @@ dependencies = [
  "gpui",
  "language",
  "lsp",
+ "project",
  "serde",
  "serde_json",
  "util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8982,7 +8982,6 @@ dependencies = [
  "serde",
  "serde_json",
  "util",
- "workspace",
  "workspace-hack",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8981,6 +8981,7 @@ dependencies = [
  "serde",
  "serde_json",
  "util",
+ "workspace",
  "workspace-hack",
 ]
 

--- a/crates/assistant_slash_command/src/extension_slash_command.rs
+++ b/crates/assistant_slash_command/src/extension_slash_command.rs
@@ -34,6 +34,11 @@ impl ExtensionSlashCommandProxy for SlashCommandRegistryProxy {
         self.slash_command_registry
             .register_command(ExtensionSlashCommand::new(extension, command), false)
     }
+
+    fn unregister_slash_command(&self, command_name: Arc<str>) {
+        self.slash_command_registry
+            .unregister_command_by_name(&command_name)
+    }
 }
 
 /// An adapter that allows an [`LspAdapterDelegate`] to be used as a [`WorktreeDelegate`].

--- a/crates/eval/src/eval.rs
+++ b/crates/eval/src/eval.rs
@@ -8,6 +8,7 @@ mod tool_metrics;
 
 use assertions::{AssertionsReport, display_error_row};
 use instance::{ExampleInstance, JudgeOutput, RunOutput, run_git};
+use language_extension::LspAccess;
 pub(crate) use tool_metrics::*;
 
 use ::fs::RealFs;
@@ -415,7 +416,11 @@ pub fn init(cx: &mut App) -> Arc<AgentAppState> {
 
     language::init(cx);
     debug_adapter_extension::init(extension_host_proxy.clone(), cx);
-    language_extension::init(extension_host_proxy.clone(), languages.clone());
+    language_extension::init(
+        LspAccess::Noop,
+        extension_host_proxy.clone(),
+        languages.clone(),
+    );
     language_model::init(client.clone(), cx);
     language_models::init(user_store.clone(), client.clone(), cx);
     languages::init(languages.clone(), node_runtime.clone(), cx);

--- a/crates/extension/src/extension_host_proxy.rs
+++ b/crates/extension/src/extension_host_proxy.rs
@@ -286,7 +286,8 @@ pub trait ExtensionLanguageServerProxy: Send + Sync + 'static {
         &self,
         language: &LanguageName,
         language_server_id: &LanguageServerName,
-    );
+        cx: &mut App,
+    ) -> Task<Result<()>>;
 
     fn update_language_server_status(
         &self,
@@ -313,12 +314,13 @@ impl ExtensionLanguageServerProxy for ExtensionHostProxy {
         &self,
         language: &LanguageName,
         language_server_id: &LanguageServerName,
-    ) {
+        cx: &mut App,
+    ) -> Task<Result<()>> {
         let Some(proxy) = self.language_server_proxy.read().clone() else {
-            return;
+            return Task::ready(Ok(()));
         };
 
-        proxy.remove_language_server(language, language_server_id)
+        proxy.remove_language_server(language, language_server_id, cx)
     }
 
     fn update_language_server_status(

--- a/crates/extension/src/extension_host_proxy.rs
+++ b/crates/extension/src/extension_host_proxy.rs
@@ -352,6 +352,8 @@ impl ExtensionSnippetProxy for ExtensionHostProxy {
 
 pub trait ExtensionSlashCommandProxy: Send + Sync + 'static {
     fn register_slash_command(&self, extension: Arc<dyn Extension>, command: SlashCommand);
+
+    fn unregister_slash_command(&self, command_name: Arc<str>);
 }
 
 impl ExtensionSlashCommandProxy for ExtensionHostProxy {
@@ -361,6 +363,14 @@ impl ExtensionSlashCommandProxy for ExtensionHostProxy {
         };
 
         proxy.register_slash_command(extension, command)
+    }
+
+    fn unregister_slash_command(&self, command_name: Arc<str>) {
+        let Some(proxy) = self.slash_command_proxy.read().clone() else {
+            return;
+        };
+
+        proxy.unregister_slash_command(command_name)
     }
 }
 
@@ -400,6 +410,8 @@ impl ExtensionContextServerProxy for ExtensionHostProxy {
 
 pub trait ExtensionIndexedDocsProviderProxy: Send + Sync + 'static {
     fn register_indexed_docs_provider(&self, extension: Arc<dyn Extension>, provider_id: Arc<str>);
+
+    fn unregister_indexed_docs_provider(&self, provider_id: Arc<str>);
 }
 
 impl ExtensionIndexedDocsProviderProxy for ExtensionHostProxy {
@@ -409,6 +421,14 @@ impl ExtensionIndexedDocsProviderProxy for ExtensionHostProxy {
         };
 
         proxy.register_indexed_docs_provider(extension, provider_id)
+    }
+
+    fn unregister_indexed_docs_provider(&self, provider_id: Arc<str>) {
+        let Some(proxy) = self.indexed_docs_provider_proxy.read().clone() else {
+            return;
+        };
+
+        proxy.unregister_indexed_docs_provider(provider_id)
     }
 }
 

--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -1152,7 +1152,7 @@ impl ExtensionStore {
                 continue;
             };
             grammars_to_remove.extend(extension.manifest.grammars.keys().cloned());
-            for (language_server_name, config) in extension.manifest.language_servers.iter() {
+            for (language_server_name, config) in &extension.manifest.language_servers {
                 for language in config.languages() {
                     server_removal_tasks.push(self.proxy.remove_language_server(
                         &language,
@@ -1162,14 +1162,21 @@ impl ExtensionStore {
                 }
             }
 
-            for (server_id, _) in extension.manifest.context_servers.iter() {
+            for (server_id, _) in &extension.manifest.context_servers {
                 self.proxy.unregister_context_server(server_id.clone(), cx);
             }
-            for (adapter, _) in extension.manifest.debug_adapters.iter() {
+            for (adapter, _) in &extension.manifest.debug_adapters {
                 self.proxy.unregister_debug_adapter(adapter.clone());
             }
-            for (locator, _) in extension.manifest.debug_locators.iter() {
+            for (locator, _) in &extension.manifest.debug_locators {
                 self.proxy.unregister_debug_locator(locator.clone());
+            }
+            for (command_name, _) in &extension.manifest.slash_commands {
+                self.proxy.unregister_slash_command(command_name.clone());
+            }
+            for (provider_id, _) in &extension.manifest.indexed_docs_providers {
+                self.proxy
+                    .unregister_indexed_docs_provider(provider_id.clone());
             }
         }
 

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -742,7 +742,6 @@ impl WasmExtension {
     {
         let (return_tx, return_rx) = oneshot::channel();
         self.tx
-            .clone()
             .unbounded_send(Box::new(move |extension, store| {
                 async {
                     let result = f(extension, store).await;

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -54,13 +54,19 @@ pub struct WasmHost {
     main_thread_message_tx: mpsc::UnboundedSender<MainThreadCall>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct WasmExtension {
     tx: UnboundedSender<ExtensionCall>,
     pub manifest: Arc<ExtensionManifest>,
     pub work_dir: Arc<Path>,
     #[allow(unused)]
     pub zed_api_version: SemanticVersion,
+}
+
+impl Drop for WasmExtension {
+    fn drop(&mut self) {
+        self.tx.close_channel();
+    }
 }
 
 #[async_trait]

--- a/crates/indexed_docs/src/extension_indexed_docs_provider.rs
+++ b/crates/indexed_docs/src/extension_indexed_docs_provider.rs
@@ -29,6 +29,11 @@ impl ExtensionIndexedDocsProviderProxy for IndexedDocsRegistryProxy {
                 ProviderId(provider_id),
             )));
     }
+
+    fn unregister_indexed_docs_provider(&self, provider_id: Arc<str>) {
+        self.indexed_docs_registry
+            .unregister_provider(&ProviderId(provider_id));
+    }
 }
 
 pub struct ExtensionIndexedDocsProvider {

--- a/crates/indexed_docs/src/registry.rs
+++ b/crates/indexed_docs/src/registry.rs
@@ -52,6 +52,10 @@ impl IndexedDocsRegistry {
         );
     }
 
+    pub fn unregister_provider(&self, provider_id: &ProviderId) {
+        self.stores_by_provider.write().remove(provider_id);
+    }
+
     pub fn get_provider_store(&self, provider_id: ProviderId) -> Option<Arc<IndexedDocsStore>> {
         self.stores_by_provider.read().get(&provider_id).cloned()
     }

--- a/crates/language_extension/Cargo.toml
+++ b/crates/language_extension/Cargo.toml
@@ -21,6 +21,7 @@ fs.workspace = true
 gpui.workspace = true
 language.workspace = true
 lsp.workspace = true
+project.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 util.workspace = true

--- a/crates/language_extension/Cargo.toml
+++ b/crates/language_extension/Cargo.toml
@@ -24,4 +24,5 @@ lsp.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 util.workspace = true
+workspace.workspace = true
 workspace-hack.workspace = true

--- a/crates/language_extension/Cargo.toml
+++ b/crates/language_extension/Cargo.toml
@@ -25,5 +25,4 @@ project.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 util.workspace = true
-workspace.workspace = true
 workspace-hack.workspace = true

--- a/crates/language_extension/src/language_extension.rs
+++ b/crates/language_extension/src/language_extension.rs
@@ -5,15 +5,14 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use extension::{ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy};
-use gpui::Entity;
+use gpui::{App, Entity};
 use language::{LanguageMatcher, LanguageName, LanguageRegistry, LoadedLanguage};
 use project::LspStore;
-use workspace::WorkspaceStore;
 
 #[derive(Clone)]
 pub enum LspAccess {
     ViaLspStore(Entity<LspStore>),
-    ViaWorkspaces(Entity<WorkspaceStore>),
+    ViaWorkspaces(Arc<dyn Fn(&mut App) -> Result<Vec<Entity<LspStore>>> + Send + Sync + 'static>),
     Noop,
 }
 

--- a/crates/language_extension/src/language_extension.rs
+++ b/crates/language_extension/src/language_extension.rs
@@ -5,13 +5,27 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use extension::{ExtensionGrammarProxy, ExtensionHostProxy, ExtensionLanguageProxy};
+use gpui::Entity;
 use language::{LanguageMatcher, LanguageName, LanguageRegistry, LoadedLanguage};
+use project::LspStore;
+use workspace::WorkspaceStore;
+
+#[derive(Clone)]
+pub enum LspAccess {
+    ViaLspStore(Entity<LspStore>),
+    ViaWorkspaces(Entity<WorkspaceStore>),
+    Noop,
+}
 
 pub fn init(
+    lsp_access: LspAccess,
     extension_host_proxy: Arc<ExtensionHostProxy>,
     language_registry: Arc<LanguageRegistry>,
 ) {
-    let language_server_registry_proxy = LanguageServerRegistryProxy { language_registry };
+    let language_server_registry_proxy = LanguageServerRegistryProxy {
+        language_registry,
+        lsp_access,
+    };
     extension_host_proxy.register_grammar_proxy(language_server_registry_proxy.clone());
     extension_host_proxy.register_language_proxy(language_server_registry_proxy.clone());
     extension_host_proxy.register_language_server_proxy(language_server_registry_proxy);
@@ -20,6 +34,7 @@ pub fn init(
 #[derive(Clone)]
 struct LanguageServerRegistryProxy {
     language_registry: Arc<LanguageRegistry>,
+    lsp_access: LspAccess,
 }
 
 impl ExtensionGrammarProxy for LanguageServerRegistryProxy {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -9712,29 +9712,31 @@ impl LspStore {
             } else {
                 let buffers =
                     lsp_store.buffer_ids_to_buffers(envelope.payload.buffer_ids.into_iter(), cx);
-                lsp_store.stop_language_servers_for_buffers(
-                    buffers,
-                    envelope
-                        .payload
-                        .also_servers
-                        .into_iter()
-                        .filter_map(|selector| {
-                            Some(match selector.selector? {
-                                proto::language_server_selector::Selector::ServerId(server_id) => {
-                                    LanguageServerSelector::Id(LanguageServerId::from_proto(
+                lsp_store
+                    .stop_language_servers_for_buffers(
+                        buffers,
+                        envelope
+                            .payload
+                            .also_servers
+                            .into_iter()
+                            .filter_map(|selector| {
+                                Some(match selector.selector? {
+                                    proto::language_server_selector::Selector::ServerId(
                                         server_id,
-                                    ))
-                                }
-                                proto::language_server_selector::Selector::Name(name) => {
-                                    LanguageServerSelector::Name(LanguageServerName(
-                                        SharedString::from(name),
-                                    ))
-                                }
+                                    ) => LanguageServerSelector::Id(LanguageServerId::from_proto(
+                                        server_id,
+                                    )),
+                                    proto::language_server_selector::Selector::Name(name) => {
+                                        LanguageServerSelector::Name(LanguageServerName(
+                                            SharedString::from(name),
+                                        ))
+                                    }
+                                })
                             })
-                        })
-                        .collect(),
-                    cx,
-                );
+                            .collect(),
+                        cx,
+                    )
+                    .detach_and_log_err(cx);
             }
         })?;
 
@@ -10290,9 +10292,9 @@ impl LspStore {
     pub fn stop_language_servers_for_buffers(
         &mut self,
         buffers: Vec<Entity<Buffer>>,
-        also_restart_servers: HashSet<LanguageServerSelector>,
+        also_stop_servers: HashSet<LanguageServerSelector>,
         cx: &mut Context<Self>,
-    ) {
+    ) -> Task<Result<()>> {
         if let Some((client, project_id)) = self.upstream_client() {
             let request = client.request(proto::StopLanguageServers {
                 project_id,
@@ -10300,7 +10302,7 @@ impl LspStore {
                     .into_iter()
                     .map(|b| b.read(cx).remote_id().to_proto())
                     .collect(),
-                also_servers: also_restart_servers
+                also_servers: also_stop_servers
                     .into_iter()
                     .map(|selector| {
                         let selector = match selector {
@@ -10322,24 +10324,31 @@ impl LspStore {
                     .collect(),
                 all: false,
             });
-            cx.background_spawn(request).detach_and_log_err(cx);
+            cx.background_spawn(async move {
+                let _ = request.await?;
+                Ok(())
+            })
         } else {
-            self.stop_local_language_servers_for_buffers(&buffers, also_restart_servers, cx)
-                .detach();
+            let task =
+                self.stop_local_language_servers_for_buffers(&buffers, also_stop_servers, cx);
+            cx.background_spawn(async move {
+                task.await;
+                Ok(())
+            })
         }
     }
 
     fn stop_local_language_servers_for_buffers(
         &mut self,
         buffers: &[Entity<Buffer>],
-        also_restart_servers: HashSet<LanguageServerSelector>,
+        also_stop_servers: HashSet<LanguageServerSelector>,
         cx: &mut Context<Self>,
     ) -> Task<()> {
         let Some(local) = self.as_local_mut() else {
             return Task::ready(());
         };
         let mut language_server_names_to_stop = BTreeSet::default();
-        let mut language_servers_to_stop = also_restart_servers
+        let mut language_servers_to_stop = also_stop_servers
             .into_iter()
             .flat_map(|selector| match selector {
                 LanguageServerSelector::Id(id) => Some(id),

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3217,9 +3217,11 @@ impl Project {
         also_restart_servers: HashSet<LanguageServerSelector>,
         cx: &mut Context<Self>,
     ) {
-        self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.stop_language_servers_for_buffers(buffers, also_restart_servers, cx)
-        })
+        self.lsp_store
+            .update(cx, |lsp_store, cx| {
+                lsp_store.stop_language_servers_for_buffers(buffers, also_restart_servers, cx)
+            })
+            .detach_and_log_err(cx);
     }
 
     pub fn cancel_language_server_work_for_buffers(

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -77,7 +77,6 @@ impl HeadlessProject {
         cx: &mut Context<Self>,
     ) -> Self {
         debug_adapter_extension::init(proxy.clone(), cx);
-        language_extension::init(proxy.clone(), languages.clone());
         languages::init(languages.clone(), node_runtime.clone(), cx);
 
         let worktree_store = cx.new(|cx| {
@@ -185,6 +184,11 @@ impl HeadlessProject {
         });
 
         cx.subscribe(&lsp_store, Self::on_lsp_store_event).detach();
+        language_extension::init(
+            language_extension::LspAccess::ViaLspStore(lsp_store.clone()),
+            proxy.clone(),
+            languages.clone(),
+        );
 
         cx.subscribe(
             &buffer_store,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6657,6 +6657,10 @@ impl WorkspaceStore {
             Ok(())
         })?
     }
+
+    pub fn workspaces(&self) -> &HashSet<WindowHandle<Workspace>> {
+        &self.workspaces
+    }
 }
 
 impl ViewId {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -439,12 +439,17 @@ pub fn main() {
         .detach();
         let node_runtime = NodeRuntime::new(client.http_client(), Some(shell_env_loaded_rx), rx);
 
+        let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
+
         debug_adapter_extension::init(extension_host_proxy.clone(), cx);
         language::init(cx);
-        language_extension::init(extension_host_proxy.clone(), languages.clone());
+        language_extension::init(
+            language_extension::LspAccess::ViaWorkspaces(workspace_store.clone()),
+            extension_host_proxy.clone(),
+            languages.clone(),
+        );
         languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
-        let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
 
         Client::set_global(client.clone(), cx);
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -439,17 +439,17 @@ pub fn main() {
         .detach();
         let node_runtime = NodeRuntime::new(client.http_client(), Some(shell_env_loaded_rx), rx);
 
-        let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
-
         debug_adapter_extension::init(extension_host_proxy.clone(), cx);
         language::init(cx);
+        languages::init(languages.clone(), node_runtime.clone(), cx);
+        let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
+        let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
+
         language_extension::init(
             language_extension::LspAccess::ViaWorkspaces(workspace_store.clone()),
             extension_host_proxy.clone(),
             languages.clone(),
         );
-        languages::init(languages.clone(), node_runtime.clone(), cx);
-        let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
 
         Client::set_global(client.clone(), cx);
 


### PR DESCRIPTION
Fixes an issue that caused Windows to fail when removing extension's directories, as Zed had never stop any related processes.

Now:

* Zed shuts down and waits until the end when the language servers are shut down

* Adds `impl Drop for WasmExtension` where does `self.tx.close_channel();` to stop a receiver loop that holds the "lock" on the extension's work dir.
The extension was dropped, but the channel was not closed for some reason.

* Does more unregistration to ensure `Arc<WasmExtension>` with the `tx` does not leak further

* Tidies up the related errors which had never reported a problematic path before

Release Notes:

- N/A