### PR TITLE
OpenAI Responses API + reasoning effort/summary + thinking streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9213,6 +9213,7 @@ dependencies = [
 name = "language_models"
 version = "0.1.0"
 dependencies = [
+ "agent_settings",
  "ai_onboarding",
  "anthropic",
  "anyhow",

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -105,6 +105,15 @@ impl AgentSettings {
             model,
         });
     }
+
+    pub fn reasoning_for_model(model: &Arc<dyn LanguageModel>, cx: &App) -> Option<ReasoningParameters> {
+        let settings = Self::get_global(cx);
+        settings
+            .model_parameters
+            .iter()
+            .rfind(|params| params.matches(model))
+            .and_then(|params| params.reasoning.clone())
+    }
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
@@ -112,6 +121,42 @@ pub struct LanguageModelParameters {
     pub provider: Option<LanguageModelProviderSetting>,
     pub model: Option<SharedString>,
     pub temperature: Option<f32>,
+    /// Optional reasoning parameters (effort/summary) to use for this model.
+    pub reasoning: Option<ReasoningParameters>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+pub struct ReasoningParameters {
+    #[serde(default)]
+    pub effort: Option<ReasoningEffortSetting>,
+    #[serde(default)]
+    pub summary: Option<ReasoningSummarySetting>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffortSetting {
+    #[serde(alias = "Minimal")]
+    Minimal,
+    #[serde(alias = "Low")]
+    Low,
+    #[serde(alias = "Medium")]
+    Medium,
+    #[serde(alias = "High")]
+    High,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningSummarySetting {
+    #[serde(alias = "Auto")]
+    Auto,
+    #[serde(alias = "Concise")]
+    Concise,
+    #[serde(alias = "Detailed")]
+    Detailed,
+    #[serde(alias = "none", alias = "None")]
+    None,
 }
 
 impl LanguageModelParameters {

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -1,4 +1,4 @@
-[package]
+л ра[package]
 name = "language_models"
 version = "0.1.0"
 edition.workspace = true
@@ -49,6 +49,7 @@ schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 settings.workspace = true
+agent_settings.workspace = true
 smol.workspace = true
 strum.workspace = true
 theme.workspace = true

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -1,4 +1,4 @@
-л ра[package]
+[package]
 name = "language_models"
 version = "0.1.0"
 edition.workspace = true

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -21,43 +21,43 @@ pub struct ResponsesRequest {
     /// Model id, e.g. "gpt-5"
     pub model: String,
 
-    /// Free-form input. Can be a string or structured array per Responses API.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub input: Option<Value>,
 
-    /// High-level instructions for the generation.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub instructions: Option<String>,
 
-    /// Reasoning options for reasoning-capable models.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ResponsesReasoning>,
 
-    /// Structured prompt reference (id/version/variables). Left as raw JSON for flexibility.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub prompt: Option<Value>,
 
-    /// Tools configuration. Kept as raw JSON to allow all tool types.
+
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub tools: Vec<Value>,
 
-    /// Tool choice. Kept as raw JSON to allow all supported shapes.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<Value>,
 
-    /// Optional output token limit for the response.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_output_tokens: Option<u64>,
 
-    /// Temperature for sampling.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
 
-    /// Whether to enable parallel function calls when using tools.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub parallel_tool_calls: Option<bool>,
 
-    /// Enable streaming SSE responses.
+
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub stream: Option<bool>,
 }
@@ -71,8 +71,7 @@ pub struct ResponsesStreamingEvent {
     pub payload: Value,
 }
 
-/// Streaming Responses API call: POST {api_url}/responses with stream = true.
-/// Parses SSE "data: ..." lines and emits typed events carrying their "type" field.
+
 pub async fn responses_stream(
     client: &dyn HttpClient,
     api_url: &str,


### PR DESCRIPTION
Summary
- Add a client for OpenAI Responses API with streaming.
- Introduce reasoning controls: effort and summary (exposed via settings and sent to the provider).
- Stream “thinking” (reasoning summary) to the thread UI with safe redaction options.
- Keep Chat Completions as a fallback path when appropriate.

Release Notes:
Responses is the recommended path for reasoning-capable models and provides explicit fields for reasoning and max_output_tokens.
- Exposing effort/summary lets users control reasoning quality/verbosity.
- Streaming the reasoning summary makes the model’s progress observable in real time.
Key changes

OpenAI client and types
- File: zed/crates/open_ai/src/open_ai.rs
  - New types: `ResponsesReasoning`, `ResponsesRequest`, `ResponsesStreamingEvent`.
  - New function: `responses_stream(...)` – SSE streaming client for Responses API.
  - Extend `Model` with new variants and helpers: `max_output_tokens()`, `reasoning_effort()`, `supports_parallel_tool_calls()`.
  - Chat Completions path (`stream_completion(...)`) remains; both paths co-exist.

Provider: OpenAI Responses integration
- File: zed/crates/language_models/src/provider/open_ai.rs
  - Route requests to Responses or Chat depending on model and settings.
  - Build Responses “input” from the full message history:
    - system → developer items (input_text/input_image)
    - user → user items (input_text/input_image)
    - assistant → visible text plus top-level function_call and function_call_output items
  - Normalize top‑level tool item IDs to keep streams consistent:
    - function_call → fc_<call_id suffix> or fc_auto_<n>
    - function_call_output → fco_<call_id suffix> or fco_auto_<n>
    - This ensures stable correlation of streamed chunks and final items (uses an incrementing index counter when needed).
  - Map tools to Responses function tools (JSON Schema subset, strict=true).
  - Tool choice mapping: auto/required/none.
  - Reasoning mapping:
    - Read `effort`/`summary` from settings for provider=model; fall back to model defaults when available.
    - Default summary to “auto” when unset.
  - Events mapping:
    - Text: response.output_text.delta
    - Thinking: response.reasoning_summary_text.delta/.done
    - Function calls: output_item events + function_call_arguments delta/done (emit interim ToolUse when JSON parses; finalize on done).
    - Usage: response.completed → token usage update (includes cached input tokens if available).
    - Stop reasons: EndTurn vs ToolUse depending on whether a function_call completed.
  - For Chat Completions:
    - `into_open_ai(...)` builds the classic request.
    - `parallel_tool_calls` is intentionally disabled when tools are present (agent expects at most one call per turn).

Agent: thread model and events
- File: zed/crates/agent/src/thread.rs
  - New message segments: `MessageSegment::Thinking { text, signature }`, `MessageSegment::RedactedThinking`.
  - New event: `ThreadEvent::StreamedAssistantThinking` to surface reasoning summary in real time.
  - Token accounting: update and report usage; detect stale streams (no chunks for a while).
  - Tooling: streaming tool calls, validation, completion events, and limits maintained.

Agent settings
- File: zed/crates/agent_settings/src/agent_settings.rs
  - Add `ReasoningParameters { effort, summary }`.
  - Add enums `ReasoningEffortSetting` and `ReasoningSummarySetting`.
  - Extend `LanguageModelParameters` to include `reasoning` alongside `temperature`.
  - Helpers to read per-model parameters.

Compatibility
- No breaking changes expected.
- Models without Responses/reasoning stay on Chat Completions with unchanged UX.
- Reasoning settings are optional and only used for supported models.

How to test
- Configure an OpenAI API key and pick a reasoning-capable model.
- In settings, set Reasoning Effort (Minimal/Low/Medium/High) and Summary (Auto/Concise/Detailed/None).
- Start a thread that triggers tool use:
  - Expect thinking chunks in real time.
  - Expect tool calls and finalization events to line up (IDs normalized).
  - Verify usage updates and no-stall behavior.
- Repeat with a non-reasoning model to confirm fallback to Chat and no regressions.
