### PR TITLE
onboarding: Go back to not having system be separate

### DIFF
--- a/crates/gpui/src/geometry.rs
+++ b/crates/gpui/src/geometry.rs
@@ -3522,7 +3522,7 @@ impl Serialize for Length {
 /// # Returns
 ///
 /// A `DefiniteLength` representing the relative length as a fraction of the parent's size.
-pub fn relative(fraction: f32) -> DefiniteLength {
+pub const fn relative(fraction: f32) -> DefiniteLength {
     DefiniteLength::Fraction(fraction)
 }
 

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -182,9 +182,7 @@ fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
                 .on_click({
                     let theme_name = theme.name.clone();
                     move |_, _, cx| {
-                        if theme_mode != ThemeMode::System {
-                            write_theme_change(theme_name.clone(), theme_mode, cx);
-                        }
+                        write_theme_change(theme_name.clone(), theme_mode, cx);
                     }
                 })
         });

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -14,7 +14,7 @@ use ui::{
 };
 use vim_mode_setting::VimModeSetting;
 
-use crate::theme_preview::ThemePreviewTile;
+use crate::theme_preview::{ThemePreviewStyle, ThemePreviewTile};
 
 fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
     let theme_selection = ThemeSettings::get_global(cx).theme_selection.clone();
@@ -139,38 +139,15 @@ fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
                                     theme_registry.get(LIGHT_THEMES[index]).unwrap(),
                                     theme_registry.get(DARK_THEMES[index]).unwrap(),
                                 );
-
                                 this.child(
-                                    h_flex()
-                                        .relative()
-                                        .size_full()
-                                        .rounded_sm()
-                                        .overflow_hidden()
-                                        .child(
-                                            div()
-                                                .size_full()
-                                                .rounded_l_sm()
-                                                .overflow_hidden()
-                                                .bg(colors.editor_background)
-                                                .child(ThemePreviewTile::new(light, theme_seed).style(
-                                                    crate::theme_preview::ThemePreviewStyle::Borderless,
-                                                )),
-                                        )
-                                        .child(
-                                            div()
-                                                .size_full()
-                                                .overflow_hidden()
-                                                .rounded_r_sm()
-                                                .absolute()
-                                                .left_1_2()
-                                                .bg(colors.editor_background)
-                                                .child(ThemePreviewTile::new(dark, theme_seed).style(
-                                                    crate::theme_preview::ThemePreviewStyle::Borderless,
-                                                )),
-                                        ),
+                                    ThemePreviewTile::new(light, theme_seed)
+                                        .style(ThemePreviewStyle::SideBySide(dark)),
                                 )
                             } else {
-                                this.child(ThemePreviewTile::new(theme.clone(), theme_seed))
+                                this.child(
+                                    ThemePreviewTile::new(theme.clone(), theme_seed)
+                                        .style(ThemePreviewStyle::Bordered),
+                                )
                             }
                         }),
                 )

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -16,22 +16,6 @@ use vim_mode_setting::VimModeSetting;
 
 use crate::theme_preview::ThemePreviewTile;
 
-// "specific-theme-name" | {
-//    "mode": "dark" | "light" | "system",
-//    "light": "light-theme-name",
-//    "dark": "dark-theme-name"
-// }
-/// separates theme "mode" ("dark" | "light" | "system") into two separate states
-/// - appearance = "dark" | "light"
-/// - "system" true/false
-/// when system selected:
-///  - toggling between light and dark does not change theme.mode, just which variant will be changed
-/// when system not selected:
-///  - toggling between light and dark does change theme.mode
-/// selecting a theme preview will always change theme.["light" | "dark"] to the selected theme,
-///
-/// this allows for selecting a dark and light theme option regardless of whether the mode is set to system or not
-/// it does not support setting theme to a static value
 fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
     let theme_selection = ThemeSettings::get_global(cx).theme_selection.clone();
     let system_appearance = theme::SystemAppearance::global(cx);

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -2,21 +2,21 @@ use std::sync::Arc;
 
 use client::TelemetrySettings;
 use fs::Fs;
