### PR TITLE
ui: Fix switch field info tooltip

### DIFF
--- a/crates/ui/src/components/toggle.rs
+++ b/crates/ui/src/components/toggle.rs
@@ -659,10 +659,12 @@ impl RenderOnce for SwitchField {
                         .icon_size(IconSize::XSmall)
                         .icon_color(Color::Muted)
                         .shape(crate::IconButtonShape::Square)
+                        .style(ButtonStyle::Transparent)
                         .tooltip({
                             let tooltip = tooltip_fn.clone();
                             move |window, cx| tooltip(window, cx)
-                        }),
+                        })
+                        .on_click(|_, _, _| {}), // Intentional empty on click handler so that clicking on the info tooltip icon doesn't trigger the switch toggle
                 )
         });
 


### PR DESCRIPTION
Passing an empty on_click handler so that clicking on the info icon doesn't actually trigger the switch itself, which happens if you click anywhere in the general switch field surface area.

Release Notes:

- N/A
