### PR TITLE
linux: Fix `ctrl-0..9`, `ctrl-[`, `ctrl-^`

### DIFF
--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -845,9 +845,15 @@ impl crate::Keystroke {
                 {
                     if key.is_ascii_graphic() {
                         key_utf8.to_lowercase()
-                    // map ctrl-a to a
-                    } else if key_utf32 <= 0x1f {
-                        ((key_utf32 as u8 + 0x60) as char).to_string()
+                    // map ctrl-a to `a`
+                    // ctrl-0..9 may emit control codes like ctrl-[, but
+                    // we don't want to map them to `[`
+                    } else if key_utf32 <= 0x1f
+                        && !name.chars().next().is_some_and(|c| c.is_ascii_digit())
+                    {
+                        ((key_utf32 as u8 + 0x40) as char)
+                            .to_ascii_lowercase()
+                            .to_string()
                     } else {
                         name
                     }


### PR DESCRIPTION
There were two different underlying reasons for the issues with ctrl-number and ctrl-punctuation:

1. Some keys in the ctrl-0..9 range send codes in the `\1b`..`\1f` range. For example, `ctrl-2` sends keycode for `ctrl-[` (0x1b), but we want to map it to `2`, not to `[`.

2. `ctrl-[` and four other ctrl-punctuation were incorrectly mapped, since the expected conversion is by adding 0x40

Closes #35012

Release Notes:

- N/A
