### PR TITLE
windows: Fix message loop using too much CPU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -714,6 +714,7 @@ features = [
     "Win32_System_LibraryLoader",
     "Win32_System_Memory",
     "Win32_System_Ole",
+    "Win32_System_Performance",
     "Win32_System_Pipes",
     "Win32_System_SystemInformation",
     "Win32_System_SystemServices",

--- a/crates/gpui/src/platform/windows.rs
+++ b/crates/gpui/src/platform/windows.rs
@@ -10,6 +10,7 @@ mod keyboard;
 mod platform;
 mod system_settings;
 mod util;
+mod vsync;
 mod window;
 mod wrapper;
 
@@ -25,6 +26,7 @@ pub(crate) use keyboard::*;
 pub(crate) use platform::*;
 pub(crate) use system_settings::*;
 pub(crate) use util::*;
+pub(crate) use vsync::*;
 pub(crate) use window::*;
 pub(crate) use wrapper::*;
 

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -208,7 +208,7 @@ impl DirectXRenderer {
 
     fn present(&mut self) -> Result<()> {
         unsafe {
-            let result = self.resources.swap_chain.Present(1, DXGI_PRESENT(0));
+            let result = self.resources.swap_chain.Present(0, DXGI_PRESENT(0));
             // Presenting the swap chain can fail if the DirectX device was removed or reset.
             if result == DXGI_ERROR_DEVICE_REMOVED || result == DXGI_ERROR_DEVICE_RESET {
                 let reason = self.devices.device.GetDeviceRemovedReason();

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -4,16 +4,15 @@ use ::util::ResultExt;
 use anyhow::{Context, Result};
 use windows::{
     Win32::{
-        Foundation::{FreeLibrary, HMODULE, HWND},
+        Foundation::{HMODULE, HWND},
         Graphics::{
             Direct3D::*,
             Direct3D11::*,
             DirectComposition::*,
             Dxgi::{Common::*, *},
         },
-        System::LibraryLoader::LoadLibraryA,
     },
-    core::{Interface, PCSTR},
+    core::Interface,
 };
 
 use crate::{
@@ -1619,22 +1618,6 @@ pub(crate) mod shader_resources {
     }
 }
 
-fn with_dll_library<R, F>(dll_name: PCSTR, f: F) -> Result<R>
-where
-    F: FnOnce(HMODULE) -> Result<R>,
-{
-    let library = unsafe {
-        LoadLibraryA(dll_name).with_context(|| format!("Loading dll: {}", dll_name.display()))?
-    };
-    let result = f(library);
-    unsafe {
-        FreeLibrary(library)
-            .with_context(|| format!("Freeing dll: {}", dll_name.display()))
-            .log_err();
-    }
-    result
-}
-
 mod nvidia {
     use std::{
         ffi::CStr,
@@ -1644,7 +1627,7 @@ mod nvidia {
     use anyhow::Result;
     use windows::{Win32::System::LibraryLoader::GetProcAddress, core::s};
 
-    use crate::platform::windows::directx_renderer::with_dll_library;
+    use crate::with_dll_library;
 
     // https://github.com/NVIDIA/nvapi/blob/7cb76fce2f52de818b3da497af646af1ec16ce27/nvapi_lite_common.h#L180
     const NVAPI_SHORT_STRING_MAX: usize = 64;
@@ -1711,7 +1694,7 @@ mod amd {
     use anyhow::Result;
     use windows::{Win32::System::LibraryLoader::GetProcAddress, core::s};
 
-    use crate::platform::windows::directx_renderer::with_dll_library;
+    use crate::with_dll_library;
 
     // https://github.com/GPUOpen-LibrariesAndSDKs/AGS_SDK/blob/5d8812d703d0335741b6f7ffc37838eeb8b967f7/ags_lib/inc/amd_ags.h#L145
     const AGS_CURRENT_VERSION: i32 = (6 << 22) | (3 << 12);

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -312,8 +312,7 @@ impl WindowsPlatform {
         let windows_version = self.windows_version;
         let all_windows = self.raw_window_handles.clone();
         std::thread::spawn(move || {
-            let vsync_provider =
-                VSyncProvider::new(windows_version).expect("Failed to create VSyncProvider");
+            let vsync_provider = VSyncProvider::new(windows_version);
             loop {
                 vsync_provider.wait_for_vsync();
                 for hwnd in all_windows.read().iter() {

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -309,10 +309,9 @@ impl WindowsPlatform {
     }
 
     fn begin_vsync_thread(&self) {
-        let windows_version = self.windows_version;
         let all_windows = self.raw_window_handles.clone();
         std::thread::spawn(move || {
-            let vsync_provider = VSyncProvider::new(windows_version);
+            let vsync_provider = VSyncProvider::new();
             loop {
                 vsync_provider.wait_for_vsync();
                 for hwnd in all_windows.read().iter() {

--- a/crates/gpui/src/platform/windows/util.rs
+++ b/crates/gpui/src/platform/windows/util.rs
@@ -1,14 +1,18 @@
 use std::sync::OnceLock;
 
 use ::util::ResultExt;
+use anyhow::Context;
 use windows::{
     UI::{
         Color,
         ViewManagement::{UIColorType, UISettings},
     },
     Wdk::System::SystemServices::RtlGetVersion,
-    Win32::{Foundation::*, Graphics::Dwm::*, UI::WindowsAndMessaging::*},
-    core::{BOOL, HSTRING},
+    Win32::{
+        Foundation::*, Graphics::Dwm::*, System::LibraryLoader::LoadLibraryA,
+        UI::WindowsAndMessaging::*,
+    },
+    core::{BOOL, HSTRING, PCSTR},
 };
 
 use crate::*;
@@ -196,4 +200,20 @@ pub(crate) fn show_error(title: &str, content: String) {
             MB_ICONERROR | MB_SYSTEMMODAL,
         )
     };
+}
+
+pub(crate) fn with_dll_library<R, F>(dll_name: PCSTR, f: F) -> Result<R>
+where
+    F: FnOnce(HMODULE) -> Result<R>,
+{
+    let library = unsafe {
+        LoadLibraryA(dll_name).with_context(|| format!("Loading dll: {}", dll_name.display()))?
+    };
+    let result = f(library);
+    unsafe {
+        FreeLibrary(library)
+            .with_context(|| format!("Freeing dll: {}", dll_name.display()))
+            .log_err();
+    }
+    result
 }

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -1,4 +1,7 @@
-use std::{sync::LazyLock, time::Duration};
+use std::{
+    sync::LazyLock,
+    time::{Duration, Instant},
+};
 
 use anyhow::Result;
 use windows::Win32::{
@@ -13,20 +16,39 @@ static QPC_TICKS_PER_SECOND: LazyLock<u64> = LazyLock::new(|| {
     let mut frequency = 0;
     // On systems that run Windows XP or later, the function will always succeed and
     // will thus never return zero.
-    unsafe { QueryPerformanceFrequency(&mut frequency) };
+    unsafe { QueryPerformanceFrequency(&mut frequency).unwrap() };
     frequency as u64
 });
 
-pub(crate) struct VsyncProvider {
+const VSYNC_INTERVAL_THRESHOLD: Duration = Duration::from_millis(1);
+
+pub(crate) struct VSyncProvider {
     interval: Duration,
     f: Box<dyn Fn() -> bool + Send>,
 }
 
-impl VsyncProvider {
-    pub fn new() -> Result<Self> {
+impl VSyncProvider {
+    pub(crate) fn new() -> Result<Self> {
         let interval = get_dwm_interval_from_direct_composition()?;
         let f = Box::new(|| unsafe { DCompositionWaitForCompositorClock(None, INFINITE) == 0 });
         Ok(Self { interval, f })
+    }
+
+    pub(crate) fn wait_for_vsync(&self) {
+        let vsync_start = Instant::now();
+        let wait_succeeded = (self.f)();
+        let elapsed = vsync_start.elapsed();
+        // WaitForVBlank and DCompositionWaitForCompositorClock returns very early
+        // instead of waiting until vblank when the monitor goes to sleep or is
+        // unplugged (nothing to present due to desktop occlusion). We use 1ms as
+        // a threshhold for the duration of the wait functions and fallback to
+        // Sleep() if it returns before that. This could happen during normal
+        // operation for the first call after the vsync thread becomes non-idle,
+        // but it shouldn't happen often.
+        if !wait_succeeded || elapsed < VSYNC_INTERVAL_THRESHOLD {
+            log::warn!("VSyncProvider::wait_for_vsync() took shorter than expected");
+            std::thread::sleep(self.interval);
+        }
     }
 }
 

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -5,18 +5,22 @@ use std::{
 
 use anyhow::{Context, Result};
 use util::ResultExt;
-use windows::Win32::{
-    Foundation::HWND,
-    Graphics::{
-        DirectComposition::{
-            COMPOSITION_FRAME_ID_COMPLETED, COMPOSITION_FRAME_STATS, DCompositionGetFrameId,
-            DCompositionGetStatistics, DCompositionWaitForCompositorClock,
+use windows::{
+    Win32::{
+        Foundation::{HANDLE, HWND},
+        Graphics::{
+            DirectComposition::{
+                COMPOSITION_FRAME_ID_COMPLETED, COMPOSITION_FRAME_ID_TYPE, COMPOSITION_FRAME_STATS,
+                COMPOSITION_TARGET_ID,
+            },
+            Dwm::{DWM_TIMING_INFO, DwmFlush, DwmGetCompositionTimingInfo},
         },
-        Dwm::{DWM_TIMING_INFO, DwmFlush, DwmGetCompositionTimingInfo},
+        System::{
+            LibraryLoader::GetProcAddress, Performance::QueryPerformanceFrequency,
+            Threading::INFINITE,
+        },
     },
-    System::{
-        LibraryLoader::GetProcAddress, Performance::QueryPerformanceFrequency, Threading::INFINITE,
-    },
+    core::{HRESULT, s},
 };
 
 use crate::with_dll_library;
@@ -32,6 +36,18 @@ static QPC_TICKS_PER_SECOND: LazyLock<u64> = LazyLock::new(|| {
 const VSYNC_INTERVAL_THRESHOLD: Duration = Duration::from_millis(1);
 const DEFAULT_VSYNC_INTERVAL: Duration = Duration::from_micros(16_666); // ~60Hz
 
+type DCompositionGetFrameId =
+    unsafe extern "system" fn(frameidtype: COMPOSITION_FRAME_ID_TYPE, frameid: *mut u64) -> HRESULT;
+type DCompositionGetStatistics = unsafe extern "system" fn(
+    frameid: u64,
+    framestats: *mut COMPOSITION_FRAME_STATS,
+    targetidcount: u32,
+    targetids: *mut COMPOSITION_TARGET_ID,
+    actualtargetidcount: *mut u32,
+) -> HRESULT;
+type DCompositionWaitForCompositorClock =
+    unsafe extern "system" fn(count: u32, handles: *const HANDLE, timeoutinms: u32) -> u32;
+
 pub(crate) struct VSyncProvider {
     interval: Duration,
     f: Box<dyn Fn() -> bool>,
@@ -39,34 +55,46 @@ pub(crate) struct VSyncProvider {
 
 impl VSyncProvider {
     pub(crate) fn new() -> Self {
-        let support_direct_composition =
-            with_dll_library(windows::core::s!("dcomp.dll"), |dcomp| unsafe {
-                let frame_id_fn =
-                    GetProcAddress(dcomp, windows::core::s!("DCompositionGetFrameId")).is_some();
-                let stats_fn =
-                    GetProcAddress(dcomp, windows::core::s!("DCompositionGetStatistics")).is_some();
-                let vsync_fn = GetProcAddress(
-                    dcomp,
-                    windows::core::s!("DCompositionWaitForCompositorClock"),
-                )
-                .is_some();
-                Ok(frame_id_fn && stats_fn && vsync_fn)
+        if let Ok((get_frame_id, get_statistics, wait_for_comp_clock)) =
+            with_dll_library(s!("dcomp.dll"), |dcomp| unsafe {
+                let get_frame_id = GetProcAddress(dcomp, s!("DCompositionGetFrameId"))
+                    .ok_or(anyhow::anyhow!("Function DCompositionGetFrameId not found"))?;
+                let get_statistics = GetProcAddress(dcomp, s!("DCompositionGetStatistics")).ok_or(
+                    anyhow::anyhow!("Function DCompositionGetStatistics not found"),
+                )?;
+                let wait_for_comp_clock =
+                    GetProcAddress(dcomp, s!("DCompositionWaitForCompositorClock")).ok_or(
+                        anyhow::anyhow!("Function DCompositionWaitForCompositorClock not found"),
+                    )?;
+                Ok((get_frame_id, get_statistics, wait_for_comp_clock))
             })
-            .is_ok_and(|result| result);
-        if support_direct_composition {
-            log::info!("DirectComposition is supported for VSync");
-            let interval = get_dwm_interval_from_direct_composition()
+        {
+            let get_frame_id: DCompositionGetFrameId = unsafe { std::mem::transmute(get_frame_id) };
+            let get_statistics: DCompositionGetStatistics =
+                unsafe { std::mem::transmute(get_statistics) };
+            let wait_for_comp_clock: DCompositionWaitForCompositorClock =
+                unsafe { std::mem::transmute(wait_for_comp_clock) };
+            let interval = get_dwm_interval_from_direct_composition(get_frame_id, get_statistics)
                 .context("Failed to get DWM interval from DirectComposition")
                 .log_err()
                 .unwrap_or(DEFAULT_VSYNC_INTERVAL);
-            let f = Box::new(|| unsafe { DCompositionWaitForCompositorClock(None, INFINITE) == 0 });
+            log::info!(
+                "DirectComposition is supported for VSync, interval: {:?}",
+                interval
+            );
+            let f = Box::new(move || unsafe {
+                wait_for_comp_clock(0, std::ptr::null(), INFINITE) == 0
+            });
             Self { interval, f }
         } else {
-            log::info!("DirectComposition is not supported for VSync, falling back to DWM");
             let interval = get_dwm_interval()
                 .context("Failed to get DWM interval")
                 .log_err()
                 .unwrap_or(DEFAULT_VSYNC_INTERVAL);
+            log::info!(
+                "DirectComposition is not supported for VSync, falling back to DWM, interval: {:?}",
+                interval
+            );
             let f = Box::new(|| unsafe { DwmFlush().is_ok() });
             Self { interval, f }
         }
@@ -90,10 +118,23 @@ impl VSyncProvider {
     }
 }
 
-fn get_dwm_interval_from_direct_composition() -> Result<Duration> {
-    let frame_id = unsafe { DCompositionGetFrameId(COMPOSITION_FRAME_ID_COMPLETED) }?;
+fn get_dwm_interval_from_direct_composition(
+    get_frame_id: DCompositionGetFrameId,
+    get_statistics: DCompositionGetStatistics,
+) -> Result<Duration> {
+    let mut frame_id = 0;
+    unsafe { get_frame_id(COMPOSITION_FRAME_ID_COMPLETED, &mut frame_id) }.ok()?;
     let mut stats = COMPOSITION_FRAME_STATS::default();
-    unsafe { DCompositionGetStatistics(frame_id, &mut stats, 0, None, None) }?;
+    unsafe {
+        get_statistics(
+            frame_id,
+            &mut stats,
+            0,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+        )
+    }
+    .ok()?;
     Ok(retrieve_duration(stats.framePeriod, *QPC_TICKS_PER_SECOND))
 }
 

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -1,12 +1,43 @@
+use std::{sync::LazyLock, time::Duration};
+
+use anyhow::Result;
+use windows::Win32::{
+    Graphics::DirectComposition::{
+        COMPOSITION_FRAME_ID_COMPLETED, COMPOSITION_FRAME_STATS, DCompositionGetFrameId,
+        DCompositionGetStatistics, DCompositionWaitForCompositorClock,
+    },
+    System::{Performance::QueryPerformanceFrequency, Threading::INFINITE},
+};
+
+static QPC_TICKS_PER_SECOND: LazyLock<u64> = LazyLock::new(|| {
+    let mut frequency = 0;
+    // On systems that run Windows XP or later, the function will always succeed and
+    // will thus never return zero.
+    unsafe { QueryPerformanceFrequency(&mut frequency) };
+    frequency as u64
+});
+
 pub(crate) struct VsyncProvider {
-    delta: Duration,
-    f: Box<dyn Fn() + Send>,
+    interval: Duration,
+    f: Box<dyn Fn() -> bool + Send>,
 }
 
 impl VsyncProvider {
-    pub fn new() -> Self {
-        Self {
-            delta: Duration::from_millis(16),
-        }
+    pub fn new() -> Result<Self> {
+        let interval = get_dwm_interval_from_direct_composition()?;
+        let f = Box::new(|| unsafe { DCompositionWaitForCompositorClock(None, INFINITE) == 0 });
+        Ok(Self { interval, f })
     }
+}
+
+fn get_dwm_interval_from_direct_composition() -> Result<Duration> {
+    let frame_id = unsafe { DCompositionGetFrameId(COMPOSITION_FRAME_ID_COMPLETED) }?;
+    let mut stats = COMPOSITION_FRAME_STATS::default();
+    unsafe { DCompositionGetStatistics(frame_id, &mut stats, 0, None, None) }?;
+    Ok(duration_from_qpc(stats.framePeriod))
+}
+
+fn duration_from_qpc(qpc: u64) -> Duration {
+    let dwm_ticks_per_microsecond = *QPC_TICKS_PER_SECOND / 1_000_000;
+    Duration::from_micros(qpc / dwm_ticks_per_microsecond)
 }

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -120,9 +120,10 @@ fn initialize_direct_composition() -> Result<(
         let wait_for_compositor_clock_addr =
             GetProcAddress(hmodule, s!("DCompositionWaitForCompositorClock"))
                 .context("Function DCompositionWaitForCompositorClock not found")?;
-        let get_frame_id = std::mem::transmute(get_frame_id_addr);
-        let get_statistics = std::mem::transmute(get_statistics_addr);
-        let wait_for_compositor_clock = std::mem::transmute(wait_for_compositor_clock_addr);
+        let get_frame_id: DCompositionGetFrameId = std::mem::transmute(get_frame_id_addr);
+        let get_statistics: DCompositionGetStatistics = std::mem::transmute(get_statistics_addr);
+        let wait_for_compositor_clock: DCompositionWaitForCompositorClock =
+            std::mem::transmute(wait_for_compositor_clock_addr);
         Ok((get_frame_id, get_statistics, wait_for_compositor_clock))
     }
 }

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -1,0 +1,12 @@
+pub(crate) struct VsyncProvider {
+    delta: Duration,
+    f: Box<dyn Fn() + Send>,
+}
+
+impl VsyncProvider {
+    pub fn new() -> Self {
+        Self {
+            delta: Duration::from_millis(16),
+        }
+    }
+}

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -63,7 +63,7 @@ impl VSyncProvider {
         let vsync_start = Instant::now();
         let wait_succeeded = (self.f)();
         let elapsed = vsync_start.elapsed();
-        // WaitForVBlank and DCompositionWaitForCompositorClock returns very early
+        // DwmFlush and DCompositionWaitForCompositorClock returns very early
         // instead of waiting until vblank when the monitor goes to sleep or is
         // unplugged (nothing to present due to desktop occlusion). We use 1ms as
         // a threshhold for the duration of the wait functions and fallback to

--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -1,6 +1,6 @@
 use std::ops::Deref;
 
-use windows::Win32::UI::WindowsAndMessaging::HCURSOR;
+use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::HCURSOR};
 
 #[derive(Debug, Clone, Copy)]
 pub(crate) struct SafeCursor {

--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -23,3 +23,31 @@ impl Deref for SafeCursor {
         &self.raw
     }
 }
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) struct SafeHwnd {
+    raw: HWND,
+}
+
+impl SafeHwnd {
+    pub(crate) fn as_raw(&self) -> HWND {
+        self.raw
+    }
+}
+
+unsafe impl Send for SafeHwnd {}
+unsafe impl Sync for SafeHwnd {}
+
+impl From<HWND> for SafeHwnd {
+    fn from(value: HWND) -> Self {
+        SafeHwnd { raw: value }
+    }
+}
+
+impl Deref for SafeHwnd {
+    type Target = HWND;
+
+    fn deref(&self) -> &Self::Target {
+        &self.raw
+    }
+}


### PR DESCRIPTION
Closes #34374

This is a leftover issue from #34374. Back in #34374, I wanted to use DirectX to handle vsync, after all, that’s how 99% of Windows apps do it. But after discussing with @maxbrunsfeld , we decided to stick with the original vsync approach given gpui’s architecture.

In my tests, there’s no noticeable performance difference between this PR’s approach and DirectX vsync. That said, this PR’s method does have a theoretical advantage, it doesn’t block the main thread while waiting for vsync.


The only difference is that in this PR, on Windows 11 we use a newer API instead of `DwmFlush`, since Chrome’s tests have shown that `DwmFlush` has some problems. This PR also removes the use of `MsgWaitForMultipleObjects`.


Release Notes:

- N/A