### PR TITLE
gpui: Allow the application to run after all windows are closed

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -33,6 +33,7 @@ use util::{ResultExt, debug_panic};
 
 #[cfg(any(feature = "inspector", debug_assertions))]
 use crate::InspectorElementRegistry;
+use crate::colors::{Colors, GlobalColors};
 use crate::{
     Action, ActionBuildError, ActionRegistry, Any, AnyView, AnyWindowHandle, AppContext, Asset,
     AssetSource, BackgroundExecutor, Bounds, ClipboardItem, CursorStyle, DispatchPhase, DisplayId,

--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -38,10 +38,10 @@ use crate::{
     AssetSource, BackgroundExecutor, Bounds, ClipboardItem, CursorStyle, DispatchPhase, DisplayId,
     EventEmitter, FocusHandle, FocusMap, ForegroundExecutor, Global, KeyBinding, KeyContext,
     Keymap, Keystroke, LayoutId, Menu, MenuItem, OwnedMenu, PathPromptOptions, Pixels, Platform,
-    PlatformDisplay, PlatformKeyboardLayout, PlatformKeyboardMapper, Point, PromptBuilder,
-    PromptButton, PromptHandle, PromptLevel, Render, RenderImage, RenderablePromptHandle,
-    Reservation, ScreenCaptureSource, SharedString, SubscriberSet, Subscription, SvgRenderer, Task,
-    TextSystem, Window, WindowAppearance, WindowHandle, WindowId, WindowInvalidator,
+    PlatformDisplay, PlatformKeyboardLayout, Point, PromptBuilder, PromptButton, PromptHandle,
+    PromptLevel, Render, RenderImage, RenderablePromptHandle, Reservation, ScreenCaptureSource,
+    SharedString, SubscriberSet, Subscription, SvgRenderer, Task, TextSystem, Window,
+    WindowAppearance, WindowHandle, WindowId, WindowInvalidator,
     colors::{Colors, GlobalColors},
     current_platform, hash, init_app_menus,
 };
@@ -165,6 +165,16 @@ impl Application {
     pub fn with_http_client(self, http_client: Arc<dyn HttpClient>) -> Self {
         let mut context_lock = self.0.borrow_mut();
         context_lock.http_client = http_client;
+        drop(context_lock);
+        self
+    }
+
+    /// Sets the behaviour of the event loop when all windows are closed.
+    pub fn keep_running(self, keep_running: bool) -> Self {
+        let mut context_lock = self.0.borrow_mut();
+        context_lock
+            .platform
+            .set_quit_when_last_window_closes(!keep_running);
         drop(context_lock);
         self
     }

--- a/crates/gpui/src/platform.rs
+++ b/crates/gpui/src/platform.rs
@@ -231,6 +231,7 @@ pub(crate) trait Platform: 'static {
 
     fn on_quit(&self, callback: Box<dyn FnMut()>);
     fn on_reopen(&self, callback: Box<dyn FnMut()>);
+    fn set_quit_when_last_window_closes(&self, should_quit: bool);
 
     fn set_menus(&self, menus: Vec<Menu>, keymap: &Keymap);
     fn get_menus(&self) -> Option<Vec<OwnedMenu>> {

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -92,6 +92,7 @@ pub(crate) struct LinuxCommon {
     pub(crate) text_system: Arc<dyn PlatformTextSystem>,
     pub(crate) appearance: WindowAppearance,
     pub(crate) auto_hide_scrollbars: bool,
+    pub(crate) quit_when_last_window_closes: bool,
     pub(crate) callbacks: PlatformHandlers,
     pub(crate) signal: LoopSignal,
     pub(crate) menus: Vec<OwnedMenu>,
@@ -118,6 +119,7 @@ impl LinuxCommon {
             text_system,
             appearance: WindowAppearance::Light,
             auto_hide_scrollbars: false,
+            quit_when_last_window_closes: true,
             callbacks,
             signal,
             menus: Vec::new(),
@@ -150,6 +152,10 @@ impl<P: LinuxClient + 'static> Platform for P {
 
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.with_common(|common| common.callbacks.keyboard_layout_change = Some(callback));
+    }
+
+    fn set_quit_when_last_window_closes(&self, should_quit: bool) {
+        self.with_common(|common| common.quit_when_last_window_closes = should_quit);
     }
 
     fn run(&self, on_finish_launching: Box<dyn FnOnce()>) {

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -353,7 +353,7 @@ impl WaylandClientStatePtr {
             }
             changed
         } else {
-            let changed: bool = &UNKNOWN_KEYBOARD_LAYOUT_NAME != state.keyboard_layout.name();
+            let changed = &UNKNOWN_KEYBOARD_LAYOUT_NAME != state.keyboard_layout.name();
             if changed {
                 state.keyboard_layout = LinuxKeyboardLayout::new(UNKNOWN_KEYBOARD_LAYOUT_NAME);
             }

--- a/crates/gpui/src/platform/linux/wayland/client.rs
+++ b/crates/gpui/src/platform/linux/wayland/client.rs
@@ -353,7 +353,7 @@ impl WaylandClientStatePtr {
             }
             changed
         } else {
-            let changed = &UNKNOWN_KEYBOARD_LAYOUT_NAME != state.keyboard_layout.name();
+            let changed: bool = &UNKNOWN_KEYBOARD_LAYOUT_NAME != state.keyboard_layout.name();
             if changed {
                 state.keyboard_layout = LinuxKeyboardLayout::new(UNKNOWN_KEYBOARD_LAYOUT_NAME);
             }
@@ -383,7 +383,8 @@ impl WaylandClientStatePtr {
         {
             state.keyboard_focused_window = Some(window);
         }
-        if state.windows.is_empty() {
+
+        if state.common.quit_when_last_window_closes && state.windows.is_empty() {
             state.common.signal.stop();
         }
     }

--- a/crates/gpui/src/platform/linux/x11/client.rs
+++ b/crates/gpui/src/platform/linux/x11/client.rs
@@ -247,7 +247,7 @@ impl X11ClientStatePtr {
         }
         state.cursor_styles.remove(&x_window);
 
-        if state.windows.is_empty() {
+        if state.common.quit_when_last_window_closes && state.windows.is_empty() {
             state.common.signal.stop();
         }
     }

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -213,6 +213,7 @@ impl MacPlatform {
             finish_launching: None,
             dock_menu: None,
             on_keyboard_layout_change: None,
+            quit_when_last_window_closes: false,
             menus: None,
             keyboard_mapper,
         }))
@@ -870,6 +871,11 @@ impl Platform for MacPlatform {
 
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.0.lock().on_keyboard_layout_change = Some(callback);
+    }
+
+    fn set_quit_when_last_window_closes(&self, should_quit: bool) {
+        self.0.lock().quit_when_last_window_closes = should_quit;
+        unimplemented!("quit_when_last_window_closes is not implemented on macOS yet");
     }
 
     fn on_app_menu_action(&self, callback: Box<dyn FnMut(&dyn Action)>) {

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -163,6 +163,7 @@ pub(crate) struct MacPlatformState {
     metadata_pasteboard_type: id,
     reopen: Option<Box<dyn FnMut()>>,
     on_keyboard_layout_change: Option<Box<dyn FnMut()>>,
+    quit_when_last_window_closes: bool,
     quit: Option<Box<dyn FnMut()>>,
     menu_command: Option<Box<dyn FnMut(&dyn Action)>>,
     validate_menu_command: Option<Box<dyn FnMut(&dyn Action) -> bool>>,

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -52,6 +52,7 @@ pub(crate) struct WindowsPlatformState {
     callbacks: PlatformCallbacks,
     menus: Vec<OwnedMenu>,
     jump_list: JumpList,
+    quit_when_last_window_closes: bool,
     // NOTE: standard cursor handles don't need to close.
     pub(crate) current_cursor: Option<HCURSOR>,
 }
@@ -78,6 +79,7 @@ impl WindowsPlatformState {
             jump_list,
             current_cursor,
             menus: Vec::new(),
+            quit_when_last_window_closes: true,
         }
     }
 }
@@ -161,7 +163,7 @@ impl WindowsPlatform {
             .unwrap();
         lock.remove(index);
 
-        lock.is_empty()
+        self.state.borrow().quit_when_last_window_closes && lock.is_empty()
     }
 
     #[inline]
@@ -357,6 +359,10 @@ impl Platform for WindowsPlatform {
 
     fn on_keyboard_layout_change(&self, callback: Box<dyn FnMut()>) {
         self.state.borrow_mut().callbacks.keyboard_layout_change = Some(callback);
+    }
+
+    fn set_quit_when_last_window_closes(&self, should_quit: bool) {
+        self.state.borrow_mut().quit_when_last_window_closes = should_quit;
     }
 
     fn run(&self, on_finish_launching: Box<dyn 'static + FnOnce()>) {


### PR DESCRIPTION
This PR adds the option to prevent the event loop from exiting when the last window is closed by the user.

This is needs more thought because:
1. The naming might not be the best
2. This wasnt tested on all platforms
3. MacOS is special and we need to make a decision on the api about the fact that it has the opposite behaviours as the other os

Release Notes:

- Added the option to keep the application running with no window open
