### PR TITLE
Refactor Helix selecting movements (w, b, e, W, t, T)

### DIFF
--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -2,10 +2,10 @@
 //! in editor given a given motion (e.g. it handles converting a "move left" command into coordinates in editor). It is exposed mostly for use by vim crate.
 
 use super::{Bias, DisplayPoint, DisplaySnapshot, SelectionGoal, ToDisplayPoint};
-use crate::{DisplayRow, EditorStyle, ToOffset, ToPoint, scroll::ScrollAnchor};
+use crate::{DisplayRow, EditorStyle, scroll::ScrollAnchor};
 use gpui::{Pixels, WindowTextSystem};
 use language::Point;
-use multi_buffer::{MultiBufferRow, MultiBufferSnapshot};
+use multi_buffer::MultiBufferRow;
 use serde::Deserialize;
 use workspace::searchable::Direction;
 
@@ -527,7 +527,7 @@ pub fn find_preceding_boundary_display_point(
         prev_ch = Some(ch);
     }
 
-    map.clip_point(offset.to_display_point(map), Bias::Left)
+    offset.to_display_point(map)
 }
 
 /// Scans for a boundary following the given start point until a boundary is found, indicated by the

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1,7 +1,6 @@
-use editor::{DisplayPoint, Editor, SelectionEffects, ToOffset, ToPoint, movement};
+use editor::{Editor, SelectionEffects, ToOffset, ToPoint, movement};
 use gpui::{Action, actions};
 use gpui::{Context, Window};
