### PR TITLE
Setting for hiding the status_bar.language_server_button

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1258,7 +1258,9 @@
     // Whether to show the active language button in the status bar.
     "active_language_button": true,
     // Whether to show the cursor position button in the status bar.
-    "cursor_position_button": true
+    "cursor_position_button": true,
+    // Whether to show the language server (LSP) button in the status bar.
+    "language_server_button": true
   },
   // Settings specific to the terminal
   "terminal": {

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -136,6 +136,10 @@ pub struct StatusBar {
     ///
     /// Default: true
     pub cursor_position_button: bool,
+    /// Whether to show the language server (LSP) button in the status bar.
+    ///
+    /// Default: true
+    pub language_server_button: bool,
 }
 
 #[derive(Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
@@ -593,6 +597,10 @@ pub struct StatusBarContent {
     ///
     /// Default: true
     pub cursor_position_button: Option<bool>,
+    /// Whether to show the language server (LSP) button in the status bar.
+    ///
+    /// Default: true
+    pub language_server_button: Option<bool>,
 }
 
 // Toolbar related settings

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -7,7 +7,7 @@ use std::{
 
 use client::proto;
 use collections::HashSet;
-use editor::{Editor, EditorEvent};
+use editor::{Editor, EditorEvent, EditorSettings};
 use gpui::{Corner, Entity, Subscription, Task, WeakEntity, actions};
 use language::{BinaryStatus, BufferId, ServerHealth};
 use lsp::{LanguageServerId, LanguageServerName, LanguageServerSelector};
@@ -964,7 +964,12 @@ impl StatusItemView for LspTool {
 
 impl Render for LspTool {
     fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl ui::IntoElement {
-        if self.server_state.read(cx).language_servers.is_empty() || self.lsp_menu.is_none() {
+        if self.server_state.read(cx).language_servers.is_empty()
+            || self.lsp_menu.is_none()
+            || !EditorSettings::get_global(cx)
+                .status_bar
+                .language_server_button
+        {
             return div();
         }
 

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1284,7 +1284,8 @@ Each option controls displaying of a particular toolbar element. If all elements
 ```json
 "status_bar": {
   "active_language_button": true,
-  "cursor_position_button": true
+  "cursor_position_button": true,
+  "language_server_button": true,
 },
 ```
 

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -320,6 +320,12 @@ TBD: Centered layout related settings
     // Clicking the button brings up an input for jumping to a line and column.
     // Defaults to true.
     "cursor_position_button": true,
+    // Show/hide a button that displays the state of the LSP language server.
+    // Clicking the button brings up a menu with the servers and ability to stop/restart them.
+    // This button will be hidden if "enable_language_server" is set to false.
+    // Activity from enablded language servers will still be displayed in the status bar even if the button is hidden.
+    // Defaults to true.
+    "language_server_button": true,
   },
 ```
 


### PR DESCRIPTION
Release Notes:

- Adds a setting `status_bar.language_server_button`, that defaults to `true`. `false` will hide the LSP button in the status bar. `true` will only show the button if `enable_language_server` is not false. Note that output from the LSP, such as `↻ Cargo Check: ...` will still be displayed.

This change is not personally too important to me, as I generally have `enable_language_server` set to false, so I am doubly open to feedback/suggestions/rejection/etc. 

Follows patterns of https://github.com/zed-industries/zed/pull/36288.

The overlap with the `enable_language_server` option makes it perhaps a bit confusing, or at least makes the explanation/docs less intuitive. Additionally having the logs from the LSPs show up in the ActivityIndicator makes this only a half measure or something.

I am not sure if that is reason enough to not have this option, but ideas for improvement are welcome, and rejection on this (or other) basis is understandable.