### PR TITLE
proto: Order `reserved` fields

### DIFF
--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -417,10 +417,10 @@ message Envelope {
     reserved 230 to 231;
     reserved 235 to 236;
     reserved 246;
-    reserved 259;
-    reserved 270;
     reserved 247 to 254;
     reserved 255 to 256;
+    reserved 259;
+    reserved 270;
     reserved 280 to 281;
     reserved 332 to 333;
 }


### PR DESCRIPTION
This PR orders the `reserved` fields in the RPC `Envelope`, as they had gotten unsorted.

Release Notes:

- N/A
