### PR TITLE
search: Fix some inconsistencies between project and buffer search bars

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -359,60 +359,34 @@ impl Render for BufferSearchBar {
                     }),
             );
 
-        let replace_line = should_show_replace_input.then(|| {
-            h_flex()
-                .gap_2()
-                .child(
-                    input_base_styles(replacement_border).child(render_text_input(
-                        &self.replacement_editor,
-                        None,
-                        cx,
-                    )),
-                )
-                .child(
-                    h_flex()
-                        .min_w_64()
-                        .gap_1()
-                        .child(
-                            IconButton::new("search-replace-next", ui::IconName::ReplaceNext)
-                                .shape(IconButtonShape::Square)
-                                .tooltip({
-                                    let focus_handle = focus_handle.clone();
-                                    move |window, cx| {
-                                        Tooltip::for_action_in(
-                                            "Replace Next Match",
-                                            &ReplaceNext,
-                                            &focus_handle,
-                                            window,
-                                            cx,
-                                        )
-                                    }
-                                })
-                                .on_click(cx.listener(|this, _, window, cx| {
-                                    this.replace_next(&ReplaceNext, window, cx)
-                                })),
-                        )
-                        .child(
-                            IconButton::new("search-replace-all", ui::IconName::ReplaceAll)
-                                .shape(IconButtonShape::Square)
-                                .tooltip({
-                                    let focus_handle = focus_handle.clone();
-                                    move |window, cx| {
-                                        Tooltip::for_action_in(
-                                            "Replace All Matches",
-                                            &ReplaceAll,
-                                            &focus_handle,
-                                            window,
-                                            cx,
-                                        )
-                                    }
-                                })
-                                .on_click(cx.listener(|this, _, window, cx| {
-                                    this.replace_all(&ReplaceAll, window, cx)
-                                })),
-                        ),
-                )
-        });
+        let replace_line =
+            should_show_replace_input.then(|| {
+                let replace_column = input_base_styles(replacement_border)
+                    .child(render_text_input(&self.replacement_editor, None, cx));
+                let focus_handle = self.replacement_editor.read(cx).focus_handle(cx);
+
+                let replace_actions = h_flex()
+                    .min_w_64()
+                    .gap_1()
+                    .child(render_nav_button(
+                        IconName::ReplaceNext,
+                        true,
+                        "Replace Next Match",
+                        &ReplaceNext,
+                        focus_handle.clone(),
+                    ))
+                    .child(render_nav_button(
+                        IconName::ReplaceAll,
+                        true,
+                        "Replace All Matches",
+                        &ReplaceAll,
+                        focus_handle,
+                    ));
+                h_flex()
+                    .gap_2()
+                    .child(replace_column)
+                    .child(replace_actions)
+            });
 
         let query_error_line = self.query_error.as_ref().map(|error| {
             Label::new(error)

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -290,7 +290,7 @@ impl Render for BufferSearchBar {
                 let query_focus = self.query_editor.focus_handle(cx);
                 let matches_column = h_flex()
                     .pl_2()
-                    .ml_1()
+                    .ml_2()
                     .border_l_1()
                     .border_color(theme_colors.border_variant)
                     .child(render_action_button(
@@ -308,7 +308,18 @@ impl Render for BufferSearchBar {
                         "Select Next Match",
                         &SelectNextMatch,
                         query_focus.clone(),
-                    ));
+                    ))
+                    .when(!narrow_mode, |this| {
+                        this.child(div().ml_2().min_w(rems_from_px(40.)).child(
+                            Label::new(match_text).size(LabelSize::Small).color(
+                                if self.active_match_index.is_some() {
+                                    Color::Default
+                                } else {
+                                    Color::Disabled
+                                },
+                            ),
+                        ))
+                    });
 
                 el.child(render_action_button(
                     "buffer-search-nav-button",
@@ -319,17 +330,6 @@ impl Render for BufferSearchBar {
                     query_focus,
                 ))
                 .child(matches_column)
-                .when(!narrow_mode, |this| {
-                    this.child(h_flex().ml_2().min_w(rems_from_px(40.)).child(
-                        Label::new(match_text).size(LabelSize::Small).color(
-                            if self.active_match_index.is_some() {
-                                Color::Default
-                            } else {
-                                Color::Disabled
-                            },
-                        ),
-                    ))
-                })
             })
             .when(find_in_results, |el| {
                 el.child(render_action_button(
@@ -343,6 +343,7 @@ impl Render for BufferSearchBar {
             });
 
         let search_line = h_flex()
+            .w_full()
             .gap_2()
             .when(find_in_results, |el| {
                 el.child(Label::new("Find in results").color(Color::Hint))
@@ -376,6 +377,7 @@ impl Render for BufferSearchBar {
                         focus_handle,
                     ));
                 h_flex()
+                    .w_full()
                     .gap_2()
                     .child(replace_column)
                     .child(replace_actions)
@@ -414,6 +416,7 @@ impl Render for BufferSearchBar {
             .id("buffer_search")
             .gap_2()
             .py(px(1.0))
+            .w_full()
             .track_scroll(&self.scroll_handle)
             .key_context(key_context)
             .capture_action(cx.listener(Self::tab))

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -4,7 +4,9 @@ use crate::{
     FocusSearch, NextHistoryQuery, PreviousHistoryQuery, ReplaceAll, ReplaceNext, SearchOptions,
     SelectAllMatches, SelectNextMatch, SelectPreviousMatch, ToggleCaseSensitive, ToggleRegex,
     ToggleReplace, ToggleSelection, ToggleWholeWord,
-    search_bar::{input_base_styles, render_nav_button, render_text_input, toggle_replace_button},
+    search_bar::{
+        input_base_styles, render_action_button, render_text_input, toggle_replace_button,
+    },
 };
 use any_vec::AnyVec;
 use anyhow::Context as _;
@@ -282,24 +284,27 @@ impl Render for BufferSearchBar {
                 )
             })
             .when(!supported_options.find_in_results, |el| {
+                let query_focus = self.query_editor.focus_handle(cx);
                 let matches_column = h_flex()
                     .pl_2()
                     .ml_1()
                     .border_l_1()
                     .border_color(cx.theme().colors().border_variant)
-                    .child(render_nav_button(
+                    .child(render_action_button(
+                        "buffer-search-nav-button",
                         ui::IconName::ChevronLeft,
                         self.active_match_index.is_some(),
                         "Select Previous Match",
                         &SelectPreviousMatch,
-                        focus_handle.clone(),
+                        query_focus.clone(),
                     ))
-                    .child(render_nav_button(
+                    .child(render_action_button(
+                        "buffer-search-nav-button",
                         ui::IconName::ChevronRight,
                         self.active_match_index.is_some(),
                         "Select Next Match",
                         &SelectNextMatch,
-                        focus_handle.clone(),
+                        query_focus,
                     ));
                 el.child(
                     IconButton::new("select-all", ui::IconName::SelectAll)
@@ -363,14 +368,16 @@ impl Render for BufferSearchBar {
                 let replace_actions = h_flex()
                     .min_w_64()
                     .gap_1()
-                    .child(render_nav_button(
+                    .child(render_action_button(
+                        "buffer-search-replace-button",
                         IconName::ReplaceNext,
                         true,
                         "Replace Next Match",
                         &ReplaceNext,
                         focus_handle.clone(),
                     ))
-                    .child(render_nav_button(
+                    .child(render_action_button(
+                        "buffer-search-replace-button",
                         IconName::ReplaceAll,
                         true,
                         "Replace All Matches",

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -3,7 +3,8 @@ mod registrar;
 use crate::{
     FocusSearch, NextHistoryQuery, PreviousHistoryQuery, ReplaceAll, ReplaceNext, SearchOptions,
     SelectAllMatches, SelectNextMatch, SelectPreviousMatch, ToggleCaseSensitive, ToggleRegex,
-    ToggleReplace, ToggleSelection, ToggleWholeWord, search_bar::render_nav_button,
+    ToggleReplace, ToggleSelection, ToggleWholeWord,
+    search_bar::{input_base_styles, render_nav_button, toggle_replace_button},
 };
 use any_vec::AnyVec;
 use anyhow::Context as _;
@@ -238,18 +239,8 @@ impl Render for BufferSearchBar {
         let container_width = window.viewport_size().width;
         let input_width = SearchInputWidth::calc_width(container_width);
 
-        let input_base_styles = |border_color| {
-            h_flex()
-                .min_w_32()
-                .w(input_width)
-                .h_8()
-                .pl_2()
-                .pr_1()
-                .py_1()
-                .border_1()
-                .border_color(border_color)
-                .rounded_lg()
-        };
+        let input_base_styles =
+            |border_color| input_base_styles(border_color, |div| div.w(input_width));
 
         let search_line = h_flex()
             .gap_2()
@@ -304,33 +295,14 @@ impl Render for BufferSearchBar {
                     .gap_1()
                     .min_w_64()
                     .when(supported_options.replacement, |this| {
-                        this.child(
-                            IconButton::new(
-                                "buffer-search-bar-toggle-replace-button",
-                                IconName::Replace,
-                            )
-                            .style(ButtonStyle::Subtle)
-                            .shape(IconButtonShape::Square)
-                            .when(self.replace_enabled, |button| {
-                                button.style(ButtonStyle::Filled)
-                            })
-                            .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
+                        this.child(toggle_replace_button(
+                            "buffer-search-bar-toggle-replace-button",
+                            focus_handle.clone(),
+                            self.replace_enabled,
+                            cx.listener(|this, _: &ClickEvent, window, cx| {
                                 this.toggle_replace(&ToggleReplace, window, cx);
-                            }))
-                            .toggle_state(self.replace_enabled)
-                            .tooltip({
-                                let focus_handle = focus_handle.clone();
-                                move |window, cx| {
-                                    Tooltip::for_action_in(
-                                        "Toggle Replace",
-                                        &ToggleReplace,
-                                        &focus_handle,
-                                        window,
-                                        cx,
-                                    )
-                                }
                             }),
-                        )
+                        ))
                     })
                     .when(supported_options.selection, |this| {
                         this.child(

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2130,6 +2130,45 @@ impl Render for ProjectSearchBar {
         });
 
         let filter_line = search.filters_enabled.then(|| {
+            let include = input_base_styles(BaseStyle::MultipleInputs, InputPanel::Include)
+                .on_action(cx.listener(|this, action, window, cx| {
+                    this.previous_history_query(action, window, cx)
+                }))
+                .on_action(cx.listener(|this, action, window, cx| {
+                    this.next_history_query(action, window, cx)
+                }))
+                .child(render_text_input(&search.included_files_editor, None, cx));
+            let exclude = input_base_styles(BaseStyle::MultipleInputs, InputPanel::Exclude)
+                .on_action(cx.listener(|this, action, window, cx| {
+                    this.previous_history_query(action, window, cx)
+                }))
+                .on_action(cx.listener(|this, action, window, cx| {
+                    this.next_history_query(action, window, cx)
+                }))
+                .child(render_text_input(&search.excluded_files_editor, None, cx));
+            let mode_column = h_flex()
+                .gap_1()
+                .min_w_64()
+                .child(
+                    IconButton::new("project-search-opened-only", IconName::FolderSearch)
+                        .shape(IconButtonShape::Square)
+                        .toggle_state(self.is_opened_only_enabled(cx))
+                        .tooltip(Tooltip::text("Only Search Open Files"))
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            this.toggle_opened_only(window, cx);
+                        })),
+                )
+                .child(
+                    SearchOptions::INCLUDE_IGNORED.as_button(
+                        search
+                            .search_options
+                            .contains(SearchOptions::INCLUDE_IGNORED),
+                        focus_handle.clone(),
+                        cx.listener(|this, _, window, cx| {
+                            this.toggle_search_option(SearchOptions::INCLUDE_IGNORED, window, cx);
+                        }),
+                    ),
+                );
             h_flex()
                 .w_full()
                 .gap_2()
@@ -2137,62 +2176,14 @@ impl Render for ProjectSearchBar {
                     h_flex()
                         .gap_2()
                         .w(input_width)
-                        .child(
-                            input_base_styles(BaseStyle::MultipleInputs, InputPanel::Include)
-                                .on_action(cx.listener(|this, action, window, cx| {
-                                    this.previous_history_query(action, window, cx)
-                                }))
-                                .on_action(cx.listener(|this, action, window, cx| {
-                                    this.next_history_query(action, window, cx)
-                                }))
-                                .child(render_text_input(&search.included_files_editor, None, cx)),
-                        )
-                        .child(
-                            input_base_styles(BaseStyle::MultipleInputs, InputPanel::Exclude)
-                                .on_action(cx.listener(|this, action, window, cx| {
-                                    this.previous_history_query(action, window, cx)
-                                }))
-                                .on_action(cx.listener(|this, action, window, cx| {
-                                    this.next_history_query(action, window, cx)
-                                }))
-                                .child(render_text_input(&search.excluded_files_editor, None, cx)),
-                        ),
+                        .child(include)
+                        .child(exclude),
                 )
-                .child(
-                    h_flex()
-                        .min_w_64()
-                        .gap_1()
-                        .child(
-                            IconButton::new("project-search-opened-only", IconName::FolderSearch)
-                                .shape(IconButtonShape::Square)
-                                .toggle_state(self.is_opened_only_enabled(cx))
-                                .tooltip(Tooltip::text("Only Search Open Files"))
-                                .on_click(cx.listener(|this, _, window, cx| {
-                                    this.toggle_opened_only(window, cx);
-                                })),
-                        )
-                        .child(
-                            SearchOptions::INCLUDE_IGNORED.as_button(
-                                search
-                                    .search_options
-                                    .contains(SearchOptions::INCLUDE_IGNORED),
-                                focus_handle.clone(),
-                                cx.listener(|this, _, window, cx| {
-                                    this.toggle_search_option(
-                                        SearchOptions::INCLUDE_IGNORED,
-                                        window,
-                                        cx,
-                                    );
-                                }),
-                            ),
-                        ),
-                )
+                .child(mode_column)
         });
 
         let mut key_context = KeyContext::default();
-
         key_context.add("ProjectSearchBar");
-
         if search
             .replacement_editor
             .focus_handle(cx)

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -3,7 +3,7 @@ use crate::{
     SearchOptions, SelectNextMatch, SelectPreviousMatch, ToggleCaseSensitive, ToggleIncludeIgnored,
     ToggleRegex, ToggleReplace, ToggleWholeWord,
     buffer_search::Deploy,
-    search_bar::{input_base_styles, render_text_input, toggle_replace_button},
+    search_bar::{input_base_styles, render_nav_button, render_text_input, toggle_replace_button},
 };
 use anyhow::Context as _;
 use collections::{HashMap, HashSet};
@@ -2052,54 +2052,20 @@ impl Render for ProjectSearchBar {
             .ml_2()
             .border_l_1()
             .border_color(cx.theme().colors().border_variant)
-            .child(
-                IconButton::new("project-search-prev-match", IconName::ChevronLeft)
-                    .shape(IconButtonShape::Square)
-                    .disabled(search.active_match_index.is_none())
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        if let Some(search) = this.active_project_search.as_ref() {
-                            search.update(cx, |this, cx| {
-                                this.select_match(Direction::Prev, window, cx);
-                            })
-                        }
-                    }))
-                    .tooltip({
-                        let focus_handle = focus_handle.clone();
-                        move |window, cx| {
-                            Tooltip::for_action_in(
-                                "Go To Previous Match",
-                                &SelectPreviousMatch,
-                                &focus_handle,
-                                window,
-                                cx,
-                            )
-                        }
-                    }),
-            )
-            .child(
-                IconButton::new("project-search-next-match", IconName::ChevronRight)
-                    .shape(IconButtonShape::Square)
-                    .disabled(search.active_match_index.is_none())
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        if let Some(search) = this.active_project_search.as_ref() {
-                            search.update(cx, |this, cx| {
-                                this.select_match(Direction::Next, window, cx);
-                            })
-                        }
-                    }))
-                    .tooltip({
-                        let focus_handle = focus_handle.clone();
-                        move |window, cx| {
-                            Tooltip::for_action_in(
-                                "Go To Next Match",
-                                &SelectNextMatch,
-                                &focus_handle,
-                                window,
-                                cx,
-                            )
-                        }
-                    }),
-            )
+            .child(render_nav_button(
+                IconName::ChevronLeft,
+                search.active_match_index.is_some(),
+                "Select Previous Match",
+                &SelectPreviousMatch,
+                focus_handle.clone(),
+            ))
+            .child(render_nav_button(
+                IconName::ChevronRight,
+                search.active_match_index.is_some(),
+                "Select Next Match",
+                &SelectNextMatch,
+                focus_handle.clone(),
+            ))
             .child(
                 div()
                     .id("matches")

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2009,6 +2009,7 @@ impl Render for ProjectSearchBar {
 
         let mode_column = h_flex()
             .gap_1()
+            .min_w_64()
             .child(
                 IconButton::new("project-search-filter-button", IconName::Filter)
                     .shape(IconButtonShape::Square)
@@ -2075,7 +2076,8 @@ impl Render for ProjectSearchBar {
             .child(
                 div()
                     .id("matches")
-                    .ml_1()
+                    .ml_2()
+                    .min_w(rems_from_px(40.))
                     .child(Label::new(match_text).size(LabelSize::Small).color(
                         if search.active_match_index.is_some() {
                             Color::Default
@@ -2201,7 +2203,9 @@ impl Render for ProjectSearchBar {
         });
 
         v_flex()
+            .gap_2()
             .py(px(1.0))
+            .w_full()
             .key_context(key_context)
             .on_action(cx.listener(|this, _: &ToggleFocus, window, cx| {
                 this.move_focus_to_results(window, cx)
@@ -2248,8 +2252,6 @@ impl Render for ProjectSearchBar {
             })
             .on_action(cx.listener(Self::select_next_match))
             .on_action(cx.listener(Self::select_prev_match))
-            .gap_2()
-            .w_full()
             .child(search_line)
             .children(query_error_line)
             .children(replace_line)

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -2099,52 +2099,20 @@ impl Render for ProjectSearchBar {
             let replace_actions = h_flex()
                 .min_w_64()
                 .gap_1()
-                .child(
-                    IconButton::new("project-search-replace-next", IconName::ReplaceNext)
-                        .shape(IconButtonShape::Square)
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            if let Some(search) = this.active_project_search.as_ref() {
-                                search.update(cx, |this, cx| {
-                                    this.replace_next(&ReplaceNext, window, cx);
-                                })
-                            }
-                        }))
-                        .tooltip({
-                            let focus_handle = focus_handle.clone();
-                            move |window, cx| {
-                                Tooltip::for_action_in(
-                                    "Replace Next Match",
-                                    &ReplaceNext,
-                                    &focus_handle,
-                                    window,
-                                    cx,
-                                )
-                            }
-                        }),
-                )
-                .child(
-                    IconButton::new("project-search-replace-all", IconName::ReplaceAll)
-                        .shape(IconButtonShape::Square)
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            if let Some(search) = this.active_project_search.as_ref() {
-                                search.update(cx, |this, cx| {
-                                    this.replace_all(&ReplaceAll, window, cx);
-                                })
-                            }
-                        }))
-                        .tooltip({
-                            let focus_handle = focus_handle.clone();
-                            move |window, cx| {
-                                Tooltip::for_action_in(
-                                    "Replace All Matches",
-                                    &ReplaceAll,
-                                    &focus_handle,
-                                    window,
-                                    cx,
-                                )
-                            }
-                        }),
-                );
+                .child(render_nav_button(
+                    IconName::ReplaceNext,
+                    true,
+                    "Replace Next Match",
+                    &ReplaceNext,
+                    focus_handle.clone(),
+                ))
+                .child(render_nav_button(
+                    IconName::ReplaceAll,
+                    true,
+                    "Replace All Matches",
+                    &ReplaceAll,
+                    focus_handle,
+                ));
 
             h_flex()
                 .w_full()

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -3,7 +3,9 @@ use crate::{
     SearchOptions, SelectNextMatch, SelectPreviousMatch, ToggleCaseSensitive, ToggleIncludeIgnored,
     ToggleRegex, ToggleReplace, ToggleWholeWord,
     buffer_search::Deploy,
-    search_bar::{input_base_styles, render_nav_button, render_text_input, toggle_replace_button},
+    search_bar::{
+        input_base_styles, render_action_button, render_text_input, toggle_replace_button,
+    },
 };
 use anyhow::Context as _;
 use collections::{HashMap, HashSet};
@@ -2047,24 +2049,28 @@ impl Render for ProjectSearchBar {
                 }),
             ));
 
+        let query_focus = search.query_editor.focus_handle(cx);
+
         let matches_column = h_flex()
             .pl_2()
             .ml_2()
             .border_l_1()
             .border_color(cx.theme().colors().border_variant)
-            .child(render_nav_button(
+            .child(render_action_button(
+                "project-search-nav-button",
                 IconName::ChevronLeft,
                 search.active_match_index.is_some(),
                 "Select Previous Match",
                 &SelectPreviousMatch,
-                focus_handle.clone(),
+                query_focus.clone(),
             ))
-            .child(render_nav_button(
+            .child(render_action_button(
+                "project-search-nav-button",
                 IconName::ChevronRight,
                 search.active_match_index.is_some(),
                 "Select Next Match",
                 &SelectNextMatch,
-                focus_handle.clone(),
+                query_focus,
             ))
             .child(
                 div()
@@ -2099,14 +2105,16 @@ impl Render for ProjectSearchBar {
             let replace_actions = h_flex()
                 .min_w_64()
                 .gap_1()
-                .child(render_nav_button(
+                .child(render_action_button(
+                    "project-search-replace-button",
                     IconName::ReplaceNext,
                     true,
                     "Replace Next Match",
                     &ReplaceNext,
                     focus_handle.clone(),
                 ))
-                .child(render_nav_button(
+                .child(render_action_button(
+                    "project-search-replace-button",
                     IconName::ReplaceAll,
                     true,
                     "Replace All Matches",

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -7,7 +7,8 @@ use ui::{Tooltip, prelude::*};
 
 use crate::ToggleReplace;
 
-pub(super) fn render_nav_button(
+pub(super) fn render_action_button(
+    id_prefix: &'static str,
     icon: ui::IconName,
     active: bool,
     tooltip: &'static str,
@@ -15,7 +16,7 @@ pub(super) fn render_nav_button(
     focus_handle: FocusHandle,
 ) -> impl IntoElement {
     IconButton::new(
-        SharedString::from(format!("search-nav-button-{}", action.name())),
+        SharedString::from(format!("{id_prefix}-{}", action.name())),
         icon,
     )
     .shape(IconButtonShape::Square)

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -1,6 +1,8 @@
-use gpui::{Action, FocusHandle, IntoElement};
+use gpui::{Action, FocusHandle, Hsla, IntoElement};
 use ui::{IconButton, IconButtonShape};
 use ui::{Tooltip, prelude::*};
+
+use crate::ToggleReplace;
 
 pub(super) fn render_nav_button(
     icon: ui::IconName,
@@ -25,4 +27,36 @@ pub(super) fn render_nav_button(
     })
     .tooltip(move |window, cx| Tooltip::for_action_in(tooltip, action, &focus_handle, window, cx))
     .disabled(!active)
+}
+
+pub(crate) fn input_base_styles(border_color: Hsla, map: impl FnOnce(Div) -> Div) -> Div {
+    h_flex()
+        .min_w_32()
+        .map(map)
+        .h_8()
+        .pl_2()
+        .pr_1()
+        .py_1()
+        .border_1()
+        .border_color(border_color)
+        .rounded_lg()
+}
+
+pub(crate) fn toggle_replace_button(
+    id: &'static str,
+    focus_handle: FocusHandle,
+    replace_enabled: bool,
+    on_click: impl Fn(&gpui::ClickEvent, &mut Window, &mut App) + 'static,
+) -> IconButton {
+    IconButton::new(id, IconName::Replace)
+        .shape(IconButtonShape::Square)
+        .style(ButtonStyle::Subtle)
+        .when(replace_enabled, |button| button.style(ButtonStyle::Filled))
+        .on_click(on_click)
+        .toggle_state(replace_enabled)
+        .tooltip({
+            move |window, cx| {
+                Tooltip::for_action_in("Toggle Replace", &ToggleReplace, &focus_handle, window, cx)
+            }
+        })
 }

--- a/crates/search/src/search_bar.rs
+++ b/crates/search/src/search_bar.rs
@@ -1,4 +1,7 @@
-use gpui::{Action, FocusHandle, Hsla, IntoElement};
+use editor::{Editor, EditorElement, EditorStyle};
+use gpui::{Action, Entity, FocusHandle, Hsla, IntoElement, TextStyle};
+use settings::Settings;
+use theme::ThemeSettings;
 use ui::{IconButton, IconButtonShape};
 use ui::{Tooltip, prelude::*};
 
@@ -59,4 +62,43 @@ pub(crate) fn toggle_replace_button(
                 Tooltip::for_action_in("Toggle Replace", &ToggleReplace, &focus_handle, window, cx)
             }
         })
+}
+
+pub(crate) fn render_text_input(
+    editor: &Entity<Editor>,
+    color_override: Option<Color>,
+    app: &App,
+) -> impl IntoElement {
+    let (color, use_syntax) = if editor.read(app).read_only(app) {
+        (app.theme().colors().text_disabled, false)
+    } else {
+        match color_override {
+            Some(color_override) => (color_override.color(app), false),
+            None => (app.theme().colors().text, true),
+        }
+    };
+
+    let settings = ThemeSettings::get_global(app);
+    let text_style = TextStyle {
+        color,
+        font_family: settings.buffer_font.family.clone(),
+        font_features: settings.buffer_font.features.clone(),
+        font_fallbacks: settings.buffer_font.fallbacks.clone(),
+        font_size: rems(0.875).into(),
+        font_weight: settings.buffer_font.weight,
+        line_height: relative(1.3),
+        ..TextStyle::default()
+    };
+
+    let mut editor_style = EditorStyle {
+        background: app.theme().colors().toolbar_background,
+        local_player: app.theme().players().local(),
+        text: text_style,
+        ..EditorStyle::default()
+    };
+    if use_syntax {
+        editor_style.syntax = app.theme().syntax().clone();
+    }
+
+    EditorElement::new(editor, editor_style)
 }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -3880,9 +3880,7 @@ impl Workspace {
                 local,
                 focus_changed,
             } => {
-                cx.on_next_frame(window, |_, window, _| {
-                    window.invalidate_character_coordinates();
-                });
+                window.invalidate_character_coordinates();
 
                 pane.update(cx, |pane, _| {
                     pane.track_alternate_file_items();
@@ -3923,9 +3921,7 @@ impl Workspace {
                 }
             }
             pane::Event::Focus => {
-                cx.on_next_frame(window, |_, window, _| {
-                    window.invalidate_character_coordinates();
-                });
+                window.invalidate_character_coordinates();
                 self.handle_pane_focused(pane.clone(), window, cx);
             }
             pane::Event::ZoomIn => {


### PR DESCRIPTION
- project search query string now turns red when no results are found matching buffer search behavior
- General code deduplication as well as more consistent layout between the two bars, as some minor details have drifted apart
- Tab cycling in buffer search now ends up in editor focus when cycling backwards, matching forward cycling
- Report parse errors in filter include and exclude editors

Release Notes:

- N/A