### PR TITLE
Add Arduino language support for .ino files

### DIFF
--- a/crates/languages/src/arduino/brackets.scm
+++ b/crates/languages/src/arduino/brackets.scm
@@ -1,0 +1,5 @@
+("(" @open ")" @close)
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)
+("'" @open "'" @close)

--- a/crates/languages/src/arduino/config.toml
+++ b/crates/languages/src/arduino/config.toml
@@ -1,6 +1,6 @@
-name = "C++"
+name = "Arduino"
 grammar = "cpp"
-path_suffixes = ["cc", "hh", "cpp", "h", "hpp", "cxx", "hxx", "c++", "ipp", "inl", "ixx", "cu", "cuh", "C", "H"]
+path_suffixes = ["ino"]
 line_comments = ["// ", "/// ", "//! "]
 decrease_indent_patterns = [
   { pattern = "^\\s*\\{.*\\}?\\s*$", valid_after = ["if", "for", "while", "do", "switch", "else"] },
@@ -15,5 +15,5 @@ brackets = [
     { start = "'", end = "'", close = true, newline = false, not_in = ["string", "comment"] },
     { start = "/*", end = " */", close = true, newline = false, not_in = ["string", "comment"] },
 ]
-debuggers = ["CodeLLDB", "GDB"]
+debuggers = []
 documentation_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }

--- a/crates/languages/src/arduino/embedding.scm
+++ b/crates/languages/src/arduino/embedding.scm
@@ -1,0 +1,61 @@
+(
+    (comment)* @context
+    .
+    (function_definition
+        (type_qualifier)? @name
+        type: (_)? @name
+        declarator: [
+            (function_declarator
+                declarator: (_) @name)
+            (pointer_declarator
+                "*" @name
+                declarator: (function_declarator
+                declarator: (_) @name))
+            (pointer_declarator
+                "*" @name
+                declarator: (pointer_declarator
+                    "*" @name
+                declarator: (function_declarator
+                    declarator: (_) @name)))
+            (reference_declarator
+                ["&" "&&"] @name
+                (function_declarator
+                declarator: (_) @name))
+        ]
+        (type_qualifier)? @name) @item
+    )
+
+(
+    (comment)* @context
+    .
+    (template_declaration
+        (class_specifier
+            "class" @name
+            name: (_) @name)
+            ) @item
+)
+
+(
+    (comment)* @context
+    .
+    (class_specifier
+        "class" @name
+        name: (_) @name) @item
+    )
+
+(
+    (comment)* @context
+    .
+    (enum_specifier
+        "enum" @name
+        name: (_) @name) @item
+    )
+
+(
+    (comment)* @context
+    .
+    (declaration
+        type: (struct_specifier
+        "struct" @name)
+        declarator: (_) @name) @item
+)

