### PR TITLE
collab: Add ability to add tax ID during Stripe Checkout

### DIFF
--- a/crates/collab/src/stripe_billing.rs
+++ b/crates/collab/src/stripe_billing.rs
@@ -19,8 +19,8 @@ use crate::stripe_client::{
     StripeCustomerId, StripeCustomerUpdate, StripeCustomerUpdateAddress, StripeCustomerUpdateName,
     StripeMeter, StripePrice, StripePriceId, StripeSubscription, StripeSubscriptionId,
     StripeSubscriptionTrialSettings, StripeSubscriptionTrialSettingsEndBehavior,
-    StripeSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod, UpdateSubscriptionItems,
-    UpdateSubscriptionParams,
+    StripeSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod, StripeTaxIdCollection,
+    UpdateSubscriptionItems, UpdateSubscriptionParams,
 };
 
 pub struct StripeBilling {
@@ -252,6 +252,7 @@ impl StripeBilling {
             name: Some(StripeCustomerUpdateName::Auto),
             shipping: None,
         });
+        params.tax_id_collection = Some(StripeTaxIdCollection { enabled: true });
 
         let session = self.client.create_checkout_session(params).await?;
         Ok(session.url.context("no checkout session URL")?)
@@ -311,6 +312,7 @@ impl StripeBilling {
             name: Some(StripeCustomerUpdateName::Auto),
             shipping: None,
         });
+        params.tax_id_collection = Some(StripeTaxIdCollection { enabled: true });
 
         let session = self.client.create_checkout_session(params).await?;
         Ok(session.url.context("no checkout session URL")?)

--- a/crates/collab/src/stripe_client.rs
+++ b/crates/collab/src/stripe_client.rs
@@ -190,6 +190,7 @@ pub struct StripeCreateCheckoutSessionParams<'a> {
     pub success_url: Option<&'a str>,
     pub billing_address_collection: Option<StripeBillingAddressCollection>,
     pub customer_update: Option<StripeCustomerUpdate>,
+    pub tax_id_collection: Option<StripeTaxIdCollection>,
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -216,6 +217,11 @@ pub struct StripeCreateCheckoutSessionSubscriptionData {
     pub metadata: Option<HashMap<String, String>>,
     pub trial_period_days: Option<u32>,
     pub trial_settings: Option<StripeSubscriptionTrialSettings>,
+}
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct StripeTaxIdCollection {
+    pub enabled: bool,
 }
 
 #[derive(Debug)]

--- a/crates/collab/src/stripe_client/fake_stripe_client.rs
+++ b/crates/collab/src/stripe_client/fake_stripe_client.rs
@@ -14,8 +14,8 @@ use crate::stripe_client::{
     StripeCreateCheckoutSessionSubscriptionData, StripeCreateMeterEventParams,
     StripeCreateSubscriptionParams, StripeCustomer, StripeCustomerId, StripeCustomerUpdate,
     StripeMeter, StripeMeterId, StripePrice, StripePriceId, StripeSubscription,
-    StripeSubscriptionId, StripeSubscriptionItem, StripeSubscriptionItemId, UpdateCustomerParams,
-    UpdateSubscriptionParams,
+    StripeSubscriptionId, StripeSubscriptionItem, StripeSubscriptionItemId, StripeTaxIdCollection,
+    UpdateCustomerParams, UpdateSubscriptionParams,
 };
 
 #[derive(Debug, Clone)]
@@ -38,6 +38,7 @@ pub struct StripeCreateCheckoutSessionCall {
     pub success_url: Option<String>,
     pub billing_address_collection: Option<StripeBillingAddressCollection>,
     pub customer_update: Option<StripeCustomerUpdate>,
+    pub tax_id_collection: Option<StripeTaxIdCollection>,
 }
 
 pub struct FakeStripeClient {
@@ -236,6 +237,7 @@ impl StripeClient for FakeStripeClient {
                 success_url: params.success_url.map(|url| url.to_string()),
                 billing_address_collection: params.billing_address_collection,
                 customer_update: params.customer_update,
+                tax_id_collection: params.tax_id_collection,
             });
 
         Ok(StripeCheckoutSession {

--- a/crates/collab/src/stripe_client/real_stripe_client.rs
+++ b/crates/collab/src/stripe_client/real_stripe_client.rs
@@ -27,8 +27,8 @@ use crate::stripe_client::{
     StripeMeter, StripePrice, StripePriceId, StripePriceRecurring, StripeSubscription,
     StripeSubscriptionId, StripeSubscriptionItem, StripeSubscriptionItemId,
     StripeSubscriptionTrialSettings, StripeSubscriptionTrialSettingsEndBehavior,
-    StripeSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod, UpdateCustomerParams,
-    UpdateSubscriptionParams,
+    StripeSubscriptionTrialSettingsEndBehaviorMissingPaymentMethod, StripeTaxIdCollection,
+    UpdateCustomerParams, UpdateSubscriptionParams,
 };
 
 pub struct RealStripeClient {
@@ -448,6 +448,7 @@ impl<'a> TryFrom<StripeCreateCheckoutSessionParams<'a>> for CreateCheckoutSessio
             success_url: value.success_url,
             billing_address_collection: value.billing_address_collection.map(Into::into),
             customer_update: value.customer_update.map(Into::into),
+            tax_id_collection: value.tax_id_collection.map(Into::into),
             ..Default::default()
         })
     }
@@ -587,6 +588,14 @@ impl From<StripeCustomerUpdate> for stripe::CreateCheckoutSessionCustomerUpdate 
             address: value.address.map(Into::into),
             name: value.name.map(Into::into),
             shipping: value.shipping.map(Into::into),
+        }
+    }
+}
+
+impl From<StripeTaxIdCollection> for stripe::CreateCheckoutSessionTaxIdCollection {
+    fn from(value: StripeTaxIdCollection) -> Self {
+        stripe::CreateCheckoutSessionTaxIdCollection {
+            enabled: value.enabled,
         }
     }
 }


### PR DESCRIPTION
### 1. **Added Tax ID Collection Types**
- Created a new `StripeTaxIdCollection` struct with an `enabled` field
- Added `tax_id_collection` field to `StripeCreateCheckoutSessionParams`

### 2. **Updated the Stripe Client Interface**
- Modified the real Stripe client to handle tax ID collection conversion
- Updated the fake Stripe client for testing purposes
- Added proper imports across all affected files

### 3. **Enabled Tax ID Collection in Checkout Sessions**
- Both `checkout_with_zed_pro` and `checkout_with_zed_pro_trial` methods now enable tax ID collection
- The implementation correctly sets `tax_id_collection.enabled = true` for all checkout sessions

### 4. **Key Implementation Details**
- Tax ID collection will be shown to new customers and existing customers without tax IDs
- Collected tax IDs will be automatically saved to the customer's `tax_ids` array in Stripe
- Business names will be saved to the customer's `name` property
- The existing `customer_update.name = auto` setting ensures compatibility with tax ID collection

Release Notes:

- N/A