### PR TITLE
Add sentry release step to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -831,3 +831,12 @@ jobs:
         run: gh release edit "$GITHUB_REF_NAME" --draft=false
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@526942b68292201ac6bbb99b9a0747d4abee354c # v3
+        env:
+          SENTRY_ORG: zed-dev
+          SENTRY_PROJECT: zed
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          environment: production

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -316,3 +316,12 @@ jobs:
           git config user.email github-actions@github.com
           git tag -f nightly
           git push origin nightly --force
+
+      - name: Create Sentry release
+        uses: getsentry/action-release@526942b68292201ac6bbb99b9a0747d4abee354c # v3
+        env:
+          SENTRY_ORG: zed-dev
+          SENTRY_PROJECT: zed
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+        with:
+          environment: production


### PR DESCRIPTION
This should allow us to associate sha's from crashes and generate links to github source in sentry.

Release Notes:

- N/A