### PR TITLE
Fix environment loading with nushell

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -18,10 +18,13 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
     // In some shells, file descriptors greater than 2 cannot be used in interactive mode,
     // so file descriptor 0 (stdin) is used instead. This impacts zsh, old bash; perhaps others.
     // See: https://github.com/zed-industries/zed/pull/32136#issuecomment-2999645482
-    const ENV_OUTPUT_FD: std::os::fd::RawFd = 0;
-    let redir = match shell_name {
-        Some("rc") => format!(">[1={}]", ENV_OUTPUT_FD), // `[1=0]`
-        _ => format!(">&{}", ENV_OUTPUT_FD),             // `>&0`
+    const FD_STDIN: std::os::fd::RawFd = 0;
+    const FD_STDOUT: std::os::fd::RawFd = 1;
+
+    let (fd_num, redir) = match shell_name {
+        Some("rc") => (FD_STDIN, format!(">[1={}]", FD_STDIN)), // `[1=0]`
+        Some("nu") => (FD_STDOUT, "".to_string()),
+        _ => (FD_STDIN, format!(">&{}", FD_STDIN)), // `>&0`
     };
     command.stdin(Stdio::null());
     command.stdout(Stdio::piped());
@@ -48,7 +51,7 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
 
     super::set_pre_exec_to_start_new_session(&mut command);
 
-    let (env_output, process_output) = spawn_and_read_fd(command, ENV_OUTPUT_FD)?;
+    let (env_output, process_output) = spawn_and_read_fd(command, fd_num)?;
     let env_output = String::from_utf8_lossy(&env_output);
 
     anyhow::ensure!(


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/34739

I believe this is a regression introduced here:
- https://github.com/zed-industries/zed/pull/33599

Release Notes:

- Fixed a regression with loading environment variables in nushell