### PR TITLE
docs: Remove link to openSUSE Tumbleweed

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -48,7 +48,6 @@ There are several third-party Zed packages for various Linux distributions and p
 - Manjaro: [`zed`](https://packages.manjaro.org/?query=zed)
 - ALT Linux (Sisyphus): [`zed`](https://packages.altlinux.org/en/sisyphus/srpms/zed/)
 - AOSC OS: [`zed`](https://packages.aosc.io/packages/zed)
-- openSUSE Tumbleweed: [`zed`](https://en.opensuse.org/Zed)
 
 See [Repology](https://repology.org/project/zed-editor/versions) for a list of Zed packages in various repositories.
 


### PR DESCRIPTION
This PR removes the link to Zed on openSUSE Tumbleweed, as it has been removed: https://en.opensuse.org/index.php?title=Archive:Zed&action=history

<img width="1178" height="517" alt="Screenshot 2025-08-17 at 8 48 59 AM" src="https://github.com/user-attachments/assets/3e441b1c-81ad-4f4b-a8a0-e872f916c2d8" />

Release Notes:

- N/A
