### PR TITLE
Make `grep` tool fail when no file matches match include pattern

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -5185,10 +5185,15 @@ async fn test_project_search(
             SearchResult::Buffer { buffer, ranges } => {
                 results.entry(buffer).or_insert(ranges);
             }
-            SearchResult::LimitReached => {
-                panic!(
+            SearchResult::Finished {
+                limit_reached,
+                any_file_matched_pattern,
+            } => {
+                assert!(
+                    !limit_reached,
                     "Unexpectedly reached search limit in tests. If you do want to assert limit-reached, change this panic call."
-                )
+                );
+                assert!(any_file_matched_pattern);
             }
         };
     }

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -8892,7 +8892,7 @@ async fn search(
             SearchResult::Buffer { buffer, ranges } => {
                 results.entry(buffer).or_insert(ranges);
             }
-            SearchResult::LimitReached => {}
+            SearchResult::Finished { .. } => {}
         }
     }
     Ok(results

--- a/crates/project/src/search.rs
+++ b/crates/project/src/search.rs
@@ -21,7 +21,10 @@ pub enum SearchResult {
         buffer: Entity<Buffer>,
         ranges: Vec<Range<Anchor>>,
     },
-    LimitReached,
+    Finished {
+        limit_reached: bool,
+        any_file_matched_pattern: bool,
+    },
 }
 
 #[derive(Clone, Copy, PartialEq)]

--- a/crates/remote_server/src/remote_editing_tests.rs
+++ b/crates/remote_server/src/remote_editing_tests.rs
@@ -222,6 +222,13 @@ async fn test_remote_project_search(cx: &mut TestAppContext, server_cx: &mut Tes
             )
         });
 
+        let SearchResult::Finished {
+            limit_reached: false,
+            any_file_matched_pattern: true,
+        } = receiver.recv().await.unwrap()
+        else {
+            panic!("invalid finisher");
+        };
         assert!(receiver.recv().await.is_err());
         buffer
     }

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -329,8 +329,11 @@ impl ProjectSearch {
                         project::search::SearchResult::Buffer { buffer, ranges } => {
                             buffers_with_ranges.push((buffer, ranges));
                         }
-                        project::search::SearchResult::LimitReached => {
-                            limit_reached = true;
+                        project::search::SearchResult::Finished {
+                            limit_reached: reached,
+                            ..
+                        } => {
+                            limit_reached = reached;
                         }
                     }
                 }


### PR DESCRIPTION
Release Notes:

- N/A

Sometimes when agents sees no matches found, it assumes that include pattern is correct. This gives better feedback to the agent. 