### PR TITLE
remote server: Use env flag to opt out of musl remote server build

### DIFF
--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -2069,11 +2069,17 @@ impl SshRemoteConnection {
             Ok(())
         }
 
+        let use_musl = !build_remote_server.contains("nomusl");
         let triple = format!(
             "{}-{}",
             self.ssh_platform.arch,
             match self.ssh_platform.os {
-                "linux" => "unknown-linux-musl",
+                "linux" =>
+                    if use_musl {
+                        "unknown-linux-musl"
+                    } else {
+                        "unknown-linux-gnu"
+                    },
                 "macos" => "apple-darwin",
                 _ => anyhow::bail!("can't cross compile for: {:?}", self.ssh_platform),
             }
@@ -2086,7 +2092,7 @@ impl SshRemoteConnection {
                 String::new()
             }
         };
-        if self.ssh_platform.os == "linux" {
+        if self.ssh_platform.os == "linux" && use_musl {
             rust_flags.push_str(" -C target-feature=+crt-static");
         }
         if build_remote_server.contains("mold") {


### PR DESCRIPTION
Closes #ISSUE

This will allow devs to opt out of the musl build when developing zed by running `ZED_BUILD_REMOTE_SERVER=nomusl cargo r` which also fixes remote builds on NixOS. 

Release Notes:

- Add a env flag (`ZED_BUILD_REMOTE_SERVER=nomusl`) to opt out of musl builds when building the remote server