### PR TITLE
collab: Make `admin` column non-nullable on `users` table

### DIFF
--- a/crates/collab/migrations/20250816124707_make_admin_required_on_users.sql
+++ b/crates/collab/migrations/20250816124707_make_admin_required_on_users.sql
@@ -1,0 +1,2 @@
+alter table users
+alter column admin set not null;


### PR DESCRIPTION
This PR updates the `admin` column on the `users` table to be non-nullable.

We were already treating it like this in practice.

All rows in the production database already have a value for the `admin` column.

Release Notes:

- N/A
