### PR TITLE
Link to `globs` documentation from `file_types` documentation [see description about CLA]

### DIFF
--- a/docs/src/configuring-languages.md
+++ b/docs/src/configuring-languages.md
@@ -81,7 +81,7 @@ This configuration tells Zed to:
 - Recognize files named "MyLockFile" as TOML
 - Apply Dockerfile syntax to any file starting with "Dockerfile"
 
-You can use glob patterns for more flexible matching, allowing you to handle complex naming conventions in your projects.
+You can use [glob patterns](./globs.md) for more flexible matching, allowing you to handle complex naming conventions in your projects.
 
 ## Working with Language Servers
 


### PR DESCRIPTION
As stated in https://github.com/zed-industries/zed/pull/18789, the globs documentation is not currently linked to because the author didn't know where to put it. This PR links to it from the `file_types` config documentation (which might be the only place where it's actually relevant at this time, I'm not sure).

I do not want to sign the CLA, but here is my statement (adapted from a portion of the CLA) that I agree to for this extremely trivial change only:

> I (Harper Andrews) hereby grant to Zed Industries, Inc., and to recipients of software distributed by Zed Industries, Inc. related hereto, a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare derivative works of, publicly display, publicly perform, sublicense, and distribute, **all changes I submitted as a part of https://github.com/zed-industries/zed/pull/36258** and such derivative works.

This change is so trivial that I don't think you actually need my permission to make a new PR containing the change yourself, but I wanted to do my best to keep legal concerns at bay. It is 100% fine if my name is not on the final commit message of this particular change.

Release Notes:

- N/A
