### PR TITLE
collab: Make `stripe_subscription_id` and `stripe_subscription_status` nullable on `billing_subscriptions`

### DIFF
--- a/crates/collab/migrations/20250819225916_make_stripe_fields_optional_on_billing_subscription.sql
+++ b/crates/collab/migrations/20250819225916_make_stripe_fields_optional_on_billing_subscription.sql
@@ -1,0 +1,3 @@
+alter table billing_subscriptions
+    alter column stripe_subscription_id drop not null,
+    alter column stripe_subscription_status drop not null;


### PR DESCRIPTION
This PR makes the `stripe_subscription_id` and `stripe_subscription_status` columns nullable on the `billing_subscriptions` table.

Release Notes:

- N/A
