### PR TITLE
emmet: Use `index.js` directly to launch language server

### DIFF
--- a/extensions/emmet/src/emmet.rs
+++ b/extensions/emmet/src/emmet.rs
@@ -5,7 +5,7 @@ struct EmmetExtension {
     did_find_server: bool,
 }
 
-const SERVER_PATH: &str = "node_modules/.bin/emmet-language-server";
+const SERVER_PATH: &str = "node_modules/@olrtg/emmet-language-server/dist/index.js";
 const PACKAGE_NAME: &str = "@olrtg/emmet-language-server";
 
 impl EmmetExtension {


### PR DESCRIPTION
This PR updates the Emmet extension to use the `index.js` file directly to launch the language server.

This provides better cross-platform support, as we're not relying on platform-specific `.bin` wrappers.

Release Notes:

- N/A
