### PR TITLE
Add runnable support for Deno.test

### DIFF
--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -56,8 +56,8 @@
         (#eq? @_method "test")
         arguments: (
             arguments . [
-                (string (string_fragment) @run)
-                (identifier) @run
+                (string) @run @test_name
+                (identifier) @run @test_name
             ]
         )
     ) @_js-test
@@ -76,7 +76,7 @@
         (#eq? @_method "test")
         arguments: (
             arguments . (function_expression
-                name: (identifier) @run
+                name: (identifier) @run @test_name
             )
         )
     ) @_js-test

--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -56,7 +56,7 @@
         (#eq? @_method "test")
         arguments: (
             arguments . [
-                (string) @run @test_name
+                (string (string_fragment) @run @test_name)
                 (identifier) @run @test_name
             ]
         )

--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -1,4 +1,4 @@
-; Add support for (node:test, bun:test and Jest) runnable
+; Add support for (node:test, bun:test, Jest and Deno.test) runnable
 ; Function expression that has `it`, `test` or `describe` as the function name
 (
     (call_expression
@@ -39,6 +39,45 @@
                 (string (string_fragment) @run)
                 (identifier) @run
             ]
+        )
+    ) @_js-test
+
+    (#set! tag js-test)
+)
+
+; Add support for Deno.test with string names
+(
+    (call_expression
+        function: (member_expression
+            object: (identifier) @_namespace
+            property: (property_identifier) @_method
+        )
+        (#eq? @_namespace "Deno")
+        (#eq? @_method "test")
+        arguments: (
+            arguments . [
+                (string (string_fragment) @run)
+                (identifier) @run
+            ]
+        )
+    ) @_js-test
+
+    (#set! tag js-test)
+)
+
+; Add support for Deno.test with named function expressions
+(
+    (call_expression
+        function: (member_expression
+            object: (identifier) @_namespace
+            property: (property_identifier) @_method
+        )
+        (#eq? @_namespace "Deno")
+        (#eq? @_method "test")
+        arguments: (
+            arguments . (function_expression
+                name: (identifier) @run
+            )
         )
     ) @_js-test
 

--- a/crates/languages/src/typescript/runnables.scm
+++ b/crates/languages/src/typescript/runnables.scm
@@ -56,8 +56,8 @@
         (#eq? @_method "test")
         arguments: (
             arguments . [
-                (string (string_fragment) @run @test_name)
-                (identifier) @run @test_name
+                (string (string_fragment) @run @DENO_TEST_NAME)
+                (identifier) @run @DENO_TEST_NAME
             ]
         )
     ) @_js-test
@@ -76,7 +76,7 @@
         (#eq? @_method "test")
         arguments: (
             arguments . (function_expression
-                name: (identifier) @run @test_name
+                name: (identifier) @run @DENO_TEST_NAME
             )
         )
     ) @_js-test

--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -57,6 +57,46 @@ See [Configuring supported languages](../configuring-languages.md) in the Zed do
 TBD: Deno Typescript REPL instructions [docs/repl#typescript-deno](../repl.md#typescript-deno)
 -->
 
+## DAP support
+
+To debug deno programs, add this to `.zed/debug.json`
+
+```json
+[
+  {
+    "adapter": "JavaScript",
+    "label": "Deno",
+    "request": "launch",
+    "type": "pwa-node",
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "program": "$ZED_FILE",
+    "runtimeExecutable": "deno",
+    "runtimeArgs": [
+      "run",
+      "--allow-all",
+      "--inspect-wait"
+    ],
+    "attachSimplePort": 9229
+  }
+]
+```
+
+## Runnable support
+
+To run deno tasks like tests from the ui, add this to `.zed/tasks.json`
+
+```json
+[
+  {
+    "label": "deno test",
+    "command": "deno test -A --filter '/^$ZED_CUSTOM_DENO_TEST_NAME$/' $ZED_FILE",
+    "tags": [
+      "js-test"
+    ]
+  }
+]
+```
+
 ## See also:
 
 - [TypeScript](./typescript.md)

--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -71,11 +71,7 @@ To debug deno programs, add this to `.zed/debug.json`
     "cwd": "$ZED_WORKTREE_ROOT",
     "program": "$ZED_FILE",
     "runtimeExecutable": "deno",
-    "runtimeArgs": [
-      "run",
-      "--allow-all",
-      "--inspect-wait"
-    ],
+    "runtimeArgs": ["run", "--allow-all", "--inspect-wait"],
     "attachSimplePort": 9229
   }
 ]
@@ -90,9 +86,7 @@ To run deno tasks like tests from the ui, add this to `.zed/tasks.json`
   {
     "label": "deno test",
     "command": "deno test -A --filter '/^$ZED_CUSTOM_DENO_TEST_NAME$/' $ZED_FILE",
-    "tags": [
-      "js-test"
-    ]
+    "tags": ["js-test"]
   }
 ]
 ```


### PR DESCRIPTION
example of detected code:
```ts
Deno.test("t", () => {
  console.log("Hello, World!");
});

Deno.test(function azaz() {
  console.log("Hello, World!");
});
```

I can't build zed locally so I didn't test this, but  I think the code is straightforward enough, hopefully someone else can verify it

Closes #ISSUE

Release Notes:

- N/A
