### PR TITLE
Add a few more testing features

### DIFF
--- a/Procfile.web
+++ b/Procfile.web
@@ -1,7 +1,2 @@
-collab: RUST_LOG=${RUST_LOG:-info} cargo run --package=collab serve all
-cloud: cd ../cloud; cargo make dev
-livekit: livekit-server --dev
-blob_store: ./script/run-local-minio
-postgrest_app: postgrest crates/collab/postgrest_app.conf
 postgrest_llm: postgrest crates/collab/postgrest_llm.conf
-website: cd ../zed.dev; npm run dev
+website: cd ../zed.dev; npm run dev -- --port=3000

--- a/Procfile.web
+++ b/Procfile.web
@@ -1,0 +1,7 @@
+collab: RUST_LOG=${RUST_LOG:-info} cargo run --package=collab serve all
+cloud: cd ../cloud; cargo make dev
+livekit: livekit-server --dev
+blob_store: ./script/run-local-minio
+postgrest_app: postgrest crates/collab/postgrest_app.conf
+postgrest_llm: postgrest crates/collab/postgrest_llm.conf
+website: cd ../zed.dev; npm run dev

--- a/crates/client/src/client.rs
+++ b/crates/client/src/client.rs
@@ -66,6 +66,8 @@ pub static IMPERSONATE_LOGIN: LazyLock<Option<String>> = LazyLock::new(|| {
         .and_then(|s| if s.is_empty() { None } else { Some(s) })
 });
 
+pub static USE_WEB_LOGIN: LazyLock<bool> = LazyLock::new(|| std::env::var("ZED_WEB_LOGIN").is_ok());
+
 pub static ADMIN_API_TOKEN: LazyLock<Option<String>> = LazyLock::new(|| {
     std::env::var("ZED_ADMIN_API_TOKEN")
         .ok()
@@ -1392,11 +1394,13 @@ impl Client {
                     if let Some((login, token)) =
                         IMPERSONATE_LOGIN.as_ref().zip(ADMIN_API_TOKEN.as_ref())
                     {
-                        eprintln!("authenticate as admin {login}, {token}");
+                        if !*USE_WEB_LOGIN {
+                            eprintln!("authenticate as admin {login}, {token}");
 
-                        return this
-                            .authenticate_as_admin(http, login.clone(), token.clone())
-                            .await;
+                            return this
+                                .authenticate_as_admin(http, login.clone(), token.clone())
+                                .await;
+                        }
                     }
 
                     // Start an HTTP server to receive the redirect from Zed's sign-in page.


### PR DESCRIPTION
This PR adds a `ZED_WEB_LOGIN` env var, for using alongside `script/zed-local` to force the auth flow to go through the website (rather than short circuiting it with collab).

This PR also adds a new `Procfile.web` for turning on the services related to `zed.dev`, in a way that works with `script/zed-local`

Release Notes:

- N/A
