### PR TITLE
keymap_ui: Only show conflicts between user bindings

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -173,7 +173,13 @@ impl ConflictState {
         key_bindings
             .iter()
             .enumerate()
-            .filter(|(_, binding)| !binding.keystroke_text.is_empty())
+            .filter(|(_, binding)| {
+                !binding.keystroke_text.is_empty()
+                    && binding
+                        .source
+                        .as_ref()
+                        .is_some_and(|source| matches!(source.0, KeybindSource::User))
+            })
             .for_each(|(index, binding)| {
                 action_keybind_mapping
                     .entry(binding.get_action_mapping())


### PR DESCRIPTION
Closes #ISSUE

This makes it so conflicts are only shown between user bindings. User bindings that override bindings in the Vim, Base, and Default keymaps are not identified as conflicts

Release Notes:

- N/A *or* Added/Fixed/Improved ...
