### PR TITLE
zeta: Rename binding back to `user_store`

### DIFF
--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1588,8 +1588,8 @@ impl inline_completion::EditPredictionProvider for ZetaInlineCompletionProvider 
             .zeta
             .read(cx)
             .user_store
-            .read_with(cx, |cloud_user_store, _cx| {
-                cloud_user_store.account_too_young() || cloud_user_store.has_overdue_invoices()
+            .read_with(cx, |user_store, _cx| {
+                user_store.account_too_young() || user_store.has_overdue_invoices()
             })
         {
             return;


### PR DESCRIPTION
This PR renames a binding from `cloud_user_store` to `user_store` now that we've consolidated the two into the `UserStore`.

Release Notes:

- N/A
