### PR TITLE
docs: Run lychee link check on generated docs output

### DIFF
--- a/.github/actions/build_docs/action.yml
+++ b/.github/actions/build_docs/action.yml
@@ -19,7 +19,7 @@ runs:
       shell: bash -euxo pipefail {0}
       run: ./script/linux
 
-    - name: Check for broken links
+    - name: Check for broken links (in MD)
       uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
       with:
         args: --no-progress --exclude '^http' './docs/src/**/*'
@@ -30,3 +30,9 @@ runs:
       run: |
         mkdir -p target/deploy
         mdbook build ./docs --dest-dir=../target/deploy/docs/
+
+    - name: Check for broken links (in HTML)
+      uses: lycheeverse/lychee-action@82202e5e9c2f4ef1a55a3d02563e1cb6041e5332 # v2.4.1
+      with:
+        args: --no-progress --exclude '^http' 'target/deploy/docs/'
+        fail: true


### PR DESCRIPTION
Closes #ISSUE

Following #35310. This PR makes it so the lychee link check is ran before building the docs on the md files to catch basic errors, and then after building on the html output to catch generation errors, including regressions like the one #35380 fixes. 

Release Notes:

- N/A
