### PR TITLE
extension_cli: Copy over snippet file when bundling extensions

### DIFF
--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -289,6 +289,24 @@ async fn copy_extension_resources(
         }
     }
 
+    if let Some(snippets_path) = manifest.snippets.as_ref() {
+        let parent = snippets_path.parent();
+        if let Some(parent) = parent.filter(|p| p.components().next().is_some()) {
+            fs::create_dir_all(output_dir.join(parent))?;
+        }
+        copy_recursive(
+            fs.as_ref(),
+            &extension_path.join(&snippets_path),
+            &output_dir.join(&snippets_path),
+            CopyOptions {
+                overwrite: true,
+                ignore_if_exists: false,
+            },
+        )
+        .await
+        .with_context(|| format!("failed to copy snippets from '{}'", snippets_path.display()))?;
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Closes #30670

Release Notes:

- Fixed snippets from extensions not working.
