### PR TITLE
claude: Don't quote executable path in mcp configuration

### DIFF
--- a/crates/agent_servers/src/claude/mcp_server.rs
+++ b/crates/agent_servers/src/claude/mcp_server.rs
@@ -69,9 +69,6 @@ impl ClaudeMcpServer {
     }
 
     pub fn server_config(&self) -> Result<McpServerConfig> {
-        #[cfg(not(target_os = "windows"))]
-        let zed_path = util::get_shell_safe_zed_path()?;
-        #[cfg(target_os = "windows")]
         let zed_path = std::env::current_exe()
             .context("finding current executable path for use in mcp_server")?
             .to_string_lossy()


### PR DESCRIPTION
This was generating an invalid string for the configuration, removing
the extra quotes makes it work. This affected the versions of Zed that
have a space in their name.

Release Notes:

- N/A
