### PR TITLE
thread_view: Trim only trailing whitespace from last chunk of user message

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -410,7 +410,7 @@ impl AcpThreadView {
                 }
 
                 if ix < text.len() {
-                    let last_chunk = text[ix..].trim();
+                    let last_chunk = text[ix..].trim_end();
                     if !last_chunk.is_empty() {
                         chunks.push(last_chunk.into());
                     }


### PR DESCRIPTION
This fixes internal whitespace after the last @mention going missing from the user message as displayed in history.

Release Notes:

- N/A