### PR TITLE
Fix shortcut for keeping an agent change in vim mode

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -115,7 +115,6 @@
       "ctrl-d": "vim::ScrollDown",
       "ctrl-u": "vim::ScrollUp",
       "ctrl-e": "vim::LineDown",
-      "ctrl-y": "vim::LineUp",
       // "g" commands
       "g shift-r": "vim::PushReplaceWithRegister",
       "g r n": "editor::Rename",
@@ -214,6 +213,12 @@
       "ctrl-6": "pane::AlternateFile",
       "ctrl-^": "pane::AlternateFile",
       ".": "vim::Repeat"
+    }
+  },
+  {
+    "context": "VimControl && !menu && !editor_agent_diff && !AgentDiff",
+    "bindings": {
+      "ctrl-y": "vim::LineUp"
     }
   },
   {


### PR DESCRIPTION
`ctrl-y` is a binding to both `agent::Keep` and `vim::LineUp`, with the later taking precedence. This change reverses that so that `ctrl-y` can be used to accept the change (when the cursor is on the change)

Release Notes:

- N/A
