### PR TITLE
Fix conflicts in Linux default keymap

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -41,7 +41,7 @@
       "shift-f11": "debugger::StepOut",
       "f11": "zed::ToggleFullScreen",
       "ctrl-alt-z": "edit_prediction::RateCompletions",
-      "ctrl-shift-i": "edit_prediction::ToggleMenu",
+      "ctrl-alt-shift-i": "edit_prediction::ToggleMenu",
       "ctrl-alt-l": "lsp_tool::ToggleMenu"
     }
   },
@@ -121,7 +121,7 @@
       "alt-g m": "git::OpenModifiedFiles",
       "menu": "editor::OpenContextMenu",
       "shift-f10": "editor::OpenContextMenu",
-      "ctrl-shift-e": "editor::ToggleEditPrediction",
+      "ctrl-alt-shift-e": "editor::ToggleEditPrediction",
       "f9": "editor::ToggleBreakpoint",
       "shift-f9": "editor::EditLogBreakpoint"
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/29746

| Action | New Key | Old Key | Former Conflict |
| - | - | - | - |
| `edit_prediction::ToggleMenu` | `ctrl-alt-shift-i` | `ctrl-shift-i` | `editor::Format` |
| `editor::ToggleEditPrediction` | `ctrl-alt-shift-e` | `ctrl-shift-e` | `project_panel::ToggleFocus` |

These aren't great keys and I'm open to alternate suggestions, but the will work out of the box without conflict.

Release Notes:

- N/A
