### PR TITLE
agent: Add plan chip in the Zed section within the settings view

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -24,6 +24,7 @@ use project::{
     context_server_store::{ContextServerConfiguration, ContextServerStatus, ContextServerStore},
     project_settings::{ContextServerSettings, ProjectSettings},
 };
+use proto::Plan;
 use settings::{Settings, update_settings_file};
 use ui::{
     ContextMenu, Disclosure, Divider, DividerColor, ElevationIndex, Indicator, PopoverMenu,
@@ -171,6 +172,15 @@ impl AgentConfiguration {
             .copied()
             .unwrap_or(false);
 
+        let is_zed_provider = provider.id() == ZED_CLOUD_PROVIDER_ID;
+        let current_plan = if is_zed_provider {
+            self.workspace
+                .upgrade()
+                .and_then(|workspace| workspace.read(cx).user_store().read(cx).current_plan())
+        } else {
+            None
+        };
+
         v_flex()
             .when(is_expanded, |this| this.mb_2())
             .child(
@@ -208,14 +218,31 @@ impl AgentConfiguration {
                                             .size(IconSize::Small)
                                             .color(Color::Muted),
                                     )
-                                    .child(Label::new(provider_name.clone()).size(LabelSize::Large))
-                                    .when(
-                                        provider.is_authenticated(cx) && !is_expanded,
-                                        |parent| {
-                                            parent.child(
-                                                Icon::new(IconName::Check).color(Color::Success),
+                                    .child(
+                                        h_flex()
+                                            .gap_1()
+                                            .child(
+                                                Label::new(provider_name.clone())
+                                                    .size(LabelSize::Large),
                                             )
-                                        },
+                                            .map(|this| {
+                                                if is_zed_provider {
+                                                    this.child(
+                                                        self.render_zed_plan_info(current_plan, cx),
+                                                    )
+                                                } else {
+                                                    this.when(
+                                                        provider.is_authenticated(cx)
+                                                            && !is_expanded,
+                                                        |parent| {
+                                                            parent.child(
+                                                                Icon::new(IconName::Check)
+                                                                    .color(Color::Success),
+                                                            )
+                                                        },
+                                                    )
+                                                }
+                                            }),
                                     ),
                             )
                             .child(
@@ -429,6 +456,48 @@ impl AgentConfiguration {
             .child(self.render_command_permission(cx))
             .child(self.render_single_file_review(cx))
             .child(self.render_sound_notification(cx))
+    }
+
+    fn render_zed_plan_info(&self, plan: Option<Plan>, cx: &mut Context<Self>) -> impl IntoElement {
+        if let Some(plan) = plan {
+            let free_chip_bg = cx
+                .theme()
+                .colors()
+                .editor_background
+                .opacity(0.5)
+                .blend(cx.theme().colors().text_accent.opacity(0.05));
+
+            let pro_chip_bg = cx
+                .theme()
+                .colors()
+                .editor_background
+                .opacity(0.5)
+                .blend(cx.theme().colors().text_accent.opacity(0.2));
+
+            let (plan_name, plan_color, bg_color) = match plan {
+                Plan::Free => ("Free", Color::Default, free_chip_bg),
+                Plan::ZedProTrial => ("Pro Trial", Color::Accent, pro_chip_bg),
+                Plan::ZedPro => ("Pro", Color::Accent, pro_chip_bg),
+            };
+
+            h_flex()
+                .ml_1()
+                .px_1()
+                .rounded_sm()
+                .border_1()
+                .border_color(cx.theme().colors().border)
+                .bg(bg_color)
+                .overflow_hidden()
+                .child(
+                    Label::new(format!("{}", plan_name))
+                        .color(plan_color)
+                        .size(LabelSize::XSmall)
+                        .buffer_font(cx),
+                )
+                .into_any_element()
+        } else {
+            div().into_any_element()
+        }
     }
 
     fn render_context_servers_section(

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -489,7 +489,7 @@ impl AgentConfiguration {
                 .bg(bg_color)
                 .overflow_hidden()
                 .child(
-                    Label::new(format!("{}", plan_name))
+                    Label::new(plan_name.to_string())
                         .color(plan_color)
                         .size(LabelSize::XSmall)
                         .buffer_font(cx),


### PR DESCRIPTION
| Free | Pro |
|--------|--------|
| <img width="1140" height="368" alt="CleanShot 2025-07-15 at 7  50 48@2x" src="https://github.com/user-attachments/assets/b54fd46d-d823-4689-b099-0a9aef8b1c9a" /> | <img width="1136" height="348" alt="CleanShot 2025-07-15 at 7  51 45@2x" src="https://github.com/user-attachments/assets/d291a1f5-511f-43df-9ce2-041c77d1cb86" /> | 

Release Notes:

- agent: Added a chip communicating which Zed plan you're subscribed to in the agent panel settings view.
