### PR TITLE
project_panel: Automatically open project panel when Rename or Duplicate is triggered from workspace

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -322,6 +322,7 @@ pub fn init(cx: &mut App) {
         });
 
         workspace.register_action(|workspace, action: &Rename, window, cx| {
+            workspace.open_panel::<ProjectPanel>(window, cx);
             if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
                 panel.update(cx, |panel, cx| {
                     if let Some(first_marked) = panel.marked_entries.first() {
@@ -335,6 +336,7 @@ pub fn init(cx: &mut App) {
         });
 
         workspace.register_action(|workspace, action: &Duplicate, window, cx| {
+            workspace.open_panel::<ProjectPanel>(window, cx);
             if let Some(panel) = workspace.panel::<ProjectPanel>(cx) {
                 panel.update(cx, |panel, cx| {
                     panel.duplicate(action, window, cx);


### PR DESCRIPTION
In project panel, `rename` and `duplicate` action further needs user input for editing, so if panel is closed we should open it. Thanks @JosephTLyons for catching this.

Release Notes:

- Fixed project panel not opening when `project panel: rename` and `project panel: duplicate` actions are triggered from workspace.
