### PR TITLE
terminal: Handle spaces in cwds of remote terminals

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -662,7 +662,7 @@ pub fn wrap_for_ssh(
 
             format!("cd \"$HOME/{trimmed_path}\"; {env_changes} {to_run}")
         } else {
-            format!("cd {path}; {env_changes} {to_run}")
+            format!("cd \"{path}\"; {env_changes} {to_run}")
         }
     } else {
         format!("cd; {env_changes} {to_run}")


### PR DESCRIPTION
Closes #34807

Release Notes:

- Fixed "Open in terminal" action not working with paths that contain spaces in SSH projects.
