### PR TITLE
debugger: Ensure that Python's adapter work dir exists

### DIFF
--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -101,6 +101,9 @@ impl PythonDebugAdapter {
             .await
             .context("Could not find Python installation for DebugPy")?;
         let work_dir = debug_adapters_dir().join(Self::ADAPTER_NAME);
+        if !work_dir.exists() {
+            std::fs::create_dir_all(&work_dir)?;
+        }
         let mut path = work_dir.clone();
         path.push("debugpy-venv");
         if !path.exists() {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -1125,6 +1125,7 @@ fn init_paths() -> HashMap<io::ErrorKind, Vec<&'static Path>> {
         paths::config_dir(),
         paths::extensions_dir(),
         paths::languages_dir(),
+        paths::debug_adapters_dir(),
         paths::database_dir(),
         paths::logs_dir(),
         paths::temp_dir(),


### PR DESCRIPTION
Related to #35388
Closes #35541

cc @Sansui233 who triaged this in https://github.com/zed-industries/zed/issues/35388#issuecomment-3146977431
Release Notes:

- debugger: Fixed an issue where a Python debug adapter could not be installed when debugging Python projects for the first time.
