### PR TITLE
python: Use a single workspace folder for basedpyright

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1625,6 +1625,10 @@ impl LspAdapter for BasedPyrightLspAdapter {
     fn manifest_name(&self) -> Option<ManifestName> {
         Some(SharedString::new_static("pyproject.toml").into())
     }
+
+    fn workspace_folders_content(&self) -> WorkspaceFoldersContent {
+        WorkspaceFoldersContent::WorktreeRoot
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Treat the new basedpyright adapter the same as pyright was treated in #35243.

Release Notes:

- N/A