### PR TITLE
Add TestCrash action

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -111,6 +111,8 @@ actions!(
         Zoom,
         /// Triggers a test panic for debugging.
         TestPanic,
+        /// Triggers a hard crash for debugging.
+        TestCrash,
     ]
 );
 
@@ -126,6 +128,14 @@ pub fn init(cx: &mut App) {
     cx.on_action(|_: &RestoreBanner, cx| title_bar::restore_banner(cx));
     if ReleaseChannel::global(cx) == ReleaseChannel::Dev || cx.has_flag::<PanicFeatureFlag>() {
         cx.on_action(|_: &TestPanic, _| panic!("Ran the TestPanic action"));
+        cx.on_action(|_: &TestCrash, _| {
+            unsafe extern "C" {
+                fn puts(s: *const i8);
+            }
+            unsafe {
+                puts(0xabad1d3a as *const i8);
+            }
+        });
     }
     cx.on_action(|_: &OpenLog, cx| {
         with_active_or_new_workspace(cx, |workspace, window, cx| {


### PR DESCRIPTION
This triggers a crash that avoids our panic-handler, which is useful for testing that our crash reporting works even when you don't get a panic.

Release Notes:

- N/A
