### PR TITLE
Bind "j k" to `NormalBefore` in initial keymap examples

### DIFF
--- a/assets/keymaps/initial.json
+++ b/assets/keymaps/initial.json
@@ -15,7 +15,7 @@
   {
     "context": "Editor && vim_mode == insert && !menu",
     "bindings": {
-      // "j k": "vim::SwitchToNormalMode"
+      // "j k": "vim::NormalBefore"
     }
   }
 ]


### PR DESCRIPTION
It looks like typically vim configurations bind "j k" to be the same as escape, which has the "NormalBefore" behavior positioning the block cursor on the character before the insertion cursor.  The [vim mode docs](https://zed.dev/docs/vim#useful-contexts-for-vim-mode-key-bindings) also use NormalBefore here. 

Thanks to @omniwrench for mentioning this in https://github.com/zed-industries/zed/discussions/6661#discussioncomment-13848043 .  This was a mistake in #31163.

Release Notes:

- N/A