### PR TITLE
keymap editor: Refine how we display matching keystrokes

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -21,10 +21,9 @@ use notifications::status_toast::{StatusToast, ToastIcon};
 use project::Project;
 use settings::{BaseKeymap, KeybindSource, KeymapFile, Settings as _, SettingsAssets};
 use ui::{
-    ActiveTheme as _, App, Banner, BorrowAppContext, ButtonLike, ContextMenu, DecoratedIcon,
-    IconButtonShape, IconDecoration, IconDecorationKind, Indicator, Modal, ModalFooter,
-    ModalHeader, ParentElement as _, Render, Section, SharedString, Styled as _, Tooltip, Window,
-    prelude::*,
+    ActiveTheme as _, App, Banner, BorrowAppContext, ContextMenu, IconButtonShape, Indicator,
+    Modal, ModalFooter, ModalHeader, ParentElement as _, Render, Section, SharedString,
+    Styled as _, Tooltip, Window, prelude::*,
 };
 use ui_input::SingleLineInput;
 use util::ResultExt;

--- a/crates/settings_ui/src/ui_components/keystroke_input.rs
+++ b/crates/settings_ui/src/ui_components/keystroke_input.rs
@@ -529,7 +529,7 @@ impl Render for KeystrokeInput {
             .w_full()
             .flex_1()
             .justify_between()
-            .rounded_lg()
+            .rounded_sm()
             .overflow_hidden()
             .map(|this| {
                 if is_recording {

--- a/crates/ui_input/src/ui_input.rs
+++ b/crates/ui_input/src/ui_input.rs
@@ -168,7 +168,7 @@ impl Render for SingleLineInput {
                     .py_1p5()
                     .flex_grow()
                     .text_color(style.text_color)
-                    .rounded_lg()
+                    .rounded_sm()
                     .bg(style.background_color)
                     .border_1()
                     .border_color(style.border_color)


### PR DESCRIPTION
| Before | After |
|--------|--------|
| <img width="1092" height="528" alt="CleanShot 2025-08-07 at 10  54 42@2x" src="https://github.com/user-attachments/assets/8b0a3b50-e1d1-4763-824c-2b419df430fc" /> | <img width="1096" height="580" alt="CleanShot 2025-08-07 at 11  29 47@2x" src="https://github.com/user-attachments/assets/bd484655-90a6-46fe-91ef-c9c8d2ab93bc" /> | 

Release Notes:

- N/A
