### PR TITLE
ai: Auto select user model when there's no default

### DIFF
--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -451,6 +451,7 @@ impl Thread {
     ) -> Self {
         let (detailed_summary_tx, detailed_summary_rx) = postage::watch::channel();
         let configured_model = LanguageModelRegistry::read_global(cx).default_model();
+        configured_model.as_ref().map(|model| model.model.name());
         let profile_id = AgentSettings::get_global(cx).default_profile.clone();
 
         Self {
@@ -664,7 +665,7 @@ impl Thread {
     }
 
     pub fn get_or_init_configured_model(&mut self, cx: &App) -> Option<ConfiguredModel> {
-        if self.configured_model.is_none() {
+        if self.configured_model.is_none() || self.messages.is_empty() {
             self.configured_model = LanguageModelRegistry::read_global(cx).default_model();
         }
         self.configured_model.clone()

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -451,7 +451,6 @@ impl Thread {
     ) -> Self {
         let (detailed_summary_tx, detailed_summary_rx) = postage::watch::channel();
         let configured_model = LanguageModelRegistry::read_global(cx).default_model();
-        configured_model.as_ref().map(|model| model.model.name());
         let profile_id = AgentSettings::get_global(cx).default_profile.clone();
 
         Self {

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2097,7 +2097,7 @@ impl Thread {
     }
 
     pub fn summarize(&mut self, cx: &mut Context<Self>) {
-        let Some(model) = LanguageModelRegistry::read_global(cx).thread_summary_model() else {
+        let Some(model) = LanguageModelRegistry::read_global(cx).thread_summary_model(cx) else {
             println!("No thread summary model");
             return;
         };
@@ -2416,7 +2416,7 @@ impl Thread {
         }
 
         let Some(ConfiguredModel { model, provider }) =
-            LanguageModelRegistry::read_global(cx).thread_summary_model()
+            LanguageModelRegistry::read_global(cx).thread_summary_model(cx)
         else {
             return;
         };
@@ -5410,13 +5410,10 @@ fn main() {{
                     }),
                     cx,
                 );
-                registry.set_thread_summary_model(
-                    Some(ConfiguredModel {
-                        provider,
-                        model: model.clone(),
-                    }),
-                    cx,
-                );
+                registry.set_thread_summary_model(Some(ConfiguredModel {
+                    provider,
+                    model: model.clone(),
+                }));
             })
         });
 

--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -228,7 +228,7 @@ impl NativeAgent {
     ) -> Entity<AcpThread> {
         let connection = Rc::new(NativeAgentConnection(cx.entity()));
         let registry = LanguageModelRegistry::read_global(cx);
-        let summarization_model = registry.thread_summary_model().map(|c| c.model);
+        let summarization_model = registry.thread_summary_model(cx).map(|c| c.model);
 
         thread_handle.update(cx, |thread, cx| {
             thread.set_summarization_model(summarization_model, cx);
@@ -500,7 +500,7 @@ impl NativeAgent {
 
         let registry = LanguageModelRegistry::read_global(cx);
         let default_model = registry.default_model().map(|m| m.model);
-        let summarization_model = registry.thread_summary_model().map(|m| m.model);
+        let summarization_model = registry.thread_summary_model(cx).map(|m| m.model);
 
         for session in self.sessions.values_mut() {
             session.thread.update(cx, |thread, cx| {

--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -1400,11 +1400,11 @@ async fn test_agent_connection(cx: &mut TestAppContext) {
         let clock = Arc::new(clock::FakeSystemClock::new());
         let client = Client::new(clock, http_client, cx);
         let user_store = cx.new(|cx| UserStore::new(client.clone(), cx));
+        Project::init_settings(cx);
+        agent_settings::init(cx);
         language_model::init(client.clone(), cx);
         language_models::init(user_store, client.clone(), cx);
-        Project::init_settings(cx);
         LanguageModelRegistry::test(cx);
-        agent_settings::init(cx);
     });
     cx.executor().forbid_parking();
 

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -373,7 +373,6 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         .collect::<Vec<_>>();
 
     LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
-        dbg!(&default);
         registry.select_default_model(default.as_ref(), cx);
         registry.select_inline_assistant_model(inline_assistant.as_ref(), cx);
         registry.select_commit_message_model(commit_message.as_ref(), cx);

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -373,6 +373,7 @@ fn update_active_language_model_from_settings(cx: &mut App) {
         .collect::<Vec<_>>();
 
     LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
+        dbg!(&default);
         registry.select_default_model(default.as_ref(), cx);
         registry.select_inline_assistant_model(inline_assistant.as_ref(), cx);
         registry.select_commit_message_model(commit_message.as_ref(), cx);

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -6,11 +6,13 @@ use feature_flags::ZedProFeatureFlag;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{Action, AnyElement, App, BackgroundExecutor, DismissEvent, Subscription, Task};
 use language_model::{
-    AuthenticateError, ConfiguredModel, LanguageModel, LanguageModelProviderId,
+    AuthenticateError, ConfiguredModel, LanguageModel, LanguageModelName, LanguageModelProviderId,
     LanguageModelRegistry,
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
+use project::DisableAiSettings;
+use settings::Settings;
 use ui::{ListItem, ListItemSpacing, prelude::*};
 
 const TRY_ZED_PRO_URL: &str = "https://zed.dev/pro";
@@ -77,7 +79,6 @@ pub struct LanguageModelPickerDelegate {
     all_models: Arc<GroupedModels>,
     filtered_entries: Vec<LanguageModelPickerEntry>,
     selected_index: usize,
-    _authenticate_all_providers_task: Task<()>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -98,7 +99,6 @@ impl LanguageModelPickerDelegate {
             selected_index: Self::get_active_model_index(&entries, get_active_model(cx)),
             filtered_entries: entries,
             get_active_model: Arc::new(get_active_model),
-            _authenticate_all_providers_task: Self::authenticate_all_providers(cx),
             _subscriptions: vec![cx.subscribe_in(
                 &LanguageModelRegistry::global(cx),
                 window,
@@ -140,56 +140,6 @@ impl LanguageModelPickerDelegate {
                 }
             })
             .unwrap_or(0)
-    }
-
-    /// Authenticates all providers in the [`LanguageModelRegistry`].
-    ///
-    /// We do this so that we can populate the language selector with all of the
-    /// models from the configured providers.
-    fn authenticate_all_providers(cx: &mut App) -> Task<()> {
-        let authenticate_all_providers = LanguageModelRegistry::global(cx)
-            .read(cx)
-            .providers()
-            .iter()
-            .map(|provider| (provider.id(), provider.name(), provider.authenticate(cx)))
-            .collect::<Vec<_>>();
-
-        cx.spawn(async move |_cx| {
-            for (provider_id, provider_name, authenticate_task) in authenticate_all_providers {
-                if let Err(err) = authenticate_task.await {
-                    if matches!(err, AuthenticateError::CredentialsNotFound) {
-                        // Since we're authenticating these providers in the
-                        // background for the purposes of populating the
-                        // language selector, we don't care about providers
-                        // where the credentials are not found.
-                    } else {
-                        // Some providers have noisy failure states that we
-                        // don't want to spam the logs with every time the
-                        // language model selector is initialized.
-                        //
-                        // Ideally these should have more clear failure modes
-                        // that we know are safe to ignore here, like what we do
-                        // with `CredentialsNotFound` above.
-                        match provider_id.0.as_ref() {
-                            "lmstudio" | "ollama" => {
-                                // LM Studio and Ollama both make fetch requests to the local APIs to determine if they are "authenticated".
-                                //
-                                // These fail noisily, so we don't log them.
-                            }
-                            "copilot_chat" => {
-                                // Copilot Chat returns an error if Copilot is not enabled, so we don't log those errors.
-                            }
-                            _ => {
-                                log::error!(
-                                    "Failed to authenticate provider: {}: {err}",
-                                    provider_name.0
-                                );
-                            }
-                        }
-                    }
-                }
-            }
-        })
     }
 
     pub fn active_model(&self, cx: &App) -> Option<ConfiguredModel> {

--- a/crates/agent_ui/src/language_model_selector.rs
+++ b/crates/agent_ui/src/language_model_selector.rs
@@ -6,13 +6,10 @@ use feature_flags::ZedProFeatureFlag;
 use fuzzy::{StringMatch, StringMatchCandidate, match_strings};
 use gpui::{Action, AnyElement, App, BackgroundExecutor, DismissEvent, Subscription, Task};
 use language_model::{
-    AuthenticateError, ConfiguredModel, LanguageModel, LanguageModelName, LanguageModelProviderId,
-    LanguageModelRegistry,
+    ConfiguredModel, LanguageModel, LanguageModelProviderId, LanguageModelRegistry,
 };
 use ordered_float::OrderedFloat;
 use picker::{Picker, PickerDelegate};
-use project::DisableAiSettings;
-use settings::Settings;
 use ui::{ListItem, ListItemSpacing, prelude::*};
 
 const TRY_ZED_PRO_URL: &str = "https://zed.dev/pro";

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4466,7 +4466,7 @@ fn current_language_model(cx: &Context<'_, GitPanel>) -> Option<Arc<dyn Language
     is_enabled
         .then(|| {
             let ConfiguredModel { provider, model } =
-                LanguageModelRegistry::read_global(cx).commit_message_model()?;
+                LanguageModelRegistry::read_global(cx).commit_message_model(cx)?;
 
             provider.is_authenticated(cx).then(|| model)
         })

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -104,9 +104,6 @@ impl ConfiguredModel {
 
 pub enum Event {
     DefaultModelChanged,
-    InlineAssistantModelChanged,
-    CommitMessageModelChanged,
-    ThreadSummaryModelChanged,
     ProviderStateChanged(LanguageModelProviderId),
     AddedProvider(LanguageModelProviderId),
     RemovedProvider(LanguageModelProviderId),
@@ -306,42 +303,15 @@ impl LanguageModelRegistry {
         self.default_model = model;
     }
 
-    pub fn set_inline_assistant_model(
-        &mut self,
-        model: Option<ConfiguredModel>,
-        cx: &mut Context<Self>,
-    ) {
-        match (self.inline_assistant_model.as_ref(), model.as_ref()) {
-            (Some(old), Some(new)) if old.is_same_as(new) => {}
-            (None, None) => {}
-            _ => cx.emit(Event::InlineAssistantModelChanged),
-        }
+    pub fn set_inline_assistant_model(&mut self, model: Option<ConfiguredModel>) {
         self.inline_assistant_model = model;
     }
 
-    pub fn set_commit_message_model(
-        &mut self,
-        model: Option<ConfiguredModel>,
-        cx: &mut Context<Self>,
-    ) {
-        match (self.commit_message_model.as_ref(), model.as_ref()) {
-            (Some(old), Some(new)) if old.is_same_as(new) => {}
-            (None, None) => {}
-            _ => cx.emit(Event::CommitMessageModelChanged),
-        }
+    pub fn set_commit_message_model(&mut self, model: Option<ConfiguredModel>) {
         self.commit_message_model = model;
     }
 
-    pub fn set_thread_summary_model(
-        &mut self,
-        model: Option<ConfiguredModel>,
-        cx: &mut Context<Self>,
-    ) {
-        match (self.thread_summary_model.as_ref(), model.as_ref()) {
-            (Some(old), Some(new)) if old.is_same_as(new) => {}
-            (None, None) => {}
-            _ => cx.emit(Event::ThreadSummaryModelChanged),
-        }
+    pub fn set_thread_summary_model(&mut self, model: Option<ConfiguredModel>) {
         self.thread_summary_model = model;
     }
 

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use collections::BTreeMap;
 use gpui::{App, Context, Entity, EventEmitter, Global, prelude::*};
-use std::{panic::Location, str::FromStr, sync::Arc};
+use std::{str::FromStr, sync::Arc};
 use thiserror::Error;
 
 pub fn init(cx: &mut App) {
@@ -301,11 +301,6 @@ impl LanguageModelRegistry {
         model: Option<ConfiguredModel>,
         cx: &mut Context<Self>,
     ) {
-        // todo! Why is environment fallback taking precedence when cloud model is in the settings?
-        dbg!(
-            "Setting environment fallback",
-            model.clone().map(|m| m.model.id())
-        );
         if self.default_model.is_none() {
             match (self.environment_fallback_model.as_ref(), model.as_ref()) {
                 (Some(old), Some(new)) if old.is_same_as(new) => {}

--- a/crates/language_models/Cargo.toml
+++ b/crates/language_models/Cargo.toml
@@ -44,6 +44,7 @@ ollama = { workspace = true, features = ["schemars"] }
 open_ai = { workspace = true, features = ["schemars"] }
 open_router = { workspace = true, features = ["schemars"] }
 partial-json-fixer.workspace = true
+project.workspace = true
 release_channel.workspace = true
 schemars.workspace = true
 serde.workspace = true

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -44,8 +44,8 @@ use crate::provider::anthropic::{AnthropicEventMapper, count_anthropic_tokens, i
 use crate::provider::google::{GoogleEventMapper, into_google};
 use crate::provider::open_ai::{OpenAiEventMapper, count_open_ai_tokens, into_open_ai};
 
-const PROVIDER_ID: LanguageModelProviderId = language_model::ZED_CLOUD_PROVIDER_ID;
-const PROVIDER_NAME: LanguageModelProviderName = language_model::ZED_CLOUD_PROVIDER_NAME;
+pub const PROVIDER_ID: LanguageModelProviderId = language_model::ZED_CLOUD_PROVIDER_ID;
+pub const PROVIDER_NAME: LanguageModelProviderName = language_model::ZED_CLOUD_PROVIDER_NAME;
 
 #[derive(Default, Clone, Debug, PartialEq)]
 pub struct ZedDotDevSettings {

--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -148,7 +148,7 @@ impl State {
             default_fast_model: None,
             recommended_models: Vec::new(),
             _fetch_models_task: cx.spawn(async move |this, cx| {
-                maybe!(async move {
+                maybe!(async {
                     let (client, llm_api_token) = this
                         .read_with(cx, |this, _cx| (client.clone(), this.llm_api_token.clone()))?;
 


### PR DESCRIPTION
This PR identifies automatic configuration options that users can select from the agent panel. If no default provider is set in their settings, the PR defaults to the first recommended option. Additionally, it updates the selected provider for a thread when a user changes the default provider through the settings file, if the thread hasn't had any queries yet.

Release Notes:

- agent: automatically select a language model provider if there's no user set provider.
