### PR TITLE
acp: Have `AcpThread` handle all interrupting

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1200,17 +1200,21 @@ impl AcpThread {
         } else {
             None
         };
-        self.push_entry(
-            AgentThreadEntry::UserMessage(UserMessage {
-                id: message_id.clone(),
-                content: block,
-                chunks: message,
-                checkpoint: None,
-            }),
-            cx,
-        );
 
         self.run_turn(cx, async move |this, cx| {
+            this.update(cx, |this, cx| {
+                this.push_entry(
+                    AgentThreadEntry::UserMessage(UserMessage {
+                        id: message_id.clone(),
+                        content: block,
+                        chunks: message,
+                        checkpoint: None,
+                    }),
+                    cx,
+                );
+            })
+            .ok();
+
             let old_checkpoint = git_store
                 .update(cx, |git, cx| git.checkpoint(cx))?
                 .await

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -201,7 +201,7 @@ mod test_support {
 
     struct Session {
         thread: WeakEntity<AcpThread>,
-        response_tx: Option<oneshot::Sender<()>>,
+        response_tx: Option<oneshot::Sender<acp::StopReason>>,
     }
 
     impl StubAgentConnection {
@@ -242,12 +242,12 @@ mod test_support {
                 .unwrap()
                 .thread
                 .update(cx, |thread, cx| {
-                    thread.handle_session_update(update.clone(), cx).unwrap();
+                    thread.handle_session_update(update, cx).unwrap();
                 })
                 .unwrap();
         }
 
-        pub fn end_turn(&self, session_id: acp::SessionId) {
+        pub fn end_turn(&self, session_id: acp::SessionId, stop_reason: acp::StopReason) {
             self.sessions
                 .lock()
                 .get_mut(&session_id)
@@ -255,7 +255,7 @@ mod test_support {
                 .response_tx
                 .take()
                 .expect("No pending turn")
-                .send(())
+                .send(stop_reason)
                 .unwrap();
         }
     }
@@ -308,10 +308,8 @@ mod test_support {
                 let (tx, rx) = oneshot::channel();
                 response_tx.replace(tx);
                 cx.spawn(async move |_| {
-                    rx.await?;
-                    Ok(acp::PromptResponse {
-                        stop_reason: acp::StopReason::EndTurn,
-                    })
+                    let stop_reason = rx.await?;
+                    Ok(acp::PromptResponse { stop_reason })
                 })
             } else {
                 for update in self.next_prompt_updates.lock().drain(..) {
@@ -353,8 +351,17 @@ mod test_support {
             }
         }
 
-        fn cancel(&self, _session_id: &acp::SessionId, _cx: &mut App) {
-            unimplemented!()
+        fn cancel(&self, session_id: &acp::SessionId, _cx: &mut App) {
+            if let Some(end_turn_tx) = self
+                .sessions
+                .lock()
+                .get_mut(session_id)
+                .unwrap()
+                .response_tx
+                .take()
+            {
+                end_turn_tx.send(acp::StopReason::Canceled).unwrap();
+            }
         }
 
         fn session_editor(


### PR DESCRIPTION
The view was cancelling the generation, but `AcpThread` already handles that, so we removed that extra code and fixed a bug where an update from the first user message would appear after the second one.

Release Notes:

- N/A
