### PR TITLE
emmet: Enable in Vue.js files

### DIFF
--- a/extensions/emmet/extension.toml
+++ b/extensions/emmet/extension.toml
@@ -1,7 +1,7 @@
 id = "emmet"
 name = "Emmet"
 description = "Emmet support"
-version = "0.0.5"
+version = "0.0.4"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"

--- a/extensions/emmet/extension.toml
+++ b/extensions/emmet/extension.toml
@@ -1,7 +1,7 @@
 id = "emmet"
 name = "Emmet"
 description = "Emmet support"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"
@@ -9,7 +9,7 @@ repository = "https://github.com/zed-industries/zed"
 [language_servers.emmet-language-server]
 name = "Emmet Language Server"
 language = "HTML"
-languages = ["HTML", "PHP", "ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "HEEX", "Elixir"]
+languages = ["HTML", "PHP", "ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "HEEX", "Elixir", "Vue.js"]
 
 [language_servers.emmet-language-server.language_ids]
 "HTML" = "html"
@@ -21,3 +21,4 @@ languages = ["HTML", "PHP", "ERB", "HTML/ERB", "JavaScript", "TSX", "CSS", "HEEX
 "CSS" = "css"
 "HEEX" = "heex"
 "Elixir" = "heex"
+"Vue.js" = "vue"


### PR DESCRIPTION
Resolves part of #34337

Actually I need also to add:

```
"languages": {
    "Vue.js": {
      "language_servers": [
        "vue-language-server",
        "emmet-language-server",
        "..."
      ]
    }
  },
```

not sure how to resolve fully, happy to continue only little guidance needed.

Release Notes:

- allow emmet in Vue.js files
