### PR TITLE
gpui: Wait for DWM vsync event before rendering

### DIFF
--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -203,7 +203,7 @@ impl DirectXRenderer {
 
     fn present(&mut self) -> Result<()> {
         unsafe {
-            let result = self.resources.swap_chain.Present(1, DXGI_PRESENT(0));
+            let result = self.resources.swap_chain.Present(0, DXGI_PRESENT(0));
             // Presenting the swap chain can fail if the DirectX device was removed or reset.
             if result == DXGI_ERROR_DEVICE_REMOVED || result == DXGI_ERROR_DEVICE_RESET {
                 let reason = self.devices.device.GetDeviceRemovedReason();


### PR DESCRIPTION
The DX11 renderer attempts to use the native DirectX presentation VSync, but GPUI does not present every frame, only when a redraw is required by the application. This caused the window to be redrawn as fast as possible, forever, resulting in a 100% CPU core load when the window *shouldn't* be drawn and a much lower CPU load when the window *should* be drawn.

This PR resolves this issue by disable the DirectX Vsync and returning to the original DWM event-based VSync, which eliminates the CPU load issue.

Release Notes:

- N/A
