### PR TITLE
agent: Fix Mistral tool use error message

### DIFF
--- a/crates/language_models/src/provider/mistral.rs
+++ b/crates/language_models/src/provider/mistral.rs
@@ -410,8 +410,20 @@ pub fn into_mistral(
                                 .push_part(mistral::MessagePart::Text { text: text.clone() });
                         }
                         MessageContent::RedactedThinking(_) => {}
-                        MessageContent::ToolUse(_) | MessageContent::ToolResult(_) => {
-                            // Tool content is not supported in User messages for Mistral
+                        MessageContent::ToolUse(_) => {
+                            // Tool use is not supported in User messages for Mistral
+                        }
+                        MessageContent::ToolResult(tool_result) => {
+                            let tool_content = match &tool_result.content {
+                                LanguageModelToolResultContent::Text(text) => text.to_string(),
+                                LanguageModelToolResultContent::Image(_) => {
+                                    "[Tool responded with an image, but Zed doesn't support these in Mistral models yet]".to_string()
+                                }
+                            };
+                            messages.push(mistral::RequestMessage::Tool {
+                                content: tool_content,
+                                tool_call_id: tool_result.tool_use_id.to_string(),
+                            });
                         }
                     }
                 }
@@ -478,24 +490,6 @@ pub fn into_mistral(
                         }
                     }
                 }
-            }
-        }
-    }
-
-    for message in &request.messages {
-        for content in &message.content {
-            if let MessageContent::ToolResult(tool_result) = content {
-                let content = match &tool_result.content {
-                    LanguageModelToolResultContent::Text(text) => text.to_string(),
-                    LanguageModelToolResultContent::Image(_) => {
-                        "[Tool responded with an image, but Zed doesn't support these in Mistral models yet]".to_string()
-                    }
-                };
-
-                messages.push(mistral::RequestMessage::Tool {
-                    content,
-                    tool_call_id: tool_result.tool_use_id.to_string(),
-                });
             }
         }
     }


### PR DESCRIPTION
Closes #32675

Exactly the same changes as in #33640 by @sviande

The PR has been in WIP state for 3 weeks with no activity, and the issue basically makes Mistral models unusable. I have tested the changes locally, and it does indeed work. Full credit goes to @sviande, I just want this feature to be finished.

Release Notes:

- agent: Fixed an issue with tool calling with the Mistral provider (thanks [@sviande](https://github.com/sviande) and [@armyhaylenko](https://github.com/armyhaylenko))