### PR TITLE
ui: Fix scrollbar mouse down handler

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -339,7 +339,7 @@ impl Element for Scrollbar {
                 move |event: &MouseDownEvent, phase, _, _| {
                     if !phase.bubble()
                         || event.button != MouseButton::Left
-                        || bounds.contains(&event.position)
+                        || !bounds.contains(&event.position)
                     {
                         return;
                     }


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/35121 - in the process of adding the check for the left mouse button to the guard (which was practically already there before, just not in the mouse-down listener), I accidentally ended up removing the negation for the bounds check. This PR fixes this.

Release Notes:

- N/A
