### PR TITLE
Revert "chore: Bump Rust to 1.89 (#35788)"

### DIFF
--- a/Dockerfile-collab
+++ b/Dockerfile-collab
@@ -1,6 +1,6 @@
 # syntax = docker/dockerfile:1.2
 
-FROM rust:1.89-bookworm as builder
+FROM rust:1.88-bookworm as builder
 WORKDIR app
 COPY . .
 

--- a/crates/fs/src/fake_git_repo.rs
+++ b/crates/fs/src/fake_git_repo.rs
@@ -402,11 +402,11 @@ impl GitRepository for FakeGitRepository {
         &self,
         _paths: Vec<RepoPath>,
         _env: Arc<HashMap<String, String>>,
-    ) -> BoxFuture<'_, Result<()>> {
+    ) -> BoxFuture<Result<()>> {
         unimplemented!()
     }
 
-    fn stash_pop(&self, _env: Arc<HashMap<String, String>>) -> BoxFuture<'_, Result<()>> {
+    fn stash_pop(&self, _env: Arc<HashMap<String, String>>) -> BoxFuture<Result<()>> {
         unimplemented!()
     }
 

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -399,9 +399,9 @@ pub trait GitRepository: Send + Sync {
         &self,
         paths: Vec<RepoPath>,
         env: Arc<HashMap<String, String>>,
-    ) -> BoxFuture<'_, Result<()>>;
+    ) -> BoxFuture<Result<()>>;
 
