### PR TITLE
worktree: Improve performance with large # of repositories

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1082,7 +1082,7 @@ impl GitStore {
         };
 
         match event {
-            WorktreeStoreEvent::WorktreeUpdatedEntries(worktree_id, updated_entries) => {
+            WorktreeStoreEvent::WorktreeUpdatedEntries(_, updated_entries) => {
                 let paths_by_git_repo =
                     self.process_updated_entries(updated_entries, cx);
                 for (repo, paths) in paths_by_git_repo {
@@ -2189,8 +2189,8 @@ impl GitStore {
         cx: &mut Context<Self>,
     ) -> HashMap<Entity<Repository>, Vec<RepoPath>> {
         let mut paths_by_git_repo = HashMap::<_, Vec<_>>::default();
-        let mut updated_copy: Vec<_> = updated_entries.as_ref().to_vec();
-        updated_copy.sort_by(|lhs, rhs| lhs.0.cmp(&rhs.0));
+        let mut updated_copy: Vec<_> = updated_entries.iter().map(|(path, _, _)| path.clone()).collect();
+        updated_copy.sort_by(|lhs, rhs| lhs.cmp(&rhs));
 
         let mut path_was_used = vec![false; updated_copy.len()];
         let mut repo_paths = self
@@ -2200,24 +2200,25 @@ impl GitStore {
             .collect::<Vec<_>>();
         repo_paths.sort_by(|lhs, rhs| rhs.0.cmp(&lhs.0));
 
+
         for (repo_path, repo) in repo_paths {
             // Find all repository paths that belong to this repo
             let mut ix =
-                updated_copy.partition_point(|(path, _, _)| path.starts_with(repo_path.as_ref()));
+                updated_copy.partition_point(|path| path.starts_with(repo_path.as_ref()));
             if ix == updated_copy.len() {
                 continue;
-            }
-            let mut paths = paths_by_git_repo
-                .entry(repo.clone()).or_default();
-            while let Some((path, _, _)) = updated_copy.get(ix) && path_was_used[ix] == false
-                && let Some(repo_path) = repo.read(cx).abs_path_to_repo_path(&path)
+            };
+            let paths = paths_by_git_repo
+                .entry(repo).or_default();
+            while let Some(path) = updated_copy.get(ix) && path_was_used[ix] == false
+                && let Some(repo_path) = RepositorySnapshot::abs_path_to_repo_path_inner(&repo_path, &path)
             {
                 ix += 1;
                 path_was_used[ix] = true;
                 paths
                     .push(repo_path);
             }
-        }
+                                }
         paths_by_git_repo
     }
 }
@@ -2689,11 +2690,17 @@ impl RepositorySnapshot {
     }
 
     pub fn abs_path_to_repo_path(&self, abs_path: &Path) -> Option<RepoPath> {
+        Self::abs_path_to_repo_path_inner(&self.work_directory_abs_path, abs_path)
+    }
+
+    #[inline]
+    fn abs_path_to_repo_path_inner(work_directory_abs_path: &Path, abs_path: &Path) -> Option<RepoPath> {
         abs_path
-            .strip_prefix(&self.work_directory_abs_path)
+            .strip_prefix(&work_directory_abs_path)
             .map(RepoPath::from)
             .ok()
     }
+
 
     pub fn had_conflict_on_last_merge_head_change(&self, repo_path: &RepoPath) -> bool {
         self.merge.conflicted_paths.contains(&repo_path)

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1094,7 +1094,6 @@ impl GitStore {
                         .as_ref()
                         .map(|downstream| downstream.updates_tx.clone());
                     cx.spawn(async move |_, cx| {
-                        let c = std::time::Instant::now();
                         let paths_by_git_repo = paths_by_git_repo.await;
                         for (repo, paths) in paths_by_git_repo {
                             repo.update(cx, |repo, cx| {
@@ -1102,7 +1101,6 @@ impl GitStore {
                             })
                             .ok();
                         }
-                        dbg!(c.elapsed());
                     })
                     .detach();
                 }

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -33,8 +33,8 @@ use git::{
     },
 };
 use gpui::{
-    App, AppContext, AsyncApp, Context, Entity, EventEmitter, Scope, SharedString, Subscription,
-    Task, WeakEntity,
+    App, AppContext, AsyncApp, Context, Entity, EventEmitter, SharedString, Subscription, Task,
+    WeakEntity,
 };
 use language::{
     Buffer, BufferEvent, Language, LanguageRegistry,
@@ -1089,7 +1089,6 @@ impl GitStore {
                     .read(cx)
                     .worktree_for_id(*worktree_id, cx)
                 {
-                    let x = std::time::Instant::now();
                     let paths_by_git_repo =
                         self.process_updated_entries(&worktree, updated_entries, cx);
                     let downstream = downstream


### PR DESCRIPTION
In this PR we've reworked how git status updates are processed. Most notable change is moving the processing into a background thread (and splitting it across multiple background workers). We believe it is safe to do so, as worktree events are not deterministic (fs updates are not guaranteed to come in any order etc), so I've figured that git store should not be overly order-reliant anyways.

Note that this PR does not solve perf issues wholesale - other parts of the system are still slow to process stuff (which I plan to nuke soon).

Related to #34302

Release Notes:

- Improved Zed's performance in projects with large # of repositories
