### PR TITLE
agent: Add optional provider options for OpenRouter models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10991,6 +10991,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "util",
  "workspace-hack",
 ]
 

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -16,7 +16,7 @@ use language_model::{
     LanguageModelToolUse, MessageContent, RateLimiter, Role, StopReason, TokenUsage,
 };
 use open_router::{
-    Model, ModelMode as OpenRouterModelMode, ProviderOptions, ResponseStreamEvent, list_models,
+    Model, ModelMode as OpenRouterModelMode, Provider, ResponseStreamEvent, list_models,
     stream_completion,
 };
 use schemars::JsonSchema;
@@ -50,7 +50,7 @@ pub struct AvailableModel {
     pub supports_tools: Option<bool>,
     pub supports_images: Option<bool>,
     pub mode: Option<ModelMode>,
-    pub provider: Option<ProviderOptions>,
+    pub provider: Option<Provider>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -4,7 +4,8 @@ use credentials_provider::CredentialsProvider;
 use editor::{Editor, EditorElement, EditorStyle};
 use futures::{FutureExt, Stream, StreamExt, future::BoxFuture};
 use gpui::{
-    AnyView, App, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle, WhiteSpace,
+    AnyView, App, AppContext, AsyncApp, Context, Entity, FontStyle, Subscription, Task, TextStyle,
+    WhiteSpace,
 };
 use http_client::HttpClient;
 use language_model::{
@@ -15,7 +16,8 @@ use language_model::{
     LanguageModelToolUse, MessageContent, RateLimiter, Role, StopReason, TokenUsage,
 };
 use open_router::{
-    Model, ModelMode as OpenRouterModelMode, ResponseStreamEvent, list_models, stream_completion,
+    Model, ModelMode as OpenRouterModelMode, ProviderOptions, ResponseStreamEvent, list_models,
+    stream_completion,
 };
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -48,6 +50,7 @@ pub struct AvailableModel {
     pub supports_tools: Option<bool>,
     pub supports_images: Option<bool>,
     pub mode: Option<ModelMode>,
+    pub provider_options: Option<ProviderOptions>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -278,6 +281,7 @@ impl LanguageModelProvider for OpenRouterLanguageModelProvider {
                 supports_tools: model.supports_tools,
                 supports_images: model.supports_images,
                 mode: model.mode.clone().unwrap_or_default().into(),
+                provider_options: model.provider_options.clone(),
             });
         }
 
@@ -551,6 +555,7 @@ pub fn into_open_router(
             LanguageModelToolChoice::Any => open_router::ToolChoice::Required,
             LanguageModelToolChoice::None => open_router::ToolChoice::None,
         }),
+        provider_options: model.provider_options.clone(),
     }
 }
 

--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -50,7 +50,7 @@ pub struct AvailableModel {
     pub supports_tools: Option<bool>,
     pub supports_images: Option<bool>,
     pub mode: Option<ModelMode>,
-    pub provider_options: Option<ProviderOptions>,
+    pub provider: Option<ProviderOptions>,
 }
 
 #[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema)]
@@ -281,7 +281,7 @@ impl LanguageModelProvider for OpenRouterLanguageModelProvider {
                 supports_tools: model.supports_tools,
                 supports_images: model.supports_images,
                 mode: model.mode.clone().unwrap_or_default().into(),
-                provider_options: model.provider_options.clone(),
+                provider: model.provider.clone(),
             });
         }
 
@@ -555,7 +555,7 @@ pub fn into_open_router(
             LanguageModelToolChoice::Any => open_router::ToolChoice::Required,
             LanguageModelToolChoice::None => open_router::ToolChoice::None,
         }),
-        provider_options: model.provider_options.clone(),
+        provider: model.provider.clone(),
     }
 }
 

--- a/crates/open_router/Cargo.toml
+++ b/crates/open_router/Cargo.toml
@@ -23,3 +23,4 @@ schemars = { workspace = true, optional = true }
 serde.workspace = true
 serde_json.workspace = true
 workspace-hack.workspace = true
+util.workspace = true

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -28,7 +28,7 @@ impl Default for DataCollection {
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct ProviderOptions {
+pub struct Provider {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     order: Option<Vec<String>>,
     #[serde(default = "default_true")]
@@ -91,7 +91,7 @@ pub struct Model {
     pub supports_images: Option<bool>,
     #[serde(default)]
     pub mode: ModelMode,
-    pub provider: Option<ProviderOptions>,
+    pub provider: Option<Provider>,
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -128,7 +128,7 @@ impl Model {
         supports_tools: Option<bool>,
         supports_images: Option<bool>,
         mode: Option<ModelMode>,
-        provider: Option<ProviderOptions>,
+        provider: Option<Provider>,
     ) -> Self {
         Self {
             name: name.to_owned(),
@@ -185,7 +185,7 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<Reasoning>,
     pub usage: RequestUsage,
-    pub provider: Option<ProviderOptions>,
+    pub provider: Option<Provider>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -91,7 +91,7 @@ pub struct Model {
     pub supports_images: Option<bool>,
     #[serde(default)]
     pub mode: ModelMode,
-    pub provider_options: Option<ProviderOptions>,
+    pub provider: Option<ProviderOptions>,
 }
 
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
@@ -128,7 +128,7 @@ impl Model {
         supports_tools: Option<bool>,
         supports_images: Option<bool>,
         mode: Option<ModelMode>,
-        provider_options: Option<ProviderOptions>,
+        provider: Option<ProviderOptions>,
     ) -> Self {
         Self {
             name: name.to_owned(),
@@ -137,7 +137,7 @@ impl Model {
             supports_tools,
             supports_images,
             mode: mode.unwrap_or(ModelMode::Default),
-            provider_options,
+            provider,
         }
     }
 
@@ -185,8 +185,7 @@ pub struct Request {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<Reasoning>,
     pub usage: RequestUsage,
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "provider")]
-    pub provider_options: Option<ProviderOptions>,
+    pub provider: Option<ProviderOptions>,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -673,7 +672,7 @@ pub async fn list_models(client: &dyn HttpClient, api_url: &str) -> Result<Vec<M
                 } else {
                     ModelMode::Default
                 },
-                provider_options: None,
+                provider: None,
             })
             .collect();
 

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -29,7 +29,7 @@ impl Default for DataCollection {
 #[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Provider {
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     order: Option<Vec<String>>,
     #[serde(default = "default_true")]
     allow_fallbacks: bool,
@@ -37,13 +37,13 @@ pub struct Provider {
     require_parameters: bool,
     #[serde(default)]
     data_collection: DataCollection,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     only: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     ignore: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     quantizations: Option<Vec<String>>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     sort: Option<String>,
 }
 


### PR DESCRIPTION
This change add option field to route requests to the desired provider when OpenRouter is used. This can be useful when user want to enforce certain inference provider, or ensure that targeted providers are not retaining promts (among other use cases..).

Example of usage:
```json
  "language_models": {
    "open_router": {
      "api_url": "https://openrouter.ai/api/v1",
      "available_models": [
        {
          "name": "qwen/qwen3-235b-a22b",
           ...,
          "provider": {
            "allow_fallbacks": false,
            "order": ["cerebras"]
          }
        }
      ]
    }
  },
```

Based on OpenRouter API documentation: https://openrouter.ai/docs/features/provider-routing

Release Notes:

- Added `provider_options` field for OpenRouter models