### PR TITLE
Implement Helix match mode (`m i` and `m a`)

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -386,7 +386,7 @@
       "right": "vim::WrappingRight",
       "h": "vim::WrappingLeft",
       "l": "vim::WrappingRight",
-      "y": "editor::Copy",
+      "y": "vim::HelixYank",
       "alt-;": "vim::OtherEnd",
       "ctrl-r": "vim::Redo",
       "f": ["vim::PushFindForward", { "before": false, "multiline": true }],

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -426,7 +426,7 @@
       "g c": "vim::WindowMiddle",
       "g b": "vim::WindowBottom",
 
-      "x": "editor::SelectLine",
+      "x": "vim::HelixSelectLine",
       "shift-x": "editor::SelectLine",
       "%": "editor::SelectAll",
       // Window mode

--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -379,6 +379,7 @@
     "bindings": {
       "i": "vim::HelixInsert",
       "a": "vim::HelixAppend",
+      "m": "vim::PushHelixMatchMode",
       "ctrl-[": "editor::Cancel",
       ";": "vim::HelixCollapseSelection",
       ":": "command_palette::Toggle",
@@ -452,8 +453,8 @@
       "space y": "editor::Copy",
       "space p": "editor::Paste",
       // Match mode
-      "m m": "vim::Matching",
-      "m i w": ["workspace::SendKeystrokes", "v i w"],
+      // "m m": "vim::Matching",
+      // "m i w": ["workspace::SendKeystrokes", "v i w"],
       "shift-u": "editor::Redo",
       "ctrl-c": "editor::ToggleComments",
       "d": "vim::HelixDelete",
@@ -462,6 +463,12 @@
       "alt-shift-c": "editor::AddSelectionAbove"
     }
   },
+  // {
+  //   "context": "VimControl && vim_mode == helix_normal && !menu",
+  //   "bindings": {
+  //     "m": "vim::Matching"
+  //   }
+  // },
   {
     "context": "vim_mode == insert && !(showing_code_actions || showing_completions)",
     "bindings": {

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -2,10 +2,10 @@
 //! in editor given a given motion (e.g. it handles converting a "move left" command into coordinates in editor). It is exposed mostly for use by vim crate.
 
 use super::{Bias, DisplayPoint, DisplaySnapshot, SelectionGoal, ToDisplayPoint};
-use crate::{DisplayRow, EditorStyle, ToOffset, ToPoint, scroll::ScrollAnchor};
+use crate::{DisplayRow, EditorStyle, scroll::ScrollAnchor};
 use gpui::{Pixels, WindowTextSystem};
 use language::Point;
-use multi_buffer::{MultiBufferRow, MultiBufferSnapshot};
+use multi_buffer::MultiBufferRow;
 use serde::Deserialize;
 use workspace::searchable::Direction;
 
@@ -527,7 +527,7 @@ pub fn find_preceding_boundary_display_point(
         prev_ch = Some(ch);
     }
 
-    map.clip_point(offset.to_display_point(map), Bias::Left)
+    offset.to_display_point(map)
 }
 
 /// Scans for a boundary following the given start point until a boundary is found, indicated by the

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1,7 +1,9 @@
-use editor::{DisplayPoint, Editor, SelectionEffects, ToOffset, ToPoint, movement};
+use editor::{
+    DisplayPoint, Editor, HideMouseCursorOrigin, SelectionEffects, ToOffset, ToPoint, movement,
+};
 use gpui::{Action, actions};
 use gpui::{Context, Window};
-use language::{CharClassifier, CharKind};
+use language::{CharClassifier, CharKind, Point};
 use text::{Bias, SelectionGoal};
 
 use crate::{
@@ -19,6 +21,8 @@ actions!(
         HelixInsert,
         /// Appends at the end of the selection.
         HelixAppend,
+        /// Select entire line or multiple lines, extending downwards.
+        HelixSelectLine,
     ]
 );
 
@@ -26,6 +30,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::helix_normal_after);
     Vim::action(editor, cx, Vim::helix_insert);
     Vim::action(editor, cx, Vim::helix_append);
+    Vim::action(editor, cx, Vim::helix_select_lines);
 }
 
 impl Vim {
@@ -415,6 +420,41 @@ impl Vim {
         });
         self.switch_mode(Mode::HelixNormal, true, window, cx);
     }
+
+    pub fn helix_select_lines(
+        &mut self,
+        _: &HelixSelectLine,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        let count = Vim::take_count(cx).unwrap_or(1);
+        self.update_editor(window, cx, |_, editor, window, cx| {
+            editor.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
+            let display_map = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
+            let mut selections = editor.selections.all::<Point>(cx);
+            let max_point = display_map.buffer_snapshot.max_point();
+
+            for selection in &mut selections {
+                // Start always goes to column 0 of the first selected line
+                let start_row = selection.start.row;
+                let current_end_row = selection.end.row;
+
+                let end_row = current_end_row + count as u32;
+
+                selection.start = Point::new(start_row, 0);
+                selection.end = if end_row > max_point.row {
+                    max_point
+                } else {
+                    Point::new(end_row, 0)
+                };
+                selection.reversed = false;
+            }
+
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.select(selections);
+            });
+        });
+    }
 }
 
 #[cfg(test)]
