### PR TITLE
terminal: Temporarily disable `test_basic_terminal` test

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2160,7 +2160,7 @@ mod tests {
     use gpui::{Pixels, Point, TestAppContext, bounds, point, size};
     use rand::{Rng, distributions::Alphanumeric, rngs::ThreadRng, thread_rng};
 
-    #[cfg_attr(windows, ignore = "TODO: fix on windows")]
+    #[ignore = "Test is flaky on macOS, and doesn't run on Windows"]
     #[gpui::test]
     async fn test_basic_terminal(cx: &mut TestAppContext) {
         cx.executor().allow_parking();


### PR DESCRIPTION
This PR temporarily disables the `test_basic_terminal` test, as it flakes on macOS.

Release Notes:

- N/A
