### PR TITLE
MCP over ACP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -279,9 +279,9 @@ dependencies = [
 
 [[package]]
 name = "agentic-coding-protocol"
-version = "0.0.9"
+version = "0.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e276b798eddd02562a339340a96919d90bbfcf78de118fdddc932524646fac7"
+checksum = "48322590276f36cf49197898cde1c54645991c96c0c83722ef321da7f2b0ae42"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -410,7 +410,7 @@ zlog_settings = { path = "crates/zlog_settings" }
 # External crates
 #
 
-agentic-coding-protocol = "0.0.9"
+agentic-coding-protocol = "0.0.11"
 aho-corasick = "1.1"
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty.git", branch = "add-hush-login-flag" }
 any_vec = "0.14"

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -375,7 +375,7 @@ pub async fn new_test_thread(
         .unwrap();
 
     thread
-        .update(cx, |thread, _| thread.initialize())
+        .update(cx, |thread, cx| thread.initialize(cx))
         .await
         .unwrap();
     thread

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -216,7 +216,7 @@ impl AcpThreadView {
 
             let init_response = async {
                 let resp = thread
-                    .read_with(cx, |thread, _cx| thread.initialize())?
+                    .update(cx, |thread, cx| thread.initialize(cx))?
                     .await?;
                 anyhow::Ok(resp)
             };


### PR DESCRIPTION
This allows Zed to share its MCP servers with any agents

Release Notes:

- N/A *or* Added/Fixed/Improved ...
