### PR TITLE
keymap_ui: Fix bug introduced in #35208

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -534,11 +534,7 @@ impl Modifiers {
 
     /// Checks if this [`Modifiers`] is a subset of another [`Modifiers`].
     pub fn is_subset_of(&self, other: &Modifiers) -> bool {
-        (other.control || !self.control)
-            && (other.alt || !self.alt)
-            && (other.shift || !self.shift)
-            && (other.platform || !self.platform)
-            && (other.function || !self.function)
+        (*other & *self) == *self
     }
 }
 

--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -3109,7 +3109,9 @@ impl KeystrokeInput {
     ) {
         let keystrokes_len = self.keystrokes.len();
 
-        if event.modifiers.is_subset_of(&self.previous_modifiers) {
+        if self.previous_modifiers.modified()
+            && event.modifiers.is_subset_of(&self.previous_modifiers)
+        {
             self.previous_modifiers &= event.modifiers;
             cx.stop_propagation();
             return;


### PR DESCRIPTION
Closes #ISSUE

Fixes a bug that was cherry picked onto stable and preview branches introduced in #35208 whereby modifier keys would show up and not be removable when editing a keybind

Release Notes:

- (preview only) Keymap Editor: Fixed an issue introduced in v0.197.2 whereby modifier keys would show up and not be removable while recording keystrokes in the keybind edit modal
