### PR TITLE
Add more info to crash reports

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -603,11 +603,31 @@ async fn upload_minidump(
         .text("platform", "rust");
     if let Some(panic) = panic {
         form = form
+            .text("channel", panic.release_channel.clone())
+            .text("version", panic.app_version.clone())
+            .text("sentry[context][os][name]", panic.os_name.clone())
             .text(
+                "sentry[context][device][architecture]",
+                panic.architecture.clone(),
+            )
+            .text("sentry[logentry][formatted]", panic.payload.clone());
+
+        if let Some(sha) = panic.app_commit_sha.clone() {
+            form = form.text("sentry[release]", sha)
+        } else {
+            form = form.text(
                 "sentry[release]",
                 format!("{}-{}", panic.release_channel, panic.app_version),
             )
-            .text("sentry[logentry][formatted]", panic.payload.clone());
+        }
+        if let Some(v) = panic.os_version.clone() {
+            form = form.text("sentry[context][os][release]", v);
+        }
+        if let Some(location) = panic.location_data.as_ref() {
+            form = form.text("span", format!("{}:{}", location.file, location.line))
+        }
+        // TODO: add gpu-context, feature-flag-context, and more of device-context like gpu
+        // name, screen resolution, available ram, device model, etc
     }
 
     let mut response_text = String::new();

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -603,8 +603,8 @@ async fn upload_minidump(
         .text("platform", "rust");
     if let Some(panic) = panic {
         form = form
-            .text("channel", panic.release_channel.clone())
-            .text("version", panic.app_version.clone())
+            .text("sentry[tags][channel]", panic.release_channel.clone())
+            .text("sentry[tags][version]", panic.app_version.clone())
             .text("sentry[context][os][name]", panic.os_name.clone())
             .text(
                 "sentry[context][device][architecture]",


### PR DESCRIPTION
None of this is new info, we're just pulling more things out of the panic message to send with the minidump. We do want to add more fields like gpu version which will come in a subsequent change.

Release Notes:

- N/A
