### PR TITLE
Add key contexts for Pickers

### DIFF
--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -136,7 +136,10 @@ impl Focusable for CommandPalette {
 
 impl Render for CommandPalette {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex()
+            .key_context("CommandPalette")
+            .w(rems(34.))
+            .child(self.picker.clone())
     }
 }
 

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -180,6 +180,7 @@ impl Focusable for BranchList {
 impl Render for BranchList {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
+            .key_context("GitBranchSelector")
             .w(self.width)
             .on_modifiers_changed(cx.listener(Self::handle_modifiers_changed))
             .child(self.picker.clone())

--- a/crates/git_ui/src/repository_selector.rs
+++ b/crates/git_ui/src/repository_selector.rs
@@ -109,7 +109,10 @@ impl Focusable for RepositorySelector {
 
 impl Render for RepositorySelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        div().w(self.width).child(self.picker.clone())
+        div()
+            .key_context("GitRepositorySelector")
+            .w(self.width)
+            .child(self.picker.clone())
     }
 }
 

--- a/crates/language_selector/src/language_selector.rs
+++ b/crates/language_selector/src/language_selector.rs
@@ -86,7 +86,10 @@ impl LanguageSelector {
 
 impl Render for LanguageSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex()
+            .key_context("LanguageSelector")
+            .w(rems(34.))
+            .child(self.picker.clone())
     }
 }
 

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -141,6 +141,7 @@ impl Focusable for RecentProjects {
 impl Render for RecentProjects {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
+            .key_context("RecentProjects")
             .w(rems(self.rem_width))
             .child(self.picker.clone())
             .on_mouse_down_out(cx.listener(|this, _, window, cx| {

--- a/crates/theme_selector/src/icon_theme_selector.rs
+++ b/crates/theme_selector/src/icon_theme_selector.rs
@@ -40,7 +40,10 @@ impl IconThemeSelector {
 
 impl Render for IconThemeSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex()
+            .key_context("IconThemeSelector")
+            .w(rems(34.))
+            .child(self.picker.clone())
     }
 }
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -92,7 +92,10 @@ impl Focusable for ThemeSelector {
 
 impl Render for ThemeSelector {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+        v_flex()
+            .key_context("ThemeSelector")
+            .w(rems(34.))
+            .child(self.picker.clone())
     }
 }
 


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/35430

Added:
- Workspace > CommandPalette
- Workspace > GitBranchSelector
- Workspace > GitRepositorySelector
- Workspace > RecentProjects
- Workspace > LanguageSelector
- Workspace > IconThemeSelector
- Workspace > ThemeSelector

Release Notes:

- Added new keymap contexts for various Pickers - CommandPalette, GitBranchSelector, GitRepositorySelector, RecentProjects, LanguageSelector, IconThemeSelector, ThemeSelector