### PR TITLE
Ignore project-local settings for always_allow_tool_actions

### DIFF
--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -443,10 +443,6 @@ impl Settings for AgentSettings {
                 value.inline_alternatives.clone(),
             );
             merge(
-                &mut settings.always_allow_tool_actions,
-                value.always_allow_tool_actions,
-            );
-            merge(
                 &mut settings.notify_when_agent_waiting,
                 value.notify_when_agent_waiting,
             );
@@ -506,6 +502,20 @@ impl Settings for AgentSettings {
                     }));
             }
         }
+
+        debug_assert_eq!(
+            sources.default.always_allow_tool_actions.unwrap_or(false),
+            false,
+            "For security, agent.always_allow_tool_actions should always be false in default.json. If it's true, that is a bug that should be fixed!"
+        );
+
+        // For security reasons, only trust the user's global settings for whether to always allow tool actions.
+        // If this could be overridden locally, an attacker could (e.g. by committing to source control and
+        // convincing you to switch branches) modify your project-local settings to disable the agent's safety checks.
+        settings.always_allow_tool_actions = sources
+            .user
+            .and_then(|setting| setting.always_allow_tool_actions)
+            .unwrap_or(false);
 
         Ok(settings)
     }


### PR DESCRIPTION
Now `always_allow_tool_actions` is only respected as the user's global setting, not as an overridable project-local setting. This way, you don't have to worry about switching into a project (or switching branches within a project) and discovering that suddenly your tool calls no longer require confirmation.

Release Notes:

- Removed always_allow_tool_actions from project-local settings (it is now global-only)
