### PR TITLE
Shutdown language servers better

### DIFF
--- a/crates/prettier/src/prettier_server.js
+++ b/crates/prettier/src/prettier_server.js
@@ -152,6 +152,10 @@ async function handleMessage(message, prettier) {
     throw new Error(`Message method is undefined: ${JSON.stringify(message)}`);
   } else if (method == "initialized") {
     return;
+  } else if (method === "shutdown") {
+    sendResponse({ result: {} });
+  } else if (method == "exit") {
+    process.exit(0);
   }
 
   if (id === undefined) {


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/33417

* adjust prettier mock LSP to handle `shutdown` and `exit` messages
* removed another `?.log_err()` backtrace from logs and improved the logging info
* always handle the last parts of the shutdown logic even if the shutdown response had failed

Release Notes:

- N/A
