### PR TITLE
collab: Remove `GET /user` endpoint

### DIFF
--- a/crates/collab/src/api.rs
+++ b/crates/collab/src/api.rs
@@ -100,7 +100,6 @@ impl std::fmt::Display for SystemIdHeader {
 
 pub fn routes(rpc_server: Arc<rpc::Server>) -> Router<(), Body> {
     Router::new()
-        .route("/user", get(update_or_create_authenticated_user))
         .route("/users/look_up", get(look_up_user))
         .route("/users/:id/access_tokens", post(create_access_token))
         .route("/users/:id/refresh_llm_tokens", post(refresh_llm_tokens))
@@ -143,48 +142,6 @@ pub async fn validate_api_token<B>(req: Request<B>, next: Next<B>) -> impl IntoR
     }
 
     Ok::<_, Error>(next.run(req).await)
-}
-
-#[derive(Debug, Deserialize)]
-struct AuthenticatedUserParams {
-    github_user_id: i32,
-    github_login: String,
-    github_email: Option<String>,
-    github_name: Option<String>,
-    github_user_created_at: chrono::DateTime<chrono::Utc>,
-}
-
-#[derive(Debug, Serialize)]
-struct AuthenticatedUserResponse {
-    user: User,
-    metrics_id: String,
-    feature_flags: Vec<String>,
-}
-
-async fn update_or_create_authenticated_user(
-    Query(params): Query<AuthenticatedUserParams>,
-    Extension(app): Extension<Arc<AppState>>,
-) -> Result<Json<AuthenticatedUserResponse>> {
-    let initial_channel_id = app.config.auto_join_channel_id;
-
-    let user = app
-        .db
-        .update_or_create_user_by_github_account(
-            &params.github_login,
-            params.github_user_id,
-            params.github_email.as_deref(),
-            params.github_name.as_deref(),
-            params.github_user_created_at,
-            initial_channel_id,
-        )
-        .await?;
-    let metrics_id = app.db.get_user_metrics_id(user.id).await?;
-    let feature_flags = app.db.get_user_flags(user.id).await?;
-    Ok(Json(AuthenticatedUserResponse {
-        user,
-        metrics_id,
-        feature_flags,
-    }))
 }
 
 #[derive(Debug, Deserialize)]

--- a/crates/collab/src/api/contributors.rs
+++ b/crates/collab/src/api/contributors.rs
@@ -8,7 +8,6 @@ use axum::{
 use chrono::{NaiveDateTime, SecondsFormat};
 use serde::{Deserialize, Serialize};
 
-use crate::api::AuthenticatedUserParams;
 use crate::db::ContributorSelector;
 use crate::{AppState, Result};
 
@@ -104,9 +103,18 @@ impl RenovateBot {
     }
 }
 
+#[derive(Debug, Deserialize)]
+struct AddContributorBody {
+    github_user_id: i32,
+    github_login: String,
+    github_email: Option<String>,
+    github_name: Option<String>,
+    github_user_created_at: chrono::DateTime<chrono::Utc>,
+}
+
 async fn add_contributor(
     Extension(app): Extension<Arc<AppState>>,
-    extract::Json(params): extract::Json<AuthenticatedUserParams>,
+    extract::Json(params): extract::Json<AddContributorBody>,
 ) -> Result<()> {
     let initial_channel_id = app.config.auto_join_channel_id;
     app.db


### PR DESCRIPTION
This PR removes the `GET /user` endpoint, as it has been moved to `cloud.zed.dev`.

Release Notes:

- N/A