### PR TITLE
Rework extension-related errors

### DIFF
--- a/crates/extension_host/src/headless_host.rs
+++ b/crates/extension_host/src/headless_host.rs
@@ -173,9 +173,8 @@ impl HeadlessExtensionStore {
             return Ok(());
         }
 
-        let wasm_extension: Arc<dyn Extension> = Arc::new(
-            WasmExtension::load(extension_dir.clone(), &manifest, wasm_host.clone(), &cx).await?,
-        );
+        let wasm_extension: Arc<dyn Extension> =
+            Arc::new(WasmExtension::load(&extension_dir, &manifest, wasm_host.clone(), &cx).await?);
 
         for (language_server_id, language_server_config) in &manifest.language_servers {
             for language in language_server_config.languages() {

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -715,7 +715,7 @@ fn parse_wasm_extension_version_custom_section(data: &[u8]) -> Option<SemanticVe
 
 impl WasmExtension {
     pub async fn load(
-        extension_dir: PathBuf,
+        extension_dir: &Path,
         manifest: &Arc<ExtensionManifest>,
         wasm_host: Arc<WasmHost>,
         cx: &AsyncApp,


### PR DESCRIPTION
Before:
<img width="1728" height="1079" alt="before" src="https://github.com/user-attachments/assets/4ab19211-8de4-458d-a835-52de859b7b20" />

After:
<img width="1728" height="1079" alt="after" src="https://github.com/user-attachments/assets/231c9362-a0b0-47ae-b92e-de6742781d36" />

Makes clear which path is causing the FS error and removes backtraces from logging.

Release Notes:

- N/A
