### PR TITLE
Tag crash reports with panic message and release

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -553,6 +553,10 @@ async fn upload_previous_panics(
             .log_err();
     }
 
+    if MINIDUMP_ENDPOINT.is_none() {
+        return Ok(most_recent_panic);
+    }
+
     // loop back over the directory again to upload any minidumps that are missing panics
     let mut children = smol::fs::read_dir(paths::logs_dir()).await?;
     while let Some(child) = children.next().await {
@@ -597,11 +601,12 @@ async fn upload_minidump(
         )
         .text("platform", "rust");
     if let Some(panic) = panic {
-        form = form.text(
-            "release",
-            format!("{}-{}", panic.release_channel, panic.app_version),
-        );
-        // TODO: tack on more fields
+        form = form
+            .text(
+                "sentry[release]",
+                format!("{}-{}", panic.release_channel, panic.app_version),
+            )
+            .text("sentry[logentry][formatted]", panic.payload.clone());
     }
 
     let mut response_text = String::new();


### PR DESCRIPTION
This _should_ allow sentry to associate related panic events with the same issue, but it doesn't change the issue title. I'm still working on figuring out how to set those fields, but in the meantime this should at least associate zed versions with crashes

Release Notes:

- N/A
