### PR TITLE
debugger: Fix not being able to stop a Go debug session when no breakpoints were ever hit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,7 +4258,7 @@ dependencies = [
 [[package]]
 name = "dap-types"
 version = "0.0.1"
-source = "git+https://github.com/zed-industries/dap-types?rev=7f39295b441614ca9dbf44293e53c32f666897f9#7f39295b441614ca9dbf44293e53c32f666897f9"
+source = "git+https://github.com/zed-industries/dap-types?rev=1b461b310481d01e02b2603c16d7144b926339f8#1b461b310481d01e02b2603c16d7144b926339f8"
 dependencies = [
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -460,7 +460,7 @@ core-video = { version = "0.4.3", features = ["metal"] }
 cpal = "0.16"
 criterion = { version = "0.5", features = ["html_reports"] }
 ctor = "0.4.0"
-dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "7f39295b441614ca9dbf44293e53c32f666897f9" }
+dap-types = { git = "https://github.com/zed-industries/dap-types", rev = "1b461b310481d01e02b2603c16d7144b926339f8" }
 dashmap = "6.0"
 derive_more = "0.99.17"
 dirs = "4.0"

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -918,7 +918,7 @@ async fn test_debug_panel_item_thread_status_reset_on_failure(
     .unwrap();
 
     let client = session.update(cx, |session, _| session.adapter_client().unwrap());
-    const THREAD_ID_NUM: u64 = 1;
+    const THREAD_ID_NUM: i64 = 1;
 
     client.on_request::<dap::requests::Threads, _>(move |_, _| {
         Ok(dap::ThreadsResponse {

--- a/crates/project/src/debugger/dap_command.rs
+++ b/crates/project/src/debugger/dap_command.rs
@@ -107,7 +107,7 @@ impl<T: DapCommand> DapCommand for Arc<T> {
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct StepCommand {
-    pub thread_id: u64,
+    pub thread_id: i64,
     pub granularity: Option<SteppingGranularity>,
     pub single_thread: Option<bool>,
 }
@@ -483,7 +483,7 @@ impl DapCommand for ContinueCommand {
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub(crate) struct PauseCommand {
-    pub thread_id: u64,
+    pub thread_id: i64,
 }
 
 impl LocalDapCommand for PauseCommand {
@@ -612,7 +612,7 @@ impl DapCommand for DisconnectCommand {
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub(crate) struct TerminateThreadsCommand {
-    pub thread_ids: Option<Vec<u64>>,
+    pub thread_ids: Option<Vec<i64>>,
 }
 
 impl LocalDapCommand for TerminateThreadsCommand {
@@ -1182,7 +1182,7 @@ impl DapCommand for LoadedSourcesCommand {
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq)]
 pub(crate) struct StackTraceCommand {
-    pub thread_id: u64,
+    pub thread_id: i64,
     pub start_frame: Option<u64>,
     pub levels: Option<u64>,
 }

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -61,15 +61,10 @@ use worktree::Worktree;
 
 #[derive(Debug, Copy, Clone, Hash, PartialEq, PartialOrd, Ord, Eq)]
 #[repr(transparent)]
-pub struct ThreadId(pub u64);
+pub struct ThreadId(pub i64);
 
-impl ThreadId {
-    pub const MIN: ThreadId = ThreadId(u64::MIN);
-    pub const MAX: ThreadId = ThreadId(u64::MAX);
-}
-
-impl From<u64> for ThreadId {
-    fn from(id: u64) -> Self {
+impl From<i64> for ThreadId {
+    fn from(id: i64) -> Self {
         Self(id)
     }
 }

--- a/crates/proto/proto/debugger.proto
+++ b/crates/proto/proto/debugger.proto
@@ -188,7 +188,7 @@ message DapSetVariableValueResponse {
 message DapPauseRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
 }
 
 message DapDisconnectRequest {
@@ -202,7 +202,7 @@ message DapDisconnectRequest {
 message DapTerminateThreadsRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    repeated uint64 thread_ids = 3;
+    repeated int64 thread_ids = 3;
 }
 
 message DapThreadsRequest {
@@ -246,7 +246,7 @@ message IgnoreBreakpointState {
 message DapNextRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
     optional bool single_thread = 4;
     optional SteppingGranularity granularity = 5;
 }
@@ -254,7 +254,7 @@ message DapNextRequest {
 message DapStepInRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
     optional uint64 target_id = 4;
     optional bool single_thread = 5;
     optional SteppingGranularity granularity = 6;
@@ -263,7 +263,7 @@ message DapStepInRequest {
 message DapStepOutRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
     optional bool single_thread = 4;
     optional SteppingGranularity granularity = 5;
 }
@@ -271,7 +271,7 @@ message DapStepOutRequest {
 message DapStepBackRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
     optional bool single_thread = 4;
     optional SteppingGranularity granularity = 5;
 }
@@ -279,7 +279,7 @@ message DapStepBackRequest {
 message DapContinueRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
     optional bool single_thread = 4;
 }
 
@@ -311,7 +311,7 @@ message DapLoadedSourcesResponse {
 message DapStackTraceRequest {
     uint64 project_id = 1;
     uint64 client_id = 2;
-    uint64 thread_id = 3;
+    int64 thread_id = 3;
     optional uint64 start_frame = 4;
     optional uint64 stack_trace_levels = 5;
 }
@@ -358,7 +358,7 @@ message DapVariable {
 }
 
 message DapThread {
-    uint64 id = 1;
+    int64 id = 1;
     string name = 2;
 }
 


### PR DESCRIPTION
Fixes #35030

Release Notes:

- debugger: Fixed a bug where a Go debug session could not be stopped if no breakpoint was ever hit.
