### PR TITLE
collab: Add `orb_subscription_id` to `billing_subscriptions`

### DIFF
--- a/crates/collab/migrations/20250819022421_add_orb_subscription_id_to_billing_subscriptions.sql
+++ b/crates/collab/migrations/20250819022421_add_orb_subscription_id_to_billing_subscriptions.sql
@@ -1,0 +1,2 @@
+alter table billing_subscriptions
+    add column orb_subscription_id text;


### PR DESCRIPTION
This PR adds an `orb_subscription_id` column to the `billing_subscriptions` table.

Release Notes:

- N/A
