### PR TITLE
Be more lenient when dealing with rust-analyzer's flycheck commands

### DIFF
--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -438,7 +438,7 @@ impl ProjectDiagnosticsEditor {
             for buffer_path in diagnostics_sources.iter().cloned() {
                 if cx
                     .update(|cx| {
-                        fetch_tasks.push(run_flycheck(project.clone(), buffer_path, cx));
+                        fetch_tasks.push(run_flycheck(project.clone(), Some(buffer_path), cx));
                     })
                     .is_err()
                 {
@@ -462,7 +462,7 @@ impl ProjectDiagnosticsEditor {
             .iter()
             .cloned()
         {
-            cancel_gasks.push(cancel_flycheck(self.project.clone(), buffer_path, cx));
+            cancel_gasks.push(cancel_flycheck(self.project.clone(), Some(buffer_path), cx));
         }
 
         self.cargo_diagnostics_fetch.cancel_task = Some(cx.background_spawn(async move {

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -834,20 +834,20 @@ message LspRunnable {
 
 message LspExtCancelFlycheck {
     uint64 project_id = 1;
-    uint64 buffer_id = 2;
+    reserved 2;
     uint64 language_server_id = 3;
 }
 
 message LspExtRunFlycheck {
     uint64 project_id = 1;
-    uint64 buffer_id = 2;
+    optional uint64 buffer_id = 2;
     uint64 language_server_id = 3;
     bool current_file_only = 4;
 }
 
 message LspExtClearFlycheck {
     uint64 project_id = 1;
-    uint64 buffer_id = 2;
+    reserved 2;
     uint64 language_server_id = 3;
 }
 

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -834,8 +834,7 @@ message LspRunnable {
 
 message LspExtCancelFlycheck {
     uint64 project_id = 1;
-    reserved 2;
-    uint64 language_server_id = 3;
+    uint64 language_server_id = 2;
 }
 
 message LspExtRunFlycheck {
@@ -847,8 +846,7 @@ message LspExtRunFlycheck {
 
 message LspExtClearFlycheck {
     uint64 project_id = 1;
-    reserved 2;
-    uint64 language_server_id = 3;
+    uint64 language_server_id = 2;
 }
 
 message LspDiagnosticRelatedInformation {


### PR DESCRIPTION
Flycheck commands are global and makes sense to fall back to looking up project's rust-analyzer even if the commands are run on a non-rust buffer. If multiple rust-analyzers are found in the project, avoid ambiguous commands and bail (as before).

Release Notes:

- Made it possible to run rust-analyzer's flycheck actions from anywhere in the project
