### PR TITLE
Fix SHA-256 verification mismatch when downloading language servers

### DIFF
--- a/crates/languages/src/github_download.rs
+++ b/crates/languages/src/github_download.rs
@@ -62,6 +62,12 @@ pub(crate) async fn download_server_binary(
                     format!("saving archive contents into the temporary file for {url}",)
                 })?;
             let asset_sha_256 = format!("{:x}", writer.hasher.finalize());
+
+            // Strip "sha256:" prefix for comparison
+            let expected_sha_256 = expected_sha_256
+                .strip_prefix("sha256:")
+                .unwrap_or(expected_sha_256);
+
             anyhow::ensure!(
                 asset_sha_256 == expected_sha_256,
                 "{url} asset got SHA-256 mismatch. Expected: {expected_sha_256}, Got: {asset_sha_256}",


### PR DESCRIPTION
Closes #35642 

Release Notes:

- Fixed: when the expected digest included a "sha256:" prefix while the computed
digest has no prefix.
