### PR TITLE
Use outlined bolt icon for the LSP tool

### DIFF
--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -1015,7 +1015,7 @@ impl Render for LspTool {
                 .anchor(Corner::BottomLeft)
                 .with_handle(self.popover_menu_handle.clone())
                 .trigger_with_tooltip(
-                    IconButton::new("zed-lsp-tool-button", IconName::Microscope)
+                    IconButton::new("zed-lsp-tool-button", IconName::Bolt)
                         .when_some(indicator, IconButton::indicator)
                         .icon_size(IconSize::Small)
                         .indicator_border_color(Some(cx.theme().colors().status_bar_background)),

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -1015,7 +1015,7 @@ impl Render for LspTool {
                 .anchor(Corner::BottomLeft)
                 .with_handle(self.popover_menu_handle.clone())
                 .trigger_with_tooltip(
-                    IconButton::new("zed-lsp-tool-button", IconName::BoltFilledAlt)
+                    IconButton::new("zed-lsp-tool-button", IconName::Microscope)
                         .when_some(indicator, IconButton::indicator)
                         .icon_size(IconSize::Small)
                         .indicator_border_color(Some(cx.theme().colors().status_bar_background)),


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="266" height="67" alt="image" src="https://github.com/user-attachments/assets/bbfc75b6-6747-4eb1-ab94-ab098eba5335" /> | <img width="266" height="67" alt="image" src="https://github.com/user-attachments/assets/4631be9d-3d5e-4eb6-bf2f-596403fdf014" /> | 

Release Notes:

- Changed the icon of the language servers entry in the status bar.