### PR TITLE
acp: Refactor agent2 `send` to have a clearer control flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,7 @@ dependencies = [
  "terminal",
  "text",
  "theme",
+ "thiserror 2.0.12",
  "tree-sitter-rust",
  "ui",
  "unindent",

--- a/crates/agent2/Cargo.toml
+++ b/crates/agent2/Cargo.toml
@@ -61,6 +61,7 @@ sqlez.workspace = true
 task.workspace = true
 telemetry.workspace = true
 terminal.workspace = true
+thiserror.workspace = true
 text.workspace = true
 ui.workspace = true
 util.workspace = true


### PR DESCRIPTION
Release Notes:

- N/A
