### PR TITLE
Add customizable commit message prompt setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -733,6 +733,9 @@
     //
     // Default: false
     "collapse_untracked_diff": false,
+    /// Customize the commit_message_prompt by overriding it.
+    /// 
+    /// default: "{default_prompt}"
     "commit_message_prompt": "{default_prompt}",
     "scrollbar": {
       // When to show the scrollbar in the git panel.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -733,6 +733,7 @@
     //
     // Default: false
     "collapse_untracked_diff": false,
+    "commit_message_prompt": "{default_prompt}",
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1819,6 +1819,7 @@ impl GitPanel {
         });
 
         let temperature = AgentSettings::temperature_for_model(&model, cx);
+        let custom_prompt = GitPanelSettings::get_global(cx).commit_message_prompt.clone();
 
         self.generate_commit_message_task = Some(cx.spawn(async move |this, cx| {
              async move {
@@ -1851,13 +1852,14 @@ impl GitPanel {
 
                 let text_empty = subject.trim().is_empty();
 
-                let content = if text_empty {
-                    format!("{PROMPT}\nHere are the changes in this commit:\n{diff_text}")
-                } else {
-                    format!("{PROMPT}\nHere is the user's subject line:\n{subject}\nHere are the changes in this commit:\n{diff_text}\n")
-                };
+                const DEFAULT_PROMPT: &str = include_str!("commit_message_prompt.txt");
+                let prompt = custom_prompt.replace("{default_prompt}", DEFAULT_PROMPT);
 
-                const PROMPT: &str = include_str!("commit_message_prompt.txt");
+                let content = if text_empty {
+                    format!("{prompt}\nHere are the changes in this commit:\n{diff_text}")
+                } else {
+                    format!("{prompt}\nHere is the user's subject line:\n{subject}\nHere are the changes in this commit:\n{diff_text}\n")
+                };
 
                 let request = LanguageModelRequest {
                     thread_id: None,

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -76,7 +76,7 @@ pub struct GitPanelSettingsContent {
     /// Default: false
     pub collapse_untracked_diff: Option<bool>,
     
-    /// Customise the commit_message_prompt by overriding it.
+    /// Customize the commit_message_prompt by overriding it.
     /// 
     /// default: "{default_prompt}"
     pub commit_message_prompt: Option<String>,

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -75,6 +75,11 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub collapse_untracked_diff: Option<bool>,
+    
+    /// Customise the commit_message_prompt by overriding it.
+    /// 
+    /// default: "{default_prompt}"
+    pub commit_message_prompt: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -87,6 +92,7 @@ pub struct GitPanelSettings {
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
     pub collapse_untracked_diff: bool,
+    pub commit_message_prompt: String,
 }
 
 impl Settings for GitPanelSettings {

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -90,6 +90,34 @@ You can specify your preferred model to use by providing a `commit_message_model
 }
 ```
 
+### Customizing the Commit Message Prompt
+
+You can customize the prompt used to generate commit messages by setting the `git_panel.commit_message_prompt` in your `settings.json` file.
+
+This setting allows for both complete overrides and simple modifications of the default prompt.
+
+- **To completely replace the default prompt**, set the value to your new prompt:
+
+  ```json
+  {
+    "git_panel": {
+      "commit_message_prompt": "My new, completely custom prompt."
+    }
+  }
+  ```
+
+- **To add instructions to the default prompt**, use the `{default_prompt}` placeholder:
+
+  ```json
+  {
+    "git_panel": {
+      "commit_message_prompt": "{default_prompt}\n Additionally, please ensure all commit messages follow the Conventional Commits rules."
+    }
+  }
+  ```
+
+If `commit_message_prompt` is not set, Zed will use the default prompt.
+
 <!-- Add media -->
 
 More advanced AI integration with Git features may come in the future.


### PR DESCRIPTION
This PR introduces a new setting that allows users to customize the default commit message prompt in Zed. Previously, the commit message prompt was hardcoded.

Solution for: https://github.com/zed-industries/zed/discussions/26503

Introduces `commit_message_prompt` inside `git_panel`settings.

This is my first OpenSource contribution, and also my first steps into rust, feel free to roast my code and this description.