--- a/crates/languages/src/arduino/highlights.scm
+++ b/crates/languages/src/arduino/highlights.scm
@@ -1,0 +1,233 @@
+(identifier) @variable
+(field_identifier) @property
+(namespace_identifier) @namespace
+
+(concept_definition
+    (identifier) @concept)
+
+
+(call_expression
+  function: (qualified_identifier
+    name: (identifier) @function))
+
+(call_expression
+  (qualified_identifier
+    (identifier) @function.call))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (identifier) @function.call)))
+
+(call_expression
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call))))
+
+((qualified_identifier
+  (qualified_identifier
+    (qualified_identifier
+      (qualified_identifier
+        (identifier) @function.call)))) @_parent
+  (#has-ancestor? @_parent call_expression))
+
+(call_expression
+  function: (identifier) @function)
+
+(call_expression
+  function: (field_expression
+    field: (field_identifier) @function))
+
+(preproc_function_def
+  name: (identifier) @function.special)
+
+(template_function
+  name: (identifier) @function)
+
+(template_method
+  name: (field_identifier) @function)
+
+(function_declarator
+  declarator: (identifier) @function)
+
+(function_declarator
+  declarator: (qualified_identifier
+    name: (identifier) @function))
+
+(function_declarator
+  declarator: (field_identifier) @function)
+
+(operator_name
+  (identifier)? @operator) @function
+
+(destructor_name (identifier) @function)
+
+((namespace_identifier) @type
+ (#match? @type "^[A-Z]"))
+
+(auto) @type
+(type_identifier) @type
+type :(primitive_type) @type.primitive
+(sized_type_specifier) @type.primitive
+
+(requires_clause
+    constraint: (template_type
+        name: (type_identifier) @concept))
+
+(attribute
+    name: (identifier) @keyword)
+
+((identifier) @constant
+ (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+
+(statement_identifier) @label
+(this) @variable.special
+("static_assert") @function.builtin
+
+[
+  "alignas"
+  "alignof"
+  "break"
+  "case"
+  "catch"
+  "class"
+  "co_await"
+  "co_return"
+  "co_yield"
+  "concept"
+  "constexpr"
+  "continue"
+  "decltype"
+  "default"
+  "delete"
+  "do"
+  "else"
+  "enum"
+  "explicit"
+  "extern"
+  "final"
+  "for"
+  "friend"
+  "if"
+  "inline"
+  "namespace"
+  "new"
+  "noexcept"
+  "override"
+  "private"
+  "protected"
+  "public"
+  "requires"
+  "return"
+  "sizeof"
+  "struct"
+  "switch"
+  "template"
+  "throw"
+  "try"
+  "typedef"
+  "typename"
+  "union"
+  "using"
+  "virtual"
+  "while"
+  (storage_class_specifier)
+  (type_qualifier)
+] @keyword
+
+[
+  "#define"
+  "#elif"
+  "#else"
+  "#endif"
+  "#if"
+  "#ifdef"
+  "#ifndef"
+  "#include"
+  (preproc_directive)
+] @keyword
+
+(comment) @comment
+
+[
+  (true)
+  (false)
+] @boolean
+
+[
+  (null)
+  ("nullptr")
+] @constant.builtin
+
+(number_literal) @number
+
+[
+  (string_literal)
+  (system_lib_string)
+  (char_literal)
+  (raw_string_literal)
+] @string
+
+[
+  ","
+  ":"
+  "::"
+  ";"
+  (raw_string_delimiter)
+] @punctuation.delimiter
+
+[
+  "{"
+  "}"
+  "("
+  ")"
+  "["
+  "]"
+] @punctuation.bracket
+
+[
+  "."
+  ".*"
+  "->*"
+  "~"
+  "-"
+  "--"
+  "-="
+  "->"
+  "="
+  "!"
+  "!="
+  "|"
+  "|="
+  "||"
+  "^"
+  "^="
+  "&"
+  "&="
+  "&&"
+  "+"
+  "++"
+  "+="
+  "*"
+  "*="
+  "/"
+  "/="
+  "%"
+  "%="
+  "<<"
+  "<<="
+  ">>"
+  ">>="
+  "<"
+  "=="
+  ">"
+  "<="
+  ">="
+  "<=>"
+  "||"
+  "?"
+] @operator
+
+(conditional_expression ":" @operator)
+(user_defined_literal (literal_suffix) @operator)

--- a/crates/languages/src/arduino/indents.scm
+++ b/crates/languages/src/arduino/indents.scm
@@ -1,0 +1,19 @@
+[
+    (field_expression)
+    (assignment_expression)
+    (if_statement)
+    (for_statement)
+    (while_statement)
+    (do_statement)
+    (else_clause)
+] @indent
+
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent
+
+(if_statement) @start.if
+(for_statement) @start.for
+(while_statement) @start.while
+(do_statement) @start.do
+(switch_statement) @start.switch
+(else_clause) @start.else

--- a/crates/languages/src/arduino/injections.scm
+++ b/crates/languages/src/arduino/injections.scm
@@ -1,0 +1,11 @@
+(preproc_def
+    value: (preproc_arg) @injection.content
+    (#set! injection.language "c++"))
+
+(preproc_function_def
+    value: (preproc_arg) @injection.content
+    (#set! injection.language "c++"))
+
+(raw_string_literal
+  delimiter: (raw_string_delimiter) @injection.language
+  (raw_string_content) @injection.content)

--- a/crates/languages/src/arduino/outline.scm
+++ b/crates/languages/src/arduino/outline.scm
@@ -1,0 +1,155 @@
+(preproc_def
+    "#define" @context
+    name: (_) @name) @item
+
+(preproc_function_def
+    "#define" @context
+    name: (_) @name
+    parameters: (preproc_params
+        "(" @context
+        ")" @context)) @item
+
+(type_definition
+    "typedef" @context
+    declarator: (_) @name) @item
+
+(struct_specifier
+    "struct" @context
+    name: (_) @name) @item
+
+(class_specifier
+    "class" @context
+    name: (_) @name) @item
+
+(enum_specifier
+    "enum" @context
+    name: (_) @name) @item
+
+(enumerator
+    name: (_) @name) @item
+
+(concept_definition
+    "concept" @context
+    name: (_) @name) @item
+
+(declaration
+    (storage_class_specifier) @context
+    (type_qualifier)? @context
+    type: (_) @context
+    declarator: (init_declarator
+      declarator: (_) @name)) @item
+
+(function_definition
+    (type_qualifier)? @context
+    type: (_)? @context
+    declarator: [
+        (function_declarator
+            declarator: (_) @name
+            parameters: (parameter_list
+                "(" @context
+                ")" @context))
+        (pointer_declarator
+            "*" @context
+            declarator: (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+        (reference_declarator
+            ["&" "&&"] @context
+            (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+    ]
+    (type_qualifier)? @context) @item
+
+(declaration
+    (type_qualifier)? @context
+    type: (_)? @context
+    declarator: [
+        (field_identifier) @name
+        (pointer_declarator
+            "*" @context
+            declarator: (field_identifier) @name)
+        (function_declarator
+            declarator: (_) @name
+            parameters: (parameter_list
+                "(" @context
+                ")" @context))
+        (pointer_declarator
+            "*" @context
+            declarator: (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+        (reference_declarator
+            ["&" "&&"] @context
+            (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+    ]
+    (type_qualifier)? @context) @item
+
+(field_declaration
+    (type_qualifier)? @context
+    type: (_) @context
+    declarator: [
+        (field_identifier) @name
+        (pointer_declarator
+            "*" @context
+            declarator: (field_identifier) @name)
+        (function_declarator
+            declarator: (_) @name
+            parameters: (parameter_list
+                "(" @context
+                ")" @context))
+        (pointer_declarator
+            "*" @context
+            declarator: (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+        (pointer_declarator
+            "*" @context
+            declarator: (pointer_declarator
+                "*" @context
+                declarator: (function_declarator
+                    declarator: (_) @name
+                    parameters: (parameter_list
+                        "(" @context
+                        ")" @context))))
+        (reference_declarator
+            ["&" "&&"] @context
+            (function_declarator
+                declarator: (_) @name
+                parameters: (parameter_list
+                    "(" @context
+                    ")" @context)))
+    ]
+    (type_qualifier)? @context) @item
+
+(comment) @annotation

--- a/crates/languages/src/arduino/overrides.scm
+++ b/crates/languages/src/arduino/overrides.scm
@@ -1,0 +1,2 @@
+(comment) @comment.inclusive
+(string_literal) @string

--- a/crates/languages/src/arduino/textobjects.scm
+++ b/crates/languages/src/arduino/textobjects.scm
@@ -1,0 +1,31 @@
+(declaration
+    declarator: (function_declarator)) @function.around
+
+(function_definition
+    body: (_
+        "{"
+        (_)* @function.inside
+        "}" )) @function.around
+
+(preproc_function_def
+    value: (_) @function.inside) @function.around
+
+(comment) @comment.around
+
+(struct_specifier
+    body: (_
+        "{"
+        (_)* @class.inside
+        "}")) @class.around
+
+(enum_specifier
+    body: (_
+        "{"
+        [(_) ","?]* @class.inside
+        "}")) @class.around
+
+(class_specifier
+  body: (_
+      "{"
+      [(_) ":"? ";"?]* @class.inside
+      "}"?)) @class.around

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -108,6 +108,11 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
 
     let built_in_languages = [
         LanguageInfo {
+            name: "arduino",
+            adapters: vec![],
+            ..Default::default()
+        },
+        LanguageInfo {
             name: "bash",
             context: Some(Arc::new(bash::bash_task_context())),
             ..Default::default()


### PR DESCRIPTION
Fixes clangd AST compilation errors and "fe_expected_compiler_job" warnings when opening .ino files introduced by #35467.

Creates dedicated Arduino language using C++ grammar but separate from main C++ language to avoid LSP conflicts while maintaining syntax highlighting and code navigation.


Release Notes:

- Added syntax highlighting for .ino files 
