### PR TITLE
Ensure `disable_ai` is properly respected

### DIFF
--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::ops::Range;
+use std::ops::{Not, Range};
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
@@ -1666,10 +1666,7 @@ impl Panel for AgentPanel {
     }
 
     fn icon(&self, _window: &Window, cx: &App) -> Option<IconName> {
-        (self.enabled(cx)
-            && AgentSettings::get_global(cx).button
-            && !DisableAiSettings::get_global(cx).disable_ai)
-            .then_some(IconName::ZedAssistant)
+        (self.enabled(cx) && AgentSettings::get_global(cx).button).then_some(IconName::ZedAssistant)
     }
 
     fn icon_tooltip(&self, _window: &Window, _cx: &App) -> Option<&'static str> {
@@ -1685,7 +1682,7 @@ impl Panel for AgentPanel {
     }
 
     fn enabled(&self, cx: &App) -> bool {
-        AgentSettings::get_global(cx).enabled
+        DisableAiSettings::get_global(cx).disable_ai.not() && AgentSettings::get_global(cx).enabled
     }
 
     fn is_zoomed(&self, _window: &Window, _cx: &App) -> bool {

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -374,12 +374,6 @@ impl Dock {
             })
     }
 
-    pub fn first_enabled_panel_idx_excluding(&self, exclude_name: &str, cx: &App) -> Option<usize> {
-        self.panel_entries.iter().position(|entry| {
-            entry.panel.persistent_name() != exclude_name && entry.panel.enabled(cx)
-        })
-    }
-
     fn active_panel_entry(&self) -> Option<&PanelEntry> {
         self.active_panel_index
             .and_then(|index| self.panel_entries.get(index))


### PR DESCRIPTION
Quick follow up to #34896 which ensures that the Agent Panel cannot be caught by actions like `workspace: toggle left dock` when `disable_ai` is set to true.

Also removes a method that was introduced but unused in the workspace because `first_enabled_panel_idx` already covers all cases this method could be useful for.

Release Notes:

- N/A
