### PR TITLE
collab: Add `orb_customer_id` to `billing_customers`

### DIFF
--- a/crates/collab/migrations/20250816133027_add_orb_customer_id_to_billing_customers.sql
+++ b/crates/collab/migrations/20250816133027_add_orb_customer_id_to_billing_customers.sql
@@ -1,0 +1,2 @@
+alter table billing_customers
+    add column orb_customer_id text;


### PR DESCRIPTION
This PR adds an `orb_customer_id` column to the `billing_customers` table.

Release Notes:

- N/A
