### PR TITLE
collab: Increase `DATABASE_MAX_CONNECTIONS` for Collab server

### DIFF
--- a/.github/workflows/deploy_collab.yml
+++ b/.github/workflows/deploy_collab.yml
@@ -137,12 +137,14 @@ jobs:
 
           export ZED_SERVICE_NAME=collab
           export ZED_LOAD_BALANCER_SIZE_UNIT=$ZED_COLLAB_LOAD_BALANCER_SIZE_UNIT
+          export DATABASE_MAX_CONNECTIONS=850
           envsubst < crates/collab/k8s/collab.template.yml | kubectl apply -f -
           kubectl -n "$ZED_KUBE_NAMESPACE" rollout status deployment/$ZED_SERVICE_NAME --watch
           echo "deployed ${ZED_SERVICE_NAME} to ${ZED_KUBE_NAMESPACE}"
 
           export ZED_SERVICE_NAME=api
           export ZED_LOAD_BALANCER_SIZE_UNIT=$ZED_API_LOAD_BALANCER_SIZE_UNIT
+          export DATABASE_MAX_CONNECTIONS=60
           envsubst < crates/collab/k8s/collab.template.yml | kubectl apply -f -
           kubectl -n "$ZED_KUBE_NAMESPACE" rollout status deployment/$ZED_SERVICE_NAME --watch
           echo "deployed ${ZED_SERVICE_NAME} to ${ZED_KUBE_NAMESPACE}"

--- a/crates/collab/k8s/environments/production.sh
+++ b/crates/collab/k8s/environments/production.sh
@@ -2,5 +2,6 @@ ZED_ENVIRONMENT=production
 RUST_LOG=info
 INVITE_LINK_PREFIX=https://zed.dev/invites/
 AUTO_JOIN_CHANNEL_ID=283
-DATABASE_MAX_CONNECTIONS=250
+# Set DATABASE_MAX_CONNECTIONS max connections in the `deploy_collab.yml`:
+# https://github.com/zed-industries/zed/blob/main/.github/workflows/deploy_collab.yml
 LLM_DATABASE_MAX_CONNECTIONS=25


### PR DESCRIPTION
This PR increases the `DATABASE_MAX_CONNECTIONS` limit for the Collab server to 850 (up from 250).

Release Notes:

- N/A
