### PR TITLE
onboarding: Improve Windows/Linux keyboard shortcuts; example ligature

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -16,7 +16,6 @@
       "up": "menu::SelectPrevious",
       "enter": "menu::Confirm",
       "ctrl-enter": "menu::SecondaryConfirm",
-      "ctrl-escape": "menu::Cancel",
       "ctrl-c": "menu::Cancel",
       "escape": "menu::Cancel",
       "alt-shift-enter": "menu::Restart",
@@ -1195,8 +1194,8 @@
       "ctrl-1": "onboarding::ActivateBasicsPage",
       "ctrl-2": "onboarding::ActivateEditingPage",
       "ctrl-3": "onboarding::ActivateAISetupPage",
-      "ctrl-escape": "onboarding::Finish",
-      "alt-tab": "onboarding::SignIn",
+      "ctrl-enter": "onboarding::Finish",
+      "alt-shift-l": "onboarding::SignIn",
       "alt-shift-a": "onboarding::OpenAccount"
     }
   }

--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -606,7 +606,7 @@ fn render_popular_settings_section(
     cx: &mut App,
 ) -> impl IntoElement {
     const LIGATURE_TOOLTIP: &str =
-        "Font ligatures combine two characters into one. For example, turning =/= into ≠.";
+        "Font ligatures combine two characters into one. For example, turning != into ≠.";
 
     v_flex()
         .pt_6()


### PR DESCRIPTION
Small fixes to onboarding.
Correct ligature example.
Replace`ctrl-escape` and `alt-tab` since they are reserved on windows (and often on linux) and so are caught by the OS.

| Before | After |
| - | - |
| <img width="491" height="117" alt="Screenshot 2025-08-21 142604" src="https://github.com/user-attachments/assets/504fba69-9d3a-4c98-87a8-35772180f83f" /> | <img width="519" height="128" alt="Screenshot 2025-08-21 143935" src="https://github.com/user-attachments/assets/eb93607d-1b19-408a-8819-7d8f1250c4b1" /> |
| <img width="444" height="529" alt="Screenshot 2025-08-21 145853" src="https://github.com/user-attachments/assets/df461dec-4e4c-4db0-b5f4-f60ea9a3d65a" /> | <img width="406" height="507" alt="Screenshot 2025-08-21 150050" src="https://github.com/user-attachments/assets/ca343eb7-cabf-4758-bf9e-186eb1c81a82" /> |

Release Notes:

- N/A
