### PR TITLE
JetBrains keymap improvements (July 2025)

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -66,22 +66,46 @@
     "context": "Editor && mode == full",
     "bindings": {
       "ctrl-f12": "outline::Toggle",
-      "alt-7": "outline::Toggle",
+      "ctrl-r": ["buffer_search::Deploy", { "replace_enabled": true }],
       "ctrl-shift-n": "file_finder::Toggle",
       "ctrl-g": "go_to_line::Toggle",
       "alt-enter": "editor::ToggleCodeActions"
     }
   },
   {
+    "context": "BufferSearchBar || ProjectSearchBar",
+    "bindings": {
+      "shift-enter": "search::SelectPreviousMatch",
+      "ctrl-alt-c": "search::ToggleCaseSensitive",
+      "ctrl-alt-e": "search::ToggleSelection",
+      "ctrl-alt-w": "search::ToggleWholeWord",
+      "ctrl-alt-x": "search::ToggleRegex"
+    }
+  },
+  {
     "context": "Workspace",
     "bindings": {
+      "ctrl-shift-f12": "workspace::CloseAllDocks",
+      "ctrl-shift-r": ["pane::DeploySearch", { "replace_enabled": true }],
+      "alt-shift-f10": "task::Spawn",
+      "ctrl-e": "file_finder::Toggle",
+      "ctrl-k": "git_panel::ToggleFocus", // bug: This should also focus commit editor
       "ctrl-shift-n": "file_finder::Toggle",
       "ctrl-shift-a": "command_palette::Toggle",
       "shift shift": "command_palette::Toggle",
       "ctrl-alt-shift-n": "project_symbols::Toggle",
+      "alt-0": "git_panel::ToggleFocus",
       "alt-1": "workspace::ToggleLeftDock",
-      "ctrl-e": "tab_switcher::Toggle",
-      "alt-6": "diagnostics::Deploy"
+      "alt-5": "debug_panel::ToggleFocus",
+      "alt-6": "diagnostics::Deploy",
+      "alt-7": "outline_panel::ToggleFocus"
+    }
+  },
+  {
+    "context": "Workspace || Editor",
+    "bindings": {
+      "alt-f12": "terminal_panel::ToggleFocus",
+      "ctrl-shift-k": "git::Push"
     }
   },
   {
@@ -95,10 +119,33 @@
     "context": "ProjectPanel",
     "bindings": {
       "enter": "project_panel::Open",
+      "ctrl-shift-f": "project_panel::NewSearchInDirectory",
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "delete": ["project_panel::Trash", { "skip_prompt": false }],
       "shift-delete": ["project_panel::Delete", { "skip_prompt": false }],
       "shift-f6": "project_panel::Rename"
     }
+  },
+  {
+    "context": "Terminal",
+    "bindings": {
+      "ctrl-shift-t": "workspace::NewTerminal",
+      "alt-f12": "workspace::CloseActiveDock",
+      "alt-left": "pane::ActivatePreviousItem",
+      "alt-right": "pane::ActivateNextItem",
+      "ctrl-up": "terminal::ScrollLineUp",
+      "ctrl-down": "terminal::ScrollLineDown",
+      "shift-pageup": "terminal::ScrollPageUp",
+      "shift-pagedown": "terminal::ScrollPageDown"
+    }
+  },
+  { "context": "GitPanel", "bindings": { "alt-0": "workspace::CloseActiveDock" } },
+  { "context": "ProjectPanel", "bindings": { "alt-1": "workspace::CloseActiveDock" } },
+  { "context": "DebugPanel", "bindings": { "alt-5": "workspace::CloseActiveDock" } },
+  { "context": "Diagnostics > Editor", "bindings": { "alt-6": "pane::CloseActiveItem" } },
+  { "context": "OutlinePanel", "bindings": { "alt-7": "workspace::CloseActiveDockk" } },
+  {
+    "context": "Dock || Workspace || Terminal || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
+    "bindings": { "escape": "editor::ToggleFocus" }
   }
 ]

