### PR TITLE
Use the same prompt as agent thread summary for text threads

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -8,7 +8,7 @@ use crate::{
     },
     tool_use::{PendingToolUse, ToolUse, ToolUseMetadata, ToolUseState},
 };
-use agent_settings::{AgentProfileId, AgentSettings, CompletionMode};
+use agent_settings::{AgentProfileId, AgentSettings, CompletionMode, SUMMARIZE_THREAD_PROMPT};
 use anyhow::{Result, anyhow};
 use assistant_tool::{ActionLog, AnyToolCard, Tool, ToolWorkingSet};
 use chrono::{DateTime, Utc};
@@ -2112,12 +2112,10 @@ impl Thread {
             return;
         }
 
-        let added_user_message = include_str!("./prompts/summarize_thread_prompt.txt");
-
         let request = self.to_summarize_request(
             &model.model,
             CompletionIntent::ThreadSummarization,
-            added_user_message.into(),
+            SUMMARIZE_THREAD_PROMPT.into(),
             cx,
         );
 

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -13,6 +13,9 @@ use std::borrow::Cow;
 
 pub use crate::agent_profile::*;
 
+pub const SUMMARIZE_THREAD_PROMPT: &str =
+    include_str!("../../agent/src/prompts/summarize_thread_prompt.txt");
+
 pub fn init(cx: &mut App) {
     AgentSettings::register(cx);
 }

--- a/crates/assistant_context/src/assistant_context.rs
+++ b/crates/assistant_context/src/assistant_context.rs
@@ -2,7 +2,7 @@
 mod assistant_context_tests;
 mod context_store;
 
-use agent_settings::AgentSettings;
+use agent_settings::{AgentSettings, SUMMARIZE_THREAD_PROMPT};
 use anyhow::{Context as _, Result, bail};
 use assistant_slash_command::{
     SlashCommandContent, SlashCommandEvent, SlashCommandLine, SlashCommandOutputSection,
@@ -2677,10 +2677,7 @@ impl AssistantContext {
             let mut request = self.to_completion_request(Some(&model.model), cx);
             request.messages.push(LanguageModelRequestMessage {
                 role: Role::User,
-                content: vec![
-                    "Generate a concise 3-7 word title for this conversation, omitting punctuation. Go straight to the title, without any preamble and prefix like `Here's a concise suggestion:...` or `Title:`"
-                        .into(),
-                ],
+                content: vec![SUMMARIZE_THREAD_PROMPT.into()],
                 cache: false,
             });
 


### PR DESCRIPTION
This was causing text thread summarization to be counted as a usage of 1 prompt

Release Notes:

- Fixed bug with agent text threads (not chat threads) counting summarization as a usage of 1 prompt.