### PR TITLE
Fix environment loading with tcsh

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -23,7 +23,7 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
 
     let (fd_num, redir) = match shell_name {
         Some("rc") => (FD_STDIN, format!(">[1={}]", FD_STDIN)), // `[1=0]`
-        Some("nu") => (FD_STDOUT, "".to_string()),
+        Some("nu") | Some("tcsh") => (FD_STDOUT, "".to_string()),
         _ => (FD_STDIN, format!(">&{}", FD_STDIN)), // `>&0`
     };
     command.stdin(Stdio::null());


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/34973

Fixes an issue where environment variables were not loaded when the user's shell was tcsh and instead a file named `0` was dumped in the current working directory with a copy of your environment variables as json.

Follow-up to: 
- https://github.com/zed-industries/zed/pull/35002
- https://github.com/zed-industries/zed/pull/33599

Release Notes:

- Fixed a regression with loading environment variables in tcsh
