### PR TITLE
project: Setup python venv via activate script irrespective of TerminalKind

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9266,6 +9266,7 @@ dependencies = [
  "snippet_provider",
  "task",
  "tempfile",
+ "terminal",
  "text",
  "theme",
  "toml 0.8.20",

--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -333,7 +333,7 @@ impl NativeAgent {
                 Err(err) => (
                     None,
                     Some(RulesLoadingError {
-                        message: format!("{err}").into(),
+                        message: format!("{err:#}").into(),
                     }),
                 ),
             };

--- a/crates/channel/src/channel_store.rs
+++ b/crates/channel/src/channel_store.rs
@@ -557,7 +557,7 @@ impl ChannelStore {
         };
         cx.background_spawn(async move {
             task.await.map_err(|error| {
-                anyhow!("{error}").context(format!("failed to open channel {resource_name}"))
+                anyhow!(error).context(format!("failed to open channel {resource_name}"))
             })
         })
     }

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -686,7 +686,7 @@ impl Client {
                             }
                             ConnectionResult::Result(r) => {
                                 if let Err(error) = r {
-                                    log::error!("failed to connect: {error}");
+                                    log::error!("failed to connect: {error:?}");
                                 } else {
                                     break;
                                 }

--- a/crates/collab/src/db/queries/buffers.rs
+++ b/crates/collab/src/db/queries/buffers.rs
@@ -874,7 +874,7 @@ fn operation_from_storage(
     _format_version: i32,
 ) -> Result<proto::operation::Variant, Error> {
     let operation =
-        storage::Operation::decode(row.value.as_slice()).map_err(|error| anyhow!("{error}"))?;
+        storage::Operation::decode(row.value.as_slice()).map_err(|error| anyhow!(error))?;
     let version = version_from_storage(&operation.version);
     Ok(if operation.is_undo {
         proto::operation::Variant::Undo(proto::operation::Undo {

--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -1312,7 +1312,7 @@ pub async fn handle_metrics(Extension(server): Extension<Arc<Server>>) -> Result
     let metric_families = prometheus::gather();
     let encoded_metrics = encoder
         .encode_to_string(&metric_families)
-        .map_err(|err| anyhow!("{err}"))?;
+        .map_err(|err| anyhow!(err))?;
     Ok(encoded_metrics)
 }
 

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -72,6 +72,7 @@ smol.workspace = true
 snippet_provider.workspace = true
 task.workspace = true
 tempfile.workspace = true
+terminal.workspace = true
 toml.workspace = true
 tree-sitter = { workspace = true, optional = true }
 tree-sitter-bash = { workspace = true, optional = true }

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1008,7 +1008,6 @@ const BINARY_DIR: &str = if cfg!(target_os = "windows") {
     "bin"
 };
 
-// TODO lw: this depends on the shell?
 const ACTIVATE_PATH: &str = if cfg!(target_os = "windows") {
     "Scripts/activate.bat"
 } else {

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1008,6 +1008,7 @@ const BINARY_DIR: &str = if cfg!(target_os = "windows") {
     "bin"
 };
 
+// TODO lw: this depends on the shell?
 const ACTIVATE_PATH: &str = if cfg!(target_os = "windows") {
     "Scripts/activate.bat"
 } else {

--- a/crates/project/src/debugger/dap_store.rs
+++ b/crates/project/src/debugger/dap_store.rs
@@ -287,7 +287,6 @@ impl DapStore {
                             .map(|command| (command, &binary.arguments)),
                         binary.cwd.as_deref(),
                         binary.envs,
-                        None,
                         path_style,
                     );
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -432,9 +432,6 @@ impl TerminalBuilder {
             }
         };
 
-        // Setup Alacritty's env, which modifies the current process's environment
-        alacritty_terminal::tty::setup_env();
-
         let default_cursor_style = AlacCursorStyle::from(cursor_shape);
         let scrolling_history = if task.is_some() {
             // Tasks like `cargo build --all` may produce a lot of output, ergo allow maximum scrolling.

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -135,6 +135,27 @@ pub enum ActivateScript {
     Pyenv,
 }
 
+impl ActivateScript {
+    pub fn by_shell(shell: &str) -> Option<Self> {
+        Some(match shell {
+            "fish" => ActivateScript::Fish,
+            "tcsh" => ActivateScript::Csh,
+            "nu" => ActivateScript::Nushell,
+            "powershell" | "pwsh" => ActivateScript::PowerShell,
+            "sh" => ActivateScript::Default,
+            _ => return None,
+        })
+    }
+
+    pub fn by_env() -> Option<Self> {
+        let shell = std::env::var("SHELL").ok()?;
+        let shell = std::path::Path::new(&shell)
+            .file_name()
+            .and_then(|name| name.to_str())?;
+        Self::by_shell(shell)
+    }
+}
+
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
 pub struct TerminalSettingsContent {
     /// What shell to use when opening a terminal.

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -416,25 +416,22 @@ impl TerminalPanel {
         let database_id = workspace.database_id();
         let weak_workspace = self.workspace.clone();
         let project = workspace.project().clone();
-        let (working_directory, python_venv_directory) = self
+        let working_directory = self
             .active_pane
             .read(cx)
             .active_item()
             .and_then(|item| item.downcast::<TerminalView>())
             .map(|terminal_view| {
                 let terminal = terminal_view.read(cx).terminal().read(cx);
-                (
-                    terminal
-                        .working_directory()
-                        .or_else(|| default_working_directory(workspace, cx)),
-                    terminal.python_venv_directory.clone(),
-                )
+                terminal
+                    .working_directory()
+                    .or_else(|| default_working_directory(workspace, cx))
             })
-            .unwrap_or((None, None));
+            .unwrap_or(None);
         let kind = TerminalKind::Shell(working_directory);
         let terminal = project
             .update(cx, |project, cx| {
-                project.create_terminal_with_venv(kind, python_venv_directory, cx)
+                project.create_terminal_with_venv(kind, None, cx)
             })
             .ok()?;
 

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1668,11 +1668,7 @@ impl Item for TerminalView {
         let terminal = self
             .project
             .update(cx, |project, cx| {
-                let terminal = self.terminal().read(cx);
-                let working_directory = terminal
-                    .working_directory()
-                    .or_else(|| Some(project.active_project_directory(cx)?.to_path_buf()));
-                project.create_terminal_with_venv(TerminalKind::Shell(working_directory), None, cx)
+                project.clone_terminal(self.terminal(), cx)
             })
             .ok()?
             .log_err()?;

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1672,12 +1672,7 @@ impl Item for TerminalView {
                 let working_directory = terminal
                     .working_directory()
                     .or_else(|| Some(project.active_project_directory(cx)?.to_path_buf()));
-                let python_venv_directory = terminal.python_venv_directory.clone();
-                project.create_terminal_with_venv(
-                    TerminalKind::Shell(working_directory),
-                    python_venv_directory,
-                    cx,
-                )
+                project.create_terminal_with_venv(TerminalKind::Shell(working_directory), None, cx)
             })
             .ok()?
             .log_err()?;


### PR DESCRIPTION
We are trying to construct the vent environment for the shell / task manually in some setups which is brittle. We should always delegate that to just running the venv's  activate script.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
