### PR TITLE
Add libx11 to openSUSE build dependencies

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -143,6 +143,7 @@ if [[ -n $zyp ]]; then
     gzip
     jq
     libvulkan1
+    libx11-devel
     libxcb-devel
     libxkbcommon-devel
     libxkbcommon-x11-devel


### PR DESCRIPTION
building on opensuse fails without `libx11-devel`

**Repro:**

```bash
$ cd $(mktemp -d)
$ git clone https://github.com/zed-industries/zed .
$ docker run --rm -it -v $(pwd):/zed -w /zed opensuse/tumbleweed

(opensuse) $ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
(opensuse) $ ./script/linux
(opensuse) $ cargo build --release
```

**Expected:** to work

**Actual:** 

```
thread 'main' panicked at /root/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/x11-2.21.0/build.rs:42:14:
  called `Result::unwrap()` on an `Err` value:
  pkg-config exited with status code 1
  > PKG_CONFIG_ALLOW_SYSTEM_LIBS=1 PKG_CONFIG_ALLOW_SYSTEM_CFLAGS=1 pkg-config --libs --cflags x11 'x11 >= 1.4.99.1'

  The system library `x11` required by crate `x11` was not found.
  The file `x11.pc` needs to be installed and the PKG_CONFIG_PATH environment variable must contain its parent directory.
  The PKG_CONFIG_PATH environment variable is not set.

  HINT: if you have installed the library, try setting PKG_CONFIG_PATH to the directory containing `x11.pc`.

  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
```


Release Notes:

- N/A