### PR TITLE
cloud_api_types: Add types for `POST /client/llm_tokens` endpoint

### DIFF
--- a/crates/cloud_api_types/src/cloud_api_types.rs
+++ b/crates/cloud_api_types/src/cloud_api_types.rs
@@ -4,6 +4,8 @@ use serde::{Deserialize, Serialize};
 
 pub use crate::timestamp::Timestamp;
 
+pub const ZED_SYSTEM_ID_HEADER_NAME: &str = "x-zed-system-id";
+
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct GetAuthenticatedUserResponse {
     pub user: AuthenticatedUser,
@@ -37,4 +39,12 @@ pub struct PlanInfo {
 pub struct SubscriptionPeriod {
     pub started_at: Timestamp,
     pub ended_at: Timestamp,
+}
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct LlmToken(pub String);
+
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+pub struct CreateLlmTokenResponse {
+    pub token: LlmToken,
 }


### PR DESCRIPTION
This PR adds some types for the new `POST /client/llm_tokens` endpoint.

Release Notes:

- N/A
