### PR TITLE
vim: Display invisibles in mode indicator

### DIFF
--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1028,13 +1028,21 @@ impl Operator {
     }
 
     pub fn status(&self) -> String {
+        fn make_visible(c: &str) -> &str {
+            match c {
+                "\n" => "enter",
+                "\t" => "tab",
+                " " => "space",
+                c => c,
+            }
+        }
         match self {
             Operator::Digraph {
                 first_char: Some(first_char),
-            } => format!("^K{first_char}"),
+            } => format!("^K{}", make_visible(&first_char.to_string())),
             Operator::Literal {
                 prefix: Some(prefix),
-            } => format!("^V{prefix}"),
+            } => format!("^V{}", make_visible(&prefix)),
             Operator::AutoIndent => "=".to_string(),
             Operator::ShellCommand => "=".to_string(),
             _ => self.id().to_string(),


### PR DESCRIPTION
Release Notes:

- Fixes bug where `ctrl-k enter` while in `INSERT` mode would put a newline in the Vim mode indicator


#### Old
<img width="729" height="486" alt="OldVimModeIndicator" src="https://github.com/user-attachments/assets/58742745-5a58-4e7b-a1ef-29aa3ff1c4f7" />

#### New
<img width="729" height="486" alt="NewVimModeIndicator" src="https://github.com/user-attachments/assets/e636359a-06b6-4cdd-9e62-5dc52c6f068f" />

