### PR TITLE
Hide status bar when it is empty (alternative solution)

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -787,7 +787,8 @@ impl Render for ActivityIndicator {
         };
         let this = cx.entity().downgrade();
         let truncate_content = content.message.len() > MAX_MESSAGE_LEN;
-        result.gap_2().child(
+        let spaced_result = result.gap_2().py(DynamicSpacing::Base04.rems(cx));
+        spaced_result.child(
             PopoverMenu::new("activity-indicator-popover")
                 .trigger(
                     ButtonLike::new("activity-indicator-trigger").child(

--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -94,6 +94,7 @@ impl Render for DiagnosticIndicator {
         };
 
         indicator
+            .py(DynamicSpacing::Base04.rems(cx))
             .child(
                 ButtonLike::new("diagnostic-indicator")
                     .child(diagnostic_indicator)

--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -76,6 +76,8 @@ impl Render for EditPredictionButton {
 
         let all_language_settings = all_language_settings(None, cx);
 
+        let spaced_div = div().py(DynamicSpacing::Base04.rems(cx));
+
         match all_language_settings.edit_predictions.provider {
             EditPredictionProvider::None => div(),
 
@@ -100,7 +102,7 @@ impl Render for EditPredictionButton {
                 };
 
                 if let Status::Error(e) = status {
-                    return div().child(
+                    return spaced_div.child(
                         IconButton::new("copilot-error", icon)
                             .icon_size(IconSize::Small)
                             .on_click(cx.listener(move |_, _, window, cx| {
@@ -129,7 +131,7 @@ impl Render for EditPredictionButton {
                 }
                 let this = cx.entity();
 
-                div().child(
+                spaced_div.child(
                     PopoverMenu::new("copilot")
                         .menu(move |window, cx| {
                             Some(match status {
@@ -185,7 +187,7 @@ impl Render for EditPredictionButton {
                 let this = cx.entity();
                 let fs = self.fs.clone();
 
-                div().child(
+                spaced_div.child(
                     PopoverMenu::new("supermaven")
                         .menu(move |window, cx| match &status {
                             SupermavenButtonStatus::NeedsActivation(activate_url) => {
@@ -253,7 +255,7 @@ impl Render for EditPredictionButton {
                         "Sign In"
                     };
 
-                    return div().child(
+                    return spaced_div.child(
                         IconButton::new("zed-predict-pending-button", zeta_icon)
                             .shape(IconButtonShape::Square)
                             .indicator(Indicator::dot().color(Color::Muted))
@@ -359,7 +361,7 @@ impl Render for EditPredictionButton {
                     popover_menu = popover_menu.trigger(icon_button);
                 }
 
-                div().child(popover_menu.into_any_element())
+                spaced_div.child(popover_menu.into_any_element())
             }
         }
     }

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -1,12 +1,12 @@
 use editor::{Editor, EditorSettings, MultiBufferSnapshot};
-use gpui::{App, Entity, FocusHandle, Focusable, Subscription, Task, WeakEntity};
+use gpui::{App, Entity, FocusHandle, Focusable, Styled, Subscription, Task, WeakEntity};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsSources};
 use std::{fmt::Write, num::NonZeroU32, time::Duration};
 use text::{Point, Selection};
 use ui::{
-    Button, ButtonCommon, Clickable, Context, FluentBuilder, IntoElement, LabelSize, ParentElement,
+    Button, ButtonCommon, Clickable, Context, DynamicSpacing, FluentBuilder, IntoElement, LabelSize, ParentElement,
     Render, Tooltip, Window, div,
 };
 use util::paths::FILE_ROW_COLUMN_DELIMITER;
@@ -223,39 +223,41 @@ impl Render for CursorPosition {
 
             let context = self.context.clone();
 
-            el.child(
-                Button::new("go-to-line-column", text)
-                    .label_size(LabelSize::Small)
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        if let Some(workspace) = this.workspace.upgrade() {
-                            workspace.update(cx, |workspace, cx| {
-                                if let Some(editor) = workspace
-                                    .active_item(cx)
-                                    .and_then(|item| item.act_as::<Editor>(cx))
-                                    && let Some((_, buffer, _)) = editor.read(cx).active_excerpt(cx)
-                                {
-                                    workspace.toggle_modal(window, cx, |window, cx| {
-                                        crate::GoToLine::new(editor, buffer, window, cx)
-                                    })
-                                }
-                            });
-                        }
-                    }))
-                    .tooltip(move |window, cx| match context.as_ref() {
-                        Some(context) => Tooltip::for_action_in(
-                            "Go to Line/Column",
-                            &editor::actions::ToggleGoToLine,
-                            context,
-                            window,
-                            cx,
-                        ),
-                        None => Tooltip::for_action(
-                            "Go to Line/Column",
-                            &editor::actions::ToggleGoToLine,
-                            window,
-                            cx,
-                        ),
-                    }),
+            el
+              .py(DynamicSpacing::Base04.rems(cx))
+              .child(
+                  Button::new("go-to-line-column", text)
+                      .label_size(LabelSize::Small)
+                      .on_click(cx.listener(|this, _, window, cx| {
+                          if let Some(workspace) = this.workspace.upgrade() {
+                              workspace.update(cx, |workspace, cx| {
+                                  if let Some(editor) = workspace
+                                      .active_item(cx)
+                                      .and_then(|item| item.act_as::<Editor>(cx))
+                                      && let Some((_, buffer, _)) = editor.read(cx).active_excerpt(cx)
+                                  {
+                                      workspace.toggle_modal(window, cx, |window, cx| {
+                                          crate::GoToLine::new(editor, buffer, window, cx)
+                                      })
+                                  }
+                              });
+                          }
+                      }))
+                      .tooltip(move |window, cx| match context.as_ref() {
+                          Some(context) => Tooltip::for_action_in(
+                              "Go to Line/Column",
+                              &editor::actions::ToggleGoToLine,
+                              context,
+                              window,
+                              cx,
+                          ),
+                          None => Tooltip::for_action(
+                              "Go to Line/Column",
+                              &editor::actions::ToggleGoToLine,
+                              window,
+                              cx,
+                          ),
+                      }),
             )
         })
     }

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -6,8 +6,8 @@ use settings::{Settings, SettingsSources};
 use std::{fmt::Write, num::NonZeroU32, time::Duration};
 use text::{Point, Selection};
 use ui::{
-    Button, ButtonCommon, Clickable, Context, DynamicSpacing, FluentBuilder, IntoElement, LabelSize, ParentElement,
-    Render, Tooltip, Window, div,
+    Button, ButtonCommon, Clickable, Context, DynamicSpacing, FluentBuilder, IntoElement,
+    LabelSize, ParentElement, Render, Tooltip, Window, div,
 };
 use util::paths::FILE_ROW_COLUMN_DELIMITER;
 use workspace::{StatusItemView, Workspace, item::ItemHandle};
@@ -223,41 +223,39 @@ impl Render for CursorPosition {
 
             let context = self.context.clone();
 
-            el
-              .py(DynamicSpacing::Base04.rems(cx))
-              .child(
-                  Button::new("go-to-line-column", text)
-                      .label_size(LabelSize::Small)
-                      .on_click(cx.listener(|this, _, window, cx| {
-                          if let Some(workspace) = this.workspace.upgrade() {
-                              workspace.update(cx, |workspace, cx| {
-                                  if let Some(editor) = workspace
-                                      .active_item(cx)
-                                      .and_then(|item| item.act_as::<Editor>(cx))
-                                      && let Some((_, buffer, _)) = editor.read(cx).active_excerpt(cx)
-                                  {
-                                      workspace.toggle_modal(window, cx, |window, cx| {
-                                          crate::GoToLine::new(editor, buffer, window, cx)
-                                      })
-                                  }
-                              });
-                          }
-                      }))
-                      .tooltip(move |window, cx| match context.as_ref() {
-                          Some(context) => Tooltip::for_action_in(
-                              "Go to Line/Column",
-                              &editor::actions::ToggleGoToLine,
-                              context,
-                              window,
-                              cx,
-                          ),
-                          None => Tooltip::for_action(
-                              "Go to Line/Column",
-                              &editor::actions::ToggleGoToLine,
-                              window,
-                              cx,
-                          ),
-                      }),
+            el.py(DynamicSpacing::Base04.rems(cx)).child(
+                Button::new("go-to-line-column", text)
+                    .label_size(LabelSize::Small)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        if let Some(workspace) = this.workspace.upgrade() {
+                            workspace.update(cx, |workspace, cx| {
+                                if let Some(editor) = workspace
+                                    .active_item(cx)
+                                    .and_then(|item| item.act_as::<Editor>(cx))
+                                    && let Some((_, buffer, _)) = editor.read(cx).active_excerpt(cx)
+                                {
+                                    workspace.toggle_modal(window, cx, |window, cx| {
+                                        crate::GoToLine::new(editor, buffer, window, cx)
+                                    })
+                                }
+                            });
+                        }
+                    }))
+                    .tooltip(move |window, cx| match context.as_ref() {
+                        Some(context) => Tooltip::for_action_in(
+                            "Go to Line/Column",
+                            &editor::actions::ToggleGoToLine,
+                            context,
+                            window,
+                            cx,
+                        ),
+                        None => Tooltip::for_action(
+                            "Go to Line/Column",
+                            &editor::actions::ToggleGoToLine,
+                            window,
+                            cx,
+                        ),
+                    }),
             )
         })
     }

--- a/crates/image_viewer/src/image_info.rs
+++ b/crates/image_viewer/src/image_info.rs
@@ -77,11 +77,9 @@ impl Render for ImageInfo {
             .to_string(),
         );
 
-        div()
-            .py(DynamicSpacing::Base04.rems(cx))
-            .child(
-                Button::new("image-metadata", components.join(" • ")).label_size(LabelSize::Small),
-            )
+        div().py(DynamicSpacing::Base04.rems(cx)).child(
+            Button::new("image-metadata", components.join(" • ")).label_size(LabelSize::Small),
+        )
     }
 }
 

--- a/crates/image_viewer/src/image_info.rs
+++ b/crates/image_viewer/src/image_info.rs
@@ -77,9 +77,11 @@ impl Render for ImageInfo {
             .to_string(),
         );
 
-        div().child(
-            Button::new("image-metadata", components.join(" • ")).label_size(LabelSize::Small),
-        )
+        div()
+            .py(DynamicSpacing::Base04.rems(cx))
+            .child(
+                Button::new("image-metadata", components.join(" • ")).label_size(LabelSize::Small),
+            )
     }
 }
 

--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -1,10 +1,10 @@
 use editor::{Editor, EditorSettings};
 use gpui::{
-    Context, Entity, IntoElement, ParentElement, Render, Subscription, WeakEntity, Window, div,
+    Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, WeakEntity, Window, div,
 };
 use language::LanguageName;
 use settings::Settings as _;
-use ui::{Button, ButtonCommon, Clickable, FluentBuilder, LabelSize, Tooltip};
+use ui::{Button, ButtonCommon, Clickable, DynamicSpacing, FluentBuilder, LabelSize, Tooltip};
 use workspace::{StatusItemView, Workspace, item::ItemHandle};
 
 use crate::{LanguageSelector, Toggle};
@@ -54,20 +54,22 @@ impl Render for ActiveBufferLanguage {
                 "Unknown".to_string()
             };
 
-            el.child(
-                Button::new("change-language", active_language_text)
-                    .label_size(LabelSize::Small)
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        if let Some(workspace) = this.workspace.upgrade() {
-                            workspace.update(cx, |workspace, cx| {
-                                LanguageSelector::toggle(workspace, window, cx)
-                            });
-                        }
-                    }))
-                    .tooltip(|window, cx| {
-                        Tooltip::for_action("Select Language", &Toggle, window, cx)
-                    }),
-            )
+            el
+                .py(DynamicSpacing::Base04.rems(cx))
+                .child(
+                  Button::new("change-language", active_language_text)
+                      .label_size(LabelSize::Small)
+                      .on_click(cx.listener(|this, _, window, cx| {
+                          if let Some(workspace) = this.workspace.upgrade() {
+                              workspace.update(cx, |workspace, cx| {
+                                  LanguageSelector::toggle(workspace, window, cx)
+                              });
+                          }
+                      }))
+                      .tooltip(|window, cx| {
+                          Tooltip::for_action("Select Language", &Toggle, window, cx)
+                      }),
+                )
         })
     }
 }

--- a/crates/language_selector/src/active_buffer_language.rs
+++ b/crates/language_selector/src/active_buffer_language.rs
@@ -1,6 +1,7 @@
 use editor::{Editor, EditorSettings};
 use gpui::{
-    Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, WeakEntity, Window, div,
+    Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, WeakEntity, Window,
+    div,
 };
 use language::LanguageName;
 use settings::Settings as _;
@@ -54,22 +55,20 @@ impl Render for ActiveBufferLanguage {
                 "Unknown".to_string()
             };
 
-            el
-                .py(DynamicSpacing::Base04.rems(cx))
-                .child(
-                  Button::new("change-language", active_language_text)
-                      .label_size(LabelSize::Small)
-                      .on_click(cx.listener(|this, _, window, cx| {
-                          if let Some(workspace) = this.workspace.upgrade() {
-                              workspace.update(cx, |workspace, cx| {
-                                  LanguageSelector::toggle(workspace, window, cx)
-                              });
-                          }
-                      }))
-                      .tooltip(|window, cx| {
-                          Tooltip::for_action("Select Language", &Toggle, window, cx)
-                      }),
-                )
+            el.py(DynamicSpacing::Base04.rems(cx)).child(
+                Button::new("change-language", active_language_text)
+                    .label_size(LabelSize::Small)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        if let Some(workspace) = this.workspace.upgrade() {
+                            workspace.update(cx, |workspace, cx| {
+                                LanguageSelector::toggle(workspace, window, cx)
+                            });
+                        }
+                    }))
+                    .tooltip(|window, cx| {
+                        Tooltip::for_action("Select Language", &Toggle, window, cx)
+                    }),
+            )
         })
     }
 }

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -1007,28 +1007,26 @@ impl Render for LspTool {
 
         let lsp_tool = cx.entity();
 
-        div()
-            .py(DynamicSpacing::Base04.rems(cx))
-            .child(
-                PopoverMenu::new("lsp-tool")
-                    .menu(move |_, cx| lsp_tool.read(cx).lsp_menu.clone())
-                    .anchor(Corner::BottomLeft)
-                    .with_handle(self.popover_menu_handle.clone())
-                    .trigger_with_tooltip(
-                        IconButton::new("zed-lsp-tool-button", IconName::BoltOutlined)
-                            .when_some(indicator, IconButton::indicator)
-                            .icon_size(IconSize::Small)
-                            .indicator_border_color(Some(cx.theme().colors().status_bar_background)),
-                        move |window, cx| {
-                            Tooltip::with_meta(
-                                "Language Servers",
-                                Some(&ToggleMenu),
-                                description,
-                                window,
-                                cx,
-                            )
-                        },
-                    ),
-            )
+        div().py(DynamicSpacing::Base04.rems(cx)).child(
+            PopoverMenu::new("lsp-tool")
+                .menu(move |_, cx| lsp_tool.read(cx).lsp_menu.clone())
+                .anchor(Corner::BottomLeft)
+                .with_handle(self.popover_menu_handle.clone())
+                .trigger_with_tooltip(
+                    IconButton::new("zed-lsp-tool-button", IconName::BoltOutlined)
+                        .when_some(indicator, IconButton::indicator)
+                        .icon_size(IconSize::Small)
+                        .indicator_border_color(Some(cx.theme().colors().status_bar_background)),
+                    move |window, cx| {
+                        Tooltip::with_meta(
+                            "Language Servers",
+                            Some(&ToggleMenu),
+                            description,
+                            window,
+                            cx,
+                        )
+                    },
+                ),
+        )
     }
 }

