### PR TITLE
Eliminate host targets from rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -3,11 +3,6 @@ channel = "1.89"
 profile = "minimal"
 components = [ "rustfmt", "clippy" ]
 targets = [
-    "x86_64-apple-darwin",
-    "aarch64-apple-darwin",
-    "x86_64-unknown-freebsd",
-    "x86_64-unknown-linux-gnu",
-    "x86_64-pc-windows-msvc",
     "wasm32-wasip2", # extensions
     "x86_64-unknown-linux-musl", # remote server
 ]


### PR DESCRIPTION
Only cross-compilation targets need to be listed in the rust toolchain. So we only need to list the wasi target for extensions, and the musl target for the linux remote server. Previously, we were causing mac, linux, and windows target to get installed onto all developer workstations, which is unnecessary.

Release Notes:

- N/A