### PR TITLE
Fix new crate license symlink

### DIFF
--- a/crates/onboarding/LICENSE-GPL
+++ b/crates/onboarding/LICENSE-GPL
@@ -1,1 +1,1 @@
-../../../LICENSE-GPL
+../../LICENSE-GPL

--- a/script/new-crate
+++ b/script/new-crate
@@ -39,7 +39,7 @@ CRATE_PATH="crates/$CRATE_NAME"
 mkdir -p "$CRATE_PATH/src"
 
 # Symlink the license
-ln -sf "../../../$LICENSE_FILE" "$CRATE_PATH/$LICENSE_FILE"
+ln -sf "../../$LICENSE_FILE" "$CRATE_PATH/$LICENSE_FILE"
 
 CARGO_TOML_TEMPLATE=$(cat << 'EOF'
 [package]


### PR DESCRIPTION
The license file is not properly linked to actual license. This was casued due to new-crate script linking the license to wrong file. Fixed both of them.

Reference logs:

```
2025-07-22T17:16:19+05:30 ERROR [worktree] error reading target of symlink "/Users/umesh/code/zed/crates/onboarding/LICENSE-GPL": canonicalizing
```

Release Notes:

- N/A
