### PR TITLE
linux: Add `file_finder::Toggle` key binding

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -999,6 +999,7 @@
   {
     "context": "FileFinder || (FileFinder > Picker > Editor)",
     "bindings": {
+      "ctrl-p": "file_finder::Toggle",
       "ctrl-shift-a": "file_finder::ToggleSplitMenu",
       "ctrl-shift-i": "file_finder::ToggleFilterMenu"
     }


### PR DESCRIPTION
This fixes a bug on linux where repeated presses of p while holding down the ctrl modifier navigates through options in reverse.

Closes #34379 

The main issue is the default biding of ctrl-p on linux is menu::SelectPrevious  hence in context "context": "FileFinder || (FileFinder > Picker > Editor)" it would navigate in reverse

Release Notes:

- Fixed `file_finder::Toggle` on Linux not scrolling forward