### PR TITLE
collab: Increase minimum required version to connect

### DIFF
--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -30,7 +30,19 @@ impl fmt::Display for ZedVersion {
 
 impl ZedVersion {
     pub fn can_collaborate(&self) -> bool {
-        self.0 >= SemanticVersion::new(0, 157, 0)
+        // v0.198.4 is the first version where we no longer connect to Collab automatically.
+        // We reject any clients older than that to prevent them from connecting to Collab just for authentication.
+        if self.0 < SemanticVersion::new(0, 198, 4) {
+            return false;
+        }
+
+        // Since we hotfixed the changes to no longer connect to Collab automatically to Preview, we also need to reject
+        // versions in the range [v0.199.0, v0.199.2].
+        if self.0 >= SemanticVersion::new(0, 199, 0) && self.0 < SemanticVersion::new(0, 199, 2) {
+            return false;
+        }
+
+        true
     }
 }
 

--- a/crates/collab/src/rpc/connection_pool.rs
+++ b/crates/collab/src/rpc/connection_pool.rs
@@ -37,7 +37,7 @@ impl ZedVersion {
         }
 
         // Since we hotfixed the changes to no longer connect to Collab automatically to Preview, we also need to reject
-        // versions in the range [v0.199.0, v0.199.2].
+        // versions in the range [v0.199.0, v0.199.1].
         if self.0 >= SemanticVersion::new(0, 199, 0) && self.0 < SemanticVersion::new(0, 199, 2) {
             return false;
         }


### PR DESCRIPTION
This PR increases the minimum required version to connect to Collab.

Previously this was set at v0.157.0.

The new minimum required version is v0.198.4, which is the first version where we no longer connect to Collab automatically.

Clients on the v0.199.x minor version will also need to be v0.199.2 or greater in order to connect, due to us hotfixing the connection changes to the Preview branch.

We're doing this to force clients to upgrade in order to connect to Collab, as we're going to be removing some of the old RPC usages related to authentication that are no longer used. Therefore, we want users to be on a version of Zed that does not rely on those messages.

Users will see a message similar to this one, prompting them to upgrade:

<img width="1209" height="875" alt="Screenshot 2025-08-15 at 11 37 55 AM" src="https://github.com/user-attachments/assets/59ffff3e-8f82-4152-84a8-776c691eaaee" />

> Note: In this case I'm simulating the error state, which is why I'm signed in via Cloud while still not being able to connect to Collab. Users on older versions will see the "Please update Zed to Collaborate" message without being signed in.

Release Notes:

- N/A
