### PR TITLE
Remove Services menu on non-macOS systems

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -35,6 +35,7 @@ pub fn app_menus() -> Vec<Menu> {
                     ],
                 }),
                 MenuItem::separator(),
+                #[cfg(target_os = "macos")]
                 MenuItem::os_submenu("Services", gpui::SystemMenuType::Services),
                 MenuItem::separator(),
                 MenuItem::action("Extensions", zed_actions::Extensions::default()),


### PR DESCRIPTION
Closes #ISSUE

<img width="420" height="379" alt="image" src="https://github.com/user-attachments/assets/7125c504-508f-4eb1-b0c3-31830598c4a7" />


Release Notes:

- Remove Services menu on non-macOS systems which was causing an empty menu item being rendered
