### PR TITLE
agent_servers: Include result text in Claude error messages

### DIFF
--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -464,11 +464,19 @@ impl ClaudeAgentSession {
                 }
             }
             SdkMessage::Result {
-                is_error, subtype, ..
+                is_error,
+                subtype,
+                result,
+                ..
             } => {
                 if let Some(end_turn_tx) = end_turn_tx.borrow_mut().take() {
                     if is_error {
-                        end_turn_tx.send(Err(anyhow!("Error: {subtype}"))).ok();
+                        end_turn_tx
+                            .send(Err(anyhow!(
+                                "Error: {}",
+                                result.unwrap_or_else(|| subtype.to_string())
+                            )))
+                            .ok();
                     } else {
                         end_turn_tx.send(Ok(())).ok();
                     }


### PR DESCRIPTION
This will better surfaces issues that are classified as "success" but
actually have a more meaningful error message attached.

Release Notes:

- N/A
