### PR TITLE
proto: Remove `AcceptTermsOfService` message

### DIFF
--- a/crates/collab/src/rpc.rs
+++ b/crates/collab/src/rpc.rs
@@ -29,7 +29,6 @@ use axum::{
     response::IntoResponse,
     routing::get,
 };
-use chrono::Utc;
 use collections::{HashMap, HashSet};
 pub use connection_pool::{ConnectionPool, ZedVersion};
 use core::fmt::{self, Debug, Formatter};
@@ -449,7 +448,6 @@ impl Server {
             .add_request_handler(follow)
             .add_message_handler(unfollow)
             .add_message_handler(update_followers)
-            .add_request_handler(accept_terms_of_service)
             .add_message_handler(acknowledge_channel_message)
             .add_message_handler(acknowledge_buffer_version)
             .add_request_handler(get_supermaven_api_key)
@@ -3982,25 +3980,6 @@ async fn mark_notification_as_read(
         notifications,
     );
     response.send(proto::Ack {})?;
-    Ok(())
-}
-
-/// Accept the terms of service (tos) on behalf of the current user
-async fn accept_terms_of_service(
-    _request: proto::AcceptTermsOfService,
-    response: Response<proto::AcceptTermsOfService>,
-    session: MessageContext,
-) -> Result<()> {
-    let db = session.db().await;
-
-    let accepted_tos_at = Utc::now();
-    db.set_user_accepted_tos_at(session.user_id(), Some(accepted_tos_at.naive_utc()))
-        .await?;
-
-    response.send(proto::AcceptTermsOfServiceResponse {
-        accepted_tos_at: accepted_tos_at.timestamp() as u64,
-    })?;
-
     Ok(())
 }
 

--- a/crates/proto/proto/app.proto
+++ b/crates/proto/proto/app.proto
@@ -6,12 +6,6 @@ message UpdateInviteInfo {
     uint32 count = 2;
 }
 
-message AcceptTermsOfService {}
-
-message AcceptTermsOfServiceResponse {
-    uint64 accepted_tos_at = 1;
-}
-
 message ShutdownRemoteServer {}
 
 message Toast {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -136,8 +136,6 @@ message Envelope {
         UpdateFollowers update_followers = 100;
         Unfollow unfollow = 101;
         UpdateDiffBases update_diff_bases = 104;
-        AcceptTermsOfService accept_terms_of_service = 239;
-        AcceptTermsOfServiceResponse accept_terms_of_service_response = 240;
 
         OnTypeFormatting on_type_formatting = 105;
         OnTypeFormattingResponse on_type_formatting_response = 106;
@@ -414,6 +412,7 @@ message Envelope {
     reserved 224 to 229;
     reserved 230 to 231;
     reserved 234 to 236;
+    reserved 239 to 240;
     reserved 246;
     reserved 247 to 254;
     reserved 255 to 256;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -20,8 +20,6 @@ pub const SSH_PEER_ID: PeerId = PeerId { owner_id: 0, id: 0 };
 pub const SSH_PROJECT_ID: u64 = 0;
 
 messages!(
-    (AcceptTermsOfService, Foreground),
-    (AcceptTermsOfServiceResponse, Foreground),
     (Ack, Foreground),
     (AckBufferOperation, Background),
     (AckChannelMessage, Background),
@@ -315,7 +313,6 @@ messages!(
 );
 
 request_messages!(
-    (AcceptTermsOfService, AcceptTermsOfServiceResponse),
     (ApplyCodeAction, ApplyCodeActionResponse),
     (
         ApplyCompletionAdditionalEdits,


### PR DESCRIPTION
This PR removes the `AcceptTermsOfService` RPC message.

We're no longer using the message after https://github.com/zed-industries/zed/pull/36255.

Release Notes:

- N/A
