### PR TITLE
sum_tree: Store context on cursor

### DIFF
--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -355,7 +355,7 @@ impl BufferDiffInner {
                     .cmp(&buffer_range.end, buffer)
                     .is_le()
             }) {
-                old_pending_hunks.next(buffer);
+                old_pending_hunks.next();
             }
 
             if (stage && secondary_status == DiffHunkSecondaryStatus::NoSecondaryHunk)
@@ -382,7 +382,7 @@ impl BufferDiffInner {
         pending_hunks.append(old_pending_hunks.suffix(buffer), buffer);
 
         let mut unstaged_hunk_cursor = unstaged_diff.hunks.cursor::<DiffHunkSummary>(buffer);
-        unstaged_hunk_cursor.next(buffer);
+        unstaged_hunk_cursor.next();
 
         // then, iterate over all pending hunks (both new ones and the existing ones) and compute the edits
         let mut prev_unstaged_hunk_buffer_end = 0;
@@ -425,7 +425,7 @@ impl BufferDiffInner {
                         buffer_offset_range.end =
                             buffer_offset_range.end.max(unstaged_hunk_offset_range.end);
 
-                        unstaged_hunk_cursor.next(buffer);
+                        unstaged_hunk_cursor.next();
                         continue;
                     }
                 }
@@ -514,7 +514,7 @@ impl BufferDiffInner {
             });
 
         let anchor_iter = iter::from_fn(move || {
-            cursor.next(buffer);
+            cursor.next();
             cursor.item()
         })
         .flat_map(move |hunk| {
@@ -531,12 +531,12 @@ impl BufferDiffInner {
         });
 
         let mut pending_hunks_cursor = self.pending_hunks.cursor::<DiffHunkSummary>(buffer);
-        pending_hunks_cursor.next(buffer);
+        pending_hunks_cursor.next();
 
         let mut secondary_cursor = None;
         if let Some(secondary) = secondary.as_ref() {
             let mut cursor = secondary.hunks.cursor::<DiffHunkSummary>(buffer);
-            cursor.next(buffer);
+            cursor.next();
             secondary_cursor = Some(cursor);
         }
 
@@ -635,7 +635,7 @@ impl BufferDiffInner {
             });
 
         iter::from_fn(move || {
-            cursor.prev(buffer);
+            cursor.prev();
 
             let hunk = cursor.item()?;
             let range = hunk.buffer_range.to_point(buffer);
@@ -653,8 +653,8 @@ impl BufferDiffInner {
     fn compare(&self, old: &Self, new_snapshot: &text::BufferSnapshot) -> Option<Range<Anchor>> {
         let mut new_cursor = self.hunks.cursor::<()>(new_snapshot);
         let mut old_cursor = old.hunks.cursor::<()>(new_snapshot);
-        old_cursor.next(new_snapshot);
-        new_cursor.next(new_snapshot);
+        old_cursor.next();
+        new_cursor.next();
         let mut start = None;
         let mut end = None;
 
@@ -669,7 +669,7 @@ impl BufferDiffInner {
                         Ordering::Less => {
                             start.get_or_insert(new_hunk.buffer_range.start);
                             end.replace(new_hunk.buffer_range.end);
-                            new_cursor.next(new_snapshot);
+                            new_cursor.next();
                         }
                         Ordering::Equal => {
                             if new_hunk != old_hunk {
@@ -686,25 +686,25 @@ impl BufferDiffInner {
                                 }
                             }
 
-                            new_cursor.next(new_snapshot);
-                            old_cursor.next(new_snapshot);
+                            new_cursor.next();
+                            old_cursor.next();
                         }
                         Ordering::Greater => {
                             start.get_or_insert(old_hunk.buffer_range.start);
                             end.replace(old_hunk.buffer_range.end);
-                            old_cursor.next(new_snapshot);
+                            old_cursor.next();
                         }
                     }
                 }
                 (Some(new_hunk), None) => {
                     start.get_or_insert(new_hunk.buffer_range.start);
                     end.replace(new_hunk.buffer_range.end);
-                    new_cursor.next(new_snapshot);
+                    new_cursor.next();
                 }
                 (None, Some(old_hunk)) => {
                     start.get_or_insert(old_hunk.buffer_range.start);
                     end.replace(old_hunk.buffer_range.end);
-                    old_cursor.next(new_snapshot);
+                    old_cursor.next();
                 }
                 (None, None) => break,
             }

--- a/crates/buffer_diff/src/buffer_diff.rs
+++ b/crates/buffer_diff/src/buffer_diff.rs
@@ -343,8 +343,7 @@ impl BufferDiffInner {
             ..
         } in hunks.iter().cloned()
         {
-            let preceding_pending_hunks =
-                old_pending_hunks.slice(&buffer_range.start, Bias::Left, buffer);
+            let preceding_pending_hunks = old_pending_hunks.slice(&buffer_range.start, Bias::Left);
             pending_hunks.append(preceding_pending_hunks, buffer);
 
             // Skip all overlapping or adjacent old pending hunks
@@ -379,7 +378,7 @@ impl BufferDiffInner {
             );
         }
         // append the remainder
-        pending_hunks.append(old_pending_hunks.suffix(buffer), buffer);
+        pending_hunks.append(old_pending_hunks.suffix(), buffer);
 
         let mut unstaged_hunk_cursor = unstaged_diff.hunks.cursor::<DiffHunkSummary>(buffer);
         unstaged_hunk_cursor.next();
@@ -397,8 +396,7 @@ impl BufferDiffInner {
         }) = pending_hunks_iter.next()
         {
             // Advance unstaged_hunk_cursor to skip unstaged hunks before current hunk
-            let skipped_unstaged =
-                unstaged_hunk_cursor.slice(&buffer_range.start, Bias::Left, buffer);
+            let skipped_unstaged = unstaged_hunk_cursor.slice(&buffer_range.start, Bias::Left);
 
             if let Some(unstaged_hunk) = skipped_unstaged.last() {
                 prev_unstaged_hunk_base_text_end = unstaged_hunk.diff_base_byte_range.end;
@@ -564,7 +562,7 @@ impl BufferDiffInner {
                     .cmp(&pending_hunks_cursor.start().buffer_range.start, buffer)
                     .is_gt()
                 {
-                    pending_hunks_cursor.seek_forward(&start_anchor, Bias::Left, buffer);
+                    pending_hunks_cursor.seek_forward(&start_anchor, Bias::Left);
                 }
 
                 if let Some(pending_hunk) = pending_hunks_cursor.item() {
@@ -590,7 +588,7 @@ impl BufferDiffInner {
                         .cmp(&secondary_cursor.start().buffer_range.start, buffer)
                         .is_gt()
                     {
-                        secondary_cursor.seek_forward(&start_anchor, Bias::Left, buffer);
+                        secondary_cursor.seek_forward(&start_anchor, Bias::Left);
                     }
 
                     if let Some(secondary_hunk) = secondary_cursor.item() {

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -333,7 +333,7 @@ impl ChannelChat {
                         if first_id <= message_id {
                             let mut cursor = chat.messages.cursor::<(ChannelMessageId, Count)>(&());
                             let message_id = ChannelMessageId::Saved(message_id);
-                            cursor.seek(&message_id, Bias::Left, &());
+                            cursor.seek(&message_id, Bias::Left);
                             return ControlFlow::Break(
                                 if cursor
                                     .item()
@@ -499,7 +499,7 @@ impl ChannelChat {
 
     pub fn message(&self, ix: usize) -> &ChannelMessage {
         let mut cursor = self.messages.cursor::<Count>(&());
-        cursor.seek(&Count(ix), Bias::Right, &());
+        cursor.seek(&Count(ix), Bias::Right);
         cursor.item().unwrap()
     }
 
@@ -516,13 +516,13 @@ impl ChannelChat {
 
     pub fn messages_in_range(&self, range: Range<usize>) -> impl Iterator<Item = &ChannelMessage> {
         let mut cursor = self.messages.cursor::<Count>(&());
-        cursor.seek(&Count(range.start), Bias::Right, &());
+        cursor.seek(&Count(range.start), Bias::Right);
         cursor.take(range.len())
     }
 
     pub fn pending_messages(&self) -> impl Iterator<Item = &ChannelMessage> {
         let mut cursor = self.messages.cursor::<ChannelMessageId>(&());
-        cursor.seek(&ChannelMessageId::Pending(0), Bias::Left, &());
+        cursor.seek(&ChannelMessageId::Pending(0), Bias::Left);
         cursor
     }
 
@@ -588,9 +588,9 @@ impl ChannelChat {
                 .collect::<HashSet<_>>();
 
             let mut old_cursor = self.messages.cursor::<(ChannelMessageId, Count)>(&());
-            let mut new_messages = old_cursor.slice(&first_message.id, Bias::Left, &());
+            let mut new_messages = old_cursor.slice(&first_message.id, Bias::Left);
             let start_ix = old_cursor.start().1.0;
-            let removed_messages = old_cursor.slice(&last_message.id, Bias::Right, &());
+            let removed_messages = old_cursor.slice(&last_message.id, Bias::Right);
             let removed_count = removed_messages.summary().count;
             let new_count = messages.summary().count;
             let end_ix = start_ix + removed_count;
@@ -599,10 +599,10 @@ impl ChannelChat {
 
             let mut ranges = Vec::<Range<usize>>::new();
             if new_messages.last().unwrap().is_pending() {
-                new_messages.append(old_cursor.suffix(&()), &());
+                new_messages.append(old_cursor.suffix(), &());
             } else {
                 new_messages.append(
-                    old_cursor.slice(&ChannelMessageId::Pending(0), Bias::Left, &()),
+                    old_cursor.slice(&ChannelMessageId::Pending(0), Bias::Left),
                     &(),
                 );
 
@@ -641,12 +641,12 @@ impl ChannelChat {
 
     fn message_removed(&mut self, id: u64, cx: &mut Context<Self>) {
         let mut cursor = self.messages.cursor::<ChannelMessageId>(&());
-        let mut messages = cursor.slice(&ChannelMessageId::Saved(id), Bias::Left, &());
+        let mut messages = cursor.slice(&ChannelMessageId::Saved(id), Bias::Left);
         if let Some(item) = cursor.item() {
             if item.id == ChannelMessageId::Saved(id) {
                 let deleted_message_ix = messages.summary().count;
                 cursor.next();
-                messages.append(cursor.suffix(&()), &());
+                messages.append(cursor.suffix(), &());
                 drop(cursor);
                 self.messages = messages;
 
@@ -680,7 +680,7 @@ impl ChannelChat {
         cx: &mut Context<Self>,
     ) {
         let mut cursor = self.messages.cursor::<ChannelMessageId>(&());
-        let mut messages = cursor.slice(&id, Bias::Left, &());
+        let mut messages = cursor.slice(&id, Bias::Left);
         let ix = messages.summary().count;
 
         if let Some(mut message_to_update) = cursor.item().cloned() {
@@ -691,7 +691,7 @@ impl ChannelChat {
             cursor.next();
         }
 
-        messages.append(cursor.suffix(&()), &());
+        messages.append(cursor.suffix(), &());
         drop(cursor);
         self.messages = messages;
 

--- a/crates/channel/src/channel_chat.rs
+++ b/crates/channel/src/channel_chat.rs
@@ -617,7 +617,7 @@ impl ChannelChat {
                     } else {
                         new_messages.push(message.clone(), &());
                     }
-                    old_cursor.next(&());
+                    old_cursor.next();
                 }
             }
 
@@ -645,7 +645,7 @@ impl ChannelChat {
         if let Some(item) = cursor.item() {
             if item.id == ChannelMessageId::Saved(id) {
                 let deleted_message_ix = messages.summary().count;
-                cursor.next(&());
+                cursor.next();
                 messages.append(cursor.suffix(&()), &());
                 drop(cursor);
                 self.messages = messages;
@@ -688,7 +688,7 @@ impl ChannelChat {
             message_to_update.mentions = mentions;
             message_to_update.edited_at = edited_at;
             messages.push(message_to_update, &());
-            cursor.next(&());
+            cursor.next();
         }
 
         messages.append(cursor.suffix(&()), &());

--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -524,7 +524,7 @@ impl BlockMap {
             // * Isomorphic transforms that end *at* the start of the edit
             // * Below blocks that end at the start of the edit
             // However, if we hit a replace block that ends at the start of the edit we want to reconstruct it.
-            new_transforms.append(cursor.slice(&old_start, Bias::Left, &()), &());
+            new_transforms.append(cursor.slice(&old_start, Bias::Left), &());
             if let Some(transform) = cursor.item() {
                 if transform.summary.input_rows > 0
                     && cursor.end() == old_start
@@ -579,7 +579,7 @@ impl BlockMap {
             let mut new_end = WrapRow(edit.new.end);
             loop {
                 // Seek to the transform starting at or after the end of the edit
-                cursor.seek(&old_end, Bias::Left, &());
+                cursor.seek(&old_end, Bias::Left);
                 cursor.next();
 
                 // Extend edit to the end of the discarded transform so it is reconstructed in full
@@ -592,7 +592,7 @@ impl BlockMap {
                     if next_edit.old.start <= cursor.start().0 {
                         old_end = WrapRow(next_edit.old.end);
                         new_end = WrapRow(next_edit.new.end);
-                        cursor.seek(&old_end, Bias::Left, &());
+                        cursor.seek(&old_end, Bias::Left);
                         cursor.next();
                         edits.next();
                     } else {
@@ -720,7 +720,7 @@ impl BlockMap {
             push_isomorphic(&mut new_transforms, rows_after_last_block, wrap_snapshot);
         }
 
-        new_transforms.append(cursor.suffix(&()), &());
+        new_transforms.append(cursor.suffix(), &());
         debug_assert_eq!(
             new_transforms.summary().input_rows,
             wrap_snapshot.max_point().row() + 1
@@ -971,7 +971,7 @@ impl BlockMapReader<'_> {
         );
 
         let mut cursor = self.transforms.cursor::<(WrapRow, BlockRow)>(&());
-        cursor.seek(&start_wrap_row, Bias::Left, &());
+        cursor.seek(&start_wrap_row, Bias::Left);
         while let Some(transform) = cursor.item() {
             if cursor.start().0 > end_wrap_row {
                 break;
@@ -1293,7 +1293,7 @@ impl BlockSnapshot {
         let max_output_row = cmp::min(rows.end, self.transforms.summary().output_rows);
 
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&BlockRow(rows.start), Bias::Right, &());
+        cursor.seek(&BlockRow(rows.start), Bias::Right);
         let transform_output_start = cursor.start().0.0;
         let transform_input_start = cursor.start().1.0;
 
@@ -1325,7 +1325,7 @@ impl BlockSnapshot {
 
     pub(super) fn row_infos(&self, start_row: BlockRow) -> BlockRows<'_> {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&start_row, Bias::Right, &());
+        cursor.seek(&start_row, Bias::Right);
         let (output_start, input_start) = cursor.start();
         let overshoot = if cursor
             .item()
@@ -1346,7 +1346,7 @@ impl BlockSnapshot {
 
     pub fn blocks_in_range(&self, rows: Range<u32>) -> impl Iterator<Item = (u32, &Block)> {
         let mut cursor = self.transforms.cursor::<BlockRow>(&());
-        cursor.seek(&BlockRow(rows.start), Bias::Left, &());
+        cursor.seek(&BlockRow(rows.start), Bias::Left);
         while cursor.start().0 < rows.start && cursor.end().0 <= rows.start {
             cursor.next();
         }
@@ -1377,7 +1377,7 @@ impl BlockSnapshot {
     pub fn sticky_header_excerpt(&self, position: f32) -> Option<StickyHeaderExcerpt<'_>> {
         let top_row = position as u32;
         let mut cursor = self.transforms.cursor::<BlockRow>(&());
-        cursor.seek(&BlockRow(top_row), Bias::Right, &());
+        cursor.seek(&BlockRow(top_row), Bias::Right);
 
         while let Some(transform) = cursor.item() {
             match &transform.block {
@@ -1414,7 +1414,7 @@ impl BlockSnapshot {
         let wrap_row = WrapRow(wrap_point.row());
 
         let mut cursor = self.transforms.cursor::<WrapRow>(&());
-        cursor.seek(&wrap_row, Bias::Left, &());
+        cursor.seek(&wrap_row, Bias::Left);
 
         while let Some(transform) = cursor.item() {
             if let Some(block) = transform.block.as_ref() {
@@ -1442,7 +1442,7 @@ impl BlockSnapshot {
 
     pub fn longest_row_in_range(&self, range: Range<BlockRow>) -> BlockRow {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&range.start, Bias::Right, &());
+        cursor.seek(&range.start, Bias::Right);
 
         let mut longest_row = range.start;
         let mut longest_row_chars = 0;
@@ -1466,7 +1466,7 @@ impl BlockSnapshot {
 
         let cursor_start_row = cursor.start().0;
         if range.end > cursor_start_row {
-            let summary = cursor.summary::<_, TransformSummary>(&range.end, Bias::Right, &());
+            let summary = cursor.summary::<_, TransformSummary>(&range.end, Bias::Right);
             if summary.longest_row_chars > longest_row_chars {
                 longest_row = BlockRow(cursor_start_row.0 + summary.longest_row);
                 longest_row_chars = summary.longest_row_chars;
@@ -1493,7 +1493,7 @@ impl BlockSnapshot {
 
     pub(super) fn line_len(&self, row: BlockRow) -> u32 {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&BlockRow(row.0), Bias::Right, &());
+        cursor.seek(&BlockRow(row.0), Bias::Right);
         if let Some(transform) = cursor.item() {
             let (output_start, input_start) = cursor.start();
             let overshoot = row.0 - output_start.0;
@@ -1511,13 +1511,13 @@ impl BlockSnapshot {
 
     pub(super) fn is_block_line(&self, row: BlockRow) -> bool {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&row, Bias::Right, &());
+        cursor.seek(&row, Bias::Right);
         cursor.item().map_or(false, |t| t.block.is_some())
     }
 
     pub(super) fn is_folded_buffer_header(&self, row: BlockRow) -> bool {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&row, Bias::Right, &());
+        cursor.seek(&row, Bias::Right);
         let Some(transform) = cursor.item() else {
             return false;
         };
@@ -1529,7 +1529,7 @@ impl BlockSnapshot {
             .wrap_snapshot
             .make_wrap_point(Point::new(row.0, 0), Bias::Left);
         let mut cursor = self.transforms.cursor::<(WrapRow, BlockRow)>(&());
-        cursor.seek(&WrapRow(wrap_point.row()), Bias::Right, &());
+        cursor.seek(&WrapRow(wrap_point.row()), Bias::Right);
         cursor.item().map_or(false, |transform| {
             transform
                 .block
@@ -1540,7 +1540,7 @@ impl BlockSnapshot {
 
     pub fn clip_point(&self, point: BlockPoint, bias: Bias) -> BlockPoint {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&BlockRow(point.row), Bias::Right, &());
+        cursor.seek(&BlockRow(point.row), Bias::Right);
 
         let max_input_row = WrapRow(self.transforms.summary().input_rows);
         let mut search_left =
@@ -1593,14 +1593,14 @@ impl BlockSnapshot {
             } else {
                 reversed = true;
                 search_left = !search_left;
-                cursor.seek(&BlockRow(point.row), Bias::Right, &());
+                cursor.seek(&BlockRow(point.row), Bias::Right);
             }
         }
     }
 
     pub fn to_block_point(&self, wrap_point: WrapPoint) -> BlockPoint {
         let mut cursor = self.transforms.cursor::<(WrapRow, BlockRow)>(&());
-        cursor.seek(&WrapRow(wrap_point.row()), Bias::Right, &());
+        cursor.seek(&WrapRow(wrap_point.row()), Bias::Right);
         if let Some(transform) = cursor.item() {
             if transform.block.is_some() {
                 BlockPoint::new(cursor.start().1.0, 0)
@@ -1618,7 +1618,7 @@ impl BlockSnapshot {
 
     pub fn to_wrap_point(&self, block_point: BlockPoint, bias: Bias) -> WrapPoint {
         let mut cursor = self.transforms.cursor::<(BlockRow, WrapRow)>(&());
-        cursor.seek(&BlockRow(block_point.row), Bias::Right, &());
+        cursor.seek(&BlockRow(block_point.row), Bias::Right);
         if let Some(transform) = cursor.item() {
             match transform.block.as_ref() {
                 Some(block) => {

--- a/crates/editor/src/display_map/crease_map.rs
+++ b/crates/editor/src/display_map/crease_map.rs
@@ -55,12 +55,12 @@ impl CreaseSnapshot {
         cursor.seek(&start, Bias::Left, snapshot);
         while let Some(item) = cursor.item() {
             match Ord::cmp(&item.crease.range().start.to_point(snapshot).row, &row.0) {
-                Ordering::Less => cursor.next(snapshot),
+                Ordering::Less => cursor.next(),
                 Ordering::Equal => {
                     if item.crease.range().start.is_valid(snapshot) {
                         return Some(&item.crease);
                     } else {
-                        cursor.next(snapshot);
+                        cursor.next();
                     }
                 }
                 Ordering::Greater => break,
@@ -80,7 +80,7 @@ impl CreaseSnapshot {
 
         std::iter::from_fn(move || {
             while let Some(item) = cursor.item() {
-                cursor.next(snapshot);
+                cursor.next();
                 let crease_range = item.crease.range();
                 let crease_start = crease_range.start.to_point(snapshot);
                 let crease_end = crease_range.end.to_point(snapshot);
@@ -102,13 +102,13 @@ impl CreaseSnapshot {
         let mut cursor = self.creases.cursor::<ItemSummary>(snapshot);
         let mut results = Vec::new();
 
-        cursor.next(snapshot);
+        cursor.next();
         while let Some(item) = cursor.item() {
             let crease_range = item.crease.range();
             let start_point = crease_range.start.to_point(snapshot);
             let end_point = crease_range.end.to_point(snapshot);
             results.push((item.id, start_point..end_point));
-            cursor.next(snapshot);
+            cursor.next();
         }
 
         results
@@ -334,7 +334,7 @@ impl CreaseMap {
             for (id, range) in &removals {
                 new_creases.append(cursor.slice(range, Bias::Left, snapshot), snapshot);
                 while let Some(item) = cursor.item() {
-                    cursor.next(snapshot);
+                    cursor.next();
                     if item.id == *id {
                         break;
                     } else {

--- a/crates/editor/src/display_map/crease_map.rs
+++ b/crates/editor/src/display_map/crease_map.rs
@@ -52,7 +52,7 @@ impl CreaseSnapshot {
     ) -> Option<&'a Crease<Anchor>> {
         let start = snapshot.anchor_before(Point::new(row.0, 0));
         let mut cursor = self.creases.cursor::<ItemSummary>(snapshot);
-        cursor.seek(&start, Bias::Left, snapshot);
+        cursor.seek(&start, Bias::Left);
         while let Some(item) = cursor.item() {
             match Ord::cmp(&item.crease.range().start.to_point(snapshot).row, &row.0) {
                 Ordering::Less => cursor.next(),
@@ -76,7 +76,7 @@ impl CreaseSnapshot {
     ) -> impl 'a + Iterator<Item = &'a Crease<Anchor>> {
         let start = snapshot.anchor_before(Point::new(range.start.0, 0));
         let mut cursor = self.creases.cursor::<ItemSummary>(snapshot);
-        cursor.seek(&start, Bias::Left, snapshot);
+        cursor.seek(&start, Bias::Left);
 
         std::iter::from_fn(move || {
             while let Some(item) = cursor.item() {
@@ -298,7 +298,7 @@ impl CreaseMap {
             let mut cursor = self.snapshot.creases.cursor::<ItemSummary>(snapshot);
             for crease in creases {
                 let crease_range = crease.range().clone();
-                new_creases.append(cursor.slice(&crease_range, Bias::Left, snapshot), snapshot);
+                new_creases.append(cursor.slice(&crease_range, Bias::Left), snapshot);
 
                 let id = self.next_id;
                 self.next_id.0 += 1;
@@ -306,7 +306,7 @@ impl CreaseMap {
                 new_creases.push(CreaseItem { crease, id }, snapshot);
                 new_ids.push(id);
             }
-            new_creases.append(cursor.suffix(snapshot), snapshot);
+            new_creases.append(cursor.suffix(), snapshot);
             new_creases
         };
         new_ids
@@ -332,7 +332,7 @@ impl CreaseMap {
             let mut cursor = self.snapshot.creases.cursor::<ItemSummary>(snapshot);
 
             for (id, range) in &removals {
-                new_creases.append(cursor.slice(range, Bias::Left, snapshot), snapshot);
+                new_creases.append(cursor.slice(range, Bias::Left), snapshot);
                 while let Some(item) = cursor.item() {
                     cursor.next();
                     if item.id == *id {
@@ -343,7 +343,7 @@ impl CreaseMap {
                 }
             }
 
-            new_creases.append(cursor.suffix(snapshot), snapshot);
+            new_creases.append(cursor.suffix(), snapshot);
             new_creases
         };
 

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -99,7 +99,7 @@ impl FoldPoint {
 
     pub fn to_inlay_point(self, snapshot: &FoldSnapshot) -> InlayPoint {
         let mut cursor = snapshot.transforms.cursor::<(FoldPoint, InlayPoint)>(&());
-        cursor.seek(&self, Bias::Right, &());
+        cursor.seek(&self, Bias::Right);
         let overshoot = self.0 - cursor.start().0.0;
         InlayPoint(cursor.start().1.0 + overshoot)
     }
@@ -108,7 +108,7 @@ impl FoldPoint {
         let mut cursor = snapshot
             .transforms
             .cursor::<(FoldPoint, TransformSummary)>(&());
-        cursor.seek(&self, Bias::Right, &());
+        cursor.seek(&self, Bias::Right);
         let overshoot = self.0 - cursor.start().1.output.lines;
         let mut offset = cursor.start().1.output.len;
         if !overshoot.is_zero() {
@@ -187,10 +187,10 @@ impl FoldMapWriter<'_> {
                         width: None,
                     },
                 );
-                new_tree.append(cursor.slice(&fold.range, Bias::Right, buffer), buffer);
+                new_tree.append(cursor.slice(&fold.range, Bias::Right), buffer);
                 new_tree.push(fold, buffer);
             }
-            new_tree.append(cursor.suffix(buffer), buffer);
+            new_tree.append(cursor.suffix(), buffer);
             new_tree
         };
 
@@ -263,10 +263,10 @@ impl FoldMapWriter<'_> {
             let mut cursor = self.0.snapshot.folds.cursor::<usize>(buffer);
             let mut folds = SumTree::new(buffer);
             for fold_ix in fold_ixs_to_delete {
-                folds.append(cursor.slice(&fold_ix, Bias::Right, buffer), buffer);
+                folds.append(cursor.slice(&fold_ix, Bias::Right), buffer);
                 cursor.next();
             }
-            folds.append(cursor.suffix(buffer), buffer);
+            folds.append(cursor.suffix(), buffer);
             folds
         };
 
@@ -412,7 +412,7 @@ impl FoldMap {
 
             let mut new_transforms = SumTree::<Transform>::default();
             let mut cursor = self.snapshot.transforms.cursor::<InlayOffset>(&());
-            cursor.seek(&InlayOffset(0), Bias::Right, &());
+            cursor.seek(&InlayOffset(0), Bias::Right);
 
             while let Some(mut edit) = inlay_edits_iter.next() {
                 if let Some(item) = cursor.item() {
@@ -428,11 +428,11 @@ impl FoldMap {
                         );
                     }
                 }
-                new_transforms.append(cursor.slice(&edit.old.start, Bias::Left, &()), &());
+                new_transforms.append(cursor.slice(&edit.old.start, Bias::Left), &());
                 edit.new.start -= edit.old.start - *cursor.start();
                 edit.old.start = *cursor.start();
 
-                cursor.seek(&edit.old.end, Bias::Right, &());
+                cursor.seek(&edit.old.end, Bias::Right);
                 cursor.next();
 
                 let mut delta = edit.new_len().0 as isize - edit.old_len().0 as isize;
@@ -449,7 +449,7 @@ impl FoldMap {
 
                         if next_edit.old.end >= edit.old.end {
                             edit.old.end = next_edit.old.end;
-                            cursor.seek(&edit.old.end, Bias::Right, &());
+                            cursor.seek(&edit.old.end, Bias::Right);
                             cursor.next();
                         }
                     } else {
@@ -467,11 +467,7 @@ impl FoldMap {
                     .snapshot
                     .folds
                     .cursor::<FoldRange>(&inlay_snapshot.buffer);
-                folds_cursor.seek(
-                    &FoldRange(anchor..Anchor::max()),
-                    Bias::Left,
-                    &inlay_snapshot.buffer,
-                );
+                folds_cursor.seek(&FoldRange(anchor..Anchor::max()), Bias::Left);
 
                 let mut folds = iter::from_fn({
                     let inlay_snapshot = &inlay_snapshot;
@@ -558,7 +554,7 @@ impl FoldMap {
                 }
             }
 
-            new_transforms.append(cursor.suffix(&()), &());
+            new_transforms.append(cursor.suffix(), &());
             if new_transforms.is_empty() {
                 let text_summary = inlay_snapshot.text_summary();
                 push_isomorphic(&mut new_transforms, text_summary);
@@ -575,14 +571,14 @@ impl FoldMap {
                 let mut new_transforms = new_transforms.cursor::<(InlayOffset, FoldOffset)>(&());
 
                 for mut edit in inlay_edits {
-                    old_transforms.seek(&edit.old.start, Bias::Left, &());
+                    old_transforms.seek(&edit.old.start, Bias::Left);
                     if old_transforms.item().map_or(false, |t| t.is_fold()) {
                         edit.old.start = old_transforms.start().0;
                     }
                     let old_start =
                         old_transforms.start().1.0 + (edit.old.start - old_transforms.start().0).0;
 
-                    old_transforms.seek_forward(&edit.old.end, Bias::Right, &());
+                    old_transforms.seek_forward(&edit.old.end, Bias::Right);
                     if old_transforms.item().map_or(false, |t| t.is_fold()) {
                         old_transforms.next();
                         edit.old.end = old_transforms.start().0;
@@ -590,14 +586,14 @@ impl FoldMap {
                     let old_end =
                         old_transforms.start().1.0 + (edit.old.end - old_transforms.start().0).0;
 
-                    new_transforms.seek(&edit.new.start, Bias::Left, &());
+                    new_transforms.seek(&edit.new.start, Bias::Left);
                     if new_transforms.item().map_or(false, |t| t.is_fold()) {
                         edit.new.start = new_transforms.start().0;
                     }
                     let new_start =
                         new_transforms.start().1.0 + (edit.new.start - new_transforms.start().0).0;
 
-                    new_transforms.seek_forward(&edit.new.end, Bias::Right, &());
+                    new_transforms.seek_forward(&edit.new.end, Bias::Right);
                     if new_transforms.item().map_or(false, |t| t.is_fold()) {
                         new_transforms.next();
                         edit.new.end = new_transforms.start().0;
@@ -656,7 +652,7 @@ impl FoldSnapshot {
         let mut summary = TextSummary::default();
 
         let mut cursor = self.transforms.cursor::<(FoldPoint, InlayPoint)>(&());
-        cursor.seek(&range.start, Bias::Right, &());
+        cursor.seek(&range.start, Bias::Right);
         if let Some(transform) = cursor.item() {
             let start_in_transform = range.start.0 - cursor.start().0.0;
             let end_in_transform = cmp::min(range.end, cursor.end().0).0 - cursor.start().0.0;
@@ -681,7 +677,7 @@ impl FoldSnapshot {
         if range.end > cursor.end().0 {
             cursor.next();
             summary += &cursor
-                .summary::<_, TransformSummary>(&range.end, Bias::Right, &())
+                .summary::<_, TransformSummary>(&range.end, Bias::Right)
                 .output;
             if let Some(transform) = cursor.item() {
                 let end_in_transform = range.end.0 - cursor.start().0.0;
@@ -705,7 +701,7 @@ impl FoldSnapshot {
 
     pub fn to_fold_point(&self, point: InlayPoint, bias: Bias) -> FoldPoint {
         let mut cursor = self.transforms.cursor::<(InlayPoint, FoldPoint)>(&());
-        cursor.seek(&point, Bias::Right, &());
+        cursor.seek(&point, Bias::Right);
         if cursor.item().map_or(false, |t| t.is_fold()) {
             if bias == Bias::Left || point == cursor.start().0 {
                 cursor.start().1
@@ -739,7 +735,7 @@ impl FoldSnapshot {
 
         let fold_point = FoldPoint::new(start_row, 0);
         let mut cursor = self.transforms.cursor::<(FoldPoint, InlayPoint)>(&());
-        cursor.seek(&fold_point, Bias::Left, &());
+        cursor.seek(&fold_point, Bias::Left);
 
         let overshoot = fold_point.0 - cursor.start().0.0;
         let inlay_point = InlayPoint(cursor.start().1.0 + overshoot);
@@ -782,7 +778,7 @@ impl FoldSnapshot {
         let buffer_offset = offset.to_offset(&self.inlay_snapshot.buffer);
         let inlay_offset = self.inlay_snapshot.to_inlay_offset(buffer_offset);
         let mut cursor = self.transforms.cursor::<InlayOffset>(&());
-        cursor.seek(&inlay_offset, Bias::Right, &());
+        cursor.seek(&inlay_offset, Bias::Right);
         cursor.item().map_or(false, |t| t.placeholder.is_some())
     }
 
@@ -791,7 +787,7 @@ impl FoldSnapshot {
             .inlay_snapshot
             .to_inlay_point(Point::new(buffer_row.0, 0));
         let mut cursor = self.transforms.cursor::<InlayPoint>(&());
-        cursor.seek(&inlay_point, Bias::Right, &());
+        cursor.seek(&inlay_point, Bias::Right);
         loop {
             match cursor.item() {
                 Some(transform) => {
@@ -809,7 +805,7 @@ impl FoldSnapshot {
                 cursor.next();
             } else {
                 inlay_point.0 += Point::new(1, 0);
-                cursor.seek(&inlay_point, Bias::Right, &());
+                cursor.seek(&inlay_point, Bias::Right);
             }
         }
     }
@@ -821,7 +817,7 @@ impl FoldSnapshot {
         highlights: Highlights<'a>,
     ) -> FoldChunks<'a> {
         let mut transform_cursor = self.transforms.cursor::<(FoldOffset, InlayOffset)>(&());
-        transform_cursor.seek(&range.start, Bias::Right, &());
+        transform_cursor.seek(&range.start, Bias::Right);
 
         let inlay_start = {
             let overshoot = range.start.0 - transform_cursor.start().0.0;
@@ -876,7 +872,7 @@ impl FoldSnapshot {
 
     pub fn clip_point(&self, point: FoldPoint, bias: Bias) -> FoldPoint {
         let mut cursor = self.transforms.cursor::<(FoldPoint, InlayPoint)>(&());
-        cursor.seek(&point, Bias::Right, &());
+        cursor.seek(&point, Bias::Right);
         if let Some(transform) = cursor.item() {
             let transform_start = cursor.start().0.0;
             if transform.placeholder.is_some() {
@@ -1208,7 +1204,7 @@ pub struct FoldRows<'a> {
 impl FoldRows<'_> {
     pub(crate) fn seek(&mut self, row: u32) {
         let fold_point = FoldPoint::new(row, 0);
-        self.cursor.seek(&fold_point, Bias::Left, &());
+        self.cursor.seek(&fold_point, Bias::Left);
         let overshoot = fold_point.0 - self.cursor.start().0.0;
         let inlay_point = InlayPoint(self.cursor.start().1.0 + overshoot);
         self.input_rows.seek(inlay_point.row());
@@ -1327,7 +1323,7 @@ pub struct FoldChunks<'a> {
 
 impl FoldChunks<'_> {
     pub(crate) fn seek(&mut self, range: Range<FoldOffset>) {
-        self.transform_cursor.seek(&range.start, Bias::Right, &());
+        self.transform_cursor.seek(&range.start, Bias::Right);
 
         let inlay_start = {
             let overshoot = range.start.0 - self.transform_cursor.start().0.0;
@@ -1453,7 +1449,7 @@ impl FoldOffset {
         let mut cursor = snapshot
             .transforms
             .cursor::<(FoldOffset, TransformSummary)>(&());
-        cursor.seek(&self, Bias::Right, &());
+        cursor.seek(&self, Bias::Right);
         let overshoot = if cursor.item().map_or(true, |t| t.is_fold()) {
             Point::new(0, (self.0 - cursor.start().0.0) as u32)
         } else {
@@ -1467,7 +1463,7 @@ impl FoldOffset {
     #[cfg(test)]
     pub fn to_inlay_offset(self, snapshot: &FoldSnapshot) -> InlayOffset {
         let mut cursor = snapshot.transforms.cursor::<(FoldOffset, InlayOffset)>(&());
-        cursor.seek(&self, Bias::Right, &());
+        cursor.seek(&self, Bias::Right);
         let overshoot = self.0 - cursor.start().0.0;
         InlayOffset(cursor.start().1.0 + overshoot)
     }

--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -358,28 +358,28 @@ impl WrapSnapshot {
 
                 old_cursor.seek_forward(&edit.old.end, Bias::Right, &());
                 if let Some(next_edit) = tab_edits_iter.peek() {
-                    if next_edit.old.start > old_cursor.end(&()) {
-                        if old_cursor.end(&()) > edit.old.end {
+                    if next_edit.old.start > old_cursor.end() {
+                        if old_cursor.end() > edit.old.end {
                             let summary = self
                                 .tab_snapshot
-                                .text_summary_for_range(edit.old.end..old_cursor.end(&()));
+                                .text_summary_for_range(edit.old.end..old_cursor.end());
                             new_transforms.push_or_extend(Transform::isomorphic(summary));
                         }
 
-                        old_cursor.next(&());
+                        old_cursor.next();
                         new_transforms.append(
                             old_cursor.slice(&next_edit.old.start, Bias::Right, &()),
                             &(),
                         );
                     }
                 } else {
-                    if old_cursor.end(&()) > edit.old.end {
+                    if old_cursor.end() > edit.old.end {
                         let summary = self
                             .tab_snapshot
-                            .text_summary_for_range(edit.old.end..old_cursor.end(&()));
+                            .text_summary_for_range(edit.old.end..old_cursor.end());
                         new_transforms.push_or_extend(Transform::isomorphic(summary));
                     }
-                    old_cursor.next(&());
+                    old_cursor.next();
                     new_transforms.append(old_cursor.suffix(&()), &());
                 }
             }
@@ -518,14 +518,14 @@ impl WrapSnapshot {
 
                 old_cursor.seek_forward(&TabPoint::new(edit.old_rows.end, 0), Bias::Right, &());
                 if let Some(next_edit) = row_edits.peek() {
-                    if next_edit.old_rows.start > old_cursor.end(&()).row() {
-                        if old_cursor.end(&()) > TabPoint::new(edit.old_rows.end, 0) {
+                    if next_edit.old_rows.start > old_cursor.end().row() {
+                        if old_cursor.end() > TabPoint::new(edit.old_rows.end, 0) {
                             let summary = self.tab_snapshot.text_summary_for_range(
-                                TabPoint::new(edit.old_rows.end, 0)..old_cursor.end(&()),
+                                TabPoint::new(edit.old_rows.end, 0)..old_cursor.end(),
                             );
                             new_transforms.push_or_extend(Transform::isomorphic(summary));
                         }
-                        old_cursor.next(&());
+                        old_cursor.next();
                         new_transforms.append(
                             old_cursor.slice(
                                 &TabPoint::new(next_edit.old_rows.start, 0),
@@ -536,13 +536,13 @@ impl WrapSnapshot {
                         );
                     }
                 } else {
-                    if old_cursor.end(&()) > TabPoint::new(edit.old_rows.end, 0) {
+                    if old_cursor.end() > TabPoint::new(edit.old_rows.end, 0) {
                         let summary = self.tab_snapshot.text_summary_for_range(
-                            TabPoint::new(edit.old_rows.end, 0)..old_cursor.end(&()),
+                            TabPoint::new(edit.old_rows.end, 0)..old_cursor.end(),
                         );
                         new_transforms.push_or_extend(Transform::isomorphic(summary));
                     }
-                    old_cursor.next(&());
+                    old_cursor.next();
                     new_transforms.append(old_cursor.suffix(&()), &());
                 }
             }
@@ -661,7 +661,7 @@ impl WrapSnapshot {
         cursor.seek(&start, Bias::Right, &());
         if let Some(transform) = cursor.item() {
             let start_in_transform = start.0 - cursor.start().0.0;
-            let end_in_transform = cmp::min(end, cursor.end(&()).0).0 - cursor.start().0.0;
+            let end_in_transform = cmp::min(end, cursor.end().0).0 - cursor.start().0.0;
             if transform.is_isomorphic() {
                 let tab_start = TabPoint(cursor.start().1.0 + start_in_transform);
                 let tab_end = TabPoint(cursor.start().1.0 + end_in_transform);
@@ -678,7 +678,7 @@ impl WrapSnapshot {
                 };
             }
 
-            cursor.next(&());
+            cursor.next();
         }
 
         if rows.end > cursor.start().0.row() {
@@ -793,14 +793,14 @@ impl WrapSnapshot {
         let mut cursor = self.transforms.cursor::<(WrapPoint, TabPoint)>(&());
         cursor.seek(&point, Bias::Right, &());
         if cursor.item().is_none() {
-            cursor.prev(&());
+            cursor.prev();
         }
 
         while let Some(transform) = cursor.item() {
             if transform.is_isomorphic() && cursor.start().1.column() == 0 {
-                return cmp::min(cursor.end(&()).0.row(), point.row());
+                return cmp::min(cursor.end().0.row(), point.row());
             } else {
-                cursor.prev(&());
+                cursor.prev();
             }
         }
 
@@ -816,7 +816,7 @@ impl WrapSnapshot {
             if transform.is_isomorphic() && cursor.start().1.column() == 0 {
                 return Some(cmp::max(cursor.start().0.row(), point.row()));
             } else {
-                cursor.next(&());
+                cursor.next();
             }
         }
 
@@ -930,7 +930,7 @@ impl<'a> Iterator for WrapChunks<'a> {
             }
 
             self.output_position.0 += summary;
-            self.transforms.next(&());
+            self.transforms.next();
             return Some(Chunk {
                 text: &display_text[start_ix..end_ix],
                 ..Default::default()
@@ -942,7 +942,7 @@ impl<'a> Iterator for WrapChunks<'a> {
         }
 
         let mut input_len = 0;
-        let transform_end = self.transforms.end(&()).0;
+        let transform_end = self.transforms.end().0;
         for c in self.input_chunk.text.chars() {
             let char_len = c.len_utf8();
             input_len += char_len;
@@ -954,7 +954,7 @@ impl<'a> Iterator for WrapChunks<'a> {
             }
 
             if self.output_position >= transform_end {
-                self.transforms.next(&());
+                self.transforms.next();
                 break;
             }
         }

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -296,7 +296,7 @@ impl GitBlame {
             let row = info
                 .buffer_row
                 .filter(|_| info.buffer_id == Some(buffer_id))?;
-            cursor.seek_forward(&row, Bias::Right, &());
+            cursor.seek_forward(&row, Bias::Right);
             cursor.item()?.blame.clone()
         })
     }
@@ -389,7 +389,7 @@ impl GitBlame {
                 }
             }
 
-            new_entries.append(cursor.slice(&edit.old.start, Bias::Right, &()), &());
+            new_entries.append(cursor.slice(&edit.old.start, Bias::Right), &());
 
             if edit.new.start > new_entries.summary().rows {
                 new_entries.push(
@@ -401,7 +401,7 @@ impl GitBlame {
                 );
             }
 
-            cursor.seek(&edit.old.end, Bias::Right, &());
+            cursor.seek(&edit.old.end, Bias::Right);
             if !edit.new.is_empty() {
                 new_entries.push(
                     GitBlameEntry {
@@ -432,7 +432,7 @@ impl GitBlame {
                 }
             }
         }
-        new_entries.append(cursor.suffix(&()), &());
+        new_entries.append(cursor.suffix(), &());
         drop(cursor);
 
         self.buffer_snapshot = new_snapshot;

--- a/crates/editor/src/git/blame.rs
+++ b/crates/editor/src/git/blame.rs
@@ -412,7 +412,7 @@ impl GitBlame {
                 );
             }
 
-            let old_end = cursor.end(&());
+            let old_end = cursor.end();
             if row_edits
                 .peek()
                 .map_or(true, |next_edit| next_edit.old.start >= old_end)
@@ -421,14 +421,14 @@ impl GitBlame {
                     if old_end > edit.old.end {
                         new_entries.push(
                             GitBlameEntry {
-                                rows: cursor.end(&()) - edit.old.end,
+                                rows: cursor.end() - edit.old.end,
                                 blame: entry.blame.clone(),
                             },
                             &(),
                         );
                     }
 
-                    cursor.next(&());
+                    cursor.next();
                 }
             }
         }

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -598,7 +598,7 @@ impl StateInner {
         // the scroll top upward.
         if rendered_height - scroll_top.offset_in_item < available_height {
             while rendered_height < available_height {
-                cursor.prev(&());
+                cursor.prev();
                 if let Some(item) = cursor.item() {
                     let item_index = cursor.start().0;
                     let mut element = (self.render_item)(item_index, window, cx);
@@ -645,7 +645,7 @@ impl StateInner {
         // Measure items in the leading overdraw
         let mut leading_overdraw = scroll_top.offset_in_item;
         while leading_overdraw < self.overdraw {
-            cursor.prev(&());
+            cursor.prev();
             if let Some(item) = cursor.item() {
                 let size = if let ListItem::Measured { size, .. } = item {
                     *size
@@ -679,7 +679,7 @@ impl StateInner {
             let mut cursor = self
                 .items
                 .filter::<_, Count>(&(), |summary| summary.has_focus_handles);
-            cursor.next(&());
+            cursor.next();
             while let Some(item) = cursor.item() {
                 if item.contains_focused(window, cx) {
                     let item_index = cursor.start().0;
@@ -692,7 +692,7 @@ impl StateInner {
                     });
                     break;
                 }
-                cursor.next(&());
+                cursor.next();
             }
         }
 
@@ -749,7 +749,7 @@ impl StateInner {
 
                                 // Keep decreasing the scroll top until we fill all the available space.
                                 while height > Pixels::ZERO {
-                                    cursor.prev(&());
+                                    cursor.prev();
                                     let Some(item) = cursor.item() else { break };
 
                                     let size = item.size().unwrap_or_else(|| {

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -249,8 +249,8 @@ impl ListState {
         let state = &mut *self.0.borrow_mut();
 
         let mut old_items = state.items.cursor::<Count>(&());
-        let mut new_items = old_items.slice(&Count(old_range.start), Bias::Right, &());
-        old_items.seek_forward(&Count(old_range.end), Bias::Right, &());
+        let mut new_items = old_items.slice(&Count(old_range.start), Bias::Right);
+        old_items.seek_forward(&Count(old_range.end), Bias::Right);
 
         let mut spliced_count = 0;
         new_items.extend(
@@ -260,7 +260,7 @@ impl ListState {
             }),
             &(),
         );
-        new_items.append(old_items.suffix(&()), &());
+        new_items.append(old_items.suffix(), &());
         drop(old_items);
         state.items = new_items;
 
@@ -300,14 +300,14 @@ impl ListState {
         let current_offset = self.logical_scroll_top();
         let state = &mut *self.0.borrow_mut();
         let mut cursor = state.items.cursor::<ListItemSummary>(&());
-        cursor.seek(&Count(current_offset.item_ix), Bias::Right, &());
+        cursor.seek(&Count(current_offset.item_ix), Bias::Right);
 
         let start_pixel_offset = cursor.start().height + current_offset.offset_in_item;
         let new_pixel_offset = (start_pixel_offset + distance).max(px(0.));
         if new_pixel_offset > start_pixel_offset {
-            cursor.seek_forward(&Height(new_pixel_offset), Bias::Right, &());
+            cursor.seek_forward(&Height(new_pixel_offset), Bias::Right);
         } else {
-            cursor.seek(&Height(new_pixel_offset), Bias::Right, &());
+            cursor.seek(&Height(new_pixel_offset), Bias::Right);
         }
 
         state.logical_scroll_top = Some(ListOffset {
@@ -343,11 +343,11 @@ impl ListState {
             scroll_top.offset_in_item = px(0.);
         } else {
             let mut cursor = state.items.cursor::<ListItemSummary>(&());
-            cursor.seek(&Count(ix + 1), Bias::Right, &());
+            cursor.seek(&Count(ix + 1), Bias::Right);
             let bottom = cursor.start().height + padding.top;
             let goal_top = px(0.).max(bottom - height + padding.bottom);
 
-            cursor.seek(&Height(goal_top), Bias::Left, &());
+            cursor.seek(&Height(goal_top), Bias::Left);
             let start_ix = cursor.start().count;
             let start_item_top = cursor.start().height;
 
@@ -372,11 +372,11 @@ impl ListState {
         }
 
         let mut cursor = state.items.cursor::<(Count, Height)>(&());
-        cursor.seek(&Count(scroll_top.item_ix), Bias::Right, &());
+        cursor.seek(&Count(scroll_top.item_ix), Bias::Right);
 
         let scroll_top = cursor.start().1.0 + scroll_top.offset_in_item;
 
-        cursor.seek_forward(&Count(ix), Bias::Right, &());
+        cursor.seek_forward(&Count(ix), Bias::Right);
         if let Some(&ListItem::Measured { size, .. }) = cursor.item() {
             let &(Count(count), Height(top)) = cursor.start();
             if count == ix {
@@ -431,7 +431,7 @@ impl ListState {
 
         let mut cursor = state.items.cursor::<ListItemSummary>(&());
         let summary: ListItemSummary =
-            cursor.summary(&Count(logical_scroll_top.item_ix), Bias::Right, &());
+            cursor.summary(&Count(logical_scroll_top.item_ix), Bias::Right);
         let content_height = state.items.summary().height;
         let drag_offset =
             // if dragging the scrollbar, we want to offset the point if the height changed
@@ -450,9 +450,9 @@ impl ListState {
 impl StateInner {
     fn visible_range(&self, height: Pixels, scroll_top: &ListOffset) -> Range<usize> {
         let mut cursor = self.items.cursor::<ListItemSummary>(&());
-        cursor.seek(&Count(scroll_top.item_ix), Bias::Right, &());
+        cursor.seek(&Count(scroll_top.item_ix), Bias::Right);
         let start_y = cursor.start().height + scroll_top.offset_in_item;
-        cursor.seek_forward(&Height(start_y + height), Bias::Left, &());
+        cursor.seek_forward(&Height(start_y + height), Bias::Left);
         scroll_top.item_ix..cursor.start().count + 1
     }
 
@@ -482,7 +482,7 @@ impl StateInner {
             self.logical_scroll_top = None;
         } else {
             let mut cursor = self.items.cursor::<ListItemSummary>(&());
-            cursor.seek(&Height(new_scroll_top), Bias::Right, &());
+            cursor.seek(&Height(new_scroll_top), Bias::Right);
             let item_ix = cursor.start().count;
             let offset_in_item = new_scroll_top - cursor.start().height;
             self.logical_scroll_top = Some(ListOffset {
@@ -523,7 +523,7 @@ impl StateInner {
 
     fn scroll_top(&self, logical_scroll_top: &ListOffset) -> Pixels {
         let mut cursor = self.items.cursor::<ListItemSummary>(&());
-        cursor.seek(&Count(logical_scroll_top.item_ix), Bias::Right, &());
+        cursor.seek(&Count(logical_scroll_top.item_ix), Bias::Right);
         cursor.start().height + logical_scroll_top.offset_in_item
     }
 
@@ -553,7 +553,7 @@ impl StateInner {
         let mut cursor = old_items.cursor::<Count>(&());
 
         // Render items after the scroll top, including those in the trailing overdraw
-        cursor.seek(&Count(scroll_top.item_ix), Bias::Right, &());
+        cursor.seek(&Count(scroll_top.item_ix), Bias::Right);
         for (ix, item) in cursor.by_ref().enumerate() {
             let visible_height = rendered_height - scroll_top.offset_in_item;
             if visible_height >= available_height + self.overdraw {
@@ -592,7 +592,7 @@ impl StateInner {
         rendered_height += padding.bottom;
 
         // Prepare to start walking upward from the item at the scroll top.
-        cursor.seek(&Count(scroll_top.item_ix), Bias::Right, &());
+        cursor.seek(&Count(scroll_top.item_ix), Bias::Right);
 
         // If the rendered items do not fill the visible region, then adjust
         // the scroll top upward.
@@ -666,10 +666,10 @@ impl StateInner {
 
         let measured_range = cursor.start().0..(cursor.start().0 + measured_items.len());
         let mut cursor = old_items.cursor::<Count>(&());
-        let mut new_items = cursor.slice(&Count(measured_range.start), Bias::Right, &());
+        let mut new_items = cursor.slice(&Count(measured_range.start), Bias::Right);
         new_items.extend(measured_items, &());
-        cursor.seek(&Count(measured_range.end), Bias::Right, &());
-        new_items.append(cursor.suffix(&()), &());
+        cursor.seek(&Count(measured_range.end), Bias::Right);
+        new_items.append(cursor.suffix(), &());
         self.items = new_items;
 
         // If none of the visible items are focused, check if an off-screen item is focused
@@ -741,7 +741,7 @@ impl StateInner {
                                 });
                             } else if autoscroll_bounds.bottom() > bounds.bottom() {
                                 let mut cursor = self.items.cursor::<Count>(&());
-                                cursor.seek(&Count(item.index), Bias::Right, &());
+                                cursor.seek(&Count(item.index), Bias::Right);
                                 let mut height = bounds.size.height - padding.top - padding.bottom;
 
                                 // Account for the height of the element down until the autoscroll bottom.
@@ -806,7 +806,7 @@ impl StateInner {
             self.logical_scroll_top = None;
         } else {
             let mut cursor = self.items.cursor::<ListItemSummary>(&());
-            cursor.seek(&Height(new_scroll_top), Bias::Right, &());
+            cursor.seek(&Height(new_scroll_top), Bias::Right);
 
             let item_ix = cursor.start().count;
             let offset_in_item = new_scroll_top - cursor.start().height;

--- a/crates/language/src/diagnostic_set.rs
+++ b/crates/language/src/diagnostic_set.rs
@@ -158,17 +158,17 @@ impl DiagnosticSet {
         });
 
         if reversed {
-            cursor.prev(buffer);
+            cursor.prev();
         } else {
-            cursor.next(buffer);
+            cursor.next();
         }
         iter::from_fn({
             move || {
                 if let Some(diagnostic) = cursor.item() {
                     if reversed {
-                        cursor.prev(buffer);
+                        cursor.prev();
                     } else {
-                        cursor.next(buffer);
+                        cursor.next();
                     }
                     Some(diagnostic.resolve(buffer))
                 } else {

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -313,7 +313,7 @@ impl SyntaxSnapshot {
                     position: edit_range.start,
                 };
                 if target.cmp(cursor.start(), text).is_gt() {
-                    let slice = cursor.slice(&target, Bias::Left, text);
+                    let slice = cursor.slice(&target, Bias::Left);
                     layers.append(slice, text);
                 }
             }
@@ -327,7 +327,6 @@ impl SyntaxSnapshot {
                         language: None,
                     },
                     Bias::Left,
-                    text,
                 );
                 layers.append(slice, text);
                 continue;
@@ -397,7 +396,7 @@ impl SyntaxSnapshot {
             cursor.next();
         }
 
-        layers.append(cursor.suffix(text), text);
+        layers.append(cursor.suffix(), text);
         drop(cursor);
         self.layers = layers;
     }
@@ -522,7 +521,7 @@ impl SyntaxSnapshot {
                     change: changed_regions.start_position(),
                 };
                 if bounded_position.cmp(cursor.start(), text).is_gt() {
-                    let slice = cursor.slice(&bounded_position, Bias::Left, text);
+                    let slice = cursor.slice(&bounded_position, Bias::Left);
                     if !slice.is_empty() {
                         layers.append(slice, text);
                         if changed_regions.prune(cursor.end(), text) {

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -297,10 +297,10 @@ impl SyntaxSnapshot {
         let mut first_edit_ix_for_depth = 0;
         let mut prev_depth = 0;
         let mut cursor = self.layers.cursor::<SyntaxLayerSummary>(text);
-        cursor.next(text);
+        cursor.next();
 
         'outer: loop {
-            let depth = cursor.end(text).max_depth;
+            let depth = cursor.end().max_depth;
             if depth > prev_depth {
                 first_edit_ix_for_depth = 0;
                 prev_depth = depth;
@@ -394,7 +394,7 @@ impl SyntaxSnapshot {
             }
 
             layers.push(layer, text);
-            cursor.next(text);
+            cursor.next();
         }
 
         layers.append(cursor.suffix(text), text);
@@ -420,7 +420,7 @@ impl SyntaxSnapshot {
                 let mut cursor = self
                     .layers
                     .filter::<_, ()>(text, |summary| summary.contains_unknown_injections);
-                cursor.next(text);
+                cursor.next();
                 while let Some(layer) = cursor.item() {
                     let SyntaxLayerContent::Pending { language_name } = &layer.content else {
                         unreachable!()
@@ -436,7 +436,7 @@ impl SyntaxSnapshot {
                         resolved_injection_ranges.push(range);
                     }
 
-                    cursor.next(text);
+                    cursor.next();
                 }
                 drop(cursor);
 
@@ -469,7 +469,7 @@ impl SyntaxSnapshot {
 
         let max_depth = self.layers.summary().max_depth;
         let mut cursor = self.layers.cursor::<SyntaxLayerSummary>(text);
-        cursor.next(text);
+        cursor.next();
         let mut layers = SumTree::new(text);
 
         let mut changed_regions = ChangeRegionSet::default();
@@ -514,7 +514,7 @@ impl SyntaxSnapshot {
             };
 
             let mut done = cursor.item().is_none();
-            while !done && position.cmp(&cursor.end(text), text).is_gt() {
+            while !done && position.cmp(&cursor.end(), text).is_gt() {
                 done = true;
 
                 let bounded_position = SyntaxLayerPositionBeforeChange {
@@ -525,13 +525,13 @@ impl SyntaxSnapshot {
                     let slice = cursor.slice(&bounded_position, Bias::Left, text);
                     if !slice.is_empty() {
                         layers.append(slice, text);
-                        if changed_regions.prune(cursor.end(text), text) {
+                        if changed_regions.prune(cursor.end(), text) {
                             done = false;
                         }
                     }
                 }
 
-                while position.cmp(&cursor.end(text), text).is_gt() {
+                while position.cmp(&cursor.end(), text).is_gt() {
                     let Some(layer) = cursor.item() else { break };
 
                     if changed_regions.intersects(layer, text) {
@@ -555,8 +555,8 @@ impl SyntaxSnapshot {
                         layers.push(layer.clone(), text);
                     }
 
-                    cursor.next(text);
-                    if changed_regions.prune(cursor.end(text), text) {
+                    cursor.next();
+                    if changed_regions.prune(cursor.end(), text) {
                         done = false;
                     }
                 }
@@ -572,7 +572,7 @@ impl SyntaxSnapshot {
                 if layer.range.to_offset(text) == (step_start_byte..step_end_byte)
                     && layer.content.language_id() == step.language.id()
                 {
-                    cursor.next(text);
+                    cursor.next();
                 } else {
                     old_layer = None;
                 }
@@ -918,7 +918,7 @@ impl SyntaxSnapshot {
             }
         });
 
-        cursor.next(buffer);
+        cursor.next();
         iter::from_fn(move || {
             while let Some(layer) = cursor.item() {
                 let mut info = None;
@@ -940,7 +940,7 @@ impl SyntaxSnapshot {
                         });
                     }
                 }
-                cursor.next(buffer);
+                cursor.next();
                 if info.is_some() {
                     return info;
                 }

--- a/crates/notifications/src/notification_store.rs
+++ b/crates/notifications/src/notification_store.rs
@@ -374,7 +374,7 @@ impl NotificationStore {
             let old_notification = cursor.item();
             if let Some(old_notification) = old_notification {
                 if old_notification.id == id {
-                    cursor.next(&());
+                    cursor.next();
 
                     if let Some(new_notification) = &new_notification {
                         if new_notification.is_read {

--- a/crates/notifications/src/notification_store.rs
+++ b/crates/notifications/src/notification_store.rs
@@ -132,12 +132,12 @@ impl NotificationStore {
         }
         let ix = count - 1 - ix;
         let mut cursor = self.notifications.cursor::<Count>(&());
-        cursor.seek(&Count(ix), Bias::Right, &());
+        cursor.seek(&Count(ix), Bias::Right);
         cursor.item()
     }
     pub fn notification_for_id(&self, id: u64) -> Option<&NotificationEntry> {
         let mut cursor = self.notifications.cursor::<NotificationId>(&());
-        cursor.seek(&NotificationId(id), Bias::Left, &());
+        cursor.seek(&NotificationId(id), Bias::Left);
         if let Some(item) = cursor.item() {
             if item.id == id {
                 return Some(item);
@@ -365,7 +365,7 @@ impl NotificationStore {
         let mut old_range = 0..0;
 
         for (i, (id, new_notification)) in notifications.into_iter().enumerate() {
-            new_notifications.append(cursor.slice(&NotificationId(id), Bias::Left, &()), &());
+            new_notifications.append(cursor.slice(&NotificationId(id), Bias::Left), &());
 
             if i == 0 {
                 old_range.start = cursor.start().1.0;
@@ -403,7 +403,7 @@ impl NotificationStore {
 
         old_range.end = cursor.start().1.0;
         let new_count = new_notifications.summary().count - old_range.start;
-        new_notifications.append(cursor.suffix(&()), &());
+        new_notifications.append(cursor.suffix(), &());
         drop(cursor);
 
         self.notifications = new_notifications;

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -4279,7 +4279,7 @@ impl Repository {
 
                         for (repo_path, status) in &*statuses.entries {
                             changed_paths.remove(repo_path);
-                            if cursor.seek_forward(&PathTarget::Path(repo_path), Bias::Left, &()) {
+                            if cursor.seek_forward(&PathTarget::Path(repo_path), Bias::Left) {
                                 if cursor.item().is_some_and(|entry| entry.status == *status) {
                                     continue;
                                 }
@@ -4292,7 +4292,7 @@ impl Repository {
                         }
                         let mut cursor = prev_statuses.cursor::<PathProgress>(&());
                         for path in changed_paths.into_iter() {
-                            if cursor.seek_forward(&PathTarget::Path(&path), Bias::Left, &()) {
+                            if cursor.seek_forward(&PathTarget::Path(&path), Bias::Left) {
                                 changed_path_statuses.push(Edit::Remove(PathKey(path.0)));
                             }
                         }

--- a/crates/project/src/git_store/git_traversal.rs
+++ b/crates/project/src/git_store/git_traversal.rs
@@ -72,14 +72,13 @@ impl<'a> GitTraversal<'a> {
 
         if entry.is_dir() {
             let mut statuses = statuses.clone();
-            statuses.seek_forward(&PathTarget::Path(repo_path.as_ref()), Bias::Left, &());
-            let summary =
-                statuses.summary(&PathTarget::Successor(repo_path.as_ref()), Bias::Left, &());
+            statuses.seek_forward(&PathTarget::Path(repo_path.as_ref()), Bias::Left);
+            let summary = statuses.summary(&PathTarget::Successor(repo_path.as_ref()), Bias::Left);
 
             self.current_entry_summary = Some(summary);
         } else if entry.is_file() {
             // For a file entry, park the cursor on the corresponding status
-            if statuses.seek_forward(&PathTarget::Path(repo_path.as_ref()), Bias::Left, &()) {
+            if statuses.seek_forward(&PathTarget::Path(repo_path.as_ref()), Bias::Left) {
                 // TODO: Investigate statuses.item() being None here.
                 self.current_entry_summary = statuses.item().map(|item| item.status.into());
             } else {

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -450,10 +450,6 @@ impl Rope {
         self.clip_point(Point::new(row, u32::MAX), Bias::Left)
             .column
     }
-
-    pub fn ptr_eq(&self, other: &Self) -> bool {
-        self.chunks.ptr_eq(&other.chunks)
-    }
 }
 
 impl<'a> From<&'a str> for Rope {

--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -43,7 +43,7 @@ impl Rope {
                 let mut chunks = rope.chunks.cursor::<()>(&());
                 chunks.next();
                 chunks.next();
-                self.chunks.append(chunks.suffix(&()), &());
+                self.chunks.append(chunks.suffix(), &());
                 self.check_invariants();
                 return;
             }
@@ -283,7 +283,7 @@ impl Rope {
             return self.summary().len_utf16;
         }
         let mut cursor = self.chunks.cursor::<(usize, OffsetUtf16)>(&());
-        cursor.seek(&offset, Bias::Left, &());
+        cursor.seek(&offset, Bias::Left);
         let overshoot = offset - cursor.start().0;
         cursor.start().1
             + cursor.item().map_or(Default::default(), |chunk| {
@@ -296,7 +296,7 @@ impl Rope {
             return self.summary().len;
         }
         let mut cursor = self.chunks.cursor::<(OffsetUtf16, usize)>(&());
-        cursor.seek(&offset, Bias::Left, &());
+        cursor.seek(&offset, Bias::Left);
         let overshoot = offset - cursor.start().0;
         cursor.start().1
             + cursor.item().map_or(Default::default(), |chunk| {
@@ -309,7 +309,7 @@ impl Rope {
             return self.summary().lines;
         }
         let mut cursor = self.chunks.cursor::<(usize, Point)>(&());
-        cursor.seek(&offset, Bias::Left, &());
+        cursor.seek(&offset, Bias::Left);
         let overshoot = offset - cursor.start().0;
         cursor.start().1
             + cursor.item().map_or(Point::zero(), |chunk| {
@@ -322,7 +322,7 @@ impl Rope {
             return self.summary().lines_utf16();
         }
         let mut cursor = self.chunks.cursor::<(usize, PointUtf16)>(&());
-        cursor.seek(&offset, Bias::Left, &());
+        cursor.seek(&offset, Bias::Left);
         let overshoot = offset - cursor.start().0;
         cursor.start().1
             + cursor.item().map_or(PointUtf16::zero(), |chunk| {
@@ -335,7 +335,7 @@ impl Rope {
             return self.summary().lines_utf16();
         }
         let mut cursor = self.chunks.cursor::<(Point, PointUtf16)>(&());
-        cursor.seek(&point, Bias::Left, &());
+        cursor.seek(&point, Bias::Left);
         let overshoot = point - cursor.start().0;
         cursor.start().1
             + cursor.item().map_or(PointUtf16::zero(), |chunk| {
@@ -348,7 +348,7 @@ impl Rope {
             return self.summary().len;
         }
         let mut cursor = self.chunks.cursor::<(Point, usize)>(&());
-        cursor.seek(&point, Bias::Left, &());
+        cursor.seek(&point, Bias::Left);
         let overshoot = point - cursor.start().0;
         cursor.start().1
             + cursor
@@ -369,7 +369,7 @@ impl Rope {
             return self.summary().len;
         }
         let mut cursor = self.chunks.cursor::<(PointUtf16, usize)>(&());
-        cursor.seek(&point, Bias::Left, &());
+        cursor.seek(&point, Bias::Left);
         let overshoot = point - cursor.start().0;
         cursor.start().1
             + cursor.item().map_or(0, |chunk| {
@@ -382,7 +382,7 @@ impl Rope {
             return self.summary().lines;
         }
         let mut cursor = self.chunks.cursor::<(PointUtf16, Point)>(&());
-        cursor.seek(&point.0, Bias::Left, &());
+        cursor.seek(&point.0, Bias::Left);
         let overshoot = Unclipped(point.0 - cursor.start().0);
         cursor.start().1
             + cursor.item().map_or(Point::zero(), |chunk| {
@@ -392,7 +392,7 @@ impl Rope {
 
     pub fn clip_offset(&self, mut offset: usize, bias: Bias) -> usize {
         let mut cursor = self.chunks.cursor::<usize>(&());
-        cursor.seek(&offset, Bias::Left, &());
+        cursor.seek(&offset, Bias::Left);
         if let Some(chunk) = cursor.item() {
             let mut ix = offset - cursor.start();
             while !chunk.text.is_char_boundary(ix) {
@@ -415,7 +415,7 @@ impl Rope {
 
     pub fn clip_offset_utf16(&self, offset: OffsetUtf16, bias: Bias) -> OffsetUtf16 {
         let mut cursor = self.chunks.cursor::<OffsetUtf16>(&());
-        cursor.seek(&offset, Bias::Right, &());
+        cursor.seek(&offset, Bias::Right);
         if let Some(chunk) = cursor.item() {
             let overshoot = offset - cursor.start();
             *cursor.start() + chunk.as_slice().clip_offset_utf16(overshoot, bias)
@@ -426,7 +426,7 @@ impl Rope {
 
     pub fn clip_point(&self, point: Point, bias: Bias) -> Point {
         let mut cursor = self.chunks.cursor::<Point>(&());
-        cursor.seek(&point, Bias::Right, &());
+        cursor.seek(&point, Bias::Right);
         if let Some(chunk) = cursor.item() {
             let overshoot = point - cursor.start();
             *cursor.start() + chunk.as_slice().clip_point(overshoot, bias)
@@ -437,7 +437,7 @@ impl Rope {
 
     pub fn clip_point_utf16(&self, point: Unclipped<PointUtf16>, bias: Bias) -> PointUtf16 {
         let mut cursor = self.chunks.cursor::<PointUtf16>(&());
-        cursor.seek(&point.0, Bias::Right, &());
+        cursor.seek(&point.0, Bias::Right);
         if let Some(chunk) = cursor.item() {
             let overshoot = Unclipped(point.0 - cursor.start());
             *cursor.start() + chunk.as_slice().clip_point_utf16(overshoot, bias)
@@ -510,7 +510,7 @@ pub struct Cursor<'a> {
 impl<'a> Cursor<'a> {
     pub fn new(rope: &'a Rope, offset: usize) -> Self {
         let mut chunks = rope.chunks.cursor(&());
-        chunks.seek(&offset, Bias::Right, &());
+        chunks.seek(&offset, Bias::Right);
         Self {
             rope,
             chunks,
@@ -521,7 +521,7 @@ impl<'a> Cursor<'a> {
     pub fn seek_forward(&mut self, end_offset: usize) {
         debug_assert!(end_offset >= self.offset);
 
-        self.chunks.seek_forward(&end_offset, Bias::Right, &());
+        self.chunks.seek_forward(&end_offset, Bias::Right);
         self.offset = end_offset;
     }
 
@@ -543,7 +543,7 @@ impl<'a> Cursor<'a> {
         if end_offset > self.chunks.end() {
             self.chunks.next();
             slice.append(Rope {
-                chunks: self.chunks.slice(&end_offset, Bias::Right, &()),
+                chunks: self.chunks.slice(&end_offset, Bias::Right),
             });
             if let Some(end_chunk) = self.chunks.item() {
                 let end_ix = end_offset - self.chunks.start();
@@ -567,7 +567,7 @@ impl<'a> Cursor<'a> {
 
         if end_offset > self.chunks.end() {
             self.chunks.next();
-            summary.add_assign(&self.chunks.summary(&end_offset, Bias::Right, &()));
+            summary.add_assign(&self.chunks.summary(&end_offset, Bias::Right));
             if let Some(end_chunk) = self.chunks.item() {
                 let end_ix = end_offset - self.chunks.start();
                 summary.add_assign(&D::from_chunk(end_chunk.slice(0..end_ix)));
@@ -599,10 +599,10 @@ impl<'a> Chunks<'a> {
     pub fn new(rope: &'a Rope, range: Range<usize>, reversed: bool) -> Self {
         let mut chunks = rope.chunks.cursor(&());
         let offset = if reversed {
-            chunks.seek(&range.end, Bias::Left, &());
+            chunks.seek(&range.end, Bias::Left);
             range.end
         } else {
-            chunks.seek(&range.start, Bias::Right, &());
+            chunks.seek(&range.start, Bias::Right);
             range.start
         };
         Self {
@@ -639,9 +639,9 @@ impl<'a> Chunks<'a> {
         };
 
         if offset >= self.chunks.end() {
-            self.chunks.seek_forward(&offset, bias, &());
+            self.chunks.seek_forward(&offset, bias);
         } else {
-            self.chunks.seek(&offset, bias, &());
+            self.chunks.seek(&offset, bias);
         }
 
         self.offset = offset;
@@ -688,7 +688,7 @@ impl<'a> Chunks<'a> {
 
         if self.offset > self.range.end {
             self.offset = cmp::min(self.offset, self.range.end);
-            self.chunks.seek(&self.offset, Bias::Right, &());
+            self.chunks.seek(&self.offset, Bias::Right);
         }
 
         found
@@ -742,7 +742,7 @@ impl<'a> Chunks<'a> {
 
         if !self.offset_is_valid() || self.chunks.item().is_none() {
             self.offset = self.range.start;
-            self.chunks.seek(&self.offset, Bias::Right, &());
+            self.chunks.seek(&self.offset, Bias::Right);
         }
 
         self.offset < initial_offset && self.offset == 0
@@ -844,9 +844,9 @@ impl<'a> Bytes<'a> {
     pub fn new(rope: &'a Rope, range: Range<usize>, reversed: bool) -> Self {
         let mut chunks = rope.chunks.cursor(&());
         if reversed {
-            chunks.seek(&range.end, Bias::Left, &());
+            chunks.seek(&range.end, Bias::Left);
         } else {
-            chunks.seek(&range.start, Bias::Right, &());
+            chunks.seek(&range.start, Bias::Right);
         }
         Self {
             chunks,

--- a/crates/sum_tree/src/cursor.rs
+++ b/crates/sum_tree/src/cursor.rs
@@ -25,6 +25,7 @@ pub struct Cursor<'a, T: Item, D> {
     position: D,
     did_seek: bool,
     at_end: bool,
+    cx: &'a <T::Summary as Summary>::Context,
 }
 
 impl<T: Item + fmt::Debug, D: fmt::Debug> fmt::Debug for Cursor<'_, T, D>
@@ -52,13 +53,14 @@ where
     T: Item,
     D: Dimension<'a, T::Summary>,
 {
-    pub fn new(tree: &'a SumTree<T>, cx: &<T::Summary as Summary>::Context) -> Self {
+    pub fn new(tree: &'a SumTree<T>, cx: &'a <T::Summary as Summary>::Context) -> Self {
         Self {
             tree,
             stack: ArrayVec::new(),
             position: D::zero(cx),
             did_seek: false,
             at_end: tree.is_empty(),
+            cx,
         }
     }
 
@@ -659,7 +661,7 @@ where
 {
     pub fn new(
         tree: &'a SumTree<T>,
-        cx: &<T::Summary as Summary>::Context,
+        cx: &'a <T::Summary as Summary>::Context,
         filter_node: F,
     ) -> Self {
         let cursor = tree.cursor::<D>(cx);

--- a/crates/sum_tree/src/cursor.rs
+++ b/crates/sum_tree/src/cursor.rs
@@ -605,10 +605,8 @@ impl<'a, T: Item> Iterator for Iter<'a, T> {
     }
 }
 
-impl<'a, T, S, D> Iterator for Cursor<'a, T, D>
+impl<'a, T: Item, D> Iterator for Cursor<'a, T, D>
 where
-    T: Item<Summary = S>,
-    S: Summary<Context = ()>,
     D: Dimension<'a, T::Summary>,
 {
     type Item = &'a T;
@@ -632,7 +630,7 @@ pub struct FilterCursor<'a, F, T: Item, D> {
     filter_node: F,
 }
 
-impl<'a, F, T, D> FilterCursor<'a, F, T, D>
+impl<'a, F, T: Item, D> FilterCursor<'a, F, T, D>
 where
     F: FnMut(&T::Summary) -> bool,
     T: Item,
@@ -675,11 +673,9 @@ where
     }
 }
 
-impl<'a, F, T, S, U> Iterator for FilterCursor<'a, F, T, U>
+impl<'a, F, T: Item, U> Iterator for FilterCursor<'a, F, T, U>
 where
     F: FnMut(&T::Summary) -> bool,
-    T: Item<Summary = S>,
-    S: Summary<Context = ()>, //Context for the summary must be unit type, as .next() doesn't take arguments
     U: Dimension<'a, T::Summary>,
 {
     type Item = &'a T;

--- a/crates/sum_tree/src/cursor.rs
+++ b/crates/sum_tree/src/cursor.rs
@@ -795,3 +795,23 @@ where
         self.0.add_summary(summary, cx);
     }
 }
+
+struct End<D>(PhantomData<D>);
+
+impl<D> End<D> {
+    fn new() -> Self {
+        Self(PhantomData)
+    }
+}
+
+impl<'a, S: Summary, D: Dimension<'a, S>> SeekTarget<'a, S, D> for End<D> {
+    fn cmp(&self, _: &D, _: &S::Context) -> Ordering {
+        Ordering::Greater
+    }
+}
+
+impl<D> fmt::Debug for End<D> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("End").finish()
+    }
+}

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -363,7 +363,7 @@ impl<T: Item> SumTree<T> {
         Iter::new(self)
     }
 
-    pub fn cursor<'a, S>(&'a self, cx: &<T::Summary as Summary>::Context) -> Cursor<'a, T, S>
+    pub fn cursor<'a, S>(&'a self, cx: &'a <T::Summary as Summary>::Context) -> Cursor<'a, T, S>
     where
         S: Dimension<'a, T::Summary>,
     {
@@ -374,7 +374,7 @@ impl<T: Item> SumTree<T> {
     /// that is returned cannot be used with Rust's iterators.
     pub fn filter<'a, F, U>(
         &'a self,
-        cx: &<T::Summary as Summary>::Context,
+        cx: &'a <T::Summary as Summary>::Context,
         filter_node: F,
     ) -> FilterCursor<'a, F, T, U>
     where
@@ -766,7 +766,11 @@ impl<T: KeyedItem> SumTree<T> {
         removed
     }
 
-    pub fn get(&self, key: &T::Key, cx: &<T::Summary as Summary>::Context) -> Option<&T> {
+    pub fn get<'a>(
+        &'a self,
+        key: &T::Key,
+        cx: &'a <T::Summary as Summary>::Context,
+    ) -> Option<&'a T> {
         let mut cursor = self.cursor::<T::Key>(cx);
         if cursor.seek(key, Bias::Left, cx) {
             cursor.item()

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -680,7 +680,7 @@ impl<T: KeyedItem> SumTree<T> {
         let mut replaced = None;
         *self = {
             let mut cursor = self.cursor::<T::Key>(cx);
-            let mut new_tree = cursor.slice(&item.key(), Bias::Left, cx);
+            let mut new_tree = cursor.slice(&item.key(), Bias::Left);
             if let Some(cursor_item) = cursor.item() {
                 if cursor_item.key() == item.key() {
                     replaced = Some(cursor_item.clone());
@@ -688,7 +688,7 @@ impl<T: KeyedItem> SumTree<T> {
                 }
             }
             new_tree.push(item, cx);
-            new_tree.append(cursor.suffix(cx), cx);
+            new_tree.append(cursor.suffix(), cx);
             new_tree
         };
         replaced
@@ -698,14 +698,14 @@ impl<T: KeyedItem> SumTree<T> {
         let mut removed = None;
         *self = {
             let mut cursor = self.cursor::<T::Key>(cx);
-            let mut new_tree = cursor.slice(key, Bias::Left, cx);
+            let mut new_tree = cursor.slice(key, Bias::Left);
             if let Some(item) = cursor.item() {
                 if item.key() == *key {
                     removed = Some(item.clone());
                     cursor.next();
                 }
             }
-            new_tree.append(cursor.suffix(cx), cx);
+            new_tree.append(cursor.suffix(), cx);
             new_tree
         };
         removed
@@ -728,7 +728,7 @@ impl<T: KeyedItem> SumTree<T> {
             let mut new_tree = SumTree::new(cx);
             let mut buffered_items = Vec::new();
 
-            cursor.seek(&T::Key::zero(cx), Bias::Left, cx);
+            cursor.seek(&T::Key::zero(cx), Bias::Left);
             for edit in edits {
                 let new_key = edit.key();
                 let mut old_item = cursor.item();
@@ -738,7 +738,7 @@ impl<T: KeyedItem> SumTree<T> {
                     .map_or(false, |old_item| old_item.key() < new_key)
                 {
                     new_tree.extend(buffered_items.drain(..), cx);
-                    let slice = cursor.slice(&new_key, Bias::Left, cx);
+                    let slice = cursor.slice(&new_key, Bias::Left);
                     new_tree.append(slice, cx);
                     old_item = cursor.item();
                 }
@@ -759,7 +759,7 @@ impl<T: KeyedItem> SumTree<T> {
             }
 
             new_tree.extend(buffered_items, cx);
-            new_tree.append(cursor.suffix(cx), cx);
+            new_tree.append(cursor.suffix(), cx);
             new_tree
         };
 
@@ -772,7 +772,7 @@ impl<T: KeyedItem> SumTree<T> {
         cx: &'a <T::Summary as Summary>::Context,
     ) -> Option<&'a T> {
         let mut cursor = self.cursor::<T::Key>(cx);
-        if cursor.seek(key, Bias::Left, cx) {
+        if cursor.seek(key, Bias::Left) {
             cursor.item()
         } else {
             None

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -38,7 +38,6 @@ pub trait Summary: Clone {
     type Context;
 
     fn zero(cx: &Self::Context) -> Self;
-
     fn add_summary(&mut self, summary: &Self, cx: &Self::Context);
 }
 
@@ -135,26 +134,6 @@ where
 {
     fn cmp(&self, cursor_location: &((D1, D2), D3), cx: &S::Context) -> Ordering {
         self.cmp(&cursor_location.0.0, cx)
-    }
-}
-
-struct End<D>(PhantomData<D>);
-
-impl<D> End<D> {
-    fn new() -> Self {
-        Self(PhantomData)
-    }
-}
-
-impl<'a, S: Summary, D: Dimension<'a, S>> SeekTarget<'a, S, D> for End<D> {
-    fn cmp(&self, _: &D, _: &S::Context) -> Ordering {
-        Ordering::Greater
-    }
-}
-
-impl<D> fmt::Debug for End<D> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("End").finish()
     }
 }
 

--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -351,10 +351,10 @@ impl<T: Item> SumTree<T> {
     pub fn items(&self, cx: &<T::Summary as Summary>::Context) -> Vec<T> {
         let mut items = Vec::new();
         let mut cursor = self.cursor::<()>(cx);
-        cursor.next(cx);
+        cursor.next();
         while let Some(item) = cursor.item() {
             items.push(item.clone());
-            cursor.next(cx);
+            cursor.next();
         }
         items
     }
@@ -684,7 +684,7 @@ impl<T: KeyedItem> SumTree<T> {
             if let Some(cursor_item) = cursor.item() {
                 if cursor_item.key() == item.key() {
                     replaced = Some(cursor_item.clone());
-                    cursor.next(cx);
+                    cursor.next();
                 }
             }
             new_tree.push(item, cx);
@@ -702,7 +702,7 @@ impl<T: KeyedItem> SumTree<T> {
             if let Some(item) = cursor.item() {
                 if item.key() == *key {
                     removed = Some(item.clone());
-                    cursor.next(cx);
+                    cursor.next();
                 }
             }
             new_tree.append(cursor.suffix(cx), cx);
@@ -746,7 +746,7 @@ impl<T: KeyedItem> SumTree<T> {
                 if let Some(old_item) = old_item {
                     if old_item.key() == new_key {
                         removed.push(old_item.clone());
-                        cursor.next(cx);
+                        cursor.next();
                     }
                 }
 
@@ -1015,10 +1015,10 @@ mod tests {
                     .collect::<Vec<_>>();
 
                 let mut item_ix = if rng.r#gen() {
-                    filter_cursor.next(&());
+                    filter_cursor.next();
                     0
                 } else {
-                    filter_cursor.prev(&());
+                    filter_cursor.prev();
                     expected_filtered_items.len().saturating_sub(1)
                 };
                 while item_ix < expected_filtered_items.len() {
@@ -1028,19 +1028,19 @@ mod tests {
                     assert_eq!(actual_item, &reference_item);
                     assert_eq!(filter_cursor.start().0, reference_index);
                     log::info!("next");
-                    filter_cursor.next(&());
+                    filter_cursor.next();
                     item_ix += 1;
 
                     while item_ix > 0 && rng.gen_bool(0.2) {
                         log::info!("prev");
-                        filter_cursor.prev(&());
+                        filter_cursor.prev();
                         item_ix -= 1;
 
                         if item_ix == 0 && rng.gen_bool(0.2) {
-                            filter_cursor.prev(&());
+                            filter_cursor.prev();
                             assert_eq!(filter_cursor.item(), None);
                             assert_eq!(filter_cursor.start().0, 0);
-                            filter_cursor.next(&());
+                            filter_cursor.next();
                         }
                     }
                 }
@@ -1077,13 +1077,13 @@ mod tests {
                     }
 
                     if i < 5 {
-                        cursor.next(&());
+                        cursor.next();
                         if pos < reference_items.len() {
                             pos += 1;
                             before_start = false;
                         }
                     } else {
-                        cursor.prev(&());
+                        cursor.prev();
                         if pos == 0 {
                             before_start = true;
                         }
@@ -1123,12 +1123,12 @@ mod tests {
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 0);
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 0);
-        cursor.next(&());
+        cursor.next();
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), None);
@@ -1147,13 +1147,13 @@ mod tests {
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 0);
 
-        cursor.next(&());
+        cursor.next();
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&1));
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 1);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), None);
@@ -1189,74 +1189,74 @@ mod tests {
         assert_eq!(cursor.next_item(), Some(&4));
         assert_eq!(cursor.start().sum, 3);
 
-        cursor.next(&());
+        cursor.next();
         assert_eq!(cursor.item(), Some(&4));
         assert_eq!(cursor.prev_item(), Some(&3));
         assert_eq!(cursor.next_item(), Some(&5));
         assert_eq!(cursor.start().sum, 6);
 
-        cursor.next(&());
+        cursor.next();
         assert_eq!(cursor.item(), Some(&5));
         assert_eq!(cursor.prev_item(), Some(&4));
         assert_eq!(cursor.next_item(), Some(&6));
         assert_eq!(cursor.start().sum, 10);
 
-        cursor.next(&());
+        cursor.next();
         assert_eq!(cursor.item(), Some(&6));
         assert_eq!(cursor.prev_item(), Some(&5));
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 15);
 
-        cursor.next(&());
-        cursor.next(&());
+        cursor.next();
+        cursor.next();
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), Some(&6));
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 21);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&6));
         assert_eq!(cursor.prev_item(), Some(&5));
         assert_eq!(cursor.next_item(), None);
         assert_eq!(cursor.start().sum, 15);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&5));
         assert_eq!(cursor.prev_item(), Some(&4));
         assert_eq!(cursor.next_item(), Some(&6));
         assert_eq!(cursor.start().sum, 10);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&4));
         assert_eq!(cursor.prev_item(), Some(&3));
         assert_eq!(cursor.next_item(), Some(&5));
         assert_eq!(cursor.start().sum, 6);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&3));
         assert_eq!(cursor.prev_item(), Some(&2));
         assert_eq!(cursor.next_item(), Some(&4));
         assert_eq!(cursor.start().sum, 3);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&2));
         assert_eq!(cursor.prev_item(), Some(&1));
         assert_eq!(cursor.next_item(), Some(&3));
         assert_eq!(cursor.start().sum, 1);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), Some(&2));
         assert_eq!(cursor.start().sum, 0);
 
-        cursor.prev(&());
+        cursor.prev();
         assert_eq!(cursor.item(), None);
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), Some(&1));
         assert_eq!(cursor.start().sum, 0);
 
-        cursor.next(&());
+        cursor.next();
         assert_eq!(cursor.item(), Some(&1));
         assert_eq!(cursor.prev_item(), None);
         assert_eq!(cursor.next_item(), Some(&2));

--- a/crates/sum_tree/src/tree_map.rs
+++ b/crates/sum_tree/src/tree_map.rs
@@ -54,7 +54,7 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
 
     pub fn get(&self, key: &K) -> Option<&V> {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
-        cursor.seek(&MapKeyRef(Some(key)), Bias::Left, &());
+        cursor.seek(&MapKeyRef(Some(key)), Bias::Left);
         if let Some(item) = cursor.item() {
             if Some(key) == item.key().0.as_ref() {
                 Some(&item.value)
@@ -86,12 +86,12 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
         let mut removed = None;
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
         let key = MapKeyRef(Some(key));
-        let mut new_tree = cursor.slice(&key, Bias::Left, &());
+        let mut new_tree = cursor.slice(&key, Bias::Left);
         if key.cmp(&cursor.end(), &()) == Ordering::Equal {
             removed = Some(cursor.item().unwrap().value.clone());
             cursor.next();
         }
-        new_tree.append(cursor.suffix(&()), &());
+        new_tree.append(cursor.suffix(), &());
         drop(cursor);
         self.0 = new_tree;
         removed
@@ -101,9 +101,9 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
         let start = MapSeekTargetAdaptor(start);
         let end = MapSeekTargetAdaptor(end);
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
-        let mut new_tree = cursor.slice(&start, Bias::Left, &());
-        cursor.seek(&end, Bias::Left, &());
-        new_tree.append(cursor.suffix(&()), &());
+        let mut new_tree = cursor.slice(&start, Bias::Left);
+        cursor.seek(&end, Bias::Left);
+        new_tree.append(cursor.suffix(), &());
         drop(cursor);
         self.0 = new_tree;
     }
@@ -112,7 +112,7 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
     pub fn closest(&self, key: &K) -> Option<(&K, &V)> {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
         let key = MapKeyRef(Some(key));
-        cursor.seek(&key, Bias::Right, &());
+        cursor.seek(&key, Bias::Right);
         cursor.prev();
         cursor.item().map(|item| (&item.key, &item.value))
     }
@@ -120,7 +120,7 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
     pub fn iter_from<'a>(&'a self, from: &K) -> impl Iterator<Item = (&'a K, &'a V)> + 'a {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
         let from_key = MapKeyRef(Some(from));
-        cursor.seek(&from_key, Bias::Left, &());
+        cursor.seek(&from_key, Bias::Left);
 
         cursor.map(|map_entry| (&map_entry.key, &map_entry.value))
     }
@@ -131,7 +131,7 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
     {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
         let key = MapKeyRef(Some(key));
-        let mut new_tree = cursor.slice(&key, Bias::Left, &());
+        let mut new_tree = cursor.slice(&key, Bias::Left);
         let mut result = None;
         if key.cmp(&cursor.end(), &()) == Ordering::Equal {
             let mut updated = cursor.item().unwrap().clone();
@@ -139,7 +139,7 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
             new_tree.push(updated, &());
             cursor.next();
         }
-        new_tree.append(cursor.suffix(&()), &());
+        new_tree.append(cursor.suffix(), &());
         drop(cursor);
         self.0 = new_tree;
         result

--- a/crates/sum_tree/src/tree_map.rs
+++ b/crates/sum_tree/src/tree_map.rs
@@ -87,9 +87,9 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
         let key = MapKeyRef(Some(key));
         let mut new_tree = cursor.slice(&key, Bias::Left, &());
-        if key.cmp(&cursor.end(&()), &()) == Ordering::Equal {
+        if key.cmp(&cursor.end(), &()) == Ordering::Equal {
             removed = Some(cursor.item().unwrap().value.clone());
-            cursor.next(&());
+            cursor.next();
         }
         new_tree.append(cursor.suffix(&()), &());
         drop(cursor);
@@ -113,7 +113,7 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
         let key = MapKeyRef(Some(key));
         cursor.seek(&key, Bias::Right, &());
-        cursor.prev(&());
+        cursor.prev();
         cursor.item().map(|item| (&item.key, &item.value))
     }
 
@@ -133,11 +133,11 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
         let key = MapKeyRef(Some(key));
         let mut new_tree = cursor.slice(&key, Bias::Left, &());
         let mut result = None;
-        if key.cmp(&cursor.end(&()), &()) == Ordering::Equal {
+        if key.cmp(&cursor.end(), &()) == Ordering::Equal {
             let mut updated = cursor.item().unwrap().clone();
             result = Some(f(&mut updated.value));
             new_tree.push(updated, &());
-            cursor.next(&());
+            cursor.next();
         }
         new_tree.append(cursor.suffix(&()), &());
         drop(cursor);
@@ -149,12 +149,12 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
         let mut new_map = SumTree::<MapEntry<K, V>>::default();
 
         let mut cursor = self.0.cursor::<MapKeyRef<'_, K>>(&());
-        cursor.next(&());
+        cursor.next();
         while let Some(item) = cursor.item() {
             if predicate(&item.key, &item.value) {
                 new_map.push(item.clone(), &());
             }
-            cursor.next(&());
+            cursor.next();
         }
         drop(cursor);
 

--- a/crates/text/src/anchor.rs
+++ b/crates/text/src/anchor.rs
@@ -101,7 +101,7 @@ impl Anchor {
         } else {
             let fragment_id = buffer.fragment_id_for_anchor(self);
             let mut fragment_cursor = buffer.fragments.cursor::<(Option<&Locator>, usize)>(&None);
-            fragment_cursor.seek(&Some(fragment_id), Bias::Left, &None);
+            fragment_cursor.seek(&Some(fragment_id), Bias::Left);
             fragment_cursor
                 .item()
                 .map_or(false, |fragment| fragment.visible)

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -1738,7 +1738,7 @@ impl Buffer {
 
         let mut cursor = self.snapshot.fragments.cursor::<Option<&Locator>>(&None);
         for insertion_fragment in self.snapshot.insertions.cursor::<()>(&()) {
-            cursor.seek(&Some(&insertion_fragment.fragment_id), Bias::Left, &None);
+            cursor.seek(&Some(&insertion_fragment.fragment_id), Bias::Left);
             let fragment = cursor.item().unwrap();
             assert_eq!(insertion_fragment.fragment_id, fragment.id);
             assert_eq!(insertion_fragment.split_offset, fragment.insertion_offset);

--- a/crates/text/src/undo_map.rs
+++ b/crates/text/src/undo_map.rs
@@ -74,7 +74,6 @@ impl UndoMap {
                 undo_id: Default::default(),
             },
             Bias::Left,
-            &(),
         );
 
         let mut undo_count = 0;
@@ -99,7 +98,6 @@ impl UndoMap {
                 undo_id: Default::default(),
             },
             Bias::Left,
-            &(),
         );
 
         let mut undo_count = 0;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2458,7 +2458,7 @@ impl Snapshot {
             while let Some(entry) = cursor.item() {
                 if entry.path.starts_with(&removed_entry.path) {
                     self.entries_by_id.remove(&entry.id, &());
-                    cursor.next(&());
+                    cursor.next();
                 } else {
                     break;
                 }
@@ -4925,8 +4925,8 @@ fn build_diff(
     let mut old_paths = old_snapshot.entries_by_path.cursor::<PathKey>(&());
     let mut new_paths = new_snapshot.entries_by_path.cursor::<PathKey>(&());
     let mut last_newly_loaded_dir_path = None;
-    old_paths.next(&());
-    new_paths.next(&());
+    old_paths.next();
+    new_paths.next();
     for path in event_paths {
         let path = PathKey(path.clone());
         if old_paths.item().map_or(false, |e| e.path < path.0) {
@@ -4949,7 +4949,7 @@ fn build_diff(
                     match Ord::cmp(&old_entry.path, &new_entry.path) {
                         Ordering::Less => {
                             changes.push((old_entry.path.clone(), old_entry.id, Removed));
-                            old_paths.next(&());
+                            old_paths.next();
                         }
                         Ordering::Equal => {
                             if phase == EventsReceivedDuringInitialScan {
@@ -4975,8 +4975,8 @@ fn build_diff(
                                     changes.push((new_entry.path.clone(), new_entry.id, Updated));
                                 }
                             }
-                            old_paths.next(&());
-                            new_paths.next(&());
+                            old_paths.next();
+                            new_paths.next();
                         }
                         Ordering::Greater => {
                             let is_newly_loaded = phase == InitialScan
@@ -4988,13 +4988,13 @@ fn build_diff(
                                 new_entry.id,
                                 if is_newly_loaded { Loaded } else { Added },
                             ));
-                            new_paths.next(&());
+                            new_paths.next();
                         }
                     }
                 }
                 (Some(old_entry), None) => {
                     changes.push((old_entry.path.clone(), old_entry.id, Removed));
-                    old_paths.next(&());
+                    old_paths.next();
                 }
                 (None, Some(new_entry)) => {
                     let is_newly_loaded = phase == InitialScan
@@ -5006,7 +5006,7 @@ fn build_diff(
                         new_entry.id,
                         if is_newly_loaded { Loaded } else { Added },
                     ));
-                    new_paths.next(&());
+                    new_paths.next();
                 }
                 (None, None) => break,
             }
@@ -5326,7 +5326,7 @@ impl<'a> Traversal<'a> {
 
     pub fn end_offset(&self) -> usize {
         self.cursor
-            .end(&())
+            .end()
             .count(self.include_files, self.include_dirs, self.include_ignored)
     }
 }

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -2454,7 +2454,7 @@ impl Snapshot {
         self.entries_by_path = {
             let mut cursor = self.entries_by_path.cursor::<TraversalProgress>(&());
             let mut new_entries_by_path =
-                cursor.slice(&TraversalTarget::path(&removed_entry.path), Bias::Left, &());
+                cursor.slice(&TraversalTarget::path(&removed_entry.path), Bias::Left);
             while let Some(entry) = cursor.item() {
                 if entry.path.starts_with(&removed_entry.path) {
                     self.entries_by_id.remove(&entry.id, &());
@@ -2463,7 +2463,7 @@ impl Snapshot {
                     break;
                 }
             }
-            new_entries_by_path.append(cursor.suffix(&()), &());
+            new_entries_by_path.append(cursor.suffix(), &());
             new_entries_by_path
         };
 
@@ -2576,7 +2576,6 @@ impl Snapshot {
                 include_ignored,
             },
             Bias::Right,
-            &(),
         );
         Traversal {
             snapshot: self,
@@ -2632,7 +2631,7 @@ impl Snapshot {
         options: ChildEntriesOptions,
     ) -> ChildEntriesIter<'a> {
         let mut cursor = self.entries_by_path.cursor(&());
-        cursor.seek(&TraversalTarget::path(parent_path), Bias::Right, &());
+        cursor.seek(&TraversalTarget::path(parent_path), Bias::Right);
         let traversal = Traversal {
             snapshot: self,
             cursor,
@@ -3056,9 +3055,9 @@ impl BackgroundScannerState {
                 .snapshot
                 .entries_by_path
                 .cursor::<TraversalProgress>(&());
-            new_entries = cursor.slice(&TraversalTarget::path(path), Bias::Left, &());
-            removed_entries = cursor.slice(&TraversalTarget::successor(path), Bias::Left, &());
-            new_entries.append(cursor.suffix(&()), &());
+            new_entries = cursor.slice(&TraversalTarget::path(path), Bias::Left);
+            removed_entries = cursor.slice(&TraversalTarget::successor(path), Bias::Left);
+            new_entries.append(cursor.suffix(), &());
         }
         self.snapshot.entries_by_path = new_entries;
 
@@ -4930,10 +4929,10 @@ fn build_diff(
     for path in event_paths {
         let path = PathKey(path.clone());
         if old_paths.item().map_or(false, |e| e.path < path.0) {
-            old_paths.seek_forward(&path, Bias::Left, &());
+            old_paths.seek_forward(&path, Bias::Left);
         }
         if new_paths.item().map_or(false, |e| e.path < path.0) {
-            new_paths.seek_forward(&path, Bias::Left, &());
+            new_paths.seek_forward(&path, Bias::Left);
         }
         loop {
             match (old_paths.item(), new_paths.item()) {
@@ -5255,7 +5254,7 @@ impl<'a> Traversal<'a> {
         start_path: &Path,
     ) -> Self {
         let mut cursor = snapshot.entries_by_path.cursor(&());
-        cursor.seek(&TraversalTarget::path(start_path), Bias::Left, &());
+        cursor.seek(&TraversalTarget::path(start_path), Bias::Left);
         let mut traversal = Self {
             snapshot,
             cursor,
@@ -5282,14 +5281,13 @@ impl<'a> Traversal<'a> {
                 include_ignored: self.include_ignored,
             },
             Bias::Left,
-            &(),
         )
     }
 
     pub fn advance_to_sibling(&mut self) -> bool {
         while let Some(entry) = self.cursor.item() {
             self.cursor
-                .seek_forward(&TraversalTarget::successor(&entry.path), Bias::Left, &());
+                .seek_forward(&TraversalTarget::successor(&entry.path), Bias::Left);
             if let Some(entry) = self.cursor.item() {
                 if (self.include_files || !entry.is_file())
                     && (self.include_dirs || !entry.is_dir())
@@ -5307,7 +5305,7 @@ impl<'a> Traversal<'a> {
             return false;
         };
         self.cursor
-            .seek(&TraversalTarget::path(parent_path), Bias::Left, &())
+            .seek(&TraversalTarget::path(parent_path), Bias::Left)
     }
 
     pub fn entry(&self) -> Option<&'a Entry> {


### PR DESCRIPTION
This gets rid of the need to pass context to all cursor functions. In practice context is always immutable when interacting with cursors.

A nicety of this is in the follow-up PR we will be able to implement Iterator for all Cursors/filter cursors (hell, we may be able to get rid of filter cursor altogether, as it is just a custom `filter` impl on iterator trait).
Release Notes:

- N/A
