### PR TITLE
settings_ui: Ensure selected keymap entry is properly updated

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -809,24 +809,12 @@ impl Render for KeymapEditor {
                                 });
 
                             right_click_menu(("keymap-table-row-menu", row_index))
-                                .trigger({
-                                    let this = cx.weak_entity();
-                                    move |is_menu_open: bool, _window, cx| {
-                                        if is_menu_open {
-                                            this.update(cx, |this, cx| {
-                                                if this.selected_index != Some(row_index) {
-                                                    this.selected_index = Some(row_index);
-                                                    cx.notify();
-                                                }
-                                            })
-                                            .ok();
-                                        }
-                                        row
-                                    }
-                                })
+                                .trigger(move |_, _, _| row)
                                 .menu({
                                     let this = cx.weak_entity();
-                                    move |window, cx| build_keybind_context_menu(&this, window, cx)
+                                    move |window, cx| {
+                                        build_keybind_context_menu(&this, row_index, window, cx)
+                                    }
                                 })
                                 .into_any_element()
                         }),
@@ -1498,14 +1486,19 @@ impl Render for KeystrokeInput {
 
 fn build_keybind_context_menu(
     this: &WeakEntity<KeymapEditor>,
+    item_idx: usize,
     window: &mut Window,
     cx: &mut App,
 ) -> Entity<ContextMenu> {
     ContextMenu::build(window, cx, |menu, _window, cx| {
-        let Some(this) = this.upgrade() else {
-            return menu;
-        };
-        let selected_binding = this.read_with(cx, |this, _cx| this.selected_binding().cloned());
+        let selected_binding = this
+            .update(cx, |this, _cx| {
+                this.selected_index = Some(item_idx);
+                this.selected_binding().cloned()
+            })
+            .ok()
+            .flatten();
+
         let Some(selected_binding) = selected_binding else {
             return menu;
         };


### PR DESCRIPTION
This change ensures that we more reliably deploy the context menu in the keymap editor as well as highlight the selected row quicker.

Release Notes:

- N/A 
