### PR TITLE
debugger: Fix built-in JavaScript debug tasks were not working due missing `type` field value

### DIFF
--- a/assets/settings/initial_debug_tasks.json
+++ b/assets/settings/initial_debug_tasks.json
@@ -15,13 +15,15 @@
     "adapter": "JavaScript",
     "program": "$ZED_FILE",
     "request": "launch",
-    "cwd": "$ZED_WORKTREE_ROOT"
+    "cwd": "$ZED_WORKTREE_ROOT",
+    "type": "pwa-node"
   },
   {
     "label": "JavaScript debug terminal",
     "adapter": "JavaScript",
     "request": "launch",
     "cwd": "$ZED_WORKTREE_ROOT",
-    "console": "integratedTerminal"
+    "console": "integratedTerminal",
+    "type": "pwa-node"
   }
 ]


### PR DESCRIPTION
Release Notes:

- Debugger: Fix built-in JavaScript debug tasks were not working due missing `type` field value
