### PR TITLE
git_ui: Add staged/unstaged view mode like VS Code

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -746,6 +746,7 @@
     //
     // Default: false
     "collapse_untracked_diff": false,
+    "display_mode": "tracked_untracked",
     "scrollbar": {
       // When to show the scrollbar in the git panel.
       //

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -36,6 +36,14 @@ pub enum StatusStyle {
     LabelColor,
 }
 
+#[derive(Default, Copy, Clone, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DisplayMode {
+    #[default]
+    TrackedUntracked,
+    StagedUnstaged,
+}
+
 #[derive(Clone, Default, Serialize, Deserialize, JsonSchema, Debug)]
 pub struct GitPanelSettingsContent {
     /// Whether to show the panel button in the status bar.
@@ -75,6 +83,13 @@ pub struct GitPanelSettingsContent {
     ///
     /// Default: false
     pub collapse_untracked_diff: Option<bool>,
+
+    /// How to group files in the git panel.
+    /// - `tracked_untracked`: Groups files by tracked vs untracked status (default)
+    /// - `staged_unstaged`: Groups files by staged vs unstaged status (like VSCode)
+    ///
+    /// Default: tracked_untracked
+    pub display_mode: Option<DisplayMode>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
@@ -87,6 +102,7 @@ pub struct GitPanelSettings {
     pub fallback_branch_name: String,
     pub sort_by_path: bool,
     pub collapse_untracked_diff: bool,
+    pub display_mode: DisplayMode,
 }
 
 impl Settings for GitPanelSettings {


### PR DESCRIPTION
Closes #26560

Release Notes:

- Added a new settings option to `git_panel` settings `display_mode` that allows you to switch to a mode similar to VSCode's default which groups files by staged/unstaged instead of tracked vs untracked. If a file has some staged changes and some unstaged changes at the same time, it will appear in both sections just like VSCode.

https://github.com/user-attachments/assets/4dc9298c-2fa7-4efc-9e55-ab38e5333041

