### PR TITLE
docs: Add a missing "," in the C/C++ debugger configuration

### DIFF
--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -77,7 +77,7 @@ You can use CodeLLDB or GDB to debug native binaries. (Make sure that your build
       "command": "make",
       "args": ["-j8"],
       "cwd": "$ZED_WORKTREE_ROOT"
-    }
+    },
     "program": "$ZED_WORKTREE_ROOT/build/prog",
     "request": "launch",
     "adapter": "CodeLLDB"

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -127,7 +127,7 @@ You can use CodeLLDB or GDB to debug native binaries. (Make sure that your build
       "command": "make",
       "args": ["-j8"],
       "cwd": "$ZED_WORKTREE_ROOT"
-    }
+    },
     "program": "$ZED_WORKTREE_ROOT/build/prog",
     "request": "launch",
     "adapter": "CodeLLDB"


### PR DESCRIPTION
Release Notes:

- N/A 