@@ -702,5 +742,81 @@ mod test {
         cx.simulate_keystrokes("r x");
 
         cx.assert_state("«xxˇ»", Mode::HelixNormal);
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_n_lines(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.set_state(
+            "line one\nline ˇtwo\nline three\nline four",
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("2 x");
+        cx.assert_state(
+            "line one\n«line two\nline three\nˇ»line four",
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_lines_with_selection(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        // Test extending existing line selection
+        cx.set_state(
+            indoc! {"
+            li«ˇne one
+            li»ne two
+            line three
+            line four"},
+            Mode::HelixNormal,
+        );
+
+        cx.simulate_keystrokes("x");
+
+        cx.assert_state(
+            indoc! {"
+            «line one
+            line two
+            ˇ»line three
+            line four"},
+            Mode::HelixNormal,
+        );
+    }
+
+    #[gpui::test]
+    async fn test_helix_select_lines_with_merging(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        // Test selecting multiple lines with count
+        cx.set_state(
+            indoc! {"
+            ˇline one
+            line two
+            line threeˇ
+            line four
+            line five"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            «line one
+            ˇ»line two
+            «line three
+            ˇ»line four
+            line five"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            «line one
+            line two
+            line three
+            line four
+            ˇ»line five"},
+            Mode::HelixNormal,
+        );
     }
 }

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -433,13 +433,19 @@ impl Vim {
             let display_map = editor.display_map.update(cx, |map, cx| map.snapshot(cx));
             let mut selections = editor.selections.all::<Point>(cx);
             let max_point = display_map.buffer_snapshot.max_point();
+            let buffer_snapshot = &display_map.buffer_snapshot;
 
             for selection in &mut selections {
                 // Start always goes to column 0 of the first selected line
                 let start_row = selection.start.row;
                 let current_end_row = selection.end.row;
 
-                let end_row = current_end_row + count as u32;
+                // Check if cursor is on empty line by checking first character
+                let line_start_offset = buffer_snapshot.point_to_offset(Point::new(start_row, 0));
+                let first_char = buffer_snapshot.chars_at(line_start_offset).next();
+                let extra_line = if first_char == Some('\n') { 1 } else { 0 };
+
+                let end_row = current_end_row + count as u32 + extra_line;
 
                 selection.start = Point::new(start_row, 0);
                 selection.end = if end_row > max_point.row {
@@ -745,7 +751,7 @@ mod test {
     }
 
     #[gpui::test]
-    async fn test_helix_select_n_lines(cx: &mut gpui::TestAppContext) {
+    async fn test_helix_select_lines(cx: &mut gpui::TestAppContext) {
         let mut cx = VimTestContext::new(cx, true).await;
         cx.set_state(
             "line one\nline ˇtwo\nline three\nline four",
@@ -756,11 +762,6 @@ mod test {
             "line one\n«line two\nline three\nˇ»line four",
             Mode::HelixNormal,
         );
-    }
-
-    #[gpui::test]
-    async fn test_helix_select_lines_with_selection(cx: &mut gpui::TestAppContext) {
-        let mut cx = VimTestContext::new(cx, true).await;
 
         // Test extending existing line selection
         cx.set_state(
@@ -771,9 +772,7 @@ mod test {
             line four"},
             Mode::HelixNormal,
         );
-
         cx.simulate_keystrokes("x");
-
         cx.assert_state(
             indoc! {"
             «line one
@@ -782,11 +781,80 @@ mod test {
             line four"},
             Mode::HelixNormal,
         );
-    }
 
-    #[gpui::test]
-    async fn test_helix_select_lines_with_merging(cx: &mut gpui::TestAppContext) {
-        let mut cx = VimTestContext::new(cx, true).await;
+        // Pressing x in empty line, select next line (because helix considers cursor a selection)
+        cx.set_state(
+            indoc! {"
+            line one
+            ˇ
+            line three
+            line four"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            line one
+            «
+            line three
+            ˇ»line four"},
+            Mode::HelixNormal,
+        );
+
+        // Empty line with count selects extra + count lines
+        cx.set_state(
+            indoc! {"
+            line one
+            ˇ
+            line three
+            line four
+            line five"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("2 x");
+        cx.assert_state(
+            indoc! {"
+            line one
+            «
+            line three
+            line four
+            ˇ»line five"},
+            Mode::HelixNormal,
+        );
+
+        // Compare empty vs non-empty line behavior
+        cx.set_state(
+            indoc! {"
+            ˇnon-empty line
+            line two
+            line three"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            «non-empty line
+            ˇ»line two
+            line three"},
+            Mode::HelixNormal,
+        );
+
+        // Same test but with empty line - should select one extra
+        cx.set_state(
+            indoc! {"
+            ˇ
+            line two
+            line three"},
+            Mode::HelixNormal,
+        );
+        cx.simulate_keystrokes("x");
+        cx.assert_state(
+            indoc! {"
+            «
+            line two
+            ˇ»line three"},
+            Mode::HelixNormal,
+        );
 
         // Test selecting multiple lines with count
         cx.set_state(

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -1,7 +1,6 @@
-use editor::{DisplayPoint, Editor, SelectionEffects, ToOffset, ToPoint, movement};
+use editor::{Editor, SelectionEffects, ToOffset, ToPoint, movement};
 use gpui::{Action, actions};
 use gpui::{Context, Window};
-use language::{CharClassifier, CharKind};
 use text::{Bias, SelectionGoal};
 
 use crate::{
@@ -45,129 +44,50 @@ impl Vim {
         return;
     }
 
-    pub fn helix_normal_motion(
-        &mut self,
-        motion: Motion,
-        times: Option<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.helix_move_cursor(motion, times, window, cx);
-    }
-
-    fn helix_find_range_forward(
+    // Helix motion which creates a selection
+    fn helix_move_and_select(
         &mut self,
         times: Option<usize>,
         window: &mut Window,
         cx: &mut Context<Self>,
-        mut is_boundary: impl FnMut(char, char, &CharClassifier) -> bool,
+        motion: Motion, //mut is_boundary: impl FnMut(char, char, &CharClassifier) -> bool,
     ) {
         self.update_editor(window, cx, |_, editor, window, cx| {
+            let text_layout_details = editor.text_layout_details(window);
             editor.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(|map, selection| {
-                    let times = times.unwrap_or(1);
-                    let new_goal = SelectionGoal::None;
-                    let mut head = selection.head();
-                    let mut tail = selection.tail();
+                    let goal = selection.goal;
+                    let old_point = selection.head();
+                    let was_empty = selection.is_empty();
 
-                    if head == map.max_point() {
-                        return;
+                    let (new_point, new_goal) = motion
+                        .move_point(
+                            map,
+                            old_point,
+                            selection.goal,
+                            times,
+                            &text_layout_details,
+                            true,
+                        )
+                        .unwrap_or((old_point, goal));
+
+                    selection.set_tail(old_point, goal);
+                    selection.set_head(new_point, new_goal);
+
+                    // include old position only if selection was empty
+                    if was_empty && selection.end == old_point {
+                        selection.end = movement::right(map, selection.end)
                     }
-
-                    // collapse to block cursor
-                    if tail < head {
-                        tail = movement::left(map, head);
-                    } else {
-                        tail = head;
-                        head = movement::right(map, head);
+                    // must include cursor position
+                    if selection.end == new_point {
+                        selection.end = movement::right(map, selection.end)
                     }
-
-                    // create a classifier
-                    let classifier = map.buffer_snapshot.char_classifier_at(head.to_point(map));
-
-                    for _ in 0..times {
-                        let (maybe_next_tail, next_head) =
-                            movement::find_boundary_trail(map, head, |left, right| {
-                                is_boundary(left, right, &classifier)
-                            });
-
-                        if next_head == head && maybe_next_tail.unwrap_or(next_head) == tail {
-                            break;
-                        }
-
-                        head = next_head;
-                        if let Some(next_tail) = maybe_next_tail {
-                            tail = next_tail;
-                        }
-                    }
-
-                    selection.set_tail(tail, new_goal);
-                    selection.set_head(head, new_goal);
                 });
             });
         });
     }
 
-    fn helix_find_range_backward(
-        &mut self,
-        times: Option<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-        mut is_boundary: impl FnMut(char, char, &CharClassifier) -> bool,
-    ) {
-        self.update_editor(window, cx, |_, editor, window, cx| {
-            editor.change_selections(Default::default(), window, cx, |s| {
-                s.move_with(|map, selection| {
-                    let times = times.unwrap_or(1);
-                    let new_goal = SelectionGoal::None;
-                    let mut head = selection.head();
-                    let mut tail = selection.tail();
-
-                    if head == DisplayPoint::zero() {
-                        return;
-                    }
-
-                    // collapse to block cursor
-                    if tail < head {
-                        tail = movement::left(map, head);
-                    } else {
-                        tail = head;
-                        head = movement::right(map, head);
-                    }
-
-                    selection.set_head(head, new_goal);
-                    selection.set_tail(tail, new_goal);
-                    // flip the selection
-                    selection.swap_head_tail();
-                    head = selection.head();
-                    tail = selection.tail();
-
-                    // create a classifier
-                    let classifier = map.buffer_snapshot.char_classifier_at(head.to_point(map));
-
-                    for _ in 0..times {
-                        let (maybe_next_tail, next_head) =
-                            movement::find_preceding_boundary_trail(map, head, |left, right| {
-                                is_boundary(left, right, &classifier)
-                            });
-
-                        if next_head == head && maybe_next_tail.unwrap_or(next_head) == tail {
-                            break;
-                        }
-
-                        head = next_head;
-                        if let Some(next_tail) = maybe_next_tail {
-                            tail = next_tail;
-                        }
-                    }
-
-                    selection.set_tail(tail, new_goal);
-                    selection.set_head(head, new_goal);
-                });
-            })
-        });
-    }
-
+    // Helix motion which do not create any selection
     pub fn helix_move_and_collapse(
         &mut self,
         motion: Motion,
@@ -187,7 +107,14 @@ impl Vim {
                     };
 
                     let (point, goal) = motion
-                        .move_point(map, cursor, selection.goal, times, &text_layout_details)
+                        .move_point(
+                            map,
+                            cursor,
+                            selection.goal,
+                            times,
+                            &text_layout_details,
+                            true,
+                        )
                         .unwrap_or((cursor, goal));
 
                     selection.collapse_to(point, goal)
@@ -196,7 +123,7 @@ impl Vim {
         });
     }
 
-    pub fn helix_move_cursor(
+    pub fn helix_normal_motion(
         &mut self,
         motion: Motion,
         times: Option<usize>,
@@ -204,107 +131,13 @@ impl Vim {
         cx: &mut Context<Self>,
     ) {
         match motion {
-            Motion::NextWordStart { ignore_punctuation } => {
-                self.helix_find_range_forward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && right_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::NextWordEnd { ignore_punctuation } => {
-                self.helix_find_range_forward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && left_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::PreviousWordStart { ignore_punctuation } => {
-                self.helix_find_range_backward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && left_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::PreviousWordEnd { ignore_punctuation } => {
-                self.helix_find_range_backward(times, window, cx, |left, right, classifier| {
-                    let left_kind = classifier.kind_with(left, ignore_punctuation);
-                    let right_kind = classifier.kind_with(right, ignore_punctuation);
-                    let at_newline = (left == '\n') ^ (right == '\n');
-
-                    let found = (left_kind != right_kind && right_kind != CharKind::Whitespace)
-                        || at_newline;
-
-                    found
-                })
-            }
-            Motion::FindForward { .. } => {
-                self.update_editor(window, cx, |_, editor, window, cx| {
-                    let text_layout_details = editor.text_layout_details(window);
-                    editor.change_selections(Default::default(), window, cx, |s| {
-                        s.move_with(|map, selection| {
-                            let goal = selection.goal;
-                            let cursor = if selection.is_empty() || selection.reversed {
-                                selection.head()
-                            } else {
-                                movement::left(map, selection.head())
-                            };
-
-                            let (point, goal) = motion
-                                .move_point(
-                                    map,
-                                    cursor,
-                                    selection.goal,
-                                    times,
-                                    &text_layout_details,
-                                )
-                                .unwrap_or((cursor, goal));
-                            selection.set_tail(selection.head(), goal);
-                            selection.set_head(movement::right(map, point), goal);
-                        })
-                    });
-                });
-            }
-            Motion::FindBackward { .. } => {
-                self.update_editor(window, cx, |_, editor, window, cx| {
-                    let text_layout_details = editor.text_layout_details(window);
-                    editor.change_selections(Default::default(), window, cx, |s| {
-                        s.move_with(|map, selection| {
-                            let goal = selection.goal;
-                            let cursor = if selection.is_empty() || selection.reversed {
-                                selection.head()
-                            } else {
-                                movement::left(map, selection.head())
-                            };
-
-                            let (point, goal) = motion
-                                .move_point(
-                                    map,
-                                    cursor,
-                                    selection.goal,
-                                    times,
-                                    &text_layout_details,
-                                )
-                                .unwrap_or((cursor, goal));
-                            selection.set_tail(selection.head(), goal);
-                            selection.set_head(point, goal);
-                        })
-                    });
-                });
+            Motion::NextWordStart { .. }
+            | Motion::NextWordEnd { .. }
+            | Motion::PreviousWordStart { .. }
+            | Motion::PreviousWordEnd { .. }
+            | Motion::FindForward { .. }
+            | Motion::FindBackward { .. } => {
+                return self.helix_move_and_select(times, window, cx, motion);
             }
             _ => self.helix_move_and_collapse(motion, times, window, cx),
         }

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -32,11 +32,8 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     Vim::action(editor, cx, Vim::helix_normal_after);
     Vim::action(editor, cx, Vim::helix_insert);
     Vim::action(editor, cx, Vim::helix_append);
-<<<<<<< HEAD
     Vim::action(editor, cx, Vim::helix_yank);
-=======
     Vim::action(editor, cx, Vim::helix_select_lines);
->>>>>>> helix-x
 }
 
 impl Vim {

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -40,22 +40,6 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 }
 
 impl Vim {
-    // pub fn helix_normal_after(
-    //     &mut self,
-    //     action: &HelixNormalAfter,
-    //     window: &mut Window,
-    //     cx: &mut Context<Self>,
-    // ) {
-    //     if self.active_operator().is_some() {
-    //         self.operator_stack.clear();
-    //         self.sync_vim_settings(window, cx);
-    //         return;
-    //     }
-    //     self.stop_recording_immediately(action.boxed_clone(), cx);
-    //     self.switch_mode(Mode::HelixNormal, false, window, cx);
-    //     return;
-    // }
-
     // Helix motion which creates a selection
     fn helix_move_and_select(
         &mut self,

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -703,4 +703,29 @@ mod test {
 
         cx.assert_state("«xxˇ»", Mode::HelixNormal);
     }
+
+    #[gpui::test]
+    async fn test_helix_yank(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+        cx.enable_helix();
+
+        // Test yanking current character with no selection
+        cx.set_state("hello ˇworld", Mode::HelixNormal);
+        cx.simulate_keystrokes("y");
+
+        // Test cursor remains at the same position after yanking single character
+        cx.assert_state("hello ˇworld", Mode::HelixNormal);
+        cx.shared_clipboard().assert_eq("w");
+
+        // Move cursor and yank another character
+        cx.simulate_keystrokes("l");
+        cx.simulate_keystrokes("y");
+        cx.shared_clipboard().assert_eq("o");
+
+        // Test yanking with existing selection
+        cx.set_state("hello «worlˇ»d", Mode::HelixNormal);
+        cx.simulate_keystrokes("y");
+        cx.shared_clipboard().assert_eq("worl");
+        cx.assert_state("hello «worlˇ»d", Mode::HelixNormal);
+    }
 }

--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -88,42 +88,6 @@ impl Vim {
         });
     }
 
-    // Helix motion which do not create any selection
-    pub fn helix_move_and_collapse(
-        &mut self,
-        motion: Motion,
-        times: Option<usize>,
-        window: &mut Window,
-        cx: &mut Context<Self>,
-    ) {
-        self.update_editor(window, cx, |_, editor, window, cx| {
-            let text_layout_details = editor.text_layout_details(window);
-            editor.change_selections(Default::default(), window, cx, |s| {
-                s.move_with(|map, selection| {
-                    let goal = selection.goal;
-                    let cursor = if selection.is_empty() || selection.reversed {
-                        selection.head()
-                    } else {
-                        movement::left(map, selection.head())
-                    };
-
-                    let (point, goal) = motion
-                        .move_point(
-                            map,
-                            cursor,
-                            selection.goal,
-                            times,
-                            &text_layout_details,
-                            true,
-                        )
-                        .unwrap_or((cursor, goal));
-
-                    selection.collapse_to(point, goal)
-                })
-            });
-        });
-    }
-
     fn helix_find_range_forward(
         &mut self,
         times: Option<usize>,
@@ -234,6 +198,42 @@ impl Vim {
                     selection.set_head(head, new_goal);
                 });
             })
+        });
+    }
+
+    // Helix motion which do not create any selection
+    pub fn helix_move_and_collapse(
+        &mut self,
+        motion: Motion,
+        times: Option<usize>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) {
+        self.update_editor(window, cx, |_, editor, window, cx| {
+            let text_layout_details = editor.text_layout_details(window);
+            editor.change_selections(Default::default(), window, cx, |s| {
+                s.move_with(|map, selection| {
+                    let goal = selection.goal;
+                    let cursor = if selection.is_empty() || selection.reversed {
+                        selection.head()
+                    } else {
+                        movement::left(map, selection.head())
+                    };
+
+                    let (point, goal) = motion
+                        .move_point(
+                            map,
+                            cursor,
+                            selection.goal,
+                            times,
+                            &text_layout_details,
+                            true,
+                        )
+                        .unwrap_or((cursor, goal));
+
+                    selection.collapse_to(point, goal)
+                })
+            });
         });
     }
 

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1836,7 +1836,7 @@ fn previous_word_start(
 
 fn previous_word_end(
     map: &DisplaySnapshot,
-    mut point: DisplayPoint,
+    point: DisplayPoint,
     ignore_punctuation: bool,
     times: usize,
 ) -> DisplayPoint {
@@ -1844,12 +1844,16 @@ fn previous_word_end(
         .buffer_snapshot
         .char_classifier_at(point.to_point(map))
         .ignore_punctuation(ignore_punctuation);
+    let mut point = point.to_point(map);
 
-    // if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
-    //     if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
-    //         point.column += ch.len_utf8() as u32;
-    //     }
-    // }
+    if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+        if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
+            point.column += ch.len_utf8() as u32;
+        }
+    }
+
+    let mut point = point.to_display_point(map);
+
     for _ in 0..times {
         let new_point =
             movement::find_preceding_boundary(&map, point, FindRange::MultiLine, |left, right| {

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -1,9 +1,7 @@
 use editor::{
     Anchor, Bias, DisplayPoint, Editor, RowExt, ToOffset, ToPoint,
     display_map::{DisplayRow, DisplaySnapshot, FoldPoint, ToDisplayPoint},
-    movement::{
-        self, FindRange, TextLayoutDetails, find_boundary, find_preceding_boundary_display_point,
-    },
+    movement::{self, FindRange, TextLayoutDetails, find_boundary, find_preceding_boundary},
 };
 use gpui::{Action, Context, Window, actions, px};
 use language::{CharKind, Point, Selection, SelectionGoal};
@@ -961,6 +959,7 @@ impl Motion {
         goal: SelectionGoal,
         maybe_times: Option<usize>,
         text_layout_details: &TextLayoutDetails,
+        helix_mode: bool,
     ) -> Option<(DisplayPoint, SelectionGoal)> {
         let times = maybe_times.unwrap_or(1);
         use Motion::*;
@@ -983,7 +982,11 @@ impl Motion {
             Right => (right(map, point, times), SelectionGoal::None),
             WrappingRight => (wrapping_right(map, point, times), SelectionGoal::None),
             NextWordStart { ignore_punctuation } => (
-                next_word_start(map, point, *ignore_punctuation, times),
+                if helix_mode {
+                    next_word_start_helix(map, point, *ignore_punctuation, times)
+                } else {
+                    next_word_start(map, point, *ignore_punctuation, times)
+                },
                 SelectionGoal::None,
             ),
             NextWordEnd { ignore_punctuation } => (
@@ -1364,9 +1367,10 @@ impl Motion {
         let maybe_new_point = self.move_point(
             map,
             selection.head(),
-            selection.goal,
+            SelectionGoal::None,
             times,
             text_layout_details,
+            false,
         );
 
         let (new_head, goal) = match (maybe_new_point, forced_motion) {
@@ -1717,6 +1721,41 @@ pub(crate) fn next_word_start(
     point
 }
 
+pub fn next_word_start_helix(
+    map: &DisplaySnapshot,
+    mut point: DisplayPoint,
+    ignore_punctuation: bool,
+    times: usize,
+) -> DisplayPoint {
+    let classifier = map
+        .buffer_snapshot
+        .char_classifier_at(point.to_point(map))
+        .ignore_punctuation(ignore_punctuation);
+    for _ in 0..times {
+        let new_point = movement::right(map, point);
+        let new_point = movement::find_boundary_exclusive(
+            map,
+            new_point,
+            FindRange::MultiLine,
+            |left, right| {
+                let left_kind = classifier.kind_with(left, ignore_punctuation);
+                let right_kind = classifier.kind_with(right, ignore_punctuation);
+                let at_newline = (left == '\n') ^ (right == '\n');
+
+                let found =
+                    (left_kind != right_kind && right_kind != CharKind::Whitespace) || at_newline;
+
+                found
+            },
+        );
+        if point == new_point {
+            break;
+        }
+        point = new_point;
+    }
+    point
+}
+
 pub(crate) fn next_word_end(
     map: &DisplaySnapshot,
     mut point: DisplayPoint,
@@ -1780,17 +1819,13 @@ fn previous_word_start(
     for _ in 0..times {
         // This works even though find_preceding_boundary is called for every character in the line containing
         // cursor because the newline is checked only once.
-        let new_point = movement::find_preceding_boundary_display_point(
-            map,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
 
                 (left_kind != right_kind && !right.is_whitespace()) || left == '\n'
-            },
-        );
+            });
         if point == new_point {
             break;
         }
@@ -1801,7 +1836,7 @@ fn previous_word_start(
 
 fn previous_word_end(
     map: &DisplaySnapshot,
-    point: DisplayPoint,
+    mut point: DisplayPoint,
     ignore_punctuation: bool,
     times: usize,
 ) -> DisplayPoint {
@@ -1809,19 +1844,15 @@ fn previous_word_end(
         .buffer_snapshot
         .char_classifier_at(point.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let mut point = point.to_point(map);
 
-    if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
-        if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
-            point.column += ch.len_utf8() as u32;
-        }
-    }
+    // if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+    //     if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
+    //         point.column += ch.len_utf8() as u32;
+    //     }
+    // }
     for _ in 0..times {
-        let new_point = movement::find_preceding_boundary_point(
-            &map.buffer_snapshot,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(&map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
                 match (left_kind, right_kind) {
@@ -1832,14 +1863,13 @@ fn previous_word_end(
                     (CharKind::Whitespace, CharKind::Whitespace) => left == '\n' && right == '\n',
                     _ => false,
                 }
-            },
-        );
+            });
         if new_point == point {
             break;
         }
         point = new_point;
     }
-    movement::saturating_left(map, point.to_display_point(map))
+    movement::saturating_left(map, point)
 }
 
 fn next_subword_start(
@@ -1944,11 +1974,8 @@ fn previous_subword_start(
         let mut crossed_newline = false;
         // This works even though find_preceding_boundary is called for every character in the line containing
         // cursor because the newline is checked only once.
-        let new_point = movement::find_preceding_boundary_display_point(
-            map,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
                 let at_newline = right == '\n';
@@ -1964,8 +1991,7 @@ fn previous_subword_start(
                 crossed_newline |= at_newline;
 
                 found
-            },
-        );
+            });
         if point == new_point {
             break;
         }
@@ -1976,7 +2002,7 @@ fn previous_subword_start(
 
 fn previous_subword_end(
     map: &DisplaySnapshot,
-    point: DisplayPoint,
+    mut point: DisplayPoint,
     ignore_punctuation: bool,
     times: usize,
 ) -> DisplayPoint {
@@ -1984,19 +2010,16 @@ fn previous_subword_end(
         .buffer_snapshot
         .char_classifier_at(point.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let mut point = point.to_point(map);
+    // let mut point = point.to_point(map);
 
-    if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
-        if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
-            point.column += ch.len_utf8() as u32;
-        }
-    }
+    // if point.column < map.buffer_snapshot.line_len(MultiBufferRow(point.row)) {
+    //     if let Some(ch) = map.buffer_snapshot.chars_at(point).next() {
+    //         point.column += ch.len_utf8() as u32;
+    //     }
+    // }
     for _ in 0..times {
-        let new_point = movement::find_preceding_boundary_point(
-            &map.buffer_snapshot,
-            point,
-            FindRange::MultiLine,
-            |left, right| {
+        let new_point =
+            movement::find_preceding_boundary(&map, point, FindRange::MultiLine, |left, right| {
                 let left_kind = classifier.kind(left);
                 let right_kind = classifier.kind(right);
 
@@ -2013,14 +2036,13 @@ fn previous_subword_end(
                     (CharKind::Whitespace, CharKind::Whitespace) => left == '\n' && right == '\n',
                     _ => false,
                 }
-            },
-        );
+            });
         if new_point == point {
             break;
         }
         point = new_point;
     }
-    movement::saturating_left(map, point.to_display_point(map))
+    movement::saturating_left(map, point)
 }
 
 pub(crate) fn first_non_whitespace(
@@ -2617,7 +2639,7 @@ fn find_backward(
     let mut to = from;
 
     for _ in 0..times {
-        let new_to = find_preceding_boundary_display_point(map, to, mode, |_, right| {
+        let new_to = find_preceding_boundary(map, to, mode, |_, right| {
             is_character_match(target, right, smartcase)
         });
         if to == new_to {
@@ -2700,12 +2722,11 @@ fn sneak_backward(
 
     for _ in 0..times {
         found = false;
-        let new_to =
-            find_preceding_boundary_display_point(map, to, FindRange::MultiLine, |left, right| {
-                found = is_character_match(first_target, left, smartcase)
-                    && is_character_match(second_target, right, smartcase);
-                found
-            });
+        let new_to = find_preceding_boundary(map, to, FindRange::MultiLine, |left, right| {
+            found = is_character_match(first_target, left, smartcase)
+                && is_character_match(second_target, right, smartcase);
+            found
+        });
         if to == new_to {
             break;
         }

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -535,7 +535,7 @@ impl Vim {
                 |s| {
                     s.move_cursors_with(|map, cursor, goal| {
                         motion
-                            .move_point(map, cursor, goal, times, &text_layout_details)
+                            .move_point(map, cursor, goal, times, &text_layout_details, false)
                             .unwrap_or((cursor, goal))
                     })
                 },
@@ -708,6 +708,7 @@ impl Vim {
                             goal,
                             None,
                             &text_layout_details,
+                            false,
                         )
                     });
                 });

--- a/crates/vim/src/normal/substitute.rs
+++ b/crates/vim/src/normal/substitute.rs
@@ -82,6 +82,7 @@ impl Vim {
                                 selection.goal,
                                 None,
                                 &text_layout_details,
+                                false,
                             ) {
                                 selection.start = point;
                             }

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -745,7 +745,7 @@ fn in_word(
         .buffer_snapshot
         .char_classifier_at(relative_to.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let start = movement::find_preceding_boundary_display_point(
+    let start = movement::find_preceding_boundary(
         map,
         right(map, relative_to, 1),
         movement::FindRange::SingleLine,
@@ -783,7 +783,7 @@ fn in_subword(
         .unwrap_or(false);
 
     let start = if in_subword {
-        movement::find_preceding_boundary_display_point(
+        movement::find_preceding_boundary(
             map,
             right(map, relative_to, 1),
             movement::FindRange::SingleLine,
@@ -937,7 +937,7 @@ fn around_subword(
         .buffer_snapshot
         .char_classifier_at(relative_to.to_point(map))
         .ignore_punctuation(ignore_punctuation);
-    let start = movement::find_preceding_boundary_display_point(
+    let start = movement::find_preceding_boundary(
         map,
         right(map, relative_to, 1),
         movement::FindRange::SingleLine,
@@ -997,7 +997,7 @@ fn around_next_word(
         .char_classifier_at(relative_to.to_point(map))
         .ignore_punctuation(ignore_punctuation);
     // Get the start of the word
-    let start = movement::find_preceding_boundary_display_point(
+    let start = movement::find_preceding_boundary(
         map,
         right(map, relative_to, 1),
         FindRange::SingleLine,

--- a/crates/vim/src/object.rs
+++ b/crates/vim/src/object.rs
@@ -403,7 +403,11 @@ impl Vim {
             Mode::Visual | Mode::VisualLine | Mode::VisualBlock => {
                 self.visual_object(object, count, window, cx)
             }
-            Mode::Insert | Mode::Replace | Mode::HelixNormal => {
+            Mode::HelixNormal => {
+                // In Helix, we don't have a separate visual mode, so we treat it like normal mode
+                self.helix_object(object, count, window, cx);
+            }
+            Mode::Insert | Mode::Replace => {
                 // Shouldn't execute a text object in insert mode. Ignoring
             }
         }

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -129,6 +129,7 @@ pub enum Operator {
     Register,
     RecordRegister,
     ReplayRegister,
+    HelixMatchMode,
     ToggleComments,
     ReplaceWithRegister,
     Exchange,
@@ -1023,6 +1024,7 @@ impl Operator {
             Operator::Register => "\"",
             Operator::RecordRegister => "q",
             Operator::ReplayRegister => "@",
+            Operator::HelixMatchMode => "m",
             Operator::ToggleComments => "gc",
         }
     }
@@ -1075,6 +1077,7 @@ impl Operator {
             | Operator::Object { .. }
             | Operator::ChangeSurrounds { target: None }
             | Operator::OppositeCase
+            | Operator::HelixMatchMode
             | Operator::ToggleComments => false,
         }
     }
@@ -1112,6 +1115,7 @@ impl Operator {
             | Operator::AddSurrounds { .. }
             | Operator::ChangeSurrounds { .. }
             | Operator::Jump { .. }
+            | Operator::HelixMatchMode
             | Operator::Register
             | Operator::RecordRegister
             | Operator::ReplayRegister => false,

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -142,6 +142,16 @@ impl VimTestContext {
         })
     }
 
+    pub fn enable_helix(&mut self) {
+        self.cx.update(|_, cx| {
+            SettingsStore::update_global(cx, |store, cx| {
+                store.update_user_settings::<vim_mode_setting::HelixModeSetting>(cx, |s| {
+                    *s = Some(true)
+                });
+            });
+        })
+    }
+
     pub fn mode(&mut self) -> Mode {
         self.update_editor(|editor, _, cx| editor.addon::<VimAddon>().unwrap().entity.read(cx).mode)
     }

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -209,6 +209,26 @@ impl VimTestContext {
         assert_eq!(self.mode(), Mode::Normal, "{}", self.assertion_context());
         assert_eq!(self.active_operator(), None, "{}", self.assertion_context());
     }
+
+    pub fn shared_clipboard(&mut self) -> VimClipboard {
+        VimClipboard {
+            editor: self
+                .read_from_clipboard()
+                .map(|item| item.text().unwrap().to_string())
+                .unwrap_or_default(),
+        }
+    }
+}
+
+pub struct VimClipboard {
+    editor: String,
+}
+
+impl VimClipboard {
+    #[track_caller]
+    pub fn assert_eq(&self, expected: &str) {
+        assert_eq!(self.editor, expected);
+    }
 }
 
 impl Deref for VimTestContext {

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -220,6 +220,8 @@ actions!(
         PushReplayRegister,
         /// Replaces with register contents.
         PushReplaceWithRegister,
+        /// Mark mode for Helix
+        PushHelixMatchMode,
         /// Toggles comments.
         PushToggleComments,
     ]
@@ -500,11 +502,7 @@ impl Vim {
 
         vim.update(cx, |_, cx| {
             Vim::action(editor, cx, |vim, _: &SwitchToNormalMode, window, cx| {
-                if HelixModeSetting::get_global(cx).0 {
-                    vim.switch_mode(Mode::HelixNormal, false, window, cx)
-                } else {
-                    vim.switch_mode(Mode::Normal, false, window, cx)
-                }
+                vim.switch_mode(Mode::Normal, false, window, cx)
             });
 
             Vim::action(editor, cx, |vim, _: &SwitchToInsertMode, window, cx| {
@@ -709,6 +707,10 @@ impl Vim {
 
             Vim::action(editor, cx, |vim, _: &PushReplayRegister, window, cx| {
                 vim.push_operator(Operator::ReplayRegister, window, cx)
+            });
+
+            Vim::action(editor, cx, |vim, _: &PushHelixMatchMode, window, cx| {
+                vim.push_operator(Operator::HelixMatchMode, window, cx)
             });
 
             Vim::action(
@@ -949,6 +951,9 @@ impl Vim {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if HelixModeSetting::get_global(cx).0 && mode == Mode::Normal {
+            return self.switch_mode(Mode::HelixNormal, leave_selections, window, cx);
+        }
         if self.temp_mode && mode == Mode::Normal {
             self.temp_mode = false;
             self.switch_mode(Mode::Normal, leave_selections, window, cx);

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -220,7 +220,7 @@ actions!(
         PushReplayRegister,
         /// Replaces with register contents.
         PushReplaceWithRegister,
-        /// Mark mode for Helix
+        /// Match mode for Helix
         PushHelixMatchMode,
         /// Toggles comments.
         PushToggleComments,

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -514,7 +514,11 @@ impl Vim {
 
     fn toggle_mode(&mut self, mode: Mode, window: &mut Window, cx: &mut Context<Self>) {
         if self.mode == mode {
-            self.switch_mode(Mode::Normal, false, window, cx);
+            if HelixModeSetting::get_global(cx).0 {
+                self.switch_mode(Mode::HelixNormal, false, window, cx);
+            } else {
+                self.switch_mode(Mode::Normal, false, window, cx);
+            }
         } else {
             self.switch_mode(mode, false, window, cx);
         }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -514,11 +514,7 @@ impl Vim {
 
     fn toggle_mode(&mut self, mode: Mode, window: &mut Window, cx: &mut Context<Self>) {
         if self.mode == mode {
-            if HelixModeSetting::get_global(cx).0 {
-                self.switch_mode(Mode::HelixNormal, false, window, cx);
-            } else {
-                self.switch_mode(Mode::Normal, false, window, cx);
-            }
+            self.switch_mode(Mode::Normal, false, window, cx);
         } else {
             self.switch_mode(mode, false, window, cx);
         }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -10,7 +10,9 @@ use gpui::{Context, Window, actions};
 use language::{Point, Selection, SelectionGoal};
 use multi_buffer::MultiBufferRow;
 use search::BufferSearchBar;
+use settings::Settings;
 use util::ResultExt;
+use vim_mode_setting::HelixModeSetting;
 use workspace::searchable::Direction;
 
 use crate::{

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -238,7 +238,6 @@ impl Vim {
                             return;
                         };
 
-                        log::info!("Motion new head:{:?}", new_head);
                         selection.set_head(new_head, goal);
 
                         // ensure the current character is included in the selection.
@@ -262,11 +261,6 @@ impl Vim {
                         } else if !was_reversed && selection.reversed {
                             selection.end = movement::right(map, selection.end);
                         }
-                        log::info!(
-                            "Selection: tail={:?} head={:?}",
-                            selection.start,
-                            selection.end
-                        );
                     })
                 });
             }

--- a/crates/vim/src/visual.rs
+++ b/crates/vim/src/visual.rs
@@ -191,6 +191,7 @@ impl Vim {
     ) {
         self.update_editor(window, cx, |vim, editor, window, cx| {
             let text_layout_details = editor.text_layout_details(window);
+            let is_helix_mode = HelixModeSetting::get_global(cx).0;
             if vim.mode == Mode::VisualBlock
                 && !matches!(
                     motion,
@@ -201,7 +202,7 @@ impl Vim {
             {
                 let is_up_or_down = matches!(motion, Motion::Up { .. } | Motion::Down { .. });
                 vim.visual_block_motion(is_up_or_down, editor, window, cx, |map, point, goal| {
-                    motion.move_point(map, point, goal, times, &text_layout_details)
+                    motion.move_point(map, point, goal, times, &text_layout_details, is_helix_mode)
                 })
             } else {
                 editor.change_selections(Default::default(), window, cx, |s| {
@@ -230,10 +231,12 @@ impl Vim {
                             selection.goal,
                             times,
                             &text_layout_details,
+                            is_helix_mode,
                         ) else {
                             return;
                         };
 
+                        log::info!("Motion new head:{:?}", new_head);
                         selection.set_head(new_head, goal);
 
                         // ensure the current character is included in the selection.
@@ -257,6 +260,11 @@ impl Vim {
                         } else if !was_reversed && selection.reversed {
                             selection.end = movement::right(map, selection.end);
                         }
+                        log::info!(
+                            "Selection: tail={:?} head={:?}",
+                            selection.start,
+                            selection.end
+                        );
                     })
                 });
             }


### PR DESCRIPTION
Resolves: #33906
Resolves: #32020
Resolves: #31997
Merge after: #35612, #35611, #35501, #35468 

This PR re-uses vim's operator logic to implement Helix "match" mode. `m i` and `m a` work well across all existing objects with some tweaks around paragraphs.

Release Notes:
 - Helix: Pressing `v v` no longer drop you into Normal mode out of HelixNormal
 - Helix: Initial implementation of `m i` and `m a` 

The gist of this PR here: [3258d258c87aa20135ad4490ead424ebb59e76be](https://github.com/zed-industries/zed/pull/35687/commits/3258d258c87aa20135ad4490ead424ebb59e76be)


Bugs:
 - [ ] TODO: temporarily breaks "m m" functionality, need to keybind it to "vim::Matching" without disrupting operators.
 