### PR TITLE
Fix keybinds and 'No default binding' shown in docs

### DIFF
--- a/docs/src/extensions/installing-extensions.md
+++ b/docs/src/extensions/installing-extensions.md
@@ -1,6 +1,6 @@
 # Installing Extensions
 
-You can search for extensions by launching the Zed Extension Gallery by pressing `cmd-shift-x` (macOS) or `ctrl-shift-x` (Linux), opening the command palette and selecting `zed: extensions` or by selecting "Zed > Extensions" from the menu bar.
+You can search for extensions by launching the Zed Extension Gallery by pressing {#kb zed::Extensions} , opening the command palette and selecting {#action zed::Extensions} or by selecting "Zed > Extensions" from the menu bar.
 
 Here you can view the extensions that you currently have installed or search and install new ones.
 

--- a/docs/src/getting-started.md
+++ b/docs/src/getting-started.md
@@ -83,6 +83,6 @@ Visit [the AI overview page](./ai/overview.md) to learn how to quickly get start
 
 ## Set up your key bindings
 
-To open your custom keymap to add your key bindings, use the {#kb zed::OpenKeymap} keybinding.
+To edit your custom keymap and add or remap bindings, you can either use {#kb zed::OpenKeymapEditor} to spawn the Zed Keymap Editor ({#action zed::OpenKeymapEditor}) or you can directly open your Zed Keymap json (`~/.config/zed/keymap.json`) with {#action zed::OpenKeymap}.
 
 To access the default key binding set, open the Command Palette with {#kb command_palette::Toggle} and search for "zed: open default keymap". See [Key Bindings](./key-bindings.md) for more info.

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -18,7 +18,7 @@ You can also enable `vim_mode`, which adds vim bindings too.
 
 ## User keymaps
 
-Zed reads your keymap from `~/.config/zed/keymap.json`. You can open the file within Zed with {#kb zed::OpenKeymap}, or via `zed: Open Keymap` in the command palette.
+Zed reads your keymap from `~/.config/zed/keymap.json`. You can open the file within Zed with {#action zed::OpenKeymap} from the command palette or to spawn the Zed Keymap Editor ({#action zed::OpenKeymapEditor}) use {#kb zed::OpenKeymapEditor}.
 
 The file contains a JSON array of objects with `"bindings"`. If no `"context"` is set the bindings are always active. If it is set the binding is only active when the [context matches](#contexts).
 


### PR DESCRIPTION
Previously:
<img width="724" height="234" alt="Screenshot 2025-07-28 at 14 49 50" src="https://github.com/user-attachments/assets/b5203316-221d-4af5-8190-124f9b2b4cdf" />


Release Notes:

- N/A
