### PR TITLE
collab: Don't use `screen-capture` feature from `gpui`

### DIFF
--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -35,7 +35,7 @@ dashmap.workspace = true
 derive_more.workspace = true
 envy = "0.4.2"
 futures.workspace = true
-gpui = { workspace = true, features = ["screen-capture"] }
+gpui.workspace = true
 hex.workspace = true
 http_client.workspace = true
 jsonwebtoken.workspace = true


### PR DESCRIPTION
This PR removes the `screen-capture` feature from `gpui` when depending on it in `collab`.

Release Notes:

- N/A
