### PR TITLE
Improve JetBrains keymap for dock toggling

### DIFF
--- a/assets/keymaps/linux/jetbrains.json
+++ b/assets/keymaps/linux/jetbrains.json
@@ -44,8 +44,8 @@
       "ctrl-alt-right": "pane::GoForward",
       "alt-f7": "editor::FindAllReferences",
       "ctrl-alt-f7": "editor::FindAllReferences",
-      // "ctrl-b": "editor::GoToDefinition", // Conflicts with workspace::ToggleLeftDock
-      // "ctrl-alt-b": "editor::GoToDefinitionSplit", // Conflicts with workspace::ToggleLeftDock
+      "ctrl-b": "editor::GoToDefinition", // Conflicts with workspace::ToggleLeftDock
+      "ctrl-alt-b": "editor::GoToDefinitionSplit", // Conflicts with workspace::ToggleRightDock
       "ctrl-shift-b": "editor::GoToTypeDefinition",
       "ctrl-alt-shift-b": "editor::GoToTypeDefinitionSplit",
       "f2": "editor::GoToDiagnostic",
@@ -100,10 +100,25 @@
       "shift shift": "command_palette::Toggle",
       "ctrl-alt-shift-n": "project_symbols::Toggle",
       "alt-0": "git_panel::ToggleFocus",
-      "alt-1": "workspace::ToggleLeftDock",
+      "alt-1": "project_panel::ToggleFocus",
       "alt-5": "debug_panel::ToggleFocus",
       "alt-6": "diagnostics::Deploy",
       "alt-7": "outline_panel::ToggleFocus"
+    }
+  },
+  {
+    "context": "Pane", // this is to override the default Pane mappings to switch tabs
+    "bindings": {
+      "alt-1": "project_panel::ToggleFocus",
+      "alt-2": null, // Bookmarks (left dock)
+      "alt-3": null, // Find Panel (bottom dock)
+      "alt-4": null, // Run Panel (bottom dock)
+      "alt-5": "debug_panel::ToggleFocus",
+      "alt-6": "diagnostics::Deploy",
+      "alt-7": "outline_panel::ToggleFocus",
+      "alt-8": null, // Services (bottom dock)
+      "alt-9": null, // Git History (bottom dock)
+      "alt-0": "git_panel::ToggleFocus"
     }
   },
   {

--- a/assets/keymaps/macos/jetbrains.json
+++ b/assets/keymaps/macos/jetbrains.json
@@ -109,6 +109,21 @@
     }
   },
   {
+    "context": "Pane", // this is to override the default Pane mappings to switch tabs
+    "bindings": {
+      "cmd-1": "project_panel::ToggleFocus",
+      "cmd-2": null, // Bookmarks (left dock)
+      "cmd-3": null, // Find Panel (bottom dock)
+      "cmd-4": null, // Run Panel (bottom dock)
+      "cmd-5": "debug_panel::ToggleFocus",
+      "cmd-6": "diagnostics::Deploy",
+      "cmd-7": "outline_panel::ToggleFocus",
+      "cmd-8": null, // Services (bottom dock)
+      "cmd-9": null, // Git History (bottom dock)
+      "cmd-0": "git_panel::ToggleFocus"
+    }
+  },
+  {
     "context": "Workspace || Editor",
     "bindings": {
       "alt-f12": "terminal_panel::ToggleFocus",
@@ -146,6 +161,7 @@
     }
   },
   { "context": "GitPanel", "bindings": { "cmd-0": "workspace::CloseActiveDock" } },
+  { "context": "ProjectPanel", "bindings": { "cmd-1": "workspace::CloseActiveDock" } },
   { "context": "DebugPanel", "bindings": { "cmd-5": "workspace::CloseActiveDock" } },
   { "context": "Diagnostics > Editor", "bindings": { "cmd-6": "pane::CloseActiveItem" } },
   { "context": "OutlinePanel", "bindings": { "cmd-7": "workspace::CloseActiveDock" } },


### PR DESCRIPTION
Follow-up to: 
- https://github.com/zed-industries/zed/pull/34641
- https://github.com/zed-industries/zed/pull/35230

This improves Zed's behavior with the Jetbrains keymap for toggling specific docks/sidebars with cmd-0 thru cmd-9 (macos) and alt-0 thru alt-9 (linux).  Added in https://github.com/zed-industries/zed/pull/34641. Additionally, this also maps `ctrl-b` / `ctrl-alt-`b to their JetBrains equivalents (`editor::GoToDefinition` and `editor::GoToDefinitionSplit`) instead of the default vscode-compatable behavior (toggle left / right dock).  This is because we those specific toggles and a default Hide keyboard shortcut (`shift-escape`) added in https://github.com/zed-industries/zed/pull/35230.

Thanks to @thomaseizinger for raising this in:
- https://github.com/zed-industries/zed/discussions/34643#discussioncomment-13856746

Release Notes:

- Improve support keyboard-based dock show/hide in Jetbrains keymap.