### PR TITLE
Lay the groundwork to create terminals in `AcpThread`

### DIFF
--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -503,29 +503,27 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
                         match event {
                             AgentResponseEvent::Text(text) => {
                                 acp_thread.update(cx, |thread, cx| {
-                                    thread.handle_session_update(
-                                        acp::SessionUpdate::AgentMessageChunk {
-                                            content: acp::ContentBlock::Text(acp::TextContent {
-                                                text,
-                                                annotations: None,
-                                            }),
-                                        },
+                                    thread.push_assistant_content_block(
+                                        acp::ContentBlock::Text(acp::TextContent {
+                                            text,
+                                            annotations: None,
+                                        }),
+                                        false,
                                         cx,
                                     )
-                                })??;
+                                })?;
                             }
                             AgentResponseEvent::Thinking(text) => {
                                 acp_thread.update(cx, |thread, cx| {
-                                    thread.handle_session_update(
-                                        acp::SessionUpdate::AgentThoughtChunk {
-                                            content: acp::ContentBlock::Text(acp::TextContent {
-                                                text,
-                                                annotations: None,
-                                            }),
-                                        },
+                                    thread.push_assistant_content_block(
+                                        acp::ContentBlock::Text(acp::TextContent {
+                                            text,
+                                            annotations: None,
+                                        }),
+                                        true,
                                         cx,
                                     )
-                                })??;
+                                })?;
                             }
                             AgentResponseEvent::ToolCallAuthorization(ToolCallAuthorization {
                                 tool_call,
@@ -551,27 +549,12 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
                             }
                             AgentResponseEvent::ToolCall(tool_call) => {
                                 acp_thread.update(cx, |thread, cx| {
-                                    thread.handle_session_update(
-                                        acp::SessionUpdate::ToolCall(tool_call),
-                                        cx,
-                                    )
-                                })??;
+                                    thread.upsert_tool_call(tool_call, cx)
+                                })?;
                             }
