### PR TITLE
agent: Push diffs of user edits to the agent

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -743,6 +743,7 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "icons",
+ "indoc",
  "language",
  "language_model",
  "log",

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1519,7 +1519,9 @@ impl Thread {
     ) -> Option<PendingToolUse> {
         let action_log = self.action_log.read(cx);
 
-        action_log.unnotified_stale_buffers(cx).next()?;
+        if !action_log.has_unnotified_user_edits() {
+            return None;
+        }
 
         // Represent notification as a simulated `project_notifications` tool call
         let tool_name = Arc::from("project_notifications");

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -3290,7 +3290,6 @@ mod tests {
     use futures::stream::BoxStream;
     use gpui::TestAppContext;
     use http_client;
-    use indoc::indoc;
     use language_model::fake_provider::{FakeLanguageModel, FakeLanguageModelProvider};
     use language_model::{
         LanguageModelCompletionError, LanguageModelName, LanguageModelProviderId,
@@ -3651,6 +3650,7 @@ fn main() {{
                 cx,
             );
         });
+        cx.run_until_parked();
 
         // We shouldn't have a stale buffer notification yet
         let notifications = thread.read_with(cx, |thread, _| {
@@ -3680,11 +3680,13 @@ fn main() {{
                 cx,
             )
         });
+        cx.run_until_parked();
 
         // Check for the stale buffer warning
         thread.update(cx, |thread, cx| {
             thread.flush_notifications(model.clone(), CompletionIntent::UserPrompt, cx)
         });
+        cx.run_until_parked();
 
         let notifications = thread.read_with(cx, |thread, _cx| {
             find_tool_uses(thread, "project_notifications")
@@ -3698,12 +3700,8 @@ fn main() {{
             panic!("`project_notifications` should return text");
         };
 
-        let expected_content = indoc! {"[The following is an auto-generated notification; do not reply]
-
-        These files have changed since the last read:
-        - code.rs
-        "};
-        assert_eq!(notification_content, expected_content);
+        assert!(notification_content.contains("These files have changed since the last read:"));
+        assert!(notification_content.contains("code.rs"));
 
         // Insert another user message and flush notifications again
         thread.update(cx, |thread, cx| {
@@ -3719,6 +3717,7 @@ fn main() {{
         thread.update(cx, |thread, cx| {
             thread.flush_notifications(model.clone(), CompletionIntent::UserPrompt, cx)
         });
+        cx.run_until_parked();
 
         // There should be no new notifications (we already flushed one)
         let notifications = thread.read_with(cx, |thread, _cx| {

--- a/crates/assistant_tool/Cargo.toml
+++ b/crates/assistant_tool/Cargo.toml
@@ -40,6 +40,7 @@ collections = { workspace = true, features = ["test-support"] }
 clock = { workspace = true, features = ["test-support"] }
 ctor.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
+indoc.workspace = true
 language = { workspace = true, features = ["test-support"] }
 language_model = { workspace = true, features = ["test-support"] }
 log.workspace = true

--- a/crates/assistant_tool/src/action_log.rs
+++ b/crates/assistant_tool/src/action_log.rs
@@ -8,7 +8,10 @@ use language::{Anchor, Buffer, BufferEvent, DiskState, Point, ToPoint};
 use project::{Project, ProjectItem, lsp_store::OpenLspBufferHandle};
 use std::{cmp, ops::Range, sync::Arc};
 use text::{Edit, Patch, Rope};
-use util::{RangeExt, ResultExt as _};
+use util::{
+    RangeExt, ResultExt as _,
+    paths::{PathStyle, RemotePathBuf},
+};
 
 /// Tracks actions performed by tools in a thread
 pub struct ActionLog {
@@ -82,7 +85,7 @@ impl ActionLog {
                 let file_path = buffer
                     .read(cx)
                     .file()
-                    .map(|file| file.full_path(cx).to_string_lossy().to_string())
+                    .map(|file| RemotePathBuf::new(file.full_path(cx), PathStyle::Posix).to_proto())
                     .unwrap_or_else(|| format!("buffer_{}", buffer.entity_id()));
 
                 let mut result = String::new();

--- a/crates/assistant_tool/src/action_log.rs
+++ b/crates/assistant_tool/src/action_log.rs
@@ -64,6 +64,10 @@ impl ActionLog {
             .tracked_buffers
             .values()
             .filter_map(|tracked| {
+                if !tracked.has_unnotified_user_edits {
+                    return None;
+                }
+
                 let text_with_latest_user_edits = tracked.diff_base.to_string();
                 let text_with_last_seen_user_edits = tracked.last_seen_base.to_string();
                 if text_with_latest_user_edits == text_with_last_seen_user_edits {

--- a/crates/assistant_tool/src/action_log.rs
+++ b/crates/assistant_tool/src/action_log.rs
@@ -107,6 +107,7 @@ impl ActionLog {
         let patch = self.unnotified_user_edits(cx);
         self.tracked_buffers.values_mut().for_each(|tracked| {
             tracked.has_unnotified_user_edits = false;
+            tracked.last_seen_base = tracked.diff_base.clone();
         });
         patch
     }

--- a/crates/assistant_tool/src/action_log.rs
+++ b/crates/assistant_tool/src/action_log.rs
@@ -88,7 +88,7 @@ impl ActionLog {
                 let mut result = String::new();
                 result.push_str(&format!("--- a/{}\n", file_path));
                 result.push_str(&format!("+++ b/{}\n", file_path));
-                result.push_str(&format!("{}", patch));
+                result.push_str(&patch);
 
                 Some(result)
             })
@@ -532,7 +532,7 @@ impl ActionLog {
 
     /// Track a buffer as read by agent, so we can notify the model about user edits.
     pub fn buffer_read(&mut self, buffer: Entity<Buffer>, cx: &mut Context<Self>) {
-        self.track_buffer_internal(buffer.clone(), false, cx);
+        self.track_buffer_internal(buffer, false, cx);
     }
 
     /// Mark a buffer as created by agent, so we can refresh it in the context

--- a/crates/assistant_tools/src/project_notifications_tool.rs
+++ b/crates/assistant_tools/src/project_notifications_tool.rs
@@ -6,7 +6,6 @@ use language_model::{LanguageModel, LanguageModelRequest, LanguageModelToolSchem
 use project::Project;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::fmt::Write as _;
 use std::sync::Arc;
 use ui::IconName;
 
@@ -52,34 +51,20 @@ impl Tool for ProjectNotificationsTool {
         _window: Option<AnyWindowHandle>,
         cx: &mut App,
     ) -> ToolResult {
-        let mut stale_files = String::new();
-        let mut notified_buffers = Vec::new();
-
-        for stale_file in action_log.read(cx).unnotified_stale_buffers(cx) {
-            if let Some(file) = stale_file.read(cx).file() {
-                writeln!(&mut stale_files, "- {}", file.path().display()).ok();
-                notified_buffers.push(stale_file.clone());
-            }
-        }
-
-        if !notified_buffers.is_empty() {
-            action_log.update(cx, |log, cx| {
-                log.mark_buffers_as_notified(notified_buffers, cx);
-            });
-        }
-
-        let response = if stale_files.is_empty() {
-            "No new notifications".to_string()
-        } else {
-            // NOTE: Changes to this prompt require a symmetric update in the LLM Worker
-            const HEADER: &str = include_str!("./project_notifications_tool/prompt_header.txt");
-
-            let patch = action_log.update(cx, |log, cx| log.user_edits_since_last_read(cx));
-            format!("{HEADER}{stale_files}\n\n```diff\n{patch}\n```\n").replace("\r\n", "\n")
+        let Some(user_edits_diff) =
+            action_log.update(cx, |log, cx| log.flush_unnotified_user_edits(cx))
+        else {
+            return result("No new notifications");
         };
 
-        Task::ready(Ok(response.into())).into()
+        // NOTE: Changes to this prompt require a symmetric update in the LLM Worker
+        const HEADER: &str = include_str!("./project_notifications_tool/prompt_header.txt");
+        result(&format!("{HEADER}\n\n```diff\n{user_edits_diff}\n```\n").replace("\r\n", "\n"))
     }
+}
+
+fn result(response: &str) -> ToolResult {
+    Task::ready(Ok(response.to_string().into())).into()
 }
 
 #[cfg(test)]
@@ -125,6 +110,7 @@ mod tests {
         action_log.update(cx, |log, cx| {
             log.buffer_read(buffer.clone(), cx);
         });
+        cx.run_until_parked();
 
         // Run the tool before any changes
         let tool = Arc::new(ProjectNotificationsTool);
@@ -144,6 +130,7 @@ mod tests {
                 cx,
             )
         });
+        cx.run_until_parked();
 
         let response = result.output.await.unwrap();
         let response_text = match &response.content {
@@ -160,6 +147,7 @@ mod tests {
         buffer.update(cx, |buffer, cx| {
             buffer.edit([(1..1, "\nChange!\n")], None, cx);
         });
+        cx.run_until_parked();
 
         // Run the tool again
         let result = cx.update(|cx| {
@@ -173,6 +161,7 @@ mod tests {
                 cx,
             )
         });
+        cx.run_until_parked();
 
         // This time the buffer is stale, so the tool should return a notification
         let response = result.output.await.unwrap();
@@ -181,10 +170,12 @@ mod tests {
             _ => panic!("Expected text response"),
         };
 
-        let expected_content = "[The following is an auto-generated notification; do not reply]\n\nThese files have changed since the last read:\n- code.rs\n";
-        assert_eq!(
-            response_text.as_str(),
-            expected_content,
+        assert!(
+            response_text.contains("These files have changed"),
+            "Tool should return the stale buffer notification"
+        );
+        assert!(
+            response_text.contains("test/code.rs"),
             "Tool should return the stale buffer notification"
         );
 
@@ -200,6 +191,7 @@ mod tests {
                 cx,
             )
         });
+        cx.run_until_parked();
 
         let response = result.output.await.unwrap();
         let response_text = match &response.content {

--- a/crates/assistant_tools/src/project_notifications_tool.rs
+++ b/crates/assistant_tools/src/project_notifications_tool.rs
@@ -73,7 +73,9 @@ impl Tool for ProjectNotificationsTool {
         } else {
             // NOTE: Changes to this prompt require a symmetric update in the LLM Worker
             const HEADER: &str = include_str!("./project_notifications_tool/prompt_header.txt");
-            format!("{HEADER}{stale_files}").replace("\r\n", "\n")
+
+            let patch = action_log.update(cx, |log, cx| log.user_edits_since_last_read_patch(cx));
+            format!("{HEADER}{stale_files}\n{patch}").replace("\r\n", "\n")
         };
 
         Task::ready(Ok(response.into())).into()

--- a/crates/assistant_tools/src/project_notifications_tool.rs
+++ b/crates/assistant_tools/src/project_notifications_tool.rs
@@ -74,7 +74,7 @@ impl Tool for ProjectNotificationsTool {
             // NOTE: Changes to this prompt require a symmetric update in the LLM Worker
             const HEADER: &str = include_str!("./project_notifications_tool/prompt_header.txt");
 
-            let patch = action_log.update(cx, |log, cx| log.user_edits_since_last_read_patch(cx));
+            let patch = action_log.update(cx, |log, cx| log.user_edits_since_last_read(cx));
             format!("{HEADER}{stale_files}\n\n```diff\n{patch}\n```\n").replace("\r\n", "\n")
         };
 

--- a/crates/assistant_tools/src/project_notifications_tool.rs
+++ b/crates/assistant_tools/src/project_notifications_tool.rs
@@ -75,7 +75,7 @@ impl Tool for ProjectNotificationsTool {
             const HEADER: &str = include_str!("./project_notifications_tool/prompt_header.txt");
 
             let patch = action_log.update(cx, |log, cx| log.user_edits_since_last_read_patch(cx));
-            format!("{HEADER}{stale_files}\n{patch}").replace("\r\n", "\n")
+            format!("{HEADER}{stale_files}\n\n```diff\n{patch}\n```\n").replace("\r\n", "\n")
         };
 
         Task::ready(Ok(response.into())).into()


### PR DESCRIPTION
This change improves user/agent collaborative editing.

When the user edits files that are used by the agent, the `project_notification` tool now pushes *diffs* of the changes, not just file names. This helps the agent to stay up to date without needing to re-read files.

Release Notes:

- Improved user/agent collaborative editing: agent now receives diffs of user edits