### PR TITLE
Better on_app_quit

### DIFF
--- a/crates/gpui/src/app/test_context.rs
+++ b/crates/gpui/src/app/test_context.rs
@@ -167,7 +167,7 @@ impl TestAppContext {
     /// public so the macro can call it.
     pub fn quit(&self) {
         self.on_quit.borrow_mut().drain(..).for_each(|f| f());
-        self.app.borrow_mut().shutdown();
+        self.app.shutdown();
     }
 
     /// Register cleanup to run when the test ends.

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -384,10 +384,9 @@ impl BackgroundExecutor {
         self.dispatcher.as_test().unwrap().advance_clock(duration)
     }
 
-    /// in tests, run one task.
-    #[cfg(any(test, feature = "test-support"))]
+    /// docs
     pub fn tick(&self) -> bool {
-        self.dispatcher.as_test().unwrap().tick(false)
+        self.dispatcher.tick(true)
     }
 
     /// in tests, run all tasks that are ready to run. If after doing so

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -545,6 +545,7 @@ pub trait PlatformDispatcher: Send + Sync {
     fn now(&self) -> Instant {
         Instant::now()
     }
+    fn tick(&self, _: bool) -> bool;
 
     #[cfg(any(test, feature = "test-support"))]
     fn as_test(&self) -> Option<&TestDispatcher> {

--- a/crates/gpui/src/platform/test/dispatcher.rs
+++ b/crates/gpui/src/platform/test/dispatcher.rs
@@ -122,68 +122,6 @@ impl TestDispatcher {
         }
     }
 
-    pub fn tick(&self, background_only: bool) -> bool {
-        let mut state = self.state.lock();
-
-        while let Some((deadline, _)) = state.delayed.first() {
-            if *deadline > state.time {
-                break;
-            }
-            let (_, runnable) = state.delayed.remove(0);
-            state.background.push(runnable);
-        }
-
-        let foreground_len: usize = if background_only {
-            0
-        } else {
-            state
-                .foreground
-                .values()
-                .map(|runnables| runnables.len())
-                .sum()
-        };
-        let background_len = state.background.len();
-
-        let runnable;
-        let main_thread;
-        if foreground_len == 0 && background_len == 0 {
-            let deprioritized_background_len = state.deprioritized_background.len();
-            if deprioritized_background_len == 0 {
-                return false;
-            }
-            let ix = state.random.gen_range(0..deprioritized_background_len);
-            main_thread = false;
-            runnable = state.deprioritized_background.swap_remove(ix);
-        } else {
-            main_thread = state.random.gen_ratio(
-                foreground_len as u32,
-                (foreground_len + background_len) as u32,
-            );
-            if main_thread {
-                let state = &mut *state;
-                runnable = state
-                    .foreground
-                    .values_mut()
-                    .filter(|runnables| !runnables.is_empty())
-                    .choose(&mut state.random)
-                    .unwrap()
-                    .pop_front()
-                    .unwrap();
-            } else {
-                let ix = state.random.gen_range(0..background_len);
-                runnable = state.background.swap_remove(ix);
-            };
-        };
-
-        let was_main_thread = state.is_main_thread;
-        state.is_main_thread = main_thread;
-        drop(state);
-        runnable.run();
-        self.state.lock().is_main_thread = was_main_thread;
-
-        true
-    }
-
     pub fn deprioritize(&self, task_label: TaskLabel) {
         self.state
             .lock()
@@ -265,6 +203,68 @@ impl PlatformDispatcher for TestDispatcher {
     fn now(&self) -> Instant {
         let state = self.state.lock();
         state.start_time + state.time
+    }
+
+    fn tick(&self, background_only: bool) -> bool {
+        let mut state = self.state.lock();
+
+        while let Some((deadline, _)) = state.delayed.first() {
+            if *deadline > state.time {
+                break;
+            }
+            let (_, runnable) = state.delayed.remove(0);
+            state.background.push(runnable);
+        }
+
+        let foreground_len: usize = if background_only {
+            0
+        } else {
+            state
+                .foreground
+                .values()
+                .map(|runnables| runnables.len())
+                .sum()
+        };
+        let background_len = state.background.len();
+
+        let runnable;
+        let main_thread;
+        if foreground_len == 0 && background_len == 0 {
+            let deprioritized_background_len = state.deprioritized_background.len();
+            if deprioritized_background_len == 0 {
+                return false;
+            }
+            let ix = state.random.gen_range(0..deprioritized_background_len);
+            main_thread = false;
+            runnable = state.deprioritized_background.swap_remove(ix);
+        } else {
+            main_thread = state.random.gen_ratio(
+                foreground_len as u32,
+                (foreground_len + background_len) as u32,
+            );
+            if main_thread {
+                let state = &mut *state;
+                runnable = state
+                    .foreground
+                    .values_mut()
+                    .filter(|runnables| !runnables.is_empty())
+                    .choose(&mut state.random)
+                    .unwrap()
+                    .pop_front()
+                    .unwrap();
+            } else {
+                let ix = state.random.gen_range(0..background_len);
+                runnable = state.background.swap_remove(ix);
+            };
+        };
+
+        let was_main_thread = state.is_main_thread;
+        state.is_main_thread = main_thread;
+        drop(state);
+        runnable.run();
+        self.state.lock().is_main_thread = was_main_thread;
+
+        true
     }
 
     fn dispatch(&self, runnable: Runnable, label: Option<TaskLabel>) {

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -136,6 +136,7 @@ impl DapStore {
         breakpoint_store: Entity<BreakpointStore>,
         cx: &mut Context<Self>,
     ) -> Self {
+        cx.on_app_quit(Self::shutdown_sessions).detach();
         let mode = DapStoreMode::Local(LocalDapStore {
             fs,
             environment,

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -650,12 +650,13 @@ impl HeadlessProject {
         cx: AsyncApp,
     ) -> Result<proto::Ack> {
         cx.spawn(async move |cx| {
-            cx.update(|cx| {
-                // TODO: This is a hack, because in a headless project, shutdown isn't executed
-                // when calling quit, but it should be.
-                cx.shutdown();
-                cx.quit();
-            })
+            // todo!("come back to this")
+            // cx.update(|cx| {
+            //     // TODO: This is a hack, because in a headless project, shutdown isn't executed
+            //     // when calling quit, but it should be.
+            //     cx.shutdown();
+            //     cx.quit();
+            // })
         })
         .detach();
 

--- a/crates/vim/test_data/test_insert_ctrl_y.json
+++ b/crates/vim/test_data/test_insert_ctrl_y.json
@@ -1,0 +1,5 @@
+{"Put":{"state":"hello\nˇ\nworld"}}
+{"Key":"i"}
+{"Key":"ctrl-y"}
+{"Key":"ctrl-e"}
+{"Get":{"state":"hello\nhoˇ\nworld","mode":"Insert"}}


### PR DESCRIPTION
Co-authored-by: Antonio Scandurra <me@as-cii.com>

Currently `on_app_quit` callbacks can cause deadlocks if they await on a task
that must run on the foreground thread (because the foreground thread is busy
running `on_app_quit`).

This makes some changes to the executor to allow `shutdown` to take control and
run the futures to completion.

Release Notes:

- N/A
