### PR TITLE
Fix incorrect minimum_contrast comment

### DIFF
--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -248,7 +248,7 @@ pub struct TerminalSettingsContent {
     /// - 75: Minimum for body text
     /// - 90: Preferred for body text
     ///
-    /// Default: 0 (no adjustment)
+    /// Default: 45
     pub minimum_contrast: Option<f32>,
 }
 


### PR DESCRIPTION
Actual default is 45

https://github.com/zed-industries/zed/blob/fd05f17fa7e0253bc98698e84a1f8939bcb6616f/assets/settings/default.json#L1402

Release Notes:

- N/A
