### PR TITLE
livekit_client: Revert a change that broke MinGW builds

### DIFF
--- a/crates/livekit_client/src/lib.rs
+++ b/crates/livekit_client/src/lib.rs
@@ -3,16 +3,41 @@ use collections::HashMap;
 mod remote_video_track_view;
 pub use remote_video_track_view::{RemoteVideoTrackView, RemoteVideoTrackViewEvent};
 
-#[cfg(not(any(test, feature = "test-support", target_os = "freebsd")))]
+#[cfg(not(any(
+    test,
+    feature = "test-support",
+    all(target_os = "windows", target_env = "gnu"),
+    target_os = "freebsd"
+)))]
 mod livekit_client;
-#[cfg(not(any(test, feature = "test-support", target_os = "freebsd")))]
+#[cfg(not(any(
+    test,
+    feature = "test-support",
+    all(target_os = "windows", target_env = "gnu"),
+    target_os = "freebsd"
+)))]
 pub use livekit_client::*;
 
-#[cfg(any(test, feature = "test-support", target_os = "freebsd"))]
+#[cfg(any(
+    test,
+    feature = "test-support",
+    all(target_os = "windows", target_env = "gnu"),
+    target_os = "freebsd"
+))]
 mod mock_client;
-#[cfg(any(test, feature = "test-support", target_os = "freebsd"))]
+#[cfg(any(
+    test,
+    feature = "test-support",
+    all(target_os = "windows", target_env = "gnu"),
+    target_os = "freebsd"
+))]
 pub mod test;
-#[cfg(any(test, feature = "test-support", target_os = "freebsd"))]
+#[cfg(any(
+    test,
+    feature = "test-support",
+    all(target_os = "windows", target_env = "gnu"),
+    target_os = "freebsd"
+))]
 pub use mock_client::*;
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
the change was made in https://github.com/zed-industries/zed/pull/34223 for unknown reason. it wasn't required actually, and the code can be safely left as before

update: after this revert Zed compiles with MinGW as before

Release Notes:

- N/A
