### PR TITLE
Attach minidump errors to uploaded crash events

### DIFF
--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -610,6 +610,9 @@ async fn upload_minidump(
         // TODO: add gpu-context, feature-flag-context, and more of device-context like gpu
         // name, screen resolution, available ram, device model, etc
     }
+    if let Some(minidump_error) = metadata.minidump_error.clone() {
+        form = form.text("minidump_error", minidump_error);
+    }
 
     let mut response_text = String::new();
     let mut response = http.send_multipart_form(endpoint, form).await?;


### PR DESCRIPTION
We see a bunch of crash events with truncated minidumps where they have a valid header but no events. We think this is due to an issue generating them, so we're attaching the relevant result to the uploaded tags.

Release Notes:

- N/A
