### PR TITLE
file_finder: Fix right border not rendering

### DIFF
--- a/crates/file_finder/src/file_finder.rs
+++ b/crates/file_finder/src/file_finder.rs
@@ -17,7 +17,7 @@ use fuzzy::{CharBag, PathMatch, PathMatchCandidate};
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
     KeyContext, Modifiers, ModifiersChangedEvent, ParentElement, Render, Styled, Task, WeakEntity,
-    Window, actions,
+    Window, actions, rems,
 };
 use open_path_prompt::OpenPathPrompt;
 use picker::{Picker, PickerDelegate};
@@ -350,7 +350,7 @@ impl FileFinder {
 
     pub fn modal_max_width(width_setting: Option<FileFinderWidth>, window: &mut Window) -> Pixels {
         let window_width = window.viewport_size().width;
-        let small_width = Pixels(545.);
+        let small_width = rems(34.).to_pixels(window.rem_size());
 
         match width_setting {
             None | Some(FileFinderWidth::Small) => small_width,


### PR DESCRIPTION
Closes #35683

Release Notes:

- Fixed file finder borders not rendering properly

Before: 

<img width="1921" height="1081" alt="image" src="https://github.com/user-attachments/assets/62f39bfb-3e0e-43af-a00a-a6c378b067fc" />

After:

<img width="1921" height="1081" alt="image" src="https://github.com/user-attachments/assets/b9a00e4c-c126-40a4-9a63-8e44396a0e84" />
