### PR TITLE
zed: Add `OpenRequestKind`

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -748,15 +748,13 @@ pub fn main() {
 }
 
 fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut App) {
-    if let Some(connection) = request.cli_connection {
-        let app_state = app_state.clone();
-        cx.spawn(async move |cx| handle_cli_connection(connection, app_state, cx).await)
-            .detach();
-        return;
-    }
-
     if let Some(kind) = request.kind {
         match kind {
+            OpenRequestKind::CliConnection(connection) => {
+                let app_state = app_state.clone();
+                cx.spawn(async move |cx| handle_cli_connection(connection, app_state, cx).await)
+                    .detach();
+            }
             OpenRequestKind::Extension { extension_id } => {
                 cx.spawn(async move |cx| {
                     let workspace =

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -755,11 +755,6 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
         return;
     }
 
-    if let Some(action_index) = request.dock_menu_action {
-        cx.perform_dock_menu_action(action_index);
-        return;
-    }
-
     if let Some(kind) = request.kind {
         match kind {
             OpenRequestKind::Extension { extension_id } => {
@@ -777,6 +772,9 @@ fn handle_open_request(request: OpenRequest, app_state: Arc<AppState>, cx: &mut 
                     })
                 })
                 .detach_and_log_err(cx);
+            }
+            OpenRequestKind::DockMenuAction { index } => {
+                cx.perform_dock_menu_action(index);
             }
         }
 

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -37,7 +37,12 @@ pub struct OpenRequest {
     pub join_channel: Option<u64>,
     pub ssh_connection: Option<SshConnectionOptions>,
     pub dock_menu_action: Option<usize>,
-    pub extension_id: Option<String>,
+    pub kind: Option<OpenRequestKind>,
+}
+
+#[derive(Debug)]
+pub enum OpenRequestKind {
+    Extension { extension_id: String },
 }
 
 impl OpenRequest {
@@ -55,8 +60,10 @@ impl OpenRequest {
             } else if let Some(file) = url.strip_prefix("zed://ssh") {
                 let ssh_url = "ssh:/".to_string() + file;
                 this.parse_ssh_file_path(&ssh_url, cx)?
-            } else if let Some(file) = url.strip_prefix("zed://extension/") {
-                this.extension_id = Some(file.to_string())
+            } else if let Some(extension_id) = url.strip_prefix("zed://extension/") {
+                this.kind = Some(OpenRequestKind::Extension {
+                    extension_id: extension_id.to_string(),
+                });
             } else if url.starts_with("ssh://") {
                 this.parse_ssh_file_path(&url, cx)?
             } else if let Some(request_path) = parse_zed_link(&url, cx) {

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -36,13 +36,13 @@ pub struct OpenRequest {
     pub open_channel_notes: Vec<(u64, Option<String>)>,
     pub join_channel: Option<u64>,
     pub ssh_connection: Option<SshConnectionOptions>,
-    pub dock_menu_action: Option<usize>,
     pub kind: Option<OpenRequestKind>,
 }
 
 #[derive(Debug)]
 pub enum OpenRequestKind {
     Extension { extension_id: String },
+    DockMenuAction { index: usize },
 }
 
 impl OpenRequest {
@@ -52,7 +52,9 @@ impl OpenRequest {
             if let Some(server_name) = url.strip_prefix("zed-cli://") {
                 this.cli_connection = Some(connect_to_cli(server_name)?);
             } else if let Some(action_index) = url.strip_prefix("zed-dock-action://") {
-                this.dock_menu_action = Some(action_index.parse()?);
+                this.kind = Some(OpenRequestKind::DockMenuAction {
+                    index: action_index.parse()?,
+                });
             } else if let Some(file) = url.strip_prefix("file://") {
                 this.parse_file_path(file)
             } else if let Some(file) = url.strip_prefix("zed://file") {


### PR DESCRIPTION
This PR refactors the `OpenRequest` to introduce an `OpenRequestKind` enum.

It seems most of the fields on `OpenRequest` are mutually-exclusive, so it is better to model it as an enum rather than using a bunch of `Option`s.

There are likely more of the existing fields that can be converted into `OpenRequestKind` variants, but I'm being conservative for this first pass.

Release Notes:

- N/A
