### PR TITLE
sum_tree: Remove Unit type

### DIFF
--- a/crates/sum_tree/src/sum_tree.rs
+++ b/crates/sum_tree/src/sum_tree.rs
@@ -41,16 +41,14 @@ pub trait Summary: Clone {
     fn add_summary(&mut self, summary: &Self, cx: &Self::Context);
 }
 
-/// This type exists because we can't implement Summary for () without causing
-/// type resolution errors
-#[derive(Copy, Clone, PartialEq, Eq, Debug)]
-pub struct Unit;
-
-impl Summary for Unit {
+/// Catch-all implementation for when you need something that implements [`Summary`] without a specific type.
+/// We implement it on a &'static, as that avoids blanket impl collisions with `impl<T: Summary> Dimension for T`
+/// (as we also need unit type to be a fill-in dimension)
+impl Summary for &'static () {
     type Context = ();
 
     fn zero(_: &()) -> Self {
-        Unit
+        &()
     }
 
     fn add_summary(&mut self, _: &Self, _: &()) {}

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -62,7 +62,7 @@ use std::{
     },
     time::{Duration, Instant},
 };
-use sum_tree::{Bias, Edit, KeyedItem, SeekTarget, SumTree, Summary, TreeMap, TreeSet, Unit};
+use sum_tree::{Bias, Edit, KeyedItem, SeekTarget, SumTree, Summary, TreeMap, TreeSet};
 use text::{LineEnding, Rope};
 use util::{
     ResultExt,
@@ -407,12 +407,12 @@ struct LocalRepositoryEntry {
 }
 
 impl sum_tree::Item for LocalRepositoryEntry {
-    type Summary = PathSummary<Unit>;
+    type Summary = PathSummary<&'static ()>;
 
     fn summary(&self, _: &<Self::Summary as Summary>::Context) -> Self::Summary {
         PathSummary {
             max_path: self.work_directory.path_key().0,
-            item_summary: Unit,
+            item_summary: &(),
         }
     }
 }
@@ -424,12 +424,6 @@ impl KeyedItem for LocalRepositoryEntry {
         self.work_directory.path_key()
     }
 }
-
-//impl LocalRepositoryEntry {
-//    pub fn repo(&self) -> &Arc<dyn GitRepository> {
-//        &self.repo_ptr
-//    }
-//}
 
 impl Deref for LocalRepositoryEntry {
     type Target = WorkDirectory;
@@ -5417,7 +5411,7 @@ impl<'a> SeekTarget<'a, EntrySummary, TraversalProgress<'a>> for TraversalTarget
     }
 }
 
-impl<'a> SeekTarget<'a, PathSummary<Unit>, TraversalProgress<'a>> for TraversalTarget<'_> {
+impl<'a> SeekTarget<'a, PathSummary<&'static ()>, TraversalProgress<'a>> for TraversalTarget<'_> {
     fn cmp(&self, cursor_location: &TraversalProgress<'a>, _: &()) -> Ordering {
         self.cmp_progress(cursor_location)
     }


### PR DESCRIPTION
This solves one ~TODO, as Unit type was a workaround for a lack of ability to implement Summary for ().


Release Notes:

- N/A
