### PR TITLE
Add a non-style lint exclusion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -802,7 +802,10 @@ unexpected_cfgs = { level = "allow" }
 dbg_macro = "deny"
 todo = "deny"
 
-# trying this out
+# This is not a style lint, see https://github.com/rust-lang/rust-clippy/pull/15454
+# Remove when the lint gets promoted to `suspicious`.
+declare_interior_mutable_const = "deny"
+
 redundant_clone = "deny"
 
 # We currently do not restrict any style rules


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/36651
Restores https://github.com/zed-industries/zed/pull/35955 footgun guard.

Release Notes:

- N/A
