### PR TITLE
keymap_ui: Additional keystroke input polish

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -417,17 +417,6 @@ impl Modifiers {
         self.control || self.alt || self.shift || self.platform || self.function
     }
 
-    /// Returns the XOR of two modifier sets
-    pub fn xor(&self, other: &Modifiers) -> Modifiers {
-        Modifiers {
-            control: self.control ^ other.control,
-            alt: self.alt ^ other.alt,
-            shift: self.shift ^ other.shift,
-            platform: self.platform ^ other.platform,
-            function: self.function ^ other.function,
-        }
-    }
-
     /// Whether the semantically 'secondary' modifier key is pressed.
     ///
     /// On macOS, this is the command key.
@@ -550,6 +539,61 @@ impl Modifiers {
             && (other.shift || !self.shift)
             && (other.platform || !self.platform)
             && (other.function || !self.function)
+    }
+}
+
+impl std::ops::BitOr for Modifiers {
+    type Output = Self;
+
+    fn bitor(mut self, other: Self) -> Self::Output {
+        self |= other;
+        self
+    }
+}
+
+impl std::ops::BitOrAssign for Modifiers {
+    fn bitor_assign(&mut self, other: Self) {
+        self.control |= other.control;
+        self.alt |= other.alt;
+        self.shift |= other.shift;
+        self.platform |= other.platform;
+        self.function |= other.function;
+    }
+}
+
+impl std::ops::BitXor for Modifiers {
+    type Output = Self;
+    fn bitxor(mut self, rhs: Self) -> Self::Output {
+        self ^= rhs;
+        self
+    }
+}
+
+impl std::ops::BitXorAssign for Modifiers {
+    fn bitxor_assign(&mut self, other: Self) {
+        self.control ^= other.control;
+        self.alt ^= other.alt;
+        self.shift ^= other.shift;
+        self.platform ^= other.platform;
+        self.function ^= other.function;
+    }
+}
+
+impl std::ops::BitAnd for Modifiers {
+    type Output = Self;
+    fn bitand(mut self, rhs: Self) -> Self::Output {
+        self &= rhs;
+        self
+    }
+}
+
+impl std::ops::BitAndAssign for Modifiers {
+    fn bitand_assign(&mut self, other: Self) {
+        self.control &= other.control;
+        self.alt &= other.alt;
+        self.shift &= other.shift;
+        self.platform &= other.platform;
+        self.function &= other.function;
     }
 }
 

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -3027,7 +3027,7 @@ impl KeystrokeInput {
     }
 
     fn key_context() -> KeyContext {
-        let mut key_context = KeyContext::new_with_defaults();
+        let mut key_context = KeyContext::default();
         key_context.add("KeystrokeInput");
         key_context
     }
@@ -3374,7 +3374,7 @@ impl Render for KeystrokeInput {
             })
             .key_context(Self::key_context())
             .on_action(cx.listener(Self::start_recording))
-            .on_action(cx.listener(Self::stop_recording))
+            .on_action(cx.listener(Self::clear_keystrokes))
             .child(
                 h_flex()
                     .w(horizontal_padding)

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -566,21 +566,36 @@ impl KeymapEditor {
                                                     && query.modifiers == keystroke.modifiers
                                             },
                                         )
+                                } else if keystroke_query.len() > keystrokes.len() {
+                                    return false;
                                 } else {
-                                    for cursor in 0..keystrokes.len() {
-                                        let matches = keystroke_query
-                                            .iter()
-                                            .zip(&keystrokes[cursor..])
-                                            .take_while(|(q, k)| {
-                                                q.modifiers.is_subset_of(&k.modifiers)
-                                                    && ((q.key.is_empty() || q.key == k.key)
-                                                        && q.key_char
+                                    for keystroke_offset in 0..keystrokes.len() {
+                                        let mut found_count = 0;
+                                        let mut query_cursor = 0;
+                                        let mut keystroke_cursor = keystroke_offset;
+                                        while query_cursor < keystroke_query.len()
+                                            && keystroke_cursor < keystrokes.len()
+                                        {
+                                            let query = &keystroke_query[query_cursor];
+                                            let keystroke = &keystrokes[keystroke_cursor];
+                                            let matches =
+                                                query.modifiers.is_subset_of(&keystroke.modifiers)
+                                                    && ((query.key.is_empty()
+                                                        || query.key == keystroke.key)
+                                                        && query
+                                                            .key_char
                                                             .as_ref()
-                                                            .map_or(true, |q_kc| q_kc == &k.key))
-                                            })
-                                            .count()
-                                            == keystroke_query.len();
-                                        if matches {
+                                                            .map_or(true, |q_kc| {
+                                                                q_kc == &keystroke.key
+                                                            }));
+                                            if matches {
+                                                found_count += 1;
+                                                query_cursor += 1;
+                                            }
+                                            keystroke_cursor += 1;
+                                        }
+
+                                        if found_count == keystroke_query.len() {
                                             return true;
                                         }
                                     }


### PR DESCRIPTION
Closes #ISSUE

Fixed various issues and improved UX around the keystroke input primarily when used for keystroke search.

Release Notes:

- Keymap Editor: FIxed an issue where the modifiers used to activate keystroke search would appear in the keystroke search
- Keymap Editor: Made it possible to search for repeat modifiers, such as a binding with `cmd-shift cmd`
- Keymap Editor: Made keystroke search matches match based on ordered (not necessarily contiguous) runs. For example, searching for `cmd shift-j` will match `cmd-k cmd-shift-j alt-q` and `cmd-i g shift-j`  but not `alt-k shift-j` or `cmd-k alt-j`
- Keymap Editor: Fixed the clear keystrokes binding (`delete` by default) not working in the keystroke input
