### PR TITLE
go: Support benchmarks named "Benchmark"

### DIFF
--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -69,7 +69,7 @@
 (
   (
     (function_declaration name: (_) @run @_name
-      (#match? @_name "^Benchmark.+"))
+      (#match? @_name "^Benchmark.*"))
   ) @_
   (#set! tag go-benchmark)
 )


### PR DESCRIPTION
The regular expression for benchmarks was enforcing using a suffix (e.g., `BenchmarkFoo`), but `Benchmark` is a valid benchmark name, just as `Test` is a valid test name, and `Fuzz` is a valid fuzz test name.

Release Notes:

- Add support for running Go benchmarks named "Benchmark"