### PR TITLE
Retry on burn mode

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2314,7 +2314,7 @@ impl Thread {
             // Show error with retry options
             cx.emit(ThreadEvent::ShowError(ThreadError::RetryableError {
                 message: format!(
-                    "{}. To automatically retry when similar errors happen, enable Burn Mode.",
+                    "{}\n\nTo automatically retry when similar errors happen, enable Burn Mode.",
                     error
                 )
                 .into(),

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2313,7 +2313,11 @@ impl Thread {
         if self.completion_mode != CompletionMode::Burn {
             // Show error with retry options
             cx.emit(ThreadEvent::ShowError(ThreadError::RetryableError {
-                message: error.to_string().into(),
+                message: format!(
+                    "{}. To automatically retry when similar errors happen, enable Burn Mode.",
+                    error
+                )
+                .into(),
                 can_enable_burn_mode: true,
             }));
             return false;

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -1265,6 +1265,8 @@ impl Thread {
 
         self.remaining_turns -= 1;
 
+        self.flush_notifications(model.clone(), intent, cx);
+
         let _checkpoint = self.finalize_pending_checkpoint(cx);
         self.stream_completion(
             self.to_completion_request(model.clone(), intent, cx),

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -397,6 +397,8 @@ pub struct Thread {
     configured_model: Option<ConfiguredModel>,
     profile: AgentProfile,
     last_error_context: Option<(Arc<dyn LanguageModel>, CompletionIntent)>,
+    #[cfg(debug_assertions)]
+    simulated_error_triggered: bool,
 }
 
 #[derive(Clone, Debug)]
@@ -496,6 +498,8 @@ impl Thread {
             remaining_turns: u32::MAX,
             configured_model: configured_model.clone(),
             profile: AgentProfile::new(profile_id, tools),
+            #[cfg(debug_assertions)]
+            simulated_error_triggered: false,
         }
     }
 
@@ -621,6 +625,8 @@ impl Thread {
             remaining_turns: u32::MAX,
             configured_model,
             profile: AgentProfile::new(profile_id, tools),
+            #[cfg(debug_assertions)]
+            simulated_error_triggered: false,
         }
     }
 
@@ -1666,6 +1672,32 @@ impl Thread {
         window: Option<AnyWindowHandle>,
         cx: &mut Context<Self>,
     ) {
+        // HACK: Return a 500 error for testing retry UI (only once per thread)
+        #[cfg(debug_assertions)]
+        if std::env::var("ZED_SIMULATE_ERROR").is_ok() && !self.simulated_error_triggered {
+            self.simulated_error_triggered = true;
+            let error = LanguageModelCompletionError::ApiInternalServerError {
+                provider: model.provider_name(),
+                message: "Simulated 500 error for testing".to_string(),
+            };
+
+            // Ensure we have a configured model for retry
+            if self.configured_model.is_none() {
+                self.configured_model = LanguageModelRegistry::read_global(cx).default_model();
+            }
+
+            if let Some(retry_strategy) = Self::get_retry_strategy(&error) {
+                self.handle_retryable_error_with_delay(
+                    &error,
+                    Some(retry_strategy),
+                    model,
+                    intent,
+                    window,
+                    cx,
+                );
+            }
+            return;
+        }
         self.tool_use_limit_reached = false;
 
         let pending_completion_id = post_inc(&mut self.completion_count);

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -2986,7 +2986,7 @@ impl AgentPanel {
                 move |_, window, cx| {
                     thread.update(cx, |thread, cx| {
                         thread.clear_last_error();
-                        thread.thread.update(cx, |thread, cx| {
+                        thread.thread().update(cx, |thread, cx| {
                             thread.retry_last_completion(Some(window.window_handle()), cx);
                         });
                     });
@@ -3028,14 +3028,19 @@ impl AgentPanel {
                 move |_, window, cx| {
                     thread.update(cx, |thread, cx| {
                         thread.clear_last_error();
-                        thread.thread.update(cx, |thread, cx| {
+                        thread.thread().update(cx, |thread, cx| {
                             thread.retry_last_completion(Some(window.window_handle()), cx);
                         });
                     });
                 }
             });
 
-        let mut actions = vec![retry_button];
+        let mut callout = Callout::new()
+            .icon(icon)
+            .title("Error")
+            .description(message.clone())
+            .bg_color(self.error_callout_bg(cx))
+            .primary_action(retry_button);
 
         if can_enable_burn_mode {
             let burn_mode_button = Button::new("enable_burn_retry", "Enable Burn Mode and Retry")
@@ -3046,32 +3051,13 @@ impl AgentPanel {
                     move |_, window, cx| {
                         thread.update(cx, |thread, cx| {
                             thread.clear_last_error();
-                            thread.thread.update(cx, |thread, cx| {
+                            thread.thread().update(cx, |thread, cx| {
                                 thread.enable_burn_mode_and_retry(Some(window.window_handle()), cx);
                             });
                         });
                     }
                 });
-            actions.push(burn_mode_button);
-        }
-
-        actions.push(self.dismiss_error_button(thread, cx));
-        actions.push(self.create_copy_button(message.to_string()));
-
-        let mut callout = Callout::new()
-            .icon(icon)
-            .title("Error")
-            .description(message.clone())
-            .bg_color(self.error_callout_bg(cx));
-
-        for (i, action) in actions.into_iter().enumerate() {
-            if i == 0 {
-                callout = callout.primary_action(action);
-            } else if i == 1 {
-                callout = callout.secondary_action(action);
-            } else {
-                callout = callout.tertiary_action(action);
-            }
+            callout = callout.secondary_action(burn_mode_button);
         }
 
         div()
@@ -3327,7 +3313,7 @@ impl Render for AgentPanel {
                                         can_enable_burn_mode,
                                     } => self.render_retryable_error(
                                         message,
-                                        *can_enable_burn_mode,
+                                        can_enable_burn_mode,
                                         thread,
                                         cx,
                                     ),

--- a/crates/language_model/src/fake_provider.rs
+++ b/crates/language_model/src/fake_provider.rs
@@ -188,37 +188,6 @@ impl LanguageModel for FakeLanguageModel {
             LanguageModelCompletionError,
         >,
     > {
-        // Check for debug environment variable to simulate errors
-        if let Ok(error_type) = std::env::var("ZED_SIMULATE_ERROR") {
-            return async move {
-                match error_type.as_str() {
-                    "rate_limit" => Err(LanguageModelCompletionError::RateLimitExceeded {
-                        provider: provider_name(),
-                        retry_after: Some(std::time::Duration::from_secs(30)),
-                    }),
-                    "server_overload" => Err(LanguageModelCompletionError::ServerOverloaded {
-                        provider: provider_name(),
-                        retry_after: Some(std::time::Duration::from_secs(5)),
-                    }),
-                    "internal_server" => {
-                        Err(LanguageModelCompletionError::ApiInternalServerError {
-                            provider: provider_name(),
-                            message: "Simulated internal server error".to_string(),
-                        })
-                    }
-                    _ => {
-                        // Unknown error type, proceed normally
-                        let (tx, rx) = mpsc::unbounded();
-                        self.current_completion_txs.lock().push((request, tx));
-                        Ok(rx
-                            .map(|text| Ok(LanguageModelCompletionEvent::Text(text)))
-                            .boxed())
-                    }
-                }
-            }
-            .boxed();
-        }
-
         let (tx, rx) = mpsc::unbounded();
         self.current_completion_txs.lock().push((request, tx));
         async move {


### PR DESCRIPTION
Now we only auto-retry if burn mode is enabled. We also show a "Retry" button (so you don't have to type "continue") if you think that's the right remedy, and additionally we show a "Retry and Enable Burn Mode" button if you don't have it enabled.

<img width="484" height="260" alt="Screenshot 2025-07-17 at 6 25 27 PM" src="https://github.com/user-attachments/assets/dc5bf1f6-8b11-4041-87aa-4f37c95ea9f0" />

<img width="478" height="307" alt="Screenshot 2025-07-17 at 6 22 36 PM" src="https://github.com/user-attachments/assets/1ed6578a-1696-449d-96d1-e447d11959fa" />


Release Notes:

- Only auto-retry Agent requests when Burn Mode is enabled