--- a/crates/language_tools/src/lsp_tool.rs
+++ b/crates/language_tools/src/lsp_tool.rs
@@ -1007,26 +1007,28 @@ impl Render for LspTool {
 
         let lsp_tool = cx.entity();
 
-        div().child(
-            PopoverMenu::new("lsp-tool")
-                .menu(move |_, cx| lsp_tool.read(cx).lsp_menu.clone())
-                .anchor(Corner::BottomLeft)
-                .with_handle(self.popover_menu_handle.clone())
-                .trigger_with_tooltip(
-                    IconButton::new("zed-lsp-tool-button", IconName::BoltOutlined)
-                        .when_some(indicator, IconButton::indicator)
-                        .icon_size(IconSize::Small)
-                        .indicator_border_color(Some(cx.theme().colors().status_bar_background)),
-                    move |window, cx| {
-                        Tooltip::with_meta(
-                            "Language Servers",
-                            Some(&ToggleMenu),
-                            description,
-                            window,
-                            cx,
-                        )
-                    },
-                ),
-        )
+        div()
+            .py(DynamicSpacing::Base04.rems(cx))
+            .child(
+                PopoverMenu::new("lsp-tool")
+                    .menu(move |_, cx| lsp_tool.read(cx).lsp_menu.clone())
+                    .anchor(Corner::BottomLeft)
+                    .with_handle(self.popover_menu_handle.clone())
+                    .trigger_with_tooltip(
+                        IconButton::new("zed-lsp-tool-button", IconName::BoltOutlined)
+                            .when_some(indicator, IconButton::indicator)
+                            .icon_size(IconSize::Small)
+                            .indicator_border_color(Some(cx.theme().colors().status_bar_background)),
+                        move |window, cx| {
+                            Tooltip::with_meta(
+                                "Language Servers",
+                                Some(&ToggleMenu),
+                                description,
+                                window,
+                                cx,
+                            )
+                        },
+                    ),
+            )
     }
 }

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -21,23 +21,21 @@ impl Render for SearchButton {
             return button.w_0().invisible();
         }
 
