### PR TITLE
editor: Add ToggleFocus action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -425,6 +425,8 @@ actions!(
         FoldRecursive,
         /// Folds the selected ranges.
         FoldSelectedRanges,
+        /// Toggles focus back to the last active buffer.
+        ToggleFocus,
         /// Toggles folding at the current position.
         ToggleFold,
         /// Toggles recursive folding at the current position.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -356,6 +356,7 @@ pub fn init(cx: &mut App) {
             workspace.register_action(Editor::new_file_vertical);
             workspace.register_action(Editor::new_file_horizontal);
             workspace.register_action(Editor::cancel_language_server_work);
+            workspace.register_action(Editor::toggle_focus);
         },
     )
     .detach();
@@ -16972,6 +16973,15 @@ impl Editor {
         });
         self.request_autoscroll(Autoscroll::newest(), cx);
         cx.notify();
+    }
+
+    pub fn toggle_focus(
+        workspace: &mut Workspace,
+        _: &actions::ToggleFocus,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        workspace.toggle_last_active_pane(window, cx);
     }
 
     pub fn toggle_fold(

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16981,7 +16981,10 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Workspace>,
     ) {
-        workspace.toggle_last_active_pane(window, cx);
+        let Some(item) = workspace.recent_active_item_by_type::<Self>(cx) else {
+            return;
+        };
+        workspace.activate_item(&item, true, true, window, cx);
     }
 
     pub fn toggle_fold(

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1716,10 +1716,11 @@ impl Workspace {
         let mut recent_timestamp = 0;
         for pane_handle in &self.panes {
             let pane = pane_handle.read(cx);
+            let item_map: HashMap<EntityId, &Box<dyn ItemHandle>> =
+                pane.items().map(|item| (item.item_id(), item)).collect();
             for entry in pane.activation_history() {
                 if entry.timestamp > recent_timestamp {
-                    if let Some(item) = pane.items().find(|item| item.item_id() == entry.entity_id)
-                    {
+                    if let Some(&item) = item_map.get(&entry.entity_id) {
                         if let Some(typed_item) = item.act_as::<T>(cx) {
                             recent_timestamp = entry.timestamp;
                             recent_item = Some(typed_item);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1791,6 +1791,14 @@ impl Workspace {
             .collect()
     }
 
+    pub fn toggle_last_active_pane(&self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Some(last_pane) = self.last_active_center_pane.as_ref() {
+            last_pane
+                .update(cx, |pane, cx| window.focus(&pane.focus_handle(cx)))
+                .ok();
+        }
+    }
+
     fn navigate_history(
         &mut self,
         pane: WeakEntity<Pane>,


### PR DESCRIPTION
This PR adds action `editor: toggle focus` which focuses to last active editor pane item in workspace.

Release Notes:

- Added `editor: toggle focus` action, which focuses to last active editor pane item.
