### PR TITLE
Fix vim increment/decrement for negative numbers without gaps

### DIFF
--- a/crates/vim/src/normal/increment.rs
+++ b/crates/vim/src/normal/increment.rs
@@ -199,9 +199,13 @@ fn find_number(
     if ch0.as_ref().is_some_and(char::is_ascii_hexdigit) || matches!(ch0, Some('-' | 'b' | 'x')) {
         // go backwards to the start of any number the selection is within
         for ch in snapshot.reversed_chars_at(offset) {
-            if ch.is_ascii_hexdigit() || ch == '-' || ch == 'b' || ch == 'x' {
+            if ch.is_ascii_hexdigit() {
                 offset -= ch.len_utf8();
                 continue;
+            }
+            if ch == '-' || ch == 'b' || ch == 'x' {
+                offset -= ch.len_utf8();
+                break;
             }
             break;
         }
@@ -704,6 +708,18 @@ mod test {
             18  2
             24
             30"});
+    }
+
+    #[gpui::test]
+    async fn test_increment_multiple_numbers_no_gaps(cx: &mut gpui::TestAppContext) {
+        let mut cx = NeovimBackedTestContext::new(cx).await;
+        cx.set_shared_state(indoc! {
+            "2025-0ˇ5-10;"
+        })
+        .await;
+        cx.simulate_shared_keystrokes("ctrl-a").await;
+        cx.shared_state().await.assert_eq(indoc! {"
+        2025-0ˇ4-10;"});
     }
 
     #[gpui::test]

--- a/crates/vim/test_data/test_increment_multiple_numbers.json
+++ b/crates/vim/test_data/test_increment_multiple_numbers.json
@@ -1,3 +1,0 @@
-{"Put":{"state":"2025-0ˇ5-10;"}}
-{"Key":"ctrl-a"}
-{"Get":{"state":"2025-0ˇ4-10;","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_multiple_numbers.json
+++ b/crates/vim/test_data/test_increment_multiple_numbers.json
@@ -1,0 +1,3 @@
+{"Put":{"state":"2025-0ˇ5-10;"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"2025-0ˇ4-10;","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_negative_numbers_no_gaps.json
+++ b/crates/vim/test_data/test_increment_negative_numbers_no_gaps.json
@@ -1,0 +1,3 @@
+{"Put":{"state":"2025-0ˇ5-10"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"2025-0ˇ4-10","mode":"Normal"}}

--- a/crates/vim/test_data/test_increment_negative_numbers_on_hyphens.json
+++ b/crates/vim/test_data/test_increment_negative_numbers_on_hyphens.json
@@ -1,0 +1,6 @@
+{"Put":{"state":"2025-05ˇ-"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"2025-05ˇ-","mode":"Normal"}}
+{"Put":{"state":"2025-05ˇ- 345"}}
+{"Key":"ctrl-a"}
+{"Get":{"state":"2025-05- 34ˇ6","mode":"Normal"}}


### PR DESCRIPTION
Closes #35193

Release Notes:
- Fixed behavior for ctrl-a/ctrl-x in vim normal mode for negative numbers without gaps
- Added a test for that special case
