### PR TITLE
editor: Ensure code actions menu doesn't grow beyond its max size

### DIFF
--- a/crates/editor/src/code_context_menus.rs
+++ b/crates/editor/src/code_context_menus.rs
@@ -844,7 +844,7 @@ impl CompletionsMenu {
         .with_sizing_behavior(ListSizingBehavior::Infer)
         .w(rems(34.));
 
-        Popover::new().child(div().child(list)).into_any_element()
+        Popover::new().child(list).into_any_element()
     }
 
     fn render_aside(

--- a/crates/ui/src/components/popover.rs
+++ b/crates/ui/src/components/popover.rs
@@ -50,7 +50,7 @@ impl RenderOnce for Popover {
                 v_flex()
                     .elevation_2(cx)
                     .py(POPOVER_Y_PADDING / 2.)
-                    .children(self.children),
+                    .child(div().children(self.children)),
             )
             .when_some(self.aside, |this, aside| {
                 this.child(


### PR DESCRIPTION
This resolves the same issue as fixed by https://github.com/zed-industries/zed/pull/34939/commits/d295409f0fc9c1ccd5e06e91c1c5365e96f16486 for the code actions menu.

No release notes since this only occurs on Nightly.

Release Notes:

- N/A
