### PR TITLE
Fix running vim tests with --features neovim

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18025,6 +18025,7 @@ dependencies = [
  "command_palette_hooks",
  "db",
  "editor",
+ "env_logger 0.11.8",
  "futures 0.3.31",
  "git_ui",
  "gpui",

--- a/crates/gpui_macros/src/test.rs
+++ b/crates/gpui_macros/src/test.rs
@@ -167,6 +167,7 @@ fn generate_test_function(
                             ));
                             cx_teardowns.extend(quote!(
                                 dispatcher.run_until_parked();
+                                #cx_varname.executor().forbid_parking();
                                 #cx_varname.quit();
                                 dispatcher.run_until_parked();
                             ));
@@ -232,7 +233,7 @@ fn generate_test_function(
                                 cx_teardowns.extend(quote!(
                                     drop(#cx_varname_lock);
                                     dispatcher.run_until_parked();
-                                    #cx_varname.update(|cx| { cx.quit() });
+                                    #cx_varname.update(|cx| { cx.background_executor().forbid_parking(); cx.quit(); });
                                     dispatcher.run_until_parked();
                                 ));
                                 continue;
@@ -247,6 +248,7 @@ fn generate_test_function(
                                 ));
                                 cx_teardowns.extend(quote!(
                                     dispatcher.run_until_parked();
+                                    #cx_varname.executor().forbid_parking();
                                     #cx_varname.quit();
                                     dispatcher.run_until_parked();
                                 ));

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -24,6 +24,7 @@ command_palette.workspace = true
 command_palette_hooks.workspace = true
 db.workspace = true
 editor.workspace = true
+env_logger.workspace = true
 futures.workspace = true
 gpui.workspace = true
 itertools.workspace = true

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -15,6 +15,7 @@ impl VimTestContext {
         if cx.has_global::<VimGlobals>() {
             return;
         }
+        env_logger::init();
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);

--- a/crates/vim/src/test/vim_test_context.rs
+++ b/crates/vim/src/test/vim_test_context.rs
@@ -15,7 +15,7 @@ impl VimTestContext {
         if cx.has_global::<VimGlobals>() {
             return;
         }
-        env_logger::init();
+        env_logger::try_init().ok();
         cx.update(|cx| {
             let settings = SettingsStore::test(cx);
             cx.set_global(settings);


### PR DESCRIPTION
This was broken incidentally in https://github.com/zed-industries/zed/pull/33417

A better fix would be to fix app shutdown to take control of the executor so that we *can* run
foreground tasks; but that is a bit fiddly (draft #36015) 

Release Notes:

- N/A