### PR TITLE
Hide Copilot commands when AI functionality is disabled

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -262,7 +262,9 @@ fn update_command_palette_filter(cx: &mut App) {
         if disable_ai {
             filter.hide_namespace("agent");
             filter.hide_namespace("assistant");
+            filter.hide_namespace("copilot");
             filter.hide_namespace("zed_predict_onboarding");
+
             filter.hide_namespace("edit_prediction");
 
             use editor::actions::{
@@ -282,6 +284,7 @@ fn update_command_palette_filter(cx: &mut App) {
         } else {
             filter.show_namespace("agent");
             filter.show_namespace("assistant");
+            filter.show_namespace("copilot");
             filter.show_namespace("zed_predict_onboarding");
 
             filter.show_namespace("edit_prediction");


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/34896

Related to https://github.com/zed-industries/zed/issues/31346

cc @rtfeldman

Release Notes:

- Hide copilot commands when AI functionality is disabled