### PR TITLE
Remove redundant `autoscroll_horizontally` during editor prepaint

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -8614,29 +8614,6 @@ impl Element for EditorElement {
                         cx,
                     );
 
-                    self.editor.update(cx, |editor, cx| {
-                        let clamped = editor.scroll_manager.clamp_scroll_left(scroll_max.x);
-
-                        let autoscrolled = if autoscroll_horizontally {
-                            editor.autoscroll_horizontally(
-                                start_row,
-                                editor_content_width,
-                                scroll_width,
-                                em_advance,
-                                &line_layouts,
-                                window,
-                                cx,
-                            )
-                        } else {
-                            false
-                        };
-
-                        if clamped || autoscrolled {
-                            snapshot = editor.snapshot(window, cx);
-                            scroll_position = snapshot.scroll_position();
-                        }
-                    });
-
                     let line_elements = self.prepaint_lines(
                         start_row,
                         &mut line_layouts,


### PR DESCRIPTION
* Experimentally `scroll_manager.anchor()` appears to be the same before and after this 2nd call of `autoscroll_horizontally`

* Nothing these depend on seem to be mutated between the calls (and since this is prepaint, stuff within editor also shouldn't be mutated)

Release Notes:

- N/A