### PR TITLE
onboarding: Wire up tab index

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1175,7 +1175,8 @@
     "bindings": {
       "ctrl-1": "onboarding::ActivateBasicsPage",
       "ctrl-2": "onboarding::ActivateEditingPage",
-      "ctrl-3": "onboarding::ActivateAISetupPage"
+      "ctrl-3": "onboarding::ActivateAISetupPage",
+      "ctrl-escape": "onboarding::Finish"
     }
   }
 ]

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1277,7 +1277,8 @@
     "bindings": {
       "cmd-1": "onboarding::ActivateBasicsPage",
       "cmd-2": "onboarding::ActivateEditingPage",
-      "cmd-3": "onboarding::ActivateAISetupPage"
+      "cmd-3": "onboarding::ActivateAISetupPage",
+      "cmd-escape": "onboarding::Finish"
     }
   }
 ]

--- a/crates/ai_onboarding/src/ai_upsell_card.rs
+++ b/crates/ai_onboarding/src/ai_upsell_card.rs
@@ -12,6 +12,7 @@ pub struct AiUpsellCard {
     pub sign_in_status: SignInStatus,
     pub sign_in: Arc<dyn Fn(&mut Window, &mut App)>,
     pub user_plan: Option<Plan>,
+    pub tab_index: Option<isize>,
 }
 
 impl AiUpsellCard {
@@ -28,6 +29,7 @@ impl AiUpsellCard {
                 })
                 .detach_and_log_err(cx);
             }),
+            tab_index: None,
         }
     }
 }
