### PR TITLE
Additions for settings profile selector

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1878,7 +1878,24 @@
     "dock": "bottom",
     "button": true
   },
-  // Configures any number of settings profiles that are temporarily applied
-  // when selected from `settings profile selector: toggle`.
+  // Configures any number of settings profiles that are temporarily applied on
+  // top of your existing user settings when selected from
+  // `settings profile selector: toggle`.
+  // Examples:
+  // "profiles": {
+  //   "Presenting": {
+  //     "agent_font_size": 20.0,
+  //     "buffer_font_size": 20.0,
+  //     "theme": "One Light",
+  //     "ui_font_size": 20.0
+  //   },
+  //   "Python (ty)": {
+  //     "languages": {
+  //       "Python": {
+  //         "language_servers": ["ty"]
+  //       }
+  //     }
+  //   }
+  // }
   "profiles": []
 }

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1078,7 +1078,7 @@ impl SettingsStore {
                         "preview": zed_settings_override_ref,
                         "profiles": {
                             "type": "object",
-                            "description": "Configures any number of settings profiles that are temporarily applied when selected from `settings profile selector: toggle`.",
+                            "description": "Configures any number of settings profiles.",
                             "additionalProperties": zed_settings_override_ref
                         }
                     }

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -25,7 +25,7 @@ pub fn app_menus() -> Vec<Menu> {
                         ),
                         MenuItem::action("Open Project Settings", super::OpenProjectSettings),
                         MenuItem::action(
-                            "Select Settings Profile",
+                            "Select Settings Profile...",
                             zed_actions::settings_profile_selector::Toggle,
                         ),
                         MenuItem::action(

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -25,6 +25,10 @@ pub fn app_menus() -> Vec<Menu> {
                         ),
                         MenuItem::action("Open Project Settings", super::OpenProjectSettings),
                         MenuItem::action(
+                            "Select Settings Profile",
+                            zed_actions::settings_profile_selector::Toggle,
+                        ),
+                        MenuItem::action(
                             "Select Theme...",
                             zed_actions::theme_selector::Toggle::default(),
                         ),


### PR DESCRIPTION
- Added profile selector to `zed > settings` submenu.
- Added examples to the `default.json` docs.
- Reduced length of the setting description that shows on autocomplete, since it was cutoff in the autocomplete popover.


Release Notes:

- N/A
