### PR TITLE
Upload debug info to sentry.io

### DIFF
--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -7,8 +7,6 @@ on:
   push:
     tags:
       - "nightly"
-    branches:
-      - "sentry-ci"
 
 env:
   CARGO_TERM_COLOR: always
@@ -292,28 +290,28 @@ jobs:
         working-directory: ${{ env.ZED_WORKSPACE }}
         run: script/upload-nightly.ps1 windows
 
-  # update-nightly-tag:
-  #   name: Update nightly tag
-  #   if: github.repository_owner == 'zed-industries'
-  #   runs-on: ubuntu-latest
-  #   needs:
-  #     - bundle-mac
-  #     - bundle-linux-x86
-  #     - bundle-linux-arm
-  #     - bundle-windows-x64
-  #   steps:
-  #     - name: Checkout repo
-  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-  #       with:
-  #         fetch-depth: 0
+  update-nightly-tag:
+    name: Update nightly tag
+    if: github.repository_owner == 'zed-industries'
+    runs-on: ubuntu-latest
+    needs:
+      - bundle-mac
+      - bundle-linux-x86
+      - bundle-linux-arm
+      - bundle-windows-x64
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          fetch-depth: 0
 
-  #     - name: Update nightly tag
-  #       run: |
-  #         if [ "$(git rev-parse nightly)" = "$(git rev-parse HEAD)" ]; then
-  #           echo "Nightly tag already points to current commit. Skipping tagging."
-  #           exit 0
-  #         fi
-  #         git config user.name github-actions
-  #         git config user.email github-actions@github.com
-  #         git tag -f nightly
-  #         git push origin nightly --force
+      - name: Update nightly tag
+        run: |
+          if [ "$(git rev-parse nightly)" = "$(git rev-parse HEAD)" ]; then
+            echo "Nightly tag already points to current commit. Skipping tagging."
+            exit 0
+          fi
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git tag -f nightly
+          git push origin nightly --force

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -136,6 +136,13 @@ jobs:
       - name: Install Linux dependencies
         run: ./script/linux && ./script/install-mold 2.34.0
 
+      - name: Setup Sentry CLI
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
+        with:
+          token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
+          organization: zed-dev
+          project: zed
+
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100
 
@@ -167,6 +174,13 @@ jobs:
 
       - name: Install Linux dependencies
         run: ./script/linux
+
+      - name: Setup Sentry CLI
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
+        with:
+          token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
+          organization: zed-dev
+          project: zed
 
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -117,8 +117,6 @@ jobs:
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
         with:
           token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
-          organization: zed-dev
-          project: zed
 
       - name: Create macOS app bundle
         run: script/bundle-mac
@@ -149,8 +147,6 @@ jobs:
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
         with:
           token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
-          organization: zed-dev
-          project: zed
 
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100
@@ -188,8 +184,6 @@ jobs:
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
         with:
           token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
-          organization: zed-dev
-          project: zed
 
       - name: Limit target directory size
         run: script/clear-target-dir-if-larger-than 100
@@ -289,8 +283,6 @@ jobs:
         uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
         with:
           token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
-          organization: zed-dev
-          project: zed
 
       - name: Build Zed installer
         working-directory: ${{ env.ZED_WORKSPACE }}

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -7,6 +7,8 @@ on:
   push:
     tags:
       - "nightly"
+    branches:
+      - "sentry-ci"
 
 env:
   CARGO_TERM_COLOR: always
@@ -110,6 +112,13 @@ jobs:
           version=$(git rev-parse --short HEAD)
           echo "Publishing version: ${version} on release channel nightly"
           echo "nightly" > crates/zed/RELEASE_CHANNEL
+
+      - name: Setup Sentry CLI
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
+        with:
+          token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
+          organization: zed-dev
+          project: zed
 
       - name: Create macOS app bundle
         run: script/bundle-mac
@@ -276,6 +285,13 @@ jobs:
           Write-Host "Publishing version: $version on release channel nightly"
           "nightly" | Set-Content -Path "crates/zed/RELEASE_CHANNEL"
 
+      - name: Setup Sentry CLI
+        uses: matbour/setup-sentry-cli@3e938c54b3018bdd019973689ef984e033b0454b #v2
+        with:
+          token: ${{ SECRETS.SENTRY_AUTH_TOKEN }}
+          organization: zed-dev
+          project: zed
+
       - name: Build Zed installer
         working-directory: ${{ env.ZED_WORKSPACE }}
         run: script/bundle-windows.ps1