@@ -112,7 +114,8 @@ impl RenderOnce for AiUpsellCard {
                         .on_click(move |_, _window, cx| {
                             telemetry::event!("Start Trial Clicked", state = "post-sign-in");
                             cx.open_url(&zed_urls::start_trial_url(cx))
-                        }),
+                        })
+                        .when_some(self.tab_index, |this, tab_index| this.tab_index(tab_index)),
                 )
                 .child(
                     Label::new("No credit card required")
@@ -123,6 +126,7 @@ impl RenderOnce for AiUpsellCard {
             _ => Button::new("sign_in", "Sign In")
                 .full_width()
                 .style(ButtonStyle::Tinted(ui::TintColor::Accent))
+                .when_some(self.tab_index, |this, tab_index| this.tab_index(tab_index))
                 .on_click({
                     let callback = self.sign_in.clone();
                     move |_, window, cx| {
@@ -193,6 +197,7 @@ impl Component for AiUpsellCard {
                             sign_in_status: SignInStatus::SignedOut,
                             sign_in: Arc::new(|_, _| {}),
                             user_plan: None,
+                            tab_index: Some(0),
                         }
                         .into_any_element(),
                     ),
@@ -202,6 +207,7 @@ impl Component for AiUpsellCard {
                             sign_in_status: SignInStatus::SignedIn,
                             sign_in: Arc::new(|_, _| {}),
                             user_plan: None,
+                            tab_index: Some(1),
                         }
                         .into_any_element(),
                     ),

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -4699,6 +4699,8 @@ pub enum ElementId {
     Path(Arc<std::path::Path>),
     /// A code location.
     CodeLocation(core::panic::Location<'static>),
+    /// A labeled child of an element.
+    NamedChild(Box<ElementId>, SharedString),
 }
 
 impl ElementId {
@@ -4719,6 +4721,7 @@ impl Display for ElementId {
             ElementId::Uuid(uuid) => write!(f, "{}", uuid)?,
             ElementId::Path(path) => write!(f, "{}", path.display())?,
             ElementId::CodeLocation(location) => write!(f, "{}", location)?,
+            ElementId::NamedChild(id, name) => write!(f, "{}-{}", id, name)?,
         }
 
         Ok(())
@@ -4806,6 +4809,12 @@ impl From<Uuid> for ElementId {
 impl From<(&'static str, u32)> for ElementId {
     fn from((name, id): (&'static str, u32)) -> Self {
         ElementId::NamedInteger(name.into(), id.into())
+    }
+}
+
+impl<T: Into<SharedString>> From<(ElementId, T)> for ElementId {
+    fn from((id, name): (ElementId, T)) -> Self {
+        ElementId::NamedChild(Box::new(id), name.into())
     }
 }
 

--- a/crates/onboarding/Cargo.toml
+++ b/crates/onboarding/Cargo.toml
@@ -15,13 +15,13 @@ path = "src/onboarding.rs"
 default = []
 
 [dependencies]
-anyhow.workspace = true
 ai_onboarding.workspace = true
+anyhow.workspace = true
 client.workspace = true
 command_palette_hooks.workspace = true
 component.workspace = true
-documented.workspace = true
 db.workspace = true
+documented.workspace = true
 editor.workspace = true
 feature_flags.workspace = true
 fs.workspace = true

--- a/crates/onboarding/src/ai_setup_page.rs
+++ b/crates/onboarding/src/ai_setup_page.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
 use ai_onboarding::{AiUpsellCard, SignInStatus};
 use client::UserStore;
@@ -18,8 +18,6 @@ use ui::{
 use util::ResultExt;
 use workspace::{ModalView, Workspace};
 use zed_actions::agent::OpenSettings;
-
-use crate::Onboarding;
 
 const FEATURED_PROVIDERS: [&'static str; 4] = ["anthropic", "google", "openai", "ollama"];
 

--- a/crates/onboarding/src/ai_setup_page.rs
+++ b/crates/onboarding/src/ai_setup_page.rs
@@ -24,6 +24,7 @@ use crate::Onboarding;
 const FEATURED_PROVIDERS: [&'static str; 4] = ["anthropic", "google", "openai", "ollama"];
 
 fn render_llm_provider_section(
+    tab_index: &mut isize,
     workspace: WeakEntity<Workspace>,
     disabled: bool,
     window: &mut Window,
@@ -39,10 +40,10 @@ fn render_llm_provider_section(
                         .color(Color::Muted),
                 ),
         )
-        .child(render_llm_provider_card(workspace, disabled, window, cx))
+        .child(render_llm_provider_card(tab_index, workspace, disabled, window, cx))
 }
 
-fn render_privacy_card(disabled: bool, cx: &mut App) -> impl IntoElement {
+fn render_privacy_card(tab_index: &mut isize, disabled: bool, cx: &mut App) -> impl IntoElement {
     let privacy_badge = || {
         Badge::new("Privacy")
             .icon(IconName::ShieldCheck)
@@ -100,6 +101,10 @@ fn render_privacy_card(disabled: bool, cx: &mut App) -> impl IntoElement {
                                     .icon_color(Color::Muted)
                                     .on_click(|_, _, cx| {
                                         cx.open_url("https://zed.dev/docs/ai/privacy-and-security");
+                                    })
+                                    .tab_index({
+                                        *tab_index += 1;
+                                        *tab_index - 1
                                     }),
                             ),
                         ),
@@ -116,6 +121,7 @@ fn render_privacy_card(disabled: bool, cx: &mut App) -> impl IntoElement {
 }
 
 fn render_llm_provider_card(
+    tab_index: &mut isize,
     workspace: WeakEntity<Workspace>,
     disabled: bool,
     _: &mut Window,
@@ -142,6 +148,10 @@ fn render_llm_provider_card(
 
                     ButtonLike::new(("onboarding-ai-setup-buttons", index))
                         .size(ButtonSize::Large)
+                        .tab_index({
+                            *tab_index += 1;
+                            *tab_index - 1
+                        })
                         .child(
                             h_flex()
                                 .group(&group_name)
@@ -221,6 +231,10 @@ fn render_llm_provider_card(
                 .icon_size(IconSize::XSmall)
                 .on_click(|_event, window, cx| {
                     window.dispatch_action(OpenSettings.boxed_clone(), cx)
+                })
+                .tab_index({
+                    *tab_index += 1;
+                    *tab_index - 1
                 }),
         )
 }
@@ -231,48 +245,42 @@ pub(crate) fn render_ai_setup_page(
     window: &mut Window,
     cx: &mut App,
 ) -> impl IntoElement {
+    let mut tab_index = 0;
     let is_ai_disabled = DisableAiSettings::get_global(cx).disable_ai;
-
-    let backdrop = div()
-        .id("backdrop")
-        .size_full()
-        .absolute()
-        .inset_0()
-        .bg(cx.theme().colors().editor_background)
-        .opacity(0.8)
-        .block_mouse_except_scroll();
 
     v_flex()
         .gap_2()
-        .child(SwitchField::new(
-            "enable_ai",
-            "Enable AI features",
-            None,
-            if is_ai_disabled {
-                ToggleState::Unselected
-            } else {
-                ToggleState::Selected
-            },
-            |toggle_state, _, cx| {
-                let enabled = match toggle_state {
-                    ToggleState::Indeterminate => {
-                        return;
-                    }
-                    ToggleState::Unselected => false,
-                    ToggleState::Selected => true,
-                };
-
-                let fs = <dyn Fs>::global(cx);
-                update_settings_file::<DisableAiSettings>(
-                    fs,
-                    cx,
-                    move |ai_settings: &mut Option<bool>, _| {
-                        *ai_settings = Some(!enabled);
-                    },
-                );
-            },
-        ))
-        .child(render_privacy_card(is_ai_disabled, cx))
+        .child(
+            SwitchField::new(
+                "enable_ai",
+                "Enable AI features",
+                None,
+                if is_ai_disabled {
+                    ToggleState::Unselected
+                } else {
+                    ToggleState::Selected
+                },
+                |&toggle_state, _, cx| {
+                    let fs = <dyn Fs>::global(cx);
+                    update_settings_file::<DisableAiSettings>(
+                        fs,
+                        cx,
+                        move |ai_settings: &mut Option<bool>, _| {
+                            *ai_settings = match toggle_state {
+                                ToggleState::Indeterminate => None,
+                                ToggleState::Unselected => Some(true),
+                                ToggleState::Selected => Some(false),
+                            };
+                        },
+                    );
+                },
+            )
+            .tab_index({
+                tab_index += 1;
+                tab_index - 1
+            }),
+        )
+        .child(render_privacy_card(&mut tab_index, is_ai_disabled, cx))
         .child(
             v_flex()
                 .mt_2()
@@ -281,14 +289,30 @@ pub(crate) fn render_ai_setup_page(
                     sign_in_status: SignInStatus::SignedIn,
                     sign_in: Arc::new(|_, _| {}),
                     user_plan: user_store.read(cx).plan(),
+                    tab_index: Some({
+                        tab_index += 1;
+                        tab_index - 1
+                    }),
                 })
                 .child(render_llm_provider_section(
+                    &mut tab_index,
                     workspace,
                     is_ai_disabled,
                     window,
                     cx,
                 ))
-                .when(is_ai_disabled, |this| this.child(backdrop)),
+                .when(is_ai_disabled, |this| {
+                    this.child(
+                        div()
+                            .id("backdrop")
+                            .size_full()
+                            .absolute()
+                            .inset_0()
+                            .bg(cx.theme().colors().editor_background)
+                            .opacity(0.8)
+                            .block_mouse_except_scroll(),
+                    )
+                }),
         )
 }
 

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -16,7 +16,7 @@ use vim_mode_setting::VimModeSetting;
 
 use crate::theme_preview::{ThemePreviewStyle, ThemePreviewTile};
 
-fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement {
+fn render_theme_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement {
     let theme_selection = ThemeSettings::get_global(cx).theme_selection.clone();
     let system_appearance = theme::SystemAppearance::global(cx);
     let theme_selection = theme_selection.unwrap_or_else(|| ThemeSelection::Dynamic {
@@ -55,6 +55,7 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
                         )
                     }),
                 )
+                .tab_index(tab_index)
                 .selected_index(theme_mode as usize)
                 .style(ui::ToggleButtonGroupStyle::Outlined)
                 .button_width(rems_from_px(64.)),
@@ -64,10 +65,11 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
             h_flex()
                 .gap_4()
                 .justify_between()
-                .children(render_theme_previews(&theme_selection, cx)),
+                .children(render_theme_previews(tab_index, &theme_selection, cx)),
         );
 
     fn render_theme_previews(
+        tab_index: &mut isize,
         theme_selection: &ThemeSelection,
         cx: &mut App,
     ) -> [impl IntoElement; 3] {
@@ -110,12 +112,12 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
             let colors = cx.theme().colors();
 
             v_flex()
-                .id(name.clone())
                 .w_full()
                 .items_center()
                 .gap_1()
                 .child(
                     h_flex()
+                        .id(name.clone())
                         .relative()
                         .w_full()
                         .border_2()
@@ -126,6 +128,20 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
                                 this.border_color(colors.border_selected)
                             } else {
                                 this.opacity(0.8).hover(|s| s.border_color(colors.border))
+                            }
+                        })
+                        .tab_index({
+                            *tab_index += 1;
+                            *tab_index - 1
+                        })
+                        .focus(|mut style| {
+                            style.border_color = Some(colors.border_focused);
+                            style
+                        })
+                        .on_click({
+                            let theme_name = theme.name.clone();
+                            move |_, _, cx| {
+                                write_theme_change(theme_name.clone(), theme_mode, cx);
                             }
                         })
                         .map(|this| {
@@ -151,12 +167,6 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
                         .color(Color::Muted)
                         .size(LabelSize::Small),
                 )
-                .on_click({
-                    let theme_name = theme.name.clone();
-                    move |_, _, cx| {
-                        write_theme_change(theme_name.clone(), theme_mode, cx);
-                    }
-                })
         });
 
         theme_previews
@@ -187,7 +197,7 @@ fn render_theme_section(_window: &mut Window, cx: &mut App) -> impl IntoElement 
     }
 }
 
-fn render_telemetry_section(cx: &App) -> impl IntoElement {
+fn render_telemetry_section(tab_index: &mut isize, cx: &App) -> impl IntoElement {
     let fs = <dyn Fs>::global(cx);
 
     v_flex()
@@ -217,7 +227,10 @@ fn render_telemetry_section(cx: &App) -> impl IntoElement {
                     move |setting, _| setting.metrics = Some(enabled),
                 );
             }},
-        ))
+        ).tab_index({
+            *tab_index += 1;
+            *tab_index
+        }))
         .child(SwitchField::new(
             "onboarding-telemetry-crash-reports",
             "Help Fix Zed",
@@ -243,10 +256,13 @@ fn render_telemetry_section(cx: &App) -> impl IntoElement {
                     );
                 }
             }
-        ))
+        ).tab_index({
+                    *tab_index += 1;
+                    *tab_index
+                }))
 }
 
