### PR TITLE
debugger: Fix Go debugger on Windows

### DIFF
--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -411,12 +411,12 @@ impl DebugAdapter for GoDebugAdapter {
         user_args: Option<Vec<String>>,
         _cx: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
-        let dlv_binary_name = if cfg!(windows) { "dlv.exe" } else { "dlv" };
+        let dlv_binary_name = format!("dlv{}", std::env::consts::EXE_SUFFIX);
         let adapter_path = paths::debug_adapters_dir().join(&Self::ADAPTER_NAME);
-        let dlv_path_in_adapter_dir = adapter_path.join(dlv_binary_name);
+        let dlv_path_in_adapter_dir = adapter_path.join(&dlv_binary_name);
         let delve_path = if let Some(path) = user_installed_path {
             path.to_string_lossy().to_string()
-        } else if let Some(path) = delegate.which(OsStr::new(dlv_binary_name)).await {
+        } else if let Some(path) = delegate.which(OsStr::new(&dlv_binary_name)).await {
             path.to_string_lossy().to_string()
         } else if delegate.fs().is_file(&dlv_path_in_adapter_dir).await {
             dlv_path_in_adapter_dir.to_string_lossy().to_string()

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -411,15 +411,15 @@ impl DebugAdapter for GoDebugAdapter {
         user_args: Option<Vec<String>>,
         _cx: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
+        let dlv_binary_name = if cfg!(windows) { "dlv.exe" } else { "dlv" };
         let adapter_path = paths::debug_adapters_dir().join(&Self::ADAPTER_NAME);
-        let dlv_path = adapter_path.join("dlv");
-
+        let dlv_path_in_adapter_dir = adapter_path.join(dlv_binary_name);
         let delve_path = if let Some(path) = user_installed_path {
             path.to_string_lossy().to_string()
-        } else if let Some(path) = delegate.which(OsStr::new("dlv")).await {
+        } else if let Some(path) = delegate.which(OsStr::new(dlv_binary_name)).await {
             path.to_string_lossy().to_string()
-        } else if delegate.fs().is_file(&dlv_path).await {
-            dlv_path.to_string_lossy().to_string()
+        } else if delegate.fs().is_file(&dlv_path_in_adapter_dir).await {
+            dlv_path_in_adapter_dir.to_string_lossy().to_string()
         } else {
             let go = delegate
                 .which(OsStr::new("go"))
@@ -443,7 +443,7 @@ impl DebugAdapter for GoDebugAdapter {
                 );
             }
 
-            adapter_path.join("dlv").to_string_lossy().to_string()
+            dlv_path_in_adapter_dir.to_string_lossy().to_string()
         };
 
         let cwd = Some(

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -929,9 +929,6 @@ impl dap::adapters::DapDelegate for DapAdapterDelegate {
 
     #[cfg(target_os = "windows")]
     async fn which(&self, command: &OsStr) -> Option<PathBuf> {
-        // todo(windows) Getting the shell env variables in a current directory on Windows is more complicated than other platforms
-        //               there isn't a 'default shell' necessarily. The closest would be the default profile on the windows terminal
-        //               SEE: https://learn.microsoft.com/en-us/windows/terminal/customize-settings/startup
         which::which(command).ok()
     }
 

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -920,10 +920,19 @@ impl dap::adapters::DapDelegate for DapAdapterDelegate {
         self.console.unbounded_send(msg).ok();
     }
 
+    #[cfg(not(target_os = "windows"))]
     async fn which(&self, command: &OsStr) -> Option<PathBuf> {
         let worktree_abs_path = self.worktree.abs_path();
         let shell_path = self.shell_env().await.get("PATH").cloned();
         which::which_in(command, shell_path.as_ref(), worktree_abs_path).ok()
+    }
+
+    #[cfg(target_os = "windows")]
+    async fn which(&self, command: &OsStr) -> Option<PathBuf> {
+        // todo(windows) Getting the shell env variables in a current directory on Windows is more complicated than other platforms
+        //               there isn't a 'default shell' necessarily. The closest would be the default profile on the windows terminal
+        //               SEE: https://learn.microsoft.com/en-us/windows/terminal/customize-settings/startup
+        which::which(command).ok()
     }
 
     async fn shell_env(&self) -> HashMap<String, String> {


### PR DESCRIPTION
This commit addresses an issue where the Go debugger (delve or go) could not be found on Windows.

The `which` function, used to locate executables, was not working correctly on Windows because it was trying to use a Unix-like shell environment to find the `dlv` or `go` executable. This commit provides a Windows-specific implementation of `which` that correctly searches the system's PATH.

Additionally, the error message for failing to spawn a debug adapter process has been improved to include more context.

before:
<img width="2229" height="1515" alt="PixPin_2025-07-24_10-39-24" src="https://github.com/user-attachments/assets/5dcd404c-3e58-48b4-8e09-74876dbe16e5" />
after:
<img width="2560" height="1536" alt="PixPin_2025-07-24_10-40-15" src="https://github.com/user-attachments/assets/ba90b010-a3e0-43ef-8deb-cca20367d899" />

everything is ok for go on windows!!!

Release Notes:

- fix  where the Go debugger (delve or go) could not be found on Windows. ...