@@ -284,28 +300,28 @@ jobs:
         working-directory: ${{ env.ZED_WORKSPACE }}
         run: script/upload-nightly.ps1 windows
 
-  update-nightly-tag:
-    name: Update nightly tag
-    if: github.repository_owner == 'zed-industries'
-    runs-on: ubuntu-latest
-    needs:
-      - bundle-mac
-      - bundle-linux-x86
-      - bundle-linux-arm
-      - bundle-windows-x64
-    steps:
-      - name: Checkout repo
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
-        with:
-          fetch-depth: 0
+  # update-nightly-tag:
+  #   name: Update nightly tag
+  #   if: github.repository_owner == 'zed-industries'
+  #   runs-on: ubuntu-latest
+  #   needs:
+  #     - bundle-mac
+  #     - bundle-linux-x86
+  #     - bundle-linux-arm
+  #     - bundle-windows-x64
+  #   steps:
+  #     - name: Checkout repo
+  #       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+  #       with:
+  #         fetch-depth: 0
 
-      - name: Update nightly tag
-        run: |
-          if [ "$(git rev-parse nightly)" = "$(git rev-parse HEAD)" ]; then
-            echo "Nightly tag already points to current commit. Skipping tagging."
-            exit 0
-          fi
-          git config user.name github-actions
-          git config user.email github-actions@github.com
-          git tag -f nightly
-          git push origin nightly --force
+  #     - name: Update nightly tag
+  #       run: |
+  #         if [ "$(git rev-parse nightly)" = "$(git rev-parse HEAD)" ]; then
+  #           echo "Nightly tag already points to current commit. Skipping tagging."
+  #           exit 0
+  #         fi
+  #         git config user.name github-actions
+  #         git config user.email github-actions@github.com
+  #         git tag -f nightly
+  #         git push origin nightly --force

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -92,7 +92,7 @@ else
         echo "Uploading zed debug symbols..."
         # note: this uploads the unstripped binary which is needed because it contains
         # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
-        sentry-cli debug-files upload --include-sources --wait \
+        sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
             "${target_dir}/${target_triple}"/release/zed \
             "${target_dir}/${remote_server_triple}"/release/remote_server
     else

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -89,7 +89,7 @@ if ! command -v sentry-cli >/dev/null 2>&1; then
     echo "install with: 'curl -sL https://sentry.io/get-cli | bash'"
 else
     if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
-        echo "Uploading zed debug symbols..."
+        echo "Uploading zed debug symbols to sentry..."
         # note: this uploads the unstripped binary which is needed because it contains
         # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
         sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \

--- a/script/bundle-linux
+++ b/script/bundle-linux
@@ -83,6 +83,23 @@ if [[ "$remote_server_triple" == "$musl_triple" ]]; then
 fi
 cargo build --release --target "${remote_server_triple}" --package remote_server
 
+# Upload debug info to sentry.io
+if ! command -v sentry-cli >/dev/null 2>&1; then
+    echo "sentry-cli not found. skipping sentry upload."
+    echo "install with: 'curl -sL https://sentry.io/get-cli | bash'"
+else
+    if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
+        echo "Uploading zed debug symbols..."
+        # note: this uploads the unstripped binary which is needed because it contains
+        # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
+        sentry-cli debug-files upload --include-sources --wait \
+            "${target_dir}/${target_triple}"/release/zed \
+            "${target_dir}/${remote_server_triple}"/release/remote_server
+    else
+        echo "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
+    fi
+fi
+
 # Strip debug symbols and save them for upload to DigitalOcean
 objcopy --only-keep-debug "${target_dir}/${target_triple}/release/zed" "${target_dir}/${target_triple}/release/zed.dbg"
 objcopy --only-keep-debug "${target_dir}/${remote_server_triple}/release/remote_server" "${target_dir}/${remote_server_triple}/release/remote_server.dbg"

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -377,8 +377,8 @@ else
         # note: this uploads the unstripped binary which is needed because it contains
         # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
         sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
