### PR TITLE
Suspend macOS threads during crashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3861,7 +3861,7 @@ dependencies = [
  "jni",
  "js-sys",
  "libc",
- "mach2",
+ "mach2 0.4.2",
  "ndk",
  "ndk-context",
  "num-derive",
@@ -4011,7 +4011,7 @@ checksum = "031ed29858d90cfdf27fe49fae28028a1f20466db97962fa2f4ea34809aeebf3"
 dependencies = [
  "cfg-if",
  "libc",
- "mach2",
+ "mach2 0.4.2",
 ]
 
 [[package]]
@@ -4023,7 +4023,7 @@ dependencies = [
  "cfg-if",
  "crash-context",
  "libc",
- "mach2",
+ "mach2 0.4.2",
  "parking_lot",
 ]
 
@@ -4033,6 +4033,7 @@ version = "0.1.0"
 dependencies = [
  "crash-handler",
  "log",
+ "mach2 0.5.0",
  "minidumper",
  "paths",
  "release_channel",
@@ -9855,6 +9856,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "mach2"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a1b95cd5421ec55b445b5ae102f5ea0e768de1f82bd3001e11f426c269c3aea"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10190,7 +10200,7 @@ dependencies = [
  "goblin",
  "libc",
  "log",
- "mach2",
+ "mach2 0.4.2",
  "memmap2",
  "memoffset",
  "minidump-common",
@@ -18246,7 +18256,7 @@ dependencies = [
  "indexmap",
  "libc",
  "log",
- "mach2",
+ "mach2 0.4.2",
  "memfd",
  "object",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -515,6 +515,7 @@ libsqlite3-sys = { version = "0.30.1", features = ["bundled"] }
 linkify = "0.10.0"
 log = { version = "0.4.16", features = ["kv_unstable_serde", "serde"] }
 lsp-types = { git = "https://github.com/zed-industries/lsp-types", rev = "39f629bdd03d59abd786ed9fc27e8bca02c0c0ec" }
+mach2 = "0.5"
 markup5ever_rcdom = "0.3.0"
 metal = "0.29"
 minidumper = "0.8"

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -8,7 +8,6 @@ license = "GPL-3.0-or-later"
 [dependencies]
 crash-handler.workspace = true
 log.workspace = true
-mach2.workspace = true
 minidumper.workspace = true
 paths.workspace = true
 release_channel.workspace = true
@@ -16,6 +15,9 @@ smol.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 workspace-hack.workspace = true
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mach2.workspace = true
 
 [lints]
 workspace = true

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -8,6 +8,7 @@ license = "GPL-3.0-or-later"
 [dependencies]
 crash-handler.workspace = true
 log.workspace = true
+mach2.workspace = true
 minidumper.workspace = true
 paths.workspace = true
 release_channel.workspace = true


### PR DESCRIPTION
This should improve our detection of which thread crashed since they wont be able to resume while the minidump is being generated.

Release Notes:

- N/A