### PR TITLE
Ensure bundled files are opened as read-only

### DIFF
--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4551,7 +4551,7 @@ mod tests {
     #[gpui::test]
     async fn test_bundled_files_editor(cx: &mut TestAppContext) {
         let app_state = init_test(cx);
-        cx.update(|cx| init(cx));
+        cx.update(init);
 
         let project = Project::test(app_state.fs.clone(), [], cx).await;
         let _window = cx.add_window(|window, cx| Workspace::test_new(project, window, cx));

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -31,6 +31,7 @@ use gpui::{
     px, retain_all,
 };
 use image_viewer::ImageInfo;
+use language::Capability;
 use language_tools::lsp_tool::{self, LspTool};
 use migrate::{MigrationBanner, MigrationEvent, MigrationNotification, MigrationType};
 use migrator::{migrate_keymap, migrate_settings};
@@ -1764,7 +1765,11 @@ fn open_bundled_file(
                 workspace.with_local_workspace(window, cx, |workspace, window, cx| {
                     let project = workspace.project();
                     let buffer = project.update(cx, move |project, cx| {
-                        project.create_local_buffer(text.as_ref(), language, cx)
+                        let buffer = project.create_local_buffer(text.as_ref(), language, cx);
+                        buffer.update(cx, |buffer, cx| {
+                            buffer.set_capability(Capability::ReadOnly, cx);
+                        });
+                        buffer
                     });
                     let buffer =
                         cx.new(|cx| MultiBuffer::singleton(buffer, cx).with_title(title.into()));
@@ -4541,6 +4546,43 @@ mod tests {
             }
         }
         assert!(has_default_theme);
+    }
+
+    #[gpui::test]
+    async fn test_bundled_files_editor(cx: &mut TestAppContext) {
+        let app_state = init_test(cx);
+        cx.update(|cx| init(cx));
+
+        let project = Project::test(app_state.fs.clone(), [], cx).await;
+        let _window = cx.add_window(|window, cx| Workspace::test_new(project, window, cx));
+
+        cx.update(|cx| {
+            cx.dispatch_action(&OpenDefaultSettings);
+        });
+        cx.run_until_parked();
+
+        assert_eq!(cx.read(|cx| cx.windows().len()), 1);
+
+        let workspace = cx.windows()[0].downcast::<Workspace>().unwrap();
+        let active_editor = workspace
+            .update(cx, |workspace, _, cx| {
+                workspace.active_item_as::<Editor>(cx)
+            })
+            .unwrap();
+        assert!(
+            active_editor.is_some(),
+            "Settings action should have opened an editor with the default file contents"
+        );
+
+        let active_editor = active_editor.unwrap();
+        assert!(
+            active_editor.read_with(cx, |editor, cx| editor.read_only(cx)),
+            "Default settings should be readonly"
+        );
+        assert!(
+            active_editor.read_with(cx, |editor, cx| editor.buffer().read(cx).read_only()),
+            "The underlying buffer should also be readonly for the shipped default settings"
+        );
     }
 
     #[gpui::test]


### PR DESCRIPTION
Closes #36297

While we set the editor as read-only for bundled files, we didn't do this for the underlying buffer. This PR fixes this and adds a test for the corresponding case.

Release Notes:

- Fixed an issue where bundled files (e.g. the default settings) could be edited in some circumstances
