### PR TITLE
Hoist `rodio` to workspace level

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -566,6 +566,7 @@ reqwest = { git = "https://github.com/zed-industries/reqwest.git", rev = "951c77
     "socks",
     "stream",
 ] }
+rodio = { version = "0.21.1", default-features = false }
 rsa = "0.9.6"
 runtimelib = {  git = "https://github.com/ConradIrwin/runtimed", rev = "7130c804216b6914355d15d0b91ea91f6babd734", default-features = false, features = [
     "async-dispatcher-runtime",

--- a/crates/audio/Cargo.toml
+++ b/crates/audio/Cargo.toml
@@ -18,6 +18,6 @@ collections.workspace = true
 derive_more.workspace = true
 gpui.workspace = true
 parking_lot.workspace = true
-rodio = { version = "0.21.1", default-features = false, features = ["wav", "playback", "tracing"] }
+rodio = { workspace = true, features = ["wav", "playback", "tracing"] }
 util.workspace = true
 workspace-hack.workspace = true


### PR DESCRIPTION
This PR hoists `rodio` up to a workspace dependency.

Release Notes:

- N/A
