### PR TITLE
Ensure *.json recognized as JSONC if checkout folder not `zed`

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -40,7 +40,7 @@
   },
   "file_types": {
     "Dockerfile": ["Dockerfile*[!dockerignore]"],
-    "JSONC": ["assets/**/*.json", "renovate.json"],
+    "JSONC": ["**/assets/**/*.json", "renovate.json"],
     "Git Ignore": ["dockerignore"]
   },
   "hard_tabs": false,


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/33410

Release Notes:

- N/A
