### PR TITLE
debugger: Add support for running test methods with function receiver in Go

### DIFF
--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -1,9 +1,21 @@
 ; Functions names start with `Test`
 (
-  (
+  [
     (function_declaration name: (_) @run
       (#match? @run "^Test.*"))
-  ) @_
+    (method_declaration
+      receiver: (parameter_list
+        (parameter_declaration
+          name: (identifier) @_receiver_name
+          type: [
+            (pointer_type (type_identifier) @_receiver_type)
+            (type_identifier) @_receiver_type
+          ]
+        )
+      )
+      name: (field_identifier) @run @_method_name
+      (#match? @_method_name "^Test.*"))
+  ] @_
   (#set! tag go-test)
 )
 


### PR DESCRIPTION
![CleanShot 2025-07-17 at 16 35 10](https://github.com/user-attachments/assets/bad794fb-198e-40a1-958c-6ff30a0a4e53)


Closes #33759

Release Notes:

- debugger: Add support for running test methods with function receiver in Go
