### PR TITLE
Rename `action_input` to `action_arguments` in keybinding contexts

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -623,7 +623,7 @@ impl KeymapFile {
                 target_keybind_source,
             } if target_keybind_source != KeybindSource::User => {
                 target.action_name = gpui::NoAction.name();
-                target.input.take();
+                target.action_arguments.take();
                 operation = KeybindUpdateOperation::Add(target);
             }
             _ => {}
@@ -848,17 +848,17 @@ pub struct KeybindUpdateTarget<'a> {
     pub keystrokes: &'a [Keystroke],
     pub action_name: &'a str,
     pub use_key_equivalents: bool,
-    pub input: Option<&'a str>,
+    pub action_arguments: Option<&'a str>,
 }
 
 impl<'a> KeybindUpdateTarget<'a> {
     fn action_value(&self) -> Result<Value> {
         let action_name: Value = self.action_name.into();
-        let value = match self.input {
-            Some(input) => {
-                let input = serde_json::from_str::<Value>(input)
-                    .context("Failed to parse action input as JSON")?;
-                serde_json::json!([action_name, input])
+        let value = match self.action_arguments {
+            Some(args) => {
+                let args = serde_json::from_str::<Value>(args)
+                    .context("Failed to parse action arguments as JSON")?;
+                serde_json::json!([action_name, args])
             }
             None => action_name,
         };
@@ -986,7 +986,7 @@ mod tests {
                 action_name: "zed::SomeAction",
                 context: None,
                 use_key_equivalents: false,
-                input: None,
+                action_arguments: None,
             }),
             r#"[
                 {
@@ -1012,7 +1012,7 @@ mod tests {
                 action_name: "zed::SomeOtherAction",
                 context: None,
                 use_key_equivalents: false,
-                input: None,
+                action_arguments: None,
             }),
             r#"[
                 {
@@ -1043,7 +1043,7 @@ mod tests {
                 action_name: "zed::SomeOtherAction",
                 context: None,
                 use_key_equivalents: false,
-                input: Some(r#"{"foo": "bar"}"#),
+                action_arguments: Some(r#"{"foo": "bar"}"#),
             }),
             r#"[
                 {
@@ -1079,7 +1079,7 @@ mod tests {
                 action_name: "zed::SomeOtherAction",
                 context: Some("Zed > Editor && some_condition = true"),
                 use_key_equivalents: true,
-                input: Some(r#"{"foo": "bar"}"#),
+                action_arguments: Some(r#"{"foo": "bar"}"#),
             }),
             r#"[
                 {
@@ -1118,14 +1118,14 @@ mod tests {
                     action_name: "zed::SomeAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: Some(r#"{"foo": "bar"}"#),
+                    action_arguments: Some(r#"{"foo": "bar"}"#),
                 },
                 target_keybind_source: KeybindSource::Base,
             },
@@ -1164,14 +1164,14 @@ mod tests {
                     action_name: "zed::SomeAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: Some(r#"{"foo": "bar"}"#),
+                    action_arguments: Some(r#"{"foo": "bar"}"#),
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1205,14 +1205,14 @@ mod tests {
                     action_name: "zed::SomeNonexistentAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1248,14 +1248,14 @@ mod tests {
                     action_name: "zed::SomeAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
                     use_key_equivalents: false,
-                    input: Some(r#"{"foo": "bar"}"#),
+                    action_arguments: Some(r#"{"foo": "bar"}"#),
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1293,14 +1293,14 @@ mod tests {
                     action_name: "foo::bar",
                     context: Some("SomeContext"),
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("c"),
                     action_name: "foo::baz",
                     context: Some("SomeOtherContext"),
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1337,14 +1337,14 @@ mod tests {
                     action_name: "foo::bar",
                     context: Some("SomeContext"),
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("c"),
                     action_name: "foo::baz",
                     context: Some("SomeOtherContext"),
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1376,7 +1376,7 @@ mod tests {
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
                     use_key_equivalents: false,
-                    input: None,
+                    action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1408,7 +1408,7 @@ mod tests {
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
                     use_key_equivalents: false,
-                    input: Some("true"),
+                    action_arguments: Some("true"),
                 },
                 target_keybind_source: KeybindSource::User,
             },
@@ -1451,7 +1451,7 @@ mod tests {
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
                     use_key_equivalents: false,
-                    input: Some("true"),
+                    action_arguments: Some("true"),
                 },
                 target_keybind_source: KeybindSource::User,
             },

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -520,9 +520,9 @@ impl KeymapEditor {
 
             let action_name = key_binding.action().name();
             unmapped_action_names.remove(&action_name);
-            let action_input = key_binding
+            let action_arguments = key_binding
                 .action_input()
-                .map(|input| SyntaxHighlightedText::new(input, json_language.clone()));
+                .map(|arguments| SyntaxHighlightedText::new(arguments, json_language.clone()));
             let action_docs = action_documentation.get(action_name).copied();
 
             let index = processed_bindings.len();
@@ -531,7 +531,7 @@ impl KeymapEditor {
                 keystroke_text: keystroke_text.into(),
                 ui_key_binding,
                 action_name: action_name.into(),
-                action_input,
+                action_arguments,
                 action_docs,
                 action_schema: action_schema.get(action_name).cloned(),
                 context: Some(context),
@@ -548,7 +548,7 @@ impl KeymapEditor {
                 keystroke_text: empty.clone(),
                 ui_key_binding: None,
                 action_name: action_name.into(),
-                action_input: None,
+                action_arguments: None,
                 action_docs: action_documentation.get(action_name).copied(),
                 action_schema: action_schema.get(action_name).cloned(),
                 context: None,
@@ -961,7 +961,7 @@ struct ProcessedKeybinding {
     keystroke_text: SharedString,
     ui_key_binding: Option<ui::KeyBinding>,
     action_name: SharedString,
-    action_input: Option<SyntaxHighlightedText>,
+    action_arguments: Option<SyntaxHighlightedText>,
     action_docs: Option<&'static str>,
     action_schema: Option<schemars::Schema>,
     context: Option<KeybindContextString>,
@@ -1244,8 +1244,8 @@ impl Render for KeymapEditor {
                                         binding.keystroke_text.clone().into_any_element(),
                                         IntoElement::into_any_element,
                                     );
-                                    let action_input = match binding.action_input.clone() {
-                                        Some(input) => input.into_any_element(),
+                                    let action_arguments = match binding.action_arguments.clone() {
+                                        Some(arguments) => arguments.into_any_element(),
                                         None => {
                                             if binding.action_schema.is_some() {
                                                 muted_styled_text(NO_ACTION_ARGUMENTS_TEXT, cx)
@@ -1279,7 +1279,14 @@ impl Render for KeymapEditor {
                                         .map(|(_source, name)| name)
                                         .unwrap_or_default()
                                         .into_any_element();
-                                    Some([icon, action, action_input, keystrokes, context, source])
+                                    Some([
+                                        icon,
+                                        action,
+                                        action_arguments,
+                                        keystrokes,
+                                        context,
+                                        source,
+                                    ])
                                 })
                                 .collect()
                         }),
@@ -1446,7 +1453,7 @@ struct KeybindingEditorModal {
     editing_keybind_idx: usize,
     keybind_editor: Entity<KeystrokeInput>,
     context_editor: Entity<SingleLineInput>,
-    input_editor: Option<Entity<Editor>>,
+    action_arguments_editor: Option<Entity<Editor>>,
     fs: Arc<dyn Fs>,
     error: Option<InputError>,
     keymap_editor: Entity<KeymapEditor>,
@@ -1511,16 +1518,16 @@ impl KeybindingEditorModal {
             input
         });
 
-        let input_editor = editing_keybind.action_schema.clone().map(|_schema| {
+        let action_arguments_editor = editing_keybind.action_schema.clone().map(|_schema| {
             cx.new(|cx| {
                 let mut editor = Editor::auto_height_unbounded(1, window, cx);
                 let workspace = workspace.clone();
 
-                if let Some(input) = editing_keybind.action_input.clone() {
-                    editor.set_text(input.text, window, cx);
+                if let Some(arguments) = editing_keybind.action_arguments.clone() {
+                    editor.set_text(arguments.text, window, cx);
                 } else {
                     // TODO: default value from schema?
-                    editor.set_placeholder_text("Action Input", cx);
+                    editor.set_placeholder_text("Action Arguments", cx);
                 }
                 cx.spawn(async |editor, cx| {
                     let json_language = load_json_language(workspace, cx).await;
@@ -1532,7 +1539,7 @@ impl KeybindingEditorModal {
                                 });
                             }
                         })
-                        .context("Failed to load JSON language for editing keybinding action input")
+                        .context("Failed to load JSON language for editing keybinding action arguments input")
                 })
                 .detach_and_log_err(cx);
                 editor
@@ -1546,7 +1553,7 @@ impl KeybindingEditorModal {
             fs,
             keybind_editor,
             context_editor,
-            input_editor,
+            action_arguments_editor,
             error: None,
             keymap_editor,
             workspace,
@@ -1567,22 +1574,22 @@ impl KeybindingEditorModal {
         }
     }
 
-    fn validate_action_input(&self, cx: &App) -> anyhow::Result<Option<String>> {
-        let input = self
-            .input_editor
+    fn validate_action_arguments(&self, cx: &App) -> anyhow::Result<Option<String>> {
+        let action_arguments = self
+            .action_arguments_editor
             .as_ref()
             .map(|editor| editor.read(cx).text(cx));
 
-        let value = input
+        let value = action_arguments
             .as_ref()
-            .map(|input| {
-                serde_json::from_str(input).context("Failed to parse action input as JSON")
+            .map(|args| {
+                serde_json::from_str(args).context("Failed to parse action arguments as JSON")
             })
             .transpose()?;
 
         cx.build_action(&self.editing_keybind.action_name, value)
-            .context("Failed to validate action input")?;
-        Ok(input)
+            .context("Failed to validate action arguments")?;
+        Ok(action_arguments)
     }
 
     fn save(&mut self, cx: &mut Context<Self>) {
@@ -1612,7 +1619,7 @@ impl KeybindingEditorModal {
             return;
         }
 
-        let new_input = match self.validate_action_input(cx) {
+        let new_action_args = match self.validate_action_arguments(cx) {
             Err(input_err) => {
                 self.set_error(InputError::error(input_err.to_string()), cx);
                 return;
@@ -1697,7 +1704,7 @@ impl KeybindingEditorModal {
                 existing_keybind,
                 &new_keystrokes,
                 new_context.as_deref(),
-                new_input.as_deref(),
+                new_action_args.as_deref(),
                 &fs,
                 tab_size,
             )
@@ -1767,7 +1774,7 @@ impl Render for KeybindingEditorModal {
                                     .gap_1()
                                     .child(self.keybind_editor.clone()),
                             )
-                            .when_some(self.input_editor.clone(), |this, editor| {
+                            .when_some(self.action_arguments_editor.clone(), |this, editor| {
                                 this.child(
                                     v_flex()
                                         .mt_1p5()
@@ -1949,7 +1956,7 @@ async fn save_keybinding_update(
     existing: ProcessedKeybinding,
     new_keystrokes: &[Keystroke],
     new_context: Option<&str>,
-    new_input: Option<&str>,
+    new_args: Option<&str>,
     fs: &Arc<dyn Fs>,
     tab_size: usize,
 ) -> anyhow::Result<()> {
@@ -1963,10 +1970,10 @@ async fn save_keybinding_update(
             .context
             .as_ref()
             .and_then(KeybindContextString::local_str);
-        let existing_input = existing
-            .action_input
+        let existing_args = existing
+            .action_arguments
             .as_ref()
-            .map(|input| input.text.as_ref());
+            .map(|args| args.text.as_ref());
 
         settings::KeybindUpdateOperation::Replace {
             target: settings::KeybindUpdateTarget {
@@ -1974,7 +1981,7 @@ async fn save_keybinding_update(
                 keystrokes: existing_keystrokes,
                 action_name: &existing.action_name,
                 use_key_equivalents: false,
-                input: existing_input,
+                action_arguments: existing_args,
             },
             target_keybind_source: existing
                 .source
@@ -1986,7 +1993,7 @@ async fn save_keybinding_update(
                 keystrokes: new_keystrokes,
                 action_name: &existing.action_name,
                 use_key_equivalents: false,
-                input: new_input,
+                action_arguments: new_args,
             },
         }
     } else {
@@ -1995,7 +2002,7 @@ async fn save_keybinding_update(
             keystrokes: new_keystrokes,
             action_name: &existing.action_name,
             use_key_equivalents: false,
-            input: new_input,
+            action_arguments: new_args,
         })
     };
     let updated_keymap_contents =
@@ -2031,10 +2038,10 @@ async fn remove_keybinding(
             keystrokes,
             action_name: &existing.action_name,
             use_key_equivalents: false,
-            input: existing
-                .action_input
+            action_arguments: existing
+                .action_arguments
                 .as_ref()
-                .map(|input| input.text.as_ref()),
+                .map(|arguments| arguments.text.as_ref()),
         },
         target_keybind_source: existing
             .source


### PR DESCRIPTION


Release Notes:

- N/A
