### PR TITLE
Add SearchHistory to command palette

### DIFF
--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -23,6 +23,7 @@ gpui.workspace = true
 log.workspace = true
 picker.workspace = true
 postage.workspace = true
+project.workspace = true
 serde.workspace = true
 settings.workspace = true
 theme.workspace = true

--- a/crates/command_palette/src/command_palette.rs
+++ b/crates/command_palette/src/command_palette.rs
@@ -402,7 +402,6 @@ impl PickerDelegate for CommandPaletteDelegate {
         _window: &mut Window,
         cx: &mut Context<Picker<Self>>,
     ) -> Option<String> {
-        dbg!(self.selected_ix);
         if self.selected_ix != 0 {
             return None;
         }

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -144,6 +144,16 @@ pub trait PickerDelegate: Sized + 'static {
         false
     }
 
+    // Allow intercepting up and down for history navigation in the command palette.
+    fn handle_history(
+        &mut self,
+        _direction: Direction,
+        _window: &mut Window,
+        _cx: &mut Context<Picker<Self>>,
+    ) -> Option<String> {
+        None
+    }
+
     /// Override if you want to have <enter> update the query instead of confirming.
     fn confirm_update_query(
         &mut self,
@@ -436,6 +446,10 @@ impl<D: PickerDelegate> Picker<D> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if let Some(query) = self.delegate.handle_history(Direction::Down, window, cx) {
+            self.set_query(query, window, cx);
+            return;
+        }
         let count = self.delegate.match_count();
         if count > 0 {
             let index = self.delegate.selected_index();
@@ -455,6 +469,10 @@ impl<D: PickerDelegate> Picker<D> {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        if let Some(query) = self.delegate.handle_history(Direction::Down, window, cx) {
+            self.set_query(query, window, cx);
+            return;
+        }
         let count = self.delegate.match_count();
         if count > 0 {
             let index = self.delegate.selected_index();

--- a/crates/vim/test_data/test_command_history.json
+++ b/crates/vim/test_data/test_command_history.json
@@ -1,0 +1,18 @@
+{"Put":{"state":"The quick\nbrown fox\nˇjumps over\nthe lazy dog\n"}}
+{"Key":":"}
+{"Key":"s"}
+{"Key":"/"}
+{"Key":"o"}
+{"Key":"/"}
+{"Key":"a"}
+{"Key":"enter"}
+{"Get":{"state":"The quick\nbrown fox\nˇjumps aver\nthe lazy dog\n","mode":"Normal"}}
+{"Key":"u"}
+{"Key":"^"}
+{"Get":{"state":"The quick\nbrown fox\nˇjumps over\nthe lazy dog\n","mode":"Normal"}}
+{"Key":":"}
+{"Key":"up"}
+{"Key":"backspace"}
+{"Key":"e"}
+{"Key":"enter"}
+{"Get":{"state":"The quick\nbrown fox\nˇjumps ever\nthe lazy dog\n","mode":"Normal"}}


### PR DESCRIPTION
This makes vim mode significantly nicer to use

In future work we want to add prefix filtering on the history, and load the
previous items from the command palette history.

Release Notes:

- `up` in the command palette now lets you access previously typed queries (as in search). This makes it significantly nicer to do complex vim actions bceause if you make a mistake, you can go back and edit it
