### PR TITLE
debugger: Fix attaching with DebugPy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4247,6 +4247,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shlex",
+ "smol",
  "task",
  "util",
  "workspace-hack",

--- a/crates/dap_adapters/Cargo.toml
+++ b/crates/dap_adapters/Cargo.toml
@@ -36,6 +36,7 @@ paths.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 shlex.workspace = true
+smol.workspace = true
 task.workspace = true
 util.workspace = true
 workspace-hack.workspace = true

--- a/crates/dap_adapters/src/dap_adapters.rs
+++ b/crates/dap_adapters/src/dap_adapters.rs
@@ -13,7 +13,6 @@ use dap::{
     DapRegistry,
     adapters::{
         self, AdapterVersion, DapDelegate, DebugAdapter, DebugAdapterBinary, DebugAdapterName,
-        GithubRepo,
     },
     configure_tcp_connection,
 };


### PR DESCRIPTION
@cole-miller found a root cause of our struggles with attach scenarios; we did not fetch .so files necessary for attaching to work,
as we were downloading DebugPy source tarballs from GitHub.

This PR does away with it by setting up a virtualenv instead that has debugpy installed.

Closes #34660
Closes #34575

Release Notes:

- debugger: Fixed attaching with DebugPy. DebugPy is now installed automatically from pip (instead of GitHub), unless it is present in active virtual environment. Additionally this should resolve any startup issues with missing .so on Linux.