--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -143,7 +143,7 @@
   { "context": "ProjectPanel", "bindings": { "alt-1": "workspace::CloseActiveDock" } },
   { "context": "DebugPanel", "bindings": { "alt-5": "workspace::CloseActiveDock" } },
   { "context": "Diagnostics > Editor", "bindings": { "alt-6": "pane::CloseActiveItem" } },
-  { "context": "OutlinePanel", "bindings": { "alt-7": "workspace::CloseActiveDockk" } },
+  { "context": "OutlinePanel", "bindings": { "alt-7": "workspace::CloseActiveDock" } },
   {
     "context": "Dock || Workspace || Terminal || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
     "bindings": { "escape": "editor::ToggleFocus" }

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -3,6 +3,7 @@
     "bindings": {
       "cmd-{": "pane::ActivatePreviousItem",
       "cmd-}": "pane::ActivateNextItem",
+      "cmd-0": "git_panel::ToggleFocus", // overrides `cmd-0` zoom reset
       "ctrl-f2": "debugger::Stop",
       "f6": "debugger::Pause",
       "f7": "debugger::StepInto",
@@ -63,28 +64,50 @@
     "context": "Editor && mode == full",
     "bindings": {
       "cmd-f12": "outline::Toggle",
-      "cmd-7": "outline::Toggle",
+      "cmd-r": ["buffer_search::Deploy", { "replace_enabled": true }],
       "cmd-shift-o": "file_finder::Toggle",
       "cmd-l": "go_to_line::Toggle",
       "alt-enter": "editor::ToggleCodeActions"
     }
   },
   {
-    "context": "BufferSearchBar > Editor",
+    "context": "BufferSearchBar || ProjectSearchBar",
     "bindings": {
-      "shift-enter": "search::SelectPreviousMatch"
+      "shift-enter": "search::SelectPreviousMatch",
+      "alt-c": "search::ToggleCaseSensitive",
+      "alt-e": "search::ToggleSelection",
+      "alt-x": "search::ToggleRegex",
+      "alt-w": "search::ToggleWholeWord",
+      "ctrl-alt-c": "search::ToggleCaseSensitive",
+      "ctrl-alt-e": "search::ToggleSelection",
+      "ctrl-alt-w": "search::ToggleWholeWord",
+      "ctrl-alt-x": "search::ToggleRegex"
     }
   },
   {
     "context": "Workspace",
     "bindings": {
+      "cmd-shift-f12": "workspace::CloseAllDocks",
+      "cmd-shift-r": ["pane::DeploySearch", { "replace_enabled": true }],
+      "ctrl-alt-r": "task::Spawn",
+      "cmd-e": "file_finder::Toggle",
+      "cmd-k": "git_panel::ToggleFocus", // bug: This should also focus commit editor
       "cmd-shift-o": "file_finder::Toggle",
       "cmd-shift-a": "command_palette::Toggle",
       "shift shift": "command_palette::Toggle",
       "cmd-alt-o": "project_symbols::Toggle", // JetBrains: Go to Symbol
       "cmd-o": "project_symbols::Toggle", // JetBrains: Go to Class
-      "cmd-1": "workspace::ToggleLeftDock",
-      "cmd-6": "diagnostics::Deploy"
+      "cmd-1": "project_panel::ToggleFocus",
+      "cmd-5": "debug_panel::ToggleFocus",
+      "cmd-6": "diagnostics::Deploy",
+      "cmd-7": "outline_panel::ToggleFocus"
+    }
+  },
+  {
+    "context": "Workspace || Editor",
+    "bindings": {
+      "alt-f12": "terminal_panel::ToggleFocus",
+      "cmd-shift-k": "git::Push"
     }
   },
   {
@@ -98,11 +121,31 @@
     "context": "ProjectPanel",
     "bindings": {
       "enter": "project_panel::Open",
+      "cmd-shift-f": "project_panel::NewSearchInDirectory",
       "cmd-backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "backspace": ["project_panel::Trash", { "skip_prompt": false }],
       "delete": ["project_panel::Trash", { "skip_prompt": false }],
       "shift-delete": ["project_panel::Delete", { "skip_prompt": false }],
       "shift-f6": "project_panel::Rename"
     }
+  },
+  {
+    "context": "Terminal",
+    "bindings": {
+      "cmd-t": "workspace::NewTerminal",
+      "alt-f12": "workspace::CloseActiveDock",
+      "cmd-up": "terminal::ScrollLineUp",
+      "cmd-down": "terminal::ScrollLineDown",
+      "shift-pageup": "terminal::ScrollPageUp",
+      "shift-pagedown": "terminal::ScrollPageDown"
+    }
+  },
+  { "context": "GitPanel", "bindings": { "cmd-0": "workspace::CloseActiveDock" } },
+  { "context": "DebugPanel", "bindings": { "cmd-5": "workspace::CloseActiveDock" } },
+  { "context": "Diagnostics > Editor", "bindings": { "cmd-6": "pane::CloseActiveItem" } },
+  { "context": "OutlinePanel", "bindings": { "cmd-7": "workspace::CloseActiveDock" } },
+  {
+    "context": "Dock || Workspace || Terminal || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
+    "bindings": { "escape": "editor::ToggleFocus" }
   }
 ]


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/14639
Closes: https://github.com/zed-industries/zed/issues/33020

