### PR TITLE
Revert "git: Intercept signing prompt from GPG when committing"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,7 +608,6 @@ dependencies = [
  "parking_lot",
  "smol",
  "tempfile",
- "unindent",
  "util",
  "workspace-hack",
 ]

--- a/crates/askpass/Cargo.toml
+++ b/crates/askpass/Cargo.toml
@@ -19,6 +19,5 @@ net.workspace = true
 parking_lot.workspace = true
 smol.workspace = true
 tempfile.workspace = true
-unindent.workspace = true
 util.workspace = true
 workspace-hack.workspace = true

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -375,10 +375,8 @@ impl GitRepository for FakeGitRepository {
         _message: gpui::SharedString,
         _name_and_email: Option<(gpui::SharedString, gpui::SharedString)>,
         _options: CommitOptions,
-        _ask_pass: AskPassDelegate,
         _env: Arc<HashMap<String, String>>,
-        _cx: AsyncApp,
-    ) -> BoxFuture<'static, Result<()>> {
+    ) -> BoxFuture<'_, Result<()>> {
         unimplemented!()
     }
 

--- a/crates/git/Cargo.toml
+++ b/crates/git/Cargo.toml
@@ -41,9 +41,9 @@ futures.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-gpui = { workspace = true, features = ["test-support"] }
 pretty_assertions.workspace = true
 serde_json.workspace = true
-tempfile.workspace = true
 text = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
+gpui = { workspace = true, features = ["test-support"] }
+tempfile.workspace = true

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1726,18 +1726,6 @@ impl GitStore {
         let repository_id = RepositoryId::from_proto(envelope.payload.repository_id);
         let repository_handle = Self::repository_for_request(&this, repository_id, &mut cx)?;
 
-        let askpass = if let Some(askpass_id) = envelope.payload.askpass_id {
-            make_remote_delegate(
-                this,
-                envelope.payload.project_id,
-                repository_id,
-                askpass_id,
-                &mut cx,
-            )
-        } else {
-            AskPassDelegate::new_always_failing()
-        };
-
         let message = SharedString::from(envelope.payload.message);
         let name = envelope.payload.name.map(SharedString::from);
         let email = envelope.payload.email.map(SharedString::from);
@@ -1751,7 +1739,6 @@ impl GitStore {
                     CommitOptions {
                         amend: options.amend,
                     },
-                    askpass,
                     cx,
                 )
             })?
@@ -3475,14 +3462,11 @@ impl Repository {
         message: SharedString,
         name_and_email: Option<(SharedString, SharedString)>,
         options: CommitOptions,
-        askpass: AskPassDelegate,
         _cx: &mut App,
     ) -> oneshot::Receiver<Result<()>> {
         let id = self.id;
-        let askpass_delegates = self.askpass_delegates.clone();
-        let askpass_id = util::post_inc(&mut self.latest_askpass_id);
 
-        self.send_job(Some("git commit".into()), move |git_repo, cx| async move {
+        self.send_job(Some("git commit".into()), move |git_repo, _cx| async move {
             match git_repo {
                 RepositoryState::Local {
                     backend,
@@ -3490,16 +3474,10 @@ impl Repository {
                     ..
                 } => {
                     backend
-                        .commit(message, name_and_email, options, askpass, environment, cx)
+                        .commit(message, name_and_email, options, environment)
                         .await
                 }
                 RepositoryState::Remote { project_id, client } => {
-                    askpass_delegates.lock().insert(askpass_id, askpass);
-                    let _defer = util::defer(|| {
-                        let askpass_delegate = askpass_delegates.lock().remove(&askpass_id);
-                        debug_assert!(askpass_delegate.is_some());
-                    });
-
                     let (name, email) = name_and_email.unzip();
                     client
                         .request(proto::Commit {
@@ -3511,9 +3489,9 @@ impl Repository {
                             options: Some(proto::commit::CommitOptions {
                                 amend: options.amend,
                             }),
-                            askpass_id: Some(askpass_id),
                         })
-                        .await?;
+                        .await
+                        .context("sending commit request")?;
 
                     Ok(())
                 }

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -294,6 +294,7 @@ message Commit {
     optional string email = 5;
     string message = 6;
     optional CommitOptions options = 7;
+    reserved 8;
 
     message CommitOptions {
         bool amend = 1;

--- a/crates/proto/proto/git.proto
+++ b/crates/proto/proto/git.proto
@@ -294,7 +294,6 @@ message Commit {
     optional string email = 5;
     string message = 6;
     optional CommitOptions options = 7;
-    optional uint64 askpass_id = 8;
 
     message CommitOptions {
         bool amend = 1;


### PR DESCRIPTION
Reverts zed-industries/zed#34096

This introduced a regression, because the unlocked key can't benefit from caching.

Release Notes:
- N/A