### PR TITLE
Fix macOS arch reporting from `arch_ios` to `arch_arm`

### DIFF
--- a/crates/zed/resources/info/SupportedPlatforms.plist
+++ b/crates/zed/resources/info/SupportedPlatforms.plist
@@ -1,0 +1,4 @@
+<key>CFBundleSupportedPlatforms</key>
+<array>
+    <string>MacOSX</string>
+</array>


### PR DESCRIPTION
```xml 
<key>arch_kind</key> 
<string>arch_arm</string> 
```

Closes #36037

Release Notes:

- N/A