-use language::{CharClassifier, CharKind};
 use text::{Bias, SelectionGoal};
 
 use crate::{
@@ -45,129 +44,50 @@ impl Vim {
         return;
     }
 
-    pub fn helix_normal_motion(
-        &mut self,
-        motion: Motion,
-        times: Option<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.helix_move_cursor(motion, times, window, cx);
-    }
-
-    fn helix_find_range_forward(
+    // Helix motion which creates a selection
+    fn helix_move_and_select(
         &mut self,
         times: Option<usize>,
         window: &mut Window,
         cx: &mut Context<Self>,
-        mut is_boundary: impl FnMut(char, char, &CharClassifier) -> bool,
+        motion: Motion, //mut is_boundary: impl FnMut(char, char, &CharClassifier) -> bool,
     ) {
         self.update_editor(window, cx, |_, editor, window, cx| {
+            let text_layout_details = editor.text_layout_details(window);
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(|map, selection| {
-                    let times = times.unwrap_or(1);
-                    let new_goal = SelectionGoal::None;
-                    let mut head = selection.head();
-                    let mut tail = selection.tail();
+                    let goal = selection.goal;
+                    let old_point = selection.head();
+                    let was_empty = selection.is_empty();
 
-                    if head == map.max_point() {
-                        return;
+                    let (new_point, new_goal) = motion
+                        .move_point(
+                            map,
+                            old_point,
+                            selection.goal,
+                            times,
+                            &text_layout_details,
+                            true,
+                        )
+                        .unwrap_or((old_point, goal));
+
+                    selection.set_tail(old_point, goal);
+                    selection.set_head(new_point, new_goal);
+
+                    // include old position only if selection was empty
+                    if was_empty && selection.end == old_point {
+                        selection.end = movement::right(map, selection.end)
                     }
-
-                    // collapse to block cursor
-                    if tail < head {
-                        tail = movement::left(map, head);
-                    } else {
-                        tail = head;
-                        head = movement::right(map, head);
+                    // must include cursor position
+                    if selection.end == new_point {
+                        selection.end = movement::right(map, selection.end)
                     }
-
-                    // create a classifier
-                    let classifier = map.buffer_snapshot.char_classifier_at(head.to_point(map));
-
-                    for _ in 0..times {
-                        let (maybe_next_tail, next_head) =
-                            movement::find_boundary_trail(map, head, |left, right| {
-                                is_boundary(left, right, &classifier)
-                            });
-
-                        if next_head == head && maybe_next_tail.unwrap_or(next_head) == tail {
-                            break;
-                        }
-
-                        head = next_head;
-                        if let Some(next_tail) = maybe_next_tail {
-                            tail = next_tail;
-                        }
-                    }
-
-                    selection.set_tail(tail, new_goal);
-                    selection.set_head(head, new_goal);
                 });
             });
         });
     }
 
-    fn helix_find_range_backward(
-        &mut self,
-        times: Option<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-        mut is_boundary: impl FnMut(char, char, &CharClassifier) -> bool,
-    ) {
-        self.update_editor(window, cx, |_, editor, window, cx| {
-            editor.change_selections(Default::default(), window, cx, |s| {
-                s.move_with(|map, selection| {
-                    let times = times.unwrap_or(1);
-                    let new_goal = SelectionGoal::None;
-                    let mut head = selection.head();
-                    let mut tail = selection.tail();
-
-                    if head == DisplayPoint::zero() {
-                        return;
-                    }
-
-                    // collapse to block cursor
-                    if tail < head {
-                        tail = movement::left(map, head);
-                    } else {
-                        tail = head;
-                        head = movement::right(map, head);
-                    }
-
-                    selection.set_head(head, new_goal);
-                    selection.set_tail(tail, new_goal);
-                    // flip the selection
-                    selection.swap_head_tail();
-                    head = selection.head();
-                    tail = selection.tail();
-
-                    // create a classifier
-                    let classifier = map.buffer_snapshot.char_classifier_at(head.to_point(map));
-
-                    for _ in 0..times {
-                        let (maybe_next_tail, next_head) =
-                            movement::find_preceding_boundary_trail(map, head, |left, right| {
-                                is_boundary(left, right, &classifier)
-                            });
-
-                        if next_head == head && maybe_next_tail.unwrap_or(next_head) == tail {
-                            break;
-                        }
-
-                        head = next_head;
-                        if let Some(next_tail) = maybe_next_tail {
-                            tail = next_tail;
-                        }
-                    }
-
-                    selection.set_tail(tail, new_goal);
-                    selection.set_head(head, new_goal);
-                });
-            })
-        });
-    }
-
+    // Helix motion which do not create any selection
     pub fn helix_move_and_collapse(
         &mut self,
         motion: Motion,
@@ -187,7 +107,14 @@ impl Vim {
                     };
 
                     let (point, goal) = motion
-                        .move_point(map, cursor, selection.goal, times, &text_layout_details)
+                        .move_point(
+                            map,
+                            cursor,
+                            selection.goal,
+                            times,
+                            &text_layout_details,
+                            true,
+                        )
                         .unwrap_or((cursor, goal));
 
                     selection.collapse_to(point, goal)
@@ -196,7 +123,7 @@ impl Vim {
         });
     }
 
-    pub fn helix_move_cursor(
+    pub fn helix_normal_motion(
         &mut self,
         motion: Motion,
         times: Option<usize>,
@@ -204,107 +131,13 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         match motion {
-            Motion::NextWordStart { ignore_punctuation } => {
-                self.helix_find_range_forward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && right_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::NextWordEnd { ignore_punctuation } => {
-                self.helix_find_range_forward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && left_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::PreviousWordStart { ignore_punctuation } => {
-                self.helix_find_range_backward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && left_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::PreviousWordEnd { ignore_punctuation } => {
-                self.helix_find_range_backward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && right_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::FindForward { .. } => {
-                self.update_editor(window, cx, |_, editor, window, cx| {
-                    let text_layout_details = editor.text_layout_details(window);
-                    editor.change_selections(Default::default(), window, cx, |s| {
-                        s.move_with(|map, selection| {
-                            let goal = selection.goal;
-                            let cursor = if selection.is_empty() || selection.reversed {
-                                selection.head()
-                            } else {
-                                movement::left(map, selection.head())
-                            };
-
-                            let (point, goal) = motion
-                                .move_point(
-                                    map,
-                                    cursor,
-                                    selection.goal,
-                                    times,
-                                    &text_layout_details,
-                                )
-                                .unwrap_or((cursor, goal));
-                            selection.set_tail(selection.head(), goal);
-                            selection.set_head(movement::right(map, point), goal);
-                        })
-                    });
-                });
-            }
-            Motion::FindBackward { .. } => {
-                self.update_editor(window, cx, |_, editor, window, cx| {
-                    let text_layout_details = editor.text_layout_details(window);
-                    editor.change_selections(Default::default(), window, cx, |s| {
-                        s.move_with(|map, selection| {
-                            let goal = selection.goal;
-                            let cursor = if selection.is_empty() || selection.reversed {
-                                selection.head()
-                            } else {
-                                movement::left(map, selection.head())
-                            };
-
-                            let (point, goal) = motion
-                                .move_point(
-                                    map,
-                                    cursor,
-                                    selection.goal,
-                                    times,
-                                    &text_layout_details,
-                                )
-                                .unwrap_or((cursor, goal));
-                            selection.set_tail(selection.head(), goal);
-                            selection.set_head(point, goal);
-                        })
-                    });
-                });
+            Motion::NextWordStart { .. }
+            | Motion::NextWordEnd { .. }
+            | Motion::PreviousWordStart { .. }
+            | Motion::PreviousWordEnd { .. }
+            | Motion::FindForward { .. }
+            | Motion::FindBackward { .. } => {
+                return self.helix_move_and_select(times, window, cx, motion);
             }
             _ => self.helix_move_and_collapse(motion, times, window, cx),
         }

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -88,42 +88,6 @@ impl Vim {
         });
     }
 
-    // Helix motion which do not create any selection
-    pub fn helix_move_and_collapse(
-        &mut self,
-        motion: Motion,
-        times: Option<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.update_editor(window, cx, |_, editor, window, cx| {
-            let text_layout_details = editor.text_layout_details(window);
-            editor.change_selections(Default::default(), window, cx, |s| {
-                s.move_with(|map, selection| {
-                    let goal = selection.goal;
-                    let cursor = if selection.is_empty() || selection.reversed {
-                        selection.head()
-                    } else {
-                        movement::left(map, selection.head())
-                    };
-
-                    let (point, goal) = motion
-                        .move_point(
-                            map,
-                            cursor,
-                            selection.goal,
-                            times,
-                            &text_layout_details,
-                            true,
-                        )
-                        .unwrap_or((cursor, goal));
-
-                    selection.collapse_to(point, goal)
-                })
-            });
-        });
-    }
-
     fn helix_find_range_forward(
         &mut self,
         times: Option<usize>,
@@ -234,6 +198,42 @@ impl Vim {
                     selection.set_head(head, new_goal);
                 });
             })
+        });
+    }
+
+    // Helix motion which do not create any selection
+    pub fn helix_move_and_collapse(
+        &mut self,
+        motion: Motion,
+        times: Option<usize>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.update_editor(window, cx, |_, editor, window, cx| {
+            let text_layout_details = editor.text_layout_details(window);
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.move_with(|map, selection| {
+                    let goal = selection.goal;
+                    let cursor = if selection.is_empty() || selection.reversed {
+                        selection.head()
+                    } else {
+                        movement::left(map, selection.head())
+                    };
+
+                    let (point, goal) = motion
+                        .move_point(
+                            map,
+                            cursor,
+                            selection.goal,
+                            times,
+                            &text_layout_details,
+                            true,
+                        )
+                        .unwrap_or((cursor, goal));
+
+                    selection.collapse_to(point, goal)
+                })
+            });
         });
     }
 

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1836,7 +1836,7 @@ fn previous_word_start(
 
 fn previous_word_end(
     map: &DisplaySnapshot,
-    mut point: DisplayPoint,
+    point: DisplayPoint,
     ignore_punctuation: bool,
     times: usize,
 ) -> DisplayPoint {
@@ -1844,12 +1844,16 @@ fn previous_word_end(
         .buffer_snapshot
         .char_classifier_at(point.to_point(map))
         .ignore_punctuation(ignore_punctuation);
+    let mut point = point.to_point(map);
 
-    // if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
-    //     if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
-    //         point.column += ch.len_utf8() as u32;
-    //     }
-    // }
+    if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+        if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
+            point.column += ch.len_utf8() as u32;
+        }
+    }
+
+    let mut point = point.to_display_point(map);
+
     for _ in 0..times {
         let new_point =
             movement::find_preceding_boundary(&map, point, FindRange::MultiLine, |left, right| {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1,9 +1,7 @@
 use editor::{
     Anchor, Bias, DisplayPoint, Editor, RowExt, ToOffset, ToPoint,
     display_map::{DisplayRow, DisplaySnapshot, FoldPoint, ToDisplayPoint},
-    movement::{
-        self, FindRange, TextLayoutDetails, find_boundary, find_preceding_boundary_display_point,
-    },
+    movement::{self, FindRange, TextLayoutDetails, find_boundary, find_preceding_boundary},
 };
 use gpui::{Action, Context, Window, actions, px};
 use language::{CharKind, Point, Selection, SelectionGoal};
@@ -961,6 +959,7 @@ impl Motion {
         goal: SelectionGoal,
         maybe_times: Option<usize>,
         text_layout_details: &TextLayoutDetails,
+        helix_mode: bool,
     ) -> Option<(DisplayPoint, SelectionGoal)> {
         let times = maybe_times.unwrap_or(1);
         use Motion::*;
@@ -983,7 +982,11 @@ impl Motion {
             Right => (right(map, point, times), SelectionGoal::None),
             WrappingRight => (wrapping_right(map, point, times), SelectionGoal::None),
             NextWordStart { ignore_punctuation } => (
-                next_word_start(map, point, *ignore_punctuation, times),
+                if helix_mode {
+                    next_word_start_helix(map, point, *ignore_punctuation, times)
+                } else {
+                    next_word_start(map, point, *ignore_punctuation, times)
+                },
                 SelectionGoal::None,
             ),
             NextWordEnd { ignore_punctuation } => (
@@ -1364,9 +1367,10 @@ impl Motion {
         let maybe_new_point = self.move_point(
             map,
             selection.head(),
-            selection.goal,
+            SelectionGoal::None,
             times,
             text_layout_details,
+            false,
         );
 
         let (new_head, goal) = match (maybe_new_point, forced_motion) {
@@ -1717,6 +1721,41 @@ pub(crate) fn next_word_start(
     point
 }
 
+pub fn next_word_start_helix(
+    map: &DisplaySnapshot,
+    mut point: DisplayPoint,
+    ignore_punctuation: bool,
+    times: usize,
+) -> DisplayPoint {
+    let classifier = map
+        .buffer_snapshot
+        .char_classifier_at(point.to_point(map))
+        .ignore_punctuation(ignore_punctuation);
+    for _ in 0..times {
+        let new_point = movement::right(map, point);
+        let new_point = movement::find_boundary_exclusive(
+            map,
+            new_point,
+            FindRange::MultiLine,
+            |left, right| {
+                let left_kind = classifier.kind_with(left, ignore_punctuation);
+                let right_kind = classifier.kind_with(right, ignore_punctuation);
+                let at_newline = (left == '\n') ^ (right == '\n');
+
+                let found =
+                    (left_kind != right_kind && right_kind != CharKind::Whitespace) || at_newline;
+
+                found
+            },
+        );
+        if point == new_point {
+            break;
+        }
+        point = new_point;
+    }
+    point
+}
+
 pub(crate) fn next_word_end(
     map: &DisplaySnapshot,
     mut point: DisplayPoint,
@@ -1780,17 +1819,13 @@ fn previous_word_start(
     for _ in 0..times {
         // This works even though find_preceding_boundary is called for every character in the line containing
         // cursor because the newline is checked only once.
-        let new_point = movement::find_preceding_boundary_display_point(
-            map,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
 
                 (left_kind != right_kind && !right.is_whitespace()) || left == '\n'
-            },
-        );
+            });
         if point == new_point {
             break;
         }
@@ -1801,7 +1836,7 @@ fn previous_word_start(
 
 fn previous_word_end(
     map: &DisplaySnapshot,
-    point: DisplayPoint,
+    mut point: DisplayPoint,
     ignore_punctuation: bool,
     times: usize,
 ) -> DisplayPoint {
@@ -1809,19 +1844,15 @@ fn previous_word_end(
         .buffer_snapshot
         .char_classifier_at(point.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let mut point = point.to_point(map);
 
-    if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
-        if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
-            point.column += ch.len_utf8() as u32;
-        }
-    }
+    // if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+    //     if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
+    //         point.column += ch.len_utf8() as u32;
+    //     }
+    // }
     for _ in 0..times {
-        let new_point = movement::find_preceding_boundary_point(
-            &map.buffer_snapshot,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(&map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
                 match (left_kind, right_kind) {
@@ -1832,14 +1863,13 @@ fn previous_word_end(
                     (CharKind::Whitespace, CharKind::Whitespace) => left == '\n' && right == '\n',
                     _ => false,
                 }
-            },
-        );
+            });
         if new_point == point {
             break;
         }
         point = new_point;
     }
-    movement::saturating_left(map, point.to_display_point(map))
+    movement::saturating_left(map, point)
 }
 
 fn next_subword_start(
@@ -1944,11 +1974,8 @@ fn previous_subword_start(
         let mut crossed_newline = false;
         // This works even though find_preceding_boundary is called for every character in the line containing
         // cursor because the newline is checked only once.
-        let new_point = movement::find_preceding_boundary_display_point(
-            map,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
                 let at_newline = right == '\n';
@@ -1964,8 +1991,7 @@ fn previous_subword_start(
                 crossed_newline |= at_newline;
 
                 found
-            },
-        );
+            });
         if point == new_point {
             break;
         }
@@ -1976,7 +2002,7 @@ fn previous_subword_start(
 
 fn previous_subword_end(
     map: &DisplaySnapshot,
-    point: DisplayPoint,
+    mut point: DisplayPoint,
     ignore_punctuation: bool,
     times: usize,
 ) -> DisplayPoint {
@@ -1984,19 +2010,16 @@ fn previous_subword_end(
         .buffer_snapshot
         .char_classifier_at(point.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let mut point = point.to_point(map);
+    // let mut point = point.to_point(map);
 
-    if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
-        if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
-            point.column += ch.len_utf8() as u32;
-        }
-    }
+    // if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+    //     if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
+    //         point.column += ch.len_utf8() as u32;
+    //     }
+    // }
     for _ in 0..times {
-        let new_point = movement::find_preceding_boundary_point(
-            &map.buffer_snapshot,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(&map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
 
@@ -2013,14 +2036,13 @@ fn previous_subword_end(
                     (CharKind::Whitespace, CharKind::Whitespace) => left == '\n' && right == '\n',
                     _ => false,
                 }
-            },
-        );
+            });
         if new_point == point {
             break;
         }
         point = new_point;
     }
-    movement::saturating_left(map, point.to_display_point(map))
+    movement::saturating_left(map, point)
 }
 
 pub(crate) fn first_non_whitespace(
@@ -2617,7 +2639,7 @@ fn find_backward(
     let mut to = from;
 
     for _ in 0..times {
-        let new_to = find_preceding_boundary_display_point(map, to, mode, |_, right| {
+        let new_to = find_preceding_boundary(map, to, mode, |_, right| {
             is_character_match(target, right, smartcase)
         });
         if to == new_to {
@@ -2700,12 +2722,11 @@ fn sneak_backward(
 
     for _ in 0..times {
         found = false;
-        let new_to =
-            find_preceding_boundary_display_point(map, to, FindRange::MultiLine, |left, right| {
-                found = is_character_match(first_target, left, smartcase)
-                    && is_character_match(second_target, right, smartcase);
-                found
-            });
+        let new_to = find_preceding_boundary(map, to, FindRange::MultiLine, |left, right| {
+            found = is_character_match(first_target, left, smartcase)
+                && is_character_match(second_target, right, smartcase);
+            found
+        });
         if to == new_to {
             break;
         }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -535,7 +535,7 @@ impl Vim {
                 |s| {
                     s.move_cursors_with(|map, cursor, goal| {
                         motion
-                            .move_point(map, cursor, goal, times, &text_layout_details)
+                            .move_point(map, cursor, goal, times, &text_layout_details, false)
                             .unwrap_or((cursor, goal))
                     })
                 },
@@ -708,6 +708,7 @@ impl Vim {
                             goal,
                             None,
                             &text_layout_details,
+                            false,
                         )
                     });
                 });

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -82,6 +82,7 @@ impl Vim {
                                 selection.goal,
                                 None,
                                 &text_layout_details,
+                                false,
                             ) {
                                 selection.start = point;
                             }

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -745,7 +745,7 @@ fn in_word(
         .buffer_snapshot
         .char_classifier_at(relative_to.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let start = movement::find_preceding_boundary_display_point(
+    let start = movement::find_preceding_boundary(
         map,
         right(map, relative_to, 1),
         movement::FindRange::SingleLine,
@@ -783,7 +783,7 @@ fn in_subword(
         .unwrap_or(false);
 
     let start = if in_subword {
-        movement::find_preceding_boundary_display_point(
+        movement::find_preceding_boundary(
             map,
             right(map, relative_to, 1),
             movement::FindRange::SingleLine,
@@ -937,7 +937,7 @@ fn around_subword(
         .buffer_snapshot
         .char_classifier_at(relative_to.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let start = movement::find_preceding_boundary_display_point(
+    let start = movement::find_preceding_boundary(
         map,
         right(map, relative_to, 1),
         movement::FindRange::SingleLine,
@@ -997,7 +997,7 @@ fn around_next_word(
         .char_classifier_at(relative_to.to_point(map))
         .ignore_punctuation(ignore_punctuation);
     // Get the start of the word
-    let start = movement::find_preceding_boundary_display_point(
+    let start = movement::find_preceding_boundary(
         map,
         right(map, relative_to, 1),
         FindRange::SingleLine,

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -10,7 +10,9 @@ use gpui::{Context, Window, actions};
 use language::{Point, Selection, SelectionGoal};
 use multi_buffer::MultiBufferRow;
 use search::BufferSearchBar;
+use settings::Settings;
 use util::ResultExt;
+use vim_mode_setting::HelixModeSetting;
 use workspace::searchable::Direction;
 
 use crate::{

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -238,7 +238,6 @@ impl Vim {
                             return;
                         };
 
-                        log::info!("Motion new head:{:?}", new_head);
                         selection.set_head(new_head, goal);
 
                         // ensure the current character is included in the selection.
@@ -262,11 +261,6 @@ impl Vim {
                         } else if !was_reversed && selection.reversed {
                             selection.end = movement::right(map, selection.end);
                         }
-                        log::info!(
-                            "Selection: tail={:?} head={:?}",
-                            selection.start,
-                            selection.end
-                        );
                     })
                 });
             }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -191,6 +191,7 @@ impl Vim {
     ) {
         self.update_editor(window, cx, |vim, editor, window, cx| {
             let text_layout_details = editor.text_layout_details(window);
+            let is_helix_mode = HelixModeSetting::get_global(cx).0;
             if vim.mode == Mode::VisualBlock
                 && !matches!(
                     motion,
@@ -201,7 +202,7 @@ impl Vim {
             {
                 let is_up_or_down = matches!(motion, Motion::Up { .. } | Motion::Down { .. });
                 vim.visual_block_motion(is_up_or_down, editor, window, cx, |map, point, goal| {
-                    motion.move_point(map, point, goal, times, &text_layout_details)
+                    motion.move_point(map, point, goal, times, &text_layout_details, is_helix_mode)
                 })
             } else {
                 editor.change_selections(Default::default(), window, cx, |s| {
@@ -230,10 +231,12 @@ impl Vim {
                             selection.goal,
                             times,
                             &text_layout_details,
+                            is_helix_mode,
                         ) else {
                             return;
                         };
 
+                        log::info!("Motion new head:{:?}", new_head);
                         selection.set_head(new_head, goal);
 
                         // ensure the current character is included in the selection.
@@ -257,6 +260,11 @@ impl Vim {
                         } else if !was_reversed && selection.reversed {
                             selection.end = movement::right(map, selection.end);
                         }
+                        log::info!(
+                            "Selection: tail={:?} head={:?}",
+                            selection.start,
+                            selection.end
+                        );
                     })
                 });
             }


### PR DESCRIPTION
Release Notes:
 - Helix: Refactor selecting movements (w, b, e, W, t, T) removing a lot of custom implementation code. Also fixes helix movement in visual mode (w).

![2025-08-02 00 19 36](https://github.com/user-attachments/assets/19785fbc-27b5-415a-8d29-839c0ef7c346)



TODO:
 I need assistance from someone more experienced, since this is my first major commit:
  - [ ] to align with existing `find_boundary` and `found_boundary_exclusive` i have created `find_preceding_boundary` and `find_preceding_boundary_exclusive`
  - [ ] `find_preceding_boundary_display_point` renamed into `find_preceding_boundary` globally.
  - [ ] `find_preceding_boundary_point` removed. Code refactored to use DisplayPoints
  - [ ] `test_find_preceding_boundary` added option to allow writing tests for exclusive boundary cases
 
Second changes is `move_point` now has `helix_mode` bool. Vim and Helix have different ideas about next_word_start, so using alternative method for `NextWordStart` allows to avoid a LOT of code, specifically when using motions in visual/select modes. This PR works even without #34136. In fact - maybe a separate select mode is not even needed with this fix.

Third big change is in `helix. `. Current Implementation redefines motions for `w, b, e, W, t, T` because in helix mode they must generate a selection. New implementation works similar to visual_move, but will not extend existing selection. As a result - I was able to drop a lot of custom helix motions and instead wrap selection after motion is done. It is still possible to customise those motions if needed.

Known issues:
 - [x] w will select newline, in helix it does not. A fix could be to trim newlines from selection after helix motion.
 - [x] 5w selects 5 words. In helix only last word is selected. Potentially we could execute motion 4 times and capture selection only on the last iteration.
 - [ ] Incorporate #35216,

Feedback welcome!