### PR TITLE
proto: Remove unused types

### DIFF
--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -1,5 +1,6 @@
 use std::{cmp::Reverse, sync::Arc};
 
+use cloud_llm_client::Plan;
 use collections::{HashSet, IndexMap};
 use feature_flags::ZedProFeatureFlag;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
@@ -10,7 +11,6 @@ use language_model::{
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use proto::Plan;
 use ui::{ListItem, ListItemSpacing, prelude::*};
 
 const TRY_ZED_PRO_URL: &str = "https://zed.dev/pro";
@@ -536,7 +536,7 @@ impl PickerDelegate for LanguageModelPickerDelegate {
     ) -> Option<gpui::AnyElement> {
         use feature_flags::FeatureFlagAppExt;
 
-        let plan = proto::Plan::ZedPro;
+        let plan = Plan::ZedPro;
 
         Some(
             h_flex()
@@ -557,7 +557,7 @@ impl PickerDelegate for LanguageModelPickerDelegate {
                                 window
                                     .dispatch_action(Box::new(zed_actions::OpenAccountSettings), cx)
                             }),
-                        Plan::Free | Plan::ZedProTrial => Button::new(
+                        Plan::ZedFree | Plan::ZedProTrial => Button::new(
                             "try-pro",
                             if plan == Plan::ZedProTrial {
                                 "Upgrade to Pro"

--- a/crates/client/src/user.rs
+++ b/crates/client/src/user.rs
@@ -998,19 +998,6 @@ impl RequestUsage {
         }
     }
 
-    pub fn from_proto(amount: u32, limit: proto::UsageLimit) -> Option<Self> {
-        let limit = match limit.variant? {
-            proto::usage_limit::Variant::Limited(limited) => {
-                UsageLimit::Limited(limited.limit as i32)
-            }
-            proto::usage_limit::Variant::Unlimited(_) => UsageLimit::Unlimited,
-        };
-        Some(RequestUsage {
-            limit,
-            amount: amount as i32,
-        })
-    }
-
     fn from_headers(
         limit_name: &str,
         amount_name: &str,

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -6,37 +6,6 @@ message UpdateInviteInfo {
     uint32 count = 2;
 }
 
-enum Plan {
-    Free = 0;
-    ZedPro = 1;
-    ZedProTrial = 2;
-}
-
-message SubscriptionPeriod {
-    uint64 started_at = 1;
-    uint64 ended_at = 2;
-}
-
-message SubscriptionUsage {
-    uint32 model_requests_usage_amount = 1;
-    UsageLimit model_requests_usage_limit = 2;
-    uint32 edit_predictions_usage_amount = 3;
-    UsageLimit edit_predictions_usage_limit = 4;
-}
-
-message UsageLimit {
-    oneof variant {
-        Limited limited = 1;
-        Unlimited unlimited = 2;
-    }
-
-    message Limited {
-        uint32 limit = 1;
-    }
-
-    message Unlimited {}
-}
-
 message AcceptTermsOfService {}
 
 message AcceptTermsOfServiceResponse {


### PR DESCRIPTION
This PR removes some unused types from the RPC protocol.

Release Notes:

- N/A
