### PR TITLE
ollama: Properly format tool calls fed back to the model

### DIFF
--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -117,6 +117,10 @@ pub enum ChatMessage {
     System {
         content: String,
     },
+    Tool {
+        tool_name: String,
+        content: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
Fix an issue that resulted in Ollama models not being able to not being able to access the input of the commands they executed (only being able to access the result).

This properly return the function history as shown in https://github.com/ollama/ollama/blob/main/docs/api.md#chat-request-with-history-with-tools

Previously, function input where not returned and result where returned as a "user" role.

Release Notes:

- ollama: Improved format when returning tool results to the models
