### PR TITLE
Improve keystroke search in keymap editor

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -417,6 +417,17 @@ impl Modifiers {
         self.control || self.alt || self.shift || self.platform || self.function
     }
 
+    /// Returns the XOR of two modifier sets
+    pub fn xor(&self, other: &Modifiers) -> Modifiers {
+        Modifiers {
+            control: self.control ^ other.control,
+            alt: self.alt ^ other.alt,
+            shift: self.shift ^ other.shift,
+            platform: self.platform ^ other.platform,
+            function: self.function ^ other.function,
+        }
+    }
+
     /// Whether the semantically 'secondary' modifier key is pressed.
     ///
     /// On macOS, this is the command key.

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -462,10 +462,20 @@ impl KeymapEditor {
                                 } else {
                                     let key_press_query =
                                         KeyPressIterator::new(keystroke_query.as_slice());
+                                    let mut last_match_idx = 0;
 
                                     key_press_query.into_iter().all(|key| {
                                         let key_presses = KeyPressIterator::new(keystrokes);
-                                        key_presses.into_iter().any(|keystroke| keystroke == key)
+                                        key_presses.into_iter().enumerate().any(
+                                            |(index, keystroke)| {
+                                                if last_match_idx > index || keystroke != key {
+                                                    return false;
+                                                }
+
+                                                last_match_idx = index;
+                                                true
+                                            },
+                                        )
                                     })
                                 }
                             })


### PR DESCRIPTION
This PR improves Keystroke search by:

1.  Allow searching by modifiers without additional keys.
2. Take match count into consideration when deciding if we should show an action as a search match.
3. Take order into consideration as well.

Release Notes:

- N/A
