### PR TITLE
Improve yaml outline

### DIFF
--- a/crates/languages/src/yaml/outline.scm
+++ b/crates/languages/src/yaml/outline.scm
@@ -1,1 +1,7 @@
-(block_mapping_pair key: (flow_node (plain_scalar (string_scalar) @name))) @item
+(block_mapping_pair
+    key: (flow_node
+            (plain_scalar
+                (string_scalar) @name))
+    value: (flow_node
+            (plain_scalar
+                (string_scalar) @context))?) @item

--- a/crates/languages/src/yaml/outline.scm
+++ b/crates/languages/src/yaml/outline.scm
@@ -1,7 +1,9 @@
 (block_mapping_pair
-    key: (flow_node
+    key:
+        (flow_node
             (plain_scalar
                 (string_scalar) @name))
-    value: (flow_node
+    value:
+        (flow_node
             (plain_scalar
                 (string_scalar) @context))?) @item


### PR DESCRIPTION
Before:

<img width="753" height="890" alt="Screenshot 2025-08-03 at 8 58 16 PM" src="https://github.com/user-attachments/assets/a3816acd-66b2-4042-8181-fbc15881bd4b" />

After:

<img width="648" height="634" alt="Screenshot 2025-08-03 at 8 59 30 PM" src="https://github.com/user-attachments/assets/0ab35f3e-36d6-42b5-bb5f-09431985878e" />

Release Notes:

- Improved the yaml outline to include the key's value if it's a simple string.
