### PR TITLE
Fix initial_tasks.json triggering diagnostic warning

### DIFF
--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -43,8 +43,8 @@
     //           "args": ["--login"]
     //         }
     //     }
-    "shell": "system",
+    "shell": "system"
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
-    "tags": []
+    // "tags": []
   }
 ]

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -45,7 +45,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     // Whether to show the task line in the output of the spawned task, defaults to `true`.
     "show_summary": true,
     // Whether to show the command line in the output of the spawned task, defaults to `true`.
-    "show_output": true,
+    "show_output": true
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     // "tags": []
   }

--- a/docs/src/tasks.md
+++ b/docs/src/tasks.md
@@ -47,7 +47,7 @@ Zed supports ways to spawn (and rerun) commands using its integrated terminal to
     // Whether to show the command line in the output of the spawned task, defaults to `true`.
     "show_output": true,
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
-    "tags": []
+    // "tags": []
   }
 ]
 ```


### PR DESCRIPTION
`zed::OpenProjectTasks` without an existing tasks.json will recreate it from the template.
This file will immediately show a warning.

<img width="810" height="168" alt="Screenshot 2025-08-19 at 17 16 07" src="https://github.com/user-attachments/assets/bbc8c7a0-7036-4927-8e85-b81b79aeaacb" />

Release Notes:

- N/A