### PR TITLE
helix: Improve "x" behavior

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -435,7 +435,7 @@
       "g b": "vim::WindowBottom",
 
       "shift-r": "editor::Paste",
-      "x": "editor::SelectLine",
+      "x": "vim::HelixSelectLine",
       "shift-x": "editor::SelectLine",
       "%": "editor::SelectAll",
       // Window mode

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -34,11 +34,11 @@ actions!(
 
 pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::helix_normal_after);
+    Vim::action(editor, cx, Vim::helix_select_lines);
     Vim::action(editor, cx, Vim::helix_insert);
     Vim::action(editor, cx, Vim::helix_append);
     Vim::action(editor, cx, Vim::helix_yank);
     Vim::action(editor, cx, Vim::helix_goto_last_modification);
-    Vim::action(editor, cx, Vim::helix_select_lines);
 }
 
 impl Vim {


### PR DESCRIPTION
Closes #32020 

Release Notes:
 - Helix: Improve `x` behaviour. Will respect modifiers (`5 x`). Pressing `x` on a empty line, will select current+next line, because helix considers current line to be already selected without the need of pressing `x`.
