### PR TITLE
open_ai: Fix GPT-5 model family max tokens

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -176,9 +176,9 @@ impl Model {
             Self::O3Mini => 200_000,
             Self::O3 => 200_000,
             Self::O4Mini => 200_000,
-            Self::Five => 272_000,
-            Self::FiveMini => 272_000,
-            Self::FiveNano => 272_000,
+            Self::Five => 400_000,
+            Self::FiveMini => 400_000,
+            Self::FiveNano => 400_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }


### PR DESCRIPTION
Follow up: #35822

Release Notes:

- Fix GPT-5 model family context length.
