### PR TITLE
pane: 'Close others' now closes relative to right-clicked tab

### DIFF
--- a/crates/collab/src/tests/following_tests.rs
+++ b/crates/collab/src/tests/following_tests.rs
@@ -1013,7 +1013,7 @@ async fn test_peers_following_each_other(cx_a: &mut TestAppContext, cx_b: &mut T
     // and some of which were originally opened by client B.
     workspace_b.update_in(cx_b, |workspace, window, cx| {
         workspace.active_pane().update(cx, |pane, cx| {
-            pane.close_inactive_items(&Default::default(), window, cx)
+            pane.close_inactive_items(&Default::default(), None, window, cx)
                 .detach();
         });
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -21465,7 +21465,7 @@ println!("5");
         .unwrap();
     pane_1
         .update_in(cx, |pane, window, cx| {
-            pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
+            pane.close_inactive_items(&CloseInactiveItems::default(), None, window, cx)
         })
         .await
         .unwrap();
@@ -21501,7 +21501,7 @@ println!("5");
         .unwrap();
     pane_2
         .update_in(cx, |pane, window, cx| {
-            pane.close_inactive_items(&CloseInactiveItems::default(), window, cx)
+            pane.close_inactive_items(&CloseInactiveItems::default(), None, window, cx)
         })
         .await
         .unwrap();

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1346,6 +1346,7 @@ impl Pane {
     pub fn close_inactive_items(
         &mut self,
         action: &CloseInactiveItems,
+        target_item_id: Option<EntityId>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<()>> {
@@ -1353,7 +1354,11 @@ impl Pane {
             return Task::ready(Ok(()));
         }
 
-        let active_item_id = self.active_item_id();
+        let active_item_id = match target_item_id {
+            Some(result) => result,
+            None => self.active_item_id(),
+        };
+
         let pinned_item_ids = self.pinned_item_ids();
 
         self.close_items(
@@ -2596,6 +2601,7 @@ impl Pane {
                                     .handler(window.handler_for(&pane, move |pane, window, cx| {
                                         pane.close_inactive_items(
                                             &close_inactive_items_action,
+                                            Some(item_id.clone()),
                                             window,
                                             cx,
                                         )
@@ -3505,7 +3511,7 @@ impl Render for Pane {
             )
             .on_action(
                 cx.listener(|pane: &mut Self, action: &CloseInactiveItems, window, cx| {
-                    pane.close_inactive_items(action, window, cx)
+                    pane.close_inactive_items(action, None, window, cx)
                         .detach_and_log_err(cx);
                 }),
             )
@@ -5841,6 +5847,7 @@ mod tests {
                     save_intent: None,
                     close_pinned: false,
                 },
+                None,
                 window,
                 cx,
             )
@@ -6206,6 +6213,7 @@ mod tests {
                     save_intent: None,
                     close_pinned: false,
                 },
+                None,
                 window,
                 cx,
             )

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2601,7 +2601,7 @@ impl Pane {
                                     .handler(window.handler_for(&pane, move |pane, window, cx| {
                                         pane.close_inactive_items(
                                             &close_inactive_items_action,
-                                            Some(item_id.clone()),
+                                            Some(item_id),
                                             window,
                                             cx,
                                         )

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2777,6 +2777,7 @@ impl Workspace {
                         save_intent: None,
                         close_pinned: false,
                     },
+                    None,
                     window,
                     cx,
                 )
@@ -9452,6 +9453,7 @@ mod tests {
                     save_intent: Some(SaveIntent::Save),
                     close_pinned: true,
                 },
+                None,
                 window,
                 cx,
             )


### PR DESCRIPTION
Closes #33445

Fixed the "Close others" context menu action to close tabs relative to the right-clicked tab instead of the currently active tab. Previously, when right-clicking on an inactive tab and selecting "Close others", it would keep the active tab open rather than the right-clicked tab.

## Before/After
https://github.com/user-attachments/assets/d76854c3-c490-4a41-8166-309dec26ba8a



## Changes

- Modified `close_inactive_items()` method to accept an optional `target_item_id` parameter
- Updated context menu handler to pass the right-clicked tab's ID as the target
- Maintained backward compatibility by defaulting to active tab when no target is specified
- Updated all existing call sites to pass `None` for the new parameter

Release Notes:

- Fixed: "Close others" context menu action now correctly keeps the right-clicked tab open instead of the active tab