### PR TITLE
Fix cursor movement in protected files on backspace/delete

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9809,6 +9809,9 @@ impl Editor {
     }
 
     pub fn backspace(&mut self, _: &Backspace, window: &mut Window, cx: &mut Context<Self>) {
+        if self.read_only(cx) {
+            return;
+        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
         self.transact(window, cx, |this, window, cx| {
             this.select_autoclose_pair(window, cx);
@@ -9902,6 +9905,9 @@ impl Editor {
     }
 
     pub fn delete(&mut self, _: &Delete, window: &mut Window, cx: &mut Context<Self>) {
+        if self.read_only(cx) {
+            return;
+        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
         self.transact(window, cx, |this, window, cx| {
             this.change_selections(Default::default(), window, cx, |s| {


### PR DESCRIPTION
## Summary

Fixes cursor movement behavior in protected files (like Default Settings) when pressing backspace or delete keys.

Previously, these keys would cause unwanted cursor movement instead of being ignored as expected in read-only files.

## Changes

- Added read-only checks to `backspace()` and `delete()` methods in the editor
- Consistent with existing pattern used by other editing methods (`indent()`, `outdent()`, `undo()`, etc.)

## Test Plan

1. Open Default Settings in Zed
2. Place cursor at arbitrary position (not at start/end of file)  
3. Press backspace - cursor should remain in place (no movement)
4. Press delete - cursor should remain in place (no movement)

Fixes #36302

Release Notes:

- Fixed backspace and delete keys moving caret in protected files