### PR TITLE
client: Make `Client::sign_in_with_optional_connect` a no-op when already connected to Collab

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -973,6 +973,11 @@ impl Client {
         try_provider: bool,
         cx: &AsyncApp,
     ) -> Result<()> {
+        // Don't try to sign in again if we're already connected to Collab, as it will temporarily disconnect us.
+        if self.status().borrow().is_connected() {
+            return Ok(());
+        }
+
         let (is_staff_tx, is_staff_rx) = oneshot::channel::<bool>();
         let mut is_staff_tx = Some(is_staff_tx);
         cx.update(|cx| {


### PR DESCRIPTION
This PR makes it so `Client::sign_in_with_optional_connect` does nothing when the user is already connected to Collab.

This fixes the issue where clicking on a channel link would temporarily disconnect you from Collab.

Release Notes:

- N/A
