### PR TITLE
onboarding: Fix keybindings showing up after a delay

### DIFF
--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -81,7 +81,7 @@ pub fn init(cx: &mut App) {
                     if let Some(existing) = existing {
                         workspace.activate_item(&existing, true, true, window, cx);
                     } else {
-                        let settings_page = WelcomePage::new(cx);
+                        let settings_page = WelcomePage::new(window, cx);
                         workspace.add_item_to_active_pane(
                             Box::new(settings_page),
                             None,

--- a/crates/onboarding/src/welcome.rs
+++ b/crates/onboarding/src/welcome.rs
@@ -7,7 +7,7 @@ use workspace::{
     NewFile, Open, Workspace, WorkspaceId,
     item::{Item, ItemEvent},
 };
-use zed_actions::{Extensions, OpenSettings, command_palette};
+use zed_actions::{Extensions, OpenSettings, agent, command_palette};
 
 actions!(
     zed,
@@ -55,8 +55,7 @@ const CONTENT: (Section<4>, Section<3>) = (
             SectionEntry {
                 icon: IconName::ZedAssistant,
                 title: "View AI Settings",
-                // TODO: use proper action
-                action: &NoAction,
+                action: &agent::OpenSettings,
             },
             SectionEntry {
                 icon: IconName::Blocks,
@@ -228,12 +227,14 @@ impl Render for WelcomePage {
 }
 
 impl WelcomePage {
-    pub fn new(cx: &mut Context<Workspace>) -> Entity<Self> {
-        let this = cx.new(|cx| WelcomePage {
-            focus_handle: cx.focus_handle(),
-        });
+    pub fn new(window: &mut Window, cx: &mut Context<Workspace>) -> Entity<Self> {
+        cx.new(|cx| {
+            let focus_handle = cx.focus_handle();
+            cx.on_focus(&focus_handle, window, |_, _, cx| cx.notify())
+                .detach();
 
-        this
+            WelcomePage { focus_handle }
+        })
     }
 }
 


### PR DESCRIPTION
This fixes an issue where keybinds would only show up after a delay on the welcome page upon re-opening it. It also binds one of the buttons to the corresponding action.

Release Notes:

- N/A
