### PR TITLE
debugger: Improve refresh inline values flickering

### DIFF
--- a/crates/debugger_ui/src/tests/inline_values.rs
+++ b/crates/debugger_ui/src/tests/inline_values.rs
@@ -1,7 +1,7 @@
 use std::{path::Path, sync::Arc};
 
 use dap::{Scope, StackFrame, Variable, requests::Variables};
-use editor::{Editor, EditorMode, MultiBuffer};
+use editor::{Editor, EditorMode, INLINE_VALUES_DEBOUNCE_TIMEOUT, MultiBuffer};
 use gpui::{BackgroundExecutor, TestAppContext, VisualTestContext};
 use language::{Language, LanguageConfig, LanguageMatcher, tree_sitter_python, tree_sitter_rust};
 use project::{FakeFs, Project};
@@ -241,6 +241,7 @@ fn main() {
 
     editor.update(cx, |editor, cx| editor.refresh_inline_values(cx));
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -298,6 +299,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -355,6 +357,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -412,6 +415,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -469,6 +473,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -576,6 +581,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -683,6 +689,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -802,6 +809,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -921,6 +929,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -1053,6 +1062,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -1110,6 +1120,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -1188,6 +1199,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -1333,6 +1345,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -1478,6 +1491,7 @@ fn main() {
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -1813,6 +1827,7 @@ def process_data(untyped_param, typed_param: int, another_typed: str):
         }))
         .await;
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {
@@ -2108,6 +2123,7 @@ async fn test_inline_values_util(
 
     editor.update(cx, |editor, cx| editor.refresh_inline_values(cx));
 
+    cx.executor().advance_clock(INLINE_VALUES_DEBOUNCE_TIMEOUT);
     cx.run_until_parked();
 
     editor.update_in(cx, |editor, window, cx| {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -19793,6 +19793,10 @@ impl Editor {
             .and_then(|lines| lines.last().map(|line| line.range.end));
 
         self.inline_value_cache.refresh_task = cx.spawn(async move |editor, cx| {
+            cx.background_executor()
+                .timer(Duration::from_millis(100))
+                .await;
+
             let inline_values = editor
                 .update(cx, |editor, cx| {
                     let Some(current_execution_position) = current_execution_position else {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -228,6 +228,7 @@ pub(crate) const CURSORS_VISIBLE_FOR: Duration = Duration::from_millis(2000);
 #[doc(hidden)]
 pub const CODE_ACTIONS_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(250);
 const SELECTION_HIGHLIGHT_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
+pub const INLINE_VALUES_DEBOUNCE_TIMEOUT: Duration = Duration::from_millis(100);
 
 pub(crate) const CODE_ACTION_TIMEOUT: Duration = Duration::from_secs(5);
 pub(crate) const FORMAT_TIMEOUT: Duration = Duration::from_secs(5);
@@ -19794,7 +19795,7 @@ impl Editor {
 
         self.inline_value_cache.refresh_task = cx.spawn(async move |editor, cx| {
             cx.background_executor()
-                .timer(Duration::from_millis(100))
+                .timer(INLINE_VALUES_DEBOUNCE_TIMEOUT)
                 .await;
 
             let inline_values = editor


### PR DESCRIPTION
Closes #34776

This PR should reduce the inline values flickering, that was caused by us not debouncing the refresh_inline_values task.
Because we call the refresh_inline_values method on every variable fetch, we frequently update the inline values, but this causes some inline values to hide because their variable was not fetched yet and when the variable was fetched we would refresh the inline values again and causing the inline value show again with an updated value.

**Note**: the flickering in my before example video is minimal, because I don't have many variables that need to be fetched, but imagine that you have a lot of nested variables for each variable fetch call we would update the inline values without a debounce that would make the flickering more obvious.

**Before**

https://github.com/user-attachments/assets/9698fb4a-a904-4537-89bc-524098502be0

**After**

https://github.com/user-attachments/assets/0d6c920b-0ab7-408c-afca-19a8ac059653

Release Notes:

- Debugger: Improve refresh inline values flickering on step debugging
