### PR TITLE
gpui: Use static keyword with `LazyLock` when loading system fonts

### DIFF
--- a/crates/gpui/src/svg_renderer.rs
+++ b/crates/gpui/src/svg_renderer.rs
@@ -27,7 +27,7 @@ pub enum SvgSize {
 
 impl SvgRenderer {
     pub fn new(asset_source: Arc<dyn AssetSource>) -> Self {
-        let font_db = LazyLock::new(|| {
+        static FONT_DB: LazyLock<Arc<usvg::fontdb::Database>> = LazyLock::new(|| {
             let mut db = usvg::fontdb::Database::new();
             db.load_system_fonts();
             Arc::new(db)
@@ -36,7 +36,7 @@ impl SvgRenderer {
         let font_resolver = Box::new(
             move |font: &usvg::Font, db: &mut Arc<usvg::fontdb::Database>| {
                 if db.is_empty() {
-                    *db = font_db.clone();
+                    *db = FONT_DB.clone();
                 }
                 default_font_resolver(font, db)
             },


### PR DESCRIPTION
Use the `static` keyword to actually make the `LazyLock` static, which previously would reinitialize on every call to `SvgRenderer::new`.

Related: #26335 

Release Notes:

- N/A
