### PR TITLE
acp: Fix panic with edit file tool

### DIFF
--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -271,10 +271,7 @@ impl AgentTool for EditFileTool {
                 })?
                 .await?;
 
-            let base_text_snapshot = cx.update(|cx| {
-                language::Buffer::build_snapshot(buffer.read(cx).text_snapshot().as_rope().clone(), buffer.read(cx).language().cloned(), buffer.read(cx).language_registry(), cx)
-            })?.await;
-            let diff = cx.new(|cx| Diff::new(buffer.clone(), base_text_snapshot, cx))?;
+            let diff = cx.new(|cx| Diff::new(buffer.clone(), cx))?;
             event_stream.update_diff(diff.clone());
 
             let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -271,7 +271,10 @@ impl AgentTool for EditFileTool {
                 })?
                 .await?;
 
-            let diff = cx.new(|cx| Diff::new(buffer.clone(), cx))?;
+            let base_text_snapshot = cx.update(|cx| {
+                language::Buffer::build_snapshot(buffer.read(cx).text_snapshot().as_rope().clone(), buffer.read(cx).language().cloned(), buffer.read(cx).language_registry(), cx)
+            })?.await;
+            let diff = cx.new(|cx| Diff::new(buffer.clone(), base_text_snapshot, cx))?;
             event_stream.update_diff(diff.clone());
 
             let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;


### PR DESCRIPTION
We had a frequent panic when the agent was using our edit file tool. The root cause was that we were constructing a `BufferDiff` with `BufferDiff::new`, then calling `set_base_text`, but not waiting for that asynchronous operation to finish. This means there was a window of time where the diff's base text was set to the initial value of `""`--that's not a problem in itself, but it was possible for us to call `PendingDiff::update` during that window, which calls `BufferDiff::update_diff`, which calls `BufferDiffSnapshot::new_with_base_buffer`, which takes two arguments `base_text` and `base_text_snapshot` that are supposed to represent the same text. We were getting the first of those arguments from the `base_text` field of `PendingDiff`, which is set immediately to the target base text without waiting for `BufferDiff::set_base_text` to run to completion; and the second from the `BufferDiff` itself, which still has the empty base text during that window.

As a result of that mismatch, we could end up adding `DeletedHunk` diff transforms to the multibuffer for the diff card even though the multibuffer's base text was empty, ultimately leading to a panic very far away in rendering code.

I've fixed this by adding a new `BufferDiff` constructor for the case where the buffer contents and the base text are (initially) the same, like for the diff cards, and so we don't need an async diff calculation. I also added a debug assertion to catch the basic issue here earlier, when `BufferDiffSnapshot::new_with_base_buffer` is called with two base texts that don't match.

Release Notes:

- N/A