### PR TITLE
editor: Fix cursor doesn’t move up and down on arrow keys when no completions are shown

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -1384,7 +1384,7 @@ impl CodeActionsMenu {
         }
     }
 
-    fn visible(&self) -> bool {
+    pub fn visible(&self) -> bool {
         !self.actions.is_empty()
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2382,13 +2382,17 @@ impl Editor {
         }
 
         match self.context_menu.borrow().as_ref() {
-            Some(CodeContextMenu::Completions(_)) => {
-                key_context.add("menu");
-                key_context.add("showing_completions");
+            Some(CodeContextMenu::Completions(menu)) => {
+                if menu.visible() {
+                    key_context.add("menu");
+                    key_context.add("showing_completions");
+                }
             }
-            Some(CodeContextMenu::CodeActions(_)) => {
-                key_context.add("menu");
-                key_context.add("showing_code_actions")
+            Some(CodeContextMenu::CodeActions(menu)) => {
+                if menu.visible() {
+                    key_context.add("menu");
+                    key_context.add("showing_code_actions")
+                }
             }
             None => {}
         }


### PR DESCRIPTION
Closes #34338

After https://github.com/zed-industries/zed/pull/31872, to avoid re-querying language servers, we keep the context menu around, which stores initial query, completions items, etc., even though it may not contain any items and hence not be rendered on screen.  In this state, up/down arrows try to switch focus in the context menu instead of propagating it to the editor. Hence blocking buffer movement.

This PR fixes it by changing the context for `menu`,   `showing_completions`, and `showing_code_actions` to only be added when the menu is actually being rendered (i.e., not empty).

Release Notes:

- Fix an issue where the cursor doesn’t move up and down on arrow keys when no completions are shown.
