### PR TITLE
Add flags for Qwen Cerebras on Hugging Face

### DIFF
--- a/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/add_llm_provider_modal.rs
@@ -136,6 +136,10 @@ impl ModelInput {
                 .text(cx)
                 .parse::<u64>()
                 .map_err(|_| SharedString::from("Max Tokens must be a number"))?,
+            supports_parallel_tools: None,
+            streaming: None,
+            multipart_allowed: None,
+            minimal_schema: None,
         })
     }
 }

--- a/crates/assistant_tool/src/tool_schema.rs
+++ b/crates/assistant_tool/src/tool_schema.rs
@@ -17,6 +17,7 @@ pub fn adapt_schema_to_format(
 
     match format {
         LanguageModelToolSchemaFormat::JsonSchema => preprocess_json_schema(json),
+        LanguageModelToolSchemaFormat::JsonSchemaMinimal |
         LanguageModelToolSchemaFormat::JsonSchemaSubset => adapt_to_json_schema_subset(json),
     }
 }

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -354,6 +354,7 @@ pub enum LanguageModelToolSchemaFormat {
     JsonSchema,
     /// A subset of an OpenAPI 3.0 schema object supported by Google AI, see https://ai.google.dev/api/caching#Schema
     JsonSchemaSubset,
+    JsonSchemaMinimal,
 }
 
 #[derive(Debug, PartialEq, Clone, Copy, Serialize, Deserialize)]

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -948,6 +948,8 @@ impl LanguageModel for CloudLanguageModel {
                     request,
                     model.id(),
                     model.supports_parallel_tool_calls(),
+                    true,
+                    true,
                     None,
                 );
                 let llm_api_token = self.llm_api_token.clone();

--- a/crates/language_models/src/provider/vercel.rs
+++ b/crates/language_models/src/provider/vercel.rs
@@ -275,7 +275,7 @@ impl VercelLanguageModel {
                 });
             };
             let request =
-                open_ai::stream_completion(http_client.as_ref(), &api_url, &api_key, request);
+                open_ai::stream_completion(http_client.as_ref(), &api_url, &api_key, request, true);
             let response = request.await?;
             Ok(response)
         });
@@ -355,6 +355,8 @@ impl LanguageModel for VercelLanguageModel {
             request,
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
+            true,
+            true,
             self.max_output_tokens(),
         );
         let completions = self.stream_completion(request, cx);

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -271,7 +271,7 @@ impl XAiLanguageModel {
         let future = self.request_limiter.stream(async move {
             let api_key = api_key.context("Missing xAI API Key")?;
             let request =
-                open_ai::stream_completion(http_client.as_ref(), &api_url, &api_key, request);
+                open_ai::stream_completion(http_client.as_ref(), &api_url, &api_key, request, true);
             let response = request.await?;
             Ok(response)
         });
@@ -359,6 +359,8 @@ impl LanguageModel for XAiLanguageModel {
             request,
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
+            true,
+            true,
             self.max_output_tokens(),
         );
         let completions = self.stream_completion(request, cx);


### PR DESCRIPTION
Add flags to OpenAI Compatible model to make it work with HuggingFace Infer with Cerebras. This allows for use with the new Qwen model https://x.com/CerebrasSystems/status/1951342434740482541

in settings.json

```
{
  "language_models": {
    "openai_compatible": {
      "Hugging Face": {
        "api_url": "https://router.huggingface.co/v1",
        "available_models": [
          {
            "name": "Qwen/Qwen3-32B:cerebras",
            "display_name": "Quen 3 Coder 480B",
            "max_tokens": 200000,
            "max_output_tokens": 40000,
            "max_completion_tokens": 200000,
            "supports_parallel_tools": false,
            "streaming": false,
            "multipart_allowed": false,
            "minimal_schema": true
          }
        ]
      }
    }
  }
}
```