### PR TITLE
typescript: Fix handling of jest/vitest tests with regex characters in name

### DIFF
--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -512,7 +512,7 @@ fn eslint_server_binary_arguments(server_path: &Path) -> Vec<OsString> {
 fn replace_test_name_parameters(test_name: &str) -> String {
     let pattern = regex::Regex::new(r"(%|\$)[0-9a-zA-Z]+").unwrap();
 
-    pattern.replace_all(test_name, "(.+?)").to_string()
+    regex::escape(&pattern.replace_all(test_name, "(.+?)"))
 }
 
 pub struct TypeScriptLspAdapter {


### PR DESCRIPTION
Closes #35065

Release Notes:

- JavaScript/TypeScript tasks: Fixed handling of Vitest/Jest tests with regex-specific characters in their name.
