### PR TITLE
docs: Fix link in configuration documentation

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3390,7 +3390,7 @@ Run the `theme selector: toggle` action in the command palette to see a current 
 
 ## Agent
 
-Visit [the Configuration page](/ai/configuration.md) under the AI section to learn more about all the agent-related settings.
+Visit [the Configuration page](./ai/configuration.md) under the AI section to learn more about all the agent-related settings.
 
 ## Outline Panel
 


### PR DESCRIPTION
# Summary

The link "under the configuration page" [on this page](https://zed.dev/docs/configuring-zed#agent) is broken. It should be linking to [this page](https://zed.dev/docs/ai/configuration).

## Approach

I noted that all other links to local markdown files in this document begin with "./" where the ai configuration link does not, I also noticed [this PR](https://github.com/zed-industries/zed/pull/31119) fixing a link with the same approach. I don't fully understand why this is the fix.

## Previous Approaches

I have tried writing the following redirect in `docs/book.toml`: `"/ai/configuration.html" = "/docs/ai/configuration.html"`. However this broke the `mdbook` build with the below error.

```
2025-07-29 08:49:36 [ERROR] (mdbook::utils): 	Caused By: Not redirecting "/Users/tmonaghan/dev/zed/docs/book/ai/configuration.html" to "/docs/ai/configuration.html" because it already exists. Are you sure it needs to be redirected?
```

Release Notes:

- N/A
