### PR TITLE
Make `editor::AcceptPartialCopilotSuggestion` a deprecated alias

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -315,9 +315,8 @@ actions!(
     [
         /// Accepts the full edit prediction.
         AcceptEditPrediction,
-        /// Accepts a partial Copilot suggestion.
-        AcceptPartialCopilotSuggestion,
         /// Accepts a partial edit prediction.
+        #[action(deprecated_aliases = ["editor::AcceptPartialCopilotSuggestion"])]
         AcceptPartialEditPrediction,
         /// Adds a cursor above the current selection.
         AddSelectionAbove,

--- a/crates/zed/src/zed/inline_completion_registry.rs
+++ b/crates/zed/src/zed/inline_completion_registry.rs
@@ -1,10 +1,10 @@
-use client::{Client, DisableAiSettings, UserStore};
+use client::{Client, UserStore};
 use collections::HashMap;
 use copilot::{Copilot, CopilotCompletionProvider};
 use editor::Editor;
 use gpui::{AnyWindowHandle, App, AppContext as _, Context, Entity, WeakEntity};
 use language::language_settings::{EditPredictionProvider, all_language_settings};
-use settings::{Settings as _, SettingsStore};
+use settings::SettingsStore;
 use smol::stream::StreamExt;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use supermaven::{Supermaven, SupermavenCompletionProvider};
@@ -192,18 +192,6 @@ fn register_backward_compatible_actions(editor: &mut Editor, cx: &mut Context<Ed
             },
         ))
         .detach();
-    if !DisableAiSettings::get_global(cx).disable_ai {
-        editor
-            .register_action(cx.listener(
-                |editor,
-                 _: &editor::actions::AcceptPartialCopilotSuggestion,
-                 window: &mut Window,
-                 cx: &mut Context<Editor>| {
-                    editor.accept_partial_inline_completion(&Default::default(), window, cx);
-                },
-            ))
-            .detach();
-    }
 }
 
 fn assign_edit_prediction_provider(


### PR DESCRIPTION
This is consistent with there being no copilot expecific variant of `editor::AcceptEditPrediction`. It also fixes a case where the `disable_ai: true` has effects at init time that aren't undone when changed, added in #35327.

Release Notes:

- N/A