### PR TITLE
docs: Update information in MSYS2 section

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -114,18 +114,18 @@ cargo test --workspace
 
 ## Installing from msys2
 
-[MSYS2](https://msys2.org/) distribution provides Zed as a package [mingw-w64-zed](https://packages.msys2.org/base/mingw-w64-zed). The package is available for UCRT64, MINGW64 and CLANG64 repositories. To download it, run
+[MSYS2](https://msys2.org/) distribution provides Zed as a package [mingw-w64-zed](https://packages.msys2.org/base/mingw-w64-zed). The package is available for UCRT64, CLANG64 and CLANGARM64 repositories. To download it, run
 
 ```sh
 pacman -Syu
 pacman -S $MINGW_PACKAGE_PREFIX-zed
 ```
 
-then you can run `zeditor` CLI. Editor executable is installed under `$MINGW_PREFIX/lib/zed` directory
-
 You can see the [build script](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-zed/PKGBUILD) for more details on build process.
 
 > Please, report any issue in [msys2/MINGW-packages/issues](https://github.com/msys2/MINGW-packages/issues?q=is%3Aissue+is%3Aopen+zed) first.
+
+See also MSYS2 [documentation page](https://www.msys2.org/docs/ides-editors).
 
 Note that `collab` is not supported for MSYS2.
 


### PR DESCRIPTION
- we are about to drop Zed for MINGW64 because `crash-handler` uses a symbol which is not presented in `msvcrt.dll`
- mention MSYS2 docs page and CLANGARM64 environment

Release Notes:

- N/A
