### PR TITLE
ci: Re-enable FreeBSD remote-server builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -701,12 +701,10 @@ jobs:
 
   freebsd:
     timeout-minutes: 60
-    runs-on: github-8vcpu-ubuntu-2404
+    runs-on: github-16vcpu-ubuntu-2404
     if: |
-      false && (
       startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling')
-      )
     needs: [linux_tests]
     name: Build Zed on FreeBSD
     steps:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -202,8 +202,8 @@ jobs:
 
   freebsd:
     timeout-minutes: 60
-    if: false && github.repository_owner == 'zed-industries'
-    runs-on: github-8vcpu-ubuntu-2404
+    if: github.repository_owner == 'zed-industries'
+    runs-on: github-16vcpu-ubuntu-2404
     needs: tests
     name: Build Zed on FreeBSD
     # env:


### PR DESCRIPTION
Previously:
- https://github.com/zed-industries/zed/pull/34511

I think this may have been caused by out of memory, hence the SIGKILL in the logs.  We recently started having similar random failures on our Linux ARM release builds ([failing job](https://github.com/zed-industries/zed/actions/runs/16756464120/job/47442060663)) which had 24GB of ram until https://github.com/zed-industries/zed/pull/35654.

So after this release build runners would have:
- 48GB (Linux aarch64)
- 48GB (macOS aarch64)
- 64GB (FreeBSD x86_64) was 32GB
- 64GB (Linux x86_64)
- 128GB (Windows x86_64)

We'll see!

Release Notes:

- Reinstate FreeBSD zed-remote-server builds
