### PR TITLE
Fix some bugs with `editor: diff clipboard with selection`

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -16864,7 +16864,7 @@ async fn test_multibuffer_reverts(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-async fn test_mutlibuffer_in_navigation_history(cx: &mut TestAppContext) {
+async fn test_multibuffer_in_navigation_history(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 
     let cols = 4;

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -552,7 +552,7 @@ mod tests {
                 "
                 - a
                 + ˇ    bb",
-                // TODO: `+ ˇbb",` is correct, by this is a byproduct have
+                // TODO: should be `+ ˇbb",`, but this is a byproduct of
                 // having to expand the selection to the beginning of the line
                 // in order to avoid the diff view from misbehaving and
                 // incorrectly displaying diffs in worse ways (dropping deleted

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -438,7 +438,6 @@ mod tests {
     use super::*;
     use editor::test::editor_test_context::assert_state_with_diff;
     use gpui::{TestAppContext, VisualContext};
-
     use project::{FakeFs, Project};
     use serde_json::json;
     use settings::{Settings, SettingsStore};


### PR DESCRIPTION
Improves testing around `editor: diff clipboard with selection` as well.

Release Notes:

- Fixed some bugs with `editor: diff clipboard with selection`
