### PR TITLE
Change default pane split directions

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -82,10 +82,10 @@
   // Layout mode of the bottom dock. Defaults to "contained"
   //   choices: contained, full, left_aligned, right_aligned
   "bottom_dock_layout": "contained",
-  // The direction that you want to split panes horizontally. Defaults to "up"
-  "pane_split_direction_horizontal": "up",
-  // The direction that you want to split panes vertically. Defaults to "left"
-  "pane_split_direction_vertical": "left",
+  // The direction that you want to split panes horizontally. Defaults to "down"
+  "pane_split_direction_horizontal": "down",
+  // The direction that you want to split panes vertically. Defaults to "right"
+  "pane_split_direction_vertical": "right",
   // Centered layout related settings.
   "centered_layout": {
     // The relative width of the left padding of the central pane from the


### PR DESCRIPTION
Closes #32538

This PR adjusts the defaults for splitting panes along the horizontal and vertical actions. Based upon user feedback, the adjusted values seem more reasonable as default settings, hence, go with these instead.

Release Notes:

- Changed the default split directions for the `pane: split horizontal` and `pane: split vertical` actions. You can restore the old behavior by modifying the `pane_split_direction_horizontal` and `pane_split_direction_vertical`  values in your settings.