### PR TITLE
Add meta description tag to docs pages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4791,7 +4791,6 @@ name = "docs_preprocessor"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "clap",
  "command_palette",
  "gpui",
  "mdbook",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4802,6 +4802,7 @@ dependencies = [
  "util",
  "workspace-hack",
  "zed",
+ "zlog",
 ]
 
 [[package]]

--- a/crates/docs_preprocessor/Cargo.toml
+++ b/crates/docs_preprocessor/Cargo.toml
@@ -8,16 +8,17 @@ license = "GPL-3.0-or-later"
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+command_palette.workspace = true
+gpui.workspace = true
 mdbook = "0.4.40"
+regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
-regex.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
 zed.workspace = true
-gpui.workspace = true
-command_palette.workspace = true
+zlog.workspace = true
 
 [lints]
 workspace = true

--- a/crates/docs_preprocessor/Cargo.toml
+++ b/crates/docs_preprocessor/Cargo.toml
@@ -7,7 +7,6 @@ license = "GPL-3.0-or-later"
 
 [dependencies]
 anyhow.workspace = true
-clap.workspace = true
 command_palette.workspace = true
 gpui.workspace = true
 mdbook = "0.4.40"

--- a/crates/zlog/src/sink.rs
+++ b/crates/zlog/src/sink.rs
@@ -21,6 +21,8 @@ const ANSI_MAGENTA: &str = "\x1b[35m";
 
 /// Whether stdout output is enabled.
 static mut ENABLED_SINKS_STDOUT: bool = false;
+/// Whether stderr output is enabled.
+static mut ENABLED_SINKS_STDERR: bool = false;
 
 /// Is Some(file) if file output is enabled.
 static ENABLED_SINKS_FILE: Mutex<Option<std::fs::File>> = Mutex::new(None);
