### PR TITLE
docs: Fix PHP docs typo

### DIFF
--- a/docs/src/languages/php.md
+++ b/docs/src/languages/php.md
@@ -15,7 +15,7 @@ The PHP extension offers both `phpactor` and `intelephense` language server supp
 
 ## Phpactor
 
-The Zed PHP Extension can install `phpactor` automatically but requires `php` to installed and available in your path:
+The Zed PHP Extension can install `phpactor` automatically but requires `php` to be installed and available in your path:
 
 ```sh
 # brew install php            # macOS


### PR DESCRIPTION
This fixes a minor typo in the PHP docs.

Release Notes:

- N/A