-use gpui::{App, Entity, IntoElement, Window};
+use gpui::{App, IntoElement, Window};
 use settings::{BaseKeymap, Settings, update_settings_file};
 use theme::{
     Appearance, SystemAppearance, ThemeMode, ThemeName, ThemeRegistry, ThemeSelection,
     ThemeSettings,
 };
 use ui::{
-    Divider, ParentElement as _, StatefulInteractiveElement, SwitchField, ToggleButtonGroup,
+    ParentElement as _, StatefulInteractiveElement, SwitchField, ToggleButtonGroup,
     ToggleButtonSimple, ToggleButtonWithIcon, prelude::*, rems_from_px,
 };
 use vim_mode_setting::VimModeSetting;
 
 use crate::theme_preview::{ThemePreviewStyle, ThemePreviewTile};
 
-fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
+fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement {
     let theme_selection = ThemeSettings::get_global(cx).theme_selection.clone();
     let system_appearance = theme::SystemAppearance::global(cx);
     let theme_selection = theme_selection.unwrap_or_else(|| ThemeSelection::Dynamic {
@@ -34,11 +34,6 @@ fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
             Appearance::Light => ThemeMode::Light,
             Appearance::Dark => ThemeMode::Dark,
         });
-    let selected_index = match theme_mode {
-        ThemeMode::Light => 0,
-        ThemeMode::Dark => 1,
-        ThemeMode::System => 2,
-    };
 
     return v_flex()
         .gap_2()
@@ -125,7 +120,7 @@ fn render_theme_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
                         .w_full()
                         .border_2()
                         .border_color(colors.border_transparent)
-                        .rounded(ThemePreviewTile::CORNER_RADIUS)
+                        .rounded(ThemePreviewTile::ROOT_RADIUS)
                         .map(|this| {
                             if is_selected {
                                 this.border_color(colors.border_selected)

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -158,6 +158,7 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
                     }
                 })
         });
+
         theme_previews
     }
 

