### PR TITLE
zed: Add support for `zed://agent` links

### DIFF
--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -42,6 +42,7 @@ pub struct OpenRequest {
 pub enum OpenRequestKind {
     CliConnection((mpsc::Receiver<CliRequest>, IpcSender<CliResponse>)),
     Extension { extension_id: String },
+    AgentPanel,
     DockMenuAction { index: usize },
 }
 
@@ -66,6 +67,8 @@ impl OpenRequest {
                 this.kind = Some(OpenRequestKind::Extension {
                     extension_id: extension_id.to_string(),
                 });
+            } else if url == "zed://agent" {
+                this.kind = Some(OpenRequestKind::AgentPanel);
             } else if url.starts_with("ssh://") {
                 this.parse_ssh_file_path(&url, cx)?
             } else if let Some(request_path) = parse_zed_link(&url, cx) {


### PR DESCRIPTION
This PR adds support for `zed://agent` links for opening the Agent Panel.

Release Notes:

- N/A
