### PR TITLE
language_models: Refresh the list of models when the LLM token is refreshed

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -145,6 +145,7 @@ pub enum Event {
     ShowContacts,
     ParticipantIndicesChanged,
     PrivateUserInfoUpdated,
+    PlanUpdated,
 }
 
 #[derive(Clone, Copy)]
@@ -387,6 +388,8 @@ impl UserStore {
                     })
                     .map(EditPredictionUsage);
             }
+
+            cx.emit(Event::PlanUpdated);
 
             cx.notify();
         })?;

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -145,7 +145,6 @@ pub enum Event {
     ShowContacts,
     ParticipantIndicesChanged,
     PrivateUserInfoUpdated,
-    PlanUpdated,
 }
 
 #[derive(Clone, Copy)]
@@ -388,8 +387,6 @@ impl UserStore {
                     })
                     .map(EditPredictionUsage);
             }
-
-            cx.emit(Event::PlanUpdated);
 
             cx.notify();
         })?;


### PR DESCRIPTION
This PR makes it so we refresh the list of models whenever the LLM token is refreshed.

This allows us to add or remove models based on the plan in the new token.

Release Notes:

- Fixed model list not refreshing when subscribing to Zed Pro.
