### PR TITLE
open_ai: Fix tool choice serialization

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -223,11 +223,12 @@ pub struct Request {
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-#[serde(untagged)]
+#[serde(rename_all = "lowercase")]
 pub enum ToolChoice {
     Auto,
     Required,
     None,
+    #[serde(untagged)]
     Other(ToolDefinition),
 }
 


### PR DESCRIPTION
According to [api spec][1], tool_choice should be passed as a lowercase string. `None` isn't a valid option.

Closes #35434

Release Notes:

- Fixed OpenAI tools call api

[1]: https://platform.openai.com/docs/guides/function-calling?api-mode=responses

