### PR TITLE
Don't separately rebuild crates for the build platform

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -720,6 +720,11 @@ workspace-hack = { path = "tooling/workspace-hack" }
 split-debuginfo = "unpacked"
 codegen-units = 16
 
+# mirror configuration for crates compiled for the build platform
+# (without this cargo will compile ~500 crates twice)
+[profile.dev.build-override]
+codegen-units = 16
+
 [profile.dev.package]
 taffy = { opt-level = 3 }
 cranelift-codegen = { opt-level = 3 }
@@ -778,10 +783,18 @@ codegen-units = 1
 [profile.release.package]
 zed = { codegen-units = 16 }
 
+[profile.release.build-override]
+opt-level = 3
+codegen-units = 1
+
 [profile.release-fast]
 inherits = "release"
 debug = "full"
 lto = false
+codegen-units = 16
+
+[profile.release-fast.build-override]
+opt-level = 3
 codegen-units = 16
 
 [workspace.lints.rust]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -721,7 +721,7 @@ split-debuginfo = "unpacked"
 codegen-units = 16
 
 # mirror configuration for crates compiled for the build platform
-# (without this cargo will compile ~500 crates twice)
+# (without this cargo will compile ~400 crates twice)
 [profile.dev.build-override]
 codegen-units = 16
 
@@ -783,18 +783,10 @@ codegen-units = 1
 [profile.release.package]
 zed = { codegen-units = 16 }
 
-[profile.release.build-override]
-opt-level = 3
-codegen-units = 1
-
 [profile.release-fast]
 inherits = "release"
 debug = "full"
 lto = false
-codegen-units = 16
-
-[profile.release-fast.build-override]
-opt-level = 3
 codegen-units = 16
 
 [workspace.lints.rust]


### PR DESCRIPTION
macos:
- `cargo build`: 1838 -> 1400
- `cargo build -r`1891 -> 1400

linux:
- `cargo build`: 1893 -> 1455
- `cargo build -r`: 1893 -> 1455

windows: 
- `cargo build`: 1830 -> 1392
- `cargo build -r`: 1880 -> 1392

We definitely want this change for debug builds, for release builds it's _possible_ that it pessimizes the critical path, but we'll see if it impacts CI times before merging.

Release Notes:

- N/A