### PR TITLE
vim: Use `d p` and `d u` for rejecting/keeping agent edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17688,6 +17688,7 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 name = "vim"
 version = "0.1.0"
 dependencies = [
+ "agent_ui",
  "anyhow",
  "assets",
  "async-compat",

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -580,6 +580,13 @@
     }
   },
   {
+    "context": "VimControl && (AgentDiff || editor_agent_diff)",
+    "bindings": {
+      "d p": "agent::Reject",
+      "d u": "agent::Keep"
+    }
+  },
+  {
     "context": "vim_operator == gu",
     "bindings": {
       "g u": "vim::CurrentLine",

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -197,6 +197,11 @@ impl ModelUsageContext {
     }
 }
 
+pub fn init_settings(cx: &mut App) {
+    AgentSettings::register(cx);
+    SlashCommandSettings::register(cx);
+}
+
 /// Initializes the `agent` crate.
 pub fn init(
     fs: Arc<dyn Fs>,
@@ -206,8 +211,7 @@ pub fn init(
     is_eval: bool,
     cx: &mut App,
 ) {
-    AgentSettings::register(cx);
-    SlashCommandSettings::register(cx);
+    init_settings(cx);
 
     assistant_context::init(client.clone(), cx);
     rules_library::init(cx);

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -52,6 +52,7 @@ zed_actions.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
+agent_ui.workspace = true
 assets.workspace = true
 command_palette.workspace = true
 editor = { workspace = true, features = ["test-support"] }

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -29,6 +29,7 @@ impl VimTestContext {
             editor::init_settings(cx);
             project::Project::init_settings(cx);
             theme::init(theme::LoadThemes::JustBase, cx);
+            agent_ui::init_settings(cx);
         });
     }
 


### PR DESCRIPTION
`ctrl-y` is bound to `agent::Keep`, but this conflicts with `vim::LineUp` in Vim mode.

This change assigns `d u` and `d p`, which we already use to stage/accept git hunk, to `agent::Keep` and `agent::Reject`, respectively.

Release Notes:

- N/A