### PR TITLE
docs: Consolidate backend setup docs into local-collaboration.md

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -16,20 +16,9 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
   If you prefer to install the system libraries manually, you can find the list of required packages in the `script/linux` file.
 
-## Backend dependencies
+### Backend Dependencies (optional) {#backend-dependencies}
 
-> This section is still in development. The instructions are not yet complete.
-
-If you are developing collaborative features of Zed, you'll need to install the dependencies of zed's `collab` server:
-
-- Install [Postgres](https://www.postgresql.org/download/linux/)
-- Install [Livekit](https://github.com/livekit/livekit-cli) and [Foreman](https://theforeman.org/manuals/3.9/quickstart_guide.html)
-
-Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
-
-```sh
-docker compose up -d
-```
+If you are looking to develop Zed collaboration features using a local collabortation server, please see: [Local Collaboration](./local-collaboration.md) docs.
 
 ## Building from source
 

--- a/docs/src/development/local-collaboration.md
+++ b/docs/src/development/local-collaboration.md
@@ -1,12 +1,75 @@
 # Local Collaboration
 
-First, make sure you've installed Zed's backend dependencies for your platform:
+First, make sure you've installed Zed's dependencies for your platform:
 
 - [macOS](./macos.md#backend-dependencies)
 - [Linux](./linux.md#backend-dependencies)
 - [Windows](./windows.md#backend-dependencies)
 
 Note that `collab` can be compiled only with MSVC toolchain on Windows
+
+## Backend Dependencies
+
+If you are developing collaborative features of Zed, you'll need to install the dependencies of zed's `collab` server:
+
+- PostgreSQL
+- LiveKit
+- Foreman
+
+You can install these dependencies natively or run them under Docker.
+
+### MacOS
+
+1. Install [Postgres.app](https://postgresapp.com) or [postgresql via homebrew](https://formulae.brew.sh/formula/postgresql@15):
+
+   ```sh
+   brew install postgresql@15
+   ```
+
+2. Install [Livekit](https://formulae.brew.sh/formula/livekit) and [Foreman](https://formulae.brew.sh/formula/foreman)
+
+    ```sh
+    brew install livekit foreman
+    ```
+
+- Follow the steps in the [collab README](https://github.com/zed-industries/zed/blob/main/crates/collab/README.md) to configure the Postgres database for integration tests
+
+Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
+
+### Linux
+
+1. Install [Postgres](https://www.postgresql.org/download/linux/)
+
+    ```sh
+    sudo apt-get install postgresql postgresql        # Ubuntu/Debian
+    sudo pacman -S postgresql                         # Arch Linux
+    sudo dnf install postgresql postgresql-server     # RHEL/Fedora
+    sudo zypper install postgresql postgresql-server  # OpenSUSE
+    ```
+
+2. Install [Livekit](https://github.com/livekit/livekit-cli)
+    ```sh
+    curl -sSL https://get.livekit.io/cli | bash
+    ```
+
+3.  Install [Foreman](https://theforeman.org/manuals/3.15/quickstart_guide.html)
+
+### Windows {#backend-windows}
+
+> This section is still in development. The instructions are not yet complete.
+
+- Install [Postgres](https://www.postgresql.org/download/windows/)
+- Install [Livekit](https://github.com/livekit/livekit), optionally you can add the `livekit-server` binary to your `PATH`.
+
+Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose.
+
+### Docker {#Docker}
+
+If you have docker or podman available, you can run the backend dependencies inside containers with Docker Compose:
+
+```sh
+docker compose up -d
+```
 
 ## Database setup
 

--- a/docs/src/development/local-collaboration.md
+++ b/docs/src/development/local-collaboration.md
@@ -28,9 +28,9 @@ You can install these dependencies natively or run them under Docker.
 
 2. Install [Livekit](https://formulae.brew.sh/formula/livekit) and [Foreman](https://formulae.brew.sh/formula/foreman)
 
-    ```sh
-    brew install livekit foreman
-    ```
+   ```sh
+   brew install livekit foreman
+   ```
 
 - Follow the steps in the [collab README](https://github.com/zed-industries/zed/blob/main/crates/collab/README.md) to configure the Postgres database for integration tests
 
@@ -40,19 +40,20 @@ Alternatively, if you have [Docker](https://www.docker.com/) installed you can b
 
 1. Install [Postgres](https://www.postgresql.org/download/linux/)
 
-    ```sh
-    sudo apt-get install postgresql postgresql        # Ubuntu/Debian
-    sudo pacman -S postgresql                         # Arch Linux
-    sudo dnf install postgresql postgresql-server     # RHEL/Fedora
-    sudo zypper install postgresql postgresql-server  # OpenSUSE
-    ```
+   ```sh
+   sudo apt-get install postgresql postgresql        # Ubuntu/Debian
+   sudo pacman -S postgresql                         # Arch Linux
+   sudo dnf install postgresql postgresql-server     # RHEL/Fedora
+   sudo zypper install postgresql postgresql-server  # OpenSUSE
+   ```
 
 2. Install [Livekit](https://github.com/livekit/livekit-cli)
-    ```sh
-    curl -sSL https://get.livekit.io/cli | bash
-    ```
 
-3.  Install [Foreman](https://theforeman.org/manuals/3.15/quickstart_guide.html)
+   ```sh
+   curl -sSL https://get.livekit.io/cli | bash
+   ```
+
+3. Install [Foreman](https://theforeman.org/manuals/3.15/quickstart_guide.html)
 
 ### Windows {#backend-windows}
 

--- a/docs/src/development/macos.md
+++ b/docs/src/development/macos.md
@@ -31,6 +31,10 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
   brew install cmake
   ```
 
+### Backend Dependencies (optional) {#backend-dependencies}
+
+If you are looking to develop Zed collaboration features using a local collabortation server, please see: [Local Collaboration](./local-collaboration.md) docs.
+
 ## Building Zed from Source
 
 Once you have the dependencies installed, you can build Zed using [Cargo](https://doc.rust-lang.org/cargo/).
@@ -51,25 +55,6 @@ And to run the tests:
 
 ```sh
 cargo test --workspace
-```
-
-## Backend Dependencies
-
-If you are developing collaborative features of Zed, you'll need to install the dependencies of zed's `collab` server:
-
-- Install [Postgres](https://postgresapp.com)
-- Install [Livekit](https://formulae.brew.sh/formula/livekit) and [Foreman](https://formulae.brew.sh/formula/foreman)
-
-  ```sh
-  brew install livekit foreman
-  ```
-
-- Follow the steps in the [collab README](https://github.com/zed-industries/zed/blob/main/crates/collab/README.md) to configure the Postgres database for integration tests
-
-Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
-
-```sh
-docker compose up -d
 ```
 
 ## Troubleshooting

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -66,20 +66,9 @@ The list can be obtained as follows:
 - Click on `More` in the `Installed` tab
 - Click on `Export configuration`
 
-## Backend dependencies
+### Backend Dependencies (optional) {#backend-dependencies}
 
-> This section is still in development. The instructions are not yet complete.
-
-If you are developing collaborative features of Zed, you'll need to install the dependencies of zed's `collab` server:
-
-- Install [Postgres](https://www.postgresql.org/download/windows/)
-- Install [Livekit](https://github.com/livekit/livekit), optionally you can add the `livekit-server` binary to your `PATH`.
-
-Alternatively, if you have [Docker](https://www.docker.com/) installed you can bring up all the `collab` dependencies using Docker Compose:
-
-```sh
-docker compose up -d
-```
+If you are looking to develop Zed collaboration features using a local collabortation server, please see: [Local Collaboration](./local-collaboration.md) docs.
 
 ### Notes
 


### PR DESCRIPTION
Simplify docs for mac/linux/windows by consolidating the backend dependencies (collaboration) docs into local-collaboration.md.  Most users building zed will not need to do this -- streamline them into getting setup to build the zed client app first.

Release Notes:

- N/A
