### PR TITLE
Fix agent being marked as generating too often

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -6,7 +6,6 @@ use anyhow::{Context as _, Result};
 use assistant_tool::ActionLog;
 use buffer_diff::BufferDiff;
 use editor::{Bias, MultiBuffer, PathKey};
-use futures::future::{Fuse, FusedFuture};
 use futures::{FutureExt, channel::oneshot, future::BoxFuture};
 use gpui::{AppContext, Context, Entity, EventEmitter, SharedString, Task};
 use itertools::Itertools;
@@ -580,7 +579,7 @@ pub struct AcpThread {
     project: Entity<Project>,
     action_log: Entity<ActionLog>,
     shared_buffers: HashMap<Entity<Buffer>, BufferSnapshot>,
-    send_task: Option<Fuse<Task<()>>>,
+    send_task: Option<Task<()>>,
     connection: Rc<dyn AgentConnection>,
     session_id: acp::SessionId,
 }
@@ -670,11 +669,7 @@ impl AcpThread {
     }
 
     pub fn status(&self) -> ThreadStatus {
-        if self
-            .send_task
-            .as_ref()
-            .map_or(false, |t| !t.is_terminated())
-        {
+        if self.send_task.as_ref().map_or(false, |t| !t.is_finished()) {
             if self.waiting_for_tool_confirmation() {
                 ThreadStatus::WaitingForToolConfirmation
             } else {
@@ -1049,31 +1044,28 @@ impl AcpThread {
         let (tx, rx) = oneshot::channel();
         let cancel_task = self.cancel(cx);
 
-        self.send_task = Some(
-            cx.spawn(async move |this, cx| {
-                async {
-                    cancel_task.await;
+        self.send_task = Some(cx.spawn(async move |this, cx| {
+            async {
+                cancel_task.await;
 
-                    let result = this
-                        .update(cx, |this, cx| {
-                            this.connection.prompt(
-                                acp::PromptRequest {
-                                    prompt: message,
-                                    session_id: this.session_id.clone(),
-                                },
-                                cx,
-                            )
-                        })?
-                        .await;
+                let result = this
+                    .update(cx, |this, cx| {
+                        this.connection.prompt(
+                            acp::PromptRequest {
+                                prompt: message,
+                                session_id: this.session_id.clone(),
+                            },
+                            cx,
+                        )
+                    })?
+                    .await;
 
-                    tx.send(result).log_err();
-                    anyhow::Ok(())
-                }
-                .await
-                .log_err();
-            })
-            .fuse(),
-        );
+                tx.send(result).log_err();
+                anyhow::Ok(())
+            }
+            .await
+            .log_err();
+        }));
 
         cx.spawn(async move |this, cx| match rx.await {
             Ok(Err(e)) => {

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -79,6 +79,14 @@ impl<T> Task<T> {
             Task(TaskState::Spawned(task)) => task.detach(),
         }
     }
+
+    /// Whether the task has run to completion.
+    pub fn is_finished(&self) -> bool {
+        match self {
+            Task(TaskState::Ready(_)) => true,
+            Task(TaskState::Spawned(task)) => task.is_finished(),
+        }
+    }
 }
 
 impl<E, T> Task<Result<T, E>>


### PR DESCRIPTION
`<Fuse<Fut>>::is_terminated` doesn't work here, because we never actually poll the `send_task` in place (as opposed to the async closure that it runs internally), so we were always getting `false`.

Instead, expose a new `<Task<T>>::is_finished` method, which can just use the method of the same name from `async_task`, and call that from the agent code.

Release Notes:

- N/A