### PR TITLE
ruby: Improve Ruby test and debug task configurations

### DIFF
--- a/docs/src/languages/ruby.md
+++ b/docs/src/languages/ruby.md
@@ -299,6 +299,7 @@ To run tests in your Ruby project, you can set up custom tasks in your local `.z
       "-n",
       "\"$ZED_CUSTOM_RUBY_TEST_NAME\""
     ],
+    "cwd": "$ZED_WORKTREE_ROOT",
     "tags": ["ruby-test"]
   }
 ]
@@ -321,6 +322,7 @@ Plain minitest does not support running tests by line number, only by name, so w
       "-n",
       "\"$ZED_CUSTOM_RUBY_TEST_NAME\""
     ],
+    "cwd": "$ZED_WORKTREE_ROOT",
     "tags": ["ruby-test"]
   }
 ]
@@ -334,6 +336,7 @@ Plain minitest does not support running tests by line number, only by name, so w
     "label": "test $ZED_RELATIVE_FILE:$ZED_ROW",
     "command": "bundle",
     "args": ["exec", "rspec", "\"$ZED_RELATIVE_FILE:$ZED_ROW\""],
+    "cwd": "$ZED_WORKTREE_ROOT",
     "tags": ["ruby-test"]
   }
 ]
@@ -369,7 +372,7 @@ The Ruby extension provides a debug adapter for debugging Ruby code. Zed's name 
     "label": "Debug Rails server",
     "adapter": "rdbg",
     "request": "launch",
-    "command": "$ZED_WORKTREE_ROOT/bin/rails",
+    "command": "./bin/rails",
     "args": ["server"],
     "cwd": "$ZED_WORKTREE_ROOT",
     "env": {


### PR DESCRIPTION
Hi! This pull request adds missing `cwd` field to all Ruby test tasks
otherwise `rdbg` will be broken when the user tries to debug a test. Thanks!

Release Notes:

- N/A
