### PR TITLE
Add line ending selector

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9516,7 +9516,6 @@ name = "line_ending_selector"
 version = "0.1.0"
 dependencies = [
  "editor",
- "fuzzy",
  "gpui",
  "language",
  "picker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9512,6 +9512,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "line_ending_selector"
+version = "0.1.0"
+dependencies = [
+ "editor",
+ "fuzzy",
+ "gpui",
+ "language",
+ "picker",
+ "project",
+ "ui",
+ "util",
+ "workspace",
+ "workspace-hack",
+]
+
+[[package]]
 name = "link-cplusplus"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -20467,6 +20483,7 @@ dependencies = [
  "language_tools",
  "languages",
  "libc",
+ "line_ending_selector",
  "livekit_client",
  "log",
  "markdown",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ members = [
     "crates/language_selector",
     "crates/language_tools",
     "crates/languages",
+    "crates/line_ending_selector",
     "crates/livekit_api",
     "crates/livekit_client",
     "crates/lmstudio",
@@ -324,6 +325,7 @@ language_models = { path = "crates/language_models" }
 language_selector = { path = "crates/language_selector" }
 language_tools = { path = "crates/language_tools" }
 languages = { path = "crates/languages" }
+line_ending_selector = { path = "crates/line_ending_selector" }
 livekit_api = { path = "crates/livekit_api" }
 livekit_client = { path = "crates/livekit_client" }
 lmstudio = { path = "crates/lmstudio" }

--- a/crates/line_ending_selector/Cargo.toml
+++ b/crates/line_ending_selector/Cargo.toml
@@ -14,7 +14,6 @@ doctest = false
 
 [dependencies]
 editor.workspace = true
-fuzzy.workspace = true
 gpui.workspace = true
 language.workspace = true
 picker.workspace = true

--- a/crates/line_ending_selector/Cargo.toml
+++ b/crates/line_ending_selector/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "line_ending_selector"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/line_ending_selector.rs"
+doctest = false
+
+[dependencies]
+editor.workspace = true
+fuzzy.workspace = true
+gpui.workspace = true
+language.workspace = true
+picker.workspace = true
+project.workspace = true
+ui.workspace = true
+util.workspace = true
+workspace.workspace = true
+workspace-hack.workspace = true

--- a/crates/line_ending_selector/LICENSE-GPL
+++ b/crates/line_ending_selector/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/line_ending_selector/src/line_ending_selector.rs
+++ b/crates/line_ending_selector/src/line_ending_selector.rs
@@ -1,0 +1,242 @@
+use editor::Editor;
+use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
+use gpui::{DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, WeakEntity, actions};
+use language::{Buffer, LineEnding};
+use picker::{Picker, PickerDelegate};
+use project::Project;
+use std::sync::Arc;
+use ui::{HighlightedLabel, ListItem, ListItemSpacing, prelude::*};
+use util::ResultExt;
+use workspace::{ModalView, Workspace};
+
+actions!(
+    line_ending_selector,
+    [
+        /// Toggles the line ending selector modal.
+        Toggle
+    ]
+);
+
+pub fn init(cx: &mut App) {
+    cx.observe_new(LineEndingSelector::register).detach();
+}
+
+pub struct LineEndingSelector {
+    picker: Entity<Picker<LineEndingSelectorDelegate>>,
+}
+
+impl LineEndingSelector {
+    fn register(
+        workspace: &mut Workspace,
+        _window: Option<&mut Window>,
+        _: &mut Context<Workspace>,
+    ) {
+        workspace.register_action(move |workspace, _: &Toggle, window, cx| {
+            Self::toggle(workspace, window, cx);
+        });
+    }
+
+    fn toggle(
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) -> Option<()> {
+        let (_, buffer, _) = workspace
+            .active_item(cx)?
+            .act_as::<Editor>(cx)?
+            .read(cx)
+            .active_excerpt(cx)?;
+        let project = workspace.project().clone();
+
+        workspace.toggle_modal(window, cx, move |window, cx| {
+            LineEndingSelector::new(buffer, project, window, cx)
+        });
+        Some(())
+    }
+
+    fn new(
+        buffer: Entity<Buffer>,
+        project: Entity<Project>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        let line_ending = buffer.read(cx).line_ending();
+        let delegate =
+            LineEndingSelectorDelegate::new(cx.entity().downgrade(), buffer, project, line_ending);
+        let picker = cx.new(|cx| Picker::uniform_list(delegate, window, cx));
+        Self { picker }
+    }
+}
+
+impl Render for LineEndingSelector {
+    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex().w(rems(34.)).child(self.picker.clone())
+    }
+}
+
+impl Focusable for LineEndingSelector {
+    fn focus_handle(&self, cx: &App) -> FocusHandle {
+        self.picker.focus_handle(cx)
+    }
+}
+
+impl EventEmitter<DismissEvent> for LineEndingSelector {}
+impl ModalView for LineEndingSelector {}
+
+struct LineEndingSelectorDelegate {
+    line_ending_selector: WeakEntity<LineEndingSelector>,
+    buffer: Entity<Buffer>,
+    project: Entity<Project>,
+    line_ending: LineEnding,
+    matches: Vec<StringMatch>,
+    selected_index: usize,
+}
+
+impl LineEndingSelectorDelegate {
+    fn new(
+        line_ending_selector: WeakEntity<LineEndingSelector>,
+        buffer: Entity<Buffer>,
+        project: Entity<Project>,
+        line_ending: LineEnding,
+    ) -> Self {
+        Self {
+            line_ending_selector,
+            buffer,
+            project,
+            line_ending,
+            matches: vec![],
+            selected_index: 0,
+        }
+    }
+}
+
+impl PickerDelegate for LineEndingSelectorDelegate {
+    type ListItem = ListItem;
+
+    fn placeholder_text(&self, _window: &mut Window, _cx: &mut App) -> Arc<str> {
+        "Select a line ending…".into()
+    }
+
+    fn match_count(&self) -> usize {
+        self.matches.len()
+    }
+
+    fn confirm(&mut self, _: bool, window: &mut Window, cx: &mut Context<Picker<Self>>) {
+        if let Some(mat) = self.matches.get(self.selected_index) {
+            let line_ending = match mat.candidate_id {
+                0 => LineEnding::Unix,
+                1 => LineEnding::Windows,
+                _ => unreachable!(),
+            };
+            self.buffer.update(cx, |this, cx| {
+                this.set_line_ending(line_ending, cx);
+            });
+            let buffer = self.buffer.clone();
+            self.project.update(cx, |this, cx| {
+                this.save_buffer(buffer, cx).detach();
+            });
+        }
+        self.dismissed(window, cx);
+    }
+
+    fn dismissed(&mut self, _: &mut Window, cx: &mut Context<Picker<Self>>) {
+        self.line_ending_selector
+            .update(cx, |_, cx| cx.emit(DismissEvent))
+            .log_err();
+    }
+
+    fn selected_index(&self) -> usize {
+        self.selected_index
+    }
+
+    fn set_selected_index(
+        &mut self,
+        ix: usize,
+        _window: &mut Window,
+        _: &mut Context<Picker<Self>>,
+    ) {
+        self.selected_index = ix;
+    }
+
+    fn update_matches(
+        &mut self,
+        query: String,
+        window: &mut Window,
+        cx: &mut Context<Picker<Self>>,
+    ) -> gpui::Task<()> {
+        let background = cx.background_executor().clone();
+        cx.spawn_in(window, async move |this, cx| {
+            let matches = if query.is_empty() {
+                vec![
+                    StringMatch {
+                        candidate_id: 0,
+                        string: "LF".to_string(),
+                        positions: Vec::new(),
+                        score: 0.0,
+                    },
+                    StringMatch {
+                        candidate_id: 1,
+                        string: "CRLF".to_string(),
+                        positions: Vec::new(),
+                        score: 0.0,
+                    },
+                ]
+            } else {
+                match_strings(
+                    &[
+                        StringMatchCandidate::new(0, "LF"),
+                        StringMatchCandidate::new(1, "CRLF"),
+                    ],
+                    &query,
+                    false,
+                    false,
+                    2,
+                    &Default::default(),
+                    background,
+                )
+                .await
+            };
+
+            this.update(cx, |this, cx| {
+                let delegate = &mut this.delegate;
+                delegate.matches = matches;
+                delegate.selected_index = delegate
+                    .selected_index
+                    .min(delegate.matches.len().saturating_sub(1));
+                cx.notify();
+            })
+            .log_err();
+        })
+    }
+
+    fn render_match(
+        &self,
+        ix: usize,
+        selected: bool,
+        _: &mut Window,
+        _: &mut Context<Picker<Self>>,
+    ) -> Option<Self::ListItem> {
+        let mat = &self.matches[ix];
+        let line_ending = match mat.candidate_id {
+            0 => LineEnding::Unix,
+            1 => LineEnding::Windows,
+            _ => unreachable!(),
+        };
+        let label = match line_ending {
+            LineEnding::Unix => "LF",
+            LineEnding::Windows => "CRLF",
+        };
+
+        let mut list_item = ListItem::new(ix)
+            .inset(true)
+            .spacing(ListItemSpacing::Sparse)
+            .toggle_state(selected)
+            .child(HighlightedLabel::new(label, mat.positions.clone()));
+
+        if self.line_ending == line_ending {
+            list_item = list_item.end_slot(Icon::new(IconName::Check).color(Color::Muted));
+        }
+
+        Some(list_item)
+    }
+}

--- a/crates/proto/proto/buffer.proto
+++ b/crates/proto/proto/buffer.proto
@@ -143,6 +143,7 @@ message Operation {
         UpdateSelections update_selections = 3;
         UpdateDiagnostics update_diagnostics = 4;
         UpdateCompletionTriggers update_completion_triggers = 5;
+        UpdateLineEnding update_line_ending = 6;
     }
 
     message Edit {
@@ -173,6 +174,12 @@ message Operation {
         uint32 lamport_timestamp = 2;
         repeated string triggers = 3;
         uint64 language_server_id = 4;
+    }
+
+    message UpdateLineEnding {
+        uint32 replica_id = 1;
+        uint32 lamport_timestamp = 2;
+        LineEnding line_ending = 3;
     }
 }
 

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -93,6 +93,7 @@ language_models.workspace = true
 language_selector.workspace = true
 language_tools.workspace = true
 languages = { workspace = true, features = ["load-grammars"] }
+line_ending_selector.workspace = true
 libc.workspace = true
 log.workspace = true
 markdown.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -620,6 +620,7 @@ pub fn main() {
         terminal_view::init(cx);
         journal::init(app_state.clone(), cx);
         language_selector::init(cx);
+        line_ending_selector::init(cx);
         toolchain_selector::init(cx);
         theme_selector::init(cx);
         settings_profile_selector::init(cx);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4480,7 +4480,7 @@ mod tests {
                 "keymap_editor",
                 "keystroke_input",
                 "language_selector",
-                "line_ending_selector",
+                "line_ending",
                 "lsp_tool",
                 "markdown",
                 "menu",

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4480,6 +4480,7 @@ mod tests {
                 "keymap_editor",
                 "keystroke_input",
                 "language_selector",
+                "line_ending_selector",
                 "lsp_tool",
                 "markdown",
                 "menu",


### PR DESCRIPTION
Partially addresses this issue #5294

Adds a selector between `LF` and `CRLF` for the buffer's line endings, the checkmark denotes the currently selected line ending.

Selector
<img width="487" height="66" alt="image" src="https://github.com/user-attachments/assets/13f2480f-4d2d-4afe-adf5-385aeb421393" />

Release Notes:

- Added line ending selector.