### PR TITLE
Fix panic with completion ranges and autoclose regions interop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4920,6 +4920,7 @@ dependencies = [
  "theme",
  "time",
  "tree-sitter-bash",
+ "tree-sitter-c",
  "tree-sitter-html",
  "tree-sitter-python",
  "tree-sitter-rust",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -22,6 +22,7 @@ test-support = [
     "theme/test-support",
     "util/test-support",
     "workspace/test-support",
+    "tree-sitter-c",
     "tree-sitter-rust",
     "tree-sitter-typescript",
     "tree-sitter-html",
@@ -76,6 +77,7 @@ telemetry.workspace = true
 text.workspace = true
 time.workspace = true
 theme.workspace = true
+tree-sitter-c = { workspace = true, optional = true }
 tree-sitter-html = { workspace = true, optional = true }
 tree-sitter-rust = { workspace = true, optional = true }
 tree-sitter-typescript = { workspace = true, optional = true }
@@ -106,6 +108,7 @@ settings = { workspace = true, features = ["test-support"] }
 tempfile.workspace = true
 text = { workspace = true, features = ["test-support"] }
 theme = { workspace = true, features = ["test-support"] }
+tree-sitter-c.workspace = true
 tree-sitter-html.workspace = true
 tree-sitter-rust.workspace = true
 tree-sitter-typescript.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -4049,9 +4049,8 @@ impl Editor {
                             // then don't insert that closing bracket again; just move the selection
                             // past the closing bracket.
                             let should_skip = selection.end == region.range.end.to_point(&snapshot)
-                                && text.as_ref() == region.pair.end.as_str();
-                            // TODO kb revert, it's still useful
-                            // && snapshot.contains_str_at(region.range.end, text.as_ref());
+                                && text.as_ref() == region.pair.end.as_str()
+                                && snapshot.contains_str_at(region.range.end, text.as_ref());
                             if should_skip {
                                 let anchor = snapshot.anchor_after(selection.end);
                                 new_selections

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2956,7 +2956,7 @@ impl Editor {
                     cx,
                 )
             });
-        };
+        }
         let display_map = self
             .display_map
             .update(cx, |display_map, cx| display_map.snapshot(cx));

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13555,6 +13555,7 @@ int fn_branch(bool do_branch1, bool do_branch2);
 #include "AGL/ˇ"##,
     );
 
+    dbg!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
     cx.update_editor(|editor, window, cx| {
         editor.handle_input("\"", window, cx);
     });

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -13555,7 +13555,6 @@ int fn_branch(bool do_branch1, bool do_branch2);
 #include "AGL/ˇ"##,
     );
 
