### PR TITLE
acp: Suggest upgrading to preview instead of latest

### DIFF
--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -89,7 +89,7 @@ impl AgentServer for Gemini {
                             current_version
                         ).into(),
                         upgrade_message: "Upgrade Gemini CLI to latest".into(),
-                        upgrade_command: "npm install -g @google/gemini-cli@latest".into(),
+                        upgrade_command: "npm install -g @google/gemini-cli@preview".into(),
                     }.into())
                 }
             }


### PR DESCRIPTION
A previous PR changed the install command from `@latest` to `@preview`, but the upgrade command kept suggesting `@latest`.

Release Notes:

- N/A
