### PR TITLE
Disable format-on-save for verilog

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1671,6 +1671,10 @@
         "allowed": true
       }
     },
+    "SystemVerilog": {
+      "format_on_save": "off",
+      "use_on_type_format": false
+    },
     "Vue.js": {
       "language_servers": ["vue-language-server", "..."],
       "prettier": {


### PR DESCRIPTION
Disables format-on-save by default for the [verilog extension](https://github.com/someone13574/zed-verilog-extension), since there isn't a standard style.

Release Notes:

- N/A
