### PR TITLE
client: Fix typo in the error message

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -1138,7 +1138,7 @@ impl Client {
                 .to_str()
                 .map_err(EstablishConnectionError::other)?
                 .to_string();
-            Url::parse(&collab_url).with_context(|| format!("parsing colab rpc url {collab_url}"))
+            Url::parse(&collab_url).with_context(|| format!("parsing collab rpc url {collab_url}"))
         }
     }
 


### PR DESCRIPTION
This PR fixes a typo in the error message for when we fail to parse the Collab URL.

Release Notes:

- N/A
