### PR TITLE
outline: Fix nesting in multi-name declarations in Go and C++

### DIFF
--- a/crates/languages/src/cpp/outline.scm
+++ b/crates/languages/src/cpp/outline.scm
@@ -149,7 +149,9 @@
                 parameters: (parameter_list
                     "(" @context
                     ")" @context)))
-    ]
-    (type_qualifier)? @context) @item
+    ; Fields declarations may define multiple fields, and so @item is on the
+    ; declarator so they each get distinct ranges.
+    ] @item
+    (type_qualifier)? @context)
 
 (comment) @annotation

--- a/crates/languages/src/go/outline.scm
+++ b/crates/languages/src/go/outline.scm
@@ -1,4 +1,5 @@
 (comment) @annotation
+
 (type_declaration
     "type" @context
     [
@@ -42,13 +43,13 @@
     (var_declaration
         "var" @context
         [
+            ; The declaration may define multiple variables, and so @item is on
+            ; the identifier so they get distinct ranges.
             (var_spec
-                name: (identifier) @name) @item
+                name: (identifier) @name @item)
             (var_spec_list
-                "("
                 (var_spec
-                    name: (identifier) @name) @item
-                ")"
+                    name: (identifier) @name @item)
             )
         ]
      )
@@ -60,5 +61,7 @@
       "(" @context
       ")" @context)) @item
 
+; Fields declarations may define multiple fields, and so @item is on the
+; declarator so they each get distinct ranges.
 (field_declaration
-    name: (_) @name) @item
+    name: (_) @name @item)

--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -31,12 +31,16 @@
     (export_statement
         (lexical_declaration
             ["let" "const"] @context
+            ; Multiple names may be exported - @item is on the declarator to keep
+            ; ranges distinct.
             (variable_declarator
                 name: (_) @name) @item)))
 
 (program
     (lexical_declaration
         ["let" "const"] @context
+        ; Multiple names may be defined - @item is on the declarator to keep
+        ; ranges distinct.
         (variable_declarator
             name: (_) @name) @item))
 

--- a/crates/languages/src/tsx/outline.scm
+++ b/crates/languages/src/tsx/outline.scm
@@ -34,12 +34,16 @@
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
+        ; Multiple names may be exported - @item is on the declarator to keep
+        ; ranges distinct.
         (variable_declarator
             name: (_) @name) @item))
 
 (program
     (lexical_declaration
         ["let" "const"] @context
+        ; Multiple names may be defined - @item is on the declarator to keep
+        ; ranges distinct.
         (variable_declarator
             name: (_) @name) @item))
 

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -34,12 +34,16 @@
 (export_statement
     (lexical_declaration
         ["let" "const"] @context
+        ; Multiple names may be exported - @item is on the declarator to keep
+        ; ranges distinct.
         (variable_declarator
             name: (_) @name) @item))
 
 (program
     (lexical_declaration
         ["let" "const"] @context
+        ; Multiple names may be defined - @item is on the declarator to keep
+        ; ranges distinct.
         (variable_declarator
             name: (_) @name) @item))
 


### PR DESCRIPTION
An alternative might be to adjust the logic to not nest items when their ranges are the same, but then clicking them doesn't work properly / moving the cursor does not change which is selected.  This could probably be made to work with some extra logic there, but it seems overkill.

The downside of fixing it at the query level is that other parts of the declaration are not inside the item range.  This seems to be fine for single line declarations - the nearest outline item is highlighted.  However, if a part of the declaration is not included in an item range and is on its own line, then no outline item is highlighted.

Release Notes:

- Outline Panel: Fixed nesting of var and field declarations with multiple identifiers in Go and C++

C++ before:

<img width="743" height="227" alt="image" src="https://github.com/user-attachments/assets/af1a1d76-ecdc-4999-ae9c-95591726ccca" />

C++ after:

<img width="795" height="250" alt="image" src="https://github.com/user-attachments/assets/49667ed3-e088-48b3-a9f0-6a119b5e7648" />

Go before:

<img width="859" height="306" alt="image" src="https://github.com/user-attachments/assets/ecc7530a-ca16-4f37-b8d1-60687f178b12" />

Go after:

<img width="900" height="334" alt="image" src="https://github.com/user-attachments/assets/d741cfb0-59e5-4d27-bd6a-f422204dc972" />