### PR TITLE
Explicitly allow `clippy::new_without_default` style lint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -813,8 +813,6 @@ style = { level = "allow", priority = -1 }
 module_inception = { level = "deny" }
 question_mark = { level = "deny" }
 redundant_closure = { level = "deny" }
-# It doesn't make sense to implement Default unilaterally
-new_without_default = "allow"
 # Individual rules that have violations in the codebase:
 type_complexity = "allow"
 # We often return trait objects from `new` functions.
@@ -823,6 +821,8 @@ new_ret_no_self = { level = "allow" }
 # compared to Iterator::next. Yet, clippy complains about those.
 should_implement_trait = { level = "allow" }
 let_underscore_future = "allow"
+# It doesn't make sense to implement Default unilaterally
+new_without_default = "allow"
 
 # in Rust it can be very tedious to reduce argument count without
 # running afoul of the borrow checker.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -813,6 +813,8 @@ style = { level = "allow", priority = -1 }
 module_inception = { level = "deny" }
 question_mark = { level = "deny" }
 redundant_closure = { level = "deny" }
+# It doesn't make sense to implement Default unilaterally
+new_without_default = "allow"
 # Individual rules that have violations in the codebase:
 type_complexity = "allow"
 # We often return trait objects from `new` functions.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -821,7 +821,7 @@ new_ret_no_self = { level = "allow" }
 # compared to Iterator::next. Yet, clippy complains about those.
 should_implement_trait = { level = "allow" }
 let_underscore_future = "allow"
-# It doesn't make sense to implement Default unilaterally
+# It doesn't make sense to implement `Default` unilaterally.
 new_without_default = "allow"
 
 # in Rust it can be very tedious to reduce argument count without


### PR DESCRIPTION
Discussed in #36432

Release Notes:

- N/A
