### PR TITLE
open_ai: Add gpt-5, gpt-5-mini, gpt-5-nano (400k ctx, 128k max output; vision)

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -301,7 +301,22 @@ impl LanguageModel for OpenAiLanguageModel {
     }
 
     fn supports_images(&self) -> bool {
-        self.model.supports_vision()
+        use open_ai::Model;
+        match &self.model {
+            Model::FourOmni
+            | Model::FourOmniMini
+            | Model::FourPointOne
+            | Model::FourPointOneMini
+            | Model::FourPointOneNano
+            | Model::O1
+            | Model::O3
+            | Model::O4Mini => true,
+            Model::ThreePointFiveTurbo
+            | Model::Four
+            | Model::FourTurbo
+            | Model::O3Mini
+            | Model::Custom { .. } => false,
+        }
     }
 
     fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -310,7 +310,10 @@ impl LanguageModel for OpenAiLanguageModel {
             | Model::FourPointOneNano
             | Model::O1
             | Model::O3
-            | Model::O4Mini => true,
+            | Model::O4Mini
+            | Model::GptFive
+            | Model::GptFiveMini
+            | Model::GptFiveNano => true,
             Model::ThreePointFiveTurbo
             | Model::Four
             | Model::FourTurbo
@@ -672,6 +675,10 @@ pub fn count_open_ai_tokens(
                     "gpt-4"
                 };
                 tiktoken_rs::num_tokens_from_messages(model, &messages)
+            }
+            // Fallback until tiktoken-rs adds native support for GPT-5 series
+            Model::GptFive | Model::GptFiveMini | Model::GptFiveNano => {
+                tiktoken_rs::num_tokens_from_messages("gpt-4o", &messages)
             }
             // Currently supported by tiktoken_rs
             // Sometimes tiktoken-rs is behind on model support. If that is the case, make a new branch

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -301,7 +301,7 @@ impl LanguageModel for OpenAiLanguageModel {
     }
 
     fn supports_images(&self) -> bool {
-        false
+        self.model.supports_vision()
     }
 
     fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -202,24 +202,6 @@ impl Model {
         }
     }
 
-    /// Returns whether the given model supports vision (image processing) capabilities.
-    pub fn supports_vision(&self) -> bool {
-        match self {
-            Self::FourOmni
-            | Self::FourOmniMini
-            | Self::FourPointOne
-            | Self::FourPointOneMini
-            | Self::FourPointOneNano
-            | Self::O1
-            | Self::O3
-            | Self::O4Mini => true,
-            Self::ThreePointFiveTurbo
-            | Self::Four
-            | Self::FourTurbo
-            | Self::O3Mini => false,
-            Self::Custom { .. } => false, // Custom models don't support vision by default
-        }
-    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -201,7 +201,6 @@ impl Model {
             Self::O1 | Self::O3 | Self::O3Mini | Self::O4Mini | Model::Custom { .. } => false,
         }
     }
-
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -201,6 +201,25 @@ impl Model {
             Self::O1 | Self::O3 | Self::O3Mini | Self::O4Mini | Model::Custom { .. } => false,
         }
     }
+
+    /// Returns whether the given model supports vision (image processing) capabilities.
+    pub fn supports_vision(&self) -> bool {
+        match self {
+            Self::FourOmni
+            | Self::FourOmniMini
+            | Self::FourPointOne
+            | Self::FourPointOneMini
+            | Self::FourPointOneNano
+            | Self::O1
+            | Self::O3
+            | Self::O4Mini => true,
+            Self::ThreePointFiveTurbo
+            | Self::Four
+            | Self::FourTurbo
+            | Self::O3Mini => false,
+            Self::Custom { .. } => false, // Custom models don't support vision by default
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -75,6 +75,13 @@ pub enum Model {
     #[serde(rename = "o4-mini")]
     O4Mini,
 
+    #[serde(rename = "gpt-5")]
+    GptFive,
+    #[serde(rename = "gpt-5-mini")]
+    GptFiveMini,
+    #[serde(rename = "gpt-5-nano")]
+    GptFiveNano,
+
     #[serde(rename = "custom")]
     Custom {
         name: String,
@@ -105,6 +112,9 @@ impl Model {
             "o3-mini" => Ok(Self::O3Mini),
             "o3" => Ok(Self::O3),
             "o4-mini" => Ok(Self::O4Mini),
+            "gpt-5" => Ok(Self::GptFive),
+            "gpt-5-mini" => Ok(Self::GptFiveMini),
+            "gpt-5-nano" => Ok(Self::GptFiveNano),
             invalid_id => anyhow::bail!("invalid model id '{invalid_id}'"),
         }
     }
@@ -123,6 +133,9 @@ impl Model {
             Self::O3Mini => "o3-mini",
             Self::O3 => "o3",
             Self::O4Mini => "o4-mini",
+            Self::GptFive => "gpt-5",
+            Self::GptFiveMini => "gpt-5-mini",
+            Self::GptFiveNano => "gpt-5-nano",
             Self::Custom { name, .. } => name,
         }
     }
@@ -141,6 +154,9 @@ impl Model {
             Self::O3Mini => "o3-mini",
             Self::O3 => "o3",
             Self::O4Mini => "o4-mini",
+            Self::GptFive => "gpt-5",
+            Self::GptFiveMini => "gpt-5-mini",
+            Self::GptFiveNano => "gpt-5-nano",
             Self::Custom {
                 name, display_name, ..
             } => display_name.as_ref().unwrap_or(name),
@@ -161,6 +177,9 @@ impl Model {
             Self::O3Mini => 200_000,
             Self::O3 => 200_000,
             Self::O4Mini => 200_000,
+            Self::GptFive => 400_000,
+            Self::GptFiveMini => 400_000,
+            Self::GptFiveNano => 400_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }
@@ -182,6 +201,9 @@ impl Model {
             Self::O3Mini => Some(100_000),
             Self::O3 => Some(100_000),
             Self::O4Mini => Some(100_000),
+            Self::GptFive => Some(128_000),
+            Self::GptFiveMini => Some(128_000),
+            Self::GptFiveNano => Some(128_000),
         }
     }
 
@@ -197,7 +219,10 @@ impl Model {
             | Self::FourOmniMini
             | Self::FourPointOne
             | Self::FourPointOneMini
-            | Self::FourPointOneNano => true,
+            | Self::FourPointOneNano
+            | Self::GptFive
+            | Self::GptFiveMini
+            | Self::GptFiveNano => true,
             Self::O1 | Self::O3 | Self::O3Mini | Self::O4Mini | Model::Custom { .. } => false,
         }
     }


### PR DESCRIPTION
Release Notes:\n- Added OpenAI models: gpt-5, gpt-5-mini, gpt-5-nano\n- 400,000 token context window; 128,000 max output tokens\n- Image input supported; token counting falls back to gpt-4o encoding until upstream support\n\nTechnical:\n- Extend open_ai::Model enum and wiring in crates/open_ai and provider\n- Mark vision support for gpt-5 series\n- Token counting fallback for GPT-5 via gpt-4o tokenizer