### PR TITLE
workspace: Add "Reveal in File Manager" to pane tab context menu

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -205,6 +205,8 @@ actions!(
         JoinAll,
         /// Reopens the most recently closed item.
         ReopenClosedItem,
+        /// Reveals the current file in the system file manager.
+        RevealInFileManager,
         /// Splits the pane to the left.
         SplitLeft,
         /// Splits the pane upward.
@@ -2750,7 +2752,7 @@ impl Pane {
                             let entry_id = entry.to_proto();
                             menu = menu
                                 .separator()
-                                .when_some(entry_abs_path, |menu, abs_path| {
+                                .when_some(entry_abs_path.clone(), |menu, abs_path| {
                                     menu.entry(
                                         "Copy Path",
                                         Some(Box::new(zed_actions::workspace::CopyPath)),
@@ -2786,6 +2788,18 @@ impl Pane {
                                                     ))
                                                 })
                                                 .ok();
+                                        }),
+                                    )
+                                })
+                                .when_some(entry_abs_path, |menu, abs_path| {
+                                    menu.entry(
+                                        #[cfg(target_os = "macos")]
+                                        "Reveal in Finder",
+                                        #[cfg(not(target_os = "macos"))]
+                                        "Reveal in File Manager",
+                                        Some(Box::new(RevealInFileManager)),
+                                        window.handler_for(&pane, move |_pane, _window, cx| {
+                                            cx.reveal_path(&abs_path);
                                         }),
                                     )
                                 })


### PR DESCRIPTION
Add "Reveal in Finder/File Manager" option to tab right-click menu, matching functionality available in project panel and editor.

Release Notes:

- N/A
