### PR TITLE
emmet: Bump to 0.0.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20338,7 +20338,7 @@ dependencies = [
 
 [[package]]
 name = "zed_emmet"
-version = "0.0.3"
+version = "0.0.4"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/emmet/Cargo.toml
+++ b/extensions/emmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_emmet"
-version = "0.0.3"
+version = "0.0.4"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"


### PR DESCRIPTION
This PR bumps the emmet extension to version 0.0.4. 

Includes:
- https://github.com/zed-industries/zed/pull/33865
- https://github.com/zed-industries/zed/pull/32208
- https://github.com/zed-industries/zed/pull/15177

Note that this intentionally does NOT include a change in the `extension.toml`: The version was bumped incorrectly once in https://github.com/zed-industries/zed/pull/32208 in both the `extension.toml` as well as the `Cargo.lock` but not in the `Cargo.toml`. After that, https://github.com/zed-industries/zed/pull/33667 only removed the changes in the `Cargo.lock` but didn't revert the change in the `extension.toml` file. Hence, the version in the `extension.toml` is already at `0.0.4`

Release Notes:

- N/A