### PR TITLE
keymap_ui: Don't try to parse empty action arguments as JSON

### DIFF
--- a/crates/settings_ui/src/keybindings.rs
+++ b/crates/settings_ui/src/keybindings.rs
@@ -2181,6 +2181,7 @@ impl KeybindingEditorModal {
 
         let value = action_arguments
             .as_ref()
+            .filter(|args| !args.is_empty())
             .map(|args| {
                 serde_json::from_str(args).context("Failed to parse action arguments as JSON")
             })


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Keymap Editor: Fixed an issue where leaving the arguments field empty would result in an error even if arguments were optional
