### PR TITLE
Fix `workspace::SendKeystrokes` example in docs

### DIFF
--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -221,7 +221,7 @@ This is useful for preventing Zed from falling back to a default keybinding when
 
 A common request is to be able to map from a single keystroke to a sequence. You can do this with the `workspace::SendKeystrokes` action.
 
-```jsonc
+```json
 [
   {
     "bindings": {

--- a/docs/src/key-bindings.md
+++ b/docs/src/key-bindings.md
@@ -221,16 +221,18 @@ This is useful for preventing Zed from falling back to a default keybinding when
 
 A common request is to be able to map from a single keystroke to a sequence. You can do this with the `workspace::SendKeystrokes` action.
 
-```json
+```jsonc
 [
   {
     "bindings": {
+      // Move down four times
       "alt-down": ["workspace::SendKeystrokes", "down down down down"],
+      // Expand the selection (editor::SelectLargerSyntaxNode);
+      // copy to the clipboard; and then undo the selection expansion.
       "cmd-alt-c": [
         "workspace::SendKeystrokes",
-        "cmd-shift-p copy relative path enter"
-      ],
-      "cmd-alt-r": ["workspace::SendKeystrokes", "cmd-p README enter"]
+        "ctrl-shift-right ctrl-shift-right ctrl-shift-right cmd-c ctrl-shift-left ctrl-shift-left ctrl-shift-left"
+      ]
     }
   },
   {


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/25683

Remove two bad examples from the key binding docs.
`cmd-shift-p` (command palette) and `cmd-p` (file finder) are async operations and thus do not work properly with `workspace::SendKeystrokes`.

Originally reported in https://github.com/zed-industries/zed/issues/25683#issuecomment-3145830534

Release Notes:

- N/A
