### PR TITLE
open_router: Fix tool_choice getting serialized to null

### DIFF
--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -153,11 +153,12 @@ pub struct RequestUsage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "lowercase")]
 pub enum ToolChoice {
     Auto,
     Required,
     None,
+    #[serde(untagged)]
     Other(ToolDefinition),
 }
 

--- a/crates/open_router/src/open_router.rs
+++ b/crates/open_router/src/open_router.rs
@@ -153,7 +153,7 @@ pub struct RequestUsage {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(rename_all = "snake_case")]
 pub enum ToolChoice {
     Auto,
     Required,


### PR DESCRIPTION
Closes #34314

This PR resolves an issue where serde(untagged) caused Rust None values to serialize as null, which OpenRouter's Mistral API (when tool_choice is present) incorrectly interprets as a defined value, leading to a 400 error. By replacing serde(untagged) with serde(snake_case), None values are now correctly omitted from the serialized JSON, fixing the problem. 
P.S. A separate PR will address serde(untagged) usage for other providers, as null is not expected for them either.

Release Notes:

- Fix ToolChoice getting serialized to null on OpenRouter
