### PR TITLE
debugger: Send initialized event from fake server at a more realistic time

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -295,7 +295,7 @@ mod tests {
                     request: dap_types::StartDebuggingRequestArgumentsRequest::Launch,
                 },
             },
-            Box::new(|_| panic!("Did not expect to hit this code path")),
+            Box::new(|_| {}),
             &mut cx.to_async(),
         )
         .await

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -883,6 +883,7 @@ impl FakeTransport {
                                         break Err(anyhow!("exit in response to request"));
                                     }
                                 };
+                                let success = response.success;
                                 let message =
                                     serde_json::to_string(&Message::Response(response)).unwrap();
 
@@ -893,6 +894,25 @@ impl FakeTransport {
                                     )
                                     .await
                                     .unwrap();
+
+                                if request.command == dap_types::requests::Initialize::COMMAND
+                                    && success
+                                {
+                                    let message = serde_json::to_string(&Message::Event(Box::new(
+                                        dap_types::messages::Events::Initialized(Some(
+                                            Default::default(),
+                                        )),
+                                    )))
+                                    .unwrap();
+                                    writer
+                                        .write_all(
+                                            TransportDelegate::build_rpc_message(message)
+                                                .as_bytes(),
+                                        )
+                                        .await
+                                        .unwrap();
+                                }
+
                                 writer.flush().await.unwrap();
                             }
                         }

--- a/crates/project/src/debugger/test.rs
+++ b/crates/project/src/debugger/test.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use dap::client::DebugAdapterClient;
-use gpui::{App, AppContext, Subscription};
+use gpui::{App, Subscription};
 
 use super::session::{Session, SessionStateEvent};
 
@@ -19,14 +19,6 @@ pub fn intercept_debug_sessions<T: Fn(&Arc<DebugAdapterClient>) + 'static>(
                     let client = session.adapter_client().unwrap();
                     register_default_handlers(session, &client, cx);
                     configure(&client);
-                    cx.background_spawn(async move {
-                        client
-                            .fake_event(dap::messages::Events::Initialized(
-                                Some(Default::default()),
-                            ))
-                            .await
-                    })
-                    .detach();
                 }
             })
             .detach();


### PR DESCRIPTION
The spec says:

> :arrow_left: Initialized Event
> This event indicates that the debug adapter is ready to accept configuration requests (e.g. setBreakpoints, setExceptionBreakpoints).
>
> A debug adapter is expected to send this event when it is ready to accept configuration requests (but not before the initialize request has finished).

Previously in tests, `intercept_debug_sessions` was just spawning off a background task to send the event after setting up the client, so the event wasn't actually synchronized with the flow of messages in the way the spec says it should be. This PR makes it so that the `FakeTransport` injects the event right after a successful response to the initialize request, and doesn't send it otherwise.

Release Notes:

- N/A