### PR TITLE
Support CC `migrate-installer` path

### DIFF
--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -89,6 +89,7 @@ impl AgentServerCommand {
     pub(crate) async fn resolve(
         path_bin_name: &'static str,
         extra_args: &[&'static str],
+        fallback_path: Option<&Path>,
         settings: Option<AgentServerSettings>,
         project: &Entity<Project>,
         cx: &mut AsyncApp,
@@ -105,13 +106,24 @@ impl AgentServerCommand {
                 env: agent_settings.command.env,
             });
         } else {
-            find_bin_in_path(path_bin_name, project, cx)
-                .await
-                .map(|path| Self {
+            match find_bin_in_path(path_bin_name, project, cx).await {
+                Some(path) => Some(Self {
                     path,
                     args: extra_args.iter().map(|arg| arg.to_string()).collect(),
                     env: None,
-                })
+                }),
+                None => fallback_path.and_then(|path| {
+                    if path.exists() {
+                        Some(Self {
+                            path: path.to_path_buf(),
+                            args: extra_args.iter().map(|arg| arg.to_string()).collect(),
+                            env: None,
+                        })
+                    } else {
+                        None
+                    }
+                }),
+            }
         }
     }
 }

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -101,8 +101,15 @@ impl AgentConnection for ClaudeAgentConnection {
                 settings.get::<AllAgentServersSettings>(None).claude.clone()
             })?;
 
-            let Some(command) =
-                AgentServerCommand::resolve("claude", &[], settings, &project, cx).await
+            let Some(command) = AgentServerCommand::resolve(
+                "claude",
+                &[],
+                Some(&util::paths::home_dir().join(".claude/local/claude")),
+                settings,
+                &project,
+                cx,
+            )
+            .await
             else {
                 anyhow::bail!("Failed to find claude binary");
             };

--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -48,7 +48,7 @@ impl AgentServer for Gemini {
             })?;
 
             let Some(command) =
-                AgentServerCommand::resolve("gemini", &[ACP_ARG], settings, &project, cx).await
+                AgentServerCommand::resolve("gemini", &[ACP_ARG], None, settings, &project, cx).await
             else {
                 anyhow::bail!("Failed to find gemini binary");
             };


### PR DESCRIPTION
If we can't find CC in the PATH, we'll now fall back to a known local install path.

Release Notes:

- N/A
