### PR TITLE
go: Add support for running sub-tests in table tests

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -487,6 +487,8 @@ const GO_MODULE_ROOT_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("GO_MODULE_ROOT"));
 const GO_SUBTEST_NAME_TASK_VARIABLE: VariableName =
     VariableName::Custom(Cow::Borrowed("GO_SUBTEST_NAME"));
+const GO_TABLE_TEST_CASE_NAME_TASK_VARIABLE: VariableName =
+    VariableName::Custom(Cow::Borrowed("GO_TABLE_TEST_CASE_NAME"));
 
 impl ContextProvider for GoContextProvider {
     fn build_context(
@@ -545,10 +547,19 @@ impl ContextProvider for GoContextProvider {
         let go_subtest_variable = extract_subtest_name(_subtest_name.unwrap_or(""))
             .map(|subtest_name| (GO_SUBTEST_NAME_TASK_VARIABLE.clone(), subtest_name));
 
+        let table_test_case_name = variables.get(&VariableName::Custom(Cow::Borrowed(
+            "_table_test_case_name",
+        )));
+
+        let go_table_test_case_variable = table_test_case_name
+            .and_then(extract_subtest_name)
+            .map(|case_name| (GO_TABLE_TEST_CASE_NAME_TASK_VARIABLE.clone(), case_name));
+
         Task::ready(Ok(TaskVariables::from_iter(
             [
                 go_package_variable,
                 go_subtest_variable,
+                go_table_test_case_variable,
                 go_module_root_variable,
             ]
             .into_iter()
@@ -570,6 +581,28 @@ impl ContextProvider for GoContextProvider {
         let module_cwd = Some(GO_MODULE_ROOT_TASK_VARIABLE.template_value());
 
         Task::ready(Some(TaskTemplates(vec![
+            TaskTemplate {
+                label: format!(
+                    "go test {} -v -run {}/{}",
+                    GO_PACKAGE_TASK_VARIABLE.template_value(),
+                    VariableName::Symbol.template_value(),
+                    GO_TABLE_TEST_CASE_NAME_TASK_VARIABLE.template_value(),
+                ),
+                command: "go".into(),
+                args: vec![
+                    "test".into(),
+                    "-v".into(),
+                    "-run".into(),
+                    format!(
+                        "\\^{}\\$/\\^{}\\$",
+                        VariableName::Symbol.template_value(),
+                        GO_TABLE_TEST_CASE_NAME_TASK_VARIABLE.template_value(),
+                    ),
+                ],
+                cwd: package_cwd.clone(),
+                tags: vec!["go-table-test-case".to_owned()],
+                ..TaskTemplate::default()
+            },
             TaskTemplate {
                 label: format!(
                     "go test {} -run {}",
@@ -842,10 +875,21 @@ mod tests {
                 .collect()
         });
 
+        let tag_strings: Vec<String> = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .map(|tag| tag.0.to_string())
+            .collect();
+
         assert!(
-            runnables.len() == 2,
-            "Should find test function and subtest with double quotes, found: {}",
-            runnables.len()
+            tag_strings.contains(&"go-test".to_string()),
+            "Should find go-test tag, found: {:?}",
+            tag_strings
+        );
+        assert!(
+            tag_strings.contains(&"go-subtest".to_string()),
+            "Should find go-subtest tag, found: {:?}",
+            tag_strings
         );
 
         let buffer = cx.new(|cx| {
@@ -860,10 +904,177 @@ mod tests {
                 .collect()
         });
 
+        let tag_strings: Vec<String> = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .map(|tag| tag.0.to_string())
+            .collect();
+
         assert!(
-            runnables.len() == 2,
-            "Should find test function and subtest with backticks, found: {}",
-            runnables.len()
+            tag_strings.contains(&"go-test".to_string()),
+            "Should find go-test tag, found: {:?}",
+            tag_strings
+        );
+        assert!(
+            tag_strings.contains(&"go-subtest".to_string()),
+            "Should find go-subtest tag, found: {:?}",
+            tag_strings
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_slice_detection(cx: &mut TestAppContext) {
+        let language = language("go", tree_sitter_go::LANGUAGE.into());
+
+        let table_test = r#"
+        package main
+
+        import "testing"
+
+        func TestExample(t *testing.T) {
+            _ = "some random string"
+
+            testCases := []struct{
+                name string
+                anotherStr string
+            }{
+                {
+                    name: "test case 1",
+                    anotherStr: "foo",
+                },
+                {
+                    name: "test case 2",
+                    anotherStr: "bar",
+                },
+            }
+
+            for _, tc := range testCases {
+                t.Run(tc.name, func(t *testing.T) {
+                    // test code here
+                })
+            }
+        }
+        "#;
+
+        let buffer =
+            cx.new(|cx| crate::Buffer::local(table_test, cx).with_language(language.clone(), cx));
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(0..table_test.len()).collect()
+        });
+
+        let tag_strings: Vec<String> = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .map(|tag| tag.0.to_string())
+            .collect();
+
+        assert!(
+            tag_strings.contains(&"go-test".to_string()),
+            "Should find go-test tag, found: {:?}",
+            tag_strings
+        );
+        assert!(
+            tag_strings.contains(&"go-table-test-case".to_string()),
+            "Should find go-table-test-case tag, found: {:?}",
+            tag_strings
+        );
+
+        let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case")
+            .count();
+
+        assert!(
+            go_test_count == 1,
+            "Should find exactly 1 go-test, found: {}",
+            go_test_count
+        );
+        assert!(
+            go_table_test_count == 2,
+            "Should find exactly 2 go-table-test-case, found: {}",
+            go_table_test_count
+        );
+    }
+
+    #[gpui::test]
+    fn test_go_table_test_map_detection(cx: &mut TestAppContext) {
+        let language = language("go", tree_sitter_go::LANGUAGE.into());
+
+        let table_test = r#"
+        package main
+
+        import "testing"
+
+        func TestExample(t *testing.T) {
+            _ = "some random string"
+
+           	testCases := map[string]struct {
+          		someStr string
+          		fail    bool
+           	}{
+          		"test failure": {
+         			someStr: "foo",
+         			fail:    true,
+          		},
+          		"test success": {
+         			someStr: "bar",
+         			fail:    false,
+          		},
+           	}
+
+            for name, tc := range testCases {
+                t.Run(name, func(t *testing.T) {
+                    // test code here
+                })
+            }
+        }
+        "#;
+
+        let buffer =
+            cx.new(|cx| crate::Buffer::local(table_test, cx).with_language(language.clone(), cx));
+        cx.executor().run_until_parked();
+
+        let runnables: Vec<_> = buffer.update(cx, |buffer, _| {
+            let snapshot = buffer.snapshot();
+            snapshot.runnable_ranges(0..table_test.len()).collect()
+        });
+
+        let tag_strings: Vec<String> = runnables
+            .iter()
+            .flat_map(|r| &r.runnable.tags)
+            .map(|tag| tag.0.to_string())
+            .collect();
+
+        assert!(
+            tag_strings.contains(&"go-test".to_string()),
+            "Should find go-test tag, found: {:?}",
+            tag_strings
+        );
+        assert!(
+            tag_strings.contains(&"go-table-test-case".to_string()),
+            "Should find go-table-test-case tag, found: {:?}",
+            tag_strings
+        );
+
+        let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
+        let go_table_test_count = tag_strings
+            .iter()
+            .filter(|&tag| tag == "go-table-test-case")
+            .count();
+
+        assert!(
+            go_test_count == 1,
+            "Should find exactly 1 go-test, found: {}",
+            go_test_count
+        );
+        assert!(
+            go_table_test_count == 2,
+            "Should find exactly 2 go-table-test-case, found: {}",
+            go_table_test_count
         );
     }
 

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -94,58 +94,68 @@
 
 ; Table test case - slice
 (
-  (function_declaration
-    name: (identifier) @_containing_function
-    (#match? @_containing_function "^Test.*")
-    body: (block
-      (short_var_declaration
-        left: (expression_list (identifier) @_slice_var)
-        right: (expression_list
-          (composite_literal
-            type: (slice_type)
-            body: (literal_value
-              (literal_element
-                (literal_value
-                  (keyed_element
-                    (literal_element
-                      (identifier) @_field_name
-                    )
-                    (literal_element
-                      [
-                        (interpreted_string_literal) @run @_table_test_case_name
-                        (raw_string_literal) @run @_table_test_case_name
-                      ]
-                    )
-                  )
+  (short_var_declaration
+    left: (expression_list (identifier) @_slice_var)
+    right: (expression_list
+      (composite_literal
+        type: (slice_type)
+        body: (literal_value
+          (literal_element
+            (literal_value
+              (keyed_element
+                (literal_element
+                  (identifier) @_field_name
+                )
+                (literal_element
+                  [
+                    (interpreted_string_literal) @run @_table_test_case_name
+                    (raw_string_literal) @run @_table_test_case_name
+                  ]
                 )
               )
             )
           )
         )
       )
-      (for_statement
-        (range_clause
-          left: (expression_list
-            (identifier)
-            (identifier) @_loop_var
+    )
+  )
+  (for_statement
+    (range_clause
+      left: (expression_list
+        (identifier)
+        (identifier) @_loop_var
+      )
+      right: (identifier) @_range_var_check
+      (#eq? @_range_var_check @_slice_var)
+    )
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @_t_var
+            field: (field_identifier) @_run_check
+            (#eq? @_run_check "Run")
           )
-          right: (identifier) @_range_var_check
-          (#eq? @_range_var_check @_slice_var)
-        )
-        body: (block
-          (expression_statement
-            (call_expression
-              function: (selector_expression
-                field: (field_identifier) @_run_check
-                (#eq? @_run_check "Run")
-              )
-              arguments: (argument_list
-                .
-                (selector_expression
-                  operand: (identifier) @_tc_var_check
-                  (#eq? @_tc_var_check @_loop_var)
-                  field: (field_identifier) @_field_check
-                  (#eq? @_field_check @_field_name)
+          arguments: (argument_list
+            .
+            (selector_expression
+              operand: (identifier) @_tc_var_check
+              (#eq? @_tc_var_check @_loop_var)
+              field: (field_identifier) @_field_check
+              (#eq? @_field_check @_field_name)
+            )
+            .
+            (func_literal
+              parameters: (parameter_list
+                (parameter_declaration
+                  type: (pointer_type
+                    (qualified_type
+                      package: (package_identifier) @_pkg
+                      name: (type_identifier) @_type
+                      (#eq? @_pkg "testing")
+                      (#eq? @_type "T")
+                    )
+                  )
                 )
               )
             )
@@ -159,63 +169,58 @@
 
 ; Table test cases - map
 (
-  (function_declaration
-    name: (identifier) @_containing_function
-    (#match? @_containing_function "^Test.*")
-    parameters: (parameter_list
-      (parameter_declaration
-        name: (identifier) @_t_param
-        type: (pointer_type
-          (qualified_type
-            package: (package_identifier) @_pkg
-            name: (type_identifier) @_type
-            (#eq? @_pkg "testing")
-            (#eq? @_type "T")
+  (short_var_declaration
+    left: (expression_list (identifier) @_map_var)
+    right: (expression_list
+      (composite_literal
+        type: (map_type
+          key: (type_identifier) @_key_type
+          (#eq? @_key_type "string")
+        )
+        body: (literal_value
+          (keyed_element
+            (literal_element
+              [
+                (interpreted_string_literal) @run @_table_test_case_name
+                (raw_string_literal) @run @_table_test_case_name
+              ]
+            )
           )
         )
       )
     )
+  )
+  (for_statement
+    (range_clause
+      left: (expression_list (identifier) @_key_var)
+      right: (identifier) @_range_var
+      (#eq? @_range_var @_map_var)
+    )
     body: (block
-      (short_var_declaration
-        left: (expression_list (identifier) @_map_var)
-        right: (expression_list
-          (composite_literal
-            type: (map_type
-              key: (type_identifier) @_key_type
-              (#eq? @_key_type "string")
-            )
-            body: (literal_value
-              (keyed_element
-                (literal_element
-                  [
-                    (interpreted_string_literal) @run @_table_test_case_name
-                    (raw_string_literal) @run @_table_test_case_name
-                  ]
-                )
-              )
-            )
+      (expression_statement
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @_t_var
+            field: (field_identifier) @_run_method
+            (#eq? @_run_method "Run")
           )
-        )
-      )
-      (for_statement
-        (range_clause
-          left: (expression_list (identifier) @_key_var)
-          right: (identifier) @_range_var
-          (#eq? @_range_var @_map_var)
-        )
-        body: (block
-          (expression_statement
-            (call_expression
-              function: (selector_expression
-                operand: (identifier) @_t_var
-                (#eq? @_t_var @_t_param)
-                field: (field_identifier) @_run_method
-                (#eq? @_run_method "Run")
-              )
-              arguments: (argument_list
-                .
-                (identifier) @_arg_var
-                (#eq? @_arg_var @_key_var)
+          arguments: (argument_list
+            .
+            (identifier) @_arg_var
+            (#eq? @_arg_var @_key_var)
+            .
+            (func_literal
+              parameters: (parameter_list
+                (parameter_declaration
+                  type: (pointer_type
+                    (qualified_type
+                      package: (package_identifier) @_pkg
+                      name: (type_identifier) @_type
+                      (#eq? @_pkg "testing")
+                      (#eq? @_type "T")
+                    )
+                  )
+                )
               )
             )
           )

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -92,29 +92,45 @@
   (#set! tag go-main)
 )
 
-; Table test case - slice
+; Table test cases - slice and map
 (
   (short_var_declaration
-    left: (expression_list (identifier) @_slice_var)
+    left: (expression_list (identifier) @_collection_var)
     right: (expression_list
       (composite_literal
-        type: (slice_type)
+        type: [
+          (slice_type)
+          (map_type
+            key: (type_identifier) @_key_type
+            (#eq? @_key_type "string")
+          )
+        ]
         body: (literal_value
-          (literal_element
-            (literal_value
-              (keyed_element
-                (literal_element
-                  (identifier) @_field_name
-                )
-                (literal_element
-                  [
-                    (interpreted_string_literal) @run @_table_test_case_name
-                    (raw_string_literal) @run @_table_test_case_name
-                  ]
+          [
+            (literal_element
+              (literal_value
+                (keyed_element
+                  (literal_element
+                    (identifier) @_field_name
+                  )
+                  (literal_element
+                    [
+                      (interpreted_string_literal) @run @_table_test_case_name
+                      (raw_string_literal) @run @_table_test_case_name
+                    ]
+                  )
                 )
               )
             )
-          )
+            (keyed_element
+              (literal_element
+                [
+                  (interpreted_string_literal) @run @_table_test_case_name
+                  (raw_string_literal) @run @_table_test_case_name
+                ]
+              )
+            )
+          ]
         )
       )
     )
@@ -122,79 +138,16 @@
   (for_statement
     (range_clause
       left: (expression_list
-        (identifier)
-        (identifier) @_loop_var
-      )
-      right: (identifier) @_range_var_check
-      (#eq? @_range_var_check @_slice_var)
-    )
-    body: (block
-      (expression_statement
-        (call_expression
-          function: (selector_expression
-            operand: (identifier) @_t_var
-            field: (field_identifier) @_run_check
-            (#eq? @_run_check "Run")
+        [
+          (
+            (identifier)
+            (identifier) @_loop_var
           )
-          arguments: (argument_list
-            .
-            (selector_expression
-              operand: (identifier) @_tc_var_check
-              (#eq? @_tc_var_check @_loop_var)
-              field: (field_identifier) @_field_check
-              (#eq? @_field_check @_field_name)
-            )
-            .
-            (func_literal
-              parameters: (parameter_list
-                (parameter_declaration
-                  type: (pointer_type
-                    (qualified_type
-                      package: (package_identifier) @_pkg
-                      name: (type_identifier) @_type
-                      (#eq? @_pkg "testing")
-                      (#eq? @_type "T")
-                    )
-                  )
-                )
-              )
-            )
-          )
-        )
+          (identifier) @_loop_var
+        ]
       )
-    )
-  ) @_
-  (#set! tag go-table-test-case)
-)
-
-; Table test cases - map
-(
-  (short_var_declaration
-    left: (expression_list (identifier) @_map_var)
-    right: (expression_list
-      (composite_literal
-        type: (map_type
-          key: (type_identifier) @_key_type
-          (#eq? @_key_type "string")
-        )
-        body: (literal_value
-          (keyed_element
-            (literal_element
-              [
-                (interpreted_string_literal) @run @_table_test_case_name
-                (raw_string_literal) @run @_table_test_case_name
-              ]
-            )
-          )
-        )
-      )
-    )
-  )
-  (for_statement
-    (range_clause
-      left: (expression_list (identifier) @_key_var)
       right: (identifier) @_range_var
-      (#eq? @_range_var @_map_var)
+      (#eq? @_range_var @_collection_var)
     )
     body: (block
       (expression_statement
@@ -206,8 +159,16 @@
           )
           arguments: (argument_list
             .
-            (identifier) @_arg_var
-            (#eq? @_arg_var @_key_var)
+            [
+              (selector_expression
+                operand: (identifier) @_tc_var
+                (#eq? @_tc_var @_loop_var)
+                field: (field_identifier) @_field_check
+                (#eq? @_field_check @_field_name)
+              )
+              (identifier) @_arg_var
+              (#eq? @_arg_var @_loop_var)
+            ]
             .
             (func_literal
               parameters: (parameter_list

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -93,25 +93,22 @@
 )
 
 ; Table test case - slice
-; Captures only the first string field as subtest name
 (
   (function_declaration
     name: (identifier) @_containing_function
     (#match? @_containing_function "^Test.*")
     body: (block
       (short_var_declaration
+        left: (expression_list (identifier) @_slice_var)
         right: (expression_list
           (composite_literal
-            type: (slice_type
-              element: (struct_type)
-            )
+            type: (slice_type)
             body: (literal_value
               (literal_element
                 (literal_value
-                  .
                   (keyed_element
                     (literal_element
-                      (identifier)
+                      (identifier) @_field_name
                     )
                     (literal_element
                       [
@@ -120,6 +117,35 @@
                       ]
                     )
                   )
+                )
+              )
+            )
+          )
+        )
+      )
+      (for_statement
+        (range_clause
+          left: (expression_list
+            (identifier)
+            (identifier) @_loop_var
+          )
+          right: (identifier) @_range_var_check
+          (#eq? @_range_var_check @_slice_var)
+        )
+        body: (block
+          (expression_statement
+            (call_expression
+              function: (selector_expression
+                field: (field_identifier) @_run_check
+                (#eq? @_run_check "Run")
+              )
+              arguments: (argument_list
+                .
+                (selector_expression
+                  operand: (identifier) @_tc_var_check
+                  (#eq? @_tc_var_check @_loop_var)
+                  field: (field_identifier) @_field_check
+                  (#eq? @_field_check @_field_name)
                 )
               )
             )
@@ -136,8 +162,22 @@
   (function_declaration
     name: (identifier) @_containing_function
     (#match? @_containing_function "^Test.*")
+    parameters: (parameter_list
+      (parameter_declaration
+        name: (identifier) @_t_param
+        type: (pointer_type
+          (qualified_type
+            package: (package_identifier) @_pkg
+            name: (type_identifier) @_type
+            (#eq? @_pkg "testing")
+            (#eq? @_type "T")
+          )
+        )
+      )
+    )
     body: (block
       (short_var_declaration
+        left: (expression_list (identifier) @_map_var)
         right: (expression_list
           (composite_literal
             type: (map_type
@@ -152,6 +192,30 @@
                     (raw_string_literal) @run @_table_test_case_name
                   ]
                 )
+              )
+            )
+          )
+        )
+      )
+      (for_statement
+        (range_clause
+          left: (expression_list (identifier) @_key_var)
+          right: (identifier) @_range_var
+          (#eq? @_range_var @_map_var)
+        )
+        body: (block
+          (expression_statement
+            (call_expression
+              function: (selector_expression
+                operand: (identifier) @_t_var
+                (#eq? @_t_var @_t_param)
+                field: (field_identifier) @_run_method
+                (#eq? @_run_method "Run")
+              )
+              arguments: (argument_list
+                .
+                (identifier) @_arg_var
+                (#eq? @_arg_var @_key_var)
               )
             )
           )

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -91,3 +91,73 @@
   ) @_
   (#set! tag go-main)
 )
+
+; Table test case - slice
+; Captures only the first string field as subtest name
+(
+  (function_declaration
+    name: (identifier) @_containing_function
+    (#match? @_containing_function "^Test.*")
+    body: (block
+      (short_var_declaration
+        right: (expression_list
+          (composite_literal
+            type: (slice_type
+              element: (struct_type)
+            )
+            body: (literal_value
+              (literal_element
+                (literal_value
+                  .
+                  (keyed_element
+                    (literal_element
+                      (identifier)
+                    )
+                    (literal_element
+                      [
+                        (interpreted_string_literal) @run @_table_test_case_name
+                        (raw_string_literal) @run @_table_test_case_name
+                      ]
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  ) @_
+  (#set! tag go-table-test-case)
+)
+
+; Table test cases - map
+(
+  (function_declaration
+    name: (identifier) @_containing_function
+    (#match? @_containing_function "^Test.*")
+    body: (block
+      (short_var_declaration
+        right: (expression_list
+          (composite_literal
+            type: (map_type
+              key: (type_identifier) @_key_type
+              (#eq? @_key_type "string")
+            )
+            body: (literal_value
+              (keyed_element
+                (literal_element
+                  [
+                    (interpreted_string_literal) @run @_table_test_case_name
+                    (raw_string_literal) @run @_table_test_case_name
+                  ]
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  ) @_
+  (#set! tag go-table-test-case)
+)


### PR DESCRIPTION
One killer feature for the Go runner is to execute individual subtests within a table-test easily. Goland has had this feature forever, while in VSCode this has been notably missing.

https://github.com/user-attachments/assets/363417a2-d1b1-43ca-8377-08ce062d6104


Release Notes:

- Added support to run Go table-test subtests.
