### PR TITLE
docs: Add a missing comma in Rust debugging JSON

### DIFF
--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -326,7 +326,7 @@ When you use `cargo build` or `cargo test` as the build command, Zed can infer t
 [
   {
     "label": "Build & Debug native binary",
-    "adapter": "CodeLLDB"
+    "adapter": "CodeLLDB",
     "build": {
       "command": "cargo",
       "args": ["build"]


### PR DESCRIPTION
Update the Rust debugging doc to include a missing comma in one of the example JSON's.

Release Notes:

- N/A