### PR TITLE
debugger: Add data breakpoint access type support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4427,6 +4427,7 @@ dependencies = [
  "pretty_assertions",
  "project",
  "rpc",
+ "schemars",
  "serde",
  "serde_json",
  "serde_json_lenient",

--- a/crates/debugger_ui/Cargo.toml
+++ b/crates/debugger_ui/Cargo.toml
@@ -35,6 +35,7 @@ command_palette_hooks.workspace = true
 dap.workspace = true
 dap_adapters = { workspace = true, optional = true }
 db.workspace = true
+debugger_tools.workspace = true
 editor.workspace = true
 file_icons.workspace = true
 futures.workspace = true
@@ -54,6 +55,7 @@ picker.workspace = true
 pretty_assertions.workspace = true
 project.workspace = true
 rpc.workspace = true
+schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
@@ -66,14 +68,13 @@ telemetry.workspace = true
 terminal_view.workspace = true
 text.workspace = true
 theme.workspace = true
-tree-sitter.workspace = true
 tree-sitter-json.workspace = true
+tree-sitter.workspace = true
 ui.workspace = true
-util.workspace = true
-workspace.workspace = true
-workspace-hack.workspace = true
-debugger_tools.workspace = true
 unindent = { workspace = true, optional = true }
+util.workspace = true
+workspace-hack.workspace = true
+workspace.workspace = true
 zed_actions.workspace = true
 
 [dev-dependencies]
@@ -83,8 +84,8 @@ debugger_tools = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
 gpui = { workspace = true, features = ["test-support"] }
 project = { workspace = true, features = ["test-support"] }
+tree-sitter-go.workspace = true
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
 workspace = { workspace = true, features = ["test-support"] }
 zlog.workspace = true
-tree-sitter-go.workspace = true

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -3,10 +3,12 @@ use std::any::TypeId;
 use dap::debugger_settings::DebuggerSettings;
 use debugger_panel::DebugPanel;
 use editor::Editor;
-use gpui::{App, DispatchPhase, EntityInputHandler, actions};
+use gpui::{Action, App, DispatchPhase, EntityInputHandler, actions};
 use new_process_modal::{NewProcessModal, NewProcessMode};
 use onboarding_modal::DebuggerOnboardingModal;
 use project::debugger::{self, breakpoint_store::SourceBreakpoint, session::ThreadStatus};
+use schemars::JsonSchema;
+use serde::Deserialize;
 use session::DebugSession;
 use settings::Settings;
 use stack_trace_view::StackTraceView;
@@ -83,10 +85,22 @@ actions!(
         Rerun,
         /// Toggles expansion of the selected item in the debugger UI.
         ToggleExpandItem,
-        /// Set a data breakpoint on the selected variable or memory region.
-        ToggleDataBreakpoint,
     ]
 );
+
+/// Extends selection down by a specified number of lines.
+#[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+#[action(namespace = debugger)]
+#[serde(deny_unknown_fields)]
+/// Set a data breakpoint on the selected variable or memory region.
+pub struct ToggleDataBreakpoint {
+    /// The type of data breakpoint
+    /// Read & Write
+    /// Read
+    /// Write
+    #[serde(default)]
+    pub access_type: Option<dap::DataBreakpointAccessType>,
+}
 
 actions!(
     dev,

--- a/crates/debugger_ui/src/session/running/memory_view.rs
+++ b/crates/debugger_ui/src/session/running/memory_view.rs
@@ -688,7 +688,7 @@ impl MemoryView {
                 menu = menu.action_disabled_when(
                     *memory_unreadable,
                     "Set Data Breakpoint",
-                    ToggleDataBreakpoint.boxed_clone(),
+                    ToggleDataBreakpoint { access_type: None }.boxed_clone(),
                 );
             }
             menu.context(self.focus_handle.clone())


### PR DESCRIPTION


Release Notes:

- Support specifying a data breakpoint's access type - Read, Write, Read & Write