-        button
-            .py(DynamicSpacing::Base04.rems(cx))
-            .child(
-                IconButton::new("project-search-indicator", SEARCH_ICON)
-                    .icon_size(IconSize::Small)
-                    .tooltip(|window, cx| {
-                        Tooltip::for_action(
-                            "Project Search",
-                            &workspace::DeploySearch::default(),
-                            window,
-                            cx,
-                        )
-                    })
-                    .on_click(cx.listener(|_this, _, window, cx| {
-                        window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);
-                    })),
-            )
+        button.py(DynamicSpacing::Base04.rems(cx)).child(
+            IconButton::new("project-search-indicator", SEARCH_ICON)
+                .icon_size(IconSize::Small)
+                .tooltip(|window, cx| {
+                    Tooltip::for_action(
+                        "Project Search",
+                        &workspace::DeploySearch::default(),
+                        window,
+                        cx,
+                    )
+                })
+                .on_click(cx.listener(|_this, _, window, cx| {
+                    window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);
+                })),
+        )
     }
 }
 

--- a/crates/search/src/search_status_button.rs
+++ b/crates/search/src/search_status_button.rs
@@ -21,21 +21,23 @@ impl Render for SearchButton {
             return button.w_0().invisible();
         }
 
-        button.child(
-            IconButton::new("project-search-indicator", SEARCH_ICON)
-                .icon_size(IconSize::Small)
-                .tooltip(|window, cx| {
-                    Tooltip::for_action(
-                        "Project Search",
-                        &workspace::DeploySearch::default(),
-                        window,
-                        cx,
-                    )
-                })
-                .on_click(cx.listener(|_this, _, window, cx| {
-                    window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);
-                })),
-        )
+        button
+            .py(DynamicSpacing::Base04.rems(cx))
+            .child(
+                IconButton::new("project-search-indicator", SEARCH_ICON)
+                    .icon_size(IconSize::Small)
+                    .tooltip(|window, cx| {
+                        Tooltip::for_action(
+                            "Project Search",
+                            &workspace::DeploySearch::default(),
+                            window,
+                            cx,
+                        )
+                    })
+                    .on_click(cx.listener(|_this, _, window, cx| {
+                        window.dispatch_action(Box::new(workspace::DeploySearch::default()), cx);
+                    })),
+            )
     }
 }
 

