### PR TITLE
cli: Use existing release channel name

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -400,7 +400,6 @@ mod linux {
         os::unix::net::{SocketAddr, UnixDatagram},
         path::{Path, PathBuf},
         process::{self, ExitStatus},
-        sync::LazyLock,
         thread,
         time::Duration,
     };
@@ -410,9 +409,6 @@ mod linux {
     use fork::Fork;
 
     use crate::{Detect, InstalledApp};
-
-    static RELEASE_CHANNEL: LazyLock<String> =
-        LazyLock::new(|| include_str!("../../zed/RELEASE_CHANNEL").trim().to_string());
 
     struct App(PathBuf);
 
@@ -444,10 +440,10 @@ mod linux {
         fn zed_version_string(&self) -> String {
             format!(
                 "Zed {}{}{} – {}",
-                if *RELEASE_CHANNEL == "stable" {
+                if *release_channel::RELEASE_CHANNEL_NAME == "stable" {
                     "".to_string()
                 } else {
-                    format!("{} ", *RELEASE_CHANNEL)
+                    format!("{} ", *release_channel::RELEASE_CHANNEL_NAME)
                 },
                 option_env!("RELEASE_VERSION").unwrap_or_default(),
                 match option_env!("ZED_COMMIT_SHA") {
@@ -459,7 +455,10 @@ mod linux {
         }
 
         fn launch(&self, ipc_url: String) -> anyhow::Result<()> {
-            let sock_path = paths::data_dir().join(format!("zed-{}.sock", *RELEASE_CHANNEL));
+            let sock_path = paths::data_dir().join(format!(
+                "zed-{}.sock",
+                *release_channel::RELEASE_CHANNEL_NAME
+            ));
             let sock = UnixDatagram::unbound()?;
             if sock.connect(&sock_path).is_err() {
                 self.boot_background(ipc_url)?;


### PR DESCRIPTION
Remove the local `RELEASE_CHANNEL` source that seems to be used only for Linux as opposed to `channel_release::CHANNEL_RELEASE_NAME` for other platform
Windows: https://github.com/zed-industries/zed/blob/eee1b1f8a8ba47a14efc524a21b63d896b03feff/crates/cli/src/main.rs#L681-L685

Release Notes:

- N/A