### PR TITLE
client: Fix `is_connected` check

### DIFF
--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -293,7 +293,7 @@ pub enum Status {
 
 impl Status {
     pub fn is_connected(&self) -> bool {
-        matches!(self, Self::Connected { .. })
+        matches!(self, Self::Connected { .. } | Self::Authenticated)
     }
 
     pub fn is_signing_in(&self) -> bool {


### PR DESCRIPTION
This fixes the agent panel's settings view where we wouldn't show the user's plan badge near the Zed provider despite the user being signed in.

Release Notes:

- Fix the user's plan badge near the Zed provider in the agent panel not showing despite being signed in.
