### PR TITLE
Do not subtract gutter margin twice from the editor width

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10025,6 +10025,7 @@ fn compute_auto_height_layout(
     let font_size = style.text.font_size.to_pixels(window.rem_size());
     let line_height = style.text.line_height_in_pixels(window.rem_size());
     let em_width = window.text_system().em_width(font_id, font_size).unwrap();
+    let em_advance = window.text_system().em_advance(font_id, font_size).unwrap();
 
     let mut snapshot = editor.snapshot(window, cx);
     let gutter_dimensions = snapshot
@@ -10040,7 +10041,7 @@ fn compute_auto_height_layout(
     let text_width = width - gutter_dimensions.width;
     let overscroll = size(em_width, px(0.));
 
-    let editor_width = text_width - gutter_dimensions.margin - overscroll.width - 2 * em_width;
+    let editor_width = text_width - gutter_dimensions.margin - overscroll.width - em_advance;
     if !matches!(editor.soft_wrap_mode(cx), SoftWrap::None) {
         if editor.set_wrap_width(Some(editor_width), cx) {
             snapshot = editor.snapshot(window, cx);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -10040,7 +10040,7 @@ fn compute_auto_height_layout(
     let text_width = width - gutter_dimensions.width;
     let overscroll = size(em_width, px(0.));
 
-    let editor_width = text_width - gutter_dimensions.margin - overscroll.width - em_width;
+    let editor_width = text_width - gutter_dimensions.margin - overscroll.width - 2 * em_width;
     if !matches!(editor.soft_wrap_mode(cx), SoftWrap::None) {
         if editor.set_wrap_width(Some(editor_width), cx) {
             snapshot = editor.snapshot(window, cx);


### PR DESCRIPTION
Closes #33176

In auto-height layouts, horizontal autoscroll can occur right before soft wrapping is triggered. This seems to be caused by gutter margin being subtracted twice from the editor width.

If we subtract gutter width only once, the horizontal autoscroll behavior goes away.

Before:

https://github.com/user-attachments/assets/03b6687e-3c0e-4b34-8e07-a228bcc6f798

After:

https://github.com/user-attachments/assets/84e54088-b5bd-4259-a193-d9fcf32cd3a7

Release Notes:

- Fixes issue with auto-height layouts where horizontal autoscroll is triggered right before text wraps
