### PR TITLE
cli: Remove manual `std::io::copy` implementation

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -315,19 +315,19 @@ fn main() -> Result<()> {
     });
 
     let stdin_pipe_handle: Option<JoinHandle<anyhow::Result<()>>> =
-        stdin_tmp_file.map(|tmp_file| {
+        stdin_tmp_file.map(|mut tmp_file| {
             thread::spawn(move || {
-                let stdin = std::io::stdin().lock();
-                if io::IsTerminal::is_terminal(&stdin) {
-                    return Ok(());
+                let mut stdin = std::io::stdin().lock();
+                if !io::IsTerminal::is_terminal(&stdin) {
+                    io::copy(&mut stdin, &mut tmp_file)?;
                 }
-                return pipe_to_tmp(stdin, tmp_file);
+                Ok(())
             })
         });
 
-    let anonymous_fd_pipe_handles: Vec<JoinHandle<anyhow::Result<()>>> = anonymous_fd_tmp_files
+    let anonymous_fd_pipe_handles: Vec<_> = anonymous_fd_tmp_files
         .into_iter()
-        .map(|(file, tmp_file)| thread::spawn(move || pipe_to_tmp(file, tmp_file)))
+        .map(|(mut file, mut tmp_file)| thread::spawn(move || io::copy(&mut file, &mut tmp_file)))
         .collect();
 
     if args.foreground {
@@ -346,22 +346,6 @@ fn main() -> Result<()> {
     if let Some(exit_status) = exit_status.lock().take() {
         std::process::exit(exit_status);
     }
-    Ok(())
-}
-
-fn pipe_to_tmp(mut src: impl io::Read, mut dest: fs::File) -> Result<()> {
-    let mut buffer = [0; 8 * 1024];
-    loop {
-        let bytes_read = match src.read(&mut buffer) {
-            Err(err) if err.kind() == io::ErrorKind::Interrupted => continue,
-            res => res?,
-        };
-        if bytes_read == 0 {
-            break;
-        }
-        io::Write::write_all(&mut dest, &buffer[..bytes_read])?;
-    }
-    io::Write::flush(&mut dest)?;
     Ok(())
 }
 


### PR DESCRIPTION
Removes a manual implementation of `std::io::copy`. The internal buffer of `std::io::copy` is also 8 kB and behaves exactly the same. On Linux `std::io::copy` also has access to some better performing file copying.

Release Notes:

- N/A
