### PR TITLE
editor_tests: Fix for potential race loading editor languages

### DIFF
--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -8612,6 +8612,7 @@ async fn test_autoclose_with_embedded_language(cx: &mut TestAppContext) {
 
     cx.language_registry().add(html_language.clone());
     cx.language_registry().add(javascript_language.clone());
+    cx.executor().run_until_parked();
 
     cx.update_buffer(|buffer, cx| {
         buffer.set_language(Some(html_language), cx);


### PR DESCRIPTION
Fix for potential race when loading HTML and JS languages (JS is slower).
Wait for both to load before continue tests.
Observed failure on linux: [job](https://github.com/zed-industries/zed/actions/runs/16662438526/job/47162345259) as part of https://github.com/zed-industries/zed/pull/35436

```
    thread 'editor_tests::test_autoclose_with_embedded_language' panicked at crates/editor/src/editor_tests.rs:8724:8:
    assertion failed: `(left == right)`: unexpected buffer text

    Diff < left / right > :
     <body><>
         <script>
    <        var x = 1;<>
    >        var x = 1;<
         </script>
     </body><>
```

Inserted `<` incorrect gets paired bracket inserted `>`.
I believe because the JS language injection hasn't fully loaded.

Release Notes:

- N/A
