### PR TITLE
Emit a `BreadcrumbsChanged` event when associated settings changed

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20209,6 +20209,7 @@ impl Editor {
         );
 
         let old_cursor_shape = self.cursor_shape;
+        let old_show_breadcrumbs = self.show_breadcrumbs;
 
         {
             let editor_settings = EditorSettings::get_global(cx);
@@ -20220,6 +20221,10 @@ impl Editor {
 
         if old_cursor_shape != self.cursor_shape {
             cx.emit(EditorEvent::CursorShapeChanged);
+        }
+
+        if old_show_breadcrumbs != self.show_breadcrumbs {
+            cx.emit(EditorEvent::BreadcrumbsChanged);
         }
 
         let project_settings = ProjectSettings::get_global(cx);
@@ -22843,6 +22848,7 @@ pub enum EditorEvent {
     },
     Reloaded,
     CursorShapeChanged,
+    BreadcrumbsChanged,
     PushedToNavHistory {
         anchor: Anchor,
         is_deactivate: bool,

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1036,6 +1036,10 @@ impl Item for Editor {
                 f(ItemEvent::UpdateBreadcrumbs);
             }
 
+            EditorEvent::BreadcrumbsChanged => {
+                f(ItemEvent::UpdateBreadcrumbs);
+            }
+
             EditorEvent::DirtyChanged => {
                 f(ItemEvent::UpdateTab);
             }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/36149

Release Notes:

- Fixed a bug where changing the `toolbar.breadcrumbs` setting didn't immediately update the UI when saving the `settings.json` file.
