### PR TITLE
language: Clean up allocations

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -1377,16 +1377,14 @@ impl Language {
         let grammar = self.grammar_mut().context("cannot mutate grammar")?;
 
         let query = Query::new(&grammar.ts_language, source)?;
-        let mut extra_captures = Vec::with_capacity(query.capture_names().len());
-
-        for name in query.capture_names().iter() {
-            let kind = if *name == "run" {
-                RunnableCapture::Run
-            } else {
-                RunnableCapture::Named(name.to_string().into())
-            };
-            extra_captures.push(kind);
-        }
+        let extra_captures: Vec<_> = query
+            .capture_names()
+            .iter()
+            .map(|&name| match name {
+                "run" => RunnableCapture::Run,
+                name => RunnableCapture::Named(name.to_string().into()),
+            })
+            .collect();
 
         grammar.runnable_config = Some(RunnableConfig {
             extra_captures,

--- a/crates/language/src/proto.rs
+++ b/crates/language/src/proto.rs
@@ -385,12 +385,10 @@ pub fn deserialize_undo_map_entry(
 
 /// Deserializes selections from the RPC representation.
 pub fn deserialize_selections(selections: Vec<proto::Selection>) -> Arc<[Selection<Anchor>]> {
-    Arc::from(
-        selections
-            .into_iter()
-            .filter_map(deserialize_selection)
-            .collect::<Vec<_>>(),
-    )
+    selections
+        .into_iter()
+        .filter_map(deserialize_selection)
+        .collect()
 }
 
 /// Deserializes a [`Selection`] from the RPC representation.


### PR DESCRIPTION
- Correctly pre-allocate `Vec` when deserializing regexes
- Simplify manual `Vec::with_capacity` calls by using `Iterator::unzip`
- Collect directly into `Arc<[T]>` (uses `Vec` internally anyway, but simplifies code)
- Remove unnecessary `LazyLock` around Atomics by not using const incompatible `Default` for initialization.

Release Notes:

- N/A
