### PR TITLE
Don't highlight partial indent guide backgrounds

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -5905,7 +5905,6 @@ impl MultiBufferSnapshot {
 
             let depth = if found_indent {
                 line_indent.len(tab_size) / tab_size
-                    + ((line_indent.len(tab_size) % tab_size) > 0) as u32
             } else {
                 0
             };


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33665

Previously if a line was indented something that was not a multiple of `tab_size` with `"ident_guides": { "background_coloring": "indent_aware" } }` the background of characters would be highlighted. E.g. indent of 6 with tab_size 4.

| Before / After |
| - |
| <img width="497" height="77" alt="Screenshot 2025-07-14 at 14 43 46" src="https://github.com/user-attachments/assets/93923117-047d-4d21-9a4f-488345f1ab89" />
|  <img width="481" height="84" alt="Screenshot 2025-07-14 at 14 43 09" src="https://github.com/user-attachments/assets/a5d383cb-50c3-4239-ae8c-f72765ae7287" /> |

CC: @bennetbo Any idea why this partial indent was enabled in your initial implementation [here](https://github.com/zed-industries/zed/pull/11503/files#diff-1781b7848dd9630f3c4f62df322c08af9a2de74af736e7eba031ebaeb4a0e2f4R3156-R3160)? This looks to be intentional.

Release Notes:

- N/A