### PR TITLE
Silence "minidump endpoint not set" errors' backtraces in the logs

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -550,7 +550,8 @@ async fn upload_previous_panics(
 
 pub async fn upload_previous_minidumps(http: Arc<HttpClientWithUrl>) -> anyhow::Result<()> {
     let Some(minidump_endpoint) = MINIDUMP_ENDPOINT.as_ref() else {
-        return Err(anyhow::anyhow!("Minidump endpoint not set"));
+        log::warn!("Minidump endpoint not set");
+        return Ok(());
     };
 
     let mut children = smol::fs::read_dir(paths::logs_dir()).await?;


### PR DESCRIPTION
<img width="1899" height="693" alt="bad" src="https://github.com/user-attachments/assets/6e6eb2d7-0933-4bb7-b339-ecebba00b60b" />

Release Notes:

- N/A
