### PR TITLE
keymap_ui: Support unbinding non-user defined keybindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14677,6 +14677,7 @@ dependencies = [
  "schemars",
  "search",
  "serde",
+ "serde_json",
  "settings",
  "theme",
  "tree-sitter-json",

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -607,14 +607,24 @@ impl KeymapFile {
         mut keymap_contents: String,
         tab_size: usize,
     ) -> Result<String> {
-        // if trying to replace a keybinding that is not user-defined, treat it as an add operation
         match operation {
+            // if trying to replace a keybinding that is not user-defined, treat it as an add operation
             KeybindUpdateOperation::Replace {
                 target_keybind_source: target_source,
                 source,
                 ..
             } if target_source != KeybindSource::User => {
                 operation = KeybindUpdateOperation::Add(source);
+            }
+            // if trying to remove a keybinding that is not user-defined, treat it as creating a binding
+            // that binds it to `zed::NoAction`
+            KeybindUpdateOperation::Remove {
+                mut target,
+                target_keybind_source,
+            } if target_keybind_source != KeybindSource::User => {
+                target.action_name = gpui::NoAction.name();
+                target.input.take();
+                operation = KeybindUpdateOperation::Add(target);
             }
             _ => {}
         }
@@ -623,14 +633,7 @@ impl KeymapFile {
         // We don't want to modify the file if it's invalid.
         let keymap = Self::parse(&keymap_contents).context("Failed to parse keymap")?;
 
-        if let KeybindUpdateOperation::Remove {
-            target,
-            target_keybind_source,
-        } = operation
-        {
-            if target_keybind_source != KeybindSource::User {
-                anyhow::bail!("Cannot remove non-user created keybinding. Not implemented yet");
-            }
+        if let KeybindUpdateOperation::Remove { target, .. } = operation {
             let target_action_value = target
                 .action_value()
                 .context("Failed to generate target action JSON value")?;

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -31,6 +31,7 @@ project.workspace = true
 schemars.workspace = true
 search.workspace = true
 serde.workspace = true
+serde_json.workspace = true
 settings.workspace = true
 theme.workspace = true
 tree-sitter-json.workspace = true


### PR DESCRIPTION
Closes #ISSUE

Makes it so that `KeymapFile::update_keybinding` treats removals of bindings that weren't user-defined as creating a new binding to `zed::NoAction`.


Release Notes:

- N/A *or* Added/Fixed/Improved ...
