### PR TITLE
docs: Clarify storage of AI API keys

### DIFF
--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -6,29 +6,29 @@ You can do that by either subscribing to [one of Zed's plans](./plans-and-usage.
 
 ## Use Your Own Keys {#use-your-own-keys}
 
-If you already have an API key for an existing LLM provider—say Anthropic or OpenAI, for example—you can insert them in Zed and use the Agent Panel **_for free_**.
+If you already have an API key for an existing LLM provider—say Anthropic or OpenAI, for example—you can insert them into Zed and use the full power of the Agent Panel **_for free_**.
 
-You can add your API key to a given provider either via the Agent Panel's settings UI or directly via the `settings.json` through the `language_models` key.
+To add an existing API key to a given provider, go to the Agent Panel settings (`agent: open settings`), look for the desired provider, paste the key into the input, and hit enter.
+
+> Note: API keys are _not_ stored as plain text in your `settings.json`, but rather in your OS's secure credential storage.
 
 ## Supported Providers
 
 Here's all the supported LLM providers for which you can use your own API keys:
 
-| Provider                                        |
-| ----------------------------------------------- |
-| [Amazon Bedrock](#amazon-bedrock)               |
-| [Anthropic](#anthropic)                         |
-| [DeepSeek](#deepseek)                           |
-| [GitHub Copilot Chat](#github-copilot-chat)     |
-| [Google AI](#google-ai)                         |
-| [LM Studio](#lmstudio)                          |
-| [Mistral](#mistral)                             |
-| [Ollama](#ollama)                               |
-| [OpenAI](#openai)                               |
-| [OpenAI API Compatible](#openai-api-compatible) |
-| [OpenRouter](#openrouter)                       |
-| [Vercel](#vercel-v0)                            |
-| [xAI](#xai)                                     |
+- Amazon Bedrock](#amazon-bedrock)
+- Anthropic](#anthropic)
+- DeepSeek](#deepseek)
+- GitHub Copilot Chat](#github-copilot-chat)
+- Google AI](#google-ai)
+- LM Studio](#lmstudio)
+- Mistral](#mistral)
+- Ollama](#ollama)
+- OpenAI](#openai)
+- OpenAI API Compatible](#openai-api-compatible)
+- OpenRouter](#openrouter)
+- Vercel](#vercel-v0)
+- xAI](#xai)
 
 ### Amazon Bedrock {#amazon-bedrock}
 

--- a/docs/src/ai/llm-providers.md
+++ b/docs/src/ai/llm-providers.md
@@ -16,19 +16,19 @@ To add an existing API key to a given provider, go to the Agent Panel settings (
 
 Here's all the supported LLM providers for which you can use your own API keys:
 
-- Amazon Bedrock](#amazon-bedrock)
-- Anthropic](#anthropic)
-- DeepSeek](#deepseek)
-- GitHub Copilot Chat](#github-copilot-chat)
-- Google AI](#google-ai)
-- LM Studio](#lmstudio)
-- Mistral](#mistral)
-- Ollama](#ollama)
-- OpenAI](#openai)
-- OpenAI API Compatible](#openai-api-compatible)
-- OpenRouter](#openrouter)
-- Vercel](#vercel-v0)
-- xAI](#xai)
+- [Amazon Bedrock](#amazon-bedrock)
+- [Anthropic](#anthropic)
+- [DeepSeek](#deepseek)
+- [GitHub Copilot Chat](#github-copilot-chat)
+- [Google AI](#google-ai)
+- [LM Studio](#lmstudio)
+- [Mistral](#mistral)
+- [Ollama](#ollama)
+- [OpenAI](#openai)
+- [OpenAI API Compatible](#openai-api-compatible)
+- [OpenRouter](#openrouter)
+- [Vercel](#vercel-v0)
+- [xAI](#xai)
 
 ### Amazon Bedrock {#amazon-bedrock}
 


### PR DESCRIPTION
Previous docs was inaccurate as Zed doesn't store LLM API keys in the `settings.json`.

Release Notes:

- N/A
