### PR TITLE
Add a CI check that Cargo.lock is up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -269,6 +269,10 @@ jobs:
           mkdir -p ./../.cargo
           cp ./.cargo/ci-config.toml ./../.cargo/config.toml
 
+      - name: Check that Cargo.lock is up to date
+        run: |
+          cargo update --frozen --workspace
+
       - name: cargo clippy
         run: ./script/clippy
 


### PR DESCRIPTION
Should catch cases like #33667 where a dependency was bumped in Cargo.toml without a corresponding lockfile update. (This can happen when committing from outside of Zed or if rust-analyzer isn't running.) Passing `--frozen --workspace` should ensure this doesn't fail just because there's a newer patch version of some third-party dependency, and prevent it from taking long.

We only need to run this on macOS because Cargo.lock is platform-independent.

Release Notes:

- N/A