### PR TITLE
Remove redundant Cargo diagnostics settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4685,7 +4685,6 @@ dependencies = [
  "component",
  "ctor",
  "editor",
- "futures 0.3.31",
  "gpui",
  "indoc",
  "language",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1133,11 +1133,6 @@
       // The minimum severity of the diagnostics to show inline.
       // Inherits editor's diagnostics' max severity settings when `null`.
       "max_severity": null
-    },
-    "cargo": {
-      // When enabled, Zed disables rust-analyzer's check on save and starts to query
-      // Cargo diagnostics separately.
-      "fetch_cargo_diagnostics": false
     }
   },
   // Files or globs of files that will be excluded by Zed entirely. They will be skipped during file

--- a/crates/diagnostics/Cargo.toml
+++ b/crates/diagnostics/Cargo.toml
@@ -18,7 +18,6 @@ collections.workspace = true
 component.workspace = true
 ctor.workspace = true
 editor.workspace = true
-futures.workspace = true
 gpui.workspace = true
 indoc.workspace = true
 language.workspace = true

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -510,20 +510,6 @@ impl LspAdapter for RustLspAdapter {
             }
         }
 
-        let cargo_diagnostics_fetched_separately = ProjectSettings::get_global(cx)
-            .diagnostics
-            .fetch_cargo_diagnostics();
-        if cargo_diagnostics_fetched_separately {
-            let disable_check_on_save = json!({
-                "checkOnSave": false,
-            });
-            if let Some(initialization_options) = &mut original.initialization_options {
-                merge_json_value_into(disable_check_on_save, initialization_options);
-            } else {
-                original.initialization_options = Some(disable_check_on_save);
-            }
-        }
-
         Ok(original)
     }
 }

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -181,17 +181,6 @@ pub struct DiagnosticsSettings {
 
     /// Settings for showing inline diagnostics.
     pub inline: InlineDiagnosticsSettings,
-
-    /// Configuration, related to Rust language diagnostics.
-    pub cargo: Option<CargoDiagnosticsSettings>,
-}
-
-impl DiagnosticsSettings {
-    pub fn fetch_cargo_diagnostics(&self) -> bool {
-        self.cargo
-            .as_ref()
-            .is_some_and(|cargo_diagnostics| cargo_diagnostics.fetch_cargo_diagnostics)
-    }
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema)]
@@ -258,7 +247,6 @@ impl Default for DiagnosticsSettings {
             include_warnings: true,
             lsp_pull_diagnostics: LspPullDiagnosticsSettings::default(),
             inline: InlineDiagnosticsSettings::default(),
-            cargo: None,
         }
     }
 }
@@ -290,16 +278,6 @@ impl Default for GlobalLspSettings {
             button: default_true(),
         }
     }
-}
-
-#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema)]
-pub struct CargoDiagnosticsSettings {
-    /// When enabled, Zed disables rust-analyzer's check on save and starts to query
-    /// Cargo diagnostics separately.
-    ///
-    /// Default: false
-    #[serde(default)]
-    pub fetch_cargo_diagnostics: bool,
 }
 
 #[derive(

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -136,22 +136,7 @@ This is enabled by default and can be configured as
 ## Manual Cargo Diagnostics fetch
 
 By default, rust-analyzer has `checkOnSave: true` enabled, which causes every buffer save to trigger a `cargo check --workspace --all-targets` command.
-For lager projects this might introduce excessive wait times, so a more fine-grained triggering could be enabled by altering the
-
-```json
-"diagnostics": {
-  "cargo": {
-    // When enabled, Zed disables rust-analyzer's check on save and starts to query
-    // Cargo diagnostics separately.
-    "fetch_cargo_diagnostics": false
-  }
-}
-```
-
-default settings.
-
-This will stop rust-analyzer from running `cargo check ...` on save, yet still allow to run
-`editor: run/clear/cancel flycheck` commands in Rust files to refresh cargo diagnostics; the project diagnostics editor will also refresh cargo diagnostics with `editor: run flycheck` command when the setting is enabled.
+If disabled with `checkOnSave: false` (see the example of the server configuration json above), it's still possible to fetch the diagnostics manually, with the `editor: run/clear/cancel flycheck` commands in Rust files to refresh cargo diagnostics; the project diagnostics editor will also refresh cargo diagnostics with `editor: run flycheck` command when the setting is enabled.
 
 ## More server configuration
 


### PR DESCRIPTION
Removes `diagnostics.cargo.fetch_cargo_diagnostics` settings as those are not needed for the flycheck diagnostics to run.
This setting disabled `checkOnSave` in rust-analyzer and allowed to update diagnostics via flycheck in the project diagnostics editor with the "refresh" button.

Instead, `"checkOnSave": false,` can be set manually as https://zed.dev/docs/languages/rust#more-server-configuration example shows and flycheck commands can be called manually from anywhere, including the diagnostics panel, to refresh the diagnostics.

Release Notes:

- Removed redundant `diagnostics.cargo.fetch_cargo_diagnostics` settings
