### PR TITLE
Improve the `read_file` tool prompt for long files

### DIFF
--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -285,7 +285,10 @@ impl Tool for ReadFileTool {
 
                         Using the line numbers in this outline, you can call this tool again
                         while specifying the start_line and end_line fields to see the
-                        implementations of symbols in the outline."
+                        implementations of symbols in the outline.
+                        
+                        Alternatively, you can fall back to the `grep` tool (if available)
+                        to search the file for specific content."
                     }
                     .into())
                 }


### PR DESCRIPTION
Closes [#ISSUE](https://github.com/zed-industries/zed/issues/31780)

Release Notes:

- Enhanced `read_file` tool call result message for long files.
