### PR TITLE
debugger: Fix endless restarts when connecting to TCP adapters over SSH

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3109,6 +3109,7 @@ dependencies = [
  "context_server",
  "ctor",
  "dap",
+ "dap-types",
  "dap_adapters",
  "dashmap 6.1.0",
  "debugger_ui",

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -94,6 +94,7 @@ context_server.workspace = true
 ctor.workspace = true
 dap = { workspace = true, features = ["test-support"] }
 dap_adapters = { workspace = true, features = ["test-support"] }
+dap-types.workspace = true
 debugger_ui = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 extension.workspace = true

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -442,10 +442,18 @@ impl DebugAdapter for FakeAdapter {
         _: Option<Vec<String>>,
         _: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
+        let connection = task_definition
+            .tcp_connection
+            .as_ref()
+            .map(|connection| TcpArguments {
+                host: connection.host(),
+                port: connection.port.unwrap_or(17),
+                timeout: connection.timeout,
+            });
         Ok(DebugAdapterBinary {
             command: Some("command".into()),
             arguments: vec![],
-            connection: None,
+            connection,
             envs: HashMap::default(),
             cwd: None,
             request_args: StartDebuggingRequestArguments {

--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -110,9 +110,7 @@ impl DebugAdapterClient {
         self.transport_delegate
             .pending_requests
             .lock()
-            .as_mut()
-            .context("client is closed")?
-            .insert(sequence_id, callback_tx);
+            .insert(sequence_id, callback_tx)?;
 
         log::debug!(
             "Client {} send `{}` request with sequence_id: {}",
@@ -170,6 +168,7 @@ impl DebugAdapterClient {
     pub fn kill(&self) {
         log::debug!("Killing DAP process");
         self.transport_delegate.transport.lock().kill();
+        self.transport_delegate.pending_requests.lock().shutdown();
     }
 
     pub fn has_adapter_logs(&self) -> bool {

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -122,7 +122,7 @@ impl DebugSession {
             .to_owned()
     }
 
-    pub(crate) fn running_state(&self) -> &Entity<RunningState> {
+    pub fn running_state(&self) -> &Entity<RunningState> {
         &self.running_state
     }
 

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1459,7 +1459,7 @@ impl RunningState {
         }
     }
 
-    pub(crate) fn selected_thread_id(&self) -> Option<ThreadId> {
+    pub fn selected_thread_id(&self) -> Option<ThreadId> {
         self.thread_id
     }
 


### PR DESCRIPTION
Closes #34323
Closes #34313

The previous PR #33932 introduced a way to "close" the `pending_requests` buffer of the `TransportDelegate`, preventing any more requests from being added. This prevents pending requests from accumulating without ever being drained during the shutdown sequence; without it, some of our tests hang at this point (due to using a single-threaded executor).

The bug occurred because we were closing `pending_requests` whenever we detected the server side of the transport shut down, and this closed state stuck around and interfered with the retry logic for SSH+TCP adapter connections.

This PR fixes the bug by only closing `pending_requests` on session shutdown, and adds a regression test covering the SSH retry logic.

Release Notes:

- debugger: Fixed a bug causing SSH connections to some adapters (Python, Go, JavaScript) to fail and restart endlessly.