### PR TITLE
ci: Double Buildjet ARM runner size (24GB to 48GB ram)

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -24,7 +24,6 @@ self-hosted-runner:
     - buildjet-8vcpu-ubuntu-2204-arm
     - buildjet-16vcpu-ubuntu-2204-arm
     - buildjet-32vcpu-ubuntu-2204-arm
-    - buildjet-64vcpu-ubuntu-2204-arm
     # Self Hosted Runners
     - self-mini-macos
     - self-32vcpu-windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,7 +650,7 @@ jobs:
     timeout-minutes: 60
     name: Linux arm64 release bundle
     runs-on:
-      - buildjet-16vcpu-ubuntu-2204-arm
+      - buildjet-32vcpu-ubuntu-2204-arm
     if: |
       startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling')

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -168,7 +168,7 @@ jobs:
     name: Create a Linux *.tar.gz bundle for ARM
     if: github.repository_owner == 'zed-industries'
     runs-on:
-      - buildjet-16vcpu-ubuntu-2204-arm
+      - buildjet-32vcpu-ubuntu-2204-arm
     needs: tests
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Release Notes:

- N/A
