### PR TITLE
helix: Uncomment one test

### DIFF
--- a/crates/vim/src/helix.rs
+++ b/crates/vim/src/helix.rs
@@ -547,27 +547,27 @@ mod test {
         );
     }
 
-    // #[gpui::test]
-    // async fn test_delete_character_end_of_line(cx: &mut gpui::TestAppContext) {
-    //     let mut cx = VimTestContext::new(cx, true).await;
+    #[gpui::test]
+    async fn test_delete_character_end_of_line(cx: &mut gpui::TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
 
-    //     cx.set_state(
-    //         indoc! {"
-    //         The quick brownˇ
-    //         fox jumps over
-    //         the lazy dog."},
-    //         Mode::HelixNormal,
-    //     );
+        cx.set_state(
+            indoc! {"
+            The quick brownˇ
+            fox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
 
-    //     cx.simulate_keystrokes("d");
+        cx.simulate_keystrokes("d");
 
-    //     cx.assert_state(
-    //         indoc! {"
-    //         The quick brownˇfox jumps over
-    //         the lazy dog."},
-    //         Mode::HelixNormal,
-    //     );
-    // }
+        cx.assert_state(
+            indoc! {"
+            The quick brownˇfox jumps over
+            the lazy dog."},
+            Mode::HelixNormal,
+        );
+    }
 
     // #[gpui::test]
     // async fn test_delete_character_end_of_buffer(cx: &mut gpui::TestAppContext) {


### PR DESCRIPTION
There are two tests commented out in the helix file, but one of them works again. I don't know if this is too little a change to be merged, but I wanted to suggest it.
The other test might be more complicated though, so I didn't touch it.

Release Notes:

- N/A
