### PR TITLE
Add the ability to disable horizontal autoscroll for editor panels

### DIFF
--- a/crates/agent_ui/src/message_editor.rs
+++ b/crates/agent_ui/src/message_editor.rs
@@ -132,6 +132,7 @@ pub(crate) fn create_editor(
             placement: Some(ContextMenuPlacement::Above),
         });
         editor.register_addon(ContextCreasesAddon::new());
+        editor.scroll_manager.set_forbid_horizontal_scroll(true);
         editor
     });
 

--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -298,7 +298,11 @@ impl ScrollManager {
                     }
                 },
             ),
-            anchor: self.anchor.anchor,
+            anchor: if self.forbid_horizontal_scroll() || self.forbid_vertical_scroll() {
+                self.anchor.anchor
+            } else {
+                anchor.anchor
+            },
         };
 
         self.autoscroll_request.take();

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -391,6 +391,9 @@ pub(crate) fn commit_message_editor(
     commit_editor.set_use_modal_editing(true);
     commit_editor.set_show_wrap_guides(false, cx);
     commit_editor.set_show_indent_guides(false, cx);
+    commit_editor
+        .scroll_manager
+        .set_forbid_horizontal_scroll(true);
     let placeholder = placeholder.unwrap_or("Enter commit message".into());
     commit_editor.set_placeholder_text(placeholder, cx);
     commit_editor


### PR DESCRIPTION
Closes #33176

In some editor panels, there's a slight horizontal shift as you approach the point where text is about to wrap. This seems to be related to horizontal autoscroll, so one solution is to disable that in panels where horizontal scroll isn't wanted.

Before:

https://github.com/user-attachments/assets/2c5573a5-dc6d-48e2-b167-91797560ab4d

After:

https://github.com/user-attachments/assets/a3b79e4a-d145-4800-8d7a-9b67b8925384

Release Notes:

- Disable horizontal autoscroll for the git commit message editor
