### PR TITLE
keymap_ui: Replace `zed::NoAction` with `null`

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -881,6 +881,9 @@ pub struct KeybindUpdateTarget<'a> {
 
 impl<'a> KeybindUpdateTarget<'a> {
     fn action_value(&self) -> Result<Value> {
+        if self.action_name == gpui::NoAction.name() {
+            return Ok(Value::Null);
+        }
         let action_name: Value = self.action_name.into();
         let value = match self.action_arguments {
             Some(args) => {
@@ -1557,7 +1560,7 @@ mod tests {
                 {
                     "context": "SomeContext",
                     "bindings": {
-                        "a": "zed::NoAction"
+                        "a": null
                     }
                 }
             ]"#

--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -1479,10 +1479,6 @@ mod tests {
             ]"#
             .unindent(),
         );
-    }
-
-    #[test]
-    fn test_append() {
         check_keymap_update(
             r#"[
                 {
@@ -1524,6 +1520,44 @@ mod tests {
                             "foo::baz",
                             true
                         ]
+                    }
+                }
+            ]"#
+            .unindent(),
+        );
+
+        check_keymap_update(
+            r#"[
+                {
+                    "context": "SomeOtherContext",
+                    "use_key_equivalents": true,
+                    "bindings": {
+                        "b": "foo::bar",
+                    }
+                },
+            ]"#
+            .unindent(),
+            KeybindUpdateOperation::Remove {
+                target: KeybindUpdateTarget {
+                    context: Some("SomeContext"),
+                    keystrokes: &parse_keystrokes("a"),
+                    action_name: "foo::baz",
+                    action_arguments: Some("true"),
+                },
+                target_keybind_source: KeybindSource::Default,
+            },
+            r#"[
+                {
+                    "context": "SomeOtherContext",
+                    "use_key_equivalents": true,
+                    "bindings": {
+                        "b": "foo::bar",
+                    }
+                },
+                {
+                    "context": "SomeContext",
+                    "bindings": {
+                        "a": "zed::NoAction"
                     }
                 }
             ]"#

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1313,7 +1313,15 @@ impl Render for KeymapEditor {
 
                                     let action = div()
                                         .id(("keymap action", index))
-                                        .child(command_palette::humanize_action_name(&action_name))
+                                        .child({
+                                            if action_name == gpui::NoAction.name() {
+                                                muted_styled_text("<null>".into(), cx)
+                                                    .into_any_element()
+                                            } else {
+                                                command_palette::humanize_action_name(&action_name)
+                                                    .into_any_element()
+                                            }
+                                        })
                                         .when(!context_menu_deployed, |this| {
                                             this.tooltip({
                                                 let action_name = binding.action_name.clone();

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1276,7 +1276,7 @@ impl Render for KeymapEditor {
                                 .filter_map(|index| {
                                     let candidate_id = this.matches.get(index)?.candidate_id;
                                     let binding = &this.keybindings[candidate_id];
-                                    let action_name = binding.action_name.clone();
+                                    let action_name = binding.action_name;
 
                                     let icon = (this.filter_state != FilterState::Conflicts
                                         && this.has_conflict(index))
@@ -1339,7 +1339,7 @@ impl Render for KeymapEditor {
                                         })
                                         .when(!context_menu_deployed, |this| {
                                             this.tooltip({
-                                                let action_name = binding.action_name.clone();
+                                                let action_name = binding.action_name;
                                                 let action_docs = binding.action_docs;
                                                 move |_, cx| {
                                                     let action_tooltip = Tooltip::new(action_name);
@@ -1785,7 +1785,7 @@ impl KeybindingEditorModal {
                 .read(cx)
                 .keybindings
                 .get(first_conflicting_index)
-                .map(|keybind| keybind.action_name.clone());
+                .map(|keybind| keybind.action_name);
 
             let warning_message = match conflicting_action_name {
                 Some(name) => {
@@ -1835,7 +1835,7 @@ impl KeybindingEditorModal {
             .log_err();
 
         cx.spawn(async move |this, cx| {
-            let action_name = existing_keybind.action_name.clone();
+            let action_name = existing_keybind.action_name;
 
             if let Err(err) = save_keybinding_update(
                 create,


### PR DESCRIPTION
Closes #ISSUE

This change applies both to the UI (we render `<null>` as muted text instead of `zed::NoAction`) as well as how we update the keymap file (the duplicated binding is bound to `null` instead of `"zed::NoAction"`)

Release Notes:

- N/A *or* Added/Fixed/Improved ...
