### PR TITLE
Add theme mode cycle action

### DIFF
--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -40,9 +40,9 @@ pub fn init(cx: &mut App) {
             toggle_icon_theme_selector(workspace, &action, window, cx);
         });
     });
-    cx.on_action(|_: &zed_actions::theme_selector::ToggleMode, cx| {
+    cx.on_action(|_: &zed_actions::theme_selector::CycleMode, cx| {
         with_active_or_new_workspace(cx, |workspace, window, cx| {
-            toggle_theme_mode(workspace, window, cx);
+            cycle_theme_mode(workspace, window, cx);
         });
     });
 }
@@ -83,7 +83,7 @@ fn toggle_icon_theme_selector(
     });
 }
 
-fn toggle_theme_mode(workspace: &mut Workspace, _window: &mut Window, cx: &mut Context<Workspace>) {
+fn cycle_theme_mode(workspace: &mut Workspace, _window: &mut Window, cx: &mut Context<Workspace>) {
     let current_settings = ThemeSettings::get_global(cx);
     let current_selection = current_settings.theme_selection.as_ref();
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -9,7 +9,9 @@ use gpui::{
 use picker::{Picker, PickerDelegate};
 use settings::{Settings as _, SettingsStore, update_settings_file};
 use std::sync::Arc;
-use theme::{Appearance, Theme, ThemeMeta, ThemeMode, ThemeRegistry, ThemeSelection, ThemeSettings};
+use theme::{
+    Appearance, Theme, ThemeMeta, ThemeMode, ThemeRegistry, ThemeSelection, ThemeSettings,
+};
 use ui::{ListItem, ListItemSpacing, prelude::*, v_flex};
 use util::ResultExt;
 use workspace::{ModalView, Workspace, ui::HighlightedLabel, with_active_or_new_workspace};
@@ -81,32 +83,26 @@ fn toggle_icon_theme_selector(
     });
 }
 
-fn toggle_theme_mode(
-    workspace: &mut Workspace,
-    _window: &mut Window,
-    cx: &mut Context<Workspace>,
-) {
+fn toggle_theme_mode(workspace: &mut Workspace, _window: &mut Window, cx: &mut Context<Workspace>) {
     let current_settings = ThemeSettings::get_global(cx);
     let current_selection = current_settings.theme_selection.as_ref();
-    
+
     let new_mode = match current_selection {
-        Some(ThemeSelection::Dynamic { mode, .. }) => {
-            match mode {
-                ThemeMode::Light => ThemeMode::Dark,
-                ThemeMode::Dark => ThemeMode::System,
-                ThemeMode::System => ThemeMode::Light,
-            }
-        }
+        Some(ThemeSelection::Dynamic { mode, .. }) => match mode {
+            ThemeMode::Light => ThemeMode::Dark,
+            ThemeMode::Dark => ThemeMode::System,
+            ThemeMode::System => ThemeMode::Light,
+        },
         Some(ThemeSelection::Static(_)) => ThemeMode::Light,
-        None => ThemeMode::Light
+        None => ThemeMode::Light,
     };
-    
+
     let fs = workspace.app_state().fs.clone();
-    
+
     update_settings_file::<ThemeSettings>(fs, cx, move |settings, _| {
         settings.set_mode(new_mode);
     });
-    
+
     ThemeSettings::reload_current_theme(cx);
 }
 

--- a/crates/theme_selector/src/theme_selector.rs
+++ b/crates/theme_selector/src/theme_selector.rs
@@ -40,9 +40,9 @@ pub fn init(cx: &mut App) {
             toggle_icon_theme_selector(workspace, &action, window, cx);
         });
     });
-    cx.on_action(|_: &zed_actions::theme_selector::CycleMode, cx| {
+    cx.on_action(|_: &zed_actions::theme_selector::ToggleMode, cx| {
         with_active_or_new_workspace(cx, |workspace, window, cx| {
-            cycle_theme_mode(workspace, window, cx);
+            toggle_theme_mode(workspace, window, cx);
         });
     });
 }
@@ -83,15 +83,21 @@ fn toggle_icon_theme_selector(
     });
 }
 
