### PR TITLE
linux: Fix keyboard events not working on first start in X11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20277,7 +20277,6 @@ dependencies = [
 [[package]]
 name = "xim"
 version = "0.4.0"
-source = "git+https://github.com/XDeme1/xim-rs?rev=d50d461764c2213655cd9cf65a0ea94c70d3c4fd#d50d461764c2213655cd9cf65a0ea94c70d3c4fd"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.14.5",
@@ -20290,7 +20289,6 @@ dependencies = [
 [[package]]
 name = "xim-ctext"
 version = "0.3.0"
-source = "git+https://github.com/XDeme1/xim-rs?rev=d50d461764c2213655cd9cf65a0ea94c70d3c4fd#d50d461764c2213655cd9cf65a0ea94c70d3c4fd"
 dependencies = [
  "encoding_rs",
 ]
@@ -20298,7 +20296,6 @@ dependencies = [
 [[package]]
 name = "xim-parser"
 version = "0.2.1"
-source = "git+https://github.com/XDeme1/xim-rs?rev=d50d461764c2213655cd9cf65a0ea94c70d3c4fd#d50d461764c2213655cd9cf65a0ea94c70d3c4fd"
 dependencies = [
  "bitflags 2.9.0",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20277,6 +20277,7 @@ dependencies = [
 [[package]]
 name = "xim"
 version = "0.4.0"
+source = "git+https://github.com/zed-industries/xim-rs?rev=c0a70c1bd2ce197364216e5e818a2cb3adb99a8d#c0a70c1bd2ce197364216e5e818a2cb3adb99a8d"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.14.5",
@@ -20289,6 +20290,7 @@ dependencies = [
 [[package]]
 name = "xim-ctext"
 version = "0.3.0"
+source = "git+https://github.com/zed-industries/xim-rs?rev=c0a70c1bd2ce197364216e5e818a2cb3adb99a8d#c0a70c1bd2ce197364216e5e818a2cb3adb99a8d"
 dependencies = [
  "encoding_rs",
 ]
@@ -20296,6 +20298,7 @@ dependencies = [
 [[package]]
 name = "xim-parser"
 version = "0.2.1"
+source = "git+https://github.com/zed-industries/xim-rs?rev=c0a70c1bd2ce197364216e5e818a2cb3adb99a8d#c0a70c1bd2ce197364216e5e818a2cb3adb99a8d"
 dependencies = [
  "bitflags 2.9.0",
 ]

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -209,7 +209,7 @@ xkbcommon = { version = "0.8.0", features = [
     "wayland",
     "x11",
 ], optional = true }
-xim = { git = "https://github.com/XDeme1/xim-rs", rev = "d50d461764c2213655cd9cf65a0ea94c70d3c4fd", features = [
+xim = { path = "/home/smit/xim-rs", features = [
     "x11rb-xcb",
     "x11rb-client",
 ], optional = true }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -209,7 +209,7 @@ xkbcommon = { version = "0.8.0", features = [
     "wayland",
     "x11",
 ], optional = true }
-xim = { path = "/home/smit/xim-rs", features = [
+xim = { git = "https://github.com/zed-industries/xim-rs", rev = "c0a70c1bd2ce197364216e5e818a2cb3adb99a8d" , features = [
     "x11rb-xcb",
     "x11rb-client",
 ], optional = true }


### PR DESCRIPTION
Closes #29083

On X11, `ibus-x11` crashes on some distros after Zed interacts with it. This is not unique to Zed, `xim-rs` shows the same behavior, and there are similar upstream `ibus` reports with apps like Blender:

- https://github.com/ibus/ibus/issues/2697

I opened an upstream issue to track this:

- https://github.com/ibus/ibus/issues/2789

When this crash happens, we don’t get a disconnect event, so Zed keeps sending events to the IM server and waits for a response. It works on subsequent starts because IM server doesn't exist now and we default to non-XIM path.

This PR detects the crash via X11 events and falls back to the non-XIM path so typing keeps working. We still need to investigate whether the root cause is in `xim-rs` or `ibus-x11`.

Release Notes:

- Fixed an issue on X11 where keyboard input sometimes didn’t work on first start. 
