### PR TITLE
keymap_ui: Additional cleanup

### DIFF
--- a/crates/settings_ui/src/ui_components/keystroke_input.rs
+++ b/crates/settings_ui/src/ui_components/keystroke_input.rs
@@ -940,7 +940,7 @@ mod tests {
 
     struct KeystrokeUpdateTracker {
         initial_keystrokes: Vec<Keystroke>,
-        subscriptions: Vec<Subscription>,
+        _subscription: Subscription,
         input: Entity<KeystrokeInput>,
         received_keystrokes_updated: bool,
     }
@@ -948,21 +948,21 @@ mod tests {
     impl KeystrokeUpdateTracker {
         fn new(input: Entity<KeystrokeInput>, cx: &mut VisualTestContext) -> Entity<Self> {
             cx.new(|cx| Self {
-                initial_keystrokes: input.read_with(cx, |input, cx| input.keystrokes.clone()),
-                subscriptions: vec![cx.subscribe(&input, |this: &mut Self, input, _evt, cx| {
+                initial_keystrokes: input.read_with(cx, |input, _| input.keystrokes.clone()),
+                _subscription: cx.subscribe(&input, |this: &mut Self, _, _, _| {
                     this.received_keystrokes_updated = true;
-                })],
+                }),
                 input,
                 received_keystrokes_updated: false,
             })
         }
         #[track_caller]
-        fn finish(mut this: Entity<Self>, cx: &VisualTestContext) {
+        fn finish(this: Entity<Self>, cx: &VisualTestContext) {
             let (received_keystrokes_updated, initial_keystrokes_str, updated_keystrokes_str) =
                 this.read_with(cx, |this, cx| {
                     let updated_keystrokes = this
                         .input
-                        .read_with(cx, |input, cx| input.keystrokes.clone());
+                        .read_with(cx, |input, _| input.keystrokes.clone());
                     let initial_keystrokes_str = keystrokes_str(&this.initial_keystrokes);
                     let updated_keystrokes_str = keystrokes_str(&updated_keystrokes);
                     (

--- a/crates/settings_ui/src/ui_components/keystroke_input.rs
+++ b/crates/settings_ui/src/ui_components/keystroke_input.rs
@@ -298,14 +298,16 @@ impl KeystrokeInput {
             && key_len <= Self::KEYSTROKE_COUNT_MAX
         {
             if self.search {
-                last.key = keystroke.key.clone();
-                if close_keystroke_result == CloseKeystrokeResult::Partial {
-                    self.upsert_close_keystrokes_start(self.keystrokes.len() - 1, cx);
+                if self.previous_modifiers.modified() {
+                    last.key = keystroke.key.clone();
+                    if close_keystroke_result == CloseKeystrokeResult::Partial {
+                        self.upsert_close_keystrokes_start(self.keystrokes.len() - 1, cx);
+                    }
+                    self.previous_modifiers = keystroke.modifiers;
+                    self.keystrokes_changed(cx);
+                    cx.stop_propagation();
+                    return;
                 }
-                self.previous_modifiers = keystroke.modifiers;
-                self.keystrokes_changed(cx);
-                cx.stop_propagation();
-                return;
             } else {
                 self.keystrokes.pop();
             }


### PR DESCRIPTION
Closes #ISSUE

Additional cleanup and testing for the keystroke input including
- Focused testing of the "previous modifiers" logic in search mode
- Not merging unmodified keystrokes into previous modifier only bindings (extension of #35208)
- Fixing a bug where input would overflow in search mode when entering only modifiers
- Additional testing logic to ensure keystrokes updated events are always emitted correctly

Release Notes:

- N/A *or* Added/Fixed/Improved ...
