### PR TITLE
gpui: Add "swipe to navigate" for macOS

### DIFF
--- a/crates/gpui/src/interactive.rs
+++ b/crates/gpui/src/interactive.rs
@@ -542,6 +542,23 @@ impl InputEvent for FileDropEvent {
 }
 impl MouseEvent for FileDropEvent {}
 
+/// A swipe direction on macOS.
+#[derive(Hash, PartialEq, Eq, Copy, Clone, Debug)]
+#[allow(missing_docs)]
+pub enum SwipeDirection {
+    Left,
+    Right,
+    Up,
+    Down,
+}
+/// Recognizing touch pad gesture, such as swipe.
+/// For now only swipe is supported.
+#[derive(Clone, Copy, Eq, PartialEq, Debug)]
+pub enum TouchPadGestureEvent {
+    /// A swipe gesture was performed.
+    Swipe(SwipeDirection),
+}
+
 /// An enum corresponding to all kinds of platform input events.
 #[derive(Clone, Debug)]
 pub enum PlatformInput {
@@ -563,6 +580,8 @@ pub enum PlatformInput {
     ScrollWheel(ScrollWheelEvent),
     /// Files were dragged and dropped onto the window.
     FileDrop(FileDropEvent),
+    /// Touch pad gesture was performed.
+    TouchPad(TouchPadGestureEvent),
 }
 
 impl PlatformInput {
@@ -577,6 +596,7 @@ impl PlatformInput {
             PlatformInput::MouseExited(event) => Some(event),
             PlatformInput::ScrollWheel(event) => Some(event),
             PlatformInput::FileDrop(event) => Some(event),
+            PlatformInput::TouchPad(_) => None,
         }
     }
 
@@ -591,6 +611,13 @@ impl PlatformInput {
             PlatformInput::MouseExited(_) => None,
             PlatformInput::ScrollWheel(_) => None,
             PlatformInput::FileDrop(_) => None,
+            PlatformInput::TouchPad(_) => None,
+        }
+    }
+    pub(crate) fn touchpad_event(&self) -> Option<&TouchPadGestureEvent> {
+        match self {
+            PlatformInput::TouchPad(event) => Some(event),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Closes #4954 

Replaces https://github.com/zed-industries/zed/pull/14939 

Release Notes:

Added: 
* Swipe to Navigate for macOS
* Listeners for both horizontal and vertical swipes
* Only active for horizontal for now

Requires these macOS settings: 
![image](https://github.com/user-attachments/assets/09e72ba6-7ae2-467f-b379-dde1b9455ae2)

Older macOS settings: 
![image](https://github.com/user-attachments/assets/895e540f-dc46-4d18-9f7a-7aa0516cebbc)



Note: 
I altered the logic from https://github.com/zed-industries/zed/pull/23332 or more specifically, I hard-coded the values to match native macOS swiping. I don't have that exact mouse and software to try to see if it works with the new values.
Either way, mouse navigation with btn4/5 still works out of the box on macOS for most mouses. 
Whatever custom software that mouse uses, it disguises itself as a swipe event, so hopefully it also matches the delta values of one. 

Thinking of using config to register custom actions to send for either axis, while defaulting for tab navigation for horizontal, and disabled for vertical, but that would be a separate PR. 

Something like
```json
"workbench.editor.swipeToNavigate": {
  "horizontal": "disabled",
  "vertical": { "previous": "customAction", "next": "someOtherCustomAction" }
}
```

Release Notes:

- Added three finger swipe to navigate.

