### PR TITLE
keymap_ui: Auto-complete for Action input in keybind editor modal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14676,6 +14676,7 @@ dependencies = [
  "search",
  "serde",
  "settings",
+ "tempfile",
  "theme",
  "tree-sitter-json",
  "tree-sitter-rust",

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -216,7 +216,7 @@ impl JsonLspAdapter {
                     paths::local_debug_file_relative_path()
                 ],
                 "schema": debug_schema,
-            },
+            }
         ]);
 
         #[cfg(debug_assertions)]

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1242,6 +1242,18 @@ impl LanguageServer {
             params,
         })
         .unwrap();
+        eprintln!("{}", {
+            let value = serde_json::from_str::<serde_json::Value>(&message).unwrap();
+            if !value
+                .get("method")
+                .and_then(|method| method.as_str())
+                .map_or(false, |method| method.starts_with("json"))
+            {
+                "other".to_string()
+            } else {
+                serde_json::to_string_pretty(&value).unwrap()
+            }
+        });
         outbound_tx.try_send(message)?;
         Ok(())
     }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1,4 +1,5 @@
 pub mod clangd_ext;
+pub mod json_language_server_ext;
 pub mod lsp_ext_command;
 pub mod rust_analyzer_ext;
 

--- a/crates/project/src/lsp_store/json_language_server_ext.rs
+++ b/crates/project/src/lsp_store/json_language_server_ext.rs
@@ -1,0 +1,74 @@
+use ::serde::{Deserialize, Serialize};
+use gpui::{App, Entity, WeakEntity};
+use language::Buffer;
+use lsp::LanguageServer;
+use util::ResultExt as _;
+
+use crate::{LspStore, Project};
+
+pub fn register_notifications(lsp_store: WeakEntity<LspStore>, language_server: &LanguageServer) {
+    let name = language_server.name();
+}
+
+// https://github.com/microsoft/vscode/blob/main/extensions/json-language-features/server/README.md#schema-associations-notification
+struct SchemaAssociationsNotification {}
+
+/// interface ISchemaAssociation {
+///   /**
+///    * The URI of the schema, which is also the identifier of the schema.
+///    */
+///   uri: string;
+///
+///   /**
+///    * A list of file path patterns that are associated to the schema. The '*' wildcard can be used. Exclusion patterns starting with '!'.
+///    * For example '*.schema.json', 'package.json', '!foo*.schema.json'.
+///    * A match succeeds when there is at least one pattern matching and last matching pattern does not start with '!'.
+///    */
+///   fileMatch: string[];
+///   /**
+///    * If provided, the association is only used if the validated document is located in the given folder (directly or in a subfolder)
+///    */
+///   folderUri?: string;
+///   /*
+///    * The schema for the given URI.
+///    * If no schema is provided, the schema will be fetched with the schema request service (if available).
+///    */
+///   schema?: JSONSchema;
+/// }
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct SchemaAssociation {
+    pub uri: String,
+    pub file_match: Vec<String>,
+    pub folder_uri: Option<String>,
+    pub schema: Option<serde_json::Value>,
+}
+
+impl lsp::notification::Notification for SchemaAssociationsNotification {
+    type Params = Vec<SchemaAssociation>;
+    const METHOD: &'static str = "json/schemaAssociations";
+}
+
+pub fn send_schema_associations_notification(
+    project: Entity<Project>,
+    buffer: Entity<Buffer>,
+    schema_associations: &Vec<SchemaAssociation>,
+    cx: &mut App,
+) {
+    let lsp_store = project.read(cx).lsp_store();
+    lsp_store.update(cx, |lsp_store, cx| {
+        let Some(local) = lsp_store.as_local() else {
+            return;
+        };
+        buffer.update(cx, |buffer, cx| {
+            for (adapter, server) in local.language_servers_for_buffer(buffer, cx) {
+                if !adapter.adapter.is_primary_zed_json_schema_adapter() {
+                    continue;
+                }
+                server
+                    .notify::<SchemaAssociationsNotification>(schema_associations)
+                    .log_err(); // todo! don't ignore error
+            }
+        })
+    })
+}

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -32,6 +32,7 @@ schemars.workspace = true
 search.workspace = true
 serde.workspace = true
 settings.workspace = true
+tempfile.workspace = true
 theme.workspace = true
 tree-sitter-json.workspace = true
 tree-sitter-rust.workspace = true


### PR DESCRIPTION
Closes #ISSUE

TODO:

- [ ] Remove attempt at telling lsp we closed and re-opened the file.
- [ ] Create "intrusive" API in LSP store to register a callback in `start_language_server` in-between initialization and registering with buffers
- [ ] Remove log warning for watch failing due to temp file being removed before worktree dropped

Release Notes:

- N/A *or* Added/Fixed/Improved ...
