### PR TITLE
claude: Respect always allow setting

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ version = "0.1.0"
 dependencies = [
  "acp_thread",
  "agent-client-protocol",
+ "agent_settings",
  "agentic-coding-protocol",
  "anyhow",
  "collections",

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -19,6 +19,7 @@ doctest = false
 [dependencies]
 acp_thread.workspace = true
 agent-client-protocol.workspace = true
+agent_settings.workspace = true
 agentic-coding-protocol.workspace = true
 anyhow.workspace = true
 collections.workspace = true

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -80,7 +80,8 @@ impl AgentConnection for ClaudeAgentConnection {
         let cwd = cwd.to_owned();
         cx.spawn(async move |cx| {
             let (mut thread_tx, thread_rx) = watch::channel(WeakEntity::new_invalid());
-            let permission_mcp_server = ClaudeZedMcpServer::new(thread_rx.clone(), cx).await?;
+            let fs = project.read_with(cx, |project, _cx| project.fs().clone())?;
+            let permission_mcp_server = ClaudeZedMcpServer::new(thread_rx.clone(), fs, cx).await?;
 
             let mut mcp_servers = HashMap::default();
             mcp_servers.insert(


### PR DESCRIPTION
Claude will now respect the `agent.always_allow_tool_actions` setting and will set it when "Always Allow" is clicked.

Release Notes:

- N/A
