### PR TITLE
Add a NewEmptyWindow action for those who don't prefer an empty tab in new windows

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -210,6 +210,8 @@ actions!(
         NewTerminal,
         /// Opens a new window.
         NewWindow,
+        /// Opens a new window but doesn't open a new file.
+        NewEmptyWindow,
         /// Opens a file or directory.
         Open,
         /// Opens multiple files.

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -71,7 +71,7 @@ use uuid::Uuid;
 use vim_mode_setting::VimModeSetting;
 use workspace::notifications::{NotificationId, dismiss_app_notification, show_app_notification};
 use workspace::{
-    AppState, NewFile, NewWindow, OpenLog, Toast, Workspace, WorkspaceSettings,
+    AppState, NewFile, NewWindow, NewEmptyWindow, OpenLog, Toast, Workspace, WorkspaceSettings,
     create_and_open_local_file, notifications::simple_message_notification::MessageNotification,
     open_new,
 };
@@ -876,6 +876,22 @@ fn register_actions(
                         |workspace, window, cx| {
                             cx.activate(true);
                             Editor::new_file(workspace, &Default::default(), window, cx)
+                        },
+                    )
+                    .detach();
+                }
+            }
+        })
+        .register_action({
+            let app_state = Arc::downgrade(&app_state);
+            move |_, _: &NewEmptyWindow, _, cx| {
+                if let Some(app_state) = app_state.upgrade() {
+                    open_new(
+                        Default::default(),
+                        app_state,
+                        cx,
+                        |_, _, cx| {
+                            cx.activate(true)
                         },
                     )
                     .detach();


### PR DESCRIPTION
### Release Notes:

- Adds a fairly straightforward new action.

### Context:

I use this alongside the following two keybinds:

```
			"cmd-n": "workspace::NewEmptyWindow",
			"cmd-t": "workspace::NewFile",
```

The result has some nice properties:
1. One `cmd-w` reverses one `cmd-n`.
2. `cmd-n` followed by `cmd-o` doesn't leave an extra empty buffer sitting around.
3. `cmd-n`, `cmd-t`, and `cmd-w` match my web-browser muscle memory fairly closely.
4. It sidesteps the flicker bug in #23742.
