### PR TITLE
Don't override ascii graphical shortcuts

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -827,6 +827,9 @@ impl crate::Keystroke {
                 let name = xkb::keysym_get_name(key_sym).to_lowercase();
                 if key_sym.is_keypad_key() {
                     name.replace("kp_", "")
+                } else if key_utf8.len() == 1 && key_utf8.chars().next().unwrap().is_ascii_graphic()
+                {
+                    key_utf8.clone()
                 } else if let Some(key_en) = guess_ascii(keycode, modifiers.shift) {
                     String::from(key_en)
                 } else {


### PR DESCRIPTION
Closes #34536

Release Notes:

- (preview only) Fix shortcuts on Extended Latin keyboards on Linux