@@ -40,6 +42,12 @@ pub struct Record<'a> {
 }
 
 pub fn init_output_stdout() {
+    unsafe {
+        ENABLED_SINKS_STDOUT = true;
+    }
+}
+
+pub fn init_output_stderr() {
     unsafe {
         ENABLED_SINKS_STDOUT = true;
     }
@@ -102,6 +110,21 @@ static LEVEL_ANSI_COLORS: [&str; 6] = [
 pub fn submit(record: Record) {
     if unsafe { ENABLED_SINKS_STDOUT } {
         let mut stdout = std::io::stdout().lock();
+        _ = writeln!(
+            &mut stdout,
+            "{} {ANSI_BOLD}{}{}{ANSI_RESET} {} {}",
+            chrono::Local::now().format("%Y-%m-%dT%H:%M:%S%:z"),
+            LEVEL_ANSI_COLORS[record.level as usize],
+            LEVEL_OUTPUT_STRINGS[record.level as usize],
+            SourceFmt {
+                scope: record.scope,
+                module_path: record.module_path,
+                ansi: true,
+            },
+            record.message
+        );
+    } else if unsafe { ENABLED_SINKS_STDERR } {
+        let mut stdout = std::io::stderr().lock();
         _ = writeln!(
             &mut stdout,
             "{} {ANSI_BOLD}{}{}{ANSI_RESET} {} {}",

--- a/crates/zlog/src/sink.rs
+++ b/crates/zlog/src/sink.rs
@@ -49,7 +49,7 @@ pub fn init_output_stdout() {
 
 pub fn init_output_stderr() {
     unsafe {
-        ENABLED_SINKS_STDOUT = true;
+        ENABLED_SINKS_STDERR = true;
     }
 }
 

--- a/crates/zlog/src/zlog.rs
+++ b/crates/zlog/src/zlog.rs
@@ -5,7 +5,7 @@ mod env_config;
 pub mod filter;
 pub mod sink;
 
-pub use sink::{flush, init_output_file, init_output_stdout};
+pub use sink::{flush, init_output_file, init_output_stderr, init_output_stdout};
 
 pub const SCOPE_DEPTH_MAX: usize = 4;
 

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -18,7 +18,7 @@ extra-watch-dirs = ["../crates/docs_preprocessor"]
 [output.zed-html]
 command = "cargo run -p docs_preprocessor -- postprocess"
 # Set here instead of above as we only use it replace the `#description#` we set in the template
-# when we can't find a `{#zed-meta ... }` value
+# when no front-matter is provided value
 default-description = "Learn how to use and customize Zed, the fast, collaborative code editor. Official docs on features, configuration, AI tools, and workflows."
 default-title = "Zed Code Editor Documentation"
 no-section-label = true

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -19,7 +19,7 @@ extra-watch-dirs = ["../crates/docs_preprocessor"]
 command = "cargo run -p docs_preprocessor -- postprocess"
 # Set here instead of above as we only use it replace the `#description#` we set in the template
 # when we can't find a `{#zed-meta ... }` value
-default-description = "Zed is the fastest way to code"
+default-description = "Learn how to use and customize Zed, the fast, collaborative code editor. Official docs on features, configuration, AI tools, and workflows."
 no-section-label = true
 preferred-dark-theme = "dark"
 additional-css = ["theme/page-toc.css", "theme/plugins.css", "theme/highlight.css"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -20,6 +20,7 @@ command = "cargo run -p docs_preprocessor -- postprocess"
 # Set here instead of above as we only use it replace the `#description#` we set in the template
 # when we can't find a `{#zed-meta ... }` value
 default-description = "Learn how to use and customize Zed, the fast, collaborative code editor. Official docs on features, configuration, AI tools, and workflows."
+default-title = "Zed Code Editor Documentation"
 no-section-label = true
 preferred-dark-theme = "dark"
 additional-css = ["theme/page-toc.css", "theme/plugins.css", "theme/highlight.css"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -6,7 +6,11 @@ src = "src"
 title = "Zed"
 site-url = "/docs/"
 
+[build]
+extra-watch-dirs = ["../crates/docs_preprocessor"]
+
 [output.html]
+command = "cargo run -p docs_preprocessor -- postprocess"
 no-section-label = true
 preferred-dark-theme = "dark"
 additional-css = ["theme/page-toc.css", "theme/plugins.css", "theme/highlight.css"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -17,6 +17,9 @@ extra-watch-dirs = ["../crates/docs_preprocessor"]
 # options that apply to html apply to zed-html
 [output.zed-html]
 command = "cargo run -p docs_preprocessor -- postprocess"
+# Set here instead of above as we only use it replace the `#description#` we set in the template
+# when we can't find a `{#zed-meta ... }` value
+default-description = "Zed is the fastest way to code"
 no-section-label = true
 preferred-dark-theme = "dark"
 additional-css = ["theme/page-toc.css", "theme/plugins.css", "theme/highlight.css"]

--- a/docs/book.toml
+++ b/docs/book.toml
@@ -9,14 +9,20 @@ site-url = "/docs/"
 [build]
 extra-watch-dirs = ["../crates/docs_preprocessor"]
 
-[output.html]
+# zed-html is a "custom" renderer that just wraps the
+# builtin mdbook html renderer, and applies post-processing
+# as post-processing is not possible with mdbook in the same way
+# pre-processing is
+# The config is passed directly to the html renderer, so all config
+# options that apply to html apply to zed-html
+[output.zed-html]
 command = "cargo run -p docs_preprocessor -- postprocess"
 no-section-label = true
 preferred-dark-theme = "dark"
 additional-css = ["theme/page-toc.css", "theme/plugins.css", "theme/highlight.css"]
 additional-js  = ["theme/page-toc.js", "theme/plugins.js"]
 
-[output.html.print]
+[output.zed-html.print]
 enable = false
 
 # Redirects for `/docs` pages.
@@ -28,7 +34,7 @@ enable = false
 # The destination URLs are interpreted relative to `https://zed.dev`.
 # - Redirects to other docs pages should end in `.html`
 # - You can link to pages on the Zed site by omitting the `/docs` in front of it.
-[output.html.redirect]
+[output.zed-html.redirect]
 # AI
 "/ai.html" = "/docs/ai/overview.html"
 "/assistant-panel.html" = "/docs/ai/agent-panel.html"

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,5 +1,4 @@
-{#zed-meta Zed is a text editor that supports lots of Git features
-}
+{#zed-meta Zed is a text editor that supports lots of Git features }
 
 # Git
 

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,4 +1,6 @@
-{#zed-meta Zed is a text editor that supports lots of Git features }
+{#zed-meta-description Zed is a text editor that supports lots of Git features }
+
+{#zed-meta-title Zed Editor Git integration documentation}
 
 # Git
 

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,3 +1,5 @@
+{#zed-meta Zed is a text editor that supports Git features }
+
 # Git
 
 Zed currently offers a set of fundamental Git features, with support coming in the future for more advanced ones, like conflict resolution tools, line by line staging, and more.

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,4 +1,5 @@
-{#zed-meta Zed is a text editor that supports Git features }
+{#zed-meta Zed is a text editor that supports lots of Git features
+}
 
 # Git
 

--- a/docs/src/git.md
+++ b/docs/src/git.md
@@ -1,6 +1,7 @@
-{#zed-meta-description Zed is a text editor that supports lots of Git features }
-
-{#zed-meta-title Zed Editor Git integration documentation}
+---
+description: Zed is a text editor that supports lots of Git features
+title: Zed Editor Git integration documentation
+---
 
 # Git
 

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -15,7 +15,7 @@
         <!-- Custom HTML head -->
         {{> head}}
 
-        <meta name="description" content="{{ description }}">
+        <meta name="description" content="#description#">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff">
 

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -16,7 +16,6 @@
         {{> head}}
 
         <meta name="description" content="#description#">
-        <meta name="title" content="#title#">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff">
 

--- a/docs/theme/index.hbs
+++ b/docs/theme/index.hbs
@@ -16,6 +16,7 @@
         {{> head}}
 
         <meta name="description" content="#description#">
+        <meta name="title" content="#title#">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         <meta name="theme-color" content="#ffffff">
 


### PR DESCRIPTION
Closes #ISSUE

Adds basic frontmatter support to `.md` files in docs. The only supported keys currently are `description` which becomes a `<meta name="description" contents="...">` tag, and `title` which becomes a normal `title` tag, with the title contents prefixed with the subject of the file. 

An example of the syntax can be found in `git.md`, as well as below

```md
---
title: Some more detailed title for this page
description: A page-specific description
---

# Editor
```

The above will be transformed into (with non-relevant tags removed)

```html
<head>
    <title>Editor | Some more detailed title for this page</title>
    <meta name="description" contents="A page-specific description">
</head>
<body>
<h1>Editor</h1>
</body>
```

If no front-matter is provided, or If one or both keys aren't provided, the title and description will be set based on the `default-title` and `default-description` keys in `book.toml` respectively. 

## Implementation details

Unfortunately, `mdbook` does not support post-processing like it does pre-processing, and only supports defining one description to put in the meta tag per book rather than per file. So in order to apply post-processing (necessary to modify the html head tags) the global book description is set to a marker value `#description#` and the html renderer is replaced with a sub-command of `docs_preprocessor` that wraps the builtin `html` renderer and applies post-processing to the `html` files, replacing the marker value and the `<title>(.*)</title>` with the contents of the front-matter if there is one. 

## Known limitations

The front-matter parsing is extremely simple, which avoids needing to take on an additional dependency, or implement full yaml parsing. 

* Double quotes and multi-line values are not supported, i.e. Keys and values must be entirely on the same line, with no double quotes around the value.

The following will not work:

```md
---
title: Some
 Multi-line
 Title
---
```

* The front-matter must be at the top of the file, with only white-space preceding it

* The contents of the title and description will not be html-escaped. They should be simple ascii text with no unicode or emoji characters

Release Notes:

- N/A *or* Added/Fixed/Improved ...
