### PR TITLE
inline_completion_button: Replace `UserStore` with `CloudUserStore`

### DIFF
--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -115,7 +115,6 @@ pub struct UserStore {
     trial_started_at: Option<DateTime<Utc>>,
     is_usage_based_billing_enabled: Option<bool>,
     account_too_young: Option<bool>,
-    has_overdue_invoices: Option<bool>,
     current_user: watch::Receiver<Option<Arc<User>>>,
     accepted_tos_at: Option<Option<DateTime<Utc>>>,
     contacts: Vec<Arc<Contact>>,
@@ -192,7 +191,6 @@ impl UserStore {
             trial_started_at: None,
             is_usage_based_billing_enabled: None,
             account_too_young: None,
-            has_overdue_invoices: None,
             accepted_tos_at: None,
             contacts: Default::default(),
             incoming_contact_requests: Default::default(),
@@ -367,7 +365,6 @@ impl UserStore {
                 .and_then(|trial_started_at| DateTime::from_timestamp(trial_started_at as i64, 0));
             this.is_usage_based_billing_enabled = message.payload.is_usage_based_billing_enabled;
             this.account_too_young = message.payload.account_too_young;
-            this.has_overdue_invoices = message.payload.has_overdue_invoices;
 
             cx.emit(Event::PlanUpdated);
             cx.notify();
@@ -766,11 +763,6 @@ impl UserStore {
     /// Returns whether the user's account is too new to use the service.
     pub fn account_too_young(&self) -> bool {
         self.account_too_young.unwrap_or(false)
-    }
-
-    /// Returns whether the current user has overdue invoices and usage should be blocked.
-    pub fn has_overdue_invoices(&self) -> bool {
-        self.has_overdue_invoices.unwrap_or(false)
     }
 
     pub fn current_user_has_accepted_terms(&self) -> Option<bool> {

--- a/crates/inline_completion_button/src/inline_completion_button.rs
+++ b/crates/inline_completion_button/src/inline_completion_button.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use client::{DisableAiSettings, UserStore, zed_urls};
+use client::{CloudUserStore, DisableAiSettings, zed_urls};
 use cloud_llm_client::UsageLimit;
 use copilot::{Copilot, Status};
 use editor::{
@@ -59,7 +59,7 @@ pub struct InlineCompletionButton {
     file: Option<Arc<dyn File>>,
     edit_prediction_provider: Option<Arc<dyn inline_completion::InlineCompletionProviderHandle>>,
     fs: Arc<dyn Fs>,
-    user_store: Entity<UserStore>,
+    cloud_user_store: Entity<CloudUserStore>,
     popover_menu_handle: PopoverMenuHandle<ContextMenu>,
 }
 
@@ -245,13 +245,16 @@ impl Render for InlineCompletionButton {
                     IconName::ZedPredictDisabled
                 };
 
-                if zeta::should_show_upsell_modal(&self.user_store, cx) {
-                    let tooltip_meta =
-                        match self.user_store.read(cx).current_user_has_accepted_terms() {
-                            Some(true) => "Choose a Plan",
-                            Some(false) => "Accept the Terms of Service",
-                            None => "Sign In",
-                        };
+                if zeta::should_show_upsell_modal(&self.cloud_user_store, cx) {
+                    let tooltip_meta = if self.cloud_user_store.read(cx).is_authenticated() {
+                        if self.cloud_user_store.read(cx).has_accepted_tos() {
+                            "Choose a Plan"
+                        } else {
+                            "Accept the Terms of Service"
+                        }
+                    } else {
+                        "Sign In"
+                    };
 
                     return div().child(
                         IconButton::new("zed-predict-pending-button", zeta_icon)
@@ -368,7 +371,7 @@ impl Render for InlineCompletionButton {
 impl InlineCompletionButton {
     pub fn new(
         fs: Arc<dyn Fs>,
-        user_store: Entity<UserStore>,
+        cloud_user_store: Entity<CloudUserStore>,
         popover_menu_handle: PopoverMenuHandle<ContextMenu>,
         cx: &mut Context<Self>,
     ) -> Self {
@@ -389,7 +392,7 @@ impl InlineCompletionButton {
             edit_prediction_provider: None,
             popover_menu_handle,
             fs,
-            user_store,
+            cloud_user_store,
         }
     }
 
@@ -760,7 +763,7 @@ impl InlineCompletionButton {
                         })
                     })
                     .separator();
-            } else if self.user_store.read(cx).account_too_young() {
+            } else if self.cloud_user_store.read(cx).account_too_young() {
                 menu = menu
                     .custom_entry(
                         |_window, _cx| {
@@ -775,7 +778,7 @@ impl InlineCompletionButton {
                         cx.open_url(&zed_urls::account_url(cx))
                     })
                     .separator();
-            } else if self.user_store.read(cx).has_overdue_invoices() {
+            } else if self.cloud_user_store.read(cx).has_overdue_invoices() {
                 menu = menu
                     .custom_entry(
                         |_window, _cx| {

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -336,7 +336,7 @@ pub fn initialize_workspace(
         let edit_prediction_button = cx.new(|cx| {
             inline_completion_button::InlineCompletionButton::new(
                 app_state.fs.clone(),
-                app_state.user_store.clone(),
+                app_state.cloud_user_store.clone(),
                 inline_completion_menu_handle.clone(),
                 cx,
             )


### PR DESCRIPTION
This PR replaces usages of the `UserStore` in the inline completion button with the `CloudUserStore`.

Release Notes:

- N/A
