### PR TITLE
Add spread operator to the @operator list for ECMAScript languages

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -146,6 +146,7 @@
   "&&="
   "||="
   "??="
+  "..."
 ] @operator
 
 (regex "/" @string.regex)

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -146,6 +146,7 @@
   "&&="
   "||="
   "??="
+  "..."
 ] @operator
 
 (regex "/" @string.regex)

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -167,6 +167,7 @@
   "&&="
   "||="
   "??="
+  "..."
 ] @operator
 
 (regex "/" @string.regex)


### PR DESCRIPTION
Previously, this was the one thing that could not be styled properly in ecmascript languages in the zed config, because it was not able to be targeted. 

Now, it is added alongside other operators. This has been tested and works as expected.

Release Notes:

- N/A
