### PR TITLE
Add injections for Isograph function calls in JavaScript and TypeScript

### DIFF
--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -73,3 +73,9 @@
   arguments: (arguments (template_string (string_fragment) @injection.content
                               (#set! injection.language "graphql")))
 )
+
+(call_expression
+  function: (identifier) @_name(#match? @_name "^iso$")
+  arguments: (arguments (template_string (string_fragment) @injection.content
+                              (#set! injection.language "isograph")))
+)

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -73,3 +73,9 @@
   arguments: (arguments (template_string (string_fragment) @injection.content
                               (#set! injection.language "graphql")))
 )
+
+(call_expression
+  function: (identifier) @_name(#match? @_name "^iso$")
+  arguments: (arguments (template_string (string_fragment) @injection.content
+                              (#set! injection.language "isograph")))
+)

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -78,6 +78,12 @@
                               (#set! injection.language "graphql")))
 )
 
+(call_expression
+  function: (identifier) @_name(#match? @_name "^iso$")
+  arguments: (arguments (template_string (string_fragment) @injection.content
+                              (#set! injection.language "isograph")))
+)
+
 ;; Angular Component template injection
 (call_expression
   function: [


### PR DESCRIPTION
Required for https://github.com/isographlabs/isograph/pull/568 to work properly. Tested with a local build and made sure everything's working great!

Release Notes:

- Added support for injecting Isograph language support into `iso` function calls
