### PR TITLE
Suggest single tracked commit message only when nothing else is staged

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1833,7 +1833,9 @@ impl GitPanel {
 
         let git_status_entry = if let Some(staged_entry) = &self.single_staged_entry {
             Some(staged_entry)
-        } else if let Some(single_tracked_entry) = &self.single_tracked_entry {
+        } else if self.total_staged_count() == 0
+            && let Some(single_tracked_entry) = &self.single_tracked_entry
+        {
             Some(single_tracked_entry)
         } else {
             None


### PR DESCRIPTION
Closes #36341

<img width="543" height="548" alt="image" src="https://github.com/user-attachments/assets/ab76a32c-c622-4025-9b28-5accc8d3f04c" />

In the case where commit message was suggested based on single tracked entry, this PR adds a clause to the condition to ensure there are no staged entries.

Release Notes:

- Fixed commit message suggestion when there is one unstaged tracked file, but multiple untracked files are staged.
