### PR TITLE
debugger: Fix the terminal popping up when the Rust debugger starts on Windows

### DIFF
--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -128,7 +128,8 @@ impl DapLocator for CargoLocator {
                 .chain(Some("--message-format=json".to_owned()))
                 .collect(),
         );
-        let mut child = Command::new(program)
+        let mut command = util::command::new_smol_command(program);
+        let mut child = command
             .args(args)
             .envs(build_config.env.iter().map(|(k, v)| (k.clone(), v.clone())))
             .current_dir(cwd)

--- a/crates/project/src/debugger/locators/cargo.rs
+++ b/crates/project/src/debugger/locators/cargo.rs
@@ -128,8 +128,7 @@ impl DapLocator for CargoLocator {
                 .chain(Some("--message-format=json".to_owned()))
                 .collect(),
         );
-        let mut command = util::command::new_smol_command(program);
-        let mut child = command
+        let mut child = util::command::new_smol_command(program)
             .args(args)
             .envs(build_config.env.iter().map(|(k, v)| (k.clone(), v.clone())))
             .current_dir(cwd)


### PR DESCRIPTION
This PR fixs a terminal popping up when debugging Rust on Windows.


Release Notes:

- N/A

