### PR TITLE
editor: Ensure topmost buffer header can be properly folded

### DIFF
--- a/crates/editor/src/scroll.rs
+++ b/crates/editor/src/scroll.rs
@@ -12,7 +12,7 @@ use crate::{
 };
 pub use autoscroll::{Autoscroll, AutoscrollStrategy};
 use core::fmt::Debug;
-use gpui::{App, Axis, Context, Global, Pixels, Task, Window, point, px};
+use gpui::{Along, App, Axis, Context, Global, Pixels, Task, Window, point, px};
 use language::language_settings::{AllLanguageSettings, SoftWrap};
 use language::{Bias, Point};
 pub use scroll_amount::ScrollAmount;
@@ -49,14 +49,14 @@ impl ScrollAnchor {
     }
 
     pub fn scroll_position(&self, snapshot: &DisplaySnapshot) -> gpui::Point<f32> {
-        let mut scroll_position = self.offset;
-        if self.anchor == Anchor::min() {
-            scroll_position.y = 0.;
-        } else {
-            let scroll_top = self.anchor.to_display_point(snapshot).row().as_f32();
-            scroll_position.y += scroll_top;
-        }
-        scroll_position
+        self.offset.apply_along(Axis::Vertical, |offset| {
+            if self.anchor == Anchor::min() {
+                0.
+            } else {
+                let scroll_top = self.anchor.to_display_point(snapshot).row().as_f32();
+                (offset + scroll_top).max(0.)
+            }
+        })
     }
 
     pub fn top_row(&self, buffer: &MultiBufferSnapshot) -> u32 {


### PR DESCRIPTION
This PR fixes an issue where the topmost header in a multibuffer would jump when the corresponding buffer was folded. 
The issue arose because for the topmost header, the offset within the scroll anchor is negative, as the corresponding buffer only starts below the header itself and thus the offset for the scroll position has to be negative. 
However, upon collapsing that buffer, we end up with a negative vertical scroll position, which causes all kinds of different problems. The issue has been present for a long time, but became more visible after https://github.com/zed-industries/zed/pull/34295 landed, as that change removed the case distinction for buffers scrolled all the way to the top.

This PR fixes this by clamping just the vertical scroll position upon return, which ensures the negative offset works as expected when the buffer is expanded, but the vertical scroll position does not turn negative once the buffer is folded.

Release Notes:

- Fixed an issue where folding the topmost buffer in a multibuffer would cause the header to jump slightly.
