### PR TITLE
Merge the application menu and title bar when menus are always shown and project items are hidden

### DIFF
--- a/crates/title_bar/src/application_menu.rs
+++ b/crates/title_bar/src/application_menu.rs
@@ -245,14 +245,14 @@ impl ApplicationMenu {
         cx.defer_in(window, move |_, window, cx| next_handle.show(window, cx));
     }
 
-    pub fn all_menus_shown(&self, cx: &mut Context<Self>) -> bool {
+    pub fn all_menus_shown(&self, cx: &App) -> bool {
         show_menus(cx)
             || self.entries.iter().any(|entry| entry.handle.is_deployed())
             || self.pending_menu_open.is_some()
     }
 }
 
-pub(crate) fn show_menus(cx: &mut App) -> bool {
+pub(crate) fn show_menus(cx: &App) -> bool {
     TitleBarSettings::get_global(cx).show_menus
         && (cfg!(not(target_os = "macos")) || option_env!("ZED_USE_CROSS_PLATFORM_MENU").is_some())
 }

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -140,7 +140,7 @@ impl Render for TitleBar {
 
         let mut render_project_items =
             title_bar_settings.show_branch_name || title_bar_settings.show_project_items;
-        let show_seperate_menus = show_menus(cx) && render_project_items;
+        let show_separate_menus = show_menus(cx) && render_project_items;
 
         let mut children = Vec::new();
 
@@ -152,7 +152,7 @@ impl Render for TitleBar {
                         .when_some(
                             self.application_menu
                                 .clone()
-                                .filter(|_| !show_seperate_menus),
+                                .filter(|_| !show_separate_menus),
                             |title_bar, menu| {
                                 render_project_items &=
                                     !menu.read_with(cx, |menu, cx| menu.all_menus_shown(cx));
@@ -203,7 +203,7 @@ impl Render for TitleBar {
                 .into_any_element(),
         );
 
-        if show_seperate_menus {
+        if show_separate_menus {
             self.platform_titlebar.update(cx, |this, _| {
                 this.set_children(
                     self.application_menu


### PR DESCRIPTION
Behavior before:
<img width="2517" height="68" alt="image" src="https://github.com/user-attachments/assets/f08bca8a-a209-4961-a564-cc5fc3f9e600" />
Usable, but lots of wasted space.

Behavior after:
<img width="1250" height="40" alt="image" src="https://github.com/user-attachments/assets/76ec6705-ea87-4e9c-a944-448e804f45e3" />


I also removed a couple of unnecessary `mut` usages introduced in d5cc1cbaa97501ff1966f60f6db41d1042e1ca4d.

Release Notes:
- Merged the application menu and title bar when menus are set to always show and project items are hidden