If would have ideas for future enhancements, please see:
- https://github.com/zed-industries/zed/discussions/34643

Various Jetbrains keymaps improvements for macOS and Linux/Windows:

| Area          | Action                     | macOS                             | Linux                             |
| ------------- | -------------------------- | --------------------------------- | --------------------------------- |
| Workspace     | Toggle Git Panel           | `cmd-0`                           | `ctrl-0`                          |
| Workspace     | Toggle Project Panel       | `cmd-1`                           | `alt-0`                           |
| Workspace     | Toggle Debug Panel         | `cmd-5`                           | `alt-1`                           |
| Workspace     | Toggle Diagnostics         | `cmd-6`                           | `alt-6`                           |
| Workspace     | Toggle Outline Panel       | `cmd-7`                           | `alt-7`                           |
| Workspace     | Toggle Terminal Panel      | `alt-f12`                         | `alt-f12`                         |
| Workspace     | File Finder                | `cmd-e`                           | `ctrl-e`                          |
| Workspace     | Task Spawn                 | `ctrl-alt-r`                      | `alt-shift-f10`                   |
| Workspace     | Close All Docks            | `ctrl-shift-f12`                  | `ctrl-shift-f12`                  |
| Project Panel | Search in Directory        | `cmd-shift-f`                     | `ctrl-shift-f`                    |
| Search        | Replace in Files           | `cmd-shift-r`                     | `ctrl-shift-r`                    |
| Search        | Replace in Buffer          | `cmd-r`                           | `ctrl-r`                          |
| Search        | Toggle Case Sensitive      | `ctrl-alt-c` / `alt-c`            | `ctrl-alt-c`                      |
| Search        | Toggle Search in Selection | `ctrl-alt-s` / `alt-s`            | `ctrl-alt-s`                      |
| Search        | Toggle Regex               | `ctrl-alt-x` / `alt-x`            | `ctrl-alt-x`                      |
| Search        | Toggle Whole Word          | `ctrl-alt-w` / `alt-w`            | `ctrl-alt-w`                      |
| Terminal      | New Terminal Tab           | `cmd-t`                           | `ctrl-shift-t`                    |
| Terminal      | Scroll Line                | `cmd-up` / `cmd-down`             | `ctrl-up` / `ctrl-down`           |
| Terminal      | Scroll Page                | `shift-pageup` / `shift-pagedown` | `shift-pageup` / `shift-pagedown` |
| Git           | Git Panel                  | `cmd-k`                           | `ctrl-k`                          |
| Git           | Git Push                   | `cmd-shift-k`                     | `ctrl-shift-k`                    |

In addition, with the help of the recently merged https://github.com/zed-industries/zed/pull/34495, no matter where you are mashing `escape` will refocus you back to your most recent editor buffer similar to the behavior of JetBrains.

Release Notes:

- jetbrains: Added 25+ keybinds to the macOS and Linux/Windows JetBrains compatibility keymaps
