### PR TITLE
Separate minidump crashes from panics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,6 +4069,8 @@ dependencies = [
  "minidumper",
  "paths",
  "release_channel",
+ "serde",
+ "serde_json",
  "smol",
  "workspace-hack",
 ]

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -12,6 +12,8 @@ minidumper.workspace = true
 paths.workspace = true
 release_channel.workspace = true
 smol.workspace = true
+serde.workspace = true
+serde_json.workspace = true
 workspace-hack.workspace = true
 
 [lints]

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -114,7 +114,7 @@ pub struct InitCrashHandler {
     pub zed_version: String,
     pub release_channel: String,
     pub commit_sha: String,
-    pub gpu: String,
+    // pub gpu: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -2,15 +2,17 @@ use crash_handler::CrashHandler;
 use log::info;
 use minidumper::{Client, LoopAction, MinidumpBinary};
 use release_channel::{RELEASE_CHANNEL, ReleaseChannel};
+use serde::{Deserialize, Serialize};
 
 use std::{
     env,
-    fs::File,
+    fs::{self, File},
     io,
+    panic::Location,
     path::{Path, PathBuf},
     process::{self, Command},
     sync::{
-        LazyLock, OnceLock,
+        Arc, OnceLock,
         atomic::{AtomicBool, Ordering},
     },
     thread,
@@ -18,19 +20,16 @@ use std::{
 };
 
 // set once the crash handler has initialized and the client has connected to it
-pub static CRASH_HANDLER: AtomicBool = AtomicBool::new(false);
+pub static CRASH_HANDLER: OnceLock<Arc<Client>> = OnceLock::new();
 // set when the first minidump request is made to avoid generating duplicate crash reports
 pub static REQUESTED_MINIDUMP: AtomicBool = AtomicBool::new(false);
 const CRASH_HANDLER_TIMEOUT: Duration = Duration::from_secs(60);
 
-pub static GENERATE_MINIDUMPS: LazyLock<bool> = LazyLock::new(|| {
-    *RELEASE_CHANNEL != ReleaseChannel::Dev || env::var("ZED_GENERATE_MINIDUMPS").is_ok()
-});
-
-pub async fn init(id: String) {
-    if !*GENERATE_MINIDUMPS {
+pub async fn init(crash_init: InitCrashHandler) {
+    if *RELEASE_CHANNEL == ReleaseChannel::Dev && env::var("ZED_GENERATE_MINIDUMPS").is_err() {
         return;
     }
+
     let exe = env::current_exe().expect("unable to find ourselves");
     let zed_pid = process::id();
     // TODO: we should be able to get away with using 1 crash-handler process per machine,
@@ -61,9 +60,11 @@ pub async fn init(id: String) {
         smol::Timer::after(retry_frequency).await;
     }
     let client = maybe_client.unwrap();
-    client.send_message(1, id).unwrap(); // set session id on the server
+    client
+        .send_message(1, serde_json::to_vec(&crash_init).unwrap())
+        .unwrap();
 
-    let client = std::sync::Arc::new(client);
+    let client = Arc::new(client);
     let handler = crash_handler::CrashHandler::attach(unsafe {
         let client = client.clone();
         crash_handler::make_crash_event(move |crash_context: &crash_handler::CrashContext| {
@@ -72,7 +73,6 @@ pub async fn init(id: String) {
                 .compare_exchange(false, true, Ordering::Acquire, Ordering::Relaxed)
                 .is_ok()
             {
-                client.send_message(2, "mistakes were made").unwrap();
                 client.ping().unwrap();
                 client.request_dump(crash_context).is_ok()
             } else {
@@ -87,7 +87,7 @@ pub async fn init(id: String) {
     {
         handler.set_ptracer(Some(server_pid));
     }
-    CRASH_HANDLER.store(true, Ordering::Release);
+    CRASH_HANDLER.set(client.clone()).ok();
     std::mem::forget(handler);
     info!("crash handler registered");
 
@@ -98,14 +98,41 @@ pub async fn init(id: String) {
 }
 
 pub struct CrashServer {
-    session_id: OnceLock<String>,
+    initialization_params: OnceLock<InitCrashHandler>,
+    panic_info: OnceLock<CrashPanic>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct CrashInfo {
+    pub init: InitCrashHandler,
+    pub panic: Option<CrashPanic>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct InitCrashHandler {
+    pub session_id: String,
+    pub zed_version: String,
+    pub release_channel: String,
+    pub commit_sha: String,
+}
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct CrashPanic {
+    message: String,
+    span: String,
 }
 
 impl minidumper::ServerHandler for CrashServer {
     fn create_minidump_file(&self) -> Result<(File, PathBuf), io::Error> {
         let err_message = "Need to send a message with the ID upon starting the crash handler";
         let dump_path = paths::logs_dir()
-            .join(self.session_id.get().expect(err_message))
+            .join(
+                &self
+                    .initialization_params
+                    .get()
+                    .expect(err_message)
+                    .session_id,
+            )
             .with_extension("dmp");
         let file = File::create(&dump_path)?;
         Ok((file, dump_path))
@@ -122,16 +149,44 @@ impl minidumper::ServerHandler for CrashServer {
                 info!("failed to write minidump: {:#}", e);
             }
         }
+
+        let crash_info = CrashInfo {
+            init: self
+                .initialization_params
+                .get()
+                .expect("not initialized")
+                .clone(),
+            panic: self.panic_info.get().cloned(),
+        };
+
+        let crash_data_path = paths::logs_dir()
+            .join(&crash_info.init.session_id)
+            .with_extension("json");
+
+        fs::write(crash_data_path, serde_json::to_vec(&crash_info).unwrap()).ok();
+
         LoopAction::Exit
     }
 
     fn on_message(&self, kind: u32, buffer: Vec<u8>) {
-        let message = String::from_utf8(buffer).expect("invalid utf-8");
-        info!("kind: {kind}, message: {message}",);
-        if kind == 1 {
-            self.session_id
-                .set(message)
-                .expect("session id already initialized");
+        match kind {
+            1 => {
+                let init_data =
+                    serde_json::from_slice::<InitCrashHandler>(&buffer).expect("invalid init data");
+                self.initialization_params
+                    .set(init_data)
+                    .expect("already initialized");
+            }
+            2 => {
+                let panic_data =
+                    serde_json::from_slice::<CrashPanic>(&buffer).expect("invalid panic data");
+                self.panic_info
+                    .set(panic_data)
+                    .expect("already initialized");
+            }
+            _ => {
+                panic!("invalid message kind");
+            }
         }
     }
 
@@ -145,15 +200,22 @@ impl minidumper::ServerHandler for CrashServer {
     }
 }
 
-pub fn handle_panic() {
-    if !*GENERATE_MINIDUMPS {
-        return;
-    }
+pub fn handle_panic(message: String, span: Option<&Location>) {
+    let span = span
+        .map(|loc| format!("{}:{}", loc.file(), loc.line()))
+        .unwrap_or_default();
+
     // wait 500ms for the crash handler process to start up
     // if it's still not there just write panic info and no minidump
     let retry_frequency = Duration::from_millis(100);
     for _ in 0..5 {
-        if CRASH_HANDLER.load(Ordering::Acquire) {
+        if let Some(client) = CRASH_HANDLER.get() {
+            client
+                .send_message(
+                    2,
+                    serde_json::to_vec(&CrashPanic { message, span }).unwrap(),
+                )
+                .ok();
             log::error!("triggering a crash to generate a minidump...");
             #[cfg(target_os = "linux")]
             CrashHandler.simulate_signal(crash_handler::Signal::Trap as u32);
@@ -174,7 +236,8 @@ pub fn crash_server(socket: &Path) {
     server
         .run(
             Box::new(CrashServer {
-                session_id: OnceLock::new(),
+                initialization_params: OnceLock::new(),
+                panic_info: OnceLock::new(),
             }),
             &ab,
             Some(CRASH_HANDLER_TIMEOUT),

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -114,12 +114,13 @@ pub struct InitCrashHandler {
     pub zed_version: String,
     pub release_channel: String,
     pub commit_sha: String,
+    pub gpu: String,
 }
 
 #[derive(Deserialize, Serialize, Debug, Clone)]
 pub struct CrashPanic {
-    message: String,
-    span: String,
+    pub message: String,
+    pub span: String,
 }
 
 impl minidumper::ServerHandler for CrashServer {

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -101,6 +101,7 @@ pub async fn init(crash_init: InitCrashHandler) {
 pub struct CrashServer {
     initialization_params: OnceLock<InitCrashHandler>,
     panic_info: OnceLock<CrashPanic>,
+    has_connection: Arc<AtomicBool>,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -182,9 +183,7 @@ impl minidumper::ServerHandler for CrashServer {
             2 => {
                 let panic_data =
                     serde_json::from_slice::<CrashPanic>(&buffer).expect("invalid panic data");
-                self.panic_info
-                    .set(panic_data)
-                    .expect("already initialized");
+                self.panic_info.set(panic_data).expect("already panicked");
             }
             _ => {
                 panic!("invalid message kind");

--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -126,7 +126,7 @@ pub struct CrashPanic {
 
 impl minidumper::ServerHandler for CrashServer {
     fn create_minidump_file(&self) -> Result<(File, PathBuf), io::Error> {
-        let err_message = "Need to send a message with the ID upon starting the crash handler";
+        let err_message = "Missing initialization data";
         let dump_path = paths::logs_dir()
             .join(
                 &self

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -88,8 +88,9 @@ message GetCrashFilesResponse {
 }
 
 message CrashReport {
-    string metadata = 1;
-    bytes minidump_contents = 2;
+    reserved 1, 2;
+    string metadata = 3;
+    bytes minidump_contents = 4;
 }
 
 message Extension {

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -84,11 +84,12 @@ message GetCrashFiles {
 
 message GetCrashFilesResponse {
     repeated CrashReport crashes = 1;
+    repeated string legacy_panics = 2;
 }
 
 message CrashReport {
-    optional string panic_contents = 1;
-    optional bytes minidump_contents = 2;
+    string metadata = 1;
+    bytes minidump_contents = 2;
 }
 
 message Extension {

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -1484,20 +1484,17 @@ impl RemoteConnection for SshRemoteConnection {
             identifier = &unique_identifier,
         );
 
-        if let Some(rust_log) = std::env::var("RUST_LOG").ok() {
-            start_proxy_command = format!(
-                "RUST_LOG={} {}",
-                shlex::try_quote(&rust_log).unwrap(),
-                start_proxy_command
-            )
+        for env_var in ["RUST_LOG", "RUST_BACKTRACE", "ZED_GENERATE_MINIDUMPS"] {
+            if let Some(value) = std::env::var(env_var).ok() {
+                start_proxy_command = format!(
+                    "{}={} {} ",
+                    env_var,
+                    shlex::try_quote(&value).unwrap(),
+                    start_proxy_command,
+                );
+            }
         }
-        if let Some(rust_backtrace) = std::env::var("RUST_BACKTRACE").ok() {
-            start_proxy_command = format!(
-                "RUST_BACKTRACE={} {}",
-                shlex::try_quote(&rust_backtrace).unwrap(),
-                start_proxy_command
-            )
-        }
+
         if reconnect {
             start_proxy_command.push_str(" --reconnect");
         }

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -2226,8 +2226,7 @@ impl SshRemoteConnection {
 
             #[cfg(not(target_os = "windows"))]
             {
-                run_cmd(Command::new("gzip").args(["-f", &bin_path.to_string_lossy()]))
-                    .await?;
+                run_cmd(Command::new("gzip").args(["-f", &bin_path.to_string_lossy()])).await?;
             }
             #[cfg(target_os = "windows")]
             {

--- a/crates/remote/src/ssh_session.rs
+++ b/crates/remote/src/ssh_session.rs
@@ -2226,7 +2226,7 @@ impl SshRemoteConnection {
 
             #[cfg(not(target_os = "windows"))]
             {
-                run_cmd(Command::new("gzip").args(["-9", "-f", &bin_path.to_string_lossy()]))
+                run_cmd(Command::new("gzip").args(["-f", &bin_path.to_string_lossy()]))
                     .await?;
             }
             #[cfg(target_os = "windows")]
@@ -2459,7 +2459,7 @@ impl ChannelClient {
             },
             async {
                 smol::Timer::after(timeout).await;
-                anyhow::bail!("Timeout detected")
+                anyhow::bail!("Timed out resyncing remote client")
             },
         )
         .await
@@ -2473,7 +2473,7 @@ impl ChannelClient {
             },
             async {
                 smol::Timer::after(timeout).await;
-                anyhow::bail!("Timeout detected")
+                anyhow::bail!("Timed out pinging remote client")
             },
         )
         .await

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -113,13 +113,14 @@ fn init_logging_server(log_file_path: PathBuf) -> Result<Receiver<Vec<u8>>> {
 
 fn init_panic_hook(session_id: String) {
     std::panic::set_hook(Box::new(move |info| {
-        crashes::handle_panic();
         let payload = info
             .payload()
             .downcast_ref::<&str>()
             .map(|s| s.to_string())
             .or_else(|| info.payload().downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "Box<Any>".to_string());
+
+        crashes::handle_panic(payload.clone(), info.location());
 
         let backtrace = backtrace::Backtrace::new();
         let mut backtrace = backtrace

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -8,6 +8,7 @@ use cli::FORCE_CLI_MODE_ENV_VAR_NAME;
 use client::{Client, ProxySettings, UserStore, parse_zed_link};
 use collab_ui::channel_view::ChannelView;
 use collections::HashMap;
+use crashes::InitCrashHandler;
 use db::kvp::{GLOBAL_KEY_VALUE_STORE, KEY_VALUE_STORE};
 use editor::Editor;
 use extension::ExtensionHostProxy;
@@ -269,7 +270,14 @@ pub fn main() {
     let session = app.background_executor().block(Session::new());
 
     app.background_executor()
-        .spawn(crashes::init(session_id.clone()))
+        .spawn(crashes::init(InitCrashHandler {
+            session_id: session_id.clone(),
+            zed_version: app_version.to_string(),
+            release_channel: release_channel::RELEASE_CHANNEL_NAME.clone(),
+            commit_sha: app_commit_sha.as_ref()
+                .map(|sha| sha.full())
+                .unwrap_or_else(|| "no sha".to_owned()),
+        }))
         .detach();
     reliability::init_panic_hook(
         app_version,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -5,7 +5,7 @@ use agent_ui::AgentPanel;
 use anyhow::{Context as _, Result};
 use clap::{Parser, command};
 use cli::FORCE_CLI_MODE_ENV_VAR_NAME;
-use client::{parse_zed_link, telemetry::os_name, Client, ProxySettings, UserStore};
+use client::{Client, ProxySettings, UserStore, parse_zed_link};
 use collab_ui::channel_view::ChannelView;
 use collections::HashMap;
 use crashes::InitCrashHandler;
@@ -274,10 +274,10 @@ pub fn main() {
             session_id: session_id.clone(),
             zed_version: app_version.to_string(),
             release_channel: release_channel::RELEASE_CHANNEL_NAME.clone(),
-            commit_sha: app_commit_sha.as_ref()
+            commit_sha: app_commit_sha
+                .as_ref()
                 .map(|sha| sha.full())
                 .unwrap_or_else(|| "no sha".to_owned()),
-            gpu: ,
         }))
         .detach();
     reliability::init_panic_hook(

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -5,7 +5,7 @@ use agent_ui::AgentPanel;
 use anyhow::{Context as _, Result};
 use clap::{Parser, command};
 use cli::FORCE_CLI_MODE_ENV_VAR_NAME;
-use client::{Client, ProxySettings, UserStore, parse_zed_link};
+use client::{parse_zed_link, telemetry::os_name, Client, ProxySettings, UserStore};
 use collab_ui::channel_view::ChannelView;
 use collections::HashMap;
 use crashes::InitCrashHandler;
@@ -277,6 +277,7 @@ pub fn main() {
             commit_sha: app_commit_sha.as_ref()
                 .map(|sha| sha.full())
                 .unwrap_or_else(|| "no sha".to_owned()),
+            gpu: ,
         }))
         .detach();
     reliability::init_panic_hook(

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -51,10 +51,6 @@ pub fn init_panic_hook(
                 thread::yield_now();
             }
         }
-        crashes::handle_panic();
-
-        let thread = thread::current();
-        let thread_name = thread.name().unwrap_or("<unnamed>");
 
         let payload = info
             .payload()
@@ -62,6 +58,11 @@ pub fn init_panic_hook(
             .map(|s| s.to_string())
             .or_else(|| info.payload().downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "Box<Any>".to_string());
+
+        crashes::handle_panic(payload.clone(), info.location());
+
+        let thread = thread::current();
+        let thread_name = thread.name().unwrap_or("<unnamed>");
 
         if *release_channel::RELEASE_CHANNEL == ReleaseChannel::Dev {
             let location = info.location().unwrap();


### PR DESCRIPTION
The minidump-based crash reporting is now entirely separate from our legacy panic_hook-based reporting. This should improve the association of minidumps with their metadata and give us more consistent crash reports.

Release Notes:

- N/A
