### PR TITLE
keymap_ui: Improve keybind display in menus

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1118,7 +1118,9 @@
       "ctrl-f": "search::FocusSearch",
       "alt-find": "keymap_editor::ToggleKeystrokeSearch",
       "alt-ctrl-f": "keymap_editor::ToggleKeystrokeSearch",
-      "alt-c": "keymap_editor::ToggleConflictFilter"
+      "alt-c": "keymap_editor::ToggleConflictFilter",
+      "enter": "keymap_editor::EditBinding",
+      "alt-enter": "keymap_editor::CreateBinding"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1217,7 +1217,9 @@
     "use_key_equivalents": true,
     "bindings": {
       "cmd-alt-f": "keymap_editor::ToggleKeystrokeSearch",
-      "cmd-alt-c": "keymap_editor::ToggleConflictFilter"
+      "cmd-alt-c": "keymap_editor::ToggleConflictFilter",
+      "enter": "keymap_editor::EditBinding",
+      "alt-enter": "keymap_editor::CreateBinding"
     }
   },
   {

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1314,9 +1314,9 @@ impl Render for KeymapEditor {
                                             .icon_color(Color::Warning)
                                             .tooltip(|window, cx| {
                                                 Tooltip::with_meta(
-                                                    "Edit Keybinding",
-                                                    None,
-                                                    "Use alt+click to show conflicts",
+                                                    "View conflicts",
+                                                    Some(&ToggleConflictFilter),
+                                                    "Use alt+click to show all conflicts",
                                                     window,
                                                     cx,
                                                 )
@@ -1341,7 +1341,10 @@ impl Render for KeymapEditor {
                                     .unwrap_or_else(|| {
                                         base_button_style(index, IconName::Pencil)
                                             .visible_on_hover(row_group_id(index))
-                                            .tooltip(Tooltip::text("Edit Keybinding"))
+                                            .tooltip(Tooltip::for_action_title(
+                                                "Edit Keybinding",
+                                                &EditBinding,
+                                            ))
                                             .on_click(cx.listener(move |this, _, window, cx| {
                                                 this.select_index(index, cx);
                                                 this.open_edit_keybinding_modal(false, window, cx);

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -724,8 +724,13 @@ impl KeymapEditor {
             .map(|r#match| r#match.candidate_id)
     }
 
+    fn selected_keybind_and_index(&self) -> Option<(&ProcessedKeybinding, usize)> {
+        self.selected_keybind_index()
+            .map(|keybind_index| (&self.keybindings[keybind_index], keybind_index))
+    }
+
     fn selected_binding(&self) -> Option<&ProcessedKeybinding> {
-        self.selected_keybind_idx()
+        self.selected_keybind_index()
             .and_then(|keybind_index| self.keybindings.get(keybind_index))
     }
 
@@ -880,22 +885,16 @@ impl KeymapEditor {
         }
     }
 
-    fn confirm(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
-        self.open_edit_keybinding_modal(false, window, cx);
-    }
-
     fn open_edit_keybinding_modal(
         &mut self,
         create: bool,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        let Some((keybind_idx, keybind)) = self
-            .selected_keybind_idx()
-            .zip(self.selected_binding().cloned())
-        else {
+        let Some((keybind, keybind_index)) = self.selected_keybind_and_index() else {
             return;
         };
+        let keybind = keybind.clone();
         let keymap_editor = cx.entity();
 
         let arguments = keybind
@@ -925,7 +924,7 @@ impl KeymapEditor {
                     let modal = KeybindingEditorModal::new(
                         create,
                         keybind,
-                        keybind_idx,
+                        keybind_index,
                         keymap_editor,
                         workspace_weak,
                         fs,
@@ -1155,7 +1154,6 @@ impl Render for KeymapEditor {
             .on_action(cx.listener(Self::select_first))
             .on_action(cx.listener(Self::select_last))
             .on_action(cx.listener(Self::focus_search))
-            .on_action(cx.listener(Self::confirm))
             .on_action(cx.listener(Self::edit_binding))
             .on_action(cx.listener(Self::create_binding))
             .on_action(cx.listener(Self::delete_binding))

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -2545,6 +2545,8 @@ impl KeystrokeInput {
                 if self.keystrokes.len() < Self::KEYSTROKE_COUNT_MAX {
                     self.keystrokes.push(Self::dummy(keystroke.modifiers));
                 }
+            } else if close_keystroke_result != CloseKeystrokeResult::Partial {
+                self.clear_keystrokes(&ClearKeystrokes, window, cx);
             }
         }
         self.keystrokes_changed(cx);

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1268,6 +1268,18 @@ impl Render for KeymapEditor {
                                                 "keystrokes-exact-match",
                                                 IconName::Equal,
                                             )
+                                            .tooltip(move |window, cx| {
+                                                Tooltip::for_action(
+                                                    if exact_match {
+                                                        "Partial match mode"
+                                                    } else {
+                                                        "Exact match mode"
+                                                    },
+                                                    &ToggleExactKeystrokeMatching,
+                                                    window,
+                                                    cx,
+                                                )
+                                            })
                                             .shape(IconButtonShape::Square)
                                             .toggle_state(exact_match)
                                             .on_click(

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -762,7 +762,7 @@ impl KeymapEditor {
             let selected_binding_is_unbound = selected_binding.keystrokes().is_none();
 
             let context_menu = ContextMenu::build(window, cx, |menu, _window, _cx| {
-                menu.action_key_context(self.key_context())
+                menu.context(self.focus_handle.clone())
                     .action_disabled_when(
                         selected_binding_is_unbound,
                         "Edit",

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use gpui::{
     Action, AnyElement, App, AppContext as _, DismissEvent, Entity, EventEmitter, FocusHandle,
-    Focusable, IntoElement, KeyContext, Render, Subscription, px,
+    Focusable, IntoElement, Render, Subscription, px,
 };
 use menu::{SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use settings::Settings;
@@ -150,7 +150,6 @@ pub struct ContextMenu {
     items: Vec<ContextMenuItem>,
     focus_handle: FocusHandle,
     action_context: Option<FocusHandle>,
-    action_key_context: Option<KeyContext>,
     selected_index: Option<usize>,
     delayed: bool,
     clicked: bool,
@@ -221,7 +220,6 @@ impl ContextMenu {
                     documentation_aside: None,
                     fixed_width: None,
                     end_slot_action: None,
-                    action_key_context: None,
                 },
                 window,
                 cx,
@@ -265,7 +263,6 @@ impl ContextMenu {
                     documentation_aside: None,
                     fixed_width: None,
                     end_slot_action: None,
-                    action_key_context: None,
                 },
                 window,
                 cx,
@@ -307,7 +304,6 @@ impl ContextMenu {
                 documentation_aside: None,
                 fixed_width: None,
                 end_slot_action: None,
-                action_key_context: None,
             },
             window,
             cx,
@@ -602,11 +598,6 @@ impl ContextMenu {
 
     pub fn key_context(mut self, context: impl Into<SharedString>) -> Self {
         self.key_context = context.into();
-        self
-    }
-
-    pub fn action_key_context(mut self, context: KeyContext) -> Self {
-        self.action_key_context = context.into();
         self
     }
 
@@ -979,20 +970,10 @@ impl ContextMenu {
                             .child(label_element)
                             .debug_selector(|| format!("MENU_ITEM-{}", label))
                             .children(action.as_ref().and_then(|action| {
-                                self.action_key_context
+                                self.action_context
                                     .as_ref()
-                                    .and_then(|context| {
-                                        KeyBinding::for_action_in_context(
-                                            &**action,
-                                            context.clone(),
-                                            window,
-                                            cx,
-                                        )
-                                    })
-                                    .or_else(|| {
-                                        self.action_context.as_ref().and_then(|focus| {
-                                            KeyBinding::for_action_in(&**action, focus, window, cx)
-                                        })
+                                    .and_then(|focus| {
+                                        KeyBinding::for_action_in(&**action, focus, window, cx)
                                     })
                                     .or_else(|| KeyBinding::for_action(&**action, window, cx))
                                     .map(|binding| {

--- a/crates/ui/src/components/context_menu.rs
+++ b/crates/ui/src/components/context_menu.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use gpui::{
     Action, AnyElement, App, AppContext as _, DismissEvent, Entity, EventEmitter, FocusHandle,
-    Focusable, IntoElement, Render, Subscription, px,
+    Focusable, IntoElement, KeyContext, Render, Subscription, px,
 };
 use menu::{SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use settings::Settings;
@@ -150,6 +150,7 @@ pub struct ContextMenu {
     items: Vec<ContextMenuItem>,
     focus_handle: FocusHandle,
     action_context: Option<FocusHandle>,
+    action_key_context: Option<KeyContext>,
     selected_index: Option<usize>,
     delayed: bool,
     clicked: bool,
@@ -220,6 +221,7 @@ impl ContextMenu {
                     documentation_aside: None,
                     fixed_width: None,
                     end_slot_action: None,
+                    action_key_context: None,
                 },
                 window,
                 cx,
@@ -263,6 +265,7 @@ impl ContextMenu {
                     documentation_aside: None,
                     fixed_width: None,
                     end_slot_action: None,
+                    action_key_context: None,
                 },
                 window,
                 cx,
@@ -304,6 +307,7 @@ impl ContextMenu {
                 documentation_aside: None,
                 fixed_width: None,
                 end_slot_action: None,
+                action_key_context: None,
             },
             window,
             cx,
@@ -598,6 +602,11 @@ impl ContextMenu {
 
     pub fn key_context(mut self, context: impl Into<SharedString>) -> Self {
         self.key_context = context.into();
+        self
+    }
+
+    pub fn action_key_context(mut self, context: KeyContext) -> Self {
+        self.action_key_context = context.into();
         self
     }
 
@@ -970,14 +979,22 @@ impl ContextMenu {
                             .child(label_element)
                             .debug_selector(|| format!("MENU_ITEM-{}", label))
                             .children(action.as_ref().and_then(|action| {
-                                self.action_context
+                                self.action_key_context
                                     .as_ref()
-                                    .map(|focus| {
-                                        KeyBinding::for_action_in(&**action, focus, window, cx)
+                                    .and_then(|context| {
+                                        KeyBinding::for_action_in_context(
+                                            &**action,
+                                            context.clone(),
+                                            window,
+                                            cx,
+                                        )
                                     })
-                                    .unwrap_or_else(|| {
-                                        KeyBinding::for_action(&**action, window, cx)
+                                    .or_else(|| {
+                                        self.action_context.as_ref().and_then(|focus| {
+                                            KeyBinding::for_action_in(&**action, focus, window, cx)
+                                        })
                                     })
+                                    .or_else(|| KeyBinding::for_action(&**action, window, cx))
                                     .map(|binding| {
                                         div().ml_4().child(binding.disabled(*disabled)).when(
                                             *disabled && documentation_aside.is_some(),

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -51,6 +51,18 @@ impl KeyBinding {
         Some(Self::new_from_gpui(key_binding, cx))
     }
 
+    /// Like `for_action`, but lets you specify the key context from which keybindings are matched.
+    pub fn for_action_in_context(
+        action: &dyn Action,
+        context: gpui::KeyContext,
+        window: &mut Window,
+        cx: &App,
+    ) -> Option<Self> {
+        let key_binding =
+            window.highest_precedence_binding_for_action_in_context(action, context)?;
+        Some(Self::new_from_gpui(key_binding, cx))
+    }
+
     pub fn set_vim_mode(cx: &mut App, enabled: bool) {
         cx.set_global(VimStyle(enabled));
     }

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -51,18 +51,6 @@ impl KeyBinding {
         Some(Self::new_from_gpui(key_binding, cx))
     }
 
-    /// Like `for_action`, but lets you specify the key context from which keybindings are matched.
-    pub fn for_action_in_context(
-        action: &dyn Action,
-        context: gpui::KeyContext,
-        window: &mut Window,
-        cx: &App,
-    ) -> Option<Self> {
-        let key_binding =
-            window.highest_precedence_binding_for_action_in_context(action, context)?;
-        Some(Self::new_from_gpui(key_binding, cx))
-    }
-
     pub fn set_vim_mode(cx: &mut App, enabled: bool) {
         cx.set_global(VimStyle(enabled));
     }


### PR DESCRIPTION
Closes #ISSUE

Defines keybindings for `keymap_editor::EditBinding` and `keymap_editor::CreateBinding`, making sure those actions are used in tooltips. 

Release Notes:

- N/A *or* Added/Fixed/Improved ...
