### PR TITLE
sum_tree: Utilize `size_hint` in `TreeSet::extend`

### DIFF
--- a/crates/sum_tree/src/tree_map.rs
+++ b/crates/sum_tree/src/tree_map.rs
@@ -71,10 +71,10 @@ impl<K: Clone + Ord, V: Clone> TreeMap<K, V> {
     }
 
     pub fn extend(&mut self, iter: impl IntoIterator<Item = (K, V)>) {
-        let mut edits = Vec::new();
-        for (key, value) in iter {
-            edits.push(Edit::Insert(MapEntry { key, value }));
-        }
+        let edits: Vec<_> = iter
+            .into_iter()
+            .map(|(key, value)| Edit::Insert(MapEntry { key, value }))
+            .collect();
         self.0.edit(edits, &());
     }
 


### PR DESCRIPTION
Collect the iterator instead of manually looping over it to utilize possible size hints. Zed usually passes in owned `Vec`'s, meaning we get to reuse memory as well.

Release Notes:

- N/A
