### PR TITLE
git: Fix commit modal contents being searchable

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -380,6 +380,9 @@ pub(crate) fn commit_message_editor(
     window: &mut Window,
     cx: &mut Context<Editor>,
 ) -> Editor {
+    project.update(cx, |this, cx| {
+        this.mark_buffer_as_non_searchable(commit_message_buffer.read(cx).remote_id(), cx);
+    });
     let buffer = cx.new(|cx| MultiBuffer::singleton(commit_message_buffer, cx));
     let max_lines = if in_panel { MAX_PANEL_EDITOR_LINES } else { 18 };
     let mut commit_editor = Editor::new(


### PR DESCRIPTION
Fixes #35093

Release Notes:

- Fixed Git commit editor being searchable.
