### PR TITLE
Add SIGHUP handler on unix systems to hot reload current theme

### DIFF
--- a/docs/src/themes.md
+++ b/docs/src/themes.md
@@ -64,6 +64,10 @@ For example, to create a new theme called `my-cool-theme`, create a file called 
 
 Find more themes at [zed-themes.com](https://zed-themes.com).
 
+## Hot Theme Reload
+
+On Unix systems, Zed accepts the `SIGHUP` signal to reload the current theme. This is useful for hot-reloading changes to your theme file without restarting Zed.
+
 ## Theme Development
 
 See: [Developing Zed Themes](./extensions/themes.md)


### PR DESCRIPTION
### Problem:

Currently, theme developers and users with dynamic themes (`wal` users) need to restart the Zed editor to see theme changes.

### Solution:
Added a `SIGHUP` signal handler on Unix systems that reloads the current theme without restarting the editor. Also added documentation explaining this feature.

`SIGHUP` has become the Unix convention for "reload configuration" used across many applications. It's particularly useful for `wal` users who frequently update system wide color schemes and want to see changes reflected in applications without manual reloading.

```sh
kill -HUP <zed_pid>
# or
pkill -HUP zed # or zed-editor, if not renamed to zed
```

## Video Demo:

https://github.com/user-attachments/assets/47acb937-e0e8-40c9-b654-10d91a81f722

(in this demo, pywal16 runs `pkill -HUP zed` after modifying my current theme in `~/.config/zed/themes`)

## Release Notes:

- Added `SIGHUP` signal handling on unix systems to reload the user theme
