### PR TITLE
Stop sending redundant LSP proto requests

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -173,6 +173,7 @@ CREATE TABLE "language_servers" (
     "id" INTEGER NOT NULL,
     "project_id" INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,
     "name" VARCHAR NOT NULL,
+    "capabilities" TEXT NOT NULL,
     PRIMARY KEY (project_id, id)
 );
 

--- a/crates/collab/migrations/20250804080620_language_server_capabilities.sql
+++ b/crates/collab/migrations/20250804080620_language_server_capabilities.sql
@@ -1,0 +1,5 @@
+ALTER TABLE language_servers
+    ADD COLUMN capabilities TEXT NOT NULL DEFAULT '{}';
+
+ALTER TABLE language_servers
+    ALTER COLUMN capabilities DROP DEFAULT;

--- a/crates/collab/src/db.rs
+++ b/crates/collab/src/db.rs
@@ -529,11 +529,17 @@ pub struct RejoinedProject {
     pub worktrees: Vec<RejoinedWorktree>,
     pub updated_repositories: Vec<proto::UpdateRepository>,
     pub removed_repositories: Vec<u64>,
-    pub language_servers: Vec<proto::LanguageServer>,
+    pub language_servers: Vec<LanguageServer>,
 }
 
 impl RejoinedProject {
     pub fn to_proto(&self) -> proto::RejoinedProject {
+        let (language_servers, language_server_capabilities) = self
+            .language_servers
+            .clone()
+            .into_iter()
+            .map(|server| (server.server, server.capabilities))
+            .unzip();
         proto::RejoinedProject {
             id: self.id.to_proto(),
             worktrees: self
@@ -551,7 +557,8 @@ impl RejoinedProject {
                 .iter()
                 .map(|collaborator| collaborator.to_proto())
                 .collect(),
-            language_servers: self.language_servers.clone(),
+            language_servers,
+            language_server_capabilities,
         }
     }
 }
@@ -598,7 +605,7 @@ pub struct Project {
     pub collaborators: Vec<ProjectCollaborator>,
     pub worktrees: BTreeMap<u64, Worktree>,
     pub repositories: Vec<proto::UpdateRepository>,
-    pub language_servers: Vec<proto::LanguageServer>,
+    pub language_servers: Vec<LanguageServer>,
 }
 
 pub struct ProjectCollaborator {
@@ -621,6 +628,12 @@ impl ProjectCollaborator {
             committer_email: self.committer_email.clone(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct LanguageServer {
+    pub server: proto::LanguageServer,
+    pub capabilities: String,
 }
 
 #[derive(Debug)]

--- a/crates/collab/src/db/queries/buffers.rs
+++ b/crates/collab/src/db/queries/buffers.rs
@@ -786,6 +786,32 @@ impl Database {
             })
             .collect())
     }
+
+    /// Update language server capabilities for a given id.
+    pub async fn update_server_capabilities(
+        &self,
+        project_id: ProjectId,
+        server_id: u64,
+        new_capabilities: String,
+    ) -> Result<()> {
+        self.transaction(|tx| {
+            let new_capabilities = new_capabilities.clone();
+            async move {
+                Ok(
+                    language_server::Entity::update(language_server::ActiveModel {
+                        project_id: ActiveValue::unchanged(project_id),
+                        id: ActiveValue::unchanged(server_id as i64),
+                        capabilities: ActiveValue::set(new_capabilities),
+                        ..Default::default()
+                    })
+                    .exec(&*tx)
+                    .await?,
+                )
+            }
+        })
+        .await?;
+        Ok(())
+    }
 }
 
 fn operation_to_storage(

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -692,6 +692,7 @@ impl Database {
                 project_id: ActiveValue::set(project_id),
                 id: ActiveValue::set(server.id as i64),
                 name: ActiveValue::set(server.name.clone()),
+                // TODO kb add more: capabilities and share on [re]join
             })
             .on_conflict(
                 OnConflict::columns([

--- a/crates/collab/src/db/queries/projects.rs
+++ b/crates/collab/src/db/queries/projects.rs
@@ -692,7 +692,7 @@ impl Database {
                 project_id: ActiveValue::set(project_id),
                 id: ActiveValue::set(server.id as i64),
                 name: ActiveValue::set(server.name.clone()),
-                // TODO kb add more: capabilities and share on [re]join
+                capabilities: ActiveValue::set(update.capabilities.clone()),
             })
             .on_conflict(
                 OnConflict::columns([
@@ -1055,10 +1055,13 @@ impl Database {
             repositories,
             language_servers: language_servers
                 .into_iter()
-                .map(|language_server| proto::LanguageServer {
-                    id: language_server.id as u64,
-                    name: language_server.name,
-                    worktree_id: None,
+                .map(|language_server| LanguageServer {
+                    server: proto::LanguageServer {
+                        id: language_server.id as u64,
+                        name: language_server.name,
+                        worktree_id: None,
+                    },
+                    capabilities: language_server.capabilities,
                 })
                 .collect(),
         };

--- a/crates/collab/src/db/queries/rooms.rs
+++ b/crates/collab/src/db/queries/rooms.rs
@@ -804,10 +804,13 @@ impl Database {
             .all(tx)
             .await?
             .into_iter()
-            .map(|language_server| proto::LanguageServer {
-                id: language_server.id as u64,
-                name: language_server.name,
-                worktree_id: None,
+            .map(|language_server| LanguageServer {
+                server: proto::LanguageServer {
+                    id: language_server.id as u64,
+                    name: language_server.name,
+                    worktree_id: None,
+                },
+                capabilities: language_server.capabilities,
             })
             .collect::<Vec<_>>();
 

--- a/crates/collab/src/db/tables/language_server.rs
+++ b/crates/collab/src/db/tables/language_server.rs
@@ -9,6 +9,7 @@ pub struct Model {
     #[sea_orm(primary_key)]
     pub id: i64,
     pub name: String,
+    pub capabilities: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -2254,10 +2254,9 @@ async fn update_language_server(
     let project_id = ProjectId::from_proto(request.project_id);
     let db = session.db().await;
 
-    if let Some(proto::update_language_server::Variant::MetadataUpdated(server_metadata_updated)) =
-        &request.variant
+    if let Some(proto::update_language_server::Variant::MetadataUpdated(update)) = &request.variant
     {
-        if let Some(capabilities) = server_metadata_updated.capabilities.clone() {
+        if let Some(capabilities) = update.capabilities.clone() {
             db.update_server_capabilities(project_id, request.language_server_id, capabilities)
                 .await?;
         }

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -2250,6 +2250,13 @@ async fn update_language_server(
         .await
         .project_connection_ids(project_id, session.connection_id, true)
         .await?;
+    if let Some(proto::update_language_server::Variant::MetadataUpdated(server_metadata_updated)) =
+        &request.variant
+    {
+        if let Some(capabilities) = &server_metadata_updated.capabilities {
+            dbg!("TODO kb update the language server DB with new capabilities {capabilities}");
+        }
+    }
     broadcast(
         Some(session.connection_id),
         project_connection_ids.iter().copied(),

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -838,6 +838,8 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
         .downcast::<Editor>()
         .unwrap();
     let fake_language_server = fake_language_servers.next().await.unwrap();
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
 
     // Move cursor to a location that can be renamed.
     let prepare_rename = editor_b.update_in(cx_b, |editor, window, cx| {
@@ -2116,6 +2118,8 @@ async fn test_lsp_document_color(cx_a: &mut TestAppContext, cx_b: &mut TestAppCo
         .unwrap();
 
     let fake_language_server = fake_language_servers.next().await.unwrap();
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
 
     let requests_made = Arc::new(AtomicUsize::new(0));
     let closure_requests_made = Arc::clone(&requests_made);
@@ -2395,6 +2399,8 @@ async fn test_lsp_pull_diagnostics(
         .unwrap();
 
     let fake_language_server = fake_language_servers.next().await.unwrap();
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
     let expected_push_diagnostic_main_message = "pushed main diagnostic";
     let expected_push_diagnostic_lib_message = "pushed lib diagnostic";
     let expected_pull_diagnostic_main_message = "pulled main diagnostic";
@@ -2750,6 +2756,7 @@ async fn test_lsp_pull_diagnostics(
         .unwrap()
         .downcast::<Editor>()
         .unwrap();
+    cx_b.run_until_parked();
 
     pull_diagnostics_handle.next().await.unwrap();
     assert_eq!(

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -2120,7 +2120,10 @@ async fn test_lsp_document_color(cx_a: &mut TestAppContext, cx_b: &mut TestAppCo
         .downcast::<Editor>()
         .unwrap();
 
+    // TODO kb send a special event and reload after didOpen LSP registration for the buffer
+    dbg!("33");
     color_request_handle.next().await.unwrap();
+    dbg!("????????????");
     executor.run_until_parked();
 
     assert_eq!(

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -1055,7 +1055,7 @@ async fn test_language_server_statuses(cx_a: &mut TestAppContext, cx_b: &mut Tes
 
     project_a.read_with(cx_a, |project, cx| {
         let status = project.language_server_statuses(cx).next().unwrap().1;
-        assert_eq!(status.name, "the-language-server");
+        assert_eq!(status.name.0, "the-language-server");
         assert_eq!(status.pending_work.len(), 1);
         assert_eq!(
             status.pending_work["the-token"].message.as_ref().unwrap(),
@@ -1072,7 +1072,7 @@ async fn test_language_server_statuses(cx_a: &mut TestAppContext, cx_b: &mut Tes
 
     project_b.read_with(cx_b, |project, cx| {
         let status = project.language_server_statuses(cx).next().unwrap().1;
-        assert_eq!(status.name, "the-language-server");
+        assert_eq!(status.name.0, "the-language-server");
     });
 
     executor.advance_clock(SERVER_PROGRESS_THROTTLE_TIMEOUT);
@@ -1089,7 +1089,7 @@ async fn test_language_server_statuses(cx_a: &mut TestAppContext, cx_b: &mut Tes
 
     project_a.read_with(cx_a, |project, cx| {
         let status = project.language_server_statuses(cx).next().unwrap().1;
-        assert_eq!(status.name, "the-language-server");
+        assert_eq!(status.name.0, "the-language-server");
         assert_eq!(status.pending_work.len(), 1);
         assert_eq!(
             status.pending_work["the-token"].message.as_ref().unwrap(),
@@ -1099,7 +1099,7 @@ async fn test_language_server_statuses(cx_a: &mut TestAppContext, cx_b: &mut Tes
 
     project_b.read_with(cx_b, |project, cx| {
         let status = project.language_server_statuses(cx).next().unwrap().1;
-        assert_eq!(status.name, "the-language-server");
+        assert_eq!(status.name.0, "the-language-server");
         assert_eq!(status.pending_work.len(), 1);
         assert_eq!(
             status.pending_work["the-token"].message.as_ref().unwrap(),

--- a/crates/collab/src/tests/editor_tests.rs
+++ b/crates/collab/src/tests/editor_tests.rs
@@ -296,19 +296,28 @@ async fn test_collaborating_with_completion(cx_a: &mut TestAppContext, cx_b: &mu
         .await;
     let active_call_a = cx_a.read(ActiveCall::global);
 
+    let capabilities = lsp::ServerCapabilities {
+        completion_provider: Some(lsp::CompletionOptions {
+            trigger_characters: Some(vec![".".to_string()]),
+            resolve_provider: Some(true),
+            ..lsp::CompletionOptions::default()
+        }),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                completion_provider: Some(lsp::CompletionOptions {
-                    trigger_characters: Some(vec![".".to_string()]),
-                    resolve_provider: Some(true),
-                    ..Default::default()
-                }),
-                ..Default::default()
-            },
-            ..Default::default()
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -566,9 +575,12 @@ async fn test_collaborating_with_code_actions(
 
     cx_b.update(editor::init);
 
-    // Set up a fake language server.
     client_a.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a
+        .language_registry()
+        .register_fake_lsp("Rust", FakeLspAdapter::default());
+    client_b.language_registry().add(rust_lang());
+    client_b
         .language_registry()
         .register_fake_lsp("Rust", FakeLspAdapter::default());
 
@@ -775,19 +787,27 @@ async fn test_collaborating_with_renames(cx_a: &mut TestAppContext, cx_b: &mut T
 
     cx_b.update(editor::init);
 
-    // Set up a fake language server.
+    let capabilities = lsp::ServerCapabilities {
+        rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
+            prepare_provider: Some(true),
+            work_done_progress_options: Default::default(),
+        })),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                rename_provider: Some(lsp::OneOf::Right(lsp::RenameOptions {
-                    prepare_provider: Some(true),
-                    work_done_progress_options: Default::default(),
-                })),
-                ..Default::default()
-            },
-            ..Default::default()
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -1422,18 +1442,27 @@ async fn test_on_input_format_from_guest_to_host(
         .await;
     let active_call_a = cx_a.read(ActiveCall::global);
 
+    let capabilities = lsp::ServerCapabilities {
+        document_on_type_formatting_provider: Some(lsp::DocumentOnTypeFormattingOptions {
+            first_trigger_character: ":".to_string(),
+            more_trigger_character: Some(vec![">".to_string()]),
+        }),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                document_on_type_formatting_provider: Some(lsp::DocumentOnTypeFormattingOptions {
-                    first_trigger_character: ":".to_string(),
-                    more_trigger_character: Some(vec![">".to_string()]),
-                }),
-                ..Default::default()
-            },
-            ..Default::default()
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -1588,16 +1617,24 @@ async fn test_mutual_editor_inlay_hint_cache_update(
         });
     });
 
+    let capabilities = lsp::ServerCapabilities {
+        inlay_hint_provider: Some(lsp::OneOf::Left(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
-    client_b.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                inlay_hint_provider: Some(lsp::OneOf::Left(true)),
-                ..Default::default()
-            },
-            ..Default::default()
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -1830,16 +1867,24 @@ async fn test_inlay_hint_refresh_is_forwarded(
         });
     });
 
+    let capabilities = lsp::ServerCapabilities {
+        inlay_hint_provider: Some(lsp::OneOf::Left(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
-    client_b.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                inlay_hint_provider: Some(lsp::OneOf::Left(true)),
-                ..Default::default()
-            },
-            ..Default::default()
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -2004,15 +2049,23 @@ async fn test_lsp_document_color(cx_a: &mut TestAppContext, cx_b: &mut TestAppCo
         });
     });
 
+    let capabilities = lsp::ServerCapabilities {
+        color_provider: Some(lsp::ColorProviderCapability::Simple(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
-    client_b.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                color_provider: Some(lsp::ColorProviderCapability::Simple(true)),
-                ..lsp::ServerCapabilities::default()
-            },
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
             ..FakeLspAdapter::default()
         },
     );
@@ -2120,10 +2173,7 @@ async fn test_lsp_document_color(cx_a: &mut TestAppContext, cx_b: &mut TestAppCo
         .downcast::<Editor>()
         .unwrap();
 
-    // TODO kb send a special event and reload after didOpen LSP registration for the buffer
-    dbg!("33");
     color_request_handle.next().await.unwrap();
-    dbg!("????????????");
     executor.run_until_parked();
 
     assert_eq!(
@@ -2267,24 +2317,32 @@ async fn test_lsp_pull_diagnostics(
     cx_a.update(editor::init);
     cx_b.update(editor::init);
 
+    let capabilities = lsp::ServerCapabilities {
+        diagnostic_provider: Some(lsp::DiagnosticServerCapabilities::Options(
+            lsp::DiagnosticOptions {
+                identifier: Some("test-pulls".to_string()),
+                inter_file_dependencies: true,
+                workspace_diagnostics: true,
+                work_done_progress_options: lsp::WorkDoneProgressOptions {
+                    work_done_progress: None,
+                },
+            },
+        )),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
-    client_b.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
-            capabilities: lsp::ServerCapabilities {
-                diagnostic_provider: Some(lsp::DiagnosticServerCapabilities::Options(
-                    lsp::DiagnosticOptions {
-                        identifier: Some("test-pulls".to_string()),
-                        inter_file_dependencies: true,
-                        workspace_diagnostics: true,
-                        work_done_progress_options: lsp::WorkDoneProgressOptions {
-                            work_done_progress: None,
-                        },
-                    },
-                )),
-                ..lsp::ServerCapabilities::default()
-            },
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
             ..FakeLspAdapter::default()
         },
     );

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4778,10 +4778,27 @@ async fn test_definition(
         .await;
     let active_call_a = cx_a.read(ActiveCall::global);
 
-    let mut fake_language_servers = client_a
-        .language_registry()
-        .register_fake_lsp("Rust", Default::default());
+    let capabilities = lsp::ServerCapabilities {
+        definition_provider: Some(OneOf::Left(true)),
+        type_definition_provider: Some(lsp::TypeDefinitionProviderCapability::Simple(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
+    let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
+        },
+    );
 
     client_a
         .fs()
@@ -4827,13 +4844,19 @@ async fn test_definition(
             )))
         },
     );
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
 
     let definitions_1 = project_b
         .update(cx_b, |p, cx| p.definitions(&buffer_b, 23, cx))
         .await
         .unwrap();
     cx_b.read(|cx| {
-        assert_eq!(definitions_1.len(), 1);
+        assert_eq!(
+            definitions_1.len(),
+            1,
+            "Unexpected definitions: {definitions_1:?}"
+        );
         assert_eq!(project_b.read(cx).worktrees(cx).count(), 2);
         let target_buffer = definitions_1[0].target.buffer.read(cx);
         assert_eq!(
@@ -4901,7 +4924,11 @@ async fn test_definition(
         .await
         .unwrap();
     cx_b.read(|cx| {
-        assert_eq!(type_definitions.len(), 1);
+        assert_eq!(
+            type_definitions.len(),
+            1,
+            "Unexpected type definitions: {type_definitions:?}"
+        );
         let target_buffer = type_definitions[0].target.buffer.read(cx);
         assert_eq!(target_buffer.text(), "type T2 = usize;");
         assert_eq!(
@@ -4925,16 +4952,26 @@ async fn test_references(
         .await;
     let active_call_a = cx_a.read(ActiveCall::global);
 
+    let capabilities = lsp::ServerCapabilities {
+        references_provider: Some(lsp::OneOf::Left(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
     let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
         "Rust",
         FakeLspAdapter {
             name: "my-fake-lsp-adapter",
-            capabilities: lsp::ServerCapabilities {
-                references_provider: Some(lsp::OneOf::Left(true)),
-                ..Default::default()
-            },
-            ..Default::default()
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            name: "my-fake-lsp-adapter",
+            capabilities: capabilities,
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -4989,6 +5026,8 @@ async fn test_references(
             }
         }
     });
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
 
     let references = project_b.update(cx_b, |p, cx| p.references(&buffer_b, 7, cx));
 
@@ -5204,10 +5243,26 @@ async fn test_document_highlights(
         )
         .await;
 
-    let mut fake_language_servers = client_a
-        .language_registry()
-        .register_fake_lsp("Rust", Default::default());
     client_a.language_registry().add(rust_lang());
+    let capabilities = lsp::ServerCapabilities {
+        document_highlight_provider: Some(lsp::OneOf::Left(true)),
+        ..lsp::ServerCapabilities::default()
+    };
+    let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
+        },
+    );
 
     let (project_a, worktree_id) = client_a.build_local_project(path!("/root-1"), cx_a).await;
     let project_id = active_call_a
@@ -5256,6 +5311,8 @@ async fn test_document_highlights(
             ]))
         },
     );
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
 
     let highlights = project_b
         .update(cx_b, |p, cx| p.document_highlights(&buffer_b, 34, cx))
@@ -5306,30 +5363,49 @@ async fn test_lsp_hover(
 
     client_a.language_registry().add(rust_lang());
     let language_server_names = ["rust-analyzer", "CrabLang-ls"];
+    let capabilities_1 = lsp::ServerCapabilities {
+        hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+        ..lsp::ServerCapabilities::default()
+    };
+    let capabilities_2 = lsp::ServerCapabilities {
+        hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     let mut language_servers = [
         client_a.language_registry().register_fake_lsp(
             "Rust",
             FakeLspAdapter {
-                name: "rust-analyzer",
-                capabilities: lsp::ServerCapabilities {
-                    hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
-                    ..lsp::ServerCapabilities::default()
-                },
+                name: language_server_names[0],
+                capabilities: capabilities_1.clone(),
                 ..FakeLspAdapter::default()
             },
         ),
         client_a.language_registry().register_fake_lsp(
             "Rust",
             FakeLspAdapter {
-                name: "CrabLang-ls",
-                capabilities: lsp::ServerCapabilities {
-                    hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
-                    ..lsp::ServerCapabilities::default()
-                },
+                name: language_server_names[1],
+                capabilities: capabilities_2.clone(),
                 ..FakeLspAdapter::default()
             },
         ),
     ];
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            name: language_server_names[0],
+            capabilities: capabilities_1,
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            name: language_server_names[1],
+            capabilities: capabilities_2,
+            ..FakeLspAdapter::default()
+        },
+    );
 
     let (project_a, worktree_id) = client_a.build_local_project(path!("/root-1"), cx_a).await;
     let project_id = active_call_a
@@ -5423,6 +5499,8 @@ async fn test_lsp_hover(
             unexpected => panic!("Unexpected server name: {unexpected}"),
         }
     }
+    cx_a.run_until_parked();
+    cx_b.run_until_parked();
 
     // Request hover information as the guest.
     let mut hovers = project_b
@@ -5605,10 +5683,26 @@ async fn test_open_buffer_while_getting_definition_pointing_to_it(
         .await;
     let active_call_a = cx_a.read(ActiveCall::global);
 
+    let capabilities = lsp::ServerCapabilities {
+        definition_provider: Some(OneOf::Left(true)),
+        ..lsp::ServerCapabilities::default()
+    };
     client_a.language_registry().add(rust_lang());
-    let mut fake_language_servers = client_a
-        .language_registry()
-        .register_fake_lsp("Rust", Default::default());
+    let mut fake_language_servers = client_a.language_registry().register_fake_lsp(
+        "Rust",
+        FakeLspAdapter {
+            capabilities: capabilities.clone(),
+            ..FakeLspAdapter::default()
+        },
+    );
+    client_b.language_registry().add(rust_lang());
+    client_b.language_registry().register_fake_lsp_adapter(
+        "Rust",
+        FakeLspAdapter {
+            capabilities,
+            ..FakeLspAdapter::default()
+        },
+    );
 
     client_a
         .fs()
@@ -5649,6 +5743,8 @@ async fn test_open_buffer_while_getting_definition_pointing_to_it(
     let definitions;
     let buffer_b2;
     if rng.r#gen() {
+        cx_a.run_until_parked();
+        cx_b.run_until_parked();
         definitions = project_b.update(cx_b, |p, cx| p.definitions(&buffer_b1, 23, cx));
         (buffer_b2, _) = project_b
             .update(cx_b, |p, cx| {
@@ -5663,11 +5759,17 @@ async fn test_open_buffer_while_getting_definition_pointing_to_it(
             })
             .await
             .unwrap();
+        cx_a.run_until_parked();
+        cx_b.run_until_parked();
         definitions = project_b.update(cx_b, |p, cx| p.definitions(&buffer_b1, 23, cx));
     }
 
     let definitions = definitions.await.unwrap();
-    assert_eq!(definitions.len(), 1);
+    assert_eq!(
+        definitions.len(),
+        1,
+        "Unexpected definitions: {definitions:?}"
+    );
     assert_eq!(definitions[0].target.buffer, buffer_b2);
 }
 

--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -4996,7 +4996,7 @@ async fn test_references(
     executor.run_until_parked();
     project_b.read_with(cx_b, |project, cx| {
         let status = project.language_server_statuses(cx).next().unwrap().1;
-        assert_eq!(status.name, "my-fake-lsp-adapter");
+        assert_eq!(status.name.0, "my-fake-lsp-adapter");
         assert_eq!(
             status.pending_work.values().next().unwrap().message,
             Some("Finding references...".into())
@@ -5054,7 +5054,7 @@ async fn test_references(
     executor.run_until_parked();
     project_b.read_with(cx_b, |project, cx| {
         let status = project.language_server_statuses(cx).next().unwrap().1;
-        assert_eq!(status.name, "my-fake-lsp-adapter");
+        assert_eq!(status.name.0, "my-fake-lsp-adapter");
         assert_eq!(
             status.pending_work.values().next().unwrap().message,
             Some("Finding references...".into())

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1885,13 +1885,8 @@ impl Editor {
                                 }
                             }
                         }
-                        project::Event::LanguageServerBufferRegistered {
-                            buffer_id,
-                            buffer_abs_path,
-                            ..
-                        } => {
+                        project::Event::LanguageServerBufferRegistered { buffer_id, .. } => {
                             if editor.buffer().read(cx).buffer(*buffer_id).is_some() {
-                                dbg!("language server buffer registered", &buffer_abs_path);
                                 editor.update_lsp_data(false, Some(*buffer_id), window, cx);
                             }
                         }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -134,7 +134,7 @@ use language::{
 use linked_editing_ranges::refresh_linked_ranges;
 use lsp::{
     CodeActionKind, CompletionItemKind, CompletionTriggerKind, InsertTextFormat, InsertTextMode,
-    LanguageServerId, LanguageServerName,
+    LanguageServerId,
 };
 use lsp_colors::LspColorData;
 use markdown::Markdown;
@@ -15844,7 +15844,7 @@ impl Editor {
                     let language_server_name = project
                         .language_server_statuses(cx)
                         .find(|(id, _)| server_id == *id)
-                        .map(|(_, status)| LanguageServerName::from(status.name.as_str()));
+                        .map(|(_, status)| status.name.clone());
                     language_server_name.map(|language_server_name| {
                         project.open_local_buffer_via_lsp(
                             lsp_location.uri.clone(),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1892,7 +1892,7 @@ impl Editor {
                         } => {
                             if editor.buffer().read(cx).buffer(*buffer_id).is_some() {
                                 dbg!("language server buffer registered", &buffer_abs_path);
-                                editor.update_lsp_data(true, Some(*buffer_id), window, cx);
+                                editor.update_lsp_data(false, Some(*buffer_id), window, cx);
                             }
                         }
                         _ => {}
@@ -2326,6 +2326,7 @@ impl Editor {
             editor.minimap =
                 editor.create_minimap(EditorSettings::get_global(cx).minimap, window, cx);
             editor.colors = Some(LspColorData::new(cx));
+            editor.update_lsp_data(false, None, window, cx);
         }
 
         if editor.mode.is_full() {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1864,7 +1864,6 @@ impl Editor {
                                 editor.tasks_update_task =
                                     Some(editor.refresh_runnables(window, cx));
                             }
-                            editor.update_lsp_data(true, None, window, cx);
                         }
                         project::Event::SnippetEdit(id, snippet_edits) => {
                             if let Some(buffer) = editor.buffer.read(cx).buffer(*id) {
@@ -1884,6 +1883,16 @@ impl Editor {
                                             .ok();
                                     }
                                 }
+                            }
+                        }
+                        project::Event::LanguageServerBufferRegistered {
+                            buffer_id,
+                            buffer_abs_path,
+                            ..
+                        } => {
+                            if editor.buffer().read(cx).buffer(*buffer_id).is_some() {
+                                dbg!("language server buffer registered", &buffer_abs_path);
+                                editor.update_lsp_data(true, Some(*buffer_id), window, cx);
                             }
                         }
                         _ => {}
@@ -2317,7 +2326,6 @@ impl Editor {
             editor.minimap =
                 editor.create_minimap(EditorSettings::get_global(cx).minimap, window, cx);
             editor.colors = Some(LspColorData::new(cx));
-            editor.update_lsp_data(false, None, window, cx);
         }
 
         if editor.mode.is_full() {

--- a/crates/editor/src/linked_editing_ranges.rs
+++ b/crates/editor/src/linked_editing_ranges.rs
@@ -95,7 +95,7 @@ pub(super) fn refresh_linked_ranges(
                     let snapshot = buffer.read(cx).snapshot();
                     let buffer_id = buffer.read(cx).remote_id();
 
-                    let linked_edits_task = project.linked_edit(buffer, *start, cx);
+                    let linked_edits_task = project.linked_edits(buffer, *start, cx);
                     let highlights = move || async move {
                         let edits = linked_edits_task.await.log_err()?;
                         // Find the range containing our current selection.

--- a/crates/extension/src/extension_manifest.rs
+++ b/crates/extension/src/extension_manifest.rs
@@ -163,7 +163,7 @@ pub struct LanguageServerManifestEntry {
     #[serde(default)]
     languages: Vec<LanguageName>,
     #[serde(default)]
-    pub language_ids: HashMap<String, String>,
+    pub language_ids: HashMap<LanguageName, String>,
     #[serde(default)]
     pub code_action_kinds: Option<Vec<lsp::CodeActionKind>>,
 }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -161,7 +161,7 @@ pub struct CachedLspAdapter {
     pub name: LanguageServerName,
     pub disk_based_diagnostic_sources: Vec<String>,
     pub disk_based_diagnostics_progress_token: Option<String>,
-    language_ids: HashMap<String, String>,
+    language_ids: HashMap<LanguageName, String>,
     pub adapter: Arc<dyn LspAdapter>,
     pub reinstall_attempt_count: AtomicU64,
     cached_binary: futures::lock::Mutex<Option<LanguageServerBinary>>,
@@ -277,10 +277,11 @@ impl CachedLspAdapter {
 
     pub fn language_id(&self, language_name: &LanguageName) -> String {
         self.language_ids
-            .get(language_name.as_ref())
+            .get(language_name)
             .cloned()
             .unwrap_or_else(|| language_name.lsp_id())
     }
+
     pub fn manifest_name(&self) -> Option<ManifestName> {
         self.manifest_name
             .get_or_init(|| self.adapter.manifest_name())
@@ -573,8 +574,8 @@ pub trait LspAdapter: 'static + Send + Sync {
         None
     }
 
-    fn language_ids(&self) -> HashMap<String, String> {
-        Default::default()
+    fn language_ids(&self) -> HashMap<LanguageName, String> {
+        HashMap::default()
     }
 
     /// Support custom initialize params.

--- a/crates/language/src/language_registry.rs
+++ b/crates/language/src/language_registry.rs
@@ -411,30 +411,6 @@ impl LanguageRegistry {
         cached
     }
 
-    pub fn get_or_register_lsp_adapter(
-        &self,
-        language_name: LanguageName,
-        server_name: LanguageServerName,
-        build_adapter: impl FnOnce() -> Arc<dyn LspAdapter> + 'static,
-    ) -> Arc<CachedLspAdapter> {
-        let registered = self
-            .state
-            .write()
-            .lsp_adapters
-            .entry(language_name.clone())
-            .or_default()
-            .iter()
-            .find(|cached_adapter| cached_adapter.name == server_name)
-            .cloned();
-
-        if let Some(found) = registered {
-            found
-        } else {
-            let adapter = build_adapter();
-            self.register_lsp_adapter(language_name, adapter)
-        }
-    }
-
     /// Register a fake language server and adapter
     /// The returned channel receives a new instance of the language server every time it is started
     #[cfg(any(feature = "test-support", test))]

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -242,7 +242,7 @@ impl LspAdapter for ExtensionLspAdapter {
         ]))
     }
 
-    fn language_ids(&self) -> HashMap<String, String> {
+    fn language_ids(&self) -> HashMap<LanguageName, String> {
         // TODO: The language IDs can be provided via the language server options
         // in `extension.toml now but we're leaving these existing usages in place temporarily
         // to avoid any compatibility issues between Zed and the extension versions.
@@ -250,7 +250,7 @@ impl LspAdapter for ExtensionLspAdapter {
         // We can remove once the following extension versions no longer see any use:
         // - php@0.0.1
         if self.extension.manifest().id.as_ref() == "php" {
-            return HashMap::from_iter([("PHP".into(), "php".into())]);
+            return HashMap::from_iter([(LanguageName::new("PHP"), "php".into())]);
         }
 
         self.extension

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -8,8 +8,8 @@ use futures::StreamExt;
 use gpui::{App, AsyncApp, Task};
 use http_client::github::{GitHubLspBinaryVersion, latest_github_release};
 use language::{
-    ContextProvider, LanguageRegistry, LanguageToolchainStore, LocalFile as _, LspAdapter,
-    LspAdapterDelegate,
+    ContextProvider, LanguageName, LanguageRegistry, LanguageToolchainStore, LocalFile as _,
+    LspAdapter, LspAdapterDelegate,
 };
 use lsp::{LanguageServerBinary, LanguageServerName};
 use node_runtime::NodeRuntime;
@@ -408,10 +408,10 @@ impl LspAdapter for JsonLspAdapter {
         Ok(config)
     }
 
-    fn language_ids(&self) -> HashMap<String, String> {
+    fn language_ids(&self) -> HashMap<LanguageName, String> {
         [
-            ("JSON".into(), "json".into()),
-            ("JSONC".into(), "jsonc".into()),
+            (LanguageName::new("JSON"), "json".into()),
+            (LanguageName::new("JSONC"), "jsonc".into()),
         ]
         .into_iter()
         .collect()

--- a/crates/languages/src/tailwind.rs
+++ b/crates/languages/src/tailwind.rs
@@ -3,7 +3,7 @@ use async_trait::async_trait;
 use collections::HashMap;
 use futures::StreamExt;
 use gpui::AsyncApp;
-use language::{LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
+use language::{LanguageName, LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
 use lsp::{LanguageServerBinary, LanguageServerName};
 use node_runtime::NodeRuntime;
 use project::{Fs, lsp_store::language_server_settings};
@@ -168,20 +168,20 @@ impl LspAdapter for TailwindLspAdapter {
         }))
     }
 
-    fn language_ids(&self) -> HashMap<String, String> {
+    fn language_ids(&self) -> HashMap<LanguageName, String> {
         HashMap::from_iter([
-            ("Astro".to_string(), "astro".to_string()),
-            ("HTML".to_string(), "html".to_string()),
-            ("CSS".to_string(), "css".to_string()),
-            ("JavaScript".to_string(), "javascript".to_string()),
-            ("TSX".to_string(), "typescriptreact".to_string()),
-            ("Svelte".to_string(), "svelte".to_string()),
-            ("Elixir".to_string(), "phoenix-heex".to_string()),
-            ("HEEX".to_string(), "phoenix-heex".to_string()),
-            ("ERB".to_string(), "erb".to_string()),
-            ("HTML/ERB".to_string(), "erb".to_string()),
-            ("PHP".to_string(), "php".to_string()),
-            ("Vue.js".to_string(), "vue".to_string()),
+            (LanguageName::new("Astro"), "astro".to_string()),
+            (LanguageName::new("HTML"), "html".to_string()),
+            (LanguageName::new("CSS"), "css".to_string()),
+            (LanguageName::new("JavaScript"), "javascript".to_string()),
+            (LanguageName::new("TSX"), "typescriptreact".to_string()),
+            (LanguageName::new("Svelte"), "svelte".to_string()),
+            (LanguageName::new("Elixir"), "phoenix-heex".to_string()),
+            (LanguageName::new("HEEX"), "phoenix-heex".to_string()),
+            (LanguageName::new("ERB"), "erb".to_string()),
+            (LanguageName::new("HTML/ERB"), "erb".to_string()),
+            (LanguageName::new("PHP"), "php".to_string()),
+            (LanguageName::new("Vue.js"), "vue".to_string()),
         ])
     }
 }

--- a/crates/languages/src/typescript.rs
+++ b/crates/languages/src/typescript.rs
@@ -8,7 +8,8 @@ use futures::future::join_all;
 use gpui::{App, AppContext, AsyncApp, Task};
 use http_client::github::{AssetKind, GitHubLspBinaryVersion, build_asset_url};
 use language::{
-    ContextLocation, ContextProvider, File, LanguageToolchainStore, LspAdapter, LspAdapterDelegate,
+    ContextLocation, ContextProvider, File, LanguageName, LanguageToolchainStore, LspAdapter,
+    LspAdapterDelegate,
 };
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
 use node_runtime::NodeRuntime;
@@ -741,11 +742,11 @@ impl LspAdapter for TypeScriptLspAdapter {
         }))
     }
 
-    fn language_ids(&self) -> HashMap<String, String> {
+    fn language_ids(&self) -> HashMap<LanguageName, String> {
         HashMap::from_iter([
-            ("TypeScript".into(), "typescript".into()),
-            ("JavaScript".into(), "javascript".into()),
-            ("TSX".into(), "typescriptreact".into()),
+            (LanguageName::new("TypeScript"), "typescript".into()),
+            (LanguageName::new("JavaScript"), "javascript".into()),
+            (LanguageName::new("TSX"), "typescriptreact".into()),
         ])
     }
 }

--- a/crates/languages/src/vtsls.rs
+++ b/crates/languages/src/vtsls.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use collections::HashMap;
 use gpui::AsyncApp;
-use language::{LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
+use language::{LanguageName, LanguageToolchainStore, LspAdapter, LspAdapterDelegate};
 use lsp::{CodeActionKind, LanguageServerBinary, LanguageServerName};
 use node_runtime::NodeRuntime;
 use project::{Fs, lsp_store::language_server_settings};
@@ -273,11 +273,11 @@ impl LspAdapter for VtslsLspAdapter {
         Ok(default_workspace_configuration)
     }
 
-    fn language_ids(&self) -> HashMap<String, String> {
+    fn language_ids(&self) -> HashMap<LanguageName, String> {
         HashMap::from_iter([
-            ("TypeScript".into(), "typescript".into()),
-            ("JavaScript".into(), "javascript".into()),
-            ("TSX".into(), "typescriptreact".into()),
+            (LanguageName::new("TypeScript"), "typescript".into()),
+            (LanguageName::new("JavaScript"), "javascript".into()),
+            (LanguageName::new("TSX"), "typescriptreact".into()),
         ])
     }
 }

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -3580,6 +3580,18 @@ impl LspCommand for GetCodeLens {
     }
 }
 
+impl LinkedEditingRange {
+    pub fn check_server_capabilities(capabilities: ServerCapabilities) -> bool {
+        let Some(linked_editing_options) = capabilities.linked_editing_range_provider else {
+            return false;
+        };
+        if let LinkedEditingRangeServerCapabilities::Simple(false) = linked_editing_options {
+            return false;
+        }
+        true
+    }
+}
+
 #[async_trait(?Send)]
 impl LspCommand for LinkedEditingRange {
     type Response = Vec<Range<Anchor>>;
@@ -3591,16 +3603,7 @@ impl LspCommand for LinkedEditingRange {
     }
 
     fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
-        let Some(linked_editing_options) = &capabilities
-            .server_capabilities
-            .linked_editing_range_provider
-        else {
-            return false;
-        };
-        if let LinkedEditingRangeServerCapabilities::Simple(false) = linked_editing_options {
-            return false;
-        }
-        true
+        Self::check_server_capabilities(capabilities.server_capabilities)
     }
 
     fn to_lsp(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -4218,17 +4218,15 @@ impl LspCommand for GetDocumentColor {
     }
 
     fn check_capabilities(&self, server_capabilities: AdapterServerCapabilities) -> bool {
-        dbg!(
-            server_capabilities
-                .server_capabilities
-                .color_provider
-                .as_ref()
-        )
-        .is_some_and(|capability| match capability {
-            lsp::ColorProviderCapability::Simple(supported) => *supported,
-            lsp::ColorProviderCapability::ColorProvider(..) => true,
-            lsp::ColorProviderCapability::Options(..) => true,
-        })
+        server_capabilities
+            .server_capabilities
+            .color_provider
+            .as_ref()
+            .is_some_and(|capability| match capability {
+                lsp::ColorProviderCapability::Simple(supported) => *supported,
+                lsp::ColorProviderCapability::ColorProvider(..) => true,
+                lsp::ColorProviderCapability::Options(..) => true,
+            })
     }
 
     fn to_lsp(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -2154,6 +2154,16 @@ impl LspCommand for GetHover {
     }
 }
 
+impl GetCompletions {
+    pub fn can_resolve_completions(capabilities: &lsp::ServerCapabilities) -> bool {
+        capabilities
+            .completion_provider
+            .as_ref()
+            .and_then(|options| options.resolve_provider)
+            .unwrap_or(false)
+    }
+}
+
 #[async_trait(?Send)]
 impl LspCommand for GetCompletions {
     type Response = CoreCompletionResponse;
@@ -2762,6 +2772,23 @@ impl GetCodeActions {
     }
 }
 
+impl OnTypeFormatting {
+    pub fn supports_on_type_formatting(trigger: &str, capabilities: &ServerCapabilities) -> bool {
+        let Some(on_type_formatting_options) = &capabilities.document_on_type_formatting_provider
+        else {
+            return false;
+        };
+        on_type_formatting_options
+            .first_trigger_character
+            .contains(trigger)
+            || on_type_formatting_options
+                .more_trigger_character
+                .iter()
+                .flatten()
+                .any(|chars| chars.contains(trigger))
+    }
+}
+
 #[async_trait(?Send)]
 impl LspCommand for OnTypeFormatting {
     type Response = Option<Transaction>;
@@ -2773,20 +2800,7 @@ impl LspCommand for OnTypeFormatting {
     }
 
     fn check_capabilities(&self, capabilities: AdapterServerCapabilities) -> bool {
-        let Some(on_type_formatting_options) = &capabilities
-            .server_capabilities
-            .document_on_type_formatting_provider
-        else {
-            return false;
-        };
-        on_type_formatting_options
-            .first_trigger_character
-            .contains(&self.trigger)
-            || on_type_formatting_options
-                .more_trigger_character
-                .iter()
-                .flatten()
-                .any(|chars| chars.contains(&self.trigger))
+        Self::supports_on_type_formatting(&self.trigger, &capabilities.server_capabilities)
     }
 
     fn to_lsp(

--- a/crates/project/src/lsp_command.rs
+++ b/crates/project/src/lsp_command.rs
@@ -4218,14 +4218,17 @@ impl LspCommand for GetDocumentColor {
     }
 
     fn check_capabilities(&self, server_capabilities: AdapterServerCapabilities) -> bool {
-        server_capabilities
-            .server_capabilities
-            .color_provider
-            .is_some_and(|capability| match capability {
-                lsp::ColorProviderCapability::Simple(supported) => supported,
-                lsp::ColorProviderCapability::ColorProvider(..) => true,
-                lsp::ColorProviderCapability::Options(..) => true,
-            })
+        dbg!(
+            server_capabilities
+                .server_capabilities
+                .color_provider
+                .as_ref()
+        )
+        .is_some_and(|capability| match capability {
+            lsp::ColorProviderCapability::Simple(supported) => *supported,
+            lsp::ColorProviderCapability::ColorProvider(..) => true,
+            lsp::ColorProviderCapability::Options(..) => true,
+        })
     }
 
     fn to_lsp(

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -8900,13 +8900,6 @@ impl LspStore {
                     progress_tokens: Default::default(),
                 },
             );
-            // TODO kb add an lsp adapter, if missing
-            dbg!(lsp_store.languages.load_available_lsp_adapter(&server_name));
-            dbg!((
-                "!!!!!!!!!!!!!!",
-                lsp_store.as_local().is_some(),
-                lsp_store.languages.adapter_for_name(&server_name),
-            ));
             cx.emit(LspStoreEvent::LanguageServerAdded(
                 server_id,
                 server_name,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3635,7 +3635,7 @@ pub enum LspStoreEvent {
 
 #[derive(Clone, Debug, Serialize)]
 pub struct LanguageServerStatus {
-    pub name: String,
+    pub name: LanguageServerName,
     pub pending_work: BTreeMap<String, LanguageServerProgress>,
     pub has_pending_diagnostic_updates: bool,
     progress_tokens: HashSet<String>,
@@ -7586,7 +7586,7 @@ impl LspStore {
                         project_id,
                         server: Some(proto::LanguageServer {
                             id: server_id.0 as u64,
-                            name: status.name.clone(),
+                            name: status.name.to_string(),
                             worktree_id: None,
                         }),
                         capabilities: serde_json::to_string(&server.capabilities())
@@ -7620,7 +7620,7 @@ impl LspStore {
                 (
                     LanguageServerId(server.id as usize),
                     LanguageServerStatus {
-                        name: server.name,
+                        name: LanguageServerName::from_proto(server.name),
                         pending_work: Default::default(),
                         has_pending_diagnostic_updates: false,
                         progress_tokens: Default::default(),
@@ -8782,7 +8782,7 @@ impl LspStore {
             this.language_server_statuses.insert(
                 server_id,
                 LanguageServerStatus {
-                    name: server.name.clone(),
+                    name: LanguageServerName::from_proto(server.name.clone()),
                     pending_work: Default::default(),
                     has_pending_diagnostic_updates: false,
                     progress_tokens: Default::default(),
@@ -10299,7 +10299,7 @@ impl LspStore {
         let name = self
             .language_server_statuses
             .remove(&server_id)
-            .map(|status| LanguageServerName::from(status.name.as_str()))
+            .map(|status| status.name.clone())
             .or_else(|| {
                 if let Some(LanguageServerState::Running { adapter, .. }) = server_state.as_ref() {
                     Some(adapter.name())
@@ -10792,7 +10792,7 @@ impl LspStore {
         self.language_server_statuses.insert(
             server_id,
             LanguageServerStatus {
-                name: language_server.name().to_string(),
+                name: language_server.name(),
                 pending_work: Default::default(),
                 has_pending_diagnostic_updates: false,
                 progress_tokens: Default::default(),

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2518,11 +2518,13 @@ impl LocalLspStore {
                 snapshot: initial_snapshot.clone(),
             };
 
+            let mut registered = false;
             self.buffer_snapshots
                 .entry(buffer_id)
                 .or_default()
                 .entry(server.server_id())
                 .or_insert_with(|| {
+                    registered = true;
                     server.register_buffer(
                         uri.clone(),
                         adapter.language_id(&language.name()),
@@ -2537,16 +2539,18 @@ impl LocalLspStore {
                 .entry(buffer_id)
                 .or_default()
                 .insert(server.server_id());
-            cx.emit(LspStoreEvent::LanguageServerUpdate {
-                language_server_id: server.server_id(),
-                name: None,
-                message: proto::update_language_server::Variant::RegisteredForBuffer(
-                    proto::RegisteredForBuffer {
-                        buffer_abs_path: abs_path.to_string_lossy().to_string(),
-                        buffer_id: buffer_id.to_proto(),
-                    },
-                ),
-            });
+            if registered {
+                cx.emit(LspStoreEvent::LanguageServerUpdate {
+                    language_server_id: server.server_id(),
+                    name: None,
+                    message: proto::update_language_server::Variant::RegisteredForBuffer(
+                        proto::RegisteredForBuffer {
+                            buffer_abs_path: abs_path.to_string_lossy().to_string(),
+                            buffer_id: buffer_id.to_proto(),
+                        },
+                    ),
+                });
+            }
         }
     }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2915,6 +2915,18 @@ impl Project {
                         },
                     )
                     .ok();
+                } else {
+                    if let proto::update_language_server::Variant::MetadataUpdated(
+                        server_metadata_updated,
+                    ) = message
+                    {
+                        if let Some(capabilities) = server_metadata_updated.capabilities {
+                            // TODO kb this has to be stored inside collab's DB and re-shared on join!
+                            // Do the same as `proto::StartLanguageServer` path does to access the data, then update it
+                            // (see `lsp_store::handle_start_language_server`)
+                            dbg!(capabilities);
+                        }
+                    }
                 }
             }
             LspStoreEvent::Notification(message) => cx.emit(Event::Toast {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -2920,11 +2920,16 @@ impl Project {
                         server_metadata_updated,
                     ) = message
                     {
-                        if let Some(capabilities) = server_metadata_updated.capabilities {
-                            // TODO kb this has to be stored inside collab's DB and re-shared on join!
-                            // Do the same as `proto::StartLanguageServer` path does to access the data, then update it
-                            // (see `lsp_store::handle_start_language_server`)
-                            dbg!(capabilities);
+                        if let Some(capabilities) = server_metadata_updated
+                            .capabilities
+                            .as_ref()
+                            .and_then(|capabilities| serde_json::from_str(capabilities).ok())
+                        {
+                            self.lsp_store.update(cx, |lsp_store, _| {
+                                lsp_store
+                                    .lsp_server_capabilities
+                                    .insert(*language_server_id, capabilities);
+                            });
                         }
                     }
                 }

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -3465,20 +3465,6 @@ impl Project {
         })
     }
 
-    fn document_highlights_impl(
-        &mut self,
-        buffer: &Entity<Buffer>,
-        position: PointUtf16,
-        cx: &mut Context<Self>,
-    ) -> Task<Result<Vec<DocumentHighlight>>> {
-        self.request_lsp(
-            buffer.clone(),
-            LanguageServerToQuery::FirstCapable,
-            GetDocumentHighlights { position },
-            cx,
-        )
-    }
-
     pub fn document_highlights<T: ToPointUtf16>(
         &mut self,
         buffer: &Entity<Buffer>,
@@ -3486,7 +3472,12 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<DocumentHighlight>>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.document_highlights_impl(buffer, position, cx)
+        self.request_lsp(
+            buffer.clone(),
+            LanguageServerToQuery::FirstCapable,
+            GetDocumentHighlights { position },
+            cx,
+        )
     }
 
     pub fn document_symbols(
@@ -3587,14 +3578,14 @@ impl Project {
             .update(cx, |lsp_store, cx| lsp_store.hover(buffer, position, cx))
     }
 
-    pub fn linked_edit(
+    pub fn linked_edits(
         &self,
         buffer: &Entity<Buffer>,
         position: Anchor,
         cx: &mut Context<Self>,
     ) -> Task<Result<Vec<Range<Anchor>>>> {
         self.lsp_store.update(cx, |lsp_store, cx| {
-            lsp_store.linked_edit(buffer, position, cx)
+            lsp_store.linked_edits(buffer, position, cx)
         })
     }
 
@@ -3686,19 +3677,6 @@ impl Project {
         })
     }
 
-    fn prepare_rename_impl(
-        &mut self,
-        buffer: Entity<Buffer>,
-        position: PointUtf16,
-        cx: &mut Context<Self>,
-    ) -> Task<Result<PrepareRenameResponse>> {
-        self.request_lsp(
-            buffer,
-            LanguageServerToQuery::FirstCapable,
-            PrepareRename { position },
-            cx,
-        )
-    }
     pub fn prepare_rename<T: ToPointUtf16>(
         &mut self,
         buffer: Entity<Buffer>,
@@ -3706,7 +3684,12 @@ impl Project {
         cx: &mut Context<Self>,
     ) -> Task<Result<PrepareRenameResponse>> {
         let position = position.to_point_utf16(buffer.read(cx));
-        self.prepare_rename_impl(buffer, position, cx)
+        self.request_lsp(
+            buffer,
+            LanguageServerToQuery::FirstCapable,
+            PrepareRename { position },
+            cx,
+        )
     }
 
     pub fn perform_rename<T: ToPointUtf16>(

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1100,7 +1100,7 @@ async fn test_reporting_fs_changes_to_language_servers(cx: &mut gpui::TestAppCon
     let fake_server = fake_servers.next().await.unwrap();
     let (server_id, server_name) = lsp_store.read_with(cx, |lsp_store, _| {
         let (id, status) = lsp_store.language_server_statuses().next().unwrap();
-        (id, LanguageServerName::from(status.name.as_str()))
+        (id, status.name.clone())
     });
 
     // Simulate jumping to a definition in a dependency outside of the worktree.

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -1698,7 +1698,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
             name: "the-language-server",
             disk_based_diagnostics_sources: vec!["disk".into()],
             disk_based_diagnostics_progress_token: Some(progress_token.into()),
-            ..Default::default()
+            ..FakeLspAdapter::default()
         },
     );
 
@@ -1710,6 +1710,7 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
         })
         .await
         .unwrap();
+    let buffer_id = buffer.read_with(cx, |buffer, _| buffer.remote_id());
     // Simulate diagnostics starting to update.
     let fake_server = fake_servers.next().await.unwrap();
     fake_server.start_progress(progress_token).await;
@@ -1736,6 +1737,14 @@ async fn test_restarting_server_with_diagnostics_running(cx: &mut gpui::TestAppC
     );
     assert_eq!(events.next().await.unwrap(), Event::RefreshInlayHints);
     fake_server.start_progress(progress_token).await;
+    assert_eq!(
+        events.next().await.unwrap(),
+        Event::LanguageServerBufferRegistered {
+            server_id: LanguageServerId(1),
+            buffer_id,
+            buffer_abs_path: PathBuf::from(path!("/dir/a.rs")),
+        }
+    );
     assert_eq!(
         events.next().await.unwrap(),
         Event::DiskBasedDiagnosticsStarted {

--- a/crates/proto/proto/call.proto
+++ b/crates/proto/proto/call.proto
@@ -70,8 +70,8 @@ message RejoinedProject {
     uint64 id = 1;
     repeated WorktreeMetadata worktrees = 2;
     repeated Collaborator collaborators = 3;
-    // TODO kb need to send the capabilities too
     repeated LanguageServer language_servers = 4;
+    repeated string language_server_capabilities = 5;
 }
 
 message LeaveRoom {}
@@ -199,8 +199,8 @@ message JoinProjectResponse {
     uint32 replica_id = 1;
     repeated WorktreeMetadata worktrees = 2;
     repeated Collaborator collaborators = 3;
-    // TODO kb need to send the capabilities too
     repeated LanguageServer language_servers = 4;
+    repeated string language_server_capabilities = 8;
     ChannelRole role = 6;
     reserved 7;
 }

--- a/crates/proto/proto/call.proto
+++ b/crates/proto/proto/call.proto
@@ -70,6 +70,7 @@ message RejoinedProject {
     uint64 id = 1;
     repeated WorktreeMetadata worktrees = 2;
     repeated Collaborator collaborators = 3;
+    // TODO kb need to send the capabilities too
     repeated LanguageServer language_servers = 4;
 }
 
@@ -198,6 +199,7 @@ message JoinProjectResponse {
     uint32 replica_id = 1;
     repeated WorktreeMetadata worktrees = 2;
     repeated Collaborator collaborators = 3;
+    // TODO kb need to send the capabilities too
     repeated LanguageServer language_servers = 4;
     ChannelRole role = 6;
     reserved 7;

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -518,6 +518,7 @@ message LanguageServer {
 message StartLanguageServer {
     uint64 project_id = 1;
     LanguageServer server = 2;
+    string capabilities = 3;
 }
 
 message UpdateDiagnosticSummary {
@@ -545,6 +546,7 @@ message UpdateLanguageServer {
         LspDiskBasedDiagnosticsUpdated disk_based_diagnostics_updated = 7;
         StatusUpdate status_update = 9;
         RegisteredForBuffer registered_for_buffer = 10;
+        ServerMetadataUpdated metadata_updated = 11;
     }
 }
 
@@ -597,6 +599,10 @@ enum ServerBinaryStatus {
 
 message RegisteredForBuffer {
     string buffer_abs_path = 1;
+}
+
+message ServerMetadataUpdated {
+    optional string capabilities = 1;
 }
 
 message LanguageServerLog {

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -599,6 +599,7 @@ enum ServerBinaryStatus {
 
 message RegisteredForBuffer {
     string buffer_abs_path = 1;
+    uint64 buffer_id = 2;
 }
 
 message ServerMetadataUpdated {


### PR DESCRIPTION
Before, each time any LSP feature was used on client remote, it always produced a `proto::` request that always had been sent to the host, from where returned as an empty response.

Instead, propagate more language server-related data to the client, `lsp::ServerCapability`, so Zed client can omit certain requests if those are not supported.

On top of that, rework the approach Zed uses to query for the data refreshes: before, editors tried to fetch the data when the server start was reported (locally and remotely).
Now, a later event is selected: on each `textDocument/didOpen` for the buffer contained in this editor, we will query for new LSP data, reusing the cache if needed.

Before, servers could reject unregistered files' LSP queries, or process them slowly when starting up.
Now, such refreshes are happening later and should be cached.

This requires a collab DB change, to restore server data on rejoin.
Besides this, collab tests now need to set a fake adapter (not the server) into `cx_b`: in regular life, Zed sets the adapter based on the extensions initialisation, but here it's mocked.

Release Notes:

- Fixed excessive LSP requests sent during remote sessions
