### PR TITLE
keymap_ui: Don't panic on `KeybindSource::from_meta`

### DIFF
--- a/crates/settings/src/keymap_file.rs
+++ b/crates/settings/src/keymap_file.rs
@@ -992,13 +992,17 @@ impl KeybindSource {
     }
 
     pub fn from_meta(index: KeyBindingMetaIndex) -> Self {
-        match index {
+        Self::try_from_meta(index).unwrap()
+    }
+
+    pub fn try_from_meta(index: KeyBindingMetaIndex) -> Result<Self> {
+        Ok(match index {
             Self::USER => KeybindSource::User,
             Self::BASE => KeybindSource::Base,
             Self::DEFAULT => KeybindSource::Default,
             Self::VIM => KeybindSource::Vim,
-            _ => unreachable!(),
-        }
+            _ => anyhow::bail!("Invalid keybind source {:?}", index),
+        })
     }
 }
 

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -540,7 +540,10 @@ impl KeymapEditor {
         let mut string_match_candidates = Vec::new();
 
         for key_binding in key_bindings {
-            let source = key_binding.meta().map(settings::KeybindSource::from_meta);
+            let source = key_binding
+                .meta()
+                .map(settings::KeybindSource::try_from_meta)
+                .and_then(|source| source.log_err());
 
             let keystroke_text = ui::text_for_keystrokes(key_binding.keystrokes(), cx);
             let ui_key_binding = Some(


### PR DESCRIPTION
Closes #ISSUE

Log error instead of panicking when `from_meta` is passed an invalid value

Release Notes:

- N/A *or* Added/Fixed/Improved ...