-            "target/${architecture}/${target_dir}/aarch64-apple-darwin/" \
-            "target/${architecture}/${target_dir}/x86_64-apple-darwin/"
+            "target/x86_64-apple-darwin/${target_dir}/" \
+            "target/aarch64-apple-darwin/${target_dir}/"
     else
         echo "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
     fi

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -97,6 +97,23 @@ else
     cargo build ${build_flag} --package remote_server     --target aarch64-apple-darwin --target x86_64-apple-darwin
 fi
 
+# Upload debug info to sentry.io
+if ! command -v sentry-cli >/dev/null 2>&1; then
+    echo "sentry-cli not found. skipping sentry upload."
+    echo "install with: 'curl -sL https://sentry.io/get-cli | bash'"
+else
+    if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
+        echo "Uploading zed debug symbols..."
+        # note: this uploads the unstripped binary which is needed because it contains
+        # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
+        sentry-cli debug-files upload --include-sources --wait \
+            "${target_dir}/aarch64-apple-darwin/ \
+            "${target_dir}/x86_64-apple-darwin/
+    else
+        echo "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
+    fi
+fi
+
 echo "Creating application bundle"
 pushd crates/zed
 cp Cargo.toml Cargo.toml.backup

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -97,23 +97,6 @@ else
     cargo build ${build_flag} --package remote_server     --target aarch64-apple-darwin --target x86_64-apple-darwin
 fi
 
-# Upload debug info to sentry.io
-if ! command -v sentry-cli >/dev/null 2>&1; then
-    echo "sentry-cli not found. skipping sentry upload."
-    echo "install with: 'curl -sL https://sentry.io/get-cli | bash'"
-else
-    if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
-        echo "Uploading zed debug symbols..."
-        # note: this uploads the unstripped binary which is needed because it contains
-        # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
-        sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
-            "${target_dir}/aarch64-apple-darwin/ \
-            "${target_dir}/x86_64-apple-darwin/
-    else
-        echo "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
-    fi
-fi
-
 echo "Creating application bundle"
 pushd crates/zed
 cp Cargo.toml Cargo.toml.backup
@@ -382,4 +365,21 @@ else
     sign_binary "target/aarch64-apple-darwin/release/remote_server"
     gzip -f --stdout --best target/x86_64-apple-darwin/release/remote_server > target/zed-remote-server-macos-x86_64.gz
     gzip -f --stdout --best target/aarch64-apple-darwin/release/remote_server > target/zed-remote-server-macos-aarch64.gz
+fi
+
+# Upload debug info to sentry.io
+if ! command -v sentry-cli >/dev/null 2>&1; then
+    echo "sentry-cli not found. skipping sentry upload."
+    echo "install with: 'curl -sL https://sentry.io/get-cli | bash'"
+else
+    if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
+        echo "Uploading zed debug symbols..."
+        # note: this uploads the unstripped binary which is needed because it contains
+        # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
+        sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
+            "target/${architecture}/${target_dir}/aarch64-apple-darwin/" \
+            "target/${architecture}/${target_dir}/x86_64-apple-darwin/"
+    else
+        echo "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
+    fi
 fi

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -106,7 +106,7 @@ else
         echo "Uploading zed debug symbols..."
         # note: this uploads the unstripped binary which is needed because it contains
         # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
-        sentry-cli debug-files upload --include-sources --wait \
+        sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \
             "${target_dir}/aarch64-apple-darwin/ \
             "${target_dir}/x86_64-apple-darwin/
     else

--- a/script/bundle-mac
+++ b/script/bundle-mac
@@ -373,7 +373,7 @@ if ! command -v sentry-cli >/dev/null 2>&1; then
     echo "install with: 'curl -sL https://sentry.io/get-cli | bash'"
 else
     if [[ -n "${SENTRY_AUTH_TOKEN:-}" ]]; then
-        echo "Uploading zed debug symbols..."
+        echo "Uploading zed debug symbols to sentry..."
         # note: this uploads the unstripped binary which is needed because it contains
         # .eh_frame data for stack unwinindg. see https://github.com/getsentry/symbolic/issues/783
         sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev \

--- a/script/bundle-windows.ps1
+++ b/script/bundle-windows.ps1
@@ -107,6 +107,7 @@ function UploadToSentry {
         Write-Output "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
         return
     }
+    Write-Output "Uploading zed debug symbols to sentry..."
     sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev .\target\release\
 }
 

