### PR TITLE
windows: Fix `RevealInFileManager`

### DIFF
--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -783,6 +783,9 @@ fn open_target_in_explorer(target: &Path) -> Result<()> {
     let highlight = [file_item as *const _];
     unsafe { SHOpenFolderAndSelectItems(dir_item as _, Some(&highlight), 0) }.or_else(|err| {
         if err.code().0 == ERROR_FILE_NOT_FOUND.0 as i32 {
+            // On some systems, the above call mysteriously fails with "file not
+            // found" even though the file is there.  In these cases, ShellExecute()
+            // seems to work as a fallback (although it won't select the file).
             open_target(dir).context("Opening target parent folder")
         } else {
             Err(anyhow::anyhow!("Can not open target path: {}", err))

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -520,13 +520,9 @@ impl Platform for WindowsPlatform {
         let path = path.to_path_buf();
         self.background_executor()
             .spawn(async move {
-                let Some(path) = file_full_path.to_str() else {
-                    return;
-                };
-                if path.is_empty() {
-                    return;
-                }
-                open_target_in_explorer(path);
+                open_target_in_explorer(path)
+                    .context("Revealing path in explorer")
+                    .log_err();
             })
             .detach();
     }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -467,8 +467,8 @@ impl Platform for WindowsPlatform {
         let url_string = url.to_string();
         self.background_executor()
             .spawn(async move {
-                open_target(url_string)
-                    .with_context(|| format!("Opening url: {}", url))
+                open_target(&url_string)
+                    .with_context(|| format!("Opening url: {}", url_string))
                     .log_err();
             })
             .detach();
@@ -537,7 +537,7 @@ impl Platform for WindowsPlatform {
         let path = path.to_path_buf();
         self.background_executor()
             .spawn(async move {
-                open_target(path)
+                open_target(&path)
                     .with_context(|| format!("Opening {} with system", path.display()))
                     .log_err();
             })


### PR DESCRIPTION
Closes #36314

This PR takes inspiration from [Electron’s implementation](https://github.com/electron/electron/blob/dd54e84a58531b52680f7f736f593ee887eff6a7/shell/common/platform_util_win.cc#L268-L314).

Before and after:


https://github.com/user-attachments/assets/53eec5d3-23c7-4ee1-8477-e524b0538f60



Release Notes:

- N/A
