### PR TITLE
docs: Document `global_lsp_settings.button` and remove duplicate docs for `lsp_highlight_debounce`

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -539,12 +539,6 @@ List of `string` values
 - Setting: `selection_highlight`
 - Default: `true`
 
-## LSP Highlight Debounce
-
-- Description: The debounce delay before querying highlights from the language server based on the current cursor location.
-- Setting: `lsp_highlight_debounce`
-- Default: `75`
-
 ## Cursor Blink
 
 - Description: Whether or not the cursor blinks.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1339,6 +1339,18 @@ While other options may be changed at a runtime and should be placed under `sett
 - Setting: `lsp_highlight_debounce`
 - Default: `75`
 
+## Global LSP Settings
+
+- Description: Common language server settings.
+- Setting: `global_lsp_settings`
+- Default:
+
+```json
+"global_lsp_settings": {
+  "button": true
+}
+```
+
 **Options**
 
 `integer` values representing milliseconds

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -321,6 +321,12 @@ TBD: Centered layout related settings
     // Defaults to true.
     "cursor_position_button": true,
   },
+  "global_lsp_settings": {
+    // Show/hide the LSP button in the status bar.
+    // Activity from the LSP is still shown.
+    // Button is not shown if "enable_language_server" if false.
+    "button": true
+  },
 ```
 
 ### Multibuffer


### PR DESCRIPTION
Follow up to this discussion: https://github.com/zed-industries/zed/pull/36337

Release Notes:

- N/A

This will (gracefully) break links to https://zed.dev/docs/configuring-zed#lsp-highlight-debounce-1 I don't see anything show up for that on google or github search and I don't think its load bearing.