### PR TITLE
Don't generate crash reports on the Dev channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4014,6 +4014,7 @@ dependencies = [
  "log",
  "minidumper",
  "paths",
+ "release_channel",
  "smol",
  "workspace-hack",
 ]

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -10,6 +10,7 @@ crash-handler.workspace = true
 log.workspace = true
 minidumper.workspace = true
 paths.workspace = true
+release_channel.workspace = true
 smol.workspace = true
 workspace-hack.workspace = true
 


### PR DESCRIPTION
We only want minidumps to be generated on actual release builds. Now we avoid spawning crash handler processes for dev builds. To test minidumping you can still set the `ZED_GENERATE_MINIDUMPS` env var which force-enable the feature.

Release Notes:

- N/A