### PR TITLE
debugger: Fix debug console persist to history when reusing a previous item

### DIFF
--- a/crates/project/src/search_history.rs
+++ b/crates/project/src/search_history.rs
@@ -155,6 +155,7 @@ mod tests {
         // add item when it equals to current item if it's not the last one
         search_history.add(&mut cursor, "php".to_string());
         search_history.previous(&mut cursor);
+        assert_eq!(search_history.current(&cursor), Some("rustlang"));
         search_history.add(&mut cursor, "rustlang".to_string());
         assert_eq!(search_history.history.len(), 3, "Should add item");
         assert_eq!(search_history.current(&cursor), Some("rustlang"));

--- a/crates/project/src/search_history.rs
+++ b/crates/project/src/search_history.rs
@@ -45,12 +45,6 @@ impl SearchHistory {
     }
 
     pub fn add(&mut self, cursor: &mut SearchHistoryCursor, search_string: String) {
-        if let Some(selected_ix) = cursor.selection {
-            if self.history.get(selected_ix) == Some(&search_string) {
-                return;
-            }
-        }
-
         if self.insertion_behavior == QueryInsertionBehavior::ReplacePreviousIfContains {
             if let Some(previously_searched) = self.history.back_mut() {
                 if search_string.contains(previously_searched.as_str()) {
@@ -156,6 +150,13 @@ mod tests {
             1,
             "Should replace previous item if it's a substring"
         );
+        assert_eq!(search_history.current(&cursor), Some("rustlang"));
+
+        // add item when it equals to current item if it's not the last one
+        search_history.add(&mut cursor, "php".to_string());
+        search_history.previous(&mut cursor);
+        search_history.add(&mut cursor, "rustlang".to_string());
+        assert_eq!(search_history.history.len(), 3, "Should add item");
         assert_eq!(search_history.current(&cursor), Some("rustlang"));
 
         // push enough items to test SEARCH_HISTORY_LIMIT


### PR DESCRIPTION
Closes #34887

Release Notes:

- Debugger: Fix debug console persist to history when reusing a previous item
