### PR TITLE
emmet: Bump to v0.0.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20686,7 +20686,7 @@ dependencies = [
 
 [[package]]
 name = "zed_emmet"
-version = "0.0.4"
+version = "0.0.5"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/emmet/Cargo.toml
+++ b/extensions/emmet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_emmet"
-version = "0.0.4"
+version = "0.0.5"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/emmet/extension.toml
+++ b/extensions/emmet/extension.toml
@@ -1,7 +1,7 @@
 id = "emmet"
 name = "Emmet"
 description = "Emmet support"
-version = "0.0.4"
+version = "0.0.5"
 schema_version = 1
 authors = ["Piotr Osiewicz <piotr@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the Emmet extension to v0.0.5.

Changes:

- https://github.com/zed-industries/zed/pull/35599
- https://github.com/zed-industries/zed/pull/36064

Release Notes:

- N/A
