### PR TITLE
workspace: Fix last removed folder from workspace used to reopen on Zed startup

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1336,6 +1336,14 @@ impl WorkspaceDb {
         }
     }
 
+    query! {
+        pub(crate) async fn set_session_id(workspace_id: WorkspaceId, session_id: Option<String>) -> Result<()> {
+            UPDATE workspaces
+            SET session_id = ?2
+            WHERE workspace_id = ?1
+        }
+    }
+
     pub async fn toolchain(
         &self,
         workspace_id: WorkspaceId,

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1139,32 +1139,14 @@ impl Workspace {
                 project::Event::CollaboratorLeft(peer_id) => {
                     this.collaborator_left(*peer_id, window, cx);
                 }
-                project::Event::WorktreeRemoved(_) => {
-                    // If no worktrees remain, remove this workspace from the session
-                    // so it won't be restored on restart.
-                    if let Some(local_paths) = this.local_paths(cx) {
-                        if local_paths.is_empty() {
-                            this.session_id.take();
-                        }
-                    }
+
+                project::Event::WorktreeRemoved(_) | project::Event::WorktreeAdded(_) => {
                     this.update_window_title(window, cx);
                     this.serialize_workspace(window, cx);
-                    // This event could be triggered by `RemoveFromProject`.
-                    // So we need to update the history.
+                    // This event could be triggered by `AddFolderToProject` or `RemoveFromProject`.
                     this.update_history(cx);
                 }
-                project::Event::WorktreeAdded(_) => {
-                    // If this workspace had its session_id removed because all worktrees were removed,
-                    // restore the session_id now that we have worktrees again.
-                    if this.session_id.is_none() {
-                        this.session_id = Some(this.app_state.session.read(cx).id().to_owned());
-                    }
-                    this.update_window_title(window, cx);
-                    this.serialize_workspace(window, cx);
-                    // This event could be triggered by `AddFolderToProject`
-                    // So we need to update the history.
-                    this.update_history(cx);
-                }
+
                 project::Event::DisconnectedFromHost => {
                     this.update_window_edited(window, cx);
                     let leaders_to_unfollow =


### PR DESCRIPTION
Closes #34924

Now, when `local_paths` are empty, we detach `session_id` from that workspace serialization item. This way, when we restore it using the default "last_session", we don't restore this workspace back. This is same as when we use `cmd-w` to close window, which also sets `session_id` to `None` before serialization.

Release Notes:

- Fixed an issue where last removed folder from workspace used to reopen on Zed startup.