--- a/crates/toolchain_selector/src/active_toolchain.rs
+++ b/crates/toolchain_selector/src/active_toolchain.rs
@@ -2,12 +2,15 @@ use std::{path::Path, sync::Arc};
 
 use editor::Editor;
 use gpui::{
-    AsyncWindowContext, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, Task,
-    WeakEntity, Window, div,
+    AsyncWindowContext, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription,
+    Task, WeakEntity, Window, div,
 };
 use language::{Buffer, BufferEvent, LanguageName, Toolchain};
 use project::{Project, ProjectPath, WorktreeId, toolchain_store::ToolchainStoreEvent};
-use ui::{Button, ButtonCommon, Clickable, DynamicSpacing, FluentBuilder, LabelSize, SharedString, Tooltip};
+use ui::{
+    Button, ButtonCommon, Clickable, DynamicSpacing, FluentBuilder, LabelSize, SharedString,
+    Tooltip,
+};
 use util::maybe;
 use workspace::{StatusItemView, Workspace, item::ItemHandle};
 
@@ -219,20 +222,18 @@ impl Render for ActiveToolchain {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div().when_some(self.active_toolchain.as_ref(), |el, active_toolchain| {
             let term = self.term.clone();
-            el
-                .py(DynamicSpacing::Base04.rems(cx))
-                .child(
-                    Button::new("change-toolchain", active_toolchain.name.clone())
-                        .label_size(LabelSize::Small)
-                        .on_click(cx.listener(|this, _, window, cx| {
-                            if let Some(workspace) = this.workspace.upgrade() {
-                                workspace.update(cx, |workspace, cx| {
-                                    ToolchainSelector::toggle(workspace, window, cx)
-                                });
-                            }
-                        }))
-                        .tooltip(Tooltip::text(format!("Select {}", &term))),
-                )
+            el.py(DynamicSpacing::Base04.rems(cx)).child(
+                Button::new("change-toolchain", active_toolchain.name.clone())
+                    .label_size(LabelSize::Small)
+                    .on_click(cx.listener(|this, _, window, cx| {
+                        if let Some(workspace) = this.workspace.upgrade() {
+                            workspace.update(cx, |workspace, cx| {
+                                ToolchainSelector::toggle(workspace, window, cx)
+                            });
+                        }
+                    }))
+                    .tooltip(Tooltip::text(format!("Select {}", &term))),
+            )
         })
     }
 }

