### PR TITLE
gpui: Ensure tab index handles are properly reused across frames

### DIFF
--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -288,6 +288,10 @@ name = "svg"
 path = "examples/svg/svg.rs"
 
 [[example]]
+name = "tab_stop"
+path = "examples/tab_stop.rs"
+
+[[example]]
 name = "text"
 path = "examples/text.rs"
 

--- a/crates/gpui/src/tab_stop.rs
+++ b/crates/gpui/src/tab_stop.rs
@@ -5,7 +5,7 @@ use crate::{FocusHandle, FocusId};
 /// Used to manage the `Tab` event to switch between focus handles.
 #[derive(Default)]
 pub(crate) struct TabHandles {
-    handles: Vec<FocusHandle>,
+    pub(crate) handles: Vec<FocusHandle>,
 }
 
 impl TabHandles {

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -702,6 +702,7 @@ pub(crate) struct PaintIndex {
     input_handlers_index: usize,
     cursor_styles_index: usize,
     accessed_element_states_index: usize,
+    tab_handle_index: usize,
     line_layout_index: LineLayoutIndex,
 }
 
@@ -2208,6 +2209,7 @@ impl Window {
             input_handlers_index: self.next_frame.input_handlers.len(),
             cursor_styles_index: self.next_frame.cursor_styles.len(),
             accessed_element_states_index: self.next_frame.accessed_element_states.len(),
+            tab_handle_index: self.next_frame.tab_handles.handles.len(),
             line_layout_index: self.text_system.layout_index(),
         }
     }
@@ -2236,6 +2238,12 @@ impl Window {
                 ..range.end.accessed_element_states_index]
                 .iter()
                 .map(|(id, type_id)| (GlobalElementId(id.0.clone()), *type_id)),
+        );
+        self.next_frame.tab_handles.handles.extend(
+            self.rendered_frame.tab_handles.handles
+                [range.start.tab_handle_index..range.end.tab_handle_index]
+                .iter()
+                .cloned(),
         );
 
         self.text_system


### PR DESCRIPTION
This fixes an issue where focus handles with a tab index would get lost between rendered frames because the focus handles were not reused for the following paint cycle.

Release Notes:

- N/A
