### PR TITLE
ci: Use faster Linux ARM runners

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -24,6 +24,9 @@ self-hosted-runner:
     - namespace-profile-8x16-ubuntu-2204
     - namespace-profile-16x32-ubuntu-2204
     - namespace-profile-32x64-ubuntu-2204
+    # Namespace Limited Preview
+    - namespace-profile-8x16-ubuntu-2004-arm-m4
+    - namespace-profile-8x32-ubuntu-2004-arm-m4
     # Self Hosted Runners
     - self-mini-macos
     - self-32vcpu-windows-2022

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
     name: Check Postgres and Protobuf migrations, mergability
     needs: [job_spec]
     if: |
+      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     timeout-minutes: 60
@@ -134,6 +135,7 @@ jobs:
     name: Check workspace-hack crate
     needs: [job_spec]
     if: |
+      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
@@ -218,6 +220,7 @@ jobs:
     name: Check docs
     needs: [job_spec]
     if: |
+      false &&
       github.repository_owner == 'zed-industries' &&
       (needs.job_spec.outputs.run_tests == 'true' || needs.job_spec.outputs.run_docs == 'true')
     runs-on:
@@ -255,6 +258,7 @@ jobs:
     name: (macOS) Run Clippy and tests
     needs: [job_spec]
     if: |
+      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
@@ -377,6 +381,7 @@ jobs:
     name: (Linux) Build Remote Server
     needs: [job_spec]
     if: |
+      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
@@ -416,6 +421,7 @@ jobs:
     name: (Windows) Run Clippy and tests
     needs: [job_spec]
     if: |
+      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on: [self-hosted, Windows, X64]
@@ -511,8 +517,9 @@ jobs:
     runs-on:
       - self-mini-macos
     if: |
-      startsWith(github.ref, 'refs/tags/v')
-      || contains(github.event.pull_request.labels.*.name, 'run-bundling')
+      false &&
+      ( startsWith(github.ref, 'refs/tags/v')
+      || contains(github.event.pull_request.labels.*.name, 'run-bundling') )
     needs: [macos_tests]
     env:
       MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -599,8 +606,9 @@ jobs:
     runs-on:
       - namespace-profile-16x32-ubuntu-2004 # ubuntu 20.04 for minimal glibc
     if: |
-      startsWith(github.ref, 'refs/tags/v')
-      || contains(github.event.pull_request.labels.*.name, 'run-bundling')
+      false &&
+      ( startsWith(github.ref, 'refs/tags/v')
+      || contains(github.event.pull_request.labels.*.name, 'run-bundling') )
     needs: [linux_tests]
     steps:
       - name: Checkout repo
@@ -772,7 +780,7 @@ jobs:
     timeout-minutes: 120
     name: Create a Windows installer
     runs-on: [self-hosted, Windows, X64]
-    if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
+    if: false && contains(github.event.pull_request.labels.*.name, 'run-bundling')
     # if: (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     needs: [windows_tests]
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -658,7 +658,7 @@ jobs:
     timeout-minutes: 60
     name: Linux arm64 release bundle
     runs-on:
-      - namespace-profile-8x16-ubuntu-2004-arm-m4 # ubuntu 20.04 for minimal glibc
+      - namespace-profile-8x32-ubuntu-2004-arm-m4 # ubuntu 20.04 for minimal glibc
     if: |
       startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -650,7 +650,7 @@ jobs:
     timeout-minutes: 60
     name: Linux arm64 release bundle
     runs-on:
-      - namespace-profile-32x64-ubuntu-2004-arm # ubuntu 20.04 for minimal glibc
+      - namespace-profile-8x16-ubuntu-2004-arm-m4 # ubuntu 20.04 for minimal glibc
     if: |
       startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,6 @@ jobs:
     name: Check Postgres and Protobuf migrations, mergability
     needs: [job_spec]
     if: |
-      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     timeout-minutes: 60
@@ -135,7 +134,6 @@ jobs:
     name: Check workspace-hack crate
     needs: [job_spec]
     if: |
-      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
@@ -220,7 +218,6 @@ jobs:
     name: Check docs
     needs: [job_spec]
     if: |
-      false &&
       github.repository_owner == 'zed-industries' &&
       (needs.job_spec.outputs.run_tests == 'true' || needs.job_spec.outputs.run_docs == 'true')
     runs-on:
@@ -258,7 +255,6 @@ jobs:
     name: (macOS) Run Clippy and tests
     needs: [job_spec]
     if: |
-      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
@@ -381,7 +377,6 @@ jobs:
     name: (Linux) Build Remote Server
     needs: [job_spec]
     if: |
-      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on:
@@ -421,7 +416,6 @@ jobs:
     name: (Windows) Run Clippy and tests
     needs: [job_spec]
     if: |
-      false &&
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
     runs-on: [self-hosted, Windows, X64]
@@ -517,7 +511,6 @@ jobs:
     runs-on:
       - self-mini-macos
     if: |
-      false &&
       ( startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling') )
     needs: [macos_tests]
@@ -606,7 +599,6 @@ jobs:
     runs-on:
       - namespace-profile-16x32-ubuntu-2004 # ubuntu 20.04 for minimal glibc
     if: |
-      false &&
       ( startsWith(github.ref, 'refs/tags/v')
       || contains(github.event.pull_request.labels.*.name, 'run-bundling') )
     needs: [linux_tests]
@@ -711,10 +703,8 @@ jobs:
     timeout-minutes: 60
     runs-on: github-8vcpu-ubuntu-2404
     if: |
-      false && (
-      startsWith(github.ref, 'refs/tags/v')
-      || contains(github.event.pull_request.labels.*.name, 'run-bundling')
-      )
+      ( startsWith(github.ref, 'refs/tags/v')
+      || contains(github.event.pull_request.labels.*.name, 'run-bundling') )
     needs: [linux_tests]
     name: Build Zed on FreeBSD
     steps:
@@ -780,7 +770,7 @@ jobs:
     timeout-minutes: 120
     name: Create a Windows installer
     runs-on: [self-hosted, Windows, X64]
-    if: false && contains(github.event.pull_request.labels.*.name, 'run-bundling')
+    if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
     # if: (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     needs: [windows_tests]
     env:

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -168,7 +168,7 @@ jobs:
     name: Create a Linux *.tar.gz bundle for ARM
     if: github.repository_owner == 'zed-industries'
     runs-on:
-      - namespace-profile-32x64-ubuntu-2004-arm # ubuntu 20.04 for minimal glibc
+      - namespace-profile-8x32-ubuntu-2004-arm-m4 # ubuntu 20.04 for minimal glibc
     needs: tests
     steps:
       - name: Checkout repo


### PR DESCRIPTION
Switch our Linux aarch_64 release builds from Linux on Graviton (32 vCPU, 64GB) to Linux running on Apple M4 Pro (8vCPU, 32GB). Builds are faster (20mins vs 30mins) for the same cost (960 unit minutes; ~$0.96/ea).

<img width="763" height="285" alt="Screenshot 2025-08-08 at 13 14 41" src="https://github.com/user-attachments/assets/12c45c8b-59f3-40d8-974c-1003b5080287" />

Release Notes:

- N/A