### PR TITLE
collab: Remove `POST /billing/subscriptions/sync` endpoint

### DIFF
--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -106,7 +106,6 @@ pub fn routes(rpc_server: Arc<rpc::Server>) -> Router<(), Body> {
         .route("/users/:id/refresh_llm_tokens", post(refresh_llm_tokens))
         .route("/users/:id/update_plan", post(update_plan))
         .route("/rpc_server_snapshot", get(get_rpc_server_snapshot))
-        .merge(billing::router())
         .merge(contributors::router())
         .layer(
             ServiceBuilder::new()

--- a/crates/collab/src/api/billing.rs
+++ b/crates/collab/src/api/billing.rs
@@ -1,15 +1,13 @@
 use anyhow::{Context as _, bail};
-use axum::{Extension, Json, Router, extract, routing::post};
 use chrono::{DateTime, Utc};
 use collections::{HashMap, HashSet};
-use reqwest::StatusCode;
 use sea_orm::ActiveValue;
-use serde::{Deserialize, Serialize};
 use std::{sync::Arc, time::Duration};
 use stripe::{CancellationDetailsReason, EventObject, EventType, ListEvents, SubscriptionStatus};
 use util::{ResultExt, maybe};
 use zed_llm_client::LanguageModelProvider;
 
+use crate::AppState;
 use crate::db::billing_subscription::{
     StripeCancellationReason, StripeSubscriptionStatus, SubscriptionKind,
 };
@@ -19,7 +17,6 @@ use crate::stripe_client::{
     StripeCancellationDetailsReason, StripeClient, StripeCustomerId, StripeSubscription,
     StripeSubscriptionId,
 };
-use crate::{AppState, Error, Result};
 use crate::{db::UserId, llm::db::LlmDatabase};
 use crate::{
     db::{
@@ -29,70 +26,6 @@ use crate::{
     },
     stripe_billing::StripeBilling,
 };
-
-pub fn router() -> Router {
-    Router::new().route(
-        "/billing/subscriptions/sync",
-        post(sync_billing_subscription),
-    )
-}
-
-#[derive(Debug, Deserialize)]
-struct SyncBillingSubscriptionBody {
-    github_user_id: i32,
-}
-
-#[derive(Debug, Serialize)]
-struct SyncBillingSubscriptionResponse {
-    stripe_customer_id: String,
-}
-
-async fn sync_billing_subscription(
-    Extension(app): Extension<Arc<AppState>>,
-    extract::Json(body): extract::Json<SyncBillingSubscriptionBody>,
-) -> Result<Json<SyncBillingSubscriptionResponse>> {
-    let Some(stripe_client) = app.stripe_client.clone() else {
-        log::error!("failed to retrieve Stripe client");
-        Err(Error::http(
-            StatusCode::NOT_IMPLEMENTED,
-            "not supported".into(),
-        ))?
-    };
-
-    let user = app
-        .db
-        .get_user_by_github_user_id(body.github_user_id)
-        .await?
-        .context("user not found")?;
-
-    let billing_customer = app
-        .db
-        .get_billing_customer_by_user_id(user.id)
-        .await?
-        .context("billing customer not found")?;
-    let stripe_customer_id = StripeCustomerId(billing_customer.stripe_customer_id.clone().into());
-
-    let subscriptions = stripe_client
-        .list_subscriptions_for_customer(&stripe_customer_id)
-        .await?;
-
-    for subscription in subscriptions {
-        let subscription_id = subscription.id.clone();
-
-        sync_subscription(&app, &stripe_client, subscription)
-            .await
-            .with_context(|| {
-                format!(
-                    "failed to sync subscription {subscription_id} for user {}",
-                    user.id,
-                )
-            })?;
-    }
-
-    Ok(Json(SyncBillingSubscriptionResponse {
-        stripe_customer_id: billing_customer.stripe_customer_id.clone(),
-    }))
-}
 
 /// The amount of time we wait in between each poll of Stripe events.
 ///


### PR DESCRIPTION
This PR removes the `POST /billing/subscriptions/sync` endpoint, as it has been moved to `cloud.zed.dev`.

Release Notes:

- N/A
