### PR TITLE
ci: Use cargo update --locked instead of --frozen

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,7 +271,7 @@ jobs:
 
       - name: Check that Cargo.lock is up to date
         run: |
-          cargo update --frozen --workspace
+          cargo update --locked --workspace
 
       - name: cargo clippy
         run: ./script/clippy


### PR DESCRIPTION
This fixes false positives when e.g. bumping git deps

Release Notes:

- N/A
