### PR TITLE
ai_onboarding: Send users directly into the trial checkout flow when starting the trial

### DIFF
--- a/crates/ai_onboarding/src/ai_onboarding.rs
+++ b/crates/ai_onboarding/src/ai_onboarding.rs
@@ -146,7 +146,7 @@ impl ZedAiOnboarding {
         let (button_label, button_url) = if self.account_too_young {
             ("Start with Pro", zed_urls::upgrade_to_zed_pro_url(cx))
         } else {
-            ("Start Pro Trial", zed_urls::account_url(cx))
+            ("Start Pro Trial", zed_urls::start_trial_url(cx))
         };
 
         v_flex()

--- a/crates/client/src/zed_urls.rs
+++ b/crates/client/src/zed_urls.rs
@@ -18,6 +18,14 @@ pub fn account_url(cx: &App) -> String {
     format!("{server_url}/account", server_url = server_url(cx))
 }
 
+/// Returns the URL to the start trial page on zed.dev.
+pub fn start_trial_url(cx: &App) -> String {
+    format!(
+        "{server_url}/account/start-trial",
+        server_url = server_url(cx)
+    )
+}
+
 /// Returns the URL to the upgrade page on zed.dev.
 pub fn upgrade_to_zed_pro_url(cx: &App) -> String {
     format!("{server_url}/account/upgrade", server_url = server_url(cx))


### PR DESCRIPTION
This PR makes it so users will be sent immediately into the trial checkout flow (by hitting zed.dev/account/start-trial) when they click the "Start Pro Trial" button.

Release Notes:

- N/A
