### PR TITLE
Add configurable working directory for local MCP servers

### DIFF
--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -181,17 +181,19 @@ impl ConfigurationSource {
 }
 
 fn context_server_input(existing: Option<(ContextServerId, ContextServerCommand)>) -> String {
-    let (name, command, args, env) = match existing {
+    let (name, command, args, env, working_directory) = match existing {
         Some((id, cmd)) => {
             let args = serde_json::to_string(&cmd.args).unwrap();
             let env = serde_json::to_string(&cmd.env.unwrap_or_default()).unwrap();
-            (id.0.to_string(), cmd.path, args, env)
+            let working_directory = serde_json::to_string(&cmd.working_directory).unwrap();
+            (id.0.to_string(), cmd.path, args, env, working_directory)
         }
         None => (
             "some-mcp-server".to_string(),
             PathBuf::new(),
             "[]".to_string(),
             "{}".to_string(),
+            "null".to_string(),
         ),
     };
 
@@ -204,7 +206,10 @@ fn context_server_input(existing: Option<(ContextServerId, ContextServerCommand)
     /// The arguments to pass to the MCP server
     "args": {args},
     /// The environment variables to set
-    "env": {env}
+    "env": {env},
+    /// The working directory to run the command in.
+    /// If not set, the project root will be used.
+    "working_directory": {working_directory}
   }}
 }}"#,
         command.display()

--- a/crates/context_server/src/context_server.rs
+++ b/crates/context_server/src/context_server.rs
@@ -113,10 +113,7 @@ impl ContextServer {
                     } else {
                         root_working_directory.clone()
                     };
-                println!(
-                    "[cx-server] configured working_directory: {:?}",
-                    &working_directory
-                );
+
                 Client::stdio(
                     client::ContextServerId(self.id.0.clone()),
                     client::ModelContextServerBinary {

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -977,6 +977,7 @@ mod tests {
                                 path: "somebinary".into(),
                                 args: vec!["arg".to_string()],
                                 env: None,
+                                working_directory: None,
                             },
                         },
                     ),
@@ -1017,6 +1018,7 @@ mod tests {
                                 path: "somebinary".into(),
                                 args: vec!["anotherArg".to_string()],
                                 env: None,
+                                working_directory: None,
                             },
                         },
                     ),
@@ -1099,6 +1101,7 @@ mod tests {
                         path: "somebinary".into(),
                         args: vec!["arg".to_string()],
                         env: None,
+                        working_directory: None,
                     },
                 },
             )],
@@ -1151,6 +1154,7 @@ mod tests {
                             path: "somebinary".into(),
                             args: vec!["arg".to_string()],
                             env: None,
+                            working_directory: None,
                         },
                     },
                 )],
@@ -1179,6 +1183,7 @@ mod tests {
                             path: "somebinary".into(),
                             args: vec!["arg".to_string()],
                             env: None,
+                            working_directory: None,
                         },
                     },
                 )],
@@ -1231,6 +1236,7 @@ mod tests {
                 path: "somebinary".into(),
                 args: vec!["arg".to_string()],
                 env: None,
+                working_directory: None,
             },
         }
     }
@@ -1319,6 +1325,7 @@ mod tests {
                 path: self.path.clone(),
                 args: vec!["arg1".to_string(), "arg2".to_string()],
                 env: None,
+                working_directory: None,
             }))
         }
 

--- a/crates/project/src/context_server_store/extension.rs
+++ b/crates/project/src/context_server_store/extension.rs
@@ -69,6 +69,7 @@ impl registry::ContextServerDescriptor for ContextServerDescriptor {
                 path: command.command,
                 args: command.args,
                 env: Some(command.env.into_iter().collect()),
+                working_directory: None,
             })
         })
     }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -592,6 +592,7 @@ impl Settings for ProjectSettings {
                     path: cmd.command,
                     args: cmd.args.unwrap_or_default(),
                     env: cmd.env,
+                    working_directory: None,
                 }
             }
         }


### PR DESCRIPTION
Closes #ISSUE
https://github.com/zed-industries/zed/issues/35354

Release Notes:

### Problem

Currently, Zed launches all custom context servers from the project's root directory. This creates issues where multiple servers reside in different directories, as any server that relies on its own local directory for dependencies or relative paths will fail to run correctly.

### Solution

I propose adding an optional `working_directory` field to the context server configuration.

*   This field would allow you to specify the launch directory for each server.
*   Relative paths would be resolved from the project root.
*   If the field is omitted, the server will default to the current behavior, ensuring backward compatibility.

This change simplifies the local development of multiple, isolated servers within a single Zed project without requiring workarounds like wrapper scripts.