--- a/crates/toolchain_selector/src/active_toolchain.rs
+++ b/crates/toolchain_selector/src/active_toolchain.rs
@@ -2,12 +2,12 @@ use std::{path::Path, sync::Arc};
 
 use editor::Editor;
 use gpui::{
-    AsyncWindowContext, Context, Entity, IntoElement, ParentElement, Render, Subscription, Task,
+    AsyncWindowContext, Context, Entity, IntoElement, ParentElement, Render, Styled, Subscription, Task,
     WeakEntity, Window, div,
 };
 use language::{Buffer, BufferEvent, LanguageName, Toolchain};
 use project::{Project, ProjectPath, WorktreeId, toolchain_store::ToolchainStoreEvent};
-use ui::{Button, ButtonCommon, Clickable, FluentBuilder, LabelSize, SharedString, Tooltip};
+use ui::{Button, ButtonCommon, Clickable, DynamicSpacing, FluentBuilder, LabelSize, SharedString, Tooltip};
 use util::maybe;
 use workspace::{StatusItemView, Workspace, item::ItemHandle};
 
@@ -219,18 +219,20 @@ impl Render for ActiveToolchain {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div().when_some(self.active_toolchain.as_ref(), |el, active_toolchain| {
             let term = self.term.clone();
-            el.child(
-                Button::new("change-toolchain", active_toolchain.name.clone())
-                    .label_size(LabelSize::Small)
-                    .on_click(cx.listener(|this, _, window, cx| {
-                        if let Some(workspace) = this.workspace.upgrade() {
-                            workspace.update(cx, |workspace, cx| {
-                                ToolchainSelector::toggle(workspace, window, cx)
-                            });
-                        }
-                    }))
-                    .tooltip(Tooltip::text(format!("Select {}", &term))),
-            )
+            el
+                .py(DynamicSpacing::Base04.rems(cx))
+                .child(
+                    Button::new("change-toolchain", active_toolchain.name.clone())
+                        .label_size(LabelSize::Small)
+                        .on_click(cx.listener(|this, _, window, cx| {
+                            if let Some(workspace) = this.workspace.upgrade() {
+                                workspace.update(cx, |workspace, cx| {
+                                    ToolchainSelector::toggle(workspace, window, cx)
+                                });
+                            }
+                        }))
+                        .tooltip(Tooltip::text(format!("Select {}", &term))),
+                )
         })
     }
 }

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -116,7 +116,7 @@ impl Render for ModeIndicator {
                 Label::new(label)
                     .size(LabelSize::Small)
                     .line_height_style(LineHeightStyle::UiLabel)
-                    .into_any_element()
+                    .into_any_element(),
             )
             .into_any_element()
     }

