### PR TITLE
Resizable columns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14756,6 +14756,7 @@ dependencies = [
  "fs",
  "fuzzy",
  "gpui",
+ "itertools 0.14.0",
  "language",
  "log",
  "menu",

--- a/crates/settings_ui/Cargo.toml
+++ b/crates/settings_ui/Cargo.toml
@@ -23,6 +23,7 @@ feature_flags.workspace = true
 fs.workspace = true
 fuzzy.workspace = true
 gpui.workspace = true
+itertools.workspace = true
 language.workspace = true
 log.workspace = true
 menu.workspace = true

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1435,11 +1435,12 @@ impl Render for KeymapEditor {
                         DefiniteLength::Fraction(0.45),
                         DefiniteLength::Fraction(0.08),
                     ])
-                    .header(["", "Action", "Arguments", "Keystrokes", "Context", "Source"])
                     .resizable_columns(
                         [false, true, true, true, true, true],
-                        self.current_widths.clone(),
+                        &self.current_widths,
+                        cx,
                     )
+                    .header(["", "Action", "Arguments", "Keystrokes", "Context", "Source"])
                     .uniform_list(
                         "keymap-editor-table",
                         row_count,

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -13,8 +13,8 @@ use gpui::{
     Action, Animation, AnimationExt, AppContext as _, AsyncApp, Axis, ClickEvent, Context,
     DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, FontWeight, Global, IsZero,
     KeyContext, Keystroke, Modifiers, ModifiersChangedEvent, MouseButton, Point, ScrollStrategy,
-    ScrollWheelEvent, StyledText, Subscription, Task, TextStyleRefinement, WeakEntity, actions,
-    anchored, deferred, div,
+    ScrollWheelEvent, Stateful, StyledText, Subscription, Task, TextStyleRefinement, WeakEntity,
+    actions, anchored, deferred, div,
 };
 use language::{Language, LanguageConfig, ToOffset as _};
 use notifications::status_toast::{StatusToast, ToastIcon};
@@ -1434,6 +1434,7 @@ impl Render for KeymapEditor {
                         DefiniteLength::Fraction(0.08),
                     ])
                     .header(["", "Action", "Arguments", "Keystrokes", "Context", "Source"])
