### PR TITLE
Fix link to panic location on GitHub

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -63,7 +63,7 @@ pub fn init_panic_hook(
                 location.column(),
                 match app_commit_sha.as_ref() {
                     Some(commit_sha) => format!(
-                        "https://github.com/zed-industries/zed/blob/{}/src/{}#L{} \
+                        "https://github.com/zed-industries/zed/blob/{}/{}#L{} \
                         (may not be uploaded, line may be incorrect if files modified)\n",
                         commit_sha.full(),
                         location.file(),


### PR DESCRIPTION
I had a panic, and it reported

``https://github.com/zed-industries/zed/blob/24c2a465bbbbb1be28259abef2f98d52184ff446/src/crates/assistant_tools/src/edit_agent.rs#L686 (may not be uploaded, line may be incorrect if files modified)``

The `/src` part seems superfluous, and result in a link that don’t work (unlike `https://github.com/zed-industries/zed/blob/24c2a465bbbbb1be28259abef2f98d52184ff446/src/crates/assistant_tools/src/edit_agent.rs#L686`). I don’t know why it originally worked (of if it even actually originally worked properly), but there seems to be no reason to keep that `/src`.

Release Notes:

- N/A
