### PR TITLE
Fix Tailwind support for HTML/ERB files

### DIFF
--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -273,6 +273,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
         "Astro",
         "CSS",
         "ERB",
+        "HTML/ERB",
         "HEEX",
         "HTML",
         "JavaScript",

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -179,6 +179,7 @@ impl LspAdapter for TailwindLspAdapter {
             ("Elixir".to_string(), "phoenix-heex".to_string()),
             ("HEEX".to_string(), "phoenix-heex".to_string()),
             ("ERB".to_string(), "erb".to_string()),
+            ("HTML/ERB".to_string(), "erb".to_string()),
             ("PHP".to_string(), "php".to_string()),
             ("Vue.js".to_string(), "vue".to_string()),
         ])


### PR DESCRIPTION
Closes #27118
Closes #34165

Fix a small issue after we landed https://github.com/zed-extensions/ruby/pull/113+ where we introduced `HTML/ERB` and `YAML/ERB` language IDs to improve user experience. Sorry about that. Thanks!

Release Notes:

- N/A
