### PR TITLE
ruff: Bump to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20585,7 +20585,7 @@ dependencies = [
 
 [[package]]
 name = "zed_ruff"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/ruff/Cargo.toml
+++ b/extensions/ruff/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_ruff"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/ruff/extension.toml
+++ b/extensions/ruff/extension.toml
@@ -1,7 +1,7 @@
 id = "ruff"
 name = "Ruff"
 description = "Support for Ruff, the Python linter and formatter"
-version = "0.1.0"
+version = "0.1.1"
 schema_version = 1
 authors = []
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
We want Ruff to be built with newer Rust version (as it was built pre-1.84 where we've fixed a bug in std).

Closes #35627

Release Notes:

- N/A
