### PR TITLE
Capture `shorthand_field_initializer` and modules in Rust highlights

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -50,17 +50,6 @@
 (mod_item
   name: (identifier) @module)
 
-[
-  (crate) @module
-  (super) @module
-]
-
-path: (scoped_identifier
-  (identifier) @module)
-path: (identifier) @module
-
-(use_wildcard (identifier) @module)
-
 (visibility_modifier [
   (crate) @keyword
   (super) @keyword

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -47,6 +47,21 @@
 (macro_definition
   name: (identifier) @function.special.definition)
 
+[
+  (crate)
+  (super)
+] @module
+
+(mod_item
+  name: (identifier) @module)
+
+(scoped_use_list
+  path: (identifier) @module)
+
+(scoped_use_list
+  path: (scoped_identifier
+    (identifier) @module))
+
 ; Identifier conventions
 
 ; Assume uppercase names are types/enum-constructors
@@ -119,9 +134,7 @@
   "where"
   "while"
   "yield"
-  (crate)
   (mutable_specifier)
-  (super)
 ] @keyword
 
 [

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -6,6 +6,9 @@
 (self) @variable.special
 (field_identifier) @property
 
+(shorthand_field_initializer
+  (identifier) @property)
+
 (trait_item name: (type_identifier) @type.interface)
 (impl_item trait: (type_identifier) @type.interface)
 (abstract_type trait: (type_identifier) @type.interface)
@@ -38,7 +41,8 @@
     (identifier) @function.special
     (scoped_identifier
       name: (identifier) @function.special)
-  ])
+  ]
+  "!" @function.special)
 
 (macro_definition
   name: (identifier) @function.special.definition)

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -47,20 +47,24 @@
 (macro_definition
   name: (identifier) @function.special.definition)
 
-[
-  (crate)
-  (super)
-] @module
-
 (mod_item
   name: (identifier) @module)
 
-(scoped_use_list
-  path: (identifier) @module)
+[
+  (crate) @module
+  (super) @module
+]
 
-(scoped_use_list
-  path: (scoped_identifier
-    (identifier) @module))
+path: (scoped_identifier
+  (identifier) @module)
+path: (identifier) @module
+
+(use_wildcard (identifier) @module)
+
+(visibility_modifier [
+  (crate) @keyword
+  (super) @keyword
+])
 
 ; Identifier conventions
 

--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -206,6 +206,7 @@
 operator: "/" @operator
 
 (lifetime) @lifetime
+(lifetime (identifier) @lifetime)
 
 (parameter (identifier) @variable.parameter)
 


### PR DESCRIPTION
Currently shorthand field initializers are not captured the same way as the full initializers, leading to awkward and mismatching highlighting. This PR addresses this fact, in addition to capturing new highlights:
- Tags the `!` as part of a macro invocation.
- Tags the identifier part of a lifetime as `@lifetime`.
- Tag module definitions as a new capture group, `@module`.
- Shorthand initializers are now properly tagged as `@property`.

Here's what the current version of Zed looks like:

<img width="596" height="683" alt="image" src="https://github.com/user-attachments/assets/c9e52d8e-03dc-426b-8545-4fe872b803e0" />

With the new highlighting applied:

<img width="596" height="683" alt="image" src="https://github.com/user-attachments/assets/b7bd9391-9910-456b-8198-6871174d0f4f" />

Release Notes:

- Improved highlighting of Rust files, including new highlight groups for modules and shorthand initializers.
