### PR TITLE
Bump `async-trait`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1304,9 +1304,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.88"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",


### PR DESCRIPTION
The latest release has span changes in it which prevents rust-analyzer from constantly showing `Box` and `Box::pin` on hover as well as those items polluting the go to definition feature on every identifier.

See https://github.com/dtolnay/async-trait/pull/293

Release Notes:

- N/A
