### PR TITLE
Docs: Fix invalid JSON syntax in Visual Customizations - Editor Scrollbar and Minimap

### DIFF
--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -267,7 +267,7 @@ TBD: Centered layout related settings
     "display_in": "active_editor",  // Where to show (active_editor, all_editor)
     "thumb": "always",              // When to show thumb (always, hover)
     "thumb_border": "left_open",    // Thumb border (left_open, right_open, full, none)
-    "max_width_columns": 80         // Maximum width of minimap
+    "max_width_columns": 80,         // Maximum width of minimap
     "current_line_highlight": null  // Highlight current line (null, line, gutter)
   },
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -267,7 +267,7 @@ TBD: Centered layout related settings
     "display_in": "active_editor",  // Where to show (active_editor, all_editor)
     "thumb": "always",              // When to show thumb (always, hover)
     "thumb_border": "left_open",    // Thumb border (left_open, right_open, full, none)
-    "max_width_columns": 80,         // Maximum width of minimap
+    "max_width_columns": 80,        // Maximum width of minimap
     "current_line_highlight": null  // Highlight current line (null, line, gutter)
   },
 


### PR DESCRIPTION
I was on the [Visual Customiztions - Editor Scrollbar](https://zed.dev/docs/visual-customization#editor-scrollbar) section of the docs, and copy and pasted the code block into my personal Zed settings and saw there was a syntax error.

This is a PR to add a missing comma and fix the syntax error in the docs.

First time contributing, please let me know if I missed any steps/important info. 

Release Notes:

- N/A