### PR TITLE
editor: Fix move line up panic when selection is at end of line next to fold marker 

### DIFF
--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -145,7 +145,6 @@ impl FoldMapWriter<'_> {
         let snapshot = self.0.snapshot.inlay_snapshot.clone();
         for (range, fold_text) in ranges.into_iter() {
             let buffer = &snapshot.buffer;
-
             let range = range.start.to_offset(buffer)..range.end.to_offset(buffer);
 
             // Ignore any empty ranges.

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -146,8 +146,6 @@ impl FoldMapWriter<'_> {
         for (range, fold_text) in ranges.into_iter() {
             let buffer = &snapshot.buffer;
 
-            dbg!(&range.start, &range.end);
-
             let range = range.start.to_offset(buffer)..range.end.to_offset(buffer);
 
             // Ignore any empty ranges.

--- a/crates/editor/src/display_map/fold_map.rs
+++ b/crates/editor/src/display_map/fold_map.rs
@@ -145,6 +145,9 @@ impl FoldMapWriter<'_> {
         let snapshot = self.0.snapshot.inlay_snapshot.clone();
         for (range, fold_text) in ranges.into_iter() {
             let buffer = &snapshot.buffer;
+
+            dbg!(&range.start, &range.end);
+
             let range = range.start.to_offset(buffer)..range.end.to_offset(buffer);
 
             // Ignore any empty ranges.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -11373,7 +11373,6 @@ impl Editor {
         let mut refold_creases = Vec::new();
 
         let selections = self.selections.all::<Point>(cx);
-
         let mut selections = selections.iter().peekable();
         let mut contiguous_row_selections = Vec::new();
         let mut new_selections = Vec::new();

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2969,6 +2969,8 @@ impl Editor {
             .invalidate(&self.selections.disjoint_anchors(), buffer);
         self.take_rename(false, window, cx);
 
+        dbg!(self.selections.all::<Point>(cx));
+
         let newest_selection = self.selections.newest_anchor();
         let new_cursor_position = newest_selection.head();
         let selection_start = newest_selection.start;
@@ -11373,6 +11375,9 @@ impl Editor {
         let mut refold_creases = Vec::new();
 
         let selections = self.selections.all::<Point>(cx);
+
+        dbg!(&selections);
+
         let mut selections = selections.iter().peekable();
         let mut contiguous_row_selections = Vec::new();
         let mut new_selections = Vec::new();
@@ -11451,12 +11456,15 @@ impl Editor {
         }
 
         self.transact(window, cx, |this, window, cx| {
+            dbg!(&unfold_ranges);
             this.unfold_ranges(&unfold_ranges, true, true, cx);
+            dbg!(&edits);
             this.buffer.update(cx, |buffer, cx| {
                 for (range, text) in edits {
                     buffer.edit([(range, text)], None, cx);
                 }
             });
+            dbg!(&refold_creases);
             this.fold_creases(refold_creases, true, window, cx);
             this.change_selections(Default::default(), window, cx, |s| {
                 s.select(new_selections);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5072,9 +5072,6 @@ fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
         let buffer = MultiBuffer::build_simple(text, cx);
         build_editor(buffer, window, cx)
     });
-    // 6 class A:
-    // 7     def __init__():
-    // 8         print(\"init\")
     _ = editor.update(cx, |editor, window, cx| {
         editor.fold_creases(
             vec![
@@ -5094,10 +5091,10 @@ fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
         assert_eq!(editor.display_text(cx), "\n\n\n\n\n\nclass A:⋯\n");
         editor.move_line_up(&MoveLineUp, window, cx);
         let buffer_text = editor.buffer.read(cx).snapshot(cx).text();
-        // assert_eq!(
-        //     buffer_text,
-        //     "\n\n\n\n\n\n        print(\"init\")\nclass A:\n    def __init__():\n"
-        // );
+        assert_eq!(
+            buffer_text,
+            "\n\n\n\n\nclass A:\n    def __init__():\n        print(\"init\")\n\n"
+        );
     });
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5072,8 +5072,10 @@ fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
         let buffer = MultiBuffer::build_simple(text, cx);
         build_editor(buffer, window, cx)
     });
+    // 6 class A:
+    // 7     def __init__():
+    // 8         print(\"init\")
     _ = editor.update(cx, |editor, window, cx| {
-        println!("before fold");
         editor.fold_creases(
             vec![
                 Crease::simple(Point::new(6, 8)..Point::new(8, 21), FoldPlaceholder::test()),
@@ -5086,14 +5088,16 @@ fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
             window,
             cx,
         );
-        println!("after fold");
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
             s.select_ranges([Point::new(8, 21)..Point::new(8, 21)])
         });
-        println!("after selection");
-        dbg!(&editor.selections.all::<Point>(cx));
         assert_eq!(editor.display_text(cx), "\n\n\n\n\n\nclass A:⋯\n");
         editor.move_line_up(&MoveLineUp, window, cx);
+        let buffer_text = editor.buffer.read(cx).snapshot(cx).text();
+        // assert_eq!(
+        //     buffer_text,
+        //     "\n\n\n\n\n\n        print(\"init\")\nclass A:\n    def __init__():\n"
+        // );
     });
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5065,36 +5065,29 @@ fn test_move_line_up_down(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
+fn test_move_line_up_selection_at_end_of_fold(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
     let editor = cx.add_window(|window, cx| {
-        let text = "\n\n\n\n\n\nclass A:\n    def __init__():\n        print(\"init\")\n";
-        let buffer = MultiBuffer::build_simple(text, cx);
+        let buffer = MultiBuffer::build_simple("\n\n\n\n\n\naaaa\nbbbb\ncccc", cx);
         build_editor(buffer, window, cx)
     });
     _ = editor.update(cx, |editor, window, cx| {
         editor.fold_creases(
-            vec![
-                Crease::simple(Point::new(6, 8)..Point::new(8, 21), FoldPlaceholder::test()),
-                Crease::simple(
-                    Point::new(7, 15)..Point::new(8, 21),
-                    FoldPlaceholder::test(),
-                ),
-            ],
+            vec![Crease::simple(
+                Point::new(6, 4)..Point::new(7, 4),
+                FoldPlaceholder::test(),
+            )],
             true,
             window,
             cx,
         );
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
-            s.select_ranges([Point::new(8, 21)..Point::new(8, 21)])
+            s.select_ranges([Point::new(7, 4)..Point::new(7, 4)])
         });
-        assert_eq!(editor.display_text(cx), "\n\n\n\n\n\nclass A:⋯\n");
+        assert_eq!(editor.display_text(cx), "\n\n\n\n\n\naaaa⋯\ncccc");
         editor.move_line_up(&MoveLineUp, window, cx);
         let buffer_text = editor.buffer.read(cx).snapshot(cx).text();
-        assert_eq!(
-            buffer_text,
-            "\n\n\n\n\nclass A:\n    def __init__():\n        print(\"init\")\n\n"
-        );
+        assert_eq!(buffer_text, "\n\n\n\n\naaaa\nbbbb\n\ncccc");
     });
 }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5065,6 +5065,48 @@ fn test_move_line_up_down(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+    let editor = cx.add_window(|window, cx| {
+        let text = "\n\n\n\n\n\nclass A:\n    def __init__():\n        print(\"init\")\n";
+        let buffer = MultiBuffer::build_simple(text, cx);
+        build_editor(buffer, window, cx)
+    });
+    _ = editor.update(cx, |editor, window, cx| {
+        editor.fold_creases(
+            vec![
+                Crease::simple(Point::new(6, 8)..Point::new(9, 0), FoldPlaceholder::test()),
+                Crease::simple(Point::new(7, 15)..Point::new(9, 0), FoldPlaceholder::test()),
+            ],
+            true,
+            window,
+            cx,
+        );
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_ranges([Point::new(8, 21)..Point::new(8, 21)])
+        });
+        assert_eq!(editor.display_text(cx), "\n\n\n\n\n\nclass A:⋯");
+
+        // // Test move_line_up - should move the folded class up one line
+        // editor.move_line_up(&MoveLineUp, window, cx);
+
+        // // Verify the folded class moved up and folds are preserved
+        // assert_eq!(
+        //     editor.display_text(cx),
+        //     "\n\n\n\n\nclass A:⋯\n"
+        // );
+
+        // // Verify cursor position adjusted correctly
+        // assert_eq!(
+        //     editor.selections.display_ranges(cx),
+        //     vec![
+        //         DisplayPoint::new(DisplayRow(5), 21)..DisplayPoint::new(DisplayRow(5), 21),
+        //     ]
+        // );
+    });
+}
+
+#[gpui::test]
 fn test_move_line_up_down_with_blocks(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -5073,36 +5073,27 @@ fn test_move_line_up_with_nested_folds(cx: &mut TestAppContext) {
         build_editor(buffer, window, cx)
     });
     _ = editor.update(cx, |editor, window, cx| {
+        println!("before fold");
         editor.fold_creases(
             vec![
-                Crease::simple(Point::new(6, 8)..Point::new(9, 0), FoldPlaceholder::test()),
-                Crease::simple(Point::new(7, 15)..Point::new(9, 0), FoldPlaceholder::test()),
+                Crease::simple(Point::new(6, 8)..Point::new(8, 21), FoldPlaceholder::test()),
+                Crease::simple(
+                    Point::new(7, 15)..Point::new(8, 21),
+                    FoldPlaceholder::test(),
+                ),
             ],
             true,
             window,
             cx,
         );
+        println!("after fold");
         editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
             s.select_ranges([Point::new(8, 21)..Point::new(8, 21)])
         });
-        assert_eq!(editor.display_text(cx), "\n\n\n\n\n\nclass A:⋯");
-
-        // // Test move_line_up - should move the folded class up one line
-        // editor.move_line_up(&MoveLineUp, window, cx);
-
-        // // Verify the folded class moved up and folds are preserved
-        // assert_eq!(
-        //     editor.display_text(cx),
-        //     "\n\n\n\n\nclass A:⋯\n"
-        // );
-
-        // // Verify cursor position adjusted correctly
-        // assert_eq!(
-        //     editor.selections.display_ranges(cx),
-        //     vec![
-        //         DisplayPoint::new(DisplayRow(5), 21)..DisplayPoint::new(DisplayRow(5), 21),
-        //     ]
-        // );
+        println!("after selection");
+        dbg!(&editor.selections.all::<Point>(cx));
+        assert_eq!(editor.display_text(cx), "\n\n\n\n\n\nclass A:⋯\n");
+        editor.move_line_up(&MoveLineUp, window, cx);
     });
 }
 


### PR DESCRIPTION
Closes #34826

In move line up method, make use of `prev_line_boundary` which accounts for fold map, etc., for selection start row so that we don't incorrectly calculate row range to move up.

Release Notes:

- Fixed an issue where `editor: move line up` action sometimes crashed if the cursor was at the end of a line beside a fold marker.
