### PR TITLE
Search Panel: Add setting for persistent include/exclude patterns

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14551,6 +14551,7 @@ dependencies = [
  "client",
  "collections",
  "editor",
+ "fs",
  "futures 0.3.31",
  "gpui",
  "language",

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -341,7 +341,7 @@ pub enum ScrollBeyondLastLine {
 }
 
 /// Default options for buffer and project search items.
-#[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 pub struct SearchSettings {
     /// Whether to show the project search button in the status bar.
     #[serde(default = "default_true")]
@@ -354,6 +354,9 @@ pub struct SearchSettings {
     pub include_ignored: bool,
     #[serde(default)]
     pub regex: bool,
+    /// Whether to automatically persist and restore include/exclude patterns when opening a new search.
+    #[serde(default)]
+    pub persistent_patterns: bool,
 }
 
 /// What to do when go to definition yields no results.

--- a/crates/search/Cargo.toml
+++ b/crates/search/Cargo.toml
@@ -46,6 +46,7 @@ workspace-hack.workspace = true
 [dev-dependencies]
 client = { workspace = true, features = ["test-support"] }
 editor = { workspace = true, features = ["test-support"] }
+fs.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 unindent.workspace = true
 workspace = { workspace = true, features = ["test-support"] }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -2842,6 +2842,7 @@ mod tests {
                 case_sensitive: false,
                 include_ignored: false,
                 regex: false,
+                persistent_patterns: true,
             },
             cx,
         );
@@ -2908,6 +2909,7 @@ mod tests {
                 case_sensitive: true,
                 include_ignored: false,
                 regex: false,
+                persistent_patterns: true,
             },
             cx,
         );

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -4374,7 +4374,6 @@ pub mod tests {
 
         let project = Project::test(fs.clone(), [path!("/dir").as_ref()], cx).await;
         let window = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
-        let workspace = window.root(cx).unwrap();
         let search = cx.new(|cx| ProjectSearch::new(project.clone(), cx));
 
         (project, window, search)

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2345,8 +2345,23 @@ If you wish to exclude certain hosts from using the proxy, set the `NO_PROXY` en
   "whole_word": false,
   "case_sensitive": false,
   "include_ignored": false,
-  "regex": false
+  "regex": false,
+  "persistent_patterns": false
 },
+```
+
+## Persistent Search Inclusion and Exclusion Patterns
+
+- Description: Whether to automatically apply the last-used patterns when opening the search panel.
+- Setting: `persistent_patterns`
+- Default: `false`
+
+Enable this feature if you frequently use the same search inclusion and exclusion patterns and want them automatically restored:
+
+```json
+"search": {
+  "persistent_patterns": true
+}
 ```
 
 ## Seed Search Query From Cursor


### PR DESCRIPTION
This uses a boolean setting to automatically apply the most recent include and exclude patterns when opening the search panel. While the history can already be recalled by pressing up in the include/exclude fields, this adds an extra degree of convenience for projects where these patterns are used always or often.

The setting is false by default, and not included in the default settings to ensure it doesn't disrupt existing default behaviours.

I hoped this might fit under the "Improve new user experience" priority, but totally understand if it doesn't. This behaviour is a common feature in other IDEs I've used, and the existing settings I could find didn't seem to provide the behaviour I wanted and expected.

Closes #17060 

Release Notes:

- Added a boolean setting to enable persistent include/exclude patterns in the search panel
