### PR TITLE
Add commands to select next/previous siblings in the syntax tree

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -643,7 +643,7 @@ actions!(
         /// Selects the next syntax node sibling.
         SelectNextSyntaxNode,
         /// Selects the previous syntax node sibling.
-        SelectPrevSyntaxNode,
+        SelectPreviousSyntaxNode,
         /// Extends selection left.
         SelectLeft,
         /// Selects the current line.

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -640,6 +640,10 @@ actions!(
         SelectEnclosingSymbol,
         /// Selects the next larger syntax node.
         SelectLargerSyntaxNode,
+        /// Selects the next syntax node sibling.
+        SelectNextSyntaxNode,
+        /// Selects the previous syntax node sibling.
+        SelectPrevSyntaxNode,
         /// Extends selection left.
         SelectLeft,
         /// Selects the current line.

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15133,7 +15133,7 @@ impl Editor {
             .map(|selection| {
                 let old_range = selection.start..selection.end;
 
-                if let Some(node) = buffer.syntax_next_sibling(old_range.clone()) {
+                if let Some(node) = buffer.syntax_next_sibling(old_range) {
                     let new_range = node.byte_range();
                     selected_sibling = true;
                     Selection {
@@ -15163,7 +15163,7 @@ impl Editor {
 
     pub fn select_prev_syntax_node(
         &mut self,
-        _: &SelectPrevSyntaxNode,
+        _: &SelectPreviousSyntaxNode,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -15182,7 +15182,7 @@ impl Editor {
             .map(|selection| {
                 let old_range = selection.start..selection.end;
 
-                if let Some(node) = buffer.syntax_prev_sibling(old_range.clone()) {
+                if let Some(node) = buffer.syntax_prev_sibling(old_range) {
                     let new_range = node.byte_range();
                     selected_sibling = true;
                     Selection {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -15112,6 +15112,104 @@ impl Editor {
         });
     }
 
+    pub fn select_next_syntax_node(
+        &mut self,
+        _: &SelectNextSyntaxNode,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let old_selections: Box<[_]> = self.selections.all::<usize>(cx).into();
+        if old_selections.is_empty() {
+            return;
+        }
+
+        self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
+
+        let buffer = self.buffer.read(cx).snapshot(cx);
+        let mut selected_sibling = false;
+
+        let new_selections = old_selections
+            .iter()
+            .map(|selection| {
+                let old_range = selection.start..selection.end;
+
+                if let Some(node) = buffer.syntax_next_sibling(old_range.clone()) {
+                    let new_range = node.byte_range();
+                    selected_sibling = true;
+                    Selection {
+                        id: selection.id,
+                        start: new_range.start,
+                        end: new_range.end,
+                        goal: SelectionGoal::None,
+                        reversed: selection.reversed,
+                    }
+                } else {
+                    selection.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if selected_sibling {
+            self.change_selections(
+                SelectionEffects::scroll(Autoscroll::fit()),
+                window,
+                cx,
+                |s| {
+                    s.select(new_selections);
+                },
+            );
+        }
+    }
+
+    pub fn select_prev_syntax_node(
+        &mut self,
+        _: &SelectPrevSyntaxNode,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let old_selections: Box<[_]> = self.selections.all::<usize>(cx).into();
+        if old_selections.is_empty() {
+            return;
+        }
+
+        self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
+
+        let buffer = self.buffer.read(cx).snapshot(cx);
+        let mut selected_sibling = false;
+
+        let new_selections = old_selections
+            .iter()
+            .map(|selection| {
+                let old_range = selection.start..selection.end;
+
+                if let Some(node) = buffer.syntax_prev_sibling(old_range.clone()) {
+                    let new_range = node.byte_range();
+                    selected_sibling = true;
+                    Selection {
+                        id: selection.id,
+                        start: new_range.start,
+                        end: new_range.end,
+                        goal: SelectionGoal::None,
+                        reversed: selection.reversed,
+                    }
+                } else {
+                    selection.clone()
+                }
+            })
+            .collect::<Vec<_>>();
+
+        if selected_sibling {
+            self.change_selections(
+                SelectionEffects::scroll(Autoscroll::fit()),
+                window,
+                cx,
+                |s| {
+                    s.select(new_selections);
+                },
+            );
+        }
+    }
+
     fn refresh_runnables(&mut self, window: &mut Window, cx: &mut Context<Self>) -> Task<()> {
         if !EditorSettings::get_global(cx).gutter.runnables {
             self.clear_tasks();

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -25252,6 +25252,75 @@ async fn test_non_utf_8_opens(cx: &mut TestAppContext) {
     );
 }
 
+#[gpui::test]
+async fn test_select_next_prev_syntax_node(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let language = Arc::new(Language::new(
+        LanguageConfig::default(),
+        Some(tree_sitter_rust::LANGUAGE.into()),
+    ));
+
+    let text = r#"
+        fn test() {
+            let a = 1;
+            let b = 2;
+            let c = 3;
+        }
+    "#;
+
+    let buffer = cx.new(|cx| Buffer::local(text, cx).with_language(language, cx));
+    let buffer = cx.new(|cx| MultiBuffer::singleton(buffer, cx));
+    let (editor, cx) = cx.add_window_view(|window, cx| build_editor(buffer, window, cx));
+
+    // Wait for parsing to complete
+    editor
+        .condition::<crate::EditorEvent>(cx, |editor, cx| !editor.buffer.read(cx).is_parsing(cx))
+        .await;
+
+    editor.update_in(cx, |editor, window, cx| {
+        // Select "let a = 1;" statement completely
+        editor.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+            s.select_display_ranges([
+                DisplayPoint::new(DisplayRow(2), 12)..DisplayPoint::new(DisplayRow(2), 22)
+            ]);
+        });
+
+        let initial_selection = editor.selections.display_ranges(cx);
+        assert_eq!(initial_selection.len(), 1, "Should have one selection");
+
+        // Test select next sibling - should move to a different statement
+        editor.select_next_syntax_node(&SelectNextSyntaxNode, window, cx);
+        let next_selection = editor.selections.display_ranges(cx);
+
+        // Should have a selection and it should be different from the initial
+        assert_eq!(
+            next_selection.len(),
+            1,
+            "Should have one selection after next"
+        );
+        assert_ne!(
+            next_selection[0], initial_selection[0],
+            "Next sibling selection should be different"
+        );
+
+        // Test select previous sibling - should move to a different statement
+        editor.select_prev_syntax_node(&SelectPrevSyntaxNode, window, cx);
+        let prev_selection = editor.selections.display_ranges(cx);
+
+        // Should have a selection and it should be different from next selection
+        assert_eq!(
+            prev_selection.len(),
+            1,
+            "Should have one selection after prev"
+        );
+        assert_ne!(
+            prev_selection[0], next_selection[0],
+            "Previous sibling selection should be different from next"
+        );
+    });
+}
+
 #[track_caller]
 fn extract_color_inlays(editor: &Editor, cx: &App) -> Vec<Rgba> {
     editor

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -25331,7 +25331,7 @@ async fn test_select_next_prev_syntax_node(cx: &mut TestAppContext) {
         );
 
         // Test select previous sibling navigation
-        editor.select_prev_syntax_node(&SelectPrevSyntaxNode, window, cx);
+        editor.select_prev_syntax_node(&SelectPreviousSyntaxNode, window, cx);
         let prev_selection = editor.selections.display_ranges(cx);
 
         // Should have a selection and it should be different

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -365,9 +365,9 @@ impl EditorElement {
         register_action(editor, window, Editor::toggle_comments);
         register_action(editor, window, Editor::select_larger_syntax_node);
         register_action(editor, window, Editor::select_smaller_syntax_node);
-        register_action(editor, window, Editor::unwrap_syntax_node);
         register_action(editor, window, Editor::select_next_syntax_node);
         register_action(editor, window, Editor::select_prev_syntax_node);
+        register_action(editor, window, Editor::unwrap_syntax_node);
         register_action(editor, window, Editor::select_enclosing_symbol);
         register_action(editor, window, Editor::move_to_enclosing_bracket);
         register_action(editor, window, Editor::undo_selection);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -366,6 +366,8 @@ impl EditorElement {
         register_action(editor, window, Editor::select_larger_syntax_node);
         register_action(editor, window, Editor::select_smaller_syntax_node);
         register_action(editor, window, Editor::unwrap_syntax_node);
+        register_action(editor, window, Editor::select_next_syntax_node);
+        register_action(editor, window, Editor::select_prev_syntax_node);
         register_action(editor, window, Editor::select_enclosing_symbol);
         register_action(editor, window, Editor::move_to_enclosing_bracket);
         register_action(editor, window, Editor::undo_selection);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -3429,46 +3429,66 @@ impl BufferSnapshot {
     }
 
     /// Returns the closest syntax node enclosing the given range.
+    /// Positions a tree cursor at the leaf node that contains or touches the given range.
+    /// This is shared logic used by syntax navigation methods.
+    fn position_cursor_at_range(cursor: &mut tree_sitter::TreeCursor, range: &Range<usize>) {
+        // Descend to the first leaf that touches the start of the range.
+        //
+        // If the range is non-empty and the current node ends exactly at the start,
+        // move to the next sibling to find a node that extends beyond the start.
+        //
+        // If the range is empty and the current node starts after the range position,
+        // move to the previous sibling to find the node that contains the position.
+        while cursor.goto_first_child_for_byte(range.start).is_some() {
+            if !range.is_empty() && cursor.node().end_byte() == range.start {
+                cursor.goto_next_sibling();
+            }
+            if range.is_empty() && cursor.node().start_byte() > range.start {
+                cursor.goto_previous_sibling();
+            }
+        }
+    }
+
+    /// Moves the cursor to find a node that contains the given range.
+    /// Returns true if such a node is found, false otherwise.
+    /// This is shared logic used by syntax navigation methods.
+    fn find_containing_node(
+        cursor: &mut tree_sitter::TreeCursor,
+        range: &Range<usize>,
+        strict: bool,
+    ) -> bool {
+        loop {
+            let node_range = cursor.node().byte_range();
+
+            if node_range.start <= range.start
+                && node_range.end >= range.end
+                && (!strict || node_range.len() > range.len())
+            {
+                return true;
+            }
+            if !cursor.goto_parent() {
+                return false;
+            }
+        }
+    }
+
     pub fn syntax_ancestor<'a, T: ToOffset>(
         &'a self,
         range: Range<T>,
     ) -> Option<tree_sitter::Node<'a>> {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let mut result: Option<tree_sitter::Node<'a>> = None;
-        'outer: for layer in self
+        for layer in self
             .syntax
             .layers_for_range(range.clone(), &self.text, true)
         {
             let mut cursor = layer.node().walk();
 
-            // Descend to the first leaf that touches the start of the range.
-            //
-            // If the range is non-empty and the current node ends exactly at the start,
-            // move to the next sibling to find a node that extends beyond the start.
-            //
-            // If the range is empty and the current node starts after the range position,
-            // move to the previous sibling to find the node that contains the position.
-            while cursor.goto_first_child_for_byte(range.start).is_some() {
-                if !range.is_empty() && cursor.node().end_byte() == range.start {
-                    cursor.goto_next_sibling();
-                }
-                if range.is_empty() && cursor.node().start_byte() > range.start {
-                    cursor.goto_previous_sibling();
-                }
-            }
+            Self::position_cursor_at_range(&mut cursor, &range);
 
             // Ascend to the smallest ancestor that strictly contains the range.
-            loop {
-                let node_range = cursor.node().byte_range();
-                if node_range.start <= range.start
-                    && node_range.end >= range.end
-                    && node_range.len() > range.len()
-                {
-                    break;
-                }
-                if !cursor.goto_parent() {
-                    continue 'outer;
-                }
+            if !Self::find_containing_node(&mut cursor, &range, true) {
+                continue;
             }
 
             let left_node = cursor.node();
@@ -3527,31 +3547,17 @@ impl BufferSnapshot {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let mut result: Option<tree_sitter::Node<'a>> = None;
 
-        'outer: for layer in self
+        for layer in self
             .syntax
             .layers_for_range(range.clone(), &self.text, true)
         {
             let mut cursor = layer.node().walk();
 
-            // Descend to the first leaf that touches the start of the range.
-            while cursor.goto_first_child_for_byte(range.start).is_some() {
-                if !range.is_empty() && cursor.node().end_byte() == range.start {
-                    cursor.goto_next_sibling();
-                }
-                if range.is_empty() && cursor.node().start_byte() > range.start {
-                    cursor.goto_previous_sibling();
-                }
-            }
+            Self::position_cursor_at_range(&mut cursor, &range);
 
             // Find the node that contains the range
-            loop {
-                let node_range = cursor.node().byte_range();
-                if node_range.start <= range.start && node_range.end >= range.end {
-                    break;
-                }
-                if !cursor.goto_parent() {
-                    continue 'outer;
-                }
+            if !Self::find_containing_node(&mut cursor, &range, false) {
+                continue;
             }
 
             // Look for the previous sibling, moving up ancestor levels if needed
@@ -3594,31 +3600,17 @@ impl BufferSnapshot {
         let range = range.start.to_offset(self)..range.end.to_offset(self);
         let mut result: Option<tree_sitter::Node<'a>> = None;
 
-        'outer: for layer in self
+        for layer in self
             .syntax
             .layers_for_range(range.clone(), &self.text, true)
         {
             let mut cursor = layer.node().walk();
 
-            // Descend to the first leaf that touches the start of the range.
-            while cursor.goto_first_child_for_byte(range.start).is_some() {
-                if !range.is_empty() && cursor.node().end_byte() == range.start {
-                    cursor.goto_next_sibling();
-                }
-                if range.is_empty() && cursor.node().start_byte() > range.start {
-                    cursor.goto_previous_sibling();
-                }
-            }
+            Self::position_cursor_at_range(&mut cursor, &range);
 
             // Find the node that contains the range
-            loop {
-                let node_range = cursor.node().byte_range();
-                if node_range.start <= range.start && node_range.end >= range.end {
-                    break;
-                }
-                if !cursor.goto_parent() {
-                    continue 'outer;
-                }
+            if !Self::find_containing_node(&mut cursor, &range, false) {
+                continue;
             }
 
             // Look for the next sibling, moving up ancestor levels if needed

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6095,6 +6095,28 @@ impl MultiBufferSnapshot {
         Some((node, range))
     }
 
+    pub fn syntax_next_sibling<T: ToOffset>(
+        &self,
+        range: Range<T>,
+    ) -> Option<tree_sitter::Node<'_>> {
+        let range = range.start.to_offset(self)..range.end.to_offset(self);
+        let mut excerpt = self.excerpt_containing(range.clone())?;
+        excerpt
+            .buffer()
+            .syntax_next_sibling(excerpt.map_range_to_buffer(range))
+    }
+
+    pub fn syntax_prev_sibling<T: ToOffset>(
+        &self,
+        range: Range<T>,
+    ) -> Option<tree_sitter::Node<'_>> {
+        let range = range.start.to_offset(self)..range.end.to_offset(self);
+        let mut excerpt = self.excerpt_containing(range.clone())?;
+        excerpt
+            .buffer()
+            .syntax_prev_sibling(excerpt.map_range_to_buffer(range))
+    }
+
     pub fn outline(&self, theme: Option<&SyntaxTheme>) -> Option<Outline<Anchor>> {
         let (excerpt_id, _, buffer) = self.as_singleton()?;
         let outline = buffer.outline(theme)?;

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -56,7 +56,7 @@ actions!(
         /// Selects the next syntax node sibling.
         SelectNextSyntaxNode,
         /// Selects the previous syntax node sibling.
-        SelectPrevSyntaxNode,
+        SelectPreviousSyntaxNode,
         /// Restores the previous visual selection.
         RestoreVisualSelection,
         /// Inserts at the end of each line in visual selection.
@@ -124,7 +124,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
         }
     });
 
-    Vim::action(editor, cx, |vim, _: &SelectPrevSyntaxNode, window, cx| {
+    Vim::action(editor, cx, |vim, _: &SelectPreviousSyntaxNode, window, cx| {
         let count = Vim::take_count(cx).unwrap_or(1);
         Vim::take_forced_motion(cx);
         for _ in 0..count {

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -53,6 +53,10 @@ actions!(
         SelectSmallerSyntaxNode,
         /// Selects the next larger syntax node.
         SelectLargerSyntaxNode,
+        /// Selects the next syntax node sibling.
+        SelectNextSyntaxNode,
+        /// Selects the previous syntax node sibling.
+        SelectPrevSyntaxNode,
         /// Restores the previous visual selection.
         RestoreVisualSelection,
         /// Inserts at the end of each line in visual selection.
@@ -106,6 +110,26 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
         for _ in 0..count {
             vim.update_editor(cx, |_, editor, cx| {
                 editor.select_larger_syntax_node(&Default::default(), window, cx);
+            });
+        }
+    });
+
+    Vim::action(editor, cx, |vim, _: &SelectNextSyntaxNode, window, cx| {
+        let count = Vim::take_count(cx).unwrap_or(1);
+        Vim::take_forced_motion(cx);
+        for _ in 0..count {
+            vim.update_editor(window, cx, |_, editor, window, cx| {
+                editor.select_next_syntax_node(&Default::default(), window, cx);
+            });
+        }
+    });
+
+    Vim::action(editor, cx, |vim, _: &SelectPrevSyntaxNode, window, cx| {
+        let count = Vim::take_count(cx).unwrap_or(1);
+        Vim::take_forced_motion(cx);
+        for _ in 0..count {
+            vim.update_editor(window, cx, |_, editor, window, cx| {
+                editor.select_prev_syntax_node(&Default::default(), window, cx);
             });
         }
     });
@@ -1838,5 +1862,38 @@ mod test {
             brown
             fˇ»ox"
         });
+    }
+
+    #[gpui::test]
+    async fn test_visual_syntax_sibling_selection(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.set_state(
+            indoc! {"
+                fn test() {
+                    let ˇa = 1;
+                    let b = 2;
+                    let c = 3;
+                }
+            "},
+            Mode::Normal,
+        );
+
+        // Enter visual mode and select the statement
+        cx.simulate_keystrokes("v w w w");
+        cx.assert_state(
+            indoc! {"
+                fn test() {
+                    let «a = 1;ˇ»
+                    let b = 2;
+                    let c = 3;
+                }
+            "},
+            Mode::Visual,
+        );
+
+        // The specific behavior of syntax sibling selection in vim mode
+        // would depend on the key bindings configured, but the actions
+        // are now available for use
     }
 }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -118,21 +118,25 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
         let count = Vim::take_count(cx).unwrap_or(1);
         Vim::take_forced_motion(cx);
         for _ in 0..count {
-            vim.update_editor(window, cx, |_, editor, window, cx| {
+            vim.update_editor(cx, |_, editor, cx| {
                 editor.select_next_syntax_node(&Default::default(), window, cx);
             });
         }
     });
 
-    Vim::action(editor, cx, |vim, _: &SelectPreviousSyntaxNode, window, cx| {
-        let count = Vim::take_count(cx).unwrap_or(1);
-        Vim::take_forced_motion(cx);
-        for _ in 0..count {
-            vim.update_editor(window, cx, |_, editor, window, cx| {
-                editor.select_prev_syntax_node(&Default::default(), window, cx);
-            });
-        }
-    });
+    Vim::action(
+        editor,
+        cx,
+        |vim, _: &SelectPreviousSyntaxNode, window, cx| {
+            let count = Vim::take_count(cx).unwrap_or(1);
+            Vim::take_forced_motion(cx);
+            for _ in 0..count {
+                vim.update_editor(cx, |_, editor, cx| {
+                    editor.select_prev_syntax_node(&Default::default(), window, cx);
+                });
+            }
+        },
+    );
 
     Vim::action(
         editor,

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -129,7 +129,7 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::action("Select Next Sibling", editor::actions::SelectNextSyntaxNode),
                 MenuItem::action(
                     "Select Previous Sibling",
-                    editor::actions::SelectPrevSyntaxNode,
+                    editor::actions::SelectPreviousSyntaxNode,
                 ),
                 MenuItem::separator(),
                 MenuItem::action("Add Cursor Above", editor::actions::AddSelectionAbove),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -126,6 +126,11 @@ pub fn app_menus() -> Vec<Menu> {
                 ),
                 MenuItem::action("Expand Selection", editor::actions::SelectLargerSyntaxNode),
                 MenuItem::action("Shrink Selection", editor::actions::SelectSmallerSyntaxNode),
+                MenuItem::action("Select Next Sibling", editor::actions::SelectNextSyntaxNode),
+                MenuItem::action(
+                    "Select Previous Sibling",
+                    editor::actions::SelectPrevSyntaxNode,
+                ),
                 MenuItem::separator(),
                 MenuItem::action("Add Cursor Above", editor::actions::AddSelectionAbove),
                 MenuItem::action("Add Cursor Below", editor::actions::AddSelectionBelow),


### PR DESCRIPTION
Closes #5133 and discussion https://github.com/zed-industries/zed/discussions/33493

This PR adds two new commands to select next/previous siblings in the syntax tree. These commands were modelled after the existing ones about expand/shrink selection. With this PR I've added new key bindings inspired by `helix` for previous / next / expand / shrink selections.


https://github.com/user-attachments/assets/4ef7fadb-0b82-4897-95c7-1737827bf4ac


Release Notes:

- Add commands to select next/previous siblings in the syntax tree