### PR TITLE
Revert "gpui: Implement support for wlr layer shell (#32651)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7367,9 +7367,8 @@ dependencies = [
  "wayland-backend",
  "wayland-client",
  "wayland-cursor",
- "wayland-protocols 0.31.2",
+ "wayland-protocols",
  "wayland-protocols-plasma",
- "wayland-protocols-wlr",
  "windows 0.61.1",
  "windows-core 0.61.0",
  "windows-numerics",
@@ -18386,9 +18385,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-backend"
-version = "0.3.10"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe770181423e5fc79d3e2a7f4410b7799d5aab1de4372853de3c6aa13ca24121"
+checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
 dependencies = [
  "cc",
  "downcast-rs",
@@ -18400,9 +18399,9 @@ dependencies = [
 
 [[package]]
 name = "wayland-client"
-version = "0.31.10"
+version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978fa7c67b0847dbd6a9f350ca2569174974cd4082737054dbb7fbb79d7d9a61"
+checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
 dependencies = [
  "bitflags 2.9.0",
  "rustix 0.38.44",
@@ -18434,18 +18433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wayland-protocols"
-version = "0.32.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "779075454e1e9a521794fed15886323ea0feda3f8b0fc1390f5398141310422a"
-dependencies = [
- "bitflags 2.9.0",
- "wayland-backend",
- "wayland-client",
- "wayland-scanner",
-]
-
-[[package]]
 name = "wayland-protocols-plasma"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18454,20 +18441,7 @@ dependencies = [
  "bitflags 2.9.0",
  "wayland-backend",
  "wayland-client",
- "wayland-protocols 0.31.2",
- "wayland-scanner",
-]
-
-[[package]]
-name = "wayland-protocols-wlr"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cb6cdc73399c0e06504c437fe3cf886f25568dd5454473d565085b36d6a8bbf"
-dependencies = [
- "bitflags 2.9.0",
- "wayland-backend",
- "wayland-client",
- "wayland-protocols 0.32.8",
+ "wayland-protocols",
  "wayland-scanner",
 ]
 

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -47,7 +47,6 @@ wayland = [
     "wayland-cursor",
     "wayland-protocols",
     "wayland-protocols-plasma",
-    "wayland-protocols-wlr",
     "filedescriptor",
     "xkbcommon",
     "open",
@@ -194,9 +193,6 @@ wayland-protocols = { version = "0.31.2", features = [
 wayland-protocols-plasma = { version = "0.2.0", features = [
     "client",
 ], optional = true }
-wayland-protocols-wlr = { version = "0.3.8", features = [
-    "client"
-], optional = true}
 
 # X11
 as-raw-xcb-connection = { version = "1", optional = true }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -1216,10 +1216,6 @@ pub enum WindowKind {
     /// A window that appears above all other windows, usually used for alerts or popups
     /// use sparingly!
     PopUp,
-    /// An overlay such as a notification window, a launcher, ...
-    ///
-    /// Only supported on wayland
-    Overlay,
 }
 
 /// The appearance of the window, as defined by the operating system.

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -61,7 +61,6 @@ use wayland_protocols::xdg::decoration::zv1::client::{
 };
 use wayland_protocols::xdg::shell::client::{xdg_surface, xdg_toplevel, xdg_wm_base};
 use wayland_protocols_plasma::blur::client::{org_kde_kwin_blur, org_kde_kwin_blur_manager};
-use wayland_protocols_wlr::layer_shell::v1::client::{zwlr_layer_shell_v1, zwlr_layer_surface_v1};
 use xkbcommon::xkb::ffi::XKB_KEYMAP_FORMAT_TEXT_V1;
 use xkbcommon::xkb::{self, KEYMAP_COMPILE_NO_FLAGS, Keycode};
 
@@ -115,7 +114,6 @@ pub struct Globals {
     pub fractional_scale_manager:
         Option<wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1>,
     pub decoration_manager: Option<zxdg_decoration_manager_v1::ZxdgDecorationManagerV1>,
-    pub layer_shell: Option<zwlr_layer_shell_v1::ZwlrLayerShellV1>,
     pub blur_manager: Option<org_kde_kwin_blur_manager::OrgKdeKwinBlurManager>,
     pub text_input_manager: Option<zwp_text_input_manager_v3::ZwpTextInputManagerV3>,
     pub executor: ForegroundExecutor,
@@ -153,7 +151,6 @@ impl Globals {
             viewporter: globals.bind(&qh, 1..=1, ()).ok(),
             fractional_scale_manager: globals.bind(&qh, 1..=1, ()).ok(),
             decoration_manager: globals.bind(&qh, 1..=1, ()).ok(),
-            layer_shell: globals.bind(&qh, 1..=1, ()).ok(),
             blur_manager: globals.bind(&qh, 1..=1, ()).ok(),
             text_input_manager: globals.bind(&qh, 1..=1, ()).ok(),
             executor,
@@ -932,7 +929,6 @@ delegate_noop!(WaylandClientStatePtr: ignore wl_buffer::WlBuffer);
 delegate_noop!(WaylandClientStatePtr: ignore wl_region::WlRegion);
 delegate_noop!(WaylandClientStatePtr: ignore wp_fractional_scale_manager_v1::WpFractionalScaleManagerV1);
 delegate_noop!(WaylandClientStatePtr: ignore zxdg_decoration_manager_v1::ZxdgDecorationManagerV1);
-delegate_noop!(WaylandClientStatePtr: ignore zwlr_layer_shell_v1::ZwlrLayerShellV1);
 delegate_noop!(WaylandClientStatePtr: ignore org_kde_kwin_blur_manager::OrgKdeKwinBlurManager);
 delegate_noop!(WaylandClientStatePtr: ignore zwp_text_input_manager_v3::ZwpTextInputManagerV3);
 delegate_noop!(WaylandClientStatePtr: ignore org_kde_kwin_blur::OrgKdeKwinBlur);
@@ -1070,31 +1066,6 @@ impl Dispatch<xdg_toplevel::XdgToplevel, ObjectId> for WaylandClientStatePtr {
 
         drop(state);
         let should_close = window.handle_toplevel_event(event);
-
-        if should_close {
-            // The close logic will be handled in drop_window()
-            window.close();
-        }
-    }
-}
-
-impl Dispatch<zwlr_layer_surface_v1::ZwlrLayerSurfaceV1, ObjectId> for WaylandClientStatePtr {
-    fn event(
-        this: &mut Self,
-        _: &zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
-        event: <zwlr_layer_surface_v1::ZwlrLayerSurfaceV1 as Proxy>::Event,
-        surface_id: &ObjectId,
-        _: &Connection,
-        _: &QueueHandle<Self>,
-    ) {
-        let client = this.get_client();
-        let mut state = client.borrow_mut();
-        let Some(window) = get_window(&mut state, surface_id) else {
-            return;
-        };
-        drop(state);
-
-        let should_close = window.handle_layersurface_event(event);
 
         if should_close {
             // The close logic will be handled in drop_window()

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -1,6 +1,3 @@
-use blade_graphics as gpu;
-use collections::HashMap;
-use futures::channel::oneshot::Receiver;
 use std::{
     cell::{Ref, RefCell, RefMut},
     ffi::c_void,
@@ -9,14 +6,9 @@ use std::{
     sync::Arc,
 };
 
-use crate::{
-    Capslock,
-    platform::{
-        PlatformAtlas, PlatformInputHandler, PlatformWindow,
-        blade::{BladeContext, BladeRenderer, BladeSurfaceConfig},
-        linux::wayland::{display::WaylandDisplay, serial::SerialKind},
-    },
-};
+use blade_graphics as gpu;
+use collections::HashMap;
+use futures::channel::oneshot::Receiver;
 
 use raw_window_handle as rwh;
 use wayland_backend::client::ObjectId;
@@ -28,8 +20,6 @@ use wayland_protocols::xdg::decoration::zv1::client::zxdg_toplevel_decoration_v1
 use wayland_protocols::xdg::shell::client::xdg_surface;
 use wayland_protocols::xdg::shell::client::xdg_toplevel::{self};
 use wayland_protocols_plasma::blur::client::org_kde_kwin_blur;
-use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_shell_v1::Layer;
-use wayland_protocols_wlr::layer_shell::v1::client::zwlr_layer_surface_v1;
 
 use crate::scene::Scene;
 use crate::{
@@ -37,7 +27,15 @@ use crate::{
     PlatformDisplay, PlatformInput, Point, PromptButton, PromptLevel, RequestFrameOptions,
     ResizeEdge, ScaledPixels, Size, Tiling, WaylandClientStatePtr, WindowAppearance,
     WindowBackgroundAppearance, WindowBounds, WindowControlArea, WindowControls, WindowDecorations,
-    WindowKind, WindowParams, px, size,
+    WindowParams, px, size,
+};
+use crate::{
+    Capslock,
+    platform::{
+        PlatformAtlas, PlatformInputHandler, PlatformWindow,
+        blade::{BladeContext, BladeRenderer, BladeSurfaceConfig},
+        linux::wayland::{display::WaylandDisplay, serial::SerialKind},
+    },
 };
 
 #[derive(Default)]
@@ -83,12 +81,14 @@ struct InProgressConfigure {
 }
 
 pub struct WaylandWindowState {
-    surface_state: WaylandSurfaceState,
+    xdg_surface: xdg_surface::XdgSurface,
     acknowledged_first_configure: bool,
     pub surface: wl_surface::WlSurface,
+    decoration: Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>,
     app_id: Option<String>,
     appearance: WindowAppearance,
     blur: Option<org_kde_kwin_blur::OrgKdeKwinBlur>,
+    toplevel: xdg_toplevel::XdgToplevel,
     viewport: Option<wp_viewport::WpViewport>,
     outputs: HashMap<ObjectId, Output>,
     display: Option<(ObjectId, Output)>,
@@ -114,78 +114,6 @@ pub struct WaylandWindowState {
     client_inset: Option<Pixels>,
 }
 
-pub enum WaylandSurfaceState {
-    Xdg(WaylandXdgSurfaceState),
-    LayerShell(WaylandLayerSurfaceState),
-}
-
-pub struct WaylandXdgSurfaceState {
-    xdg_surface: xdg_surface::XdgSurface,
-    toplevel: xdg_toplevel::XdgToplevel,
-    decoration: Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>,
-}
-
-pub struct WaylandLayerSurfaceState {
-    layer_surface: zwlr_layer_surface_v1::ZwlrLayerSurfaceV1,
-}
-
-impl WaylandSurfaceState {
-    fn ack_configure(&self, serial: u32) {
-        match self {
-            WaylandSurfaceState::Xdg(WaylandXdgSurfaceState { xdg_surface, .. }) => {
-                xdg_surface.ack_configure(serial);
-            }
-            WaylandSurfaceState::LayerShell(WaylandLayerSurfaceState { layer_surface, .. }) => {
-                layer_surface.ack_configure(serial);
-            }
-        }
-    }
-
-    fn decoration(&self) -> Option<&zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1> {
-        if let WaylandSurfaceState::Xdg(WaylandXdgSurfaceState { decoration, .. }) = self {
-            decoration.as_ref()
-        } else {
-            None
-        }
-    }
-
-    fn toplevel(&self) -> Option<&xdg_toplevel::XdgToplevel> {
-        if let WaylandSurfaceState::Xdg(WaylandXdgSurfaceState { toplevel, .. }) = self {
-            Some(toplevel)
-        } else {
-            None
-        }
-    }
-
-    fn set_geometry(&self, x: i32, y: i32, width: i32, height: i32) {
-        match self {
-            WaylandSurfaceState::Xdg(WaylandXdgSurfaceState { xdg_surface, .. }) => {
-                xdg_surface.set_window_geometry(x, y, width, height);
-            }
-            WaylandSurfaceState::LayerShell(WaylandLayerSurfaceState { layer_surface, .. }) => {
-                // cannot set window position of a layer surface
-                layer_surface.set_size(width as u32, height as u32);
-            }
-        }
-    }
-
-    fn destroy(&mut self) {
-        match self {
-            WaylandSurfaceState::Xdg(WaylandXdgSurfaceState {
-                xdg_surface,
-                toplevel,
-                decoration: _decoration,
-            }) => {
-                toplevel.destroy();
-                xdg_surface.destroy();
-            }
-            WaylandSurfaceState::LayerShell(WaylandLayerSurfaceState { layer_surface }) => {
-                layer_surface.destroy();
-            }
-        }
-    }
-}
-
 #[derive(Clone)]
 pub struct WaylandWindowStatePtr {
     state: Rc<RefCell<WaylandWindowState>>,
@@ -196,7 +124,9 @@ impl WaylandWindowState {
     pub(crate) fn new(
         handle: AnyWindowHandle,
         surface: wl_surface::WlSurface,
-        surface_state: WaylandSurfaceState,
+        xdg_surface: xdg_surface::XdgSurface,
+        toplevel: xdg_toplevel::XdgToplevel,
+        decoration: Option<zxdg_toplevel_decoration_v1::ZxdgToplevelDecorationV1>,
         appearance: WindowAppearance,
         viewport: Option<wp_viewport::WpViewport>,
         client: WaylandClientStatePtr,
@@ -226,11 +156,13 @@ impl WaylandWindowState {
         };
 
         Ok(Self {
-            surface_state,
+            xdg_surface,
             acknowledged_first_configure: false,
             surface,
+            decoration,
             app_id: None,
             blur: None,
+            toplevel,
             viewport,
             globals,
             outputs: HashMap::default(),
@@ -303,16 +235,17 @@ impl Drop for WaylandWindow {
         let client = state.client.clone();
 
         state.renderer.destroy();
-        if let Some(decoration) = &state.surface_state.decoration() {
+        if let Some(decoration) = &state.decoration {
             decoration.destroy();
         }
         if let Some(blur) = &state.blur {
             blur.release();
         }
-        state.surface_state.destroy();
+        state.toplevel.destroy();
         if let Some(viewport) = &state.viewport {
             viewport.destroy();
         }
+        state.xdg_surface.destroy();
         state.surface.destroy();
 
         let state_ptr = self.0.clone();
@@ -346,64 +279,26 @@ impl WaylandWindow {
         appearance: WindowAppearance,
     ) -> anyhow::Result<(Self, ObjectId)> {
         let surface = globals.compositor.create_surface(&globals.qh, ());
+        let xdg_surface = globals
+            .wm_base
+            .get_xdg_surface(&surface, &globals.qh, surface.id());
+        let toplevel = xdg_surface.get_toplevel(&globals.qh, surface.id());
 
-        let surface_state = match (params.kind, globals.layer_shell.as_ref()) {
-            // Matching on layer_shell here means that if kind is Overlay, but the compositor doesn't support layer_shell,
-            // we end up defaulting to xdg_surface anyway
-            (WindowKind::Overlay, Some(layer_shell)) => {
-                let layer_surface = layer_shell.get_layer_surface(
-                    &surface,
-                    None,
-                    Layer::Overlay,
-                    "".to_string(),
-                    &globals.qh,
-                    surface.id(),
-                );
-
-                let width = params.bounds.size.width.0;
-                let height = params.bounds.size.height.0;
-                layer_surface.set_size(width as u32, height as u32);
-                layer_surface.set_keyboard_interactivity(
-                    zwlr_layer_surface_v1::KeyboardInteractivity::OnDemand,
-                );
-
-                WaylandSurfaceState::LayerShell(WaylandLayerSurfaceState { layer_surface })
-            }
-            _ => {
-                let xdg_surface =
-                    globals
-                        .wm_base
-                        .get_xdg_surface(&surface, &globals.qh, surface.id());
-
-                let toplevel = xdg_surface.get_toplevel(&globals.qh, surface.id());
-
-                if let Some(size) = params.window_min_size {
-                    toplevel.set_min_size(size.width.0 as i32, size.height.0 as i32);
-                }
-
-                // Attempt to set up window decorations based on the requested configuration
-                let decoration = globals
-                    .decoration_manager
-                    .as_ref()
-                    .map(|decoration_manager| {
-                        decoration_manager.get_toplevel_decoration(
-                            &toplevel,
-                            &globals.qh,
-                            surface.id(),
-                        )
-                    });
-
-                WaylandSurfaceState::Xdg(WaylandXdgSurfaceState {
-                    xdg_surface,
-                    toplevel,
-                    decoration,
-                })
-            }
-        };
+        if let Some(size) = params.window_min_size {
+            toplevel.set_min_size(size.width.0 as i32, size.height.0 as i32);
+        }
 
         if let Some(fractional_scale_manager) = globals.fractional_scale_manager.as_ref() {
             fractional_scale_manager.get_fractional_scale(&surface, &globals.qh, surface.id());
         }
+
+        // Attempt to set up window decorations based on the requested configuration
+        let decoration = globals
+            .decoration_manager
+            .as_ref()
+            .map(|decoration_manager| {
+                decoration_manager.get_toplevel_decoration(&toplevel, &globals.qh, surface.id())
+            });
 
         let viewport = globals
             .viewporter
@@ -414,7 +309,9 @@ impl WaylandWindow {
             state: Rc::new(RefCell::new(WaylandWindowState::new(
                 handle,
                 surface.clone(),
-                surface_state,
+                xdg_surface,
+                toplevel,
+                decoration,
                 appearance,
                 viewport,
                 client,
@@ -506,7 +403,7 @@ impl WaylandWindowStatePtr {
                     }
                 }
                 let mut state = self.state.borrow_mut();
-                state.surface_state.ack_configure(serial);
+                state.xdg_surface.ack_configure(serial);
 
                 let window_geometry = inset_by_tiling(
                     state.bounds.map_origin(|_| px(0.0)),
@@ -516,7 +413,7 @@ impl WaylandWindowStatePtr {
                 .map(|v| v.0 as i32)
                 .map_size(|v| if v <= 0 { 1 } else { v });
 
-                state.surface_state.set_geometry(
+                state.xdg_surface.set_window_geometry(
                     window_geometry.origin.x,
                     window_geometry.origin.y,
                     window_geometry.size.width,
@@ -676,42 +573,6 @@ impl WaylandWindowStatePtr {
                 let mut state = self.state.borrow_mut();
                 state.in_progress_window_controls = Some(window_controls);
                 false
-            }
-            _ => false,
-        }
-    }
-
-    pub fn handle_layersurface_event(&self, event: zwlr_layer_surface_v1::Event) -> bool {
-        match event {
-            zwlr_layer_surface_v1::Event::Configure {
-                width,
-                height,
-                serial,
-            } => {
-                let mut size = if width == 0 || height == 0 {
-                    None
-                } else {
-                    Some(size(px(width as f32), px(height as f32)))
-                };
-
-                let mut state = self.state.borrow_mut();
-                state.in_progress_configure = Some(InProgressConfigure {
-                    size,
-                    fullscreen: false,
-                    maximized: false,
-                    resizing: false,
-                    tiling: Tiling::default(),
-                });
-                drop(state);
-
-                // just do the same thing we'd do as an xdg_surface
-                self.handle_xdg_surface_event(xdg_surface::Event::Configure { serial });
-
-                false
-            }
-            zwlr_layer_surface_v1::Event::Closed => {
-                // unlike xdg, we don't have a choice here: the surface is closing.
-                true
             }
             _ => false,
         }
@@ -979,7 +840,7 @@ impl PlatformWindow for WaylandWindow {
         let state_ptr = self.0.clone();
         let dp_size = size.to_device_pixels(self.scale_factor());
 
-        state.surface_state.set_geometry(
+        state.xdg_surface.set_window_geometry(
             state.bounds.origin.x.0 as i32,
             state.bounds.origin.y.0 as i32,
             dp_size.width.0,
@@ -1073,16 +934,12 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn set_title(&mut self, title: &str) {
-        if let Some(toplevel) = self.borrow().surface_state.toplevel() {
-            toplevel.set_title(title.to_string());
-        }
+        self.borrow().toplevel.set_title(title.to_string());
     }
 
     fn set_app_id(&mut self, app_id: &str) {
         let mut state = self.borrow_mut();
-        if let Some(toplevel) = self.borrow().surface_state.toplevel() {
-            toplevel.set_app_id(app_id.to_owned());
-        }
+        state.toplevel.set_app_id(app_id.to_owned());
         state.app_id = Some(app_id.to_owned());
     }
 
@@ -1093,30 +950,24 @@ impl PlatformWindow for WaylandWindow {
     }
 
     fn minimize(&self) {
-        if let Some(toplevel) = self.borrow().surface_state.toplevel() {
-            toplevel.set_minimized();
-        }
+        self.borrow().toplevel.set_minimized();
     }
 
     fn zoom(&self) {
         let state = self.borrow();
-        if let Some(toplevel) = state.surface_state.toplevel() {
-            if !state.maximized {
-                toplevel.set_maximized();
-            } else {
-                toplevel.unset_maximized();
-            }
+        if !state.maximized {
+            state.toplevel.set_maximized();
+        } else {
+            state.toplevel.unset_maximized();
         }
     }
 
     fn toggle_fullscreen(&self) {
-        let mut state = self.borrow();
-        if let Some(toplevel) = state.surface_state.toplevel() {
-            if !state.fullscreen {
-                toplevel.set_fullscreen(None);
-            } else {
-                toplevel.unset_fullscreen();
-            }
+        let mut state = self.borrow_mut();
+        if !state.fullscreen {
+            state.toplevel.set_fullscreen(None);
+        } else {
+            state.toplevel.unset_fullscreen();
         }
     }
 
@@ -1181,33 +1032,27 @@ impl PlatformWindow for WaylandWindow {
     fn show_window_menu(&self, position: Point<Pixels>) {
         let state = self.borrow();
         let serial = state.client.get_serial(SerialKind::MousePress);
-        if let Some(toplevel) = state.surface_state.toplevel() {
-            toplevel.show_window_menu(
-                &state.globals.seat,
-                serial,
-                position.x.0 as i32,
-                position.y.0 as i32,
-            );
-        }
+        state.toplevel.show_window_menu(
+            &state.globals.seat,
+            serial,
+            position.x.0 as i32,
+            position.y.0 as i32,
+        );
     }
 
     fn start_window_move(&self) {
         let state = self.borrow();
         let serial = state.client.get_serial(SerialKind::MousePress);
-        if let Some(toplevel) = state.surface_state.toplevel() {
-            toplevel._move(&state.globals.seat, serial);
-        }
+        state.toplevel._move(&state.globals.seat, serial);
     }
 
     fn start_window_resize(&self, edge: crate::ResizeEdge) {
         let state = self.borrow();
-        if let Some(toplevel) = state.surface_state.toplevel() {
-            toplevel.resize(
-                &state.globals.seat,
-                state.client.get_serial(SerialKind::MousePress),
-                edge.to_xdg(),
-            )
-        }
+        state.toplevel.resize(
+            &state.globals.seat,
+            state.client.get_serial(SerialKind::MousePress),
+            edge.to_xdg(),
+        )
     }
 
     fn window_decorations(&self) -> Decorations {
@@ -1223,7 +1068,7 @@ impl PlatformWindow for WaylandWindow {
     fn request_decorations(&self, decorations: WindowDecorations) {
         let mut state = self.borrow_mut();
         state.decorations = decorations;
-        if let Some(decoration) = state.surface_state.decoration() {
+        if let Some(decoration) = state.decoration.as_ref() {
             decoration.set_mode(decorations.to_xdg());
             update_window(state);
         }

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -559,7 +559,7 @@ impl MacWindow {
             }
 
             let native_window: id = match kind {
-                WindowKind::Normal | WindowKind::Overlay => msg_send![WINDOW_CLASS, alloc],
+                WindowKind::Normal => msg_send![WINDOW_CLASS, alloc],
                 WindowKind::PopUp => {
                     style_mask |= NSWindowStyleMaskNonactivatingPanel;
                     msg_send![PANEL_CLASS, alloc]
@@ -711,7 +711,7 @@ impl MacWindow {
             native_window.makeFirstResponder_(native_view);
 
             match kind {
-                WindowKind::Normal | WindowKind::Overlay => {
+                WindowKind::Normal => {
                     native_window.setLevel_(NSNormalWindowLevel);
                     native_window.setAcceptsMouseMovedEvents_(YES);
                 }


### PR DESCRIPTION
This reverts commit c110f7801516a1948ade4a51213f1fc8ea7f8efc.

On Linux Wayland, that causes a panic:

```
already mutably borrowed: BorrowError
zed::reliability::init_panic_hook::{{closure}}::h276cc55bf0717738+165677654
std::panicking::rust_panic_with_hook::h409da73ddef13937+139331443
std::panicking::begin_panic_handler::{{closure}}::h159b61b27f96a9c2+139330666
std::sys::backtrace::__rust_end_short_backtrace::h5b56844d75e766fc+139314825
__rustc[4794b31dd7191200]::rust_begin_unwind+139329805
core::panicking::panic_fmt::hc8737e8cca20a7c8+9934576
core::cell::panic_already_mutably_borrowed::h95c7d326eb19a92a+9934403
<gpui::platform::linux::wayland::window::WaylandWindow as gpui::platform::PlatformWindow>::set_app_id::hfa7deae0be264f60+10621600
gpui::window::Window::new::h6505f6042d99702f+80424235
gpui::app::async_context::AsyncApp::open_window::h62ef8f80789a0af2+159117345
workspace::Workspace::new_local::{{closure}}::{{closure}}::h4d786ba393f391b5+160720110
gpui::app::App::spawn::{{closure}}::haf6a6ef0f9bab21c+159294806
async_task::raw::RawTask<F,T,S,M>::run::h9e5f668e091fddff+158375501
<gpui::platform::linux::wayland::client::WaylandClient as gpui::platform::linux::platform::LinuxClient>::run::h69e40feabd97f1bb+79906738
gpui::platform::linux::platform::<impl gpui::platform::Platform for P>::run::hd80e5b2da41c7d0a+79758141
gpui::app::Application::run::h9136595e7346a2c9+163935333
zed::main::h83f7ef86a32dbbfd+165755480
std::sys::backtrace::__rust_begin_short_backtrace::hb6da6fe5454d7688+168421891
std::rt::lang_start::{{closure}}::h51a50d6423746d5f+168421865
std::rt::lang_start_internal::ha8ef919ae4984948+139244369
main+168421964
__libc_start_call_main+29344125649354
__libc_start_main_impl+29344125649547
_start+12961358
```


Release Notes:

- N/A
