### PR TITLE
collab: Add Orb subscription status and period to `billing_subscriptions` table

### DIFF
--- a/crates/collab/migrations/20250821133754_add_orb_subscription_status_and_period_to_billing_subscriptions.sql
+++ b/crates/collab/migrations/20250821133754_add_orb_subscription_status_and_period_to_billing_subscriptions.sql
@@ -1,0 +1,4 @@
+alter table billing_subscriptions
+    add column orb_subscription_status text,
+    add column orb_current_billing_period_start_date timestamp without time zone,
+    add column orb_current_billing_period_end_date timestamp without time zone;


### PR DESCRIPTION
This PR adds the following new columns to the `billing_subscriptions` table:

- `orb_subscription_status`
- `orb_current_billing_period_start_date`
- `orb_current_billing_period_end_date`

Release Notes:

- N/A
