### PR TITLE
Emacs: Reset selection mark mode after a non-movement action

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1154,6 +1154,7 @@ pub struct Editor {
     /// Whether we are temporarily displaying a diff other than git's
     temporary_diff_override: bool,
     selection_mark_mode: bool,
+    continue_selection_mark_mode: bool,
     toggle_fold_multiple_buffers: Task<()>,
     _scroll_cursor_center_top_bottom_task: Task<()>,
     serialize_selections: Task<()>,
@@ -2184,6 +2185,7 @@ impl Editor {
             registered_buffers: HashMap::default(),
             _scroll_cursor_center_top_bottom_task: Task::ready(()),
             selection_mark_mode: false,
+            continue_selection_mark_mode: false,
             toggle_fold_multiple_buffers: Task::ready(()),
             serialize_selections: Task::ready(()),
             serialize_folds: Task::ready(()),
@@ -12335,7 +12337,9 @@ impl Editor {
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.change_selections(Default::default(), window, cx, |s| {
             s.move_heads_with(|map, head, _| (movement::left(map, head), SelectionGoal::None));
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_right(&mut self, _: &MoveRight, window: &mut Window, cx: &mut Context<Self>) {
@@ -12356,7 +12360,9 @@ impl Editor {
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.change_selections(Default::default(), window, cx, |s| {
             s.move_heads_with(|map, head, _| (movement::right(map, head), SelectionGoal::None));
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_up(&mut self, _: &MoveUp, window: &mut Window, cx: &mut Context<Self>) {
@@ -12483,7 +12489,9 @@ impl Editor {
             s.move_heads_with(|map, head, goal| {
                 movement::down_by_rows(map, head, action.lines, goal, false, text_layout_details)
             })
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_up_by_lines(
@@ -12498,7 +12506,9 @@ impl Editor {
             s.move_heads_with(|map, head, goal| {
                 movement::up_by_rows(map, head, action.lines, goal, false, text_layout_details)
             })
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_page_up(
@@ -12519,7 +12529,9 @@ impl Editor {
             s.move_heads_with(|map, head, goal| {
                 movement::up_by_rows(map, head, row_count, goal, false, text_layout_details)
             })
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_page_up(
@@ -12586,7 +12598,9 @@ impl Editor {
             s.move_heads_with(|map, head, goal| {
                 movement::up(map, head, goal, false, text_layout_details)
             })
-        })
+        });
+
+        self.continue_selection_mark_mode = true;
     }
 
     pub fn move_down(&mut self, _: &MoveDown, window: &mut Window, cx: &mut Context<Self>) {
@@ -12643,7 +12657,9 @@ impl Editor {
             s.move_heads_with(|map, head, goal| {
                 movement::down_by_rows(map, head, row_count, goal, false, text_layout_details)
             })
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_page_down(
@@ -12710,6 +12726,8 @@ impl Editor {
                 movement::down(map, head, goal, false, text_layout_details)
             })
         });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn context_menu_first(
@@ -12836,7 +12854,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_to_previous_subword_start(
@@ -12853,7 +12873,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn delete_to_previous_word_start(
@@ -12941,7 +12963,9 @@ impl Editor {
             s.move_heads_with(|map, head, _| {
                 (movement::next_word_end(map, head), SelectionGoal::None)
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_to_next_subword_end(
@@ -12955,7 +12979,9 @@ impl Editor {
             s.move_heads_with(|map, head, _| {
                 (movement::next_subword_end(map, head), SelectionGoal::None)
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn delete_to_next_word_end(
@@ -13044,6 +13070,8 @@ impl Editor {
                 )
             });
         });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn delete_to_beginning_of_line(
@@ -13103,7 +13131,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn delete_to_end_of_line(
@@ -13204,7 +13234,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_to_end_of_paragraph(
@@ -13225,7 +13257,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_to_start_of_excerpt(
@@ -13346,7 +13380,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_to_start_of_next_excerpt(
@@ -13367,7 +13403,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_to_end_of_excerpt(
@@ -13388,7 +13426,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_to_end_of_previous_excerpt(
@@ -13409,7 +13449,9 @@ impl Editor {
                     SelectionGoal::None,
                 )
             });
-        })
+        });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_to_beginning(
@@ -13440,6 +13482,8 @@ impl Editor {
         self.change_selections(Default::default(), window, cx, |s| {
             s.select(vec![selection]);
         });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn move_to_end(&mut self, _: &MoveToEnd, window: &mut Window, cx: &mut Context<Self>) {
@@ -13518,6 +13562,8 @@ impl Editor {
         self.change_selections(Default::default(), window, cx, |s| {
             s.select(vec![selection]);
         });
+
+        self.continue_selection_mark_mode = self.selection_mark_mode;
     }
 
     pub fn select_all(&mut self, _: &SelectAll, window: &mut Window, cx: &mut Context<Self>) {
@@ -17065,7 +17111,22 @@ impl Editor {
             })
         }
         self.selection_mark_mode = true;
+        self.continue_selection_mark_mode = true;
         cx.notify();
+    }
+
+    pub fn reset_mark(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if self.selection_mark_mode && !self.continue_selection_mark_mode {
+            self.change_selections(SelectionEffects::no_scroll(), window, cx, |s| {
+                s.move_with(|_, sel| {
+                    sel.collapse_to(sel.head(), SelectionGoal::None);
+                });
+            });
+
+            self.selection_mark_mode = false;
+        }
+
+        self.continue_selection_mark_mode = false;
     }
 
     pub fn swap_selection_ends(

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9977,6 +9977,7 @@ pub fn register_action<T: Action>(
         if phase == DispatchPhase::Bubble {
             editor.update(cx, |editor, cx| {
                 listener(editor, action, window, cx);
+                editor.reset_mark(window, cx);
             })
         }
     })


### PR DESCRIPTION
* If the editor is in selection mark mode and an action other than movement occurs, the editor needs to exit selection mark mode.
* A movement action will not change the status of selection mark mode. `continue_selection_mark_mode` flag is added to allow such actions to notify that it does not want to change the status.

Release Notes:

- Improved: Reset selection mark mode after an action.

**Problem**

Zed has Emacs-like selection mode. It can be activated using `set_mark` action. However after selection mark mode is activated (e.g. by using ctrl-space), it keeps working until it is canceled (e.g. by using ctrl-g). It would be nice if the selection mark mode can be deactivated automatically after any non-movement action.

**Solution**

Since there are so many supported action, deactivating selection mark mode in every actions would create a big change. In this pull request, a new variable named `continue_selection_mark_mode` is added to `Editor` so that movement actions can keep the mode going while all other actions by default deactivate selection mark mode.
