### PR TITLE
Ignore whitespace in git blame invocation

### DIFF
--- a/crates/git/src/blame.rs
+++ b/crates/git/src/blame.rs
@@ -73,6 +73,7 @@ async fn run_git_blame(
         .current_dir(working_directory)
         .arg("blame")
         .arg("--incremental")
+        .arg("-w")
         .arg("--contents")
         .arg("-")
         .arg(path.as_os_str())


### PR DESCRIPTION
This works around a bug wherein inline git blame is unavailable for files with CRLF line endings. At the same time, this prevents users from seeing whitespace-only changes in the editor's git blame

Closes #35836

Release Notes:

- N/A *or* Added/Fixed/Improved ...
