### PR TITLE
onboarding: Fix minimap typo on editing page

### DIFF
--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -676,7 +676,7 @@ fn render_popular_settings_section(
                 .items_start()
                 .justify_between()
                 .child(
-                    v_flex().child(Label::new("Mini Map")).child(
+                    v_flex().child(Label::new("Minimap")).child(
                         Label::new("See a high-level overview of your source code.")
                             .color(Color::Muted),
                     ),


### PR DESCRIPTION
This PR fixes a small typo on the onboarding editing page where it should be "Minimap" instead of "Mini Map"

Release Notes:

- N/A
