### PR TITLE
keymap_ui: Show existing keystrokes as placeholders in edit modal

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -783,8 +783,12 @@ impl KeymapFile {
             target: &KeybindUpdateTarget<'a>,
             target_action_value: &Value,
         ) -> Option<(usize, &'b str)> {
+            let target_context_parsed =
+                KeyBindingContextPredicate::parse(target.context.unwrap_or("")).ok();
             for (index, section) in keymap.sections().enumerate() {
-                if section.context != target.context.unwrap_or("") {
+                let section_context_parsed =
+                    KeyBindingContextPredicate::parse(&section.context).ok();
+                if section_context_parsed != target_context_parsed {
                     continue;
                 }
                 if section.use_key_equivalents != target.use_key_equivalents {
@@ -835,6 +839,7 @@ pub enum KeybindUpdateOperation<'a> {
     },
 }
 
+#[derive(Debug)]
 pub struct KeybindUpdateTarget<'a> {
     pub context: Option<&'a str>,
     pub keystrokes: &'a [Keystroke],

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -632,6 +632,11 @@ impl KeymapEditor {
                     Box::new(EditBinding),
                 )
                 .action("Create", Box::new(CreateBinding))
+                .action_disabled_when(
+                    selected_binding_is_unbound,
+                    "Delete",
+                    Box::new(DeleteBinding),
+                )
                 .action("Copy action", Box::new(CopyAction))
                 .action_disabled_when(
                     selected_binding_has_no_context,


### PR DESCRIPTION
Closes #ISSUE

Previously, the keystroke input would be empty, even when editing an existing binding. This meant you had to re-enter the bindings even if you just wanted to edit the context. Now, the existing keystrokes are rendered as a placeholder, are re-shown if newly entered keystrokes are cleared, and will be returned from the `KeystrokeInput::keystrokes()` method if no new keystrokes were entered.

Additionally fixed a bug in `KeymapFile::update_keybinding` where semantically identical contexts would be treated as unequal due to formatting differences.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
