### PR TITLE
linux: Fix buttons clicks wouldn’t work on startup until clicked on center pane

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -22,9 +22,9 @@ use auto_update::AutoUpdateStatus;
 use call::ActiveCall;
 use client::{Client, UserStore};
 use gpui::{
-    Action, AnyElement, App, Context, Corner, Element, Entity, InteractiveElement, IntoElement,
-    MouseButton, ParentElement, Render, StatefulInteractiveElement, Styled, Subscription,
-    WeakEntity, Window, actions, div,
+    Action, AnyElement, App, Context, Corner, Element, Entity, Focusable, InteractiveElement,
+    IntoElement, MouseButton, ParentElement, Render, StatefulInteractiveElement, Styled,
+    Subscription, WeakEntity, Window, actions, div,
 };
 use onboarding_banner::OnboardingBanner;
 use project::Project;
@@ -503,7 +503,8 @@ impl TitleBar {
                     )
                 })
                 .on_click(move |_, window, cx| {
-                    let _ = workspace.update(cx, |_this, cx| {
+                    let _ = workspace.update(cx, |this, cx| {
+                        window.focus(&this.active_pane().focus_handle(cx));
                         window.dispatch_action(zed_actions::git::Branch.boxed_clone(), cx);
                     });
                 })

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -873,6 +873,8 @@ impl Render for PanelButtons {
                     (action, icon_tooltip.into())
                 };
 
+                let focus_handle = dock.focus_handle(cx);
+
                 Some(
                     right_click_menu(name)
                         .menu(move |window, cx| {
@@ -909,6 +911,7 @@ impl Render for PanelButtons {
                                 .on_click({
                                     let action = action.boxed_clone();
                                     move |_, window, cx| {
+                                        window.focus(&focus_handle);
                                         window.dispatch_action(action.boxed_clone(), cx)
                                     }
                                 })


### PR DESCRIPTION
Closes #31805

This is an issue with Linux currently that `window.focus` is `None` upon startup in both X11 and Wayland. Specifically, the order in which [this](https://github.com/zed-industries/zed/blob/8d05a3d389b6a1caa80bb18f26c3dac0c26debcb/crates/gpui/src/window.rs#L3116) and [this](https://github.com/zed-industries/zed/blob/8d05a3d389b6a1caa80bb18f26c3dac0c26debcb/crates/gpui/src/app.rs#L956) are executed varies between Linux and macOS. That is, one tries to remove (blur) focus from a window, while other checks window focus to put that focus id to a frame. In macOS, blur happens afterwards setting focus on a frame, but in Linux, the inverse of it happens, leading to `window.focus` to `None`. 

For the time being, we handle all visible buttons to take care of this **focus can be `None`** case, and make it work anyway. But, we should look at the deeper issue mentioned above with GPUI. Created new issue to track that https://github.com/zed-industries/zed/issues/34591.

Release Notes:

- Fixed an issue where button clicks wouldn’t work on startup until clicked on the center pane on Linux.
