### PR TITLE
chore: Default settings: Comments: dock option

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -717,7 +717,7 @@
     // Can be 'never', 'always', or 'when_in_call',
     // or a boolean (interpreted as 'never'/'always').
     "button": "when_in_call",
-    // Where to the chat panel. Can be 'left' or 'right'.
+    // Where to dock the chat panel. Can be 'left' or 'right'.
     "dock": "right",
     // Default width of the chat panel.
     "default_width": 240
@@ -725,7 +725,7 @@
   "git_panel": {
     // Whether to show the git panel button in the status bar.
     "button": true,
-    // Where to show the git panel. Can be 'left' or 'right'.
+    // Where to dock the git panel. Can be 'left' or 'right'.
     "dock": "left",
     // Default width of the git panel.
     "default_width": 360,


### PR DESCRIPTION
Minor tweak in the wording of the comments for the default settings regarding the `dock` option of the panels, in order to make them congruent across all panels.

Release Notes:

- N/A
