### PR TITLE
project: Register dynamic capabilities even when registerOptions doesn't exist

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -12041,16 +12041,15 @@ impl LspStore {
     }
 }
 
-// Registration with empty capabilities should be ignored.
-// https://github.com/microsoft/vscode-languageserver-node/blob/d90a87f9557a0df9142cfb33e251cfa6fe27d970/client/src/common/formatting.ts#L67-L70
+// Registration with registerOptions as null, should fallback to true.
+// https://github.com/microsoft/vscode-languageserver-node/blob/d90a87f9557a0df9142cfb33e251cfa6fe27d970/client/src/common/client.ts#L2133
 fn parse_register_capabilities<T: serde::de::DeserializeOwned>(
     reg: lsp::Registration,
 ) -> anyhow::Result<Option<OneOf<bool, T>>> {
-    Ok(reg
-        .register_options
-        .map(|options| serde_json::from_value::<T>(options))
-        .transpose()?
-        .map(OneOf::Right))
+    Ok(match reg.register_options {
+        Some(options) => Some(OneOf::Right(serde_json::from_value::<T>(options)?)),
+        None => Some(OneOf::Left(true)),
+    })
 }
 
 fn subscribe_to_binary_statuses(


### PR DESCRIPTION
Closes #36482

Looks like we accidentally referenced [common/formatting.ts#L67-L70](https://github.com/microsoft/vscode-languageserver-node/blob/d90a87f9557a0df9142cfb33e251cfa6fe27d970/client/src/common/formatting.ts#L67-L70) instead of [common/client.ts#L2133](https://github.com/microsoft/vscode-languageserver-node/blob/d90a87f9557a0df9142cfb33e251cfa6fe27d970/client/src/common/client.ts#L2133).

Release Notes:

- Fixed code not formatting on save in language servers like Biome. (Preview Only)
