### PR TITLE
git_ui: Show current branch first in branch picker

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -112,10 +112,13 @@ impl BranchList {
                     all_branches.retain(|branch| !remote_upstreams.contains(&branch.ref_name));
 
                     all_branches.sort_by_key(|branch| {
-                        branch
-                            .most_recent_commit
-                            .as_ref()
-                            .map(|commit| 0 - commit.commit_timestamp)
+                        (
+                            !branch.is_head, // Current branch (is_head=true) comes first
+                            branch
+                                .most_recent_commit
+                                .as_ref()
+                                .map(|commit| 0 - commit.commit_timestamp),
+                        )
                     });
 
                     all_branches


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Put current branch first in branch picker
