### PR TITLE
Hide status bar when it is empty

### DIFF
--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -35,13 +35,16 @@ pub struct StatusBar {
     _observe_active_pane: Subscription,
 }
 
+use log::{info, warn};
+
+
 impl Render for StatusBar {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         h_flex()
             .w_full()
             .justify_between()
             .gap(DynamicSpacing::Base08.rems(cx))
-            .py(DynamicSpacing::Base04.rems(cx))
+            // .py(DynamicSpacing::Base04.rems(cx))
             .px(DynamicSpacing::Base06.rems(cx))
             .bg(cx.theme().colors().status_bar_background)
             .map(|el| match window.window_decorations() {
@@ -60,6 +63,12 @@ impl Render for StatusBar {
             })
             .child(self.render_left_tools())
             .child(self.render_right_tools())
+            .on_children_prepainted(|bounds, _, _| {
+                if bounds.iter().any(|&b| b.size.height > px(0.0)) {
+                  warn!("bar, this is hit.");
+                }
+                warn!("foo: {bounds:?}");
+            })
     }
 }
 


### PR DESCRIPTION
The status bar can be in a state where it is empty. This state was possible previously, but more likely now with recent PRs https://github.com/zed-industries/zed/pull/33977 and https://github.com/zed-industries/zed/pull/36288. 

In this state, Zed currently shows an empty, but visible, slim status bar.

<img width="1486" height="1152" alt="image" src="https://github.com/user-attachments/assets/9ff23a03-3dfe-4abd-94c1-0478c40b2708" />

With this fix:

<img width="1486" height="1152" alt="image" src="https://github.com/user-attachments/assets/d5e7c267-906c-4f3e-afac-9e1d0da66ccd" />

I believe this is much nicer. However, I suspect there could be a much better implementation of this solution. Maybe something more declarative, or simpler, or more performant, etc. Not having much experience with Rust or Zed is probably limiting me here.

An alternative solution can be found here: https://github.com/zed-industries/zed/pull/36738 but I would be happy to hear any feedback or ideas as to the best solution.


Release Notes:

- Status bar is no longer visible when it is empty.
