### PR TITLE
Use a better message for the InvalidBufferView

### DIFF
--- a/crates/workspace/src/invalid_buffer_view.rs
+++ b/crates/workspace/src/invalid_buffer_view.rs
@@ -88,7 +88,7 @@ impl Render for InvalidBufferView {
                     v_flex()
                         .justify_center()
                         .gap_2()
-                        .child("Cannot display the file contents in Zed")
+                        .child(h_flex().justify_center().child("Unsupported file type"))
                         .when(self.is_local, |contents| {
                             contents.child(
                                 h_flex().justify_center().child(


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/36764

<img width="720" height="439" alt="image" src="https://github.com/user-attachments/assets/799ba475-1269-4bf3-bb5e-32a54f559b6a" />


Release Notes:

- N/A 
