### PR TITLE
theme_importer: Add missing color imports for the minimap thumb

### DIFF
--- a/crates/theme_importer/src/vscode/converter.rs
+++ b/crates/theme_importer/src/vscode/converter.rs
@@ -175,6 +175,8 @@ impl VsCodeThemeConverter {
             scrollbar_track_background: vscode_editor_background.clone(),
             scrollbar_track_border: vscode_colors.editor_overview_ruler.border.clone(),
             minimap_thumb_background: vscode_colors.minimap_slider.background.clone(),
+            minimap_thumb_hover_background: vscode_colors.minimap_slider.hover_background.clone(),
+            minimap_thumb_active_background: vscode_colors.minimap_slider.active_background.clone(),
             editor_foreground: vscode_editor_foreground
                 .clone()
                 .or(vscode_token_colors_foreground.clone()),


### PR DESCRIPTION
These should have been part of https://github.com/zed-industries/zed/pull/30785 but I forgot to add them there.

Release Notes:

- N/A
