### PR TITLE
Fix inlay hints using status theming instead of syntax theming

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -581,11 +581,22 @@ pub fn make_inlay_hints_style(cx: &mut App) -> HighlightStyle {
         .inlay_hints
         .show_background;
 
-    HighlightStyle {
-        color: Some(cx.theme().status().hint),
-        background_color: show_background.then(|| cx.theme().status().hint_background),
-        ..HighlightStyle::default()
+    let mut style = cx.theme().syntax().get("hint");
+
+    if style.color.is_none() {
+        style.color = Some(cx.theme().status().hint);
     }
+
+    if !show_background {
+        style.background_color = None;
+        return style;
+    }
+
+    if style.background_color.is_none() {
+        style.background_color = Some(cx.theme().status().hint_background);
+    }
+
+    style
 }
 
 pub fn make_suggestion_styles(cx: &mut App) -> EditPredictionStyles {


### PR DESCRIPTION
Release Notes:

- Fixed editor inlay hints incorrectly using status theming when syntax theming is available

Previously, a theme's `style.syntax.hint` object is completely ignored, and `style.hint` `style.hint.background` are used instead. However, these seem to be related to status hints, such as the inline git blame integration.

For syntax hints (as given by an LSP), the reasonable assumption would be that the `style.syntax.hint` object is used instead, but it isn't. This means that defining other style characteristics (`font_style`, for example) does nothing.

I've fixed the issue in a backward-compatible way, by using the theme `syntax` `HighlightStyle` as the base for inlay hint styling, and falling back to the original `status` colors should the syntax object not contain the color definitions.

 With the following theme settings:
```jsonc
{
  "hint": "#ff00ff",                    // Status hints (git blame, etc.)
  "hint.background": "#ff00ff10",
  "syntax": {
    "hint": {
      "color": "#ffffff",               // LSP inlay hints
      "background_color": "#ffffff10",
      "font_style": "italic",           // Now properly applied
      "font_weight": 700
    }
  }
}
```


Current behavior:
<img width="896" height="201" alt="image" src="https://github.com/user-attachments/assets/e89d212f-ed7e-4d27-94e4-96d716e229d2" />

Italics and font weight are ignored. Uses status colors instead.

Fixed behavior:
<img width="896" height="202" alt="image" src="https://github.com/user-attachments/assets/f14ed2c3-bb60-4b74-886d-6b409d338714" />

Italics and font weight are used properly. Status color is preserved for the git blame status, but correct syntax colors are used for the inlay hints.
