### PR TITLE
telemetry: Add panel button clicked event

### DIFF
--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -915,6 +915,11 @@ impl Render for PanelButtons {
                                 .on_click({
                                     let action = action.boxed_clone();
                                     move |_, window, cx| {
+                                        telemetry::event!(
+                                            "Panel Button Clicked",
+                                            name = name,
+                                            toggle_state = !is_open
+                                        );
                                         window.focus(&focus_handle);
                                         window.dispatch_action(action.boxed_clone(), cx)
                                     }


### PR DESCRIPTION
The event has two fields

1. name: The name of the panel being clicked
2. toggle_state: true if clicking to open, otherwise false

cc @katie-z-geer 

Release Notes:

- N/A
