### PR TITLE
keymap_ui: Infer use key equivalents

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -10,6 +10,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use std::borrow::Cow;
 use std::{any::TypeId, fmt::Write, rc::Rc, sync::Arc, sync::LazyLock};
+use util::ResultExt as _;
 use util::{
     asset_str,
     markdown::{MarkdownEscaped, MarkdownInlineCode, MarkdownString},
@@ -612,19 +613,26 @@ impl KeymapFile {
             KeybindUpdateOperation::Replace {
                 target_keybind_source: target_source,
                 source,
-                ..
+                target,
             } if target_source != KeybindSource::User => {
-                operation = KeybindUpdateOperation::Add(source);
+                operation = KeybindUpdateOperation::Add {
+                    source,
+                    from: Some(target),
+                };
             }
             // if trying to remove a keybinding that is not user-defined, treat it as creating a binding
             // that binds it to `zed::NoAction`
             KeybindUpdateOperation::Remove {
-                mut target,
+                target,
                 target_keybind_source,
             } if target_keybind_source != KeybindSource::User => {
-                target.action_name = gpui::NoAction.name();
-                target.action_arguments.take();
-                operation = KeybindUpdateOperation::Add(target);
+                let mut source = target.clone();
+                source.action_name = gpui::NoAction.name();
+                source.action_arguments.take();
+                operation = KeybindUpdateOperation::Add {
+                    source,
+                    from: Some(target),
+                };
             }
             _ => {}
         }
@@ -742,7 +750,10 @@ impl KeymapFile {
                         )
                         .context("Failed to replace keybinding")?;
                     keymap_contents.replace_range(replace_range, &replace_value);
-                    operation = KeybindUpdateOperation::Add(source);
+                    operation = KeybindUpdateOperation::Add {
+                        source,
+                        from: Some(target),
+                    };
                 }
             } else {
                 log::warn!(
@@ -752,16 +763,28 @@ impl KeymapFile {
                     source.keystrokes,
                     source_action_value,
                 );
-                operation = KeybindUpdateOperation::Add(source);
+                operation = KeybindUpdateOperation::Add {
+                    source,
+                    from: Some(target),
+                };
             }
         }
 
