### PR TITLE
dock: Add divider between panels on the right side, too

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -934,6 +934,10 @@ impl Render for PanelButtons {
 
         h_flex()
             .gap_1()
+            .when(
+                has_buttons && dock.position == DockPosition::Bottom,
+                |this| this.child(Divider::vertical().color(DividerColor::Border)),
+            )
             .children(buttons)
             .when(has_buttons && dock.position == DockPosition::Left, |this| {
                 this.child(Divider::vertical().color(DividerColor::Border))


### PR DESCRIPTION
A while ago, we added a divider in the left side of the status bar between the icon buttons that open panels vs. those that open something else (tabs, popover menus, etc.). There isn't a super good reason why we wouldn't do the same in the right side, even more so given that (at least by default) we usually have more buttons on that side; buttons that _don't_ open panels (regardless of being docked to the bottom or right). So, this PR does this!

<img width="700" height="314" alt="CleanShot 2025-07-24 at 1  59 10@2x" src="https://github.com/user-attachments/assets/5f8bd4bc-a983-4000-a8f9-05a36b9e4b81" />

Release Notes:

- N/A
