### PR TITLE
zeta: Collect git sha / remote urls when data collection from OSS is enabled

### DIFF
--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -159,9 +159,6 @@ pub struct PredictEditsGitInfo {
     /// SHA of git HEAD commit at time of prediction.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub head_sha: Option<String>,
-    /// Name of the current branch at time of prediction.
-    #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub branch_name: Option<String>,
     /// URL of the remote called `origin`.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub remote_origin_url: Option<String>,

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -162,6 +162,12 @@ pub struct PredictEditsGitInfo {
     /// Name of the current branch at time of prediction.
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub branch_name: Option<String>,
+    /// URL of the remote called `origin`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub remote_origin_url: Option<String>,
+    /// URL of the remote called `upstream`.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub remote_upstream_url: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -149,9 +149,19 @@ pub struct PredictEditsBody {
     pub can_collect_data: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub diagnostic_groups: Option<Vec<(String, serde_json::Value)>>,
+    /// Info about the git repository state, only present when can_collect_data is true.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub git_info: Option<PredictEditsGitInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PredictEditsGitInfo {
     /// SHA of git HEAD commit at time of prediction.
     #[serde(skip_serializing_if = "Option::is_none", default)]
-    pub git_head_sha: Option<String>,
+    pub head_sha: Option<String>,
+    /// Name of the current branch at time of prediction.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub branch_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -149,6 +149,9 @@ pub struct PredictEditsBody {
     pub can_collect_data: bool,
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub diagnostic_groups: Option<Vec<(String, serde_json::Value)>>,
+    /// SHA of git HEAD commit at time of prediction.
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub git_head_sha: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -246,6 +246,8 @@ pub struct RepositorySnapshot {
     pub head_commit: Option<CommitDetails>,
     pub scan_id: u64,
     pub merge: MergeDetails,
+    pub remote_origin_url: Option<String>,
+    pub remote_upstream_url: Option<String>,
 }
 
 type JobId = u64;
@@ -2673,6 +2675,8 @@ impl RepositorySnapshot {
             head_commit: None,
             scan_id: 0,
             merge: Default::default(),
+            remote_origin_url: None,
+            remote_upstream_url: None,
         }
     }
 
@@ -4799,6 +4803,10 @@ async fn compute_snapshot(
         None => None,
     };
 
+    // Used by edit prediction data collection
+    let remote_origin_url = backend.remote_url("origin");
+    let remote_upstream_url = backend.remote_url("upstream");
+
     let snapshot = RepositorySnapshot {
         id,
         statuses_by_path,
@@ -4807,6 +4815,8 @@ async fn compute_snapshot(
         branch,
         head_commit,
         merge: merge_details,
+        remote_origin_url,
+        remote_upstream_url,
     };
 
     Ok((snapshot, events))

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1178,22 +1178,13 @@ fn git_info_for_file(
             .head_commit
             .as_ref()
             .map(|head_commit| head_commit.sha.to_string());
-        let branch_name = repository
-            .branch
-            .as_ref()
-            .map(|branch| branch.name().to_string());
         let remote_origin_url = repository.remote_origin_url.clone();
         let remote_upstream_url = repository.remote_upstream_url.clone();
-        if head_sha.is_none()
-            && branch_name.is_none()
-            && remote_origin_url.is_none()
-            && remote_upstream_url.is_none()
-        {
+        if head_sha.is_none() && remote_origin_url.is_none() && remote_upstream_url.is_none() {
             return None;
         }
         Some(PredictEditsGitInfo {
             head_sha,
-            branch_name,
             remote_origin_url,
             remote_upstream_url,
         })

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -1182,12 +1182,20 @@ fn git_info_for_file(
             .branch
             .as_ref()
             .map(|branch| branch.name().to_string());
-        if head_sha.is_none() && branch_name.is_none() {
+        let remote_origin_url = repository.remote_origin_url.clone();
+        let remote_upstream_url = repository.remote_upstream_url.clone();
+        if head_sha.is_none()
+            && branch_name.is_none()
+            && remote_origin_url.is_none()
+            && remote_upstream_url.is_none()
+        {
             return None;
         }
         Some(PredictEditsGitInfo {
             head_sha,
             branch_name,
+            remote_origin_url,
+            remote_upstream_url,
         })
     } else {
         None

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -172,7 +172,7 @@ async fn get_context(
         None => String::new(),
     };
     let can_collect_data = false;
-    let git_head_sha = None;
+    let git_info = None;
     cx.update(|cx| {
         gather_context(
             project.as_ref(),
@@ -181,7 +181,7 @@ async fn get_context(
             clipped_cursor,
             move || events,
             can_collect_data,
-            git_head_sha,
+            git_info,
             cx,
         )
     })?

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -172,6 +172,7 @@ async fn get_context(
         None => String::new(),
     };
     let can_collect_data = false;
+    let git_head_sha = None;
     cx.update(|cx| {
         gather_context(
             project.as_ref(),
@@ -180,6 +181,7 @@ async fn get_context(
             clipped_cursor,
             move || events,
             can_collect_data,
+            git_head_sha,
             cx,
         )
     })?


### PR DESCRIPTION
Release Notes:

- Edit Prediction: Added Git info to edit predictions requests (only sent for opensource projects when data collection is enabled). The sent Git info is the SHA of the current commit and the URLs for the `origin` and `upstream` remotes.
