### PR TITLE
Fix `clippy::assertions_on_constants` lint violations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -826,6 +826,7 @@ style = { level = "allow", priority = -1 }
 
 # Temporary list of style lints that we've fixed so far.
 # Progress is being tracked in #36577
+assertions_on_constants = "warn"
 blocks_in_conditions = "warn"
 bool_assert_comparison = "warn"
 borrow_interior_mutable_const = "warn"

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -418,8 +418,7 @@ async fn test_handle_start_debugging_request(
                 Ok(())
             });
             client.on_request::<dap::requests::Attach, _>(move |_, _| {
-                assert!(false, "should not get attach request");
-                Ok(())
+                panic!("should not get attach request");
             });
         }
     });

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -10925,8 +10925,7 @@ impl LspStore {
                         .or_default()
                         .entry(server_id)
                         .and_modify(|_| {
-                            assert!(
-                            false,
+                            panic!(
                             "There should not be an existing snapshot for a newly inserted buffer"
                         )
                         })

--- a/crates/terminal/src/terminal_hyperlinks.rs
+++ b/crates/terminal/src/terminal_hyperlinks.rs
@@ -1210,8 +1210,7 @@ mod tests {
                 check_hyperlink_match.check_iri_and_match(hyperlink_word, &hyperlink_match);
             }
             _ => {
-                assert!(
-                    false,
+                panic!(
                     "No hyperlink found\n     at {source_location}:\n{}",
                     check_hyperlink_match.format_renderable_content()
                 )


### PR DESCRIPTION
Related #36577

Release Notes:

- N/A
