### PR TITLE
keymap_ui: Limit length of keystroke input and hook up actions

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1126,7 +1126,8 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "keystroke_input::StartRecording",
-      "escape escape escape": "keystroke_input::StopRecording"
+      "escape escape escape": "keystroke_input::StopRecording",
+      "delete": "keystroke_input::ClearKeystrokes"
     }
   }
 ]

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1120,5 +1120,13 @@
       "alt-ctrl-f": "keymap_editor::ToggleKeystrokeSearch",
       "alt-c": "keymap_editor::ToggleConflictFilter"
     }
+  },
+  {
+    "context": "KeystrokeInput",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "keystroke_input::StartRecording",
+      "escape escape escape": "keystroke_input::StopRecording"
+    }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1223,7 +1223,8 @@
     "use_key_equivalents": true,
     "bindings": {
       "enter": "keystroke_input::StartRecording",
-      "escape escape escape": "keystroke_input::StopRecording"
+      "escape escape escape": "keystroke_input::StopRecording",
+      "delete": "keystroke_input::ClearKeystrokes"
     }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1217,5 +1217,13 @@
       "cmd-alt-f": "keymap_editor::ToggleKeystrokeSearch",
       "cmd-alt-c": "keymap_editor::ToggleConflictFilter"
     }
+  },
+  {
+    "context": "KeystrokeInput",
+    "use_key_equivalents": true,
+    "bindings": {
+      "enter": "keystroke_input::StartRecording",
+      "escape escape escape": "keystroke_input::StopRecording"
+    }
   }
 ]

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -2324,11 +2324,14 @@ impl Render for KeystrokeInput {
                                 IconButton::new("stop-record-btn", IconName::StopFilled)
                                     .shape(ui::IconButtonShape::Square)
                                     .map(|this| {
-                                        if self.search {
-                                            this.tooltip(Tooltip::text("Stop Searching"))
-                                        } else {
-                                            this.tooltip(Tooltip::text("Stop Recording"))
-                                        }
+                                        this.tooltip(Tooltip::for_action_title(
+                                            if self.search {
+                                                "Stop Searching"
+                                            } else {
+                                                "Stop Recording"
+                                            },
+                                            &StopRecording,
+                                        ))
                                     })
                                     .icon_color(Color::Error)
                                     .on_click(cx.listener(|this, _event, window, cx| {
@@ -2340,11 +2343,14 @@ impl Render for KeystrokeInput {
                                 IconButton::new("record-btn", record_icon)
                                     .shape(ui::IconButtonShape::Square)
                                     .map(|this| {
-                                        if self.search {
-                                            this.tooltip(Tooltip::text("Start Searching"))
-                                        } else {
-                                            this.tooltip(Tooltip::text("Start Recording"))
-                                        }
+                                        this.tooltip(Tooltip::for_action_title(
+                                            if self.search {
+                                                "Start Searching"
+                                            } else {
+                                                "Start Recording"
+                                            },
+                                            &StartRecording,
+                                        ))
                                     })
                                     .when(!is_focused, |this| this.icon_color(Color::Muted))
                                     .on_click(cx.listener(|this, _event, window, cx| {
@@ -2356,7 +2362,10 @@ impl Render for KeystrokeInput {
                     .child(
                         IconButton::new("clear-btn", IconName::Delete)
                             .shape(ui::IconButtonShape::Square)
-                            .tooltip(Tooltip::text("Clear Keystrokes"))
+                            .tooltip(Tooltip::for_action_title(
+                                "Clear Keystrokes",
+                                &ClearKeystrokes,
+                            ))
                             .when(!is_recording || !is_focused, |this| {
                                 this.icon_color(Color::Muted)
                             })

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -12,7 +12,7 @@ use fuzzy::{StringMatch, StringMatchCandidate};
 use gpui::{
     Action, Animation, AnimationExt, AppContext as _, AsyncApp, ClickEvent, Context, DismissEvent,
     Entity, EventEmitter, FocusHandle, Focusable, FontWeight, Global, IsZero, KeyContext,
-    KeyDownEvent, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, Point, ScrollStrategy,
+    Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, Point, ScrollStrategy,
     ScrollWheelEvent, StyledText, Subscription, WeakEntity, actions, anchored, deferred, div,
 };
 use language::{Language, LanguageConfig, ToOffset as _};

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1973,7 +1973,7 @@ impl KeystrokeInput {
             self.close_keystrokes.take();
             return CloseKeystrokeResult::None;
         };
-        let action_keystrokes = dbg!(keybind_for_close_action.keystrokes());
+        let action_keystrokes = keybind_for_close_action.keystrokes();
 
         if let Some(mut close_keystrokes) = self.close_keystrokes.take() {
             let mut index = 0;
@@ -2058,7 +2058,7 @@ impl KeystrokeInput {
             if close_keystroke_result == CloseKeystrokeResult::Partial
                 && self.close_keystrokes_start.is_none()
             {
-                self.close_keystrokes_start = dbg!(Some(self.keystrokes.len()));
+                self.close_keystrokes_start = Some(self.keystrokes.len());
             }
             self.keystrokes.push(keystroke.clone());
             if self.keystrokes.len() < Self::KEYSTROKE_COUNT_MAX {
@@ -2072,7 +2072,6 @@ impl KeystrokeInput {
     fn on_inner_focus_in(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         if self.intercept_subscription.is_none() {
             let listener = cx.listener(|this, event: &gpui::KeystrokeEvent, window, cx| {
-                dbg!(&event.keystroke);
                 this.handle_keystroke(&event.keystroke, window, cx);
             });
             self.intercept_subscription = Some(cx.intercept_keystrokes(listener))
@@ -2132,7 +2131,15 @@ impl KeystrokeInput {
         self.search = search;
     }
 
-    fn start_recording(&mut self, _: &StartRecording, window: &mut Window, cx: &mut Context<Self>) {
+    fn start_recording(
+        &mut self,
+        _: &StartRecording,
+        window: &mut Window,
+        _cx: &mut Context<Self>,
+    ) {
+        if !self.outer_focus_handle.is_focused(window) {
+            return;
+        }
         window.focus(&self.inner_focus_handle);
     }
 
@@ -2142,10 +2149,10 @@ impl KeystrokeInput {
         }
         window.focus(&self.outer_focus_handle);
         cx.notify();
-        // todo! clear inputs
         if let Some(close_keystrokes_start) = self.close_keystrokes_start.take() {
             self.keystrokes.drain(close_keystrokes_start..);
         }
+        self.close_keystrokes.take();
     }
 }
 

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -2106,18 +2106,22 @@ impl KeystrokeInput {
         return &self.keystrokes;
     }
 
-    fn render_keystrokes(&self) -> impl Iterator<Item = Div> {
-        let (keystrokes, color) = if let Some(placeholders) = self.placeholder_keystrokes.as_ref()
+    fn render_keystrokes(&self, is_recording: bool) -> impl Iterator<Item = Div> {
+        let keystrokes = if let Some(placeholders) = self.placeholder_keystrokes.as_ref()
             && self.keystrokes.is_empty()
         {
-            (placeholders, Color::Placeholder)
+            if is_recording {
+                &[]
+            } else {
+                placeholders.as_slice()
+            }
         } else {
-            (&self.keystrokes, Color::Default)
+            &self.keystrokes
         };
         keystrokes.iter().map(move |keystroke| {
             h_flex().children(ui::render_keystroke(
                 keystroke,
-                Some(color),
+                Some(Color::Default),
                 Some(rems(0.875).into()),
                 ui::PlatformStyle::platform(),
                 false,
@@ -2306,7 +2310,7 @@ impl Render for KeystrokeInput {
                     .justify_center()
                     .flex_wrap()
                     .gap(ui::DynamicSpacing::Base04.rems(cx))
-                    .children(self.render_keystrokes()),
+                    .children(self.render_keystrokes(is_recording)),
             )
             .child(
                 h_flex()

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -75,6 +75,8 @@ actions!(
         StartRecording,
         /// Stops recording keystrokes
         StopRecording,
+        /// Clears the recorded keystrokes
+        ClearKeystrokes,
     ]
 );
 
@@ -2151,6 +2153,19 @@ impl KeystrokeInput {
         self.close_keystrokes.take();
         cx.notify();
     }
+
+    fn clear_keystrokes(
+        &mut self,
+        _: &ClearKeystrokes,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        if !self.outer_focus_handle.is_focused(window) {
+            return;
+        }
+        self.keystrokes.clear();
+        cx.notify();
+    }
 }
 
 impl EventEmitter<()> for KeystrokeInput {}
@@ -2341,10 +2356,8 @@ impl Render for KeystrokeInput {
                             .when(!is_recording || !is_focused, |this| {
                                 this.icon_color(Color::Muted)
                             })
-                            .on_click(cx.listener(|this, _event, _window, cx| {
-                                this.keystrokes.clear();
-                                cx.emit(());
-                                cx.notify();
+                            .on_click(cx.listener(|this, _event, window, cx| {
+                                this.clear_keystrokes(&ClearKeystrokes, window, cx);
                             })),
                     ),
             );

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4327,6 +4327,7 @@ mod tests {
                 "jj",
                 "journal",
                 "keymap_editor",
+                "keystroke_input",
                 "language_selector",
                 "lsp_tool",
                 "markdown",


### PR DESCRIPTION
Closes #ISSUE

Changes direction on the design of the keystroke input. Due to MacOS limitations, it was decided that the complex repeat keystroke logic could be avoided by limiting the number of keystrokes so that accidental repeats were less damaging to ux. This PR follows up on the design pass in #34437 that assumed these changes would be made, hooking up actions and greatly improving the keyboard navigability of the keystroke input.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
