### PR TITLE
Map shift-escape in the Jetbrains keymaps

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -4,6 +4,7 @@
       "ctrl-alt-s": "zed::OpenSettings",
       "ctrl-{": "pane::ActivatePreviousItem",
       "ctrl-}": "pane::ActivateNextItem",
+      "shift-escape": null, // Unmap workspace::zoom
       "ctrl-f2": "debugger::Stop",
       "f6": "debugger::Pause",
       "f7": "debugger::StepInto",
@@ -151,6 +152,9 @@
   { "context": "OutlinePanel", "bindings": { "alt-7": "workspace::CloseActiveDock" } },
   {
     "context": "Dock || Workspace || Terminal || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
-    "bindings": { "escape": "editor::ToggleFocus" }
+    "bindings": {
+      "escape": "editor::ToggleFocus",
+      "shift-escape": "workspace::CloseActiveDock"
+    }
   }
 ]

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -4,6 +4,7 @@
       "cmd-{": "pane::ActivatePreviousItem",
       "cmd-}": "pane::ActivateNextItem",
       "cmd-0": "git_panel::ToggleFocus", // overrides `cmd-0` zoom reset
+      "shift-escape": null, // Unmap workspace::zoom
       "ctrl-f2": "debugger::Stop",
       "f6": "debugger::Pause",
       "f7": "debugger::StepInto",
@@ -151,6 +152,9 @@
   { "context": "OutlinePanel", "bindings": { "cmd-7": "workspace::CloseActiveDock" } },
   {
     "context": "Dock || Workspace || Terminal || OutlinePanel || ProjectPanel || CollabPanel || (Editor && mode == auto_height)",
-    "bindings": { "escape": "editor::ToggleFocus" }
+    "bindings": {
+      "escape": "editor::ToggleFocus",
+      "shift-escape": "workspace::CloseActiveDock"
+    }
   }
 ]


### PR DESCRIPTION
Release Notes:

- Added support for closing docks (sidebars) with `shift-escape` in the Jetbrains keymaps.