--- a/crates/onboarding/src/theme_preview.rs
+++ b/crates/onboarding/src/theme_preview.rs
@@ -238,41 +238,35 @@ impl ThemePreviewTile {
         seed: f32,
         theme: Arc<Theme>,
         other_theme: Arc<Theme>,
+        border_color: Hsla,
     ) -> impl IntoElement {
         let sidebar_width = relative(0.20);
-        return h_flex()
+
+        return div()
             .size_full()
             .p(Self::ROOT_PADDING)
             .rounded(Self::ROOT_RADIUS)
-            .relative()
-            .overflow_hidden()
             .child(
-                div()
+                h_flex()
                     .size_full()
+                    .relative()
                     .rounded(*Self::CHILD_RADIUS)
                     .border(Self::CHILD_BORDER)
-                    .border_color(theme.colors().border)
-                    .child(Self::render_editor(
+                    .border_color(border_color)
+                    .overflow_hidden()
+                    .child(div().size_full().child(Self::render_editor(
                         seed,
                         theme.clone(),
                         sidebar_width,
                         Self::SKELETON_HEIGHT_DEFAULT,
-                    )),
-            )
-            .child(
-                div()
-                    .size_full()
-                    .absolute()
-                    .left_1_2()
-                    .rounded_r(*Self::CHILD_RADIUS)
-                    .border_r(Self::CHILD_BORDER)
-                    .border_y(Self::CHILD_BORDER)
-                    .border_color(other_theme.colors().border)
-                    .child(Self::render_editor(
-                        seed,
-                        other_theme,
-                        sidebar_width,
-                        Self::SKELETON_HEIGHT_DEFAULT,
+                    )))
+                    .child(div().size_full().absolute().left_1_2().bg(bg_color).child(
+                        Self::render_editor(
+                            seed,
+                            other_theme,
+                            sidebar_width,
+                            Self::SKELETON_HEIGHT_DEFAULT,
+                        ),
                     )),
             )
             .into_any_element();
@@ -288,9 +282,13 @@ impl RenderOnce for ThemePreviewTile {
             ThemePreviewStyle::Borderless => {
                 Self::render_borderless(self.seed, self.theme).into_any_element()
             }
-            ThemePreviewStyle::SideBySide(other_theme) => {
-                Self::render_side_by_side(self.seed, self.theme, other_theme).into_any_element()
-            }
+            ThemePreviewStyle::SideBySide(other_theme) => Self::render_side_by_side(
+                self.seed,
+                self.theme,
+                other_theme,
+                _cx.theme().colors().border,
+            )
+            .into_any_element(),
         }
     }
 }

--- a/crates/onboarding/src/theme_preview.rs
+++ b/crates/onboarding/src/theme_preview.rs
@@ -6,19 +6,35 @@ use ui::{
     IntoElement, RenderOnce, component_prelude::Documented, prelude::*, utils::inner_corner_radius,
 };
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum ThemePreviewStyle {
+    Bordered,
+    Borderless,
+}
+
 /// Shows a preview of a theme as an abstract illustration
 /// of a thumbnail-sized editor.
 #[derive(IntoElement, RegisterComponent, Documented)]
 pub struct ThemePreviewTile {
     theme: Arc<Theme>,
     seed: f32,
+    style: ThemePreviewStyle,
 }
 
 impl ThemePreviewTile {
     pub const CORNER_RADIUS: Pixels = px(8.0);
 
     pub fn new(theme: Arc<Theme>, seed: f32) -> Self {
-        Self { theme, seed }
+        Self {
+            theme,
+            seed,
+            style: ThemePreviewStyle::Bordered,
+        }
+    }
+
+    pub fn style(mut self, size: ThemePreviewStyle) -> Self {
+        self.style = style;
+        self
     }
 }
 
@@ -159,14 +175,18 @@ impl RenderOnce for ThemePreviewTile {
 
         div()
             .size_full()
-            .rounded(root_radius)
             .p(root_padding)
+            .when(self.style == ThemePreviewStyle::Bordered, |this| {
+                this.rounded(root_radius)
+            })
             .child(
                 div()
                     .size_full()
-                    .rounded(inner_radius)
-                    .border(child_border)
-                    .border_color(color.border)
+                    .when(self.style == ThemePreviewStyle::Bordered, |this| {
+                        this.rounded(inner_radius)
+                            .border(child_border)
+                            .border_color(color.border)
+                    })
                     .bg(color.background)
                     .child(content),
             )

--- a/crates/onboarding/src/theme_preview.rs
+++ b/crates/onboarding/src/theme_preview.rs
@@ -1,7 +1,7 @@
 #![allow(unused, dead_code)]
 use gpui::{Hsla, Length};
 use std::sync::Arc;
-use theme::{Theme, ThemeRegistry};
+use theme::{Theme, ThemeColors, ThemeRegistry};
 use ui::{
     IntoElement, RenderOnce, component_prelude::Documented, prelude::*, utils::inner_corner_radius,
 };
@@ -23,6 +23,9 @@ pub struct ThemePreviewTile {
 
 impl ThemePreviewTile {
     pub const CORNER_RADIUS: Pixels = px(8.0);
+    pub const SKELETON_HEIGHT_DEFAULT: Pixels = px(2.);
+    pub const SIDEBAR_SKELETON_ITEM_COUNT: usize = 8;
+    pub const SIDEBAR_WIDTH_DEFAULT: DefiniteLength = relative(0.25);
 
     pub fn new(theme: Arc<Theme>, seed: f32) -> Self {
         Self {
@@ -36,12 +39,173 @@ impl ThemePreviewTile {
         self.style = style;
         self
     }
+
+    pub fn item_skeleton(w: Length, h: Length, bg: Hsla) -> impl IntoElement {
+        div().w(w).h(h).rounded_full().bg(bg)
+    }
+
+    pub fn render_sidebar_skeleton_items(
+        seed: f32,
+        colors: &ThemeColors,
+        skeleton_height: impl Into<Length> + Clone,
+    ) -> [impl IntoElement; Self::SIDEBAR_SKELETON_ITEM_COUNT] {
+        let skeleton_height = skeleton_height.into();
+        std::array::from_fn(|index| {
+            let width = {
+                let value = (seed * 1000.0 + index as f32 * 10.0).sin() * 0.5 + 0.5;
+                0.5 + value * 0.45
+            };
+            Self::item_skeleton(
+                relative(width).into(),
+                skeleton_height,
+                colors.text.alpha(0.45),
+            )
+        })
+    }
+
+    pub fn render_pseudo_code_skeleton(
+        seed: f32,
+        theme: Arc<Theme>,
+        skeleton_height: impl Into<Length>,
+    ) -> impl IntoElement {
+        let colors = theme.colors();
+        let syntax = theme.syntax();
+
+        let keyword_color = syntax.get("keyword").color;
+        let function_color = syntax.get("function").color;
+        let string_color = syntax.get("string").color;
+        let comment_color = syntax.get("comment").color;
+        let variable_color = syntax.get("variable").color;
+        let type_color = syntax.get("type").color;
+        let punctuation_color = syntax.get("punctuation").color;
+
+        let syntax_colors = [
+            keyword_color,
+            function_color,
+            string_color,
+            variable_color,
+            type_color,
+            punctuation_color,
+            comment_color,
+        ];
+
+        let skeleton_height = skeleton_height.into();
+
+        let line_width = |line_idx: usize, block_idx: usize| -> f32 {
+            let val =
+                (seed * 100.0 + line_idx as f32 * 20.0 + block_idx as f32 * 5.0).sin() * 0.5 + 0.5;
+            0.05 + val * 0.2
+        };
+
+        let indentation = |line_idx: usize| -> f32 {
+            let step = line_idx % 6;
+            if step < 3 {
+                step as f32 * 0.1
+            } else {
+                (5 - step) as f32 * 0.1
+            }
+        };
+
+        let pick_color = |line_idx: usize, block_idx: usize| -> Hsla {
+            let idx = ((seed * 10.0 + line_idx as f32 * 7.0 + block_idx as f32 * 3.0).sin() * 3.5)
+                .abs() as usize
+                % syntax_colors.len();
+            syntax_colors[idx].unwrap_or(colors.text)
+        };
+
+        let line_count = 13;
+
+        let lines = (0..line_count)
+            .map(|line_idx| {
+                let block_count = (((seed * 30.0 + line_idx as f32 * 12.0).sin() * 0.5 + 0.5) * 3.0)
+                    .round() as usize
+                    + 2;
+
+                let indent = indentation(line_idx);
+
+                let blocks = (0..block_count)
+                    .map(|block_idx| {
+                        let width = line_width(line_idx, block_idx);
+                        let color = pick_color(line_idx, block_idx);
+                        Self::item_skeleton(relative(width).into(), skeleton_height, color)
+                    })
+                    .collect::<Vec<_>>();
+
+                h_flex().gap(px(2.)).ml(relative(indent)).children(blocks)
+            })
+            .collect::<Vec<_>>();
+
+        v_flex().size_full().p_1().gap_1p5().children(lines)
+    }
+
+    pub fn render_sidebar(
+        seed: f32,
+        colors: &ThemeColors,
+        width: impl Into<Length> + Clone,
+        skeleton_height: impl Into<Length>,
+    ) -> impl IntoElement {
+        div()
+            .h_full()
+            .w(width)
+            .border_r(px(1.))
+            .border_color(colors.border_transparent)
+            .bg(colors.panel_background)
+            .child(v_flex().p_2().size_full().gap_1().children(
+                Self::render_sidebar_skeleton_items(seed, colors, skeleton_height.into()),
+            ))
+    }
+
+    pub fn render_pane(
+        seed: f32,
+        theme: Arc<Theme>,
+        skeleton_height: impl Into<Length>,
+    ) -> impl IntoElement {
+        v_flex().h_full().flex_grow().child(
+            div()
+                .size_full()
+                .overflow_hidden()
+                .bg(theme.colors().editor_background)
+                .p_2()
+                .child(Self::render_pseudo_code_skeleton(
+                    seed,
+                    theme,
+                    skeleton_height.into(),
+                )),
+        )
+    }
+
+    pub fn render_editor(
+        seed: f32,
+        theme: Arc<Theme>,
+        sidebar_width: impl Into<Length> + Clone,
+        skeleton_height: impl Into<Length> + Clone,
+    ) -> impl IntoElement {
+        div()
+            .size_full()
+            .flex()
+            .bg(theme.colors().background)
+            .child(Self::render_sidebar(
+                seed,
+                theme.colors(),
+                sidebar_width,
+                skeleton_height.clone(),
+            ))
+            .child(Self::render_pane(seed, theme, skeleton_height.clone()))
+    }
 }
 
 impl RenderOnce for ThemePreviewTile {
     fn render(self, _window: &mut ui::Window, _cx: &mut ui::App) -> impl IntoElement {
-        let color = self.theme.colors();
+        let content = Self::render_editor(
+            self.seed,
+            self.theme.clone(),
+            Self::SIDEBAR_WIDTH_DEFAULT,
+            Self::SKELETON_HEIGHT_DEFAULT,
+        );
 
+        if self.style == ThemePreviewStyle::Borderless {
+            return content.into_any_element();
+        }
         let root_radius = Self::CORNER_RADIUS;
         let root_border = px(2.0);
         let root_padding = px(2.0);
@@ -49,147 +213,19 @@ impl RenderOnce for ThemePreviewTile {
         let inner_radius =
             inner_corner_radius(root_radius, root_border, root_padding, child_border);
 
-        let item_skeleton = |w: Length, h: Pixels, bg: Hsla| div().w(w).h(h).rounded_full().bg(bg);
-
-        let skeleton_height = px(2.);
-
-        let sidebar_seeded_width = |seed: f32, index: usize| {
-            let value = (seed * 1000.0 + index as f32 * 10.0).sin() * 0.5 + 0.5;
-            0.5 + value * 0.45
-        };
-
-        let sidebar_skeleton_items = 8;
-
-        let sidebar_skeleton = (0..sidebar_skeleton_items)
-            .map(|i| {
-                let width = sidebar_seeded_width(self.seed, i);
-                item_skeleton(
-                    relative(width).into(),
-                    skeleton_height,
-                    color.text.alpha(0.45),
-                )
-            })
-            .collect::<Vec<_>>();
-
-        let sidebar = div()
-            .h_full()
-            .w(relative(0.25))
-            .border_r(px(1.))
-            .border_color(color.border_transparent)
-            .bg(color.panel_background)
-            .child(
-                v_flex()
-                    .p_2()
-                    .size_full()
-                    .gap_1()
-                    .children(sidebar_skeleton),
-            );
-
-        let pseudo_code_skeleton = |theme: Arc<Theme>, seed: f32| -> AnyElement {
-            let colors = theme.colors();
-            let syntax = theme.syntax();
-
-            let keyword_color = syntax.get("keyword").color;
-            let function_color = syntax.get("function").color;
-            let string_color = syntax.get("string").color;
-            let comment_color = syntax.get("comment").color;
-            let variable_color = syntax.get("variable").color;
-            let type_color = syntax.get("type").color;
-            let punctuation_color = syntax.get("punctuation").color;
-
-            let syntax_colors = [
-                keyword_color,
-                function_color,
-                string_color,
-                variable_color,
-                type_color,
-                punctuation_color,
-                comment_color,
-            ];
-
-            let line_width = |line_idx: usize, block_idx: usize| -> f32 {
-                let val = (seed * 100.0 + line_idx as f32 * 20.0 + block_idx as f32 * 5.0).sin()
-                    * 0.5
-                    + 0.5;
-                0.05 + val * 0.2
-            };
-
-            let indentation = |line_idx: usize| -> f32 {
-                let step = line_idx % 6;
-                if step < 3 {
-                    step as f32 * 0.1
-                } else {
-                    (5 - step) as f32 * 0.1
-                }
-            };
-
-            let pick_color = |line_idx: usize, block_idx: usize| -> Hsla {
-                let idx = ((seed * 10.0 + line_idx as f32 * 7.0 + block_idx as f32 * 3.0).sin()
-                    * 3.5)
-                    .abs() as usize
-                    % syntax_colors.len();
-                syntax_colors[idx].unwrap_or(colors.text)
-            };
-
-            let line_count = 13;
-
-            let lines = (0..line_count)
-                .map(|line_idx| {
-                    let block_count = (((seed * 30.0 + line_idx as f32 * 12.0).sin() * 0.5 + 0.5)
-                        * 3.0)
-                        .round() as usize
-                        + 2;
-
-                    let indent = indentation(line_idx);
-
-                    let blocks = (0..block_count)
-                        .map(|block_idx| {
-                            let width = line_width(line_idx, block_idx);
-                            let color = pick_color(line_idx, block_idx);
-                            item_skeleton(relative(width).into(), skeleton_height, color)
-                        })
-                        .collect::<Vec<_>>();
-
-                    h_flex().gap(px(2.)).ml(relative(indent)).children(blocks)
-                })
-                .collect::<Vec<_>>();
-
-            v_flex()
-                .size_full()
-                .p_1()
-                .gap_1p5()
-                .children(lines)
-                .into_any_element()
-        };
-
-        let pane = v_flex().h_full().flex_grow().child(
-            div()
-                .size_full()
-                .overflow_hidden()
-                .bg(color.editor_background)
-                .p_2()
-                .child(pseudo_code_skeleton(self.theme.clone(), self.seed)),
-        );
-
-        let content = div().size_full().flex().child(sidebar).child(pane);
-
         div()
             .size_full()
             .p(root_padding)
-            .when(self.style == ThemePreviewStyle::Bordered, |this| {
-                this.rounded(root_radius)
-            })
+            .rounded(root_radius)
             .child(
                 div()
                     .size_full()
-                    .when(self.style == ThemePreviewStyle::Bordered, |this| {
-                        this.rounded(inner_radius)
-                            .border(child_border)
-                            .border_color(color.border)
-                    })
-                    .bg(color.background)
+                    .rounded(inner_radius)
+                    .border(child_border)
+                    .border_color(self.theme.colors().border)
                     .child(content),
             )
+            .into_any_element()
     }
 }
 

--- a/crates/onboarding/src/theme_preview.rs
+++ b/crates/onboarding/src/theme_preview.rs
@@ -260,14 +260,19 @@ impl ThemePreviewTile {
                         sidebar_width,
                         Self::SKELETON_HEIGHT_DEFAULT,
                     )))
-                    .child(div().size_full().absolute().left_1_2().bg(bg_color).child(
-                        Self::render_editor(
-                            seed,
-                            other_theme,
-                            sidebar_width,
-                            Self::SKELETON_HEIGHT_DEFAULT,
-                        ),
-                    )),
+                    .child(
+                        div()
+                            .size_full()
+                            .absolute()
+                            .left_1_2()
+                            .bg(other_theme.colors().editor_background)
+                            .child(Self::render_editor(
+                                seed,
+                                other_theme,
+                                sidebar_width,
+                                Self::SKELETON_HEIGHT_DEFAULT,
+                            )),
+                    ),
             )
             .into_any_element();
     }

--- a/crates/onboarding/src/theme_preview.rs
+++ b/crates/onboarding/src/theme_preview.rs
@@ -32,7 +32,7 @@ impl ThemePreviewTile {
         }
     }
 
-    pub fn style(mut self, size: ThemePreviewStyle) -> Self {
+    pub fn style(mut self, style: ThemePreviewStyle) -> Self {
         self.style = style;
         self
     }


### PR DESCRIPTION
Going back to having system be mutually exclusive with light/dark to simplify the system. We instead just show both light and dark when system is selected

Release Notes:

- N/A
