### PR TITLE
ollama: Add support for gpt-oss

### DIFF
--- a/crates/ollama/src/ollama.rs
+++ b/crates/ollama/src/ollama.rs
@@ -58,7 +58,7 @@ fn get_max_tokens(name: &str) -> u64 {
         "magistral" => 40000,
         "llama3.1" | "llama3.2" | "llama3.3" | "phi3" | "phi3.5" | "phi4" | "command-r"
         | "qwen3" | "gemma3" | "deepseek-coder-v2" | "deepseek-v3" | "deepseek-r1" | "yi-coder"
-        | "devstral" => 128000,
+        | "devstral" | "gpt-oss" => 128000,
         _ => DEFAULT_TOKENS,
     }
     .clamp(1, MAXIMUM_TOKENS)


### PR DESCRIPTION
There is a know bug when calling tool discussion: https://discord.com/channels/1128867683291627614/1402385744038858853
I have raised the issue with ollama team and they are currently fixing it.

Release Notes:

- ollama: Add support for gpt-oss
