### PR TITLE
agent: Fix settings view switch field about permissions for running commands

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -404,9 +404,9 @@ impl AgentConfiguration {
         let fs = self.fs.clone();
 
         SwitchField::new(
-            "single-file-review",
-            "Enable single-file agent reviews",
-            "Agent edits are also displayed in single-file editors for review.",
+            "always-allow-tool-actions-switch",
+            "Allow running commands without asking for confirmation",
+            "The agent can perform potentially destructive actions without asking for your confirmation.",
             always_allow_tool_actions,
             move |state, _window, cx| {
                 let allow = state == &ToggleState::Selected;


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/34866, where I mistakenly didn't update the copy and id for this item.

Closes https://github.com/zed-industries/zed/issues/34850 — that's because the edit tool runs by default, but the terminal tool does not. I updated the original copy to reflect this, which should be enough to close the issue, given that in terms of behavior, it is working correctly.

Release Notes:

- agent: Fixed duplicated settings item in the agent panel as well as improve copy for the setting to allow running commands without permission.
