### PR TITLE
editor: Use `highlight_text` to highlight matching brackets, fix unnecessary inlay hint highlighting

### DIFF
--- a/crates/editor/src/highlight_matching_bracket.rs
+++ b/crates/editor/src/highlight_matching_bracket.rs
@@ -10,7 +10,7 @@ pub fn refresh_matching_bracket_highlights(
     window: &mut Window,
     cx: &mut Context<Editor>,
 ) {
-    editor.clear_background_highlights::<MatchingBracketHighlight>(cx);
+    editor.clear_highlights::<MatchingBracketHighlight>(cx);
 
     let newest_selection = editor.selections.newest::<usize>(cx);
     // Don't highlight brackets if the selection isn't empty
@@ -112,7 +112,7 @@ mod tests {
                 another_test(1, 2, 3);
             }
         "#});
-        cx.assert_editor_background_highlights::<MatchingBracketHighlight>(indoc! {r#"
+        cx.assert_editor_text_highlights::<MatchingBracketHighlight>(indoc! {r#"
             pub fn test«(»"Test argument"«)» {
                 another_test(1, 2, 3);
             }
@@ -123,7 +123,7 @@ mod tests {
                 another_test(1, ˇ2, 3);
             }
         "#});
-        cx.assert_editor_background_highlights::<MatchingBracketHighlight>(indoc! {r#"
+        cx.assert_editor_text_highlights::<MatchingBracketHighlight>(indoc! {r#"
             pub fn test("Test argument") {
                 another_test«(»1, 2, 3«)»;
             }
@@ -134,7 +134,7 @@ mod tests {
                 anotherˇ_test(1, 2, 3);
             }
         "#});
-        cx.assert_editor_background_highlights::<MatchingBracketHighlight>(indoc! {r#"
+        cx.assert_editor_text_highlights::<MatchingBracketHighlight>(indoc! {r#"
             pub fn test("Test argument") «{»
                 another_test(1, 2, 3);
             «}»
@@ -146,7 +146,7 @@ mod tests {
                 another_test(1, 2, 3);
             }
         "#});
-        cx.assert_editor_background_highlights::<MatchingBracketHighlight>(indoc! {r#"
+        cx.assert_editor_text_highlights::<MatchingBracketHighlight>(indoc! {r#"
             pub fn test("Test argument") {
                 another_test(1, 2, 3);
             }
@@ -158,8 +158,8 @@ mod tests {
                 another_test(1, 2, 3);
             }
         "#});
-        cx.assert_editor_background_highlights::<MatchingBracketHighlight>(indoc! {r#"
-            pub fn test("Test argument") {
+        cx.assert_editor_text_highlights::<MatchingBracketHighlight>(indoc! {r#"
+            pub fn test«("Test argument") {
                 another_test(1, 2, 3);
             }
         "#});

--- a/crates/editor/src/highlight_matching_bracket.rs
+++ b/crates/editor/src/highlight_matching_bracket.rs
@@ -1,6 +1,7 @@
 use crate::{Editor, RangeToAnchorExt};
-use gpui::{Context, Window};
+use gpui::{Context, HighlightStyle, Window};
 use language::CursorShape;
+use theme::ActiveTheme;
 
 enum MatchingBracketHighlight {}
 
@@ -35,12 +36,19 @@ pub fn refresh_matching_bracket_highlights(
         .buffer_snapshot
         .innermost_enclosing_bracket_ranges(head..tail, None)
     {
-        editor.highlight_background::<MatchingBracketHighlight>(
-            &[
+        editor.highlight_text::<MatchingBracketHighlight>(
+            vec![
                 opening_range.to_anchors(&snapshot.buffer_snapshot),
                 closing_range.to_anchors(&snapshot.buffer_snapshot),
             ],
-            |theme| theme.colors().editor_document_highlight_bracket_background,
+            HighlightStyle {
+                background_color: Some(
+                    cx.theme()
+                        .colors()
+                        .editor_document_highlight_bracket_background,
+                ),
+                ..Default::default()
+            },
             cx,
         )
     }


### PR DESCRIPTION
Closes #35981

Release Notes:

- Fixed bracket highlights overly including parts of inlays when highlighting

Before -
<img width="1480" height="602" alt="Screenshot from 2025-08-19 17-15-06" src="https://github.com/user-attachments/assets/8e6b5ed8-f133-4867-8352-ed93441fbd8b" />

After -
<img width="1480" height="602" alt="Screenshot from 2025-08-19 17-24-26" src="https://github.com/user-attachments/assets/1314e54e-ecf9-4280-9d53-eed6e96e393f" />