### PR TITLE
Automatically retry in more situations

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2269,17 +2269,14 @@ impl Thread {
             // Max retries exceeded
             self.retry_state = None;
 
-            let notification_text = if max_attempts == 1 {
-                "Failed after retrying.".into()
-            } else {
-                format!("Failed after retrying {} times.", max_attempts).into()
-            };
+            let notification_text = "Agent stopped due to an error".into();
 
             // Stop generating since we're giving up on retrying.
             self.pending_completions.clear();
 
             cx.emit(ThreadEvent::RetriesFailed {
                 message: notification_text,
+                error: Arc::new(anyhow::Error::msg(error.to_string())),
             });
 
             false
@@ -3239,6 +3236,7 @@ pub enum ThreadEvent {
     ProfileChanged,
     RetriesFailed {
         message: SharedString,
+        error: Arc<anyhow::Error>,
     },
 }
 

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2223,10 +2223,14 @@ impl Thread {
 
             // Add a transient message to inform the user
             let delay_secs = delay.as_secs();
-            let retry_message = format!(
-                "{error}. Retrying (attempt {attempt} of {max_attempts}) \
-                in {delay_secs} seconds..."
-            );
+            let retry_message = if max_attempts == 1 {
+                format!("{error}. Retrying in {delay_secs} seconds...")
+            } else {
+                format!(
+                    "{error}. Retrying (attempt {attempt} of {max_attempts}) \
+                    in {delay_secs} seconds..."
+                )
+            };
             log::warn!(
                 "Retrying completion request (attempt {attempt} of {max_attempts}) \
                 in {delay_secs} seconds: {error:?}",
@@ -4256,7 +4260,8 @@ fn main() {{
                             if let MessageSegment::Text(text) = seg {
                                 text.contains("internal")
                                     && text.contains("Fake")
-                                    && text.contains("attempt 1 of 1")
+                                    && text.contains("Retrying in")
+                                    && !text.contains("attempt")
                             } else {
                                 false
                             }

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -4285,7 +4285,7 @@ fn main() {{
         let project = create_test_project(cx, json!({})).await;
         let (_, _, thread, _, _base_model) = setup_test_environment(cx, project.clone()).await;
 
-        // Create model that returns internal server error (which now uses fixed delay with 1 retry)
+        // Create model that returns internal server error
         let model = Arc::new(ErrorInjector::new(TestError::InternalServerError));
 
         // Insert a user message
@@ -4419,7 +4419,6 @@ fn main() {{
         cx.run_until_parked();
 
         // Advance through all retries
-        // ServerOverloaded now uses fixed delay, not exponential backoff
         for _ in 0..MAX_RETRY_ATTEMPTS {
             cx.executor().advance_clock(BASE_RETRY_DELAY);
             cx.run_until_parked();

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1316,7 +1316,12 @@ impl Thread {
                 .generate_assistant_system_prompt(project_context, model_context)
             {
                 Err(err) => {
-                    log::error!("Error generating system prompt: {err:?}");
+                    let message = format!("{err:?}").into();
+                    log::error!("{message}");
+                    cx.emit(ThreadEvent::ShowError(ThreadError::Message {
+                        header: "Error generating system prompt".into(),
+                        message,
+                    }));
                 }
                 Ok(system_prompt) => {
                     request.messages.push(LanguageModelRequestMessage {
@@ -1327,7 +1332,12 @@ impl Thread {
                 }
             }
         } else {
-            log::error!("Context for system prompt unexpectedly not ready.");
+            let message = "Context for system prompt unexpectedly not ready.".into();
+            log::error!("{message}");
+            cx.emit(ThreadEvent::ShowError(ThreadError::Message {
+                header: "Error generating system prompt".into(),
+                message,
+            }));
         }
 
         let mut message_ix_to_cache = None;
@@ -1919,9 +1929,12 @@ impl Thread {
                                         }
                                     }
 
-                                    log::info!(
-                                        "Model refused to generate content for safety reasons."
-                                    );
+                                    cx.emit(ThreadEvent::ShowError(ThreadError::Message {
+                                        header: "Language model refusal".into(),
+                                        message:
+                                            "Model refused to generate content for safety reasons."
+                                                .into(),
+                                    }));
                                 }
                             }
 

--- a/crates/agent_ui/src/active_thread.rs
+++ b/crates/agent_ui/src/active_thread.rs
@@ -1184,8 +1184,19 @@ impl ActiveThread {
                 self.save_thread(cx);
                 cx.notify();
             }
-            ThreadEvent::RetriesFailed { message } => {
+            ThreadEvent::RetriesFailed { message, error } => {
                 self.show_notification(message, ui::IconName::Warning, window, cx);
+
+                // Also show the error in the UI
+                let error_message = error
+                    .chain()
+                    .map(|err| err.to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n");
+                self.last_error = Some(ThreadError::Message {
+                    header: "Error interacting with language model".into(),
+                    message: error_message.into(),
+                });
             }
         }
     }

--- a/crates/agent_ui/src/active_thread.rs
+++ b/crates/agent_ui/src/active_thread.rs
@@ -1013,7 +1013,7 @@ impl ActiveThread {
                         );
                     }
                     Ok(StopReason::ToolUse) => {
-                        // Don't show notification for intermediate tool use
+                        // Don't notify for intermediate tool use
                     }
                     Ok(StopReason::Refusal) => {
                         self.play_notification_sound(window, cx);

--- a/crates/agent_ui/src/active_thread.rs
+++ b/crates/agent_ui/src/active_thread.rs
@@ -1022,13 +1022,23 @@ impl ActiveThread {
                             cx,
                         );
                     }
-                    Err(_) => {
+                    Err(error) => {
                         self.notify_with_sound(
                             "Agent stopped due to an error",
                             IconName::Warning,
                             window,
                             cx,
                         );
+
+                        let error_message = error
+                            .chain()
+                            .map(|err| err.to_string())
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        self.last_error = Some(ThreadError::Message {
+                            header: "Error interacting with language model".into(),
+                            message: error_message.into(),
+                        });
                     }
                 }
             }
@@ -1178,20 +1188,6 @@ impl ActiveThread {
             ThreadEvent::ProfileChanged => {
                 self.save_thread(cx);
                 cx.notify();
-            }
-            ThreadEvent::RetriesFailed { message, error } => {
-                self.notify_with_sound(message, ui::IconName::Warning, window, cx);
-
-                // Also show the error in the UI
-                let error_message = error
-                    .chain()
-                    .map(|err| err.to_string())
-                    .collect::<Vec<_>>()
-                    .join("\n");
-                self.last_error = Some(ThreadError::Message {
-                    header: "Error interacting with language model".into(),
-                    message: error_message.into(),
-                });
             }
         }
     }

--- a/crates/agent_ui/src/active_thread.rs
+++ b/crates/agent_ui/src/active_thread.rs
@@ -999,9 +999,8 @@ impl ActiveThread {
             ThreadEvent::Stopped(reason) => {
                 match reason {
                     Ok(StopReason::EndTurn | StopReason::MaxTokens) => {
-                        self.play_notification_sound(window, cx);
                         let used_tools = self.thread.read(cx).used_tools_since_last_user_message();
-                        self.show_notification(
+                        self.notify_with_sound(
                             if used_tools {
                                 "Finished running tools"
                             } else {
@@ -1016,8 +1015,7 @@ impl ActiveThread {
                         // Don't notify for intermediate tool use
                     }
                     Ok(StopReason::Refusal) => {
-                        self.play_notification_sound(window, cx);
-                        self.show_notification(
+                        self.notify_with_sound(
                             "Language model refused to respond",
                             IconName::Warning,
                             window,
@@ -1025,8 +1023,7 @@ impl ActiveThread {
                         );
                     }
                     Err(_) => {
-                        self.play_notification_sound(window, cx);
-                        self.show_notification(
+                        self.notify_with_sound(
                             "Agent stopped due to an error",
                             IconName::Warning,
                             window,
@@ -1036,12 +1033,10 @@ impl ActiveThread {
                 }
             }
             ThreadEvent::ToolConfirmationNeeded => {
-                self.play_notification_sound(window, cx);
-                self.show_notification("Waiting for tool confirmation", IconName::Info, window, cx);
+                self.notify_with_sound("Waiting for tool confirmation", IconName::Info, window, cx);
             }
             ThreadEvent::ToolUseLimitReached => {
-                self.play_notification_sound(window, cx);
-                self.show_notification(
+                self.notify_with_sound(
                     "Consecutive tool use limit reached.",
                     IconName::Warning,
                     window,
@@ -1185,7 +1180,7 @@ impl ActiveThread {
                 cx.notify();
             }
             ThreadEvent::RetriesFailed { message, error } => {
-                self.show_notification(message, ui::IconName::Warning, window, cx);
+                self.notify_with_sound(message, ui::IconName::Warning, window, cx);
 
                 // Also show the error in the UI
                 let error_message = error
@@ -1250,6 +1245,17 @@ impl ActiveThread {
                 // Don't show anything
             }
         }
+    }
+
+    fn notify_with_sound(
+        &mut self,
+        caption: impl Into<SharedString>,
+        icon: IconName,
+        window: &mut Window,
+        cx: &mut Context<ActiveThread>,
+    ) {
+        self.play_notification_sound(window, cx);
+        self.show_notification(caption, icon, window, cx);
     }
 
     fn pop_up(

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1488,7 +1488,6 @@ impl AgentDiff {
             | ThreadEvent::ToolConfirmationNeeded
             | ThreadEvent::ToolUseLimitReached
             | ThreadEvent::CancelEditing
-            | ThreadEvent::RetriesFailed { .. }
             | ThreadEvent::ProfileChanged => {}
         }
     }

--- a/crates/eval/src/example.rs
+++ b/crates/eval/src/example.rs
@@ -221,9 +221,6 @@ impl ExampleContext {
                 ThreadEvent::ShowError(thread_error) => {
                     tx.try_send(Err(anyhow!(thread_error.clone()))).ok();
                 }
-                ThreadEvent::RetriesFailed { .. } => {
-                    // Ignore retries failed events
-                }
                 ThreadEvent::Stopped(reason) => match reason {
                     Ok(StopReason::EndTurn) => {
                         tx.close_channel();


### PR DESCRIPTION
In #33275 I was very conservative about when to retry when there are errors in language completions in the Agent panel.

Now we retry in more scenarios (e.g. HTTP 5xx and 4xx errors that aren't in the specific list of ones that we handle differently, such as 429s), and also we show a notification if the thread halts for any reason.

<img width="441" height="68" alt="Screenshot 2025-07-15 at 12 51 30 PM" src="https://github.com/user-attachments/assets/433775d0-a8b2-403d-9427-1e296d164980" />
<img width="482" height="322" alt="Screenshot 2025-07-15 at 12 44 15 PM" src="https://github.com/user-attachments/assets/5a508224-0fe0-4d34-9768-25d95873eab8" />


Release Notes:

- Automatic retry for more Agent errors
- Whenever the Agent stops, play a sound (if configured) and show a notification (if configured) if the Zed window was in the background.
