### PR TITLE
ci: Switch Windows jobs to target explicit tag

### DIFF
--- a/.github/actionlint.yml
+++ b/.github/actionlint.yml
@@ -30,3 +30,15 @@ self-hosted-runner:
     # Self Hosted Runners
     - self-mini-macos
     - self-32vcpu-windows-2022
+
+# Disable shellcheck because it doesn't like powershell
+# This should have been triggered with initial rollout of actionlint
+# but https://github.com/zed-industries/zed/pull/36693
+# somehow caused actionlint to actually check those windows jobs
+# where previously they were being skipped. Likely caused by an
+# unknown bug in actionlint where parsing of `runs-on: [ ]`
+# breaks something else. (yuck)
+paths:
+  .github/workflows/{ci,release_nightly}.yml:
+    ignore:
+      - "shellcheck"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,7 +418,7 @@ jobs:
     if: |
       github.repository_owner == 'zed-industries' &&
       needs.job_spec.outputs.run_tests == 'true'
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-32vcpu-windows-2022]
     steps:
       - name: Environment Setup
         run: |
@@ -784,7 +784,7 @@ jobs:
   bundle-windows-x64:
     timeout-minutes: 120
     name: Create a Windows installer
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-32vcpu-windows-2022]
     if: contains(github.event.pull_request.labels.*.name, 'run-bundling')
     # if: (startsWith(github.ref, 'refs/tags/v') || contains(github.event.pull_request.labels.*.name, 'run-bundling'))
     needs: [windows_tests]

--- a/.github/workflows/release_nightly.yml
+++ b/.github/workflows/release_nightly.yml
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 60
     name: Run tests on Windows
     if: github.repository_owner == 'zed-industries'
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-32vcpu-windows-2022]
     steps:
       - name: Checkout repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
@@ -248,7 +248,7 @@ jobs:
     timeout-minutes: 60
     name: Create a Windows installer
     if: github.repository_owner == 'zed-industries'
-    runs-on: [self-hosted, Windows, X64]
+    runs-on: [self-32vcpu-windows-2022]
     needs: windows-tests
     env:
       AZURE_TENANT_ID: ${{ secrets.AZURE_SIGNING_TENANT_ID }}


### PR DESCRIPTION
The previous tags are non-customizable (added by default).
This will enable us to pull specific runs out of the pool for maintenance.

Also disable actionlint invoking shellcheck because it chokes on PowerShell. 

Release Notes:

- N/A