-    fn stash_pop(&self, env: Arc<HashMap<String, String>>) -> BoxFuture<'_, Result<()>>;
+    fn stash_pop(&self, env: Arc<HashMap<String, String>>) -> BoxFuture<Result<()>>;
 
     fn push(
         &self,
@@ -1203,7 +1203,7 @@ impl GitRepository for RealGitRepository {
         &self,
         paths: Vec<RepoPath>,
         env: Arc<HashMap<String, String>>,
-    ) -> BoxFuture<'_, Result<()>> {
+    ) -> BoxFuture<Result<()>> {
         let working_directory = self.working_directory();
         self.executor
             .spawn(async move {
@@ -1227,7 +1227,7 @@ impl GitRepository for RealGitRepository {
             .boxed()
     }
 
-    fn stash_pop(&self, env: Arc<HashMap<String, String>>) -> BoxFuture<'_, Result<()>> {
+    fn stash_pop(&self, env: Arc<HashMap<String, String>>) -> BoxFuture<Result<()>> {
         let working_directory = self.working_directory();
         self.executor
             .spawn(async move {

--- a/crates/gpui/src/keymap/context.rs
+++ b/crates/gpui/src/keymap/context.rs
@@ -461,8 +461,6 @@ fn skip_whitespace(source: &str) -> &str {
 
 #[cfg(test)]
 mod tests {
-    use core::slice;
-
     use super::*;
     use crate as gpui;
     use KeyBindingContextPredicate::*;
@@ -676,11 +674,11 @@ mod tests {
         assert!(predicate.eval(&contexts));
 
         assert!(!predicate.eval(&[]));
-        assert!(!predicate.eval(slice::from_ref(&child_context)));
+        assert!(!predicate.eval(&[child_context.clone()]));
         assert!(!predicate.eval(&[parent_context]));
 
         let zany_predicate = KeyBindingContextPredicate::parse("child > child").unwrap();
-        assert!(!zany_predicate.eval(slice::from_ref(&child_context)));
+        assert!(!zany_predicate.eval(&[child_context.clone()]));
         assert!(zany_predicate.eval(&[child_context.clone(), child_context.clone()]));
     }
 
@@ -692,13 +690,13 @@ mod tests {
         let parent_context = KeyContext::try_from("parent").unwrap();
         let child_context = KeyContext::try_from("child").unwrap();
 
-        assert!(not_predicate.eval(slice::from_ref(&workspace_context)));
-        assert!(!not_predicate.eval(slice::from_ref(&editor_context)));
+        assert!(not_predicate.eval(&[workspace_context.clone()]));
+        assert!(!not_predicate.eval(&[editor_context.clone()]));
         assert!(!not_predicate.eval(&[editor_context.clone(), workspace_context.clone()]));
         assert!(!not_predicate.eval(&[workspace_context.clone(), editor_context.clone()]));
 
         let complex_not = KeyBindingContextPredicate::parse("!editor && workspace").unwrap();
-        assert!(complex_not.eval(slice::from_ref(&workspace_context)));
+        assert!(complex_not.eval(&[workspace_context.clone()]));
         assert!(!complex_not.eval(&[editor_context.clone(), workspace_context.clone()]));
 
         let not_mode_predicate = KeyBindingContextPredicate::parse("!(mode == full)").unwrap();
@@ -711,18 +709,18 @@ mod tests {
         assert!(not_mode_predicate.eval(&[other_mode_context]));
 
         let not_descendant = KeyBindingContextPredicate::parse("!(parent > child)").unwrap();
-        assert!(not_descendant.eval(slice::from_ref(&parent_context)));
-        assert!(not_descendant.eval(slice::from_ref(&child_context)));
+        assert!(not_descendant.eval(&[parent_context.clone()]));
+        assert!(not_descendant.eval(&[child_context.clone()]));
         assert!(!not_descendant.eval(&[parent_context.clone(), child_context.clone()]));
 
         let not_descendant = KeyBindingContextPredicate::parse("parent > !child").unwrap();
-        assert!(!not_descendant.eval(slice::from_ref(&parent_context)));
-        assert!(!not_descendant.eval(slice::from_ref(&child_context)));
+        assert!(!not_descendant.eval(&[parent_context.clone()]));
+        assert!(!not_descendant.eval(&[child_context.clone()]));
         assert!(!not_descendant.eval(&[parent_context.clone(), child_context.clone()]));
 
         let double_not = KeyBindingContextPredicate::parse("!!editor").unwrap();
-        assert!(double_not.eval(slice::from_ref(&editor_context)));
-        assert!(!double_not.eval(slice::from_ref(&workspace_context)));
+        assert!(double_not.eval(&[editor_context.clone()]));
+        assert!(!double_not.eval(&[workspace_context.clone()]));
 
         // Test complex descendant cases
         let workspace_context = KeyContext::try_from("Workspace").unwrap();
@@ -756,9 +754,9 @@ mod tests {
 
         // !Workspace - shouldn't match when Workspace is in the context
         let not_workspace = KeyBindingContextPredicate::parse("!Workspace").unwrap();
-        assert!(!not_workspace.eval(slice::from_ref(&workspace_context)));
-        assert!(not_workspace.eval(slice::from_ref(&pane_context)));
-        assert!(not_workspace.eval(slice::from_ref(&editor_context)));
+        assert!(!not_workspace.eval(&[workspace_context.clone()]));
+        assert!(not_workspace.eval(&[pane_context.clone()]));
+        assert!(not_workspace.eval(&[editor_context.clone()]));
         assert!(!not_workspace.eval(&workspace_pane_editor));
     }
 }

--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -1,6 +1,28 @@
 use std::ops::Deref;
 
-use windows::Win32::UI::WindowsAndMessaging::HCURSOR;
+use windows::Win32::{Foundation::HANDLE, UI::WindowsAndMessaging::HCURSOR};
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SafeHandle {
+    raw: HANDLE,
+}
+
+unsafe impl Send for SafeHandle {}
+unsafe impl Sync for SafeHandle {}
+
+impl From<HANDLE> for SafeHandle {
+    fn from(value: HANDLE) -> Self {
+        SafeHandle { raw: value }
+    }
+}
+
+impl Deref for SafeHandle {
+    type Target = HANDLE;
+
+    fn deref(&self) -> &Self::Target {
+        &self.raw
+    }
+}
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SafeCursor {

--- a/crates/terminal_view/src/terminal_element.rs
+++ b/crates/terminal_view/src/terminal_element.rs
@@ -136,7 +136,7 @@ impl BatchedTextRun {
             .shape_line(
                 self.text.clone().into(),
                 self.font_size.to_pixels(window.rem_size()),
-                std::slice::from_ref(&self.style),
+                &[self.style.clone()],
                 Some(dimensions.cell_width),
             )
             .paint(pos, dimensions.line_height, window, cx);

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1754269165,
-        "narHash": "sha256-0tcS8FHd4QjbCVoxN9jI+PjHgA4vc/IjkUSp+N3zy0U=",
+        "lastModified": 1750266157,
+        "narHash": "sha256-tL42YoNg9y30u7zAqtoGDNdTyXTi8EALDeCB13FtbQA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "444e81206df3f7d92780680e45858e31d2f07a08",
+        "rev": "e37c943371b73ed87faf33f7583860f81f1d5a48",
         "type": "github"
       },
       "original": {
@@ -33,10 +33,10 @@
     "nixpkgs": {
       "locked": {
         "lastModified": 315532800,
-        "narHash": "sha256-5VYevX3GccubYeccRGAXvCPA1ktrGmIX1IFC0icX07g=",
-        "rev": "a683adc19ff5228af548c6539dbc3440509bfed3",
+        "narHash": "sha256-j+zO+IHQ7VwEam0pjPExdbLT2rVioyVS3iq4bLO3GEc=",
+        "rev": "61c0f513911459945e2cb8bf333dc849f1b976ff",
         "type": "tarball",
-        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre840248.a683adc19ff5/nixexprs.tar.xz"
+        "url": "https://releases.nixos.org/nixpkgs/nixpkgs-25.11pre821324.61c0f5139114/nixexprs.tar.xz"
       },
       "original": {
         "type": "tarball",
@@ -58,11 +58,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1754575663,
-        "narHash": "sha256-afOx8AG0KYtw7mlt6s6ahBBy7eEHZwws3iCRoiuRQS4=",
+        "lastModified": 1750964660,
+        "narHash": "sha256-YQ6EyFetjH1uy5JhdhRdPe6cuNXlYpMAQePFfZj4W7M=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6db0fb0e9cec2e9729dc52bf4898e6c135bb8a0f",
+        "rev": "04f0fcfb1a50c63529805a798b4b5c21610ff390",
         "type": "github"
       },
       "original": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89"
+channel = "1.88"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [


### PR DESCRIPTION
This reverts commit efba2cbfd371bdd85dc3bfdd6b98d1d405ad9a89.

Unfortunately, the Docker image for 1.89 has not shown up yet. Once it has, we should re-land this.

Release Notes:

- N/A