-    dbg!("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~");
     cx.update_editor(|editor, window, cx| {
         editor.handle_input("\"", window, cx);
     });

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -167,10 +167,10 @@ impl Anchor {
         if *self == Anchor::min() || *self == Anchor::max() {
             true
         } else if let Some(excerpt) = snapshot.excerpt(self.excerpt_id) {
-            self.text_anchor.is_valid(&excerpt.buffer)
+            (self.text_anchor == excerpt.range.context.start
+                || self.text_anchor == excerpt.range.context.end
+                || self.text_anchor.is_valid(&excerpt.buffer))
                 && excerpt.contains(self)
-                && (self.text_anchor == excerpt.range.context.start
-                    || self.text_anchor == excerpt.range.context.end)
         } else {
             false
         }

--- a/crates/multi_buffer/src/anchor.rs
+++ b/crates/multi_buffer/src/anchor.rs
@@ -167,10 +167,10 @@ impl Anchor {
         if *self == Anchor::min() || *self == Anchor::max() {
             true
         } else if let Some(excerpt) = snapshot.excerpt(self.excerpt_id) {
-            excerpt.contains(self)
+            self.text_anchor.is_valid(&excerpt.buffer)
+                && excerpt.contains(self)
                 && (self.text_anchor == excerpt.range.context.start
-                    || self.text_anchor == excerpt.range.context.end
-                    || self.text_anchor.is_valid(&excerpt.buffer))
+                    || self.text_anchor == excerpt.range.context.end)
         } else {
             false
         }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2269,7 +2269,7 @@ impl LspCommand for GetCompletions {
                     // the range based on the syntax tree.
                     None => {
                         if self.position != clipped_position {
-                            log::info!("completion out of expected range");
+                            log::info!("completion out of expected range 1");
                             return false;
                         }
 
@@ -2288,7 +2288,7 @@ impl LspCommand for GetCompletions {
                             let start = snapshot.clip_point_utf16(range.start, Bias::Left);
                             let end = snapshot.clip_point_utf16(range.end, Bias::Left);
                             if start != range.start.0 || end != range.end.0 {
-                                log::info!("completion out of expected range");
+                                log::info!("completion out of expected range 2");
                                 return false;
                             }
 
@@ -2483,8 +2483,12 @@ pub(crate) fn parse_completion_text_edit(
         let start = snapshot.clip_point_utf16(range.start, Bias::Left);
         let end = snapshot.clip_point_utf16(range.end, Bias::Left);
         if start != range.start.0 || end != range.end.0 {
-            log::info!("completion out of expected range");
+            log::info!(
+                "completion out of expected range 3, start: {start:?}, end: {end:?}, range: {range:?}"
+            );
             return None;
+        } else {
+            log::info!("!!!!! all ok, start: {start:?}, end: {end:?}, range: {range:?}");
         }
         snapshot.anchor_before(start)..snapshot.anchor_after(end)
     };

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2269,7 +2269,7 @@ impl LspCommand for GetCompletions {
                     // the range based on the syntax tree.
                     None => {
                         if self.position != clipped_position {
-                            log::info!("completion out of expected range 1");
+                            log::info!("completion out of expected range ");
                             return false;
                         }
 
@@ -2288,7 +2288,7 @@ impl LspCommand for GetCompletions {
                             let start = snapshot.clip_point_utf16(range.start, Bias::Left);
                             let end = snapshot.clip_point_utf16(range.end, Bias::Left);
                             if start != range.start.0 || end != range.end.0 {
-                                log::info!("completion out of expected range 2");
+                                log::info!("completion out of expected range");
                                 return false;
                             }
 
@@ -2484,11 +2484,9 @@ pub(crate) fn parse_completion_text_edit(
         let end = snapshot.clip_point_utf16(range.end, Bias::Left);
         if start != range.start.0 || end != range.end.0 {
             log::info!(
-                "completion out of expected range 3, start: {start:?}, end: {end:?}, range: {range:?}"
+                "completion out of expected range, start: {start:?}, end: {end:?}, range: {range:?}"
             );
             return None;
-        } else {
-            log::info!("!!!!! all ok, start: {start:?}, end: {end:?}, range: {range:?}");
         }
         snapshot.anchor_before(start)..snapshot.anchor_after(end)
     };

--- a/crates/text/src/anchor.rs
+++ b/crates/text/src/anchor.rs
@@ -99,7 +99,9 @@ impl Anchor {
         } else if self.buffer_id != Some(buffer.remote_id) {
             false
         } else {
-            let fragment_id = buffer.fragment_id_for_anchor(self);
+            let Some(fragment_id) = buffer.try_fragment_id_for_anchor(self) else {
+                return false;
+            };
             let mut fragment_cursor = buffer.fragments.cursor::<(Option<&Locator>, usize)>(&None);
             fragment_cursor.seek(&Some(fragment_id), Bias::Left);
             fragment_cursor


### PR DESCRIPTION
As reported [in Discord](https://discord.com/channels/869392257814519848/1106226198494859355/1398470747227426948) C projects with `"` as "brackets" that autoclose, may invoke panics when edited at the end of the file.

With a single selection-caret (`ˇ`), at the end of the file,
```c
ifndef BAR_H
#define BAR_H

#include <stdbool.h>

int fn_branch(bool do_branch1, bool do_branch2);

#endif // BAR_H
#include"ˇ"
```
gets an LSP response from clangd
```jsonc
{
  "filterText": "AGL/",
  "insertText": "AGL/",
  "insertTextFormat": 1,
  "kind": 17,
  "label": " AGL/",
  "labelDetails": {},
  "score": 0.78725427389144897,
  "sortText": "40b67681AGL/",
  "textEdit": {
    "newText": "AGL/",
    "range": { "end": { "character": 11, "line": 8 }, "start": { "character": 10, "line": 8 } }
  }
}
```

which replaces `"` after the caret (character/column 11, 0-indexed).
This is reasonable, as regular follow-up (proposed in further completions), is a suffix + a closing `"`:

<img width="842" height="259" alt="image" src="https://github.com/user-attachments/assets/ea56f621-7008-4ce2-99ba-87344ddf33d2" />

Yet when Zed handles user input of `"`, it panics due to multiple reasons:

* after applying any snippet text edit, Zed did a selection change: https://github.com/zed-industries/zed/blob/55379876301bd4dcfe054a146b66288d2e60a523/crates/editor/src/editor.rs#L9539-L9545
which caused eventual autoclose region invalidation: https://github.com/zed-industries/zed/blob/55379876301bd4dcfe054a146b66288d2e60a523/crates/editor/src/editor.rs#L2970

This covers all cases that insert the `include""` text.

* after applying any user input and "plain" text edit, Zed did not invalidate any autoclose regions at all, relying on the "bracket" (which includes `"`) autoclose logic to rule edge cases out

* bracket autoclose logic detects previous `"` and considers the new user input as a valid closure, hence no autoclose region needed. 
But there is an autoclose bracket data after the plaintext completion insertion (`AGL/`) really, and it's not invalidated after `"` handling

* in addition to that, `Anchor::is_valid` method in `text` panicked, and required `fn try_fragment_id_for_anchor` to handle "pointing at odd, after the end of the file, offset" cases as `false`

A test reproducing the feedback and 2 fixes added: proper, autoclose region invalidation call which required the invalidation logic tweaked a bit, and "superficial", "do not apply bad selections that cause panics" fix in the editor to be more robust

Release Notes:

- Fixed panic with completion ranges and autoclose regions interop