-        if let KeybindUpdateOperation::Add(keybinding) = operation {
+        if let KeybindUpdateOperation::Add {
+            source: keybinding,
+            from,
+        } = operation
+        {
             let mut value = serde_json::Map::with_capacity(4);
             if let Some(context) = keybinding.context {
                 value.insert("context".to_string(), context.into());
             }
-            if keybinding.use_key_equivalents {
+            let use_key_equivalents = from.and_then(|from| {
+                let action_value = from.action_value().context("Failed to serialize action value. `use_key_equivalents` on new keybinding may be incorrect.").log_err()?;
+                let (index, _) = find_binding(&keymap, &from, &action_value)?;
+                Some(keymap.0[index].use_key_equivalents)
+            }).unwrap_or(false);
+            if use_key_equivalents {
                 value.insert("use_key_equivalents".to_string(), true.into());
             }
 
@@ -792,9 +815,6 @@ impl KeymapFile {
                 let section_context_parsed =
                     KeyBindingContextPredicate::parse(&section.context).ok();
                 if section_context_parsed != target_context_parsed {
-                    continue;
-                }
-                if section.use_key_equivalents != target.use_key_equivalents {
                     continue;
                 }
                 let Some(bindings) = &section.bindings else {
@@ -835,19 +855,27 @@ pub enum KeybindUpdateOperation<'a> {
         target: KeybindUpdateTarget<'a>,
         target_keybind_source: KeybindSource,
     },
-    Add(KeybindUpdateTarget<'a>),
+    Add {
+        source: KeybindUpdateTarget<'a>,
+        from: Option<KeybindUpdateTarget<'a>>,
+    },
     Remove {
         target: KeybindUpdateTarget<'a>,
         target_keybind_source: KeybindSource,
     },
 }
 
-#[derive(Debug)]
+impl<'a> KeybindUpdateOperation<'a> {
+    pub fn add(source: KeybindUpdateTarget<'a>) -> Self {
+        Self::Add { source, from: None }
+    }
+}
+
+#[derive(Debug, Clone)]
 pub struct KeybindUpdateTarget<'a> {
     pub context: Option<&'a str>,
     pub keystrokes: &'a [Keystroke],
     pub action_name: &'a str,
-    pub use_key_equivalents: bool,
     pub action_arguments: Option<&'a str>,
 }
 
@@ -981,11 +1009,10 @@ mod tests {
 
         check_keymap_update(
             "[]",
-            KeybindUpdateOperation::Add(KeybindUpdateTarget {
+            KeybindUpdateOperation::add(KeybindUpdateTarget {
                 keystrokes: &parse_keystrokes("ctrl-a"),
                 action_name: "zed::SomeAction",
                 context: None,
-                use_key_equivalents: false,
                 action_arguments: None,
             }),
             r#"[
@@ -1007,11 +1034,10 @@ mod tests {
                 }
             ]"#
             .unindent(),
-            KeybindUpdateOperation::Add(KeybindUpdateTarget {
+            KeybindUpdateOperation::add(KeybindUpdateTarget {
                 keystrokes: &parse_keystrokes("ctrl-b"),
                 action_name: "zed::SomeOtherAction",
                 context: None,
-                use_key_equivalents: false,
                 action_arguments: None,
             }),
             r#"[
@@ -1038,11 +1064,10 @@ mod tests {
                 }
             ]"#
             .unindent(),
-            KeybindUpdateOperation::Add(KeybindUpdateTarget {
+            KeybindUpdateOperation::add(KeybindUpdateTarget {
                 keystrokes: &parse_keystrokes("ctrl-b"),
                 action_name: "zed::SomeOtherAction",
                 context: None,
-                use_key_equivalents: false,
                 action_arguments: Some(r#"{"foo": "bar"}"#),
             }),
             r#"[
@@ -1074,11 +1099,10 @@ mod tests {
                 }
             ]"#
             .unindent(),
-            KeybindUpdateOperation::Add(KeybindUpdateTarget {
+            KeybindUpdateOperation::add(KeybindUpdateTarget {
                 keystrokes: &parse_keystrokes("ctrl-b"),
                 action_name: "zed::SomeOtherAction",
                 context: Some("Zed > Editor && some_condition = true"),
-                use_key_equivalents: true,
                 action_arguments: Some(r#"{"foo": "bar"}"#),
             }),
             r#"[
@@ -1089,7 +1113,6 @@ mod tests {
                 },
                 {
                     "context": "Zed > Editor && some_condition = true",
-                    "use_key_equivalents": true,
                     "bindings": {
                         "ctrl-b": [
                             "zed::SomeOtherAction",
@@ -1117,14 +1140,12 @@ mod tests {
                     keystrokes: &parse_keystrokes("ctrl-a"),
                     action_name: "zed::SomeAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: Some(r#"{"foo": "bar"}"#),
                 },
                 target_keybind_source: KeybindSource::Base,
@@ -1163,14 +1184,12 @@ mod tests {
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "zed::SomeAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: Some(r#"{"foo": "bar"}"#),
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1204,14 +1223,12 @@ mod tests {
                     keystrokes: &parse_keystrokes("ctrl-a"),
                     action_name: "zed::SomeNonexistentAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1247,14 +1264,12 @@ mod tests {
                     keystrokes: &parse_keystrokes("ctrl-a"),
                     action_name: "zed::SomeAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("ctrl-b"),
                     action_name: "zed::SomeOtherAction",
                     context: None,
-                    use_key_equivalents: false,
                     action_arguments: Some(r#"{"foo": "bar"}"#),
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1292,14 +1307,12 @@ mod tests {
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
                     context: Some("SomeContext"),
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("c"),
                     action_name: "foo::baz",
                     context: Some("SomeOtherContext"),
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1336,14 +1349,12 @@ mod tests {
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
                     context: Some("SomeContext"),
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 source: KeybindUpdateTarget {
                     keystrokes: &parse_keystrokes("c"),
                     action_name: "foo::baz",
                     context: Some("SomeOtherContext"),
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1375,7 +1386,6 @@ mod tests {
                     context: Some("SomeContext"),
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
-                    use_key_equivalents: false,
                     action_arguments: None,
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1407,7 +1417,6 @@ mod tests {
                     context: Some("SomeContext"),
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
-                    use_key_equivalents: false,
                     action_arguments: Some("true"),
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1450,7 +1459,6 @@ mod tests {
                     context: Some("SomeContext"),
                     keystrokes: &parse_keystrokes("a"),
                     action_name: "foo::bar",
-                    use_key_equivalents: false,
                     action_arguments: Some("true"),
                 },
                 target_keybind_source: KeybindSource::User,
@@ -1466,6 +1474,50 @@ mod tests {
                     "context": "SomeContext",
                     "bindings": {
                         "c": "foo::baz",
+                    }
+                },
+            ]"#
+            .unindent(),
+        );
+
+        check_keymap_update(
+            r#"[
+                {
+                    "context": "SomeOtherContext",
+                    "use_key_equivalents": true,
+                    "bindings": {
+                        "b": "foo::bar",
+                    }
+                },
+            ]"#
+            .unindent(),
+            KeybindUpdateOperation::Add {
+                source: KeybindUpdateTarget {
+                    context: Some("SomeContext"),
+                    keystrokes: &parse_keystrokes("a"),
+                    action_name: "foo::baz",
+                    action_arguments: Some("true"),
+                },
+                from: Some(KeybindUpdateTarget {
+                    context: Some("SomeContext"),
+                    keystrokes: &parse_keystrokes("a"),
+                    action_name: "foo::bar",
+                    action_arguments: None,
+                }),
+            },
+            r#"[
+                {
+                    "context": "SomeOtherContext",
+                    "use_key_equivalents": true,
+                    "bindings": {
+                        "b": "foo::bar",
+                    }
+                },
+                {
+                    "context": "SomeContext",
+                    "use_key_equivalents": true,
+                    "bindings": {
+                        "a": "foo::baz",
                     }
                 },
             ]"#

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1,5 +1,5 @@
 use std::{
-    ops::{Not, Range},
+    ops::{Not as _, Range},
     sync::Arc,
 };
 
@@ -1602,32 +1602,45 @@ impl KeybindingEditorModal {
         Ok(action_arguments)
     }
 
-    fn save(&mut self, cx: &mut Context<Self>) {
-        let existing_keybind = self.editing_keybind.clone();
-        let fs = self.fs.clone();
+    fn validate_keystrokes(&self, cx: &App) -> anyhow::Result<Vec<Keystroke>> {
         let new_keystrokes = self
             .keybind_editor
             .read_with(cx, |editor, _| editor.keystrokes().to_vec());
-        if new_keystrokes.is_empty() {
-            self.set_error(InputError::error("Keystrokes cannot be empty"), cx);
-            return;
-        }
-        let tab_size = cx.global::<settings::SettingsStore>().json_tab_size();
+        anyhow::ensure!(!new_keystrokes.is_empty(), "Keystrokes cannot be empty");
+        Ok(new_keystrokes)
+    }
+
+    fn validate_context(&self, cx: &App) -> anyhow::Result<Option<String>> {
         let new_context = self
             .context_editor
             .read_with(cx, |input, cx| input.editor().read(cx).text(cx));
-        let new_context = new_context.is_empty().not().then_some(new_context);
-        let new_context_err = new_context.as_deref().and_then(|context| {
-            gpui::KeyBindingContextPredicate::parse(context)
-                .context("Failed to parse key context")
-                .err()
-        });
-        if let Some(err) = new_context_err {
-            // TODO: store and display as separate error
-            // TODO: also, should be validating on keystroke
-            self.set_error(InputError::error(err.to_string()), cx);
-            return;
-        }
+        let Some(context) = new_context.is_empty().not().then_some(new_context) else {
+            return Ok(None);
+        };
+        gpui::KeyBindingContextPredicate::parse(&context).context("Failed to parse key context")?;
+
+        Ok(Some(context))
+    }
+
+    fn save(&mut self, cx: &mut Context<Self>) {
+        let existing_keybind = self.editing_keybind.clone();
+        let fs = self.fs.clone();
+        let tab_size = cx.global::<settings::SettingsStore>().json_tab_size();
+        let new_keystrokes = match self.validate_keystrokes(cx) {
+            Err(err) => {
+                self.set_error(InputError::error(err.to_string()), cx);
+                return;
+            }
+            Ok(keystrokes) => keystrokes,
+        };
+
+        let new_context = match self.validate_context(cx) {
+            Err(err) => {
+                self.set_error(InputError::error(err.to_string()), cx);
+                return;
+            }
+            Ok(context) => context,
+        };
 
         let new_action_args = match self.validate_action_arguments(cx) {
             Err(input_err) => {

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -2149,7 +2149,6 @@ async fn remove_keybinding(
                 .and_then(KeybindContextString::local_str),
             keystrokes,
             action_name: &existing.action_name,
-            use_key_equivalents: false,
             action_arguments: existing
                 .action_arguments
                 .as_ref()


### PR DESCRIPTION
Closes #ISSUE

This PR attempts to add workarounds for `use_key_equivalents` in the keymap UI. First of all it makes it so that `use_key_equivalents` is ignored when searching for a binding to replace so that replacing a keybind with `use_key_equivalents` set to true does not result in a new binding. Second, it attempts to infer the value of `use_key_equivalents` off of a base binding when adding a binding by adding an optional `from` parameter to the `KeymapUpdateOperation::Add` variant. Neither workaround will work when the `from` binding for an add or the `target` binding for a replace are not in the user keymap.

cc: @Anthony-Eid 

Release Notes:

- N/A *or* Added/Fixed/Improved ...
