### PR TITLE
workspace: Fix multiple remote projects not restoring on reconnect or restart and not visible in recent projects

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1090,7 +1090,8 @@ pub struct Workspace {
     _subscriptions: Vec<Subscription>,
     _apply_leader_updates: Task<Result<()>>,
     _observe_current_user: Task<Result<()>>,
-    _schedule_serialize: Option<Task<()>>,
+    _schedule_serialize_workspace: Option<Task<()>>,
+    _schedule_serialize_ssh_paths: Option<Task<()>>,
     pane_history_timestamp: Arc<AtomicUsize>,
     bounds: Bounds<Pixels>,
     pub centered_layout: bool,
@@ -1418,7 +1419,8 @@ impl Workspace {
             app_state,
             _observe_current_user,
             _apply_leader_updates,
-            _schedule_serialize: None,
+            _schedule_serialize_workspace: None,
+            _schedule_serialize_ssh_paths: None,
             leader_updates_tx,
             _subscriptions: subscriptions,
             pane_history_timestamp,
@@ -5088,20 +5090,31 @@ impl Workspace {
         }
     }
 
-    fn serialize_ssh_paths(&self, window: &mut Window, cx: &mut Context<Workspace>) {
-        let Some(ssh_project) = &self.serialized_ssh_project else {
-            return;
-        };
-        println!("serializing ssh paths");
-        let ssh_project_id = ssh_project.id;
-        let ssh_project_paths = ssh_project.paths.clone();
-        window
-            .spawn(cx, async move |_| {
-                let _ = persistence::DB
-                    .update_ssh_project_paths(ssh_project_id, ssh_project_paths)
-                    .await;
-            })
-            .detach();
+    fn serialize_ssh_paths(&mut self, window: &mut Window, cx: &mut Context<Workspace>) {
+        if self._schedule_serialize_ssh_paths.is_none() {
+            self._schedule_serialize_ssh_paths =
+                Some(cx.spawn_in(window, async move |this, cx| {
+                    cx.background_executor()
+                        .timer(SERIALIZATION_THROTTLE_TIME)
+                        .await;
+                    this.update_in(cx, |this, window, cx| {
+                        let task = if let Some(ssh_project) = &this.serialized_ssh_project {
+                            let ssh_project_id = ssh_project.id;
+                            let ssh_project_paths = ssh_project.paths.clone();
+                            window.spawn(cx, async move |_| {
+                                persistence::DB
+                                    .update_ssh_project_paths(ssh_project_id, ssh_project_paths)
+                                    .await
+                            })
+                        } else {
+                            Task::ready(Err(anyhow::anyhow!("No SSH project to serialize")))
+                        };
+                        task.detach();
+                        this._schedule_serialize_ssh_paths.take();
+                    })
+                    .log_err();
+                }));
+        }
     }
 
     fn remove_panes(&mut self, member: Member, window: &mut Window, cx: &mut Context<Workspace>) {
@@ -5147,17 +5160,18 @@ impl Workspace {
     }
 
     fn serialize_workspace(&mut self, window: &mut Window, cx: &mut Context<Self>) {
-        if self._schedule_serialize.is_none() {
-            self._schedule_serialize = Some(cx.spawn_in(window, async move |this, cx| {
-                cx.background_executor()
-                    .timer(Duration::from_millis(100))
-                    .await;
-                this.update_in(cx, |this, window, cx| {
-                    this.serialize_workspace_internal(window, cx).detach();
-                    this._schedule_serialize.take();
-                })
-                .log_err();
-            }));
+        if self._schedule_serialize_workspace.is_none() {
+            self._schedule_serialize_workspace =
+                Some(cx.spawn_in(window, async move |this, cx| {
+                    cx.background_executor()
+                        .timer(SERIALIZATION_THROTTLE_TIME)
+                        .await;
+                    this.update_in(cx, |this, window, cx| {
+                        this.serialize_workspace_internal(window, cx).detach();
+                        this._schedule_serialize_workspace.take();
+                    })
+                    .log_err();
+                }));
         }
     }
 


### PR DESCRIPTION
Closes #33787

We were not updating SSH paths after initial project was created. Now we update paths when worktrees are added/removed and serialize these updated paths. This is separate from workspace because unlike local paths, SSH paths are not part of the workspace table, but the SSH table instead. We don't need to update SSH paths every time we serialize the workspace.

<img width="400" src="https://github.com/user-attachments/assets/9e1a9893-e08e-4ecf-8dab-1e9befced58b" />

Release Notes:

- Fixed issue where multiple remote folders in a project were lost on reconnect, not restored on restart, and not visible in recent projects.
