### PR TITLE
Fix error in OpenRouter svg logo

### DIFF
--- a/assets/icons/ai_open_router.svg
+++ b/assets/icons/ai_open_router.svg
@@ -1,5 +1,5 @@
 <svg width="16" height="16" viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill="currentColor" stroke="currentColor">
-  <g clip-path="url(#clip0_205_3)">
+  <g>
     <path d="M0.094 7.78c0.469 0 2.281 -0.405 3.219 -0.936s0.938 -0.531 2.875 -1.906c2.453 -1.741 4.188 -1.158 7.031 -1.158" stroke-width="2.8125" />
     <path d="m15.969 3.797 -4.805 2.774V1.023z" />
     <path d="M0 7.781c0.469 0 2.281 0.405 3.219 0.936s0.938 0.531 2.875 1.906C8.547 12.364 10.281 11.781 13.125 11.781" stroke-width="2.8125" />


### PR DESCRIPTION
Fix a spurious error in Zed logs from the OpenRouter svg Logo introduced in https://github.com/zed-industries/zed/pull/29496:

```log
WARN  [usvg::parser::svgtree] Failed to parse clip-path value: 'url(#clip0_205_3)'.
```

Release Notes:

- N/A