--- a/crates/vim/src/mode_indicator.rs
+++ b/crates/vim/src/mode_indicator.rs
@@ -110,9 +110,14 @@ impl Render for ModeIndicator {
             format!("{} -- {} --", pending, mode).into()
         };
 
-        Label::new(label)
-            .size(LabelSize::Small)
-            .line_height_style(LineHeightStyle::UiLabel)
+        div()
+            .py(DynamicSpacing::Base04.rems(cx))
+            .child(
+                Label::new(label)
+                    .size(LabelSize::Small)
+                    .line_height_style(LineHeightStyle::UiLabel)
+                    .into_any_element()
+            )
             .into_any_element()
     }
 }

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -933,6 +933,7 @@ impl Render for PanelButtons {
 
         h_flex()
             .gap_1()
+            .when(has_buttons, |this| this.py(DynamicSpacing::Base04.rems(cx)))
             .when(
                 has_buttons && dock.position == DockPosition::Bottom,
                 |this| this.child(Divider::vertical().color(DividerColor::Border)),

--- a/crates/workspace/src/status_bar.rs
+++ b/crates/workspace/src/status_bar.rs
@@ -41,7 +41,6 @@ impl Render for StatusBar {
             .w_full()
             .justify_between()
             .gap(DynamicSpacing::Base08.rems(cx))
-            .py(DynamicSpacing::Base04.rems(cx))
             .px(DynamicSpacing::Base06.rems(cx))
             .bg(cx.theme().colors().status_bar_background)
             .map(|el| match window.window_decorations() {


### PR DESCRIPTION
This is an alternative solution for hiding the status bar when empty. Another solution can be found here: https://github.com/zed-industries/zed/pull/36729

This approach is perhaps simpler in some ways, or more performant, but lack encapsulation, and I am still figuring out how to get it to play nice with dock-button items put into the status bar in `crates/workspace/src/workspace.rs`

The status bar can be in a state where it is empty. This state was possible previously, but more likely now with recent PRs https://github.com/zed-industries/zed/pull/33977 and https://github.com/zed-industries/zed/pull/36288. 

In this state, Zed currently shows an empty, but visible, slim status bar.

<img width="1486" height="1152" alt="image" src="https://github.com/user-attachments/assets/9ff23a03-3dfe-4abd-94c1-0478c40b2708" />

With this fix:

<img width="1486" height="1152" alt="image" src="https://github.com/user-attachments/assets/d5e7c267-906c-4f3e-afac-9e1d0da66ccd" />

Release Notes:

- Status bar is no longer visible when it is empty.