### PR TITLE
Fix "Find in Folder" presenting undesired search regions

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -2725,6 +2725,15 @@ impl ProjectPanel {
                 dir_path
             };
 
+            // Ensure trailing slash.
+            let dir_path = {
+                let mut complete_path = dir_path.to_path_buf();
+                if !complete_path.ends_with("/") {
+                    complete_path.as_mut_os_string().push("/");
+                }
+                Arc::from(complete_path)
+            };
+
             self.workspace
                 .update(cx, |workspace, cx| {
                     search::ProjectSearchView::new_search_in_directory(


### PR DESCRIPTION
Closes #35195.

This PR ensures the path produced by the "Find in Folder" panel action has a trailing "/" to prevent incorrect search results.

As mentioned in #35195, directories which are prefixed by the intended search directory are presented erroneously. But this also extends to files! (This was my motivation for creating this PR)

Tested on macOS.

Release Notes:
- Fixed "Find in Folder" panel action