### PR TITLE
Change behavior of search with vim mode enabled

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -231,14 +231,8 @@ impl Vim {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;
-                // If search was initiated with vim shortcut '/', focus on editor, else if initiated
-                // via standard search shortcut, keep search bar focused (and always move by count=1).
-                if self.search.vim_mode_search {
-                    search_bar.select_match(direction, count, window, cx);
-                    search_bar.focus_editor(&Default::default(), window, cx);
-                } else {
-                    search_bar.select_match(direction, 1, window, cx);
-                }
+                search_bar.select_match(direction, count, window, cx);
+                search_bar.focus_editor(&Default::default(), window, cx);
 
                 let prior_selections: Vec<_> = self.search.prior_selections.drain(..).collect();
                 let prior_mode = self.search.prior_mode;

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -192,6 +192,7 @@ impl Vim {
                     self.search = SearchState {
                         direction,
                         count,
+                        vim_mode_search: true,
                         prior_selections,
                         prior_operator: self.operator_stack.last().cloned(),
                         prior_mode,
@@ -230,8 +231,14 @@ impl Vim {
                     count = count.saturating_sub(1)
                 }
                 self.search.count = 1;
-                search_bar.select_match(direction, count, window, cx);
-                search_bar.focus_editor(&Default::default(), window, cx);
+                // If search was initiated with vim shortcut '/', focus on editor, else if initiated
+                // via standard search shortcut, keep search bar focused (and always move by count=1).
+                if self.search.vim_mode_search {
+                    search_bar.select_match(direction, count, window, cx);
+                    search_bar.focus_editor(&Default::default(), window, cx);
+                } else {
+                    search_bar.select_match(direction, 1, window, cx);
+                }
 
                 let prior_selections: Vec<_> = self.search.prior_selections.drain(..).collect();
                 let prior_mode = self.search.prior_mode;

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -979,6 +979,7 @@ impl Clone for ReplayableAction {
 pub struct SearchState {
     pub direction: Direction,
     pub count: usize,
+    pub vim_mode_search: bool,
 
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -336,8 +336,12 @@ pub fn init(cx: &mut App) {
                 .and_then(|item| item.act_as::<Editor>(cx))
                 .and_then(|editor| editor.read(cx).addon::<VimAddon>().cloned());
             let Some(vim) = vim else { return };
-            vim.entity.update(cx, |_, cx| {
-                cx.defer_in(window, |vim, window, cx| vim.search_submit(window, cx))
+            vim.entity.update(cx, |vim, cx| {
+                if vim.search.vim_mode_search {
+                    cx.defer_in(window, |vim, window, cx| vim.search_submit(window, cx))
+                } else {
+                    cx.propagate()
+                }
             })
         });
     })


### PR DESCRIPTION
When vim mode is enabled, previously if `Cmd-F` (or platform equivalent) was pressed, enter will go to the editor's first match, and then hitting enter again goes to the next line rather than next match. This PR changes it to make enter go to the next match, which matches the convention in most other programs. The behavior when search is initiated with `/` is left unchanged.

Closes #7692

Release Notes:

- Improved: In vim mode, if search is not triggered with `/` and instead a keyboard shortcut, hitting enter goes to the next match
