### PR TITLE
terminal_view: Ensure breadcrumbs are updated on settings change

### DIFF
--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -430,6 +430,7 @@ impl TerminalView {
 
     fn settings_changed(&mut self, cx: &mut Context<Self>) {
         let settings = TerminalSettings::get_global(cx);
+        let breadcrumb_visibility_changed = self.show_breadcrumbs != settings.toolbar.breadcrumbs;
         self.show_breadcrumbs = settings.toolbar.breadcrumbs;
 
         let new_cursor_shape = settings.cursor_shape.unwrap_or_default();
@@ -441,6 +442,9 @@ impl TerminalView {
             });
         }
 
+        if breadcrumb_visibility_changed {
+            cx.emit(ItemEvent::UpdateBreadcrumbs);
+        }
         cx.notify();
     }
 


### PR DESCRIPTION
Currently, terminal breadcrumbs are only updated after a settings change once the terminal view is focused again. This change ensures that the breadcrumbs are updated instantaneously once the breadcrumb settings changes.

Release Notes:

- Fixed an issue where terminal breadcrumbs would not react instantly to settings changes.