-fn cycle_theme_mode(workspace: &mut Workspace, _window: &mut Window, cx: &mut Context<Workspace>) {
+fn toggle_theme_mode(workspace: &mut Workspace, _window: &mut Window, cx: &mut Context<Workspace>) {
     let current_settings = ThemeSettings::get_global(cx);
     let current_selection = current_settings.theme_selection.as_ref();
 
     let new_mode = match current_selection {
         Some(ThemeSelection::Dynamic { mode, .. }) => match mode {
             ThemeMode::Light => ThemeMode::Dark,
-            ThemeMode::Dark => ThemeMode::System,
-            ThemeMode::System => ThemeMode::Light,
+            ThemeMode::Dark => ThemeMode::Light,
+            ThemeMode::System => {
+                if cx.theme().appearance().is_light() {
+                    ThemeMode::Dark
+                } else {
+                    ThemeMode::Light
+                }
+            }
         },
         Some(ThemeSelection::Static(_)) => ThemeMode::Light,
         None => ThemeMode::Light,

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -33,8 +33,8 @@ pub fn app_menus() -> Vec<Menu> {
                             zed_actions::theme_selector::Toggle::default(),
                         ),
                         MenuItem::action(
-                            "Cycle Theme Mode",
-                            zed_actions::theme_selector::CycleMode,
+                            "Toggle Theme Mode",
+                            zed_actions::theme_selector::ToggleMode,
                         ),
                     ],
                 }),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -33,8 +33,8 @@ pub fn app_menus() -> Vec<Menu> {
                             zed_actions::theme_selector::Toggle::default(),
                         ),
                         MenuItem::action(
-                            "Toggle Theme Mode",
-                            zed_actions::theme_selector::ToggleMode,
+                            "Cycle Theme Mode",
+                            zed_actions::theme_selector::CycleMode,
                         ),
                     ],
                 }),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -32,6 +32,10 @@ pub fn app_menus() -> Vec<Menu> {
                             "Select Theme...",
                             zed_actions::theme_selector::Toggle::default(),
                         ),
+                        MenuItem::action(
+                            "Toggle Theme Mode",
+                            zed_actions::theme_selector::ToggleMode,
+                        ),
                     ],
                 }),
                 MenuItem::separator(),

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -243,6 +243,12 @@ pub mod theme_selector {
         /// A list of theme names to filter the theme selector down to.
         pub themes_filter: Option<Vec<String>>,
     }
+
+    /// Toggles between light, dark, and system theme modes.
+    #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
+    #[action(namespace = theme_selector)]
+    #[serde(deny_unknown_fields)]
+    pub struct ToggleMode;
 }
 
 pub mod icon_theme_selector {

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -244,11 +244,11 @@ pub mod theme_selector {
         pub themes_filter: Option<Vec<String>>,
     }
 
-    /// Toggles between light, dark, and system theme modes.
+    /// Cycles between light, dark, and system theme modes.
     #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
     #[action(namespace = theme_selector)]
     #[serde(deny_unknown_fields)]
-    pub struct ToggleMode;
+    pub struct CycleMode;
 }
 
 pub mod icon_theme_selector {

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -244,11 +244,11 @@ pub mod theme_selector {
         pub themes_filter: Option<Vec<String>>,
     }
 
-    /// Cycles between light, dark, and system theme modes.
+    /// Toggles between light and dark theme modes.
     #[derive(PartialEq, Clone, Default, Debug, Deserialize, JsonSchema, Action)]
     #[action(namespace = theme_selector)]
     #[serde(deny_unknown_fields)]
-    pub struct CycleMode;
+    pub struct ToggleMode;
 }
 
 pub mod icon_theme_selector {


### PR DESCRIPTION
Fixes #35552

Closes #35552

Release Notes:

- Added "Cycle Theme Mode" command palette action that cycles through light/dark/system theme modes