### PR TITLE
collab: Drop `rate_buckets` table

### DIFF
--- a/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
+++ b/crates/collab/migrations.sqlite/20221109000000_test_schema.sql
@@ -474,17 +474,6 @@ CREATE UNIQUE INDEX "index_extensions_external_id" ON "extensions" ("external_id
 
 CREATE INDEX "index_extensions_total_download_count" ON "extensions" ("total_download_count");
 
-CREATE TABLE rate_buckets (
-    user_id INT NOT NULL,
-    rate_limit_name VARCHAR(255) NOT NULL,
-    token_count INT NOT NULL,
-    last_refill TIMESTAMP WITHOUT TIME ZONE NOT NULL,
-    PRIMARY KEY (user_id, rate_limit_name),
-    FOREIGN KEY (user_id) REFERENCES users (id)
-);
-
-CREATE INDEX idx_user_id_rate_limit ON rate_buckets (user_id, rate_limit_name);
-
 CREATE TABLE IF NOT EXISTS "breakpoints" (
     "id" INTEGER PRIMARY KEY AUTOINCREMENT,
     "project_id" INTEGER NOT NULL REFERENCES projects (id) ON DELETE CASCADE,

--- a/crates/collab/migrations/20250816135346_drop_rate_buckets_table.sql
+++ b/crates/collab/migrations/20250816135346_drop_rate_buckets_table.sql
@@ -1,0 +1,1 @@
+drop table rate_buckets;


### PR DESCRIPTION
This PR drops the `rate_buckets` table, as we're no longer using it.

Release Notes:

- N/A
