### PR TITLE
gpui: Fix crash when starting Zed on macOS during texture creation

### DIFF
--- a/crates/gpui/src/platform/mac/metal_renderer.rs
+++ b/crates/gpui/src/platform/mac/metal_renderer.rs
@@ -314,6 +314,15 @@ impl MetalRenderer {
     }
 
     fn update_path_intermediate_textures(&mut self, size: Size<DevicePixels>) {
+        // We are uncertain when this happens, but sometimes size can be 0 here. Most likely before
+        // the layout pass on window creation. Zero-sized texture creation causes SIGABRT.
+        // https://github.com/zed-industries/zed/issues/36229
+        if size.width.0 <= 0 || size.height.0 <= 0 {
+            self.path_intermediate_texture = None;
+            self.path_intermediate_msaa_texture = None;
+            return;
+        }
+
         let texture_descriptor = metal::TextureDescriptor::new();
         texture_descriptor.set_width(size.width.0 as u64);
         texture_descriptor.set_height(size.height.0 as u64);


### PR DESCRIPTION
Closes #36229

Fix zero-sized texture creation that triggers a SIGABRT in the Metal renderer. Not sure why this happens yet, but it likely occurs when `native_window.contentView()` returns a zero `NSSize` during initial window creation, before the view size is computed.

Release Notes:

- Fixed a rare startup crash on macOS.
