### PR TITLE
agent: Create checkpoint before/after every edit operation

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -844,11 +844,17 @@ impl Thread {
                     .await
                     .unwrap_or(false);
 
-                if !equal {
-                    this.update(cx, |this, cx| {
-                        this.insert_checkpoint(pending_checkpoint, cx)
-                    })?;
-                }
+                this.update(cx, |this, cx| {
+                    this.pending_checkpoint = if equal {
+                        Some(pending_checkpoint)
+                    } else {
+                        this.insert_checkpoint(pending_checkpoint, cx);
+                        Some(ThreadCheckpoint {
+                            message_id: this.next_message_id,
+                            git_checkpoint: final_checkpoint,
+                        })
+                    }
+                })?;
 
                 Ok(())
             }


### PR DESCRIPTION
1. Previously, checkpoints only appeared when an agent's edit happened immediately after a user message. This is rare (agent usually collects some context first), so they were almost never shown. This is now fixed.

2. After this change, a checkpoint is created after every edit operation. So when the agent edits files five times in a single dialog turn, we will now display five checkpoints.

   As a bonus, it's now possible to undo only a part of a long agent response.

Closes #36092, #32917

Release Notes:

- Create agent checkpoints more frequently (before every edit)