### PR TITLE
cloud_api_client: Add `create_llm_token` method

### DIFF
--- a/crates/cloud_api_client/src/cloud_api_client.rs
+++ b/crates/cloud_api_client/src/cloud_api_client.rs
@@ -86,7 +86,7 @@ impl CloudApiClient {
         system_id: Option<String>,
     ) -> Result<CreateLlmTokenResponse> {
         let mut request_builder = Request::builder()
-            .method(Method::GET)
+            .method(Method::POST)
             .uri(
                 self.http_client
                     .build_zed_cloud_url("/client/llm_tokens", &[])?


### PR DESCRIPTION
This PR adds a `create_llm_token` method to the `CloudApiClient`.

Release Notes:

- N/A
