### PR TITLE
Add option to include folders in file finder

### DIFF
--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -9,6 +9,7 @@ pub struct FileFinderSettings {
     pub modal_max_width: Option<FileFinderWidth>,
     pub skip_focus_for_active_in_search: bool,
     pub include_ignored: Option<bool>,
+    pub include_folders: Option<bool>,
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
@@ -39,6 +40,10 @@ pub struct FileFinderSettingsContent {
     ///
     /// Default: None
     pub include_ignored: Option<Option<bool>>,
+    /// Determines whether to include folders or not in the file finder.
+    ///
+    /// Default: false
+    pub include_folders: Option<bool>,
 }
 
 impl Settings for FileFinderSettings {


### PR DESCRIPTION
This PR adds an option to include folders in file finder results.

## Changes
- Added setting to include directory entries in file finder results
- Modified file finder to respect this setting
- Updated tests to verify folder inclusion functionality