### PR TITLE
linux: Fix not accepting key press / key release event on startup

### DIFF
--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -428,7 +428,10 @@ impl X11Client {
         let xcb_connection = Rc::new(xcb_connection);
 
         // bug in ibus causes it to crash, which results in us not receiving xim callbacks, see #29083
-        let ximc = if get_package_version("ibus").as_deref() == Some("1.5.32~rc2-1") {
+        let ximc = if get_package_version("ibus")
+            .as_deref()
+            .map_or(false, |version| version.starts_with("1.5.32~rc2-1"))
+        {
             None
         } else {
             X11rbClient::init(Rc::clone(&xcb_connection), x_root_index, None).ok()
@@ -2515,16 +2518,6 @@ fn get_package_version(name: &str) -> Option<String> {
         if output.status.success() {
             if let Ok(version) = std::str::from_utf8(&output.stdout) {
                 return Some(version.trim().to_string());
-            }
-        }
-    }
-
-    if let Ok(output) = new_std_command("pacman").args(["-Q", &name]).output() {
-        if output.status.success() {
-            if let Ok(stdout) = std::str::from_utf8(&output.stdout) {
-                if let Some(version) = stdout.trim().split_whitespace().nth(1) {
-                    return Some(version.to_string());
-                }
             }
         }
     }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -2494,11 +2494,11 @@ fn valid_scale_factor(scale_factor: f32) -> bool {
     scale_factor.is_sign_positive() && scale_factor.is_normal()
 }
 
-fn get_package_version(name: String) -> Option<String> {
+fn get_package_version(name: &str) -> Option<String> {
     use util::command::new_std_command;
 
     if let Ok(output) = new_std_command("dpkg-query")
-        .args(["-W", "-f=${Version}", name])
+        .args(["-W", "-f=${Version}", &name])
         .output()
     {
         if output.status.success() {
@@ -2509,7 +2509,7 @@ fn get_package_version(name: String) -> Option<String> {
     }
 
     if let Ok(output) = new_std_command("rpm")
-        .args(["-q", "--qf", "%{VERSION}-%{RELEASE}", name])
+        .args(["-q", "--qf", "%{VERSION}-%{RELEASE}", &name])
         .output()
     {
         if output.status.success() {
@@ -2519,10 +2519,7 @@ fn get_package_version(name: String) -> Option<String> {
         }
     }
 
-    if let Ok(output) = new_std_command("pacman")
-        .args(["-Q", name])
-        .output()
-    {
+    if let Ok(output) = new_std_command("pacman").args(["-Q", &name]).output() {
         if output.status.success() {
             if let Ok(stdout) = std::str::from_utf8(&output.stdout) {
                 if let Some(version) = stdout.trim().split_whitespace().nth(1) {


### PR DESCRIPTION
Closes #29083

The specific ibus build `1.5.32~rc2-1` crashes after some time when it’s being interacted with. In Zed, we send `forward_event` to ibus through `xim-rs` and expects `handle_forward_event` callbacks to actually commit characters into the buffer. Once ibus crashes, those callbacks stop, and we have no reliable way to detect the crash in the moment.

We only get X11 error on the *next* key press, the one that triggers the crash so that keystroke is effectively lost. This isn’t just Zed specific, the `xim-rs` examples hit the same crash.

As a workaround, we skip XIM entirely when we detect that exact ibus version. In that mode we handle keys the same way we do without XIM, which at least keeps typing unblocked.

Release Notes:

- Fixed an issue on Linux where, in some cases, no keyboard events were accepted at startup.
