### PR TITLE
onboarding: Fix onboarding font context menu not scrolling to selected entry open

### DIFF
--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -573,7 +573,7 @@ fn font_picker(
 ) -> FontPicker {
     let delegate = FontPickerDelegate::new(current_font, on_font_changed, cx);
 
-    Picker::list(delegate, window, cx)
+    Picker::uniform_list(delegate, window, cx)
         .show_scrollbar(true)
         .width(rems_from_px(210.))
         .max_height(Some(rems(20.).into()))


### PR DESCRIPTION
The fix was changing the picker kind we used from `list` variant to a `uniform` list

`Picker::list()` still has a bug where it's unable to scroll to it's selected entry when the list is first openned. This is likely caused by list not knowing the pixel offset of each element it would have to scroll pass to get to the selected element


Release Notes:

- N/A
