### PR TITLE
gpui: Add more default font fallbacks

### DIFF
--- a/crates/gpui/examples/data_table.rs
+++ b/crates/gpui/examples/data_table.rs
@@ -374,7 +374,6 @@ impl DataTable {
 impl Render for DataTable {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
-            .font_family(".SystemUIFont")
             .bg(gpui::white())
             .text_sm()
             .size_full()

--- a/crates/gpui/examples/gradient.rs
+++ b/crates/gpui/examples/gradient.rs
@@ -20,7 +20,6 @@ impl Render for GradientViewer {
         let color_space = self.color_space;
 
         div()
-            .font_family(".SystemUIFont")
             .bg(gpui::white())
             .size_full()
             .p_4()

--- a/crates/gpui/examples/image_gallery.rs
+++ b/crates/gpui/examples/image_gallery.rs
@@ -47,7 +47,6 @@ impl Render for ImageGallery {
                 div()
                     .image_cache(self.image_cache.clone())
                     .id("main")
-                    .font_family(".SystemUIFont")
                     .text_color(gpui::black())
                     .bg(rgb(0xE9E9E9))
                     .overflow_y_scroll()
@@ -102,7 +101,6 @@ impl Render for ImageGallery {
             .child(image_cache(simple_lru_cache("lru-cache", IMAGES_IN_GALLERY)).child(
                 div()
                     .id("main")
-                    .font_family(".SystemUIFont")
                     .bg(rgb(0xE9E9E9))
                     .text_color(gpui::black())
                     .overflow_y_scroll()

--- a/crates/gpui/examples/painting.rs
+++ b/crates/gpui/examples/painting.rs
@@ -189,7 +189,6 @@ impl Render for PaintingViewer {
         let dashed = self.dashed;
 
         div()
-            .font_family(".SystemUIFont")
             .bg(gpui::white())
             .size_full()
             .p_4()

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -385,13 +385,7 @@ impl Default for TextStyle {
         TextStyle {
             color: black(),
             // todo(linux) make this configurable or choose better default
-            font_family: if cfg!(any(target_os = "linux", target_os = "freebsd")) {
-                "FreeMono".into()
-            } else if cfg!(target_os = "windows") {
-                "Segoe UI".into()
-            } else {
-                "Helvetica".into()
-            },
+            font_family: ".SystemUIFont".into(),
             font_features: FontFeatures::default(),
             font_fallbacks: None,
             font_size: rems(1.).into(),

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -68,8 +68,9 @@ impl TextSystem {
                 font("Zed Plex Mono"),
                 font("Helvetica"),
                 font("Segoe UI"),  // Windows
-                font("Cantarell"), // Gnome
                 font("Ubuntu"),    // Gnome (Ubuntu)
+                font("Adwaita Sans"), // Gnome 47
+                font("Cantarell"), // Gnome
                 font("Noto Sans"), // KDE
                 font("DejaVu Sans"),
                 font("Arial"), // macOS, Windows

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -67,11 +67,11 @@ impl TextSystem {
                 // TODO: Remove this when Linux have implemented setting fallbacks.
                 font("Zed Plex Mono"),
                 font("Helvetica"),
-                font("Segoe UI"),  // Windows
-                font("Ubuntu"),    // Gnome (Ubuntu)
+                font("Segoe UI"),     // Windows
+                font("Ubuntu"),       // Gnome (Ubuntu)
                 font("Adwaita Sans"), // Gnome 47
-                font("Cantarell"), // Gnome
-                font("Noto Sans"), // KDE
+                font("Cantarell"),    // Gnome
+                font("Noto Sans"),    // KDE
                 font("DejaVu Sans"),
                 font("Arial"), // macOS, Windows
             ],

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -71,7 +71,8 @@ impl TextSystem {
                 font("Cantarell"), // Gnome
                 font("Ubuntu"),    // Gnome (Ubuntu)
                 font("Noto Sans"), // KDE
-                font("DejaVu Sans")
+                font("DejaVu Sans"),
+                font("Arial"), // macOS, Windows
             ],
         }
     }


### PR DESCRIPTION
Release Notes:

- N/A

---

- Set `.SystemUIFont` as the GPUI default font.
- Add `Arial` to font fallback list.
- Add `Adwaita Sans` to default fallback list for Gnome.
- Move `Ubuntu` font to front of Gnome to make sure Ubuntu System takes priority over `Ubuntu` font.

Our application get some crash report:

```
panicked at /Users/admin/.cargo/git/checkouts/zed-a70e2ad075855582/f1db3b4/crates/gpui/src/text_system.rs:150:9:
failed to resolve font 'Helvetica' or any of the fallbacks: Zed Plex Mono, Helvetica, Segoe UI, Cantarell, Ubuntu, Noto Sans, DejaVu Sans
```

This change to add `Arial` to fallback list, this font was included in macOS and Windows.
Ref link (search "Arial"):

> Mac OS X (now known as [macOS](https://en.wikipedia.org/wiki/MacOS)) was the first Mac OS version to include Arial;
> https://en.wikipedia.org/wiki/Arial

- macOS Sequoia: https://support.apple.com/en-us/120414
- Windows 10: https://learn.microsoft.com/en-us/typography/fonts/windows_10_font_list
- Gnome: https://developer.gnome.org/hig/guidelines/typography.html