### PR TITLE
collab_ui: Show signed-out state when not connected to Collab

### DIFF
--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -3053,7 +3053,7 @@ impl Render for CollabPanel {
             .on_action(cx.listener(CollabPanel::move_channel_down))
             .track_focus(&self.focus_handle)
             .size_full()
-            .child(if self.user_store.read(cx).current_user().is_none() {
+            .child(if !self.client.status().borrow().is_connected() {
                 self.render_signed_out(cx)
             } else {
                 self.render_signed_in(window, cx)


### PR DESCRIPTION
This PR updates signed-out state of the Collab panel to show when not connected to Collab, as opposed to just when the user is signed-out.

Release Notes:

- N/A
