### PR TITLE
lsp: Enable dynamic registration for TextDocumentSyncClientCapabilities post revert

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -827,7 +827,7 @@ impl LanguageServer {
                     }),
                     synchronization: Some(TextDocumentSyncClientCapabilities {
                         did_save: Some(true),
-                        dynamic_registration: Some(false),
+                        dynamic_registration: Some(true),
                         ..TextDocumentSyncClientCapabilities::default()
                     }),
                     code_lens: Some(CodeLensClientCapabilities {


### PR DESCRIPTION
Follow up: https://github.com/zed-industries/zed/pull/36485

Release Notes:

- N/A