+                    .resizable_columns([false, true, true, true, true, true])
                     .uniform_list(
                         "keymap-editor-table",
                         row_count,

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -36,7 +36,7 @@ use workspace::{
 
 use crate::{
     keybindings::persistence::KEYBINDING_EDITORS,
-    ui_components::table::{ColumnWidths, Table, TableInteractionState},
+    ui_components::table::{ColumnWidths, ResizeBehavior, Table, TableInteractionState},
 };
 
 const NO_ACTION_ARGUMENTS_TEXT: SharedString = SharedString::new_static("<no arguments>");
@@ -1436,7 +1436,15 @@ impl Render for KeymapEditor {
                         DefiniteLength::Fraction(0.08),
                     ])
                     .resizable_columns(
-                        [false, true, true, true, true, true],
+                        // todo! Resize doesn't fully work
+                        [
+                            ResizeBehavior::None,
+                            ResizeBehavior::Resizable,
+                            ResizeBehavior::Resizable,
+                            ResizeBehavior::Resizable,
+                            ResizeBehavior::Resizable,
+                            ResizeBehavior::Resizable, // this column doesn't matter
+                        ],
                         &self.current_widths,
                         cx,
                     )

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -36,7 +36,7 @@ use workspace::{
 
 use crate::{
     keybindings::persistence::KEYBINDING_EDITORS,
-    ui_components::table::{Table, TableInteractionState},
+    ui_components::table::{ColumnWidths, Table, TableInteractionState},
 };
 
 const NO_ACTION_ARGUMENTS_TEXT: SharedString = SharedString::new_static("<no arguments>");
@@ -284,6 +284,7 @@ struct KeymapEditor {
     context_menu: Option<(Entity<ContextMenu>, Point<Pixels>, Subscription)>,
     previous_edit: Option<PreviousEdit>,
     humanized_action_names: HumanizedActionNameCache,
+    current_widths: Entity<ColumnWidths<6>>,
     show_hover_menus: bool,
     /// In order for the JSON LSP to run in the actions arguments editor, we
     /// require a backing file In order to avoid issues (primarily log spam)
@@ -400,6 +401,7 @@ impl KeymapEditor {
             show_hover_menus: true,
             action_args_temp_dir: None,
             action_args_temp_dir_worktree: None,
+            current_widths: cx.new(|cx| ColumnWidths::new(cx)),
         };
 
         this.on_keymap_changed(window, cx);
@@ -1434,7 +1436,10 @@ impl Render for KeymapEditor {
                         DefiniteLength::Fraction(0.08),
                     ])
                     .header(["", "Action", "Arguments", "Keystrokes", "Context", "Source"])
-                    .resizable_columns([false, true, true, true, true, true])
+                    .resizable_columns(
+                        [false, true, true, true, true, true],
+                        self.current_widths.clone(),
+                    )
                     .uniform_list(
                         "keymap-editor-table",
                         row_count,

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1594,15 +1594,14 @@ impl Render for KeymapEditor {
                                 .collect()
                         }),
                     )
-                    .map_row(
-                        cx.processor(|this, (row_index, row): (usize, Div), _window, cx| {
+                    .map_row(cx.processor(
+                        |this, (row_index, row): (usize, Stateful<Div>), _window, cx| {
                             let is_conflict = this.has_conflict(row_index);
                             let is_selected = this.selected_index == Some(row_index);
 
                             let row_id = row_group_id(row_index);
 
                             let row = row
-                                .id(row_id.clone())
                                 .on_any_mouse_down(cx.listener(
                                     move |this,
                                           mouse_down_event: &gpui::MouseDownEvent,
@@ -1636,11 +1635,12 @@ impl Render for KeymapEditor {
                                 })
                                 .when(is_selected, |row| {
                                     row.border_color(cx.theme().colors().panel_focused_border)
+                                        .border_2()
                                 });
 
                             row.into_any_element()
-                        }),
-                    ),
+                        },
+                    )),
             )
             .on_scroll_wheel(cx.listener(|this, event: &ScrollWheelEvent, _, cx| {
                 // This ensures that the menu is not dismissed in cases where scroll events

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -1436,7 +1436,6 @@ impl Render for KeymapEditor {
                         DefiniteLength::Fraction(0.08),
                     ])
                     .resizable_columns(
-                        // todo! Resize doesn't fully work
                         [
                             ResizeBehavior::None,
                             ResizeBehavior::Resizable,

--- a/crates/settings_ui/src/ui_components/table.rs
+++ b/crates/settings_ui/src/ui_components/table.rs
@@ -605,10 +605,13 @@ impl<const COLS: usize> ColumnWidths<COLS> {
             );
         } else {
             curr_column = col_idx;
-            while diff_left < 0.0 && curr_column > 0 {
-                // todo! When resize is none and dragging to the left this doesn't work correctly
-                // This could be done by making min_size equal to current size if resizable is None
-                let Some(min_size) = resize_behavior[curr_column].min_size() else {
+            // Resize behavior should be improved in the future by also seeking to the right column when there's not enough space
+            while diff_left < 0.0 {
+                let Some(min_size) = resize_behavior[curr_column.saturating_sub(1)].min_size()
+                else {
+                    if curr_column == 0 {
+                        break;
+                    }
                     curr_column -= 1;
                     continue;
                 };
@@ -624,6 +627,9 @@ impl<const COLS: usize> ColumnWidths<COLS> {
                 }
 
                 self.widths[curr_column] = DefiniteLength::Fraction(curr_width);
+                if curr_column == 0 {
+                    break;
+                }
                 curr_column -= 1;
             }
 

--- a/crates/settings_ui/src/ui_components/table.rs
+++ b/crates/settings_ui/src/ui_components/table.rs
@@ -17,6 +17,9 @@ use ui::{
     StyledTypography, Window, div, example_group_with_title, h_flex, px, single_example, v_flex,
 };
 
+#[derive(Debug)]
+struct DraggedColumn(usize);
+
 struct UniformListData<const COLS: usize> {
     render_item_fn: Box<dyn Fn(Range<usize>, &mut Window, &mut App) -> Vec<[AnyElement; COLS]>>,
     element_id: ElementId,
@@ -232,11 +235,13 @@ impl TableInteractionState {
                     resize_handle = resize_handle
                         .on_hover(move |&was_hovered, _, cx| hovered.write(cx, was_hovered))
                         .cursor_col_resize()
-                        .on_mouse_down(MouseButton::Left, {
-                            let column_idx = column_ix;
-                            move |_event, _window, _cx| {
-                                eprintln!("Start resizing column {}", column_idx);
-                            }
+                        .on_drag(DraggedColumn(column_ix), |ix, _offset, _window, cx| {
+                            eprintln!("Start resizing column {:?}", ix);
+                            cx.new(|_cx| gpui::Empty)
+                        })
+                        .on_drag_move::<DraggedColumn>(|e, _window, cx| {
+                            eprintln!("Resizing column {:?}", e.drag(cx));
+                            // Do something here
                         })
                 }
 

--- a/crates/workspace/src/pane_group.rs
+++ b/crates/workspace/src/pane_group.rs
@@ -943,6 +943,8 @@ mod element {
     pub struct PaneAxisElement {
         axis: Axis,
         basis: usize,
+        /// Equivalent to ColumnWidths (but in terms of flexes instead of percentages)
+        /// For example, flexes "1.33, 1, 1", instead of "40%, 30%, 30%"
         flexes: Arc<Mutex<Vec<f32>>>,
         bounding_boxes: Arc<Mutex<Vec<Option<Bounds<Pixels>>>>>,
         children: SmallVec<[AnyElement; 2]>,
@@ -995,8 +997,6 @@ mod element {
                 Axis::Horizontal => px(HORIZONTAL_MIN_SIZE),
                 Axis::Vertical => px(VERTICAL_MIN_SIZE),
             };
-            // Equivalent to ColumnWidths (but in terms of flexes instead of percentages)
-            // Flexes make this annoying, because we have to output "1.33, 1, 1", instead of "40%, 30%, 30%"
             let mut flexes = flexes.lock();
             debug_assert!(flex_values_in_bounds(flexes.as_slice()));
 


### PR DESCRIPTION
This PR adds resizable columns to the keymap editor and the ability to double-click on a resizable column to set a column back to its default size.

The table uses a column's width to calculate what position it should be laid out at. So `column[i]` x position is calculated by the summation of `column[..i]`. When resizing `column[i]`, `column[i+1]`’s size is adjusted to keep all columns’ relative positions the same. If `column[i+1]` is at its minimum size, we keep seeking to the right to find a column with space left to take.

An improvement to resizing behavior and double-clicking could be made by checking both column ranges `0..i-1` and `i+1..COLS`, since only one range of columns is checked for resize capacity. 

Release Notes:

- N/A
