### PR TITLE
Improve Helix insert

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -220,6 +220,7 @@
     "context": "vim_mode == normal",
     "bindings": {
       "i": "vim::InsertBefore",
+      "a": "vim::InsertAfter",
       "ctrl-[": "editor::Cancel",
       ":": "command_palette::Toggle",
       "c": "vim::PushChange",
@@ -354,7 +355,6 @@
       "shift-j": "vim::JoinLines",
       "shift-y": "vim::YankLine",
       "shift-i": "vim::InsertFirstNonWhitespace",
-      "a": "vim::InsertAfter",
       "shift-a": "vim::InsertEndOfLine",
       "o": "vim::InsertLineBelow",
       "shift-o": "vim::InsertLineAbove",
@@ -377,6 +377,7 @@
     "context": "vim_mode == helix_normal && !menu",
     "bindings": {
       "i": "vim::HelixInsert",
+      "a": "vim::HelixAppend",
       "ctrl-[": "editor::Cancel",
       ";": "vim::HelixCollapseSelection",
       ":": "command_palette::Toggle",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -219,6 +219,7 @@
   {
     "context": "vim_mode == normal",
     "bindings": {
+      "i": "vim::InsertBefore",
       "ctrl-[": "editor::Cancel",
       ":": "command_palette::Toggle",
       "c": "vim::PushChange",
@@ -352,7 +353,6 @@
       "shift-d": "vim::DeleteToEndOfLine",
       "shift-j": "vim::JoinLines",
       "shift-y": "vim::YankLine",
-      "i": "vim::InsertBefore",
       "shift-i": "vim::InsertFirstNonWhitespace",
       "a": "vim::InsertAfter",
       "shift-a": "vim::InsertEndOfLine",
@@ -376,6 +376,7 @@
   {
     "context": "vim_mode == helix_normal && !menu",
     "bindings": {
+      "i": "vim::HelixInsert",
       "ctrl-[": "editor::Cancel",
       ";": "vim::HelixCollapseSelection",
       ":": "command_palette::Toggle",

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -4,7 +4,11 @@ use gpui::{Context, Window};
 use language::{CharClassifier, CharKind};
 use text::SelectionGoal;
 
-use crate::{Vim, motion::Motion, state::Mode};
+use crate::{
+    Vim,
+    motion::{Motion, right},
+    state::Mode,
+};
 
 actions!(
     vim,
@@ -13,12 +17,15 @@ actions!(
         HelixNormalAfter,
         /// Inserts at the beginning of the selection.
         HelixInsert,
+        /// Appends at the end of the selection.
+        HelixAppend,
     ]
 );
 
 pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::helix_normal_after);
     Vim::action(editor, cx, Vim::helix_insert);
+    Vim::action(editor, cx, Vim::helix_append);
 }
 
 impl Vim {
@@ -317,6 +324,23 @@ impl Vim {
         });
         self.switch_mode(Mode::Insert, false, window, cx);
     }
+
+    fn helix_append(&mut self, _: &HelixAppend, window: &mut Window, cx: &mut Context<Self>) {
+        self.start_recording(cx);
+        self.switch_mode(Mode::Insert, false, window, cx);
+        self.update_editor(window, cx, |_, editor, window, cx| {
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.move_with(|map, selection| {
+                    let point = if selection.is_empty() {
+                        right(map, selection.head(), 1)
+                    } else {
+                        selection.end
+                    };
+                    selection.collapse_to(point, SelectionGoal::None);
+                });
+            });
+        });
+    }
 }
 
 #[cfg(test)]
@@ -532,6 +556,48 @@ mod test {
         cx.assert_state(
             indoc! {"
             ˇThe quick brown
+            fox jumps over
+            the lazy dog."},
+            Mode::Insert,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_append(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        // test from the end of the selection
+        cx.set_state(
+            indoc! {"
+            «Theˇ» quick brown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("a");
+
+        cx.assert_state(
+            indoc! {"
+            Theˇ quick brown
+            fox jumps over
+            the lazy dog."},
+            Mode::Insert,
+        );
+
+        // test from the beginning of the selection
+        cx.set_state(
+            indoc! {"
+            «ˇThe» quick brown
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("a");
+
+        cx.assert_state(
+            indoc! {"
+            Theˇ quick brown
             fox jumps over
             the lazy dog."},
             Mode::Insert,


### PR DESCRIPTION
Closes #34763 

Release Notes:

- Improved insert in `helix_mode` when a selection exists to better match helix's behavior: collapse selection to avoid replacing it
- Improved append (`insert_after`) to better match helix's behavior: move cursor to end of selection if it exists
