### PR TITLE
git: Improve perf of traversing Git metadata with multiple repositories in a single worktree

### DIFF
--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -2570,8 +2570,8 @@ impl OutlinePanel {
         let auto_fold_dirs = OutlinePanelSettings::get_global(cx).auto_fold_dirs;
         let active_multi_buffer = active_editor.read(cx).buffer().clone();
         let new_entries = self.new_entries_for_fs_update.clone();
-        let repo_snapshots = self.project.update(cx, |project, cx| {
-            project.git_store().read(cx).repo_snapshots(cx)
+        let snapshots_by_abs_path = self.project.update(cx, |project, cx| {
+            project.git_store().read(cx).repo_snapshots_by_path(cx)
         });
         self.updating_fs_entries = true;
         self.fs_entries_update_task = cx.spawn_in(window, async move |outline_panel, cx| {
@@ -2698,7 +2698,7 @@ impl OutlinePanel {
                                         entry,
                                     };
                                     let mut traversal = GitTraversal::new(
-                                        &repo_snapshots,
+                                        &snapshots_by_abs_path,
                                         worktree.traverse_from_path(
                                             true,
                                             true,

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -54,7 +54,7 @@ use std::{
     ops::Range,
     path::{Path, PathBuf},
     sync::{
-        Arc, OnceLock,
+        Arc,
         atomic::{self, AtomicU64},
     },
     time::Instant,
@@ -2209,6 +2209,13 @@ impl GitStore {
         self.repositories
             .iter()
             .map(|(id, repo)| (*id, repo.read(cx).snapshot.clone()))
+            .collect()
+    }
+
+    pub fn repo_snapshots_by_path(&self, cx: &App) -> BTreeMap<Arc<Path>, RepositorySnapshot> {
+        self.repositories_by_abs_root_path
+            .iter()
+            .map(|(path, repo)| (path.clone(), repo.read(cx).snapshot.clone()))
             .collect()
     }
 }


### PR DESCRIPTION
- **git: Improve perf of syncing changes**
- **git: Improve traversal perf with multiple repositories in a single worktree**

Related to: #34302
Release Notes:

- Improved performance in projects with large quantity of Git repositories.
