### PR TITLE
docs: Discuss `inlay_hints.show_value_hints` in debugger docs

### DIFF
--- a/docs/src/debugger.md
+++ b/docs/src/debugger.md
@@ -180,8 +180,8 @@ The debug adapter will then stop whenever an exception of a given kind occurs. W
 ### Stepping granularity
 
 - Description: The Step granularity that the debugger will use
-- Default: line
-- Setting: debugger.stepping_granularity
+- Default: `line`
+- Setting: `debugger.stepping_granularity`
 
 **Options**
 
@@ -220,8 +220,8 @@ The debug adapter will then stop whenever an exception of a given kind occurs. W
 ### Save Breakpoints
 
 - Description: Whether the breakpoints should be saved across Zed sessions.
-- Default: true
-- Setting: debugger.save_breakpoints
+- Default: `true`
+- Setting: `debugger.save_breakpoints`
 
 **Options**
 
@@ -238,8 +238,8 @@ The debug adapter will then stop whenever an exception of a given kind occurs. W
 ### Button
 
 - Description: Whether the button should be displayed in the debugger toolbar.
-- Default: true
-- Setting: debugger.show_button
+- Default: `true`
+- Setting: `debugger.show_button`
 
 **Options**
 
@@ -256,8 +256,8 @@ The debug adapter will then stop whenever an exception of a given kind occurs. W
 ### Timeout
 
 - Description: Time in milliseconds until timeout error when connecting to a TCP debug adapter.
-- Default: 2000
-- Setting: debugger.timeout
+- Default: `2000`
+- Setting: `debugger.timeout`
 
 **Options**
 
@@ -270,6 +270,24 @@ The debug adapter will then stop whenever an exception of a given kind occurs. W
   }
 }
 ```
+
+### Inline Values
+
+- Description: Whether to enable editor inlay hints showing the values of variables in your code during debugging sessions.
+- Default: `true`
+- Setting: `inlay_hints.show_value_hints`
+
+**Options**
+
+```json
+{
+  "inlay_hints": {
+    "show_value_hints": false
+  }
+}
+```
+
+Inline value hints can also be toggled from the Editor Controls menu in the editor toolbar.
 
 ### Log Dap Communications
 


### PR DESCRIPTION
This isn't under the `debugger` settings key, but it seems good to document on the debugger page anyway.

Release Notes:

- N/A