### PR TITLE
search: Update results multi-buffer before search is finished

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -355,8 +355,9 @@ impl ProjectSearch {
 
                 while let Some(new_ranges) = new_ranges.next().await {
                     project_search
-                        .update(cx, |project_search, _| {
+                        .update(cx, |project_search, cx| {
                             project_search.match_ranges.extend(new_ranges);
+                            cx.notify();
                         })
                         .ok()?;
                 }


### PR DESCRIPTION
I'm not sure when we've lost that notify, but it's causing the time to first search result equal to the time to run the whole search, which is not great.

Co-authored-by: Remco <djsmits12@gmail.com>

This discussion has originally started in #35444

Release Notes:

- Improved project search speed.
