### PR TITLE
keymap_ui: Clear close keystroke capture on timeout

### DIFF
--- a/crates/settings_ui/src/ui_components/keystroke_input.rs
+++ b/crates/settings_ui/src/ui_components/keystroke_input.rs
@@ -879,7 +879,7 @@ mod tests {
         }
 
         pub async fn wait_for_close_keystroke_capture_end(&mut self) -> &mut Self {
-            let task = self.input.update_in(&mut self.cx, |input, window, cx| {
+            let task = self.input.update_in(&mut self.cx, |input, _, _| {
                 input.clear_close_keystrokes_timer.take()
             });
             let task = task.expect("No close keystroke capture end timer task");

--- a/crates/settings_ui/src/ui_components/keystroke_input.rs
+++ b/crates/settings_ui/src/ui_components/keystroke_input.rs
@@ -1245,7 +1245,7 @@ mod tests {
         init_test(cx)
             .await
             .send_events(&["+ctrl", "g", "-ctrl", "escape"])
-            .expect_keystrokes(&["ctrl-g", "escape", ""])
+            .expect_keystrokes(&["ctrl-g", "escape"])
             .wait_for_close_keystroke_capture_end()
             .await
             .send_events(&["escape", "escape"])


### PR DESCRIPTION
Closes #ISSUE

Introduces a mechanism whereby keystrokes that have a post-fix which matches the prefix of the stop recording binding can still be entered. The solution is to introduce a (as of right now) 300ms timeout before the close keystroke state is wiped. 

Previously, with the default stop recording binding `esc esc esc`, searching or entering a binding ending in esc was not possible without using the mouse. `e.g.` entering keystroke `ctrl-g esc` and then attempting to hit `esc` three times would stop recording on the penultimate `esc` press and the final `esc` would not be intercepted. Now with the timeout, it is possible to enter `ctrl-g esc`, pause for a moment, then hit `esc esc esc` and end the recording with the keystroke input state being `ctrl-g esc`.

I arrived at 300ms for this delay as it was long enough that I didn't run into it very often when trying to escape, but short enough that a natural pause will almost always work as expected.

Release Notes:

- Keymap Editor: Added a short timeout to the stop recording keybind handling in the keystroke input, so that it is now possible using the default bindings as an example (custom bindings should work as well) to search for/enter a binding ending with `escape` (with no modifier), pause for a moment, then hit `escape escape escape` to stop recording and search for/enter a keystroke ending with `escape`.
