### PR TITLE
Document alternative method to providing intelephense license key

### DIFF
--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -27,7 +27,7 @@ which php
 
 ## Intelephense
 
-[Intelephense](https://intelephense.com/) is a [proprietary](https://github.com/bmewburn/vscode-intelephense/blob/master/LICENSE.txt#L29) language server for PHP operating under a freemium model. Certain features require purchase of a [premium license](https://intelephense.com/). To use these features you must place your [licence.txt file](https://intelephense.com/faq.html) at `~/intelephense/licence.txt` inside your home directory.
+[Intelephense](https://intelephense.com/) is a [proprietary](https://github.com/bmewburn/vscode-intelephense/blob/master/LICENSE.txt#L29) language server for PHP operating under a freemium model. Certain features require purchase of a [premium license](https://intelephense.com/).
 
 To switch to `intelephense`, add the following to your `settings.json`:
 
@@ -36,6 +36,20 @@ To switch to `intelephense`, add the following to your `settings.json`:
   "languages": {
     "PHP": {
       "language_servers": ["intelephense", "!phpactor", "..."]
+    }
+  }
+}
+```
+
+To use the premium features, you can place your [licence.txt file](https://intelephense.com/faq.html) at `~/intelephense/licence.txt` inside your home directory. Alternatively, you can pass the licence key or a path to a file containing the licence key as an initialization option for the `intelephense` language server. To do this, add the following to your `settings.json`:
+
+```json
+{
+  "lsp": {
+    "intelephense": {
+      "initialization_options": {
+        "licenceKey": "/path/to/licence.txt"
+      }
     }
   }
 }


### PR DESCRIPTION
This PR updates the [Intelephense section in the docs](https://zed.dev/docs/languages/php#intelephense) to include an alternative way to provide the premium license key.

Release Notes:

- N/A
