### PR TITLE
Add `editor::ToggleFoldAll` action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -410,6 +410,8 @@ actions!(
         ToggleFold,
         /// Toggles recursive folding at the current position.
         ToggleFoldRecursive,
+        /// Toggles all folds in a buffer or all excerpts in multibuffer.
+        ToggleFoldAll,
         /// Formats the entire document.
         Format,
         /// Formats only the selected text.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -17075,6 +17075,48 @@ impl Editor {
         }
     }
 
+    pub fn toggle_fold_all(
+        &mut self,
+        _: &actions::ToggleFoldAll,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if self.buffer.read(cx).is_singleton() {
+            // For singleton buffers, delegate to existing fold_all/unfold_all
+            let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let has_folds = display_map
+                .folds_in_range(0..display_map.buffer_snapshot.len())
+                .next()
+                .is_some();
+
+            if has_folds {
+                self.unfold_all(&actions::UnfoldAll, window, cx);
+            } else {
+                self.fold_all(&actions::FoldAll, window, cx);
+            }
+        } else {
+            // For multibuffers, check if any buffers are folded
+            let buffer_ids = self.buffer.read(cx).excerpt_buffer_ids();
+            let should_unfold = buffer_ids
+                .iter()
+                .any(|buffer_id| self.is_buffer_folded(*buffer_id, cx));
+
+            self.toggle_fold_multiple_buffers = cx.spawn_in(window, async move |editor, cx| {
+                editor
+                    .update_in(cx, |editor, _, cx| {
+                        for buffer_id in buffer_ids {
+                            if should_unfold {
+                                editor.unfold_buffer(buffer_id, cx);
+                            } else {
+                                editor.fold_buffer(buffer_id, cx);
+                            }
+                        }
+                    })
+                    .ok();
+            });
+        }
+    }
+
     fn fold_at_level(
         &mut self,
         fold_at: &FoldAtLevel,

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -17082,7 +17082,6 @@ impl Editor {
         cx: &mut Context<Self>,
     ) {
         if self.buffer.read(cx).is_singleton() {
-            // For singleton buffers, delegate to existing fold_all/unfold_all
             let display_map = self.display_map.update(cx, |map, cx| map.snapshot(cx));
             let has_folds = display_map
                 .folds_in_range(0..display_map.buffer_snapshot.len())
@@ -17095,7 +17094,6 @@ impl Editor {
                 self.fold_all(&actions::FoldAll, window, cx);
             }
         } else {
-            // For multibuffers, check if any buffers are folded
             let buffer_ids = self.buffer.read(cx).excerpt_buffer_ids();
             let should_unfold = buffer_ids
                 .iter()


### PR DESCRIPTION
In multibuffers adds the ability to alt-click to fold/unfold all excepts.  In singleton buffers it adds the ability to toggle back and forth between `editor::FoldAll` and `editor::UnfoldAll`.

Bind it in your keymap with:

```json
  {
    "context": "Editor && (mode == full || multibuffer)",
    "bindings": {
      "cmd-k cmd-o": "editor::ToggleFoldAll"
    }
  },
```

<img width="253" height="99" alt="Screenshot 2025-07-11 at 17 04 25" src="https://github.com/user-attachments/assets/94de8275-d2ee-4cf8-a46c-a698ccdb60e3" />

Release Notes:

- Add ability to fold all excerpts in a multibuffer (alt-click) and in singleton buffers `editor::ToggleFoldAll`
