### PR TITLE
Truncate multi-line debug value hints

### DIFF
--- a/crates/debugger_ui/src/tests/inline_values.rs
+++ b/crates/debugger_ui/src/tests/inline_values.rs
@@ -2241,3 +2241,34 @@ func main() {
     )
     .await;
 }
+
+#[gpui::test]
+async fn test_trim_multi_line_inline_value(executor: BackgroundExecutor, cx: &mut TestAppContext) {
+    let variables = [("y", "hello\n world")];
+
+    let before = r#"
+fn main() {
+    let y = "hello\n world";
+}
+"#
+    .unindent();
+
+    let after = r#"
+fn main() {
+    let y: hello… = "hello\n world";
+}
+"#
+    .unindent();
+
+    test_inline_values_util(
+        &variables,
+        &[],
+        &before,
+        &after,
+        None,
+        rust_lang(),
+        executor,
+        cx,
+    )
+    .await;
+}

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19655,8 +19655,9 @@ impl Editor {
                                     Anchor::in_buffer(excerpt_id, buffer_id, hint.position),
                                     hint.text(),
                                 );
-
-                                new_inlays.push(inlay);
+                                if !inlay.text.chars().contains(&'\n') {
+                                    new_inlays.push(inlay);
+                                }
                             });
                     }
 

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -560,6 +560,11 @@ impl DapStore {
         fn format_value(mut value: String) -> String {
             const LIMIT: usize = 100;
 
+            if let Some(index) = value.find("\n") {
+                value.truncate(index);
+                value.push_str("…");
+            }
+
             if value.len() > LIMIT {
                 let mut index = LIMIT;
                 // If index isn't a char boundary truncate will cause a panic
@@ -567,7 +572,7 @@ impl DapStore {
                     index -= 1;
                 }
                 value.truncate(index);
-                value.push_str("...");
+                value.push_str("…");
             }
 
             format!(": {}", value)


### PR DESCRIPTION
Release Notes:

- Multi-line debug inline values are now truncated.