### PR TITLE
title_bar: Show the plan from the `CloudUserStore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16537,6 +16537,7 @@ dependencies = [
  "call",
  "chrono",
  "client",
+ "cloud_llm_client",
  "collections",
  "db",
  "gpui",

--- a/crates/client/src/cloud/user_store.rs
+++ b/crates/client/src/cloud/user_store.rs
@@ -1,36 +1,32 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::{Context as _, Result};
+use anyhow::Context as _;
 use chrono::{DateTime, Utc};
 use cloud_api_client::{AuthenticatedUser, CloudApiClient, GetAuthenticatedUserResponse, PlanInfo};
 use cloud_llm_client::Plan;
-use gpui::{AsyncApp, Context, Entity, Task};
-use rpc::{TypedEnvelope, proto};
+use gpui::{Context, Entity, Subscription, Task};
 use util::{ResultExt as _, maybe};
 
-use crate::{Client, Subscription};
+use crate::UserStore;
+use crate::user::Event as RpcUserStoreEvent;
 
 pub struct CloudUserStore {
     cloud_client: Arc<CloudApiClient>,
     authenticated_user: Option<Arc<AuthenticatedUser>>,
     plan_info: Option<Arc<PlanInfo>>,
     _maintain_authenticated_user_task: Task<()>,
-    _rpc_subscriptions: Vec<Subscription>,
+    _rpc_plan_updated_subscription: Subscription,
 }
 
 impl CloudUserStore {
     pub fn new(
         cloud_client: Arc<CloudApiClient>,
-        rpc_client: Arc<Client>,
+        rpc_user_store: Entity<UserStore>,
         cx: &mut Context<Self>,
     ) -> Self {
-        // We're registering an RPC subscription to listen for updates that get pushed down to us from the server.
-        //
-        // We should avoid relying on any data coming over the RPC connection except as a signal that we need to refetch
-        // some data from Cloud.
-        let rpc_subscriptions =
-            vec![rpc_client.add_message_handler(cx.weak_entity(), Self::handle_rpc_update_plan)];
+        let rpc_plan_updated_subscription =
+            cx.subscribe(&rpc_user_store, Self::handle_rpc_user_store_event);
 
         Self {
             cloud_client: cloud_client.clone(),
@@ -78,7 +74,7 @@ impl CloudUserStore {
                 .await
                 .log_err();
             }),
-            _rpc_subscriptions: rpc_subscriptions,
+            _rpc_plan_updated_subscription: rpc_plan_updated_subscription,
         }
     }
 
@@ -111,28 +107,34 @@ impl CloudUserStore {
         self.plan_info = Some(Arc::new(response.plan));
     }
 
-    /// Handles an `UpdateUserPlan` RPC message.
-    ///
-    /// We are solely using this message as a signal that we should re-fetch the authenticated user and their plan
-    /// information.
-    async fn handle_rpc_update_plan(
-        this: Entity<Self>,
-        _message: TypedEnvelope<proto::UpdateUserPlan>,
-        cx: AsyncApp,
-    ) -> Result<()> {
-        let cloud_client = cx.update(|cx| this.read(cx).cloud_client.clone())?;
+    fn handle_rpc_user_store_event(
+        &mut self,
+        _: Entity<UserStore>,
+        event: &RpcUserStoreEvent,
+        cx: &mut Context<Self>,
+    ) {
+        match event {
+            RpcUserStoreEvent::PlanUpdated => {
+                cx.spawn(async move |this, cx| {
+                    let cloud_client =
+                        cx.update(|cx| this.read_with(cx, |this, _cx| this.cloud_client.clone()))??;
 
-        let response = cloud_client
-            .get_authenticated_user()
-            .await
-            .context("failed to fetch authenticated user")?;
+                    let response = cloud_client
+                        .get_authenticated_user()
+                        .await
+                        .context("failed to fetch authenticated user")?;
 
-        cx.update(|cx| {
-            this.update(cx, |this, _cx| {
-                this.update_authenticated_user(response);
-            })
-        })?;
+                    cx.update(|cx| {
+                        this.update(cx, |this, _cx| {
+                            this.update_authenticated_user(response);
+                        })
+                    })??;
 
-        Ok(())
+                    anyhow::Ok(())
+                })
+                .detach_and_log_err(cx);
+            }
+            _ => {}
+        }
     }
 }

--- a/crates/client/src/cloud/user_store.rs
+++ b/crates/client/src/cloud/user_store.rs
@@ -1,22 +1,39 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Context as _;
+use anyhow::{Context as _, Result};
 use chrono::{DateTime, Utc};
-use cloud_api_client::{AuthenticatedUser, CloudApiClient, PlanInfo};
+use cloud_api_client::{AuthenticatedUser, CloudApiClient, GetAuthenticatedUserResponse, PlanInfo};
 use cloud_llm_client::Plan;
-use gpui::{Context, Task};
+use gpui::{AsyncApp, Context, Entity, Task};
+use rpc::{TypedEnvelope, proto};
 use util::{ResultExt as _, maybe};
 
+use crate::{Client, Subscription};
+
 pub struct CloudUserStore {
+    cloud_client: Arc<CloudApiClient>,
     authenticated_user: Option<Arc<AuthenticatedUser>>,
     plan_info: Option<Arc<PlanInfo>>,
     _maintain_authenticated_user_task: Task<()>,
+    _rpc_subscriptions: Vec<Subscription>,
 }
 
 impl CloudUserStore {
-    pub fn new(cloud_client: Arc<CloudApiClient>, cx: &mut Context<Self>) -> Self {
+    pub fn new(
+        cloud_client: Arc<CloudApiClient>,
+        rpc_client: Arc<Client>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        // We're registering an RPC subscription to listen for updates that get pushed down to us from the server.
+        //
+        // We should avoid relying on any data coming over the RPC connection except as a signal that we need to refetch
+        // some data from Cloud.
+        let rpc_subscriptions =
+            vec![rpc_client.add_message_handler(cx.weak_entity(), Self::handle_rpc_update_plan)];
+
         Self {
+            cloud_client: cloud_client.clone(),
             authenticated_user: None,
             plan_info: None,
             _maintain_authenticated_user_task: cx.spawn(async move |this, cx| {
@@ -40,8 +57,7 @@ impl CloudUserStore {
                                     .context("failed to fetch authenticated user");
                                 if let Some(response) = authenticated_user_result.log_err() {
                                     this.update(cx, |this, _cx| {
-                                        this.authenticated_user = Some(Arc::new(response.user));
-                                        this.plan_info = Some(Arc::new(response.plan));
+                                        this.update_authenticated_user(response);
                                     })
                                     .ok();
                                 }
@@ -62,6 +78,7 @@ impl CloudUserStore {
                 .await
                 .log_err();
             }),
+            _rpc_subscriptions: rpc_subscriptions,
         }
     }
 
@@ -87,5 +104,35 @@ impl CloudUserStore {
                     subscription_period.ended_at.0,
                 )
             })
+    }
+
+    fn update_authenticated_user(&mut self, response: GetAuthenticatedUserResponse) {
+        self.authenticated_user = Some(Arc::new(response.user));
+        self.plan_info = Some(Arc::new(response.plan));
+    }
+
+    /// Handles an `UpdateUserPlan` RPC message.
+    ///
+    /// We are solely using this message as a signal that we should re-fetch the authenticated user and their plan
+    /// information.
+    async fn handle_rpc_update_plan(
+        this: Entity<Self>,
+        _message: TypedEnvelope<proto::UpdateUserPlan>,
+        cx: AsyncApp,
+    ) -> Result<()> {
+        let cloud_client = cx.update(|cx| this.read(cx).cloud_client.clone())?;
+
+        let response = cloud_client
+            .get_authenticated_user()
+            .await
+            .context("failed to fetch authenticated user")?;
+
+        cx.update(|cx| {
+            this.update(cx, |this, _cx| {
+                this.update_authenticated_user(response);
+            })
+        })?;
+
+        Ok(())
     }
 }

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -145,6 +145,7 @@ pub enum Event {
     ShowContacts,
     ParticipantIndicesChanged,
     PrivateUserInfoUpdated,
+    PlanUpdated,
 }
 
 #[derive(Clone, Copy)]
@@ -388,6 +389,7 @@ impl UserStore {
                     .map(EditPredictionUsage);
             }
 
+            cx.emit(Event::PlanUpdated);
             cx.notify();
         })?;
         Ok(())

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -282,7 +282,8 @@ impl TestServer {
             .register_hosting_provider(Arc::new(git_hosting_providers::Github::public_instance()));
 
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
-        let cloud_user_store = cx.new(|cx| CloudUserStore::new(client.cloud_client(), cx));
+        let cloud_user_store =
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
         let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
         let session = cx.new(|cx| AppSession::new(Session::test(), cx));

--- a/crates/collab/src/tests/test_server.rs
+++ b/crates/collab/src/tests/test_server.rs
@@ -283,7 +283,7 @@ impl TestServer {
 
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
         let cloud_user_store =
-            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), user_store.clone(), cx));
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
         let language_registry = Arc::new(LanguageRegistry::test(cx.executor()));
         let session = cx.new(|cx| AppSession::new(Session::test(), cx));

--- a/crates/title_bar/Cargo.toml
+++ b/crates/title_bar/Cargo.toml
@@ -32,6 +32,7 @@ auto_update.workspace = true
 call.workspace = true
 chrono.workspace = true
 client.workspace = true
+cloud_llm_client.workspace = true
 db.workspace = true
 gpui = { workspace = true, features = ["screen-capture"] }
 notifications.workspace = true

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -913,7 +913,8 @@ impl AppState {
         let client = Client::new(clock, http_client.clone(), cx);
         let session = cx.new(|cx| AppSession::new(Session::test(), cx));
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
-        let cloud_user_store = cx.new(|cx| CloudUserStore::new(client.cloud_client(), cx));
+        let cloud_user_store =
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
 
         theme::init(theme::LoadThemes::JustBase, cx);
@@ -5738,7 +5739,8 @@ impl Workspace {
 
         let client = project.read(cx).client();
         let user_store = project.read(cx).user_store();
-        let cloud_user_store = cx.new(|cx| CloudUserStore::new(client.cloud_client(), cx));
+        let cloud_user_store =
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
 
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
         let session = cx.new(|cx| AppSession::new(Session::test(), cx));

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -914,7 +914,7 @@ impl AppState {
         let session = cx.new(|cx| AppSession::new(Session::test(), cx));
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
         let cloud_user_store =
-            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), user_store.clone(), cx));
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
 
         theme::init(theme::LoadThemes::JustBase, cx);
@@ -5740,7 +5740,7 @@ impl Workspace {
         let client = project.read(cx).client();
         let user_store = project.read(cx).user_store();
         let cloud_user_store =
-            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), user_store.clone(), cx));
 
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
         let session = cx.new(|cx| AppSession::new(Session::test(), cx));

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -458,7 +458,7 @@ pub fn main() {
         languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
         let cloud_user_store =
-            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), user_store.clone(), cx));
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
 
         language_extension::init(

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -457,7 +457,8 @@ pub fn main() {
         language::init(cx);
         languages::init(languages.clone(), node_runtime.clone(), cx);
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
-        let cloud_user_store = cx.new(|cx| CloudUserStore::new(client.cloud_client(), cx));
+        let cloud_user_store =
+            cx.new(|cx| CloudUserStore::new(client.cloud_client(), client.clone(), cx));
         let workspace_store = cx.new(|cx| WorkspaceStore::new(client.clone(), cx));
 
         language_extension::init(


### PR DESCRIPTION
This PR updates the user menu in the title bar to show the plan from the `CloudUserStore` instead of the `UserStore`.

We're still leveraging the RPC connection to listen for `UpdateUserPlan` messages so that we can get live-updates from the server, but we are merely using this as a signal to re-fetch the information from Cloud.

Release Notes:

- N/A
