### PR TITLE
Fix stale branch name display after worktree removal

### DIFF
--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1296,7 +1296,7 @@ impl GitStore {
             .iter()
             .filter_map(|(repo_id, repo)| {
                 let repo_work_dir = &repo.read(cx).work_directory_abs_path;
-                if repo_work_dir.starts_with(worktree_abs_path) {
+                if repo_work_dir.starts_with(&worktree_abs_path) {
                     Some(*repo_id)
                 } else {
                     None

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1136,7 +1136,11 @@ impl GitStore {
                 self.local_worktree_git_repos_changed(worktree, changed_repos, cx);
             }
             WorktreeStoreEvent::WorktreeRemoved(_, worktree_id) => {
-                self.cleanup_repositories_for_worktree(*worktree_id, downstream.as_ref().map(|d| d.updates_tx.clone()), cx);
+                self.cleanup_repositories_for_worktree(
+                    *worktree_id,
+                    downstream.as_ref().map(|d| d.updates_tx.clone()),
+                    cx,
+                );
             }
             _ => {}
         }
@@ -1286,7 +1290,7 @@ impl GitStore {
         };
 
         let worktree_abs_path = worktree.read(cx).abs_path();
-        
+
         let removed_repo_ids: Vec<RepositoryId> = self
             .repositories
             .iter()


### PR DESCRIPTION
When removing a git project/worktree from a Zed window, the title bar continued to show the branch name from the removed project instead of clearing it. This occurred because GitStore was ignoring WorktreeRemoved events, leaving repository references active after worktree removal.

This change adds a WorktreeRemoved event handler to GitStore that:
- Identifies repositories belonging to the removed worktree
- Clears the active repository if it's being removed
- Removes stale repository entries from storage
- Emits proper cleanup events to downstream components

Closes #35997

Release Notes:

- Fixed display of stale branch name in title bar, after removal of a Git repository folder from the window/project.
