### PR TITLE
gpui: Allow Animation to be cloned

### DIFF
--- a/crates/gpui/src/elements/animation.rs
+++ b/crates/gpui/src/elements/animation.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    rc::Rc,
+    time::{Duration, Instant},
+};
 
 use crate::{
     AnyElement, App, Element, ElementId, GlobalElementId, InspectorElementId, IntoElement, Window,
@@ -8,6 +11,7 @@ pub use easing::*;
 use smallvec::SmallVec;
 
 /// An animation that can be applied to an element.
+#[derive(Clone)]
 pub struct Animation {
     /// The amount of time for which this animation should run
     pub duration: Duration,
@@ -15,7 +19,7 @@ pub struct Animation {
     pub oneshot: bool,
     /// A function that takes a delta between 0 and 1 and returns a new delta
     /// between 0 and 1 based on the given easing function.
-    pub easing: Box<dyn Fn(f32) -> f32>,
+    pub easing: Rc<dyn Fn(f32) -> f32>,
 }
 
 impl Animation {
@@ -25,7 +29,7 @@ impl Animation {
         Self {
             duration,
             oneshot: true,
-            easing: Box::new(linear),
+            easing: Rc::new(linear),
         }
     }
 
@@ -39,7 +43,7 @@ impl Animation {
     /// The easing function will take a time delta between 0 and 1 and return a new delta
     /// between 0 and 1
     pub fn with_easing(mut self, easing: impl Fn(f32) -> f32 + 'static) -> Self {
-        self.easing = Box::new(easing);
+        self.easing = Rc::new(easing);
         self
     }
 }


### PR DESCRIPTION
Release Notes:

- N/A

---

Let `Animation` able to clone, then we can define one to share for multiple places. 

For example:

<img width="914" height="637" alt="image" src="https://github.com/user-attachments/assets/8eafb318-afba-4399-a975-d83cb7afe74c" />
