### PR TITLE
ai_onboarding: Read the plan from the `CloudUserStore`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ name = "ai_onboarding"
 version = "0.1.0"
 dependencies = [
  "client",
+ "cloud_llm_client",
  "component",
  "gpui",
  "language_model",

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -697,6 +697,7 @@ impl AgentPanel {
         let onboarding = cx.new(|cx| {
             AgentPanelOnboarding::new(
                 user_store.clone(),
+                cloud_user_store.clone(),
                 client,
                 |_window, cx| {
                     OnboardingUpsell::set_dismissed(true, cx);

--- a/crates/ai_onboarding/Cargo.toml
+++ b/crates/ai_onboarding/Cargo.toml
@@ -16,6 +16,7 @@ default = []
 
 [dependencies]
 client.workspace = true
+cloud_llm_client.workspace = true
 component.workspace = true
 gpui.workspace = true
 language_model.workspace = true


### PR DESCRIPTION
This PR updates the AI onboarding to read the plan from the `CloudUserStore` so that we don't need to connect to Collab.

Release Notes:

- N/A
