### PR TITLE
Fix `InlineCompletion` -> `EditPrediction` keymap migration

### DIFF
--- a/crates/migrator/src/migrations/m_2025_01_29/keymap.rs
+++ b/crates/migrator/src/migrations/m_2025_01_29/keymap.rs
@@ -242,22 +242,22 @@ static STRING_REPLACE: LazyLock<HashMap<&str, &str>> = LazyLock::new(|| {
             "inline_completion::ToggleMenu",
             "edit_prediction::ToggleMenu",
         ),
-        ("editor::NextEditPrediction", "editor::NextEditPrediction"),
+        ("editor::NextInlineCompletion", "editor::NextEditPrediction"),
         (
+            "editor::PreviousInlineCompletion",
             "editor::PreviousEditPrediction",
-            "editor::PreviousEditPrediction",
         ),
         (
+            "editor::AcceptPartialInlineCompletion",
             "editor::AcceptPartialEditPrediction",
-            "editor::AcceptPartialEditPrediction",
         ),
-        ("editor::ShowEditPrediction", "editor::ShowEditPrediction"),
+        ("editor::ShowInlineCompletion", "editor::ShowEditPrediction"),
         (
-            "editor::AcceptEditPrediction",
+            "editor::AcceptInlineCompletion",
             "editor::AcceptEditPrediction",
         ),
         (
-            "editor::ToggleEditPredictions",
+            "editor::ToggleInlineCompletions",
             "editor::ToggleEditPrediction",
         ),
     ])


### PR DESCRIPTION
Accidentally regressed this in #35512, causing this migration to not work and an error log to appear when one of these actions is in the user keymap

Release Notes:

- N/A