### PR TITLE
Add setting for hiding the status_bar.cursor_position_button

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1256,7 +1256,9 @@
   // Status bar-related settings.
   "status_bar": {
     // Whether to show the active language button in the status bar.
-    "active_language_button": true
+    "active_language_button": true,
+    // Whether to show the cursor position button in the status bar.
+    "cursor_position_button": true
   },
   // Settings specific to the terminal
   "terminal": {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -132,6 +132,10 @@ pub struct StatusBar {
     ///
     /// Default: true
     pub active_language_button: bool,
+    /// Whether to show the cursor position button in the status bar.
+    ///
+    /// Default: true
+    pub cursor_position_button: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -585,6 +589,10 @@ pub struct StatusBarContent {
     ///
     /// Default: true
     pub active_language_button: Option<bool>,
+    /// Whether to show the cursor position button in the status bar.
+    ///
+    /// Default: true
+    pub cursor_position_button: Option<bool>,
 }
 
 // Toolbar related settings

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -1,4 +1,4 @@
-use editor::{Editor, MultiBufferSnapshot, EditorSettings};
+use editor::{Editor, EditorSettings, MultiBufferSnapshot};
 use gpui::{App, Entity, FocusHandle, Focusable, Subscription, Task, WeakEntity};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -1,4 +1,4 @@
-use editor::{Editor, MultiBufferSnapshot};
+use editor::{Editor, MultiBufferSnapshot, EditorSettings};
 use gpui::{App, Entity, FocusHandle, Focusable, Subscription, Task, WeakEntity};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -209,6 +209,13 @@ impl CursorPosition {
 
 impl Render for CursorPosition {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        if !EditorSettings::get_global(cx)
+            .status_bar
+            .cursor_position_button
+        {
+            return div();
+        }
+
         div().when_some(self.position, |el, position| {
             let mut text = format!(
                 "{}{FILE_ROW_COLUMN_DELIMITER}{}",

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1284,6 +1284,7 @@ Each option controls displaying of a particular toolbar element. If all elements
 ```json
 "status_bar": {
   "active_language_button": true,
+  "cursor_position_button": true
 },
 ```
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -316,6 +316,10 @@ TBD: Centered layout related settings
     // Clicking the button brings up the language selector.
     // Defaults to true.
     "active_language_button": true,
+    // Show/hide a button that displays the cursor's position.
+    // Clicking the button brings up an input for jumping to a line and column.
+    // Defaults to true.
+    "cursor_position_button": true,
   },
 ```
 


### PR DESCRIPTION
Release Notes:

- Added an option for the status_bar.cursor_position_button. Setting to `false` will hide the button. It defaults to `true`.

This builds off the recent work to hide the language selection button (https://github.com/zed-industries/zed/pull/33977). I tried to follow that pattern, and to pick a clear name for the option, but any feedback/change is welcome. 