### PR TITLE
workspace: Fix closing remote workspace restores last local workspace on startup

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -7359,6 +7359,17 @@ async fn open_ssh_project_inner(
         return Err(project_path_errors.pop().context("no paths given")?);
     }
 
+    if let Some(detach_session_task) = window
+        .update(cx, |_workspace, window, cx| {
+            cx.spawn_in(window, async move |this, cx| {
+                this.update_in(cx, |this, window, cx| this.remove_from_session(window, cx))
+            })
+        })
+        .ok()
+    {
+        detach_session_task.await.ok();
+    }
+
     cx.update_window(window.into(), |_, window, cx| {
         window.replace_root(cx, |window, cx| {
             telemetry::event!("SSH Project Opened");


### PR DESCRIPTION
Closes #7759

While opening a new SSH project if we are reusing an existing window, i.e. drop the existing workspace and create a new one, then before dropping it, we should remove `session_id` from that workspace's serialized entry. That way:

1. Upon closing (cmd-w) this remote workspace (which also clears `session_id` for this), and then quitting. No workspace with that `session_id` is found, and it starts fresh.
2. Upon directly quitting (cmd-q) this remote workspace, only this workspace exists in db (among two of them) with that `session_id`, and it restores correctly.
 
Release Notes:

- Fixed an issue while closing remote workspace restores last local workspace on startup.