-                            AgentResponseEvent::ToolCallUpdate(tool_call_update) => {
+                            AgentResponseEvent::ToolCallUpdate(update) => {
                                 acp_thread.update(cx, |thread, cx| {
-                                    thread.handle_session_update(
-                                        acp::SessionUpdate::ToolCallUpdate(tool_call_update),
-                                        cx,
-                                    )
-                                })??;
-                            }
-                            AgentResponseEvent::ToolCallDiff(tool_call_diff) => {
-                                acp_thread.update(cx, |thread, cx| {
-                                    thread.set_tool_call_diff(
-                                        &tool_call_diff.tool_call_id,
-                                        tool_call_diff.diff,
-                                        cx,
-                                    )
+                                    thread.update_tool_call(update, cx)
                                 })??;
                             }
                             AgentResponseEvent::Stop(stop_reason) => {

--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -668,7 +668,7 @@ async fn test_tool_updates_to_completion(cx: &mut TestAppContext) {
     fake_model.send_last_completion_stream_event(LanguageModelCompletionEvent::ToolUse(
         LanguageModelToolUse {
             id: "1".into(),
-            name: ThinkingTool.name().into(),
+            name: "thinking".into(),
             raw_input: input.to_string(),
             input,
             is_input_complete: true,
@@ -682,7 +682,7 @@ async fn test_tool_updates_to_completion(cx: &mut TestAppContext) {
         tool_call,
         acp::ToolCall {
             id: acp::ToolCallId("1".into()),
-            title: "thinking".into(),
+            title: "Thinking".into(),
             kind: acp::ToolKind::Think,
             status: acp::ToolCallStatus::Pending,
             content: vec![],

--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -27,7 +27,7 @@ mod test_tools;
 use test_tools::*;
 
 #[gpui::test]
-// #[ignore = "can't run on CI yet"]
+#[ignore = "can't run on CI yet"]
 async fn test_echo(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Sonnet4).await;
 
@@ -47,7 +47,7 @@ async fn test_echo(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-// #[ignore = "can't run on CI yet"]
+#[ignore = "can't run on CI yet"]
 async fn test_thinking(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Sonnet4Thinking).await;
 
@@ -119,7 +119,7 @@ async fn test_system_prompt(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-// #[ignore = "can't run on CI yet"]
+#[ignore = "can't run on CI yet"]
 async fn test_basic_tool_calls(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Sonnet4).await;
 
@@ -169,7 +169,7 @@ async fn test_basic_tool_calls(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-// #[ignore = "can't run on CI yet"]
+#[ignore = "can't run on CI yet"]
 async fn test_streaming_tool_calls(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Sonnet4).await;
 
@@ -373,7 +373,7 @@ async fn next_tool_call_authorization(
 }
 
 #[gpui::test]
-// #[ignore = "can't run on CI yet"]
+#[ignore = "can't run on CI yet"]
 async fn test_concurrent_tool_calls(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Sonnet4).await;
 
@@ -412,7 +412,7 @@ async fn test_concurrent_tool_calls(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
-// #[ignore = "can't run on CI yet"]
+#[ignore = "can't run on CI yet"]
 async fn test_cancellation(cx: &mut TestAppContext) {
     let ThreadTest { model, thread, .. } = setup(cx, TestModel::Sonnet4).await;
 
@@ -431,7 +431,7 @@ async fn test_cancellation(cx: &mut TestAppContext) {
     let mut echo_id = None;
     let mut echo_completed = false;
     while let Some(event) = events.next().await {
-        match dbg!(event.unwrap()) {
+        match event.unwrap() {
             AgentResponseEvent::ToolCall(tool_call) => {
                 assert_eq!(tool_call.title, expected_tools.remove(0));
                 if tool_call.title == "Echo" {

--- a/crates/agent2/src/tests/test_tools.rs
+++ b/crates/agent2/src/tests/test_tools.rs
@@ -24,7 +24,7 @@ impl AgentTool for EchoTool {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
+    fn initial_title(&self, _input: Result<Self::Input, serde_json::Value>) -> SharedString {
         "Echo".into()
     }
 
@@ -55,8 +55,8 @@ impl AgentTool for DelayTool {
         "delay".into()
     }
 
-    fn initial_title(&self, input: Option<Self::Input>) -> SharedString {
-        if let Some(input) = input {
+    fn initial_title(&self, input: Result<Self::Input, serde_json::Value>) -> SharedString {
+        if let Ok(input) = input {
             format!("Delay {}ms", input.ms).into()
         } else {
             "Delay".into()
@@ -100,7 +100,7 @@ impl AgentTool for ToolRequiringPermission {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
+    fn initial_title(&self, _input: Result<Self::Input, serde_json::Value>) -> SharedString {
         "This tool requires permission".into()
     }
 
@@ -135,7 +135,7 @@ impl AgentTool for InfiniteTool {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
+    fn initial_title(&self, _input: Result<Self::Input, serde_json::Value>) -> SharedString {
         "Infinite Tool".into()
     }
 
@@ -186,7 +186,7 @@ impl AgentTool for WordListTool {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
+    fn initial_title(&self, _input: Result<Self::Input, serde_json::Value>) -> SharedString {
         "List of random words".into()
     }
 

--- a/crates/agent2/src/tests/test_tools.rs
+++ b/crates/agent2/src/tests/test_tools.rs
@@ -24,7 +24,7 @@ impl AgentTool for EchoTool {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _: Self::Input) -> SharedString {
+    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
         "Echo".into()
     }
 
@@ -55,8 +55,12 @@ impl AgentTool for DelayTool {
         "delay".into()
     }
 
-    fn initial_title(&self, input: Self::Input) -> SharedString {
-        format!("Delay {}ms", input.ms).into()
+    fn initial_title(&self, input: Option<Self::Input>) -> SharedString {
+        if let Some(input) = input {
+            format!("Delay {}ms", input.ms).into()
+        } else {
+            "Delay".into()
+        }
     }
 
     fn kind(&self) -> acp::ToolKind {
@@ -96,7 +100,7 @@ impl AgentTool for ToolRequiringPermission {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Self::Input) -> SharedString {
+    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
         "This tool requires permission".into()
     }
 
@@ -131,8 +135,8 @@ impl AgentTool for InfiniteTool {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Self::Input) -> SharedString {
-        "This is the tool that never ends... it just goes on and on my friends!".into()
+    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
+        "Infinite Tool".into()
     }
 
     fn run(
@@ -182,7 +186,7 @@ impl AgentTool for WordListTool {
         acp::ToolKind::Other
     }
 
-    fn initial_title(&self, _input: Self::Input) -> SharedString {
+    fn initial_title(&self, _input: Option<Self::Input>) -> SharedString {
         "List of random words".into()
     }
 

--- a/crates/agent2/src/thread.rs
+++ b/crates/agent2/src/thread.rs
@@ -102,9 +102,8 @@ pub enum AgentResponseEvent {
     Text(String),
     Thinking(String),
     ToolCall(acp::ToolCall),
-    ToolCallUpdate(acp::ToolCallUpdate),
+    ToolCallUpdate(acp_thread::ToolCallUpdate),
     ToolCallAuthorization(ToolCallAuthorization),
-    ToolCallDiff(ToolCallDiff),
     Stop(acp::StopReason),
 }
 
@@ -113,12 +112,6 @@ pub struct ToolCallAuthorization {
     pub tool_call: acp::ToolCall,
     pub options: Vec<acp::PermissionOption>,
     pub response: oneshot::Sender<acp::PermissionOptionId>,
-}
-
-#[derive(Debug)]
-pub struct ToolCallDiff {
-    pub tool_call_id: acp::ToolCallId,
-    pub diff: Entity<acp_thread::Diff>,
 }
 
 pub struct Thread {
@@ -294,7 +287,7 @@ impl Thread {
                     while let Some(tool_result) = tool_uses.next().await {
                         log::info!("Tool finished {:?}", tool_result);
 
-                        event_stream.send_tool_call_update(
+                        event_stream.update_tool_call_fields(
                             &tool_result.tool_use_id,
                             acp::ToolCallUpdateFields {
                                 status: Some(if tool_result.is_error {
@@ -477,9 +470,7 @@ impl Thread {
         let mut title = SharedString::from(&tool_use.name);
         let mut kind = acp::ToolKind::Other;
         if let Some(tool) = tool.as_ref() {
-            if let Ok(initial_title) = tool.initial_title(tool_use.input.clone()) {
-                title = initial_title;
-            }
+            title = tool.initial_title(tool_use.input.clone());
             kind = tool.kind();
         }
 
@@ -489,7 +480,7 @@ impl Thread {
                 .content
                 .push(MessageContent::ToolUse(tool_use.clone()));
         } else {
-            event_stream.send_tool_call_update(
+            event_stream.update_tool_call_fields(
                 &tool_use.id,
                 acp::ToolCallUpdateFields {
                     title: Some(title.into()),
@@ -517,7 +508,7 @@ impl Thread {
 
         let tool_event_stream =
             ToolCallEventStream::new(&tool_use, tool.kind(), event_stream.clone());
-        tool_event_stream.send_update(acp::ToolCallUpdateFields {
+        tool_event_stream.update_fields(acp::ToolCallUpdateFields {
             status: Some(acp::ToolCallStatus::InProgress),
             ..Default::default()
         });
@@ -704,7 +695,7 @@ where
     fn kind(&self) -> acp::ToolKind;
 
     /// The initial tool title to display. Can be updated during the tool run.
-    fn initial_title(&self, input: Self::Input) -> SharedString;
+    fn initial_title(&self, input: Option<Self::Input>) -> SharedString;
 
     /// Returns the JSON schema that describes the tool's input.
     fn input_schema(&self) -> Schema {
@@ -735,7 +726,7 @@ pub trait AnyAgentTool {
     fn name(&self) -> SharedString;
     fn description(&self, cx: &mut App) -> SharedString;
     fn kind(&self) -> acp::ToolKind;
-    fn initial_title(&self, input: serde_json::Value) -> Result<SharedString>;
+    fn initial_title(&self, input: serde_json::Value) -> SharedString;
     fn input_schema(&self, format: LanguageModelToolSchemaFormat) -> Result<serde_json::Value>;
     fn run(
         self: Arc<Self>,
@@ -761,9 +752,9 @@ where
         self.0.kind()
     }
 
-    fn initial_title(&self, input: serde_json::Value) -> Result<SharedString> {
-        let parsed_input = serde_json::from_value(input)?;
-        Ok(self.0.initial_title(parsed_input))
+    fn initial_title(&self, input: serde_json::Value) -> SharedString {
+        let parsed_input = serde_json::from_value(input).ok();
+        self.0.initial_title(parsed_input)
     }
 
     fn input_schema(&self, format: LanguageModelToolSchemaFormat) -> Result<serde_json::Value> {
@@ -886,7 +877,7 @@ impl AgentResponseEventStream {
         }
     }
 
-    fn send_tool_call_update(
+    fn update_tool_call_fields(
         &self,
         tool_use_id: &LanguageModelToolUseId,
         fields: acp::ToolCallUpdateFields,
@@ -896,14 +887,21 @@ impl AgentResponseEventStream {
                 acp::ToolCallUpdate {
                     id: acp::ToolCallId(tool_use_id.to_string().into()),
                     fields,
-                },
+                }
+                .into(),
             )))
             .ok();
     }
 
-    fn send_tool_call_diff(&self, tool_call_diff: ToolCallDiff) {
+    fn update_tool_call_diff(&self, tool_use_id: &LanguageModelToolUseId, diff: Entity<Diff>) {
         self.0
-            .unbounded_send(Ok(AgentResponseEvent::ToolCallDiff(tool_call_diff)))
+            .unbounded_send(Ok(AgentResponseEvent::ToolCallUpdate(
+                acp_thread::ToolCallUpdateDiff {
+                    id: acp::ToolCallId(tool_use_id.to_string().into()),
+                    diff,
+                }
+                .into(),
+            )))
             .ok();
     }
 
@@ -975,15 +973,13 @@ impl ToolCallEventStream {
         }
     }
 
-    pub fn send_update(&self, fields: acp::ToolCallUpdateFields) {
-        self.stream.send_tool_call_update(&self.tool_use_id, fields);
+    pub fn update_fields(&self, fields: acp::ToolCallUpdateFields) {
+        self.stream
+            .update_tool_call_fields(&self.tool_use_id, fields);
     }
 
-    pub fn send_diff(&self, diff: Entity<Diff>) {
-        self.stream.send_tool_call_diff(ToolCallDiff {
-            tool_call_id: acp::ToolCallId(self.tool_use_id.to_string().into()),
-            diff,
-        });
+    pub fn update_diff(&self, diff: Entity<Diff>) {
+        self.stream.update_tool_call_diff(&self.tool_use_id, diff);
     }
 
     pub fn authorize(&self, title: String) -> impl use<> + Future<Output = Result<()>> {

--- a/crates/agent2/src/thread.rs
+++ b/crates/agent2/src/thread.rs
@@ -695,7 +695,7 @@ where
     fn kind(&self) -> acp::ToolKind;
 
     /// The initial tool title to display. Can be updated during the tool run.
-    fn initial_title(&self, input: Option<Self::Input>) -> SharedString;
+    fn initial_title(&self, input: Result<Self::Input, serde_json::Value>) -> SharedString;
 
     /// Returns the JSON schema that describes the tool's input.
     fn input_schema(&self) -> Schema {
@@ -753,7 +753,7 @@ where
     }
 
     fn initial_title(&self, input: serde_json::Value) -> SharedString {
-        let parsed_input = serde_json::from_value(input).ok();
+        let parsed_input = serde_json::from_value(input.clone()).map_err(|_| input);
         self.0.initial_title(parsed_input)
     }
 

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -1,3 +1,4 @@
+use crate::{AgentTool, Thread, ToolCallEventStream};
 use acp_thread::Diff;
 use agent_client_protocol as acp;
 use anyhow::{anyhow, Context as _, Result};
@@ -20,7 +21,7 @@ use std::sync::Arc;
 use ui::SharedString;
 use util::ResultExt;
 
-use crate::{AgentTool, Thread, ToolCallEventStream};
+const DEFAULT_UI_TEXT: &str = "Editing file";
 
 /// This is a tool for creating a new file or editing an existing file. For moving or renaming files, you should generally use the `terminal` tool with the 'mv' command instead.
 ///
@@ -76,6 +77,14 @@ pub struct EditFileToolInput {
     /// When a file already exists or you just created it, prefer editing
     /// it as opposed to recreating it from scratch.
     pub mode: EditFileMode,
+}
+
+#[derive(Debug, Serialize, Deserialize, JsonSchema)]
+struct EditFileToolPartialInput {
+    #[serde(default)]
+    path: String,
+    #[serde(default)]
+    display_description: String,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
@@ -182,11 +191,26 @@ impl AgentTool for EditFileTool {
         acp::ToolKind::Edit
     }
 
-    fn initial_title(&self, input: Option<Self::Input>) -> SharedString {
-        if let Some(input) = input {
-            input.display_description.into()
-        } else {
-            "Editing file".into()
+    fn initial_title(&self, input: Result<Self::Input, serde_json::Value>) -> SharedString {
+        match input {
+            Ok(input) => input.display_description.into(),
+            Err(raw_input) => {
+                if let Some(input) =
+                    serde_json::from_value::<EditFileToolPartialInput>(raw_input).ok()
+                {
+                    let description = input.display_description.trim();
+                    if !description.is_empty() {
+                        return description.to_string().into();
+                    }
+
+                    let path = input.path.trim().to_string();
+                    if !path.is_empty() {
+                        return path.into();
+                    }
+                }
+
+                DEFAULT_UI_TEXT.into()
+            }
         }
     }
 
@@ -1350,6 +1374,66 @@ mod tests {
             .unwrap();
             assert!(stream_rx.try_next().is_err());
         }
+    }
+
+    #[gpui::test]
+    async fn test_initial_title_with_partial_input(cx: &mut TestAppContext) {
+        init_test(cx);
+        let fs = project::FakeFs::new(cx.executor());
+        let project = Project::test(fs.clone(), [path!("/project").as_ref()], cx).await;
+        let action_log = cx.new(|_| ActionLog::new(project.clone()));
+        let model = Arc::new(FakeLanguageModel::default());
+        let thread = cx.new(|_| {
+            Thread::new(
+                project.clone(),
+                Rc::default(),
+                action_log.clone(),
+                Templates::new(),
+                model.clone(),
+            )
+        });
+        let tool = Arc::new(EditFileTool { thread });
+
+        assert_eq!(
+            tool.initial_title(Err(json!({
+                "path": "src/main.rs",
+                "display_description": "",
+                "old_string": "old code",
+                "new_string": "new code"
+            }))),
+            "src/main.rs"
+        );
+        assert_eq!(
+            tool.initial_title(Err(json!({
+                "path": "",
+                "display_description": "Fix error handling",
+                "old_string": "old code",
+                "new_string": "new code"
+            }))),
+            "Fix error handling"
+        );
+        assert_eq!(
+            tool.initial_title(Err(json!({
+                "path": "src/main.rs",
+                "display_description": "Fix error handling",
+                "old_string": "old code",
+                "new_string": "new code"
+            }))),
+            "Fix error handling"
+        );
+        assert_eq!(
+            tool.initial_title(Err(json!({
+                "path": "",
+                "display_description": "",
+                "old_string": "old code",
+                "new_string": "new code"
+            }))),
+            DEFAULT_UI_TEXT
+        );
+        assert_eq!(
+            tool.initial_title(Err(serde_json::Value::Null)),
+            DEFAULT_UI_TEXT
+        );
     }
 
     fn init_test(cx: &mut TestAppContext) {

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -182,8 +182,12 @@ impl AgentTool for EditFileTool {
         acp::ToolKind::Edit
     }
 
-    fn initial_title(&self, input: Self::Input) -> SharedString {
-        input.display_description.into()
+    fn initial_title(&self, input: Option<Self::Input>) -> SharedString {
+        if let Some(input) = input {
+            input.display_description.into()
+        } else {
+            "Editing file".into()
+        }
     }
 
     fn run(
@@ -226,7 +230,7 @@ impl AgentTool for EditFileTool {
                 .await?;
 
             let diff = cx.new(|cx| Diff::new(buffer.clone(), cx))?;
-            event_stream.send_diff(diff.clone());
+            event_stream.update_diff(diff.clone());
 
             let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
             let old_text = cx

--- a/crates/agent2/src/tools/find_path_tool.rs
+++ b/crates/agent2/src/tools/find_path_tool.rs
@@ -111,7 +111,7 @@ impl AgentTool for FindPathTool {
             let paginated_matches: &[PathBuf] = &matches[cmp::min(input.offset, matches.len())
                 ..cmp::min(input.offset + RESULTS_PER_PAGE, matches.len())];
 
-            event_stream.send_update(acp::ToolCallUpdateFields {
+            event_stream.update_fields(acp::ToolCallUpdateFields {
                 title: Some(if paginated_matches.len() == 0 {
                     "No matches".into()
                 } else if paginated_matches.len() == 1 {

--- a/crates/agent2/src/tools/find_path_tool.rs
+++ b/crates/agent2/src/tools/find_path_tool.rs
@@ -94,8 +94,12 @@ impl AgentTool for FindPathTool {
         acp::ToolKind::Search
     }
 
-    fn initial_title(&self, input: Self::Input) -> SharedString {
-        format!("Find paths matching “`{}`”", input.glob).into()
+    fn initial_title(&self, input: Result<Self::Input, serde_json::Value>) -> SharedString {
+        let mut title = "Find paths".to_string();
+        if let Ok(input) = input {
+            title.push_str(&format!(" matching “`{}`”", input.glob));
+        }
+        title.into()
     }
 
     fn run(

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -70,24 +70,28 @@ impl AgentTool for ReadFileTool {
         acp::ToolKind::Read
     }
 
-    fn initial_title(&self, input: Self::Input) -> SharedString {
-        let path = &input.path;
-        match (input.start_line, input.end_line) {
-            (Some(start), Some(end)) => {
-                format!(
-                    "[Read file `{}` (lines {}-{})](@selection:{}:({}-{}))",
-                    path, start, end, path, start, end
-                )
+    fn initial_title(&self, input: Result<Self::Input, serde_json::Value>) -> SharedString {
+        if let Ok(input) = input {
+            let path = &input.path;
+            match (input.start_line, input.end_line) {
+                (Some(start), Some(end)) => {
+                    format!(
+                        "[Read file `{}` (lines {}-{})](@selection:{}:({}-{}))",
+                        path, start, end, path, start, end
+                    )
+                }
+                (Some(start), None) => {
+                    format!(
+                        "[Read file `{}` (from line {})](@selection:{}:({}-{}))",
+                        path, start, path, start, start
+                    )
+                }
+                _ => format!("[Read file `{}`](@file:{})", path, path),
             }
-            (Some(start), None) => {
-                format!(
-                    "[Read file `{}` (from line {})](@selection:{}:({}-{}))",
-                    path, start, path, start, start
-                )
-            }
-            _ => format!("[Read file `{}`](@file:{})", path, path),
+            .into()
+        } else {
+            "Read file".into()
         }
-        .into()
     }
 
     fn run(

--- a/crates/agent2/src/tools/thinking_tool.rs
+++ b/crates/agent2/src/tools/thinking_tool.rs
@@ -40,7 +40,7 @@ impl AgentTool for ThinkingTool {
         event_stream: ToolCallEventStream,
         _cx: &mut App,
     ) -> Task<Result<String>> {
-        event_stream.send_update(acp::ToolCallUpdateFields {
+        event_stream.update_fields(acp::ToolCallUpdateFields {
             content: Some(vec![input.content.into()]),
             ..Default::default()
         });

--- a/crates/agent2/src/tools/thinking_tool.rs
+++ b/crates/agent2/src/tools/thinking_tool.rs
@@ -30,7 +30,7 @@ impl AgentTool for ThinkingTool {
         acp::ToolKind::Think
     }
 
-    fn initial_title(&self, _input: Self::Input) -> SharedString {
+    fn initial_title(&self, _input: Result<Self::Input, serde_json::Value>) -> SharedString {
         "Thinking".into()
     }
 


### PR DESCRIPTION
This just prepares the types so that it will be easy later to update a tool call with a terminal entity. We paused because we realized we want to simplify how terminals are created in zed, and so that warrants a dedicated pull request that can be reviewed in isolation.

Release Notes:

- N/A
