### PR TITLE
agent: Support GEMINI_API_KEY environment variable

### DIFF
--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -94,6 +94,8 @@ pub struct State {
     _subscription: Subscription,
 }
 
+const GEMINI_API_KEY_VAR: &str = "GEMINI_API_KEY";
+const GOOGLE_API_KEY_VAR: &str = "GOOGLE_API_KEY";
 const GOOGLE_AI_API_KEY_VAR: &str = "GOOGLE_AI_API_KEY";
 
 impl State {
@@ -150,6 +152,10 @@ impl State {
 
         cx.spawn(async move |this, cx| {
             let (api_key, from_env) = if let Ok(api_key) = std::env::var(GOOGLE_AI_API_KEY_VAR) {
+                (api_key, true)
+            } else if let Ok(api_key) = std::env::var(GOOGLE_API_KEY_VAR) {
+                (api_key, true)
+            } else if let Ok(api_key) = std::env::var(GEMINI_API_KEY_VAR) {
                 (api_key, true)
             } else {
                 let (_, api_key) = credentials_provider
@@ -903,7 +909,7 @@ impl Render for ConfigurationView {
                 )
                 .child(
                     Label::new(
-                        format!("You can also assign the {GOOGLE_AI_API_KEY_VAR} environment variable and restart Zed."),
+                        format!("You can also assign the {GEMINI_API_KEY_VAR} environment variable and restart Zed."),
                     )
                     .size(LabelSize::Small).color(Color::Muted),
                 )
@@ -922,7 +928,7 @@ impl Render for ConfigurationView {
                         .gap_1()
                         .child(Icon::new(IconName::Check).color(Color::Success))
                         .child(Label::new(if env_var_set {
-                            format!("API key set in {GOOGLE_AI_API_KEY_VAR} environment variable.")
+                            format!("API key set in {GEMINI_API_KEY_VAR} environment variable.")
                         } else {
                             "API key configured.".to_string()
                         })),
@@ -935,7 +941,7 @@ impl Render for ConfigurationView {
                         .icon_position(IconPosition::Start)
                         .disabled(env_var_set)
                         .when(env_var_set, |this| {
-                            this.tooltip(Tooltip::text(format!("To reset your API key, unset the {GOOGLE_AI_API_KEY_VAR} environment variable.")))
+                            this.tooltip(Tooltip::text(format!("To reset your API key, make sure {GEMINI_API_KEY_VAR}, {GOOGLE_API_KEY_VAR} and {GOOGLE_AI_API_KEY_VAR} environment variables are unset.")))
                         })
                         .on_click(cx.listener(|this, _, window, cx| this.reset_api_key(window, cx))),
                 )

--- a/crates/language_models/src/provider/google.rs
+++ b/crates/language_models/src/provider/google.rs
@@ -95,7 +95,6 @@ pub struct State {
 }
 
 const GEMINI_API_KEY_VAR: &str = "GEMINI_API_KEY";
-const GOOGLE_API_KEY_VAR: &str = "GOOGLE_API_KEY";
 const GOOGLE_AI_API_KEY_VAR: &str = "GOOGLE_AI_API_KEY";
 
 impl State {
@@ -152,8 +151,6 @@ impl State {
 
         cx.spawn(async move |this, cx| {
             let (api_key, from_env) = if let Ok(api_key) = std::env::var(GOOGLE_AI_API_KEY_VAR) {
-                (api_key, true)
-            } else if let Ok(api_key) = std::env::var(GOOGLE_API_KEY_VAR) {
                 (api_key, true)
             } else if let Ok(api_key) = std::env::var(GEMINI_API_KEY_VAR) {
                 (api_key, true)
@@ -941,7 +938,7 @@ impl Render for ConfigurationView {
                         .icon_position(IconPosition::Start)
                         .disabled(env_var_set)
                         .when(env_var_set, |this| {
-                            this.tooltip(Tooltip::text(format!("To reset your API key, make sure {GEMINI_API_KEY_VAR}, {GOOGLE_API_KEY_VAR} and {GOOGLE_AI_API_KEY_VAR} environment variables are unset.")))
+                            this.tooltip(Tooltip::text(format!("To reset your API key, make sure {GEMINI_API_KEY_VAR} and {GOOGLE_AI_API_KEY_VAR} environment variables are unset.")))
                         })
                         .on_click(cx.listener(|this, _, window, cx| this.reset_api_key(window, cx))),
                 )

--- a/docs/src/ai/configuration.md
+++ b/docs/src/ai/configuration.md
@@ -237,7 +237,7 @@ You can use Gemini models with the Zed agent by choosing it via the model dropdo
 
 The Google AI API key will be saved in your keychain.
 
-Zed will also use the `GOOGLE_AI_API_KEY` environment variable if it's defined.
+Zed will also use the `GEMINI_API_KEY` environment variable if it's defined. See [Using Gemini API keys](Using Gemini API keys) in the Gemini docs for more.
 
 #### Custom Models {#google-ai-custom-models}
 


### PR DESCRIPTION
Google Gemini Docs now recommend usage of `GEMINI_API_KEY` and the legacy `GOOGLE_AI_API_KEY` variable is no longer supported in the modern SDKs.

Zed will now accept either.

Release Notes:

- N/A
