### PR TITLE
keymap_ui: Dual-phase focus for keystroke input

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1922,9 +1922,10 @@ impl KeystrokeInput {
         &mut self,
         _event: gpui::FocusOutEvent,
         _window: &mut Window,
-        _cx: &mut Context<Self>,
+        cx: &mut Context<Self>,
     ) {
         self.intercept_subscription.take();
+        cx.notify();
     }
 
     fn keystrokes(&self) -> &[Keystroke] {
@@ -2025,6 +2026,24 @@ impl Render for KeystrokeInput {
                 h_flex()
                     .gap_0p5()
                     .flex_none()
+                    .when(is_inner_focused, |this| {
+                        this.child(
+                            Icon::new(IconName::Circle)
+                                .color(Color::Error)
+                                .with_animation(
+                                    "recording-pulse",
+                                    gpui::Animation::new(std::time::Duration::from_secs(1))
+                                        .repeat()
+                                        .with_easing(gpui::pulsating_between(0.8, 1.0)),
+                                    {
+                                        let color = Color::Error.color(cx);
+                                        move |this, delta| {
+                                            this.color(Color::Custom(color.opacity(delta)))
+                                        }
+                                    },
+                                ),
+                        )
+                    })
                     .child(
                         IconButton::new("backspace-btn", IconName::Delete)
                             .tooltip(Tooltip::text("Delete Keystroke"))


### PR DESCRIPTION
Closes #ISSUE

An idea I and @MrSubidubi came up with, to improve UX around the keystroke input.

Currently, there's a hard tradeoff with what to focus first in the edit keybind modal, if we focus the keystroke input, it makes keybind modification very easy, however, if you don't want to edit a keybind, you must use the mouse to escape the keystroke input before editing something else - breaking keyboard navigation. 

The idea in this PR is to have a dual-phased focus system for the keystroke input. There is an outer focus that has some sort of visual indicator to communicate it is focused (currently a border). While the outer focus region is focused, keystrokes are not intercepted. Then there is a keybind (currently hardcoded to `enter`) to enter the inner focus where keystrokes are intercepted, and which must be exited using the mouse. When the inner focus region is focused, there is a visual indicator for the fact it is "recording" (currently a hacked together red pulsing recording icon)


<details><summary>Video</summary>

https://github.com/user-attachments/assets/490538d0-f092-4df1-a53a-a47d7efe157b


</details>

Release Notes:

- N/A *or* Added/Fixed/Improved ...