-fn render_base_keymap_section(cx: &mut App) -> impl IntoElement {
+fn render_base_keymap_section(tab_index: &mut isize, cx: &mut App) -> impl IntoElement {
     let base_keymap = match BaseKeymap::get_global(cx) {
         BaseKeymap::VSCode => Some(0),
         BaseKeymap::JetBrains => Some(1),
@@ -286,6 +302,7 @@ fn render_base_keymap_section(cx: &mut App) -> impl IntoElement {
         .when_some(base_keymap, |this, base_keymap| {
             this.selected_index(base_keymap)
         })
+        .tab_index(tab_index)
         .button_width(rems_from_px(216.))
         .size(ui::ToggleButtonGroupSize::Medium)
         .style(ui::ToggleButtonGroupStyle::Outlined),
@@ -300,7 +317,7 @@ fn render_base_keymap_section(cx: &mut App) -> impl IntoElement {
     }
 }
 
-fn render_vim_mode_switch(cx: &mut App) -> impl IntoElement {
+fn render_vim_mode_switch(tab_index: &mut isize, cx: &mut App) -> impl IntoElement {
     let toggle_state = if VimModeSetting::get_global(cx).0 {
         ui::ToggleState::Selected
     } else {
@@ -327,13 +344,18 @@ fn render_vim_mode_switch(cx: &mut App) -> impl IntoElement {
             }
         },
     )
+    .tab_index({
+        *tab_index += 1;
+        *tab_index - 1
+    })
 }
 
 pub(crate) fn render_basics_page(window: &mut Window, cx: &mut App) -> impl IntoElement {
+    let mut tab_index = 0;
     v_flex()
         .gap_6()
-        .child(render_theme_section(window, cx))
-        .child(render_base_keymap_section(cx))
-        .child(render_vim_mode_switch(cx))
-        .child(render_telemetry_section(cx))
+        .child(render_theme_section(&mut tab_index, cx))
+        .child(render_base_keymap_section(&mut tab_index, cx))
+        .child(render_vim_mode_switch(&mut tab_index, cx))
+        .child(render_telemetry_section(&mut tab_index, cx))
 }

--- a/crates/onboarding/src/basics_page.rs
+++ b/crates/onboarding/src/basics_page.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use client::TelemetrySettings;
 use fs::Fs;
-use gpui::{App, IntoElement, Window};
+use gpui::{App, IntoElement};
 use settings::{BaseKeymap, Settings, update_settings_file};
 use theme::{
     Appearance, SystemAppearance, ThemeMode, ThemeName, ThemeRegistry, ThemeSelection,
@@ -350,7 +350,7 @@ fn render_vim_mode_switch(tab_index: &mut isize, cx: &mut App) -> impl IntoEleme
     })
 }
 
-pub(crate) fn render_basics_page(window: &mut Window, cx: &mut App) -> impl IntoElement {
+pub(crate) fn render_basics_page(cx: &mut App) -> impl IntoElement {
     let mut tab_index = 0;
     v_flex()
         .gap_6()

--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -171,6 +171,7 @@ fn write_format_on_save(format_on_save: bool, cx: &mut App) {
 }
 
 fn render_setting_import_button(
+    tab_index: isize,
     label: SharedString,
     icon_name: IconName,
     action: &dyn Action,
@@ -182,6 +183,7 @@ fn render_setting_import_button(
             .full_width()
             .style(ButtonStyle::Outlined)
             .size(ButtonSize::Large)
+            .tab_index(tab_index)
             .child(
                 h_flex()
                     .w_full()
@@ -214,7 +216,7 @@ fn render_setting_import_button(
     )
 }
 
-fn render_import_settings_section(cx: &App) -> impl IntoElement {
+fn render_import_settings_section(tab_index: &mut isize, cx: &App) -> impl IntoElement {
     let import_state = SettingsImportState::global(cx);
     let imports: [(SharedString, IconName, &dyn Action, bool); 2] = [
         (
@@ -232,7 +234,8 @@ fn render_import_settings_section(cx: &App) -> impl IntoElement {
     ];
 
     let [vscode, cursor] = imports.map(|(label, icon_name, action, imported)| {
-        render_setting_import_button(label, icon_name, action, imported)
+        *tab_index += 1;
+        render_setting_import_button(*tab_index - 1, label, icon_name, action, imported)
     });
 
     v_flex()
@@ -248,7 +251,11 @@ fn render_import_settings_section(cx: &App) -> impl IntoElement {
         .child(h_flex().w_full().gap_4().child(vscode).child(cursor))
 }
 
-fn render_font_customization_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
+fn render_font_customization_section(
+    tab_index: &mut isize,
+    window: &mut Window,
+    cx: &mut App,
+) -> impl IntoElement {
     let theme_settings = ThemeSettings::get_global(cx);
     let ui_font_size = theme_settings.ui_font_size(cx);
     let ui_font_family = theme_settings.ui_font.family.clone();
@@ -294,6 +301,10 @@ fn render_font_customization_section(window: &mut Window, cx: &mut App) -> impl 
                                         .style(ButtonStyle::Outlined)
                                         .size(ButtonSize::Medium)
                                         .full_width()
+                                        .tab_index({
+                                            *tab_index += 1;
+                                            *tab_index - 1
+                                        })
                                         .child(
                                             h_flex()
                                                 .w_full()
@@ -325,7 +336,11 @@ fn render_font_customization_section(window: &mut Window, cx: &mut App) -> impl 
                                     write_ui_font_size(ui_font_size + px(1.), cx);
                                 },
                             )
-                            .style(ui::NumericStepperStyle::Outlined),
+                            .style(ui::NumericStepperStyle::Outlined)
+                            .tab_index({
+                                *tab_index += 2;
+                                *tab_index - 2
+                            }),
                         ),
                 ),
         )
@@ -350,6 +365,10 @@ fn render_font_customization_section(window: &mut Window, cx: &mut App) -> impl 
                                         .style(ButtonStyle::Outlined)
                                         .size(ButtonSize::Medium)
                                         .full_width()
+                                        .tab_index({
+                                            *tab_index += 1;
+                                            *tab_index - 1
+                                        })
                                         .child(
                                             h_flex()
                                                 .w_full()
@@ -381,7 +400,11 @@ fn render_font_customization_section(window: &mut Window, cx: &mut App) -> impl 
                                     write_buffer_font_size(buffer_font_size + px(1.), cx);
                                 },
                             )
-                            .style(ui::NumericStepperStyle::Outlined),
+                            .style(ui::NumericStepperStyle::Outlined)
+                            .tab_index({
+                                *tab_index += 2;
+                                *tab_index - 2
+                            }),
                         ),
                 ),
         )
@@ -556,13 +579,17 @@ fn font_picker(
         .max_height(Some(rems(20.).into()))
 }
 
-fn render_popular_settings_section(window: &mut Window, cx: &mut App) -> impl IntoElement {
+fn render_popular_settings_section(
+    tab_index: &mut isize,
+    window: &mut Window,
+    cx: &mut App,
+) -> impl IntoElement {
     const LIGATURE_TOOLTIP: &'static str = "Ligatures are when a font creates a special character out of combining two characters into one. For example, with ligatures turned on, =/= would become ≠.";
 
     v_flex()
         .gap_5()
         .child(Label::new("Popular Settings").size(LabelSize::Large).mt_8())
-        .child(render_font_customization_section(window, cx))
+        .child(render_font_customization_section(tab_index, window, cx))
         .child(
             SwitchField::new(
                 "onboarding-font-ligatures",
@@ -577,47 +604,69 @@ fn render_popular_settings_section(window: &mut Window, cx: &mut App) -> impl In
                     write_font_ligatures(toggle_state == &ToggleState::Selected, cx);
                 },
             )
+            .tab_index({
+                *tab_index += 1;
+                *tab_index - 1
+            })
             .tooltip(Tooltip::text(LIGATURE_TOOLTIP)),
         )
-        .child(SwitchField::new(
-            "onboarding-format-on-save",
-            "Format on Save",
-            Some("Format code automatically when saving.".into()),
-            if read_format_on_save(cx) {
-                ui::ToggleState::Selected
-            } else {
-                ui::ToggleState::Unselected
-            },
-            |toggle_state, _, cx| {
-                write_format_on_save(toggle_state == &ToggleState::Selected, cx);
-            },
-        ))
-        .child(SwitchField::new(
-            "onboarding-enable-inlay-hints",
-            "Inlay Hints",
-            Some("See parameter names for function and method calls inline.".into()),
-            if read_inlay_hints(cx) {
-                ui::ToggleState::Selected
-            } else {
-                ui::ToggleState::Unselected
-            },
-            |toggle_state, _, cx| {
-                write_inlay_hints(toggle_state == &ToggleState::Selected, cx);
-            },
-        ))
-        .child(SwitchField::new(
-            "onboarding-git-blame-switch",
-            "Git Blame",
-            Some("See who committed each line on a given file.".into()),
-            if read_git_blame(cx) {
-                ui::ToggleState::Selected
-            } else {
-                ui::ToggleState::Unselected
-            },
-            |toggle_state, _, cx| {
-                set_git_blame(toggle_state == &ToggleState::Selected, cx);
-            },
-        ))
+        .child(
+            SwitchField::new(
+                "onboarding-format-on-save",
+                "Format on Save",
+                Some("Format code automatically when saving.".into()),
+                if read_format_on_save(cx) {
+                    ui::ToggleState::Selected
+                } else {
+                    ui::ToggleState::Unselected
+                },
+                |toggle_state, _, cx| {
+                    write_format_on_save(toggle_state == &ToggleState::Selected, cx);
+                },
+            )
+            .tab_index({
+                *tab_index += 1;
+                *tab_index - 1
+            }),
+        )
+        .child(
+            SwitchField::new(
+                "onboarding-enable-inlay-hints",
+                "Inlay Hints",
+                Some("See parameter names for function and method calls inline.".into()),
+                if read_inlay_hints(cx) {
+                    ui::ToggleState::Selected
+                } else {
+                    ui::ToggleState::Unselected
+                },
+                |toggle_state, _, cx| {
+                    write_inlay_hints(toggle_state == &ToggleState::Selected, cx);
+                },
+            )
+            .tab_index({
+                *tab_index += 1;
+                *tab_index - 1
+            }),
+        )
+        .child(
+            SwitchField::new(
+                "onboarding-git-blame-switch",
+                "Git Blame",
+                Some("See who committed each line on a given file.".into()),
+                if read_git_blame(cx) {
+                    ui::ToggleState::Selected
+                } else {
+                    ui::ToggleState::Unselected
+                },
+                |toggle_state, _, cx| {
+                    set_git_blame(toggle_state == &ToggleState::Selected, cx);
+                },
+            )
+            .tab_index({
+                *tab_index += 1;
+                *tab_index - 1
+            }),
+        )
         .child(
             h_flex()
                 .items_start()
@@ -648,6 +697,7 @@ fn render_popular_settings_section(window: &mut Window, cx: &mut App) -> impl In
                         ShowMinimap::Always => 1,
                         ShowMinimap::Never => 2,
                     })
+                    .tab_index(tab_index)
                     .style(ToggleButtonGroupStyle::Outlined)
                     .button_width(ui::rems_from_px(64.)),
                 ),
@@ -655,8 +705,9 @@ fn render_popular_settings_section(window: &mut Window, cx: &mut App) -> impl In
 }
 
 pub(crate) fn render_editing_page(window: &mut Window, cx: &mut App) -> impl IntoElement {
+    let mut tab_index = 0;
     v_flex()
         .gap_4()
-        .child(render_import_settings_section(cx))
-        .child(render_popular_settings_section(window, cx))
+        .child(render_import_settings_section(&mut tab_index, cx))
+        .child(render_popular_settings_section(&mut tab_index, window, cx))
 }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -470,9 +470,13 @@ impl Onboarding {
             SelectedPage::Editing => {
                 crate::editing_page::render_editing_page(window, cx).into_any_element()
             }
-            SelectedPage::AiSetup => {
-                crate::ai_setup_page::render_ai_setup_page(&self, window, cx).into_any_element()
-            }
+            SelectedPage::AiSetup => crate::ai_setup_page::render_ai_setup_page(
+                self.workspace.clone(),
+                self.user_store.clone(),
+                window,
+                cx,
+            )
+            .into_any_element(),
         }
     }
 }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -453,9 +453,7 @@ impl Onboarding {
 
     fn render_page(&mut self, window: &mut Window, cx: &mut Context<Self>) -> AnyElement {
         match self.selected_page {
-            SelectedPage::Basics => {
-                crate::basics_page::render_basics_page(window, cx).into_any_element()
-            }
+            SelectedPage::Basics => crate::basics_page::render_basics_page(cx).into_any_element(),
             SelectedPage::Editing => {
                 crate::editing_page::render_editing_page(window, cx).into_any_element()
             }

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -488,6 +488,7 @@ impl Render for Onboarding {
             .key_context({
                 let mut ctx = KeyContext::new_with_defaults();
                 ctx.add("Onboarding");
+                ctx.add("menu");
                 ctx
             })
             .track_focus(&self.focus_handle)
@@ -501,6 +502,14 @@ impl Render for Onboarding {
             }))
             .on_action(cx.listener(|this, _: &ActivateAISetupPage, _, cx| {
                 this.set_page(SelectedPage::AiSetup, cx);
+            }))
+            .on_action(cx.listener(|_, _: &menu::SelectNext, window, cx| {
+                window.focus_next();
+                cx.notify();
+            }))
+            .on_action(cx.listener(|_, _: &menu::SelectPrevious, window, cx| {
+                window.focus_prev();
+                cx.notify();
             }))
             .child(
                 h_flex()

--- a/crates/ui/src/components/button/button.rs
+++ b/crates/ui/src/components/button/button.rs
@@ -393,6 +393,11 @@ impl ButtonCommon for Button {
         self
     }
 
+    fn tab_index(mut self, tab_index: impl Into<isize>) -> Self {
+        self.base = self.base.tab_index(tab_index);
+        self
+    }
+
     fn layer(mut self, elevation: ElevationIndex) -> Self {
         self.base = self.base.layer(elevation);
         self

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -1,7 +1,7 @@
 use documented::Documented;
 use gpui::{
     AnyElement, AnyView, ClickEvent, CursorStyle, DefiniteLength, Hsla, MouseButton,
-    MouseDownEvent, MouseUpEvent, Rems, relative, transparent_black,
+    MouseDownEvent, MouseUpEvent, Rems, StyleRefinement, relative, transparent_black,
 };
 use smallvec::SmallVec;
 
@@ -36,6 +36,8 @@ pub trait ButtonCommon: Clickable + Disableable {
     /// Nearly all interactable elements should have a tooltip. Some example
     /// exceptions might a scroll bar, or a slider.
     fn tooltip(self, tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static) -> Self;
+
+    fn tab_index(self, tab_index: impl Into<isize>) -> Self;
 
     fn layer(self, elevation: ElevationIndex) -> Self;
 }
@@ -393,6 +395,7 @@ pub struct ButtonLike {
     pub(super) width: Option<DefiniteLength>,
     pub(super) height: Option<DefiniteLength>,
     pub(super) layer: Option<ElevationIndex>,
+    tab_index: Option<isize>,
     size: ButtonSize,
     rounding: Option<ButtonLikeRounding>,
     tooltip: Option<Box<dyn Fn(&mut Window, &mut App) -> AnyView>>,
@@ -421,6 +424,7 @@ impl ButtonLike {
             on_click: None,
             on_right_click: None,
             layer: None,
+            tab_index: None,
         }
     }
 
@@ -525,6 +529,11 @@ impl ButtonCommon for ButtonLike {
         self
     }
 
+    fn tab_index(mut self, tab_index: impl Into<isize>) -> Self {
+        self.tab_index = Some(tab_index.into());
+        self
+    }
+
     fn layer(mut self, elevation: ElevationIndex) -> Self {
         self.layer = Some(elevation);
         self
@@ -554,6 +563,7 @@ impl RenderOnce for ButtonLike {
         self.base
             .h_flex()
             .id(self.id.clone())
+            .when_some(self.tab_index, |this, tab_index| this.tab_index(tab_index))
             .font_ui(cx)
             .group("")
             .flex_none()
@@ -591,8 +601,12 @@ impl RenderOnce for ButtonLike {
                 }
             })
             .when(!self.disabled, |this| {
+                let hovered_style = style.hovered(self.layer, cx);
+                let focus_color =
+                    |refinement: StyleRefinement| refinement.bg(hovered_style.background);
                 this.cursor(self.cursor_style)
-                    .hover(|hover| hover.bg(style.hovered(self.layer, cx).background))
+                    .hover(focus_color)
+                    .focus(focus_color)
                     .active(|active| active.bg(style.active(cx).background))
             })
             .when_some(

--- a/crates/ui/src/components/button/icon_button.rs
+++ b/crates/ui/src/components/button/icon_button.rs
@@ -164,6 +164,11 @@ impl ButtonCommon for IconButton {
         self
     }
 
+    fn tab_index(mut self, tab_index: impl Into<isize>) -> Self {
+        self.base = self.base.tab_index(tab_index);
+        self
+    }
+
     fn layer(mut self, elevation: ElevationIndex) -> Self {
         self.base = self.base.layer(elevation);
         self

--- a/crates/ui/src/components/button/toggle_button.rs
+++ b/crates/ui/src/components/button/toggle_button.rs
@@ -412,6 +412,7 @@ where
     size: ToggleButtonGroupSize,
     button_width: Rems,
     selected_index: usize,
+    tab_index: Option<isize>,
 }
 
 impl<T: ButtonBuilder, const COLS: usize> ToggleButtonGroup<T, COLS> {
@@ -423,6 +424,7 @@ impl<T: ButtonBuilder, const COLS: usize> ToggleButtonGroup<T, COLS> {
             size: ToggleButtonGroupSize::Default,
             button_width: rems_from_px(100.),
             selected_index: 0,
+            tab_index: None,
         }
     }
 }
@@ -436,6 +438,7 @@ impl<T: ButtonBuilder, const COLS: usize> ToggleButtonGroup<T, COLS, 2> {
             size: ToggleButtonGroupSize::Default,
             button_width: rems_from_px(100.),
             selected_index: 0,
+            tab_index: None,
         }
     }
 }
@@ -460,6 +463,15 @@ impl<T: ButtonBuilder, const COLS: usize, const ROWS: usize> ToggleButtonGroup<T
         self.selected_index = index;
         self
     }
+
+    /// Sets the tab index for the toggle button group.
+    /// The tab index is set to the initial value provided, then the
+    /// value is incremented by the number of buttons in the group.
+    pub fn tab_index(mut self, tab_index: &mut isize) -> Self {
+        self.tab_index = Some(*tab_index);
+        *tab_index += (COLS * ROWS) as isize;
+        self
+    }
 }
 
 impl<T: ButtonBuilder, const COLS: usize, const ROWS: usize> RenderOnce