--- a/script/bundle-windows.ps1
+++ b/script/bundle-windows.ps1
@@ -96,6 +96,14 @@ function ZipZedAndItsFriendsDebug {
     Compress-Archive -Path $items -DestinationPath ".\target\release\zed-$env:RELEASE_VERSION-$env:ZED_RELEASE_CHANNEL.dbg.zip" -Force
 }
 
+
+function UploadToSentry {
+    param (
+        [string]$exe,
+        [string]$debugArchive
+    )
+}
+
 function MakeAppx {
     switch ($channel) {
         "stable" {
@@ -125,14 +133,6 @@ function CollectFiles {
     Move-Item -Path "$innoDir\zed_explorer_command_injector.dll" -Destination "$innoDir\appx\zed_explorer_command_injector.dll" -Force
     Move-Item -Path "$innoDir\cli.exe" -Destination "$innoDir\bin\zed.exe" -Force
     Move-Item -Path "$innoDir\auto_update_helper.exe" -Destination "$innoDir\tools\auto_update_helper.exe" -Force
-}
-
-function UploadToSentry {
-    param (
-        [string]$exe,
-        [string]$debugArchive
-    )
-
 }
 
 function BuildInstaller {
@@ -264,7 +264,9 @@ BuildInstaller
 $debugArchive = ".\target\release\zed-$env:RELEASE_VERSION-$env:ZED_RELEASE_CHANNEL.dbg.zip"
 $debugStoreKey = "$env:ZED_RELEASE_CHANNEL/zed-$env:RELEASE_VERSION-$env:ZED_RELEASE_CHANNEL.dbg.zip"
 UploadToBlobStorePublic -BucketName "zed-debug-symbols" -FileToUpload $debugArchive -BlobStoreKey $debugStoreKey
-UploadToSentry
+if (Get-Command "sentry-cli" -ErrorAction SilentlyContinue) {
+    UploadToSentry
+}
 
 if ($buildSuccess) {
     Write-Output "Build successful"

--- a/script/bundle-windows.ps1
+++ b/script/bundle-windows.ps1
@@ -127,6 +127,14 @@ function CollectFiles {
     Move-Item -Path "$innoDir\auto_update_helper.exe" -Destination "$innoDir\tools\auto_update_helper.exe" -Force
 }
 
+function UploadToSentry {
+    param (
+        [string]$exe,
+        [string]$debugArchive
+    )
+
+}
+
 function BuildInstaller {
     $issFilePath = "$innoDir\zed.iss"
     switch ($channel) {
@@ -256,6 +264,7 @@ BuildInstaller
 $debugArchive = ".\target\release\zed-$env:RELEASE_VERSION-$env:ZED_RELEASE_CHANNEL.dbg.zip"
 $debugStoreKey = "$env:ZED_RELEASE_CHANNEL/zed-$env:RELEASE_VERSION-$env:ZED_RELEASE_CHANNEL.dbg.zip"
 UploadToBlobStorePublic -BucketName "zed-debug-symbols" -FileToUpload $debugArchive -BlobStoreKey $debugStoreKey
+UploadToSentry
 
 if ($buildSuccess) {
     Write-Output "Build successful"

--- a/script/bundle-windows.ps1
+++ b/script/bundle-windows.ps1
@@ -98,7 +98,7 @@ function ZipZedAndItsFriendsDebug {
 
 
 function UploadToSentry {
-    if (-not Get-Command "sentry-cli" -ErrorAction SilentlyContinue) {
+    if (-not (Get-Command "sentry-cli" -ErrorAction SilentlyContinue)) {
         Write-Output "sentry-cli not found. skipping sentry upload."
         Write-Output "install with: 'winget install -e --id=Sentry.sentry-cli'"
         return
@@ -107,7 +107,7 @@ function UploadToSentry {
         Write-Output "missing SENTRY_AUTH_TOKEN. skipping sentry upload."
         return
     }
-    sentry-cli debug-files upload --include-sources --wait .\target\release\
+    sentry-cli debug-files upload --include-sources --wait -p zed -o zed-dev .\target\release\
 }
 
 function MakeAppx {


### PR DESCRIPTION
This is a preparatory change which will allow us to use sentry for crash reporting once we start uploading minidumps.

Release Notes:

- N/A
