### PR TITLE
debugger: Remove `Start` button from the attach modal

### DIFF
--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -766,14 +766,7 @@ impl Render for NewProcessModal {
                             ))
                             .child(
                                 h_flex()
-                                    .child(div().child(self.adapter_drop_down_menu(window, cx)))
-                                    .child(
-                                        Button::new("debugger-spawn", "Start")
-                                            .on_click(cx.listener(|this, _, window, cx| {
-                                                this.start_new_session(window, cx)
-                                            }))
-                                            .disabled(disabled),
-                                    ),
+                                    .child(div().child(self.adapter_drop_down_menu(window, cx))),
                             )
                     }),
                     NewProcessMode::Debug => el,


### PR DESCRIPTION
Right now it doesn't work at all (the PID doesn't get set in the generated scenario), and it's sort of redundant with the picker functionality.

Release Notes:

- N/A