@@ -479,6 +491,9 @@ impl<T: ButtonBuilder, const COLS: usize, const ROWS: usize> RenderOnce
                     let entry_index = row_index * COLS + col_index;
 
                     ButtonLike::new((self.group_name, entry_index))
+                        .when_some(self.tab_index, |this, tab_index| {
+                            this.tab_index(tab_index + entry_index as isize)
+                        })
                         .when(entry_index == self.selected_index || selected, |this| {
                             this.toggle_state(true)
                                 .selected_style(ButtonStyle::Tinted(TintColor::Accent))

--- a/crates/ui/src/components/button/toggle_button.rs
+++ b/crates/ui/src/components/button/toggle_button.rs
@@ -121,6 +121,11 @@ impl ButtonCommon for ToggleButton {
         self
     }
 
+    fn tab_index(mut self, tab_index: impl Into<isize>) -> Self {
+        self.base = self.base.tab_index(tab_index);
+        self
+    }
+
     fn layer(mut self, elevation: ElevationIndex) -> Self {
         self.base = self.base.layer(elevation);
         self

--- a/crates/ui/src/components/numeric_stepper.rs
+++ b/crates/ui/src/components/numeric_stepper.rs
@@ -19,6 +19,7 @@ pub struct NumericStepper {
     /// Whether to reserve space for the reset button.
     reserve_space_for_reset: bool,
     on_reset: Option<Box<dyn Fn(&ClickEvent, &mut Window, &mut App) + 'static>>,
+    tab_index: Option<isize>,
 }
 
 impl NumericStepper {
@@ -36,6 +37,7 @@ impl NumericStepper {
             on_increment: Box::new(on_increment),
             reserve_space_for_reset: false,
             on_reset: None,
+            tab_index: None,
         }
     }
 
@@ -56,6 +58,11 @@ impl NumericStepper {
         self.on_reset = Some(Box::new(on_reset));
         self
     }
+
+    pub fn tab_index(mut self, tab_index: isize) -> Self {
+        self.tab_index = Some(tab_index);
+        self
+    }
 }
 
 impl RenderOnce for NumericStepper {
@@ -64,6 +71,7 @@ impl RenderOnce for NumericStepper {
         let icon_size = IconSize::Small;
 
         let is_outlined = matches!(self.style, NumericStepperStyle::Outlined);
+        let mut tab_index = self.tab_index;
 
         h_flex()
             .id(self.id)
@@ -74,6 +82,10 @@ impl RenderOnce for NumericStepper {
                         IconButton::new("reset", IconName::RotateCcw)
                             .shape(shape)
                             .icon_size(icon_size)
+                            .when_some(tab_index.as_mut(), |this, tab_index| {
+                                *tab_index += 1;
+                                this.tab_index(*tab_index - 1)
+                            })
                             .on_click(on_reset),
                     )
                 } else if self.reserve_space_for_reset {
@@ -113,6 +125,12 @@ impl RenderOnce for NumericStepper {
                                     .border_r_1()
                                     .border_color(cx.theme().colors().border_variant)
                                     .child(Icon::new(IconName::Dash).size(IconSize::Small))
+                                    .when_some(tab_index.as_mut(), |this, tab_index| {
+                                        *tab_index += 1;
+                                        this.tab_index(*tab_index - 1).focus(|style| {
+                                            style.bg(cx.theme().colors().element_hover)
+                                        })
+                                    })
                                     .on_click(self.on_decrement),
                             )
                         } else {
@@ -120,6 +138,10 @@ impl RenderOnce for NumericStepper {
                                 IconButton::new("decrement", IconName::Dash)
                                     .shape(shape)
                                     .icon_size(icon_size)
+                                    .when_some(tab_index.as_mut(), |this, tab_index| {
+                                        *tab_index += 1;
+                                        this.tab_index(*tab_index - 1)
+                                    })
                                     .on_click(self.on_decrement),
                             )
                         }
@@ -137,6 +159,12 @@ impl RenderOnce for NumericStepper {
                                     .border_l_1()
                                     .border_color(cx.theme().colors().border_variant)
                                     .child(Icon::new(IconName::Plus).size(IconSize::Small))
+                                    .when_some(tab_index.as_mut(), |this, tab_index| {
+                                        *tab_index += 1;
+                                        this.tab_index(*tab_index - 1).focus(|style| {
+                                            style.bg(cx.theme().colors().element_hover)
+                                        })
+                                    })
                                     .on_click(self.on_increment),
                             )
                         } else {
@@ -144,6 +172,10 @@ impl RenderOnce for NumericStepper {
                                 IconButton::new("increment", IconName::Dash)
                                     .shape(shape)
                                     .icon_size(icon_size)
+                                    .when_some(tab_index.as_mut(), |this, tab_index| {
+                                        *tab_index += 1;
+                                        this.tab_index(*tab_index - 1)
+                                    })
                                     .on_click(self.on_increment),
                             )
                         }


### PR DESCRIPTION
Closes #ISSUE

Allows tabbing through everything in all three pages. Until #35075 is merged it is not possible to actually "click" tab focused buttons with the keyboard. 

Additionally adds an action `onboarding::Finish` and displays the keybind. The action corresponds to both the "Skip all" and "Start Building" buttons, with the keybind displayed similar to how it is for the page nav buttons

Release Notes:

- N/A *or* Added/Fixed/Improved ...
