### PR TITLE
git: List the number of files about to be committed as button text

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -442,7 +442,7 @@ impl CommitModal {
                         .size(ui::ButtonSize::Compact)
                         .child(
                             div()
-                                .child(Label::new(commit_label).size(LabelSize::Small))
+                                .child(Label::new(commit_label.clone()).size(LabelSize::Small))
                                 .mr_0p5(),
                         )
                         .on_click(cx.listener(move |this, _: &ClickEvent, window, cx| {
@@ -462,10 +462,11 @@ impl CommitModal {
                         .disabled(!can_commit)
                         .tooltip({
                             let focus_handle = focus_handle.clone();
+                            let tooltip = tooltip.clone();
                             move |window, cx| {
                                 if can_commit {
                                     Tooltip::with_meta_in(
-                                        tooltip,
+                                        tooltip.clone(),
                                         Some(&git::Commit),
                                         format!(
                                             "git commit{}{}",
@@ -477,7 +478,7 @@ impl CommitModal {
                                         cx,
                                     )
                                 } else {
-                                    Tooltip::simple(tooltip, cx)
+                                    Tooltip::simple(tooltip.clone(), cx)
                                 }
                             }
                         }),


### PR DESCRIPTION
Previously, the button would say "Commit" when committing a number of staged files, and "Commit Tracked" when committing changes in all tracked files (or when there were no changes to commit). This could result in accidentally committing all tracked changes. This often happens to me when I select a file in the file list but don't click the checkbox, and proceed to click "Commit Tracked", which ends up committing all outstanding changes.

This change makes the text more clear:

- When committing will commit N files, we say how many files will be committed. If multiple files have outstanding changes and the file wasn't staged properly, it will say "Commit 5 files" when the intention was to commit just one, which is hopefully more clear.
- When there are no changes to commit, the button says "No changes".

(Please feel free to suggest alternative wording/etc.! This is what seemed to make sense to me to prevent the aforementioned UX issue I keep running into.)

Release Notes:

- Git: Commit button now lists the number of files about to be committed