### PR TITLE
Actually disable AI for now

### DIFF
--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -265,8 +265,8 @@ fn update_command_palette_filter(cx: &mut App) {
             filter.hide_namespace("agent");
             filter.hide_namespace("assistant");
             filter.hide_namespace("copilot");
+            filter.hide_namespace("supermaven");
             filter.hide_namespace("zed_predict_onboarding");
-
             filter.hide_namespace("edit_prediction");
 
             use editor::actions::{

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -56,7 +56,7 @@ use aho_corasick::AhoCorasick;
 use anyhow::{Context as _, Result, anyhow};
 use blink_manager::BlinkManager;
 use buffer_diff::DiffHunkStatus;
-use client::{Collaborator, ParticipantIndex};
+use client::{Collaborator, DisableAiSettings, ParticipantIndex};
 use clock::{AGENT_REPLICA_ID, ReplicaId};
 use collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use convert_case::{Case, Casing};
@@ -7048,7 +7048,7 @@ impl Editor {
     }
 
     pub fn update_edit_prediction_settings(&mut self, cx: &mut Context<Self>) {
-        if self.edit_prediction_provider.is_none() {
+        if self.edit_prediction_provider.is_none() || DisableAiSettings::get_global(cx).disable_ai {
             self.edit_prediction_settings = EditPredictionSettings::Disabled;
         } else {
             let selection = self.selections.newest_anchor();

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -1,10 +1,10 @@
-use client::{Client, UserStore};
+use client::{Client, DisableAiSettings, UserStore};
 use collections::HashMap;
 use copilot::{Copilot, CopilotCompletionProvider};
 use editor::Editor;
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{EditPredictionProvider, all_language_settings};
-use settings::SettingsStore;
+use settings::{Settings as _, SettingsStore};
 use smol::stream::StreamExt;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use supermaven::{Supermaven, SupermavenCompletionProvider};
@@ -195,16 +195,18 @@ fn register_backward_compatible_actions(editor: &mut Editor, cx: &mut Context<Ed
             },
         ))
         .detach();
-    editor
-        .register_action(cx.listener(
-            |editor,
-             _: &editor::actions::AcceptPartialCopilotSuggestion,
-             window: &mut Window,
-             cx: &mut Context<Editor>| {
-                editor.accept_partial_inline_completion(&Default::default(), window, cx);
-            },
-        ))
-        .detach();
+    if !DisableAiSettings::get_global(cx).disable_ai {
+        editor
+            .register_action(cx.listener(
+                |editor,
+                 _: &editor::actions::AcceptPartialCopilotSuggestion,
+                 window: &mut Window,
+                 cx: &mut Context<Editor>| {
+                    editor.accept_partial_inline_completion(&Default::default(), window, cx);
+                },
+            ))
+            .detach();
+    }
 }
 
 fn assign_edit_prediction_provider(


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/35325

* removes Supermaven actions
* removes copilot-related action
* stops re-enabling edit predictions when disabled

Release Notes:

- N/A 
