### PR TITLE
Fix: Update Ruff extension repository link to correct URL

### DIFF
--- a/extensions/ruff/extension.toml
+++ b/extensions/ruff/extension.toml
@@ -4,7 +4,7 @@ description = "Support for Ruff, the Python linter and formatter"
 version = "0.1.0"
 schema_version = 1
 authors = []
-repository = "https://github.com/zed-industries/zed"
+repository = "https://github.com/astral-sh/ruff"
 
 [language_servers.ruff]
 name = "Ruff"


### PR DESCRIPTION
The repository link in extensions/ruff/extension.toml for the Ruff extension was previously pointing to the Zed repository (https://github.com/zed-industries/zed). This commit updates the repository field to the correct Ruff project URL: https://github.com/astral-sh/ruff. This fix ensures users and contributors can easily find the official Ruff repository for more information, support, and contributions.

Closes #35183

Release Notes:

- N/A
