### PR TITLE
language: Increase cursor match limit

### DIFF
--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1878,7 +1878,7 @@ impl<'a> Iterator for ByteChunks<'a> {
 impl QueryCursorHandle {
     pub fn new() -> Self {
         let mut cursor = QUERY_CURSORS.lock().pop().unwrap_or_default();
-        cursor.set_match_limit(64);
+        cursor.set_match_limit(256);
         QueryCursorHandle(Some(cursor))
     }
 }

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1878,7 +1878,7 @@ impl<'a> Iterator for ByteChunks<'a> {
 impl QueryCursorHandle {
     pub fn new() -> Self {
         let mut cursor = QUERY_CURSORS.lock().pop().unwrap_or_default();
-        cursor.set_match_limit(1024);
+        cursor.set_match_limit(128);
         QueryCursorHandle(Some(cursor))
     }
 }

--- a/crates/language/src/syntax_map.rs
+++ b/crates/language/src/syntax_map.rs
@@ -1878,7 +1878,7 @@ impl<'a> Iterator for ByteChunks<'a> {
 impl QueryCursorHandle {
     pub fn new() -> Self {
         let mut cursor = QUERY_CURSORS.lock().pop().unwrap_or_default();
-        cursor.set_match_limit(256);
+        cursor.set_match_limit(1024);
         QueryCursorHandle(Some(cursor))
     }
 }

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -975,7 +975,7 @@ mod tests {
                 {
                     name: "test case 9",
                     anotherStr: "foooooooo",
-                },
+                }
             }
 
             notATableTest := []struct{
@@ -1006,39 +1006,41 @@ mod tests {
             snapshot.runnable_ranges(0..table_test.len()).collect()
         });
 
-        let tag_strings: Vec<String> = runnables
+        let expected_test_names = vec![
+            "test case 1",
+            "test case 2",
+            "test case 3",
+            "test case 4",
+            "test case 5",
+            "test case 6",
+            "test case 7",
+            "test case 8",
+            "test case 9",
+        ];
+
+        let table_test_runnables: Vec<_> = runnables
             .iter()
-            .flat_map(|r| &r.runnable.tags)
-            .map(|tag| tag.0.to_string())
+            .filter(|r| {
+                r.runnable
+                    .tags
+                    .iter()
+                    .any(|tag| tag.0 == "go-table-test-case")
+            })
             .collect();
 
-        assert!(
-            tag_strings.contains(&"go-test".to_string()),
-            "Should find go-test tag, found: {:?}",
-            tag_strings
-        );
-        assert!(
-            tag_strings.contains(&"go-table-test-case".to_string()),
-            "Should find go-table-test-case tag, found: {:?}",
-            tag_strings
-        );
-
-        let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
-        let go_table_test_count = tag_strings
+        let actual_test_names: Vec<String> = table_test_runnables
             .iter()
-            .filter(|&tag| tag == "go-table-test-case")
-            .count();
+            .filter_map(|r| {
+                r.extra_captures.get("_table_test_case_name").map(|s| {
+                    s.strip_prefix('"')
+                        .and_then(|s| s.strip_suffix('"'))
+                        .unwrap_or(s)
+                        .to_string()
+                })
+            })
+            .collect();
 
-        assert!(
-            go_test_count == 1,
-            "Should find exactly 1 go-test, found: {}",
-            go_test_count
-        );
-        assert!(
-            go_table_test_count == 9,
-            "Should find exactly 9 go-table-test-case, found: {}",
-            go_table_test_count
-        );
+        assert_eq!(actual_test_names, expected_test_names,);
     }
 
     #[gpui::test]
@@ -1107,14 +1109,42 @@ mod tests {
           		someStr string
           		fail    bool
            	}{
-          		"test failure": {
+          		"test case 1": {
          			someStr: "foo",
          			fail:    true,
           		},
-          		"test success": {
+          		"test case 2": {
          			someStr: "bar",
          			fail:    false,
           		},
+          		"test case 3": {
+         			someStr: "foo",
+         			fail:    true,
+          		},
+          		"test case 4": {
+         			someStr: "bar",
+         			fail:    false,
+          		},
+          		"test case 5": {
+         			someStr: "foo",
+         			fail:    true,
+          		},
+          		"test case 6": {
+         			someStr: "bar",
+         			fail:    false,
+          		},
+          		"test case 7": {
+         			someStr: "foo",
+         			fail:    true,
+          		},
+          		"test case 8": {
+         			someStr: "bar",
+         			fail:    false,
+          		},
+          		"test case 9": {
+         			someStr: "foo",
+         			fail:    true,
+          		}
            	}
 
            	notATableTest := map[string]struct {
@@ -1145,39 +1175,41 @@ mod tests {
             snapshot.runnable_ranges(0..table_test.len()).collect()
         });
 
-        let tag_strings: Vec<String> = runnables
+        let expected_test_names = vec![
+            "test case 1",
+            "test case 2",
+            "test case 3",
+            "test case 4",
+            "test case 5",
+            "test case 6",
+            "test case 7",
+            "test case 8",
+            "test case 9",
+        ];
+
+        let table_test_runnables: Vec<_> = runnables
             .iter()
-            .flat_map(|r| &r.runnable.tags)
-            .map(|tag| tag.0.to_string())
+            .filter(|r| {
+                r.runnable
+                    .tags
+                    .iter()
+                    .any(|tag| tag.0 == "go-table-test-case")
+            })
             .collect();
 
-        assert!(
-            tag_strings.contains(&"go-test".to_string()),
-            "Should find go-test tag, found: {:?}",
-            tag_strings
-        );
-        assert!(
-            tag_strings.contains(&"go-table-test-case".to_string()),
-            "Should find go-table-test-case tag, found: {:?}",
-            tag_strings
-        );
-
-        let go_test_count = tag_strings.iter().filter(|&tag| tag == "go-test").count();
-        let go_table_test_count = tag_strings
+        let actual_test_names: Vec<String> = table_test_runnables
             .iter()
-            .filter(|&tag| tag == "go-table-test-case")
-            .count();
+            .filter_map(|r| {
+                r.extra_captures.get("_table_test_case_name").map(|s| {
+                    s.strip_prefix('"')
+                        .and_then(|s| s.strip_suffix('"'))
+                        .unwrap_or(s)
+                        .to_string()
+                })
+            })
+            .collect();
 
-        assert!(
-            go_test_count == 1,
-            "Should find exactly 1 go-test, found: {}",
-            go_test_count
-        );
-        assert!(
-            go_table_test_count == 2,
-            "Should find exactly 2 go-table-test-case, found: {}",
-            go_table_test_count
-        );
+        assert_eq!(actual_test_names, expected_test_names,);
     }
 
     #[gpui::test]

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -948,6 +948,34 @@ mod tests {
                     name: "test case 2",
                     anotherStr: "bar",
                 },
+                {
+                    name: "test case 3",
+                    anotherStr: "fooo",
+                },
+                {
+                    name: "test case 4",
+                    anotherStr: "baar",
+                },
+                {
+                    name: "test case 5",
+                    anotherStr: "foooo",
+                },
+                {
+                    name: "test case 6",
+                    anotherStr: "baaar",
+                },
+                {
+                    name: "test case 7",
+                    anotherStr: "foooooo",
+                },
+                {
+                    name: "test case 8",
+                    anotherStr: "baaaar",
+                },
+                {
+                    name: "test case 9",
+                    anotherStr: "foooooooo",
+                },
             }
 
             notATableTest := []struct{
@@ -1007,8 +1035,8 @@ mod tests {
             go_test_count
         );
         assert!(
-            go_table_test_count == 2,
-            "Should find exactly 2 go-table-test-case, found: {}",
+            go_table_test_count == 9,
+            "Should find exactly 9 go-table-test-case, found: {}",
             go_table_test_count
         );
     }

--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -92,45 +92,29 @@
   (#set! tag go-main)
 )
 
-; Table test cases - slice and map
+; Table test cases - slice
 (
   (short_var_declaration
     left: (expression_list (identifier) @_collection_var)
     right: (expression_list
       (composite_literal
-        type: [
-          (slice_type)
-          (map_type
-            key: (type_identifier) @_key_type
-            (#eq? @_key_type "string")
-          )
-        ]
+        type: (slice_type)
         body: (literal_value
-          [
-            (literal_element
-              (literal_value
-                (keyed_element
-                  (literal_element
-                    (identifier) @_field_name
-                  )
-                  (literal_element
-                    [
-                      (interpreted_string_literal) @run @_table_test_case_name
-                      (raw_string_literal) @run @_table_test_case_name
-                    ]
-                  )
+          (literal_element
+            (literal_value
+              (keyed_element
+                (literal_element
+                  (identifier) @_field_name
+                )
+                (literal_element
+                  [
+                    (interpreted_string_literal)
+                    (raw_string_literal)
+                  ] @run @_table_test_case_name
                 )
               )
             )
-            (keyed_element
-              (literal_element
-                [
-                  (interpreted_string_literal) @run @_table_test_case_name
-                  (raw_string_literal) @run @_table_test_case_name
-                ]
-              )
-            )
-          ]
+          )
         )
       )
     )
@@ -138,13 +122,10 @@
   (for_statement
     (range_clause
       left: (expression_list
-        [
-          (
-            (identifier)
-            (identifier) @_loop_var
-          )
+        (
+          (identifier)
           (identifier) @_loop_var
-        ]
+        )
       )
       right: (identifier) @_range_var
       (#eq? @_range_var @_collection_var)
@@ -159,16 +140,78 @@
           )
           arguments: (argument_list
             .
-            [
-              (selector_expression
-                operand: (identifier) @_tc_var
-                (#eq? @_tc_var @_loop_var)
-                field: (field_identifier) @_field_check
-                (#eq? @_field_check @_field_name)
+            (selector_expression
+              operand: (identifier) @_tc_var
+              (#eq? @_tc_var @_loop_var)
+              field: (field_identifier) @_field_check
+              (#eq? @_field_check @_field_name)
+            )
+            .
+            (func_literal
+              parameters: (parameter_list
+                (parameter_declaration
+                  type: (pointer_type
+                    (qualified_type
+                      package: (package_identifier) @_pkg
+                      name: (type_identifier) @_type
+                      (#eq? @_pkg "testing")
+                      (#eq? @_type "T")
+                    )
+                  )
+                )
               )
-              (identifier) @_arg_var
-              (#eq? @_arg_var @_loop_var)
-            ]
+            )
+          )
+        )
+      )
+    )
+  ) @_
+  (#set! tag go-table-test-case)
+)
+
+; Table test cases - map
+(
+  (short_var_declaration
+    left: (expression_list (identifier) @_collection_var)
+    right: (expression_list
+      (composite_literal
+        type: (map_type
+          key: (type_identifier) @_key_type
+          (#eq? @_key_type "string")
+        )
+        body: (literal_value
+          (keyed_element
+            (literal_element
+              [
+                (interpreted_string_literal)
+                (raw_string_literal)
+              ] @run @_table_test_case_name
+            )
+          )
+        )
+      )
+    )
+  )
+  (for_statement
+    (range_clause
+      left: (expression_list
+        (identifier) @_loop_var
+      )
+      right: (identifier) @_range_var
+      (#eq? @_range_var @_collection_var)
+    )
+    body: (block
+      (expression_statement
+        (call_expression
+          function: (selector_expression
+            operand: (identifier) @_t_var
+            field: (field_identifier) @_run_method
+            (#eq? @_run_method "Run")
+          )
+          arguments: (argument_list
+            .
+            (identifier) @_arg_var
+            (#eq? @_arg_var @_loop_var)
             .
             (func_literal
               parameters: (parameter_list


### PR DESCRIPTION
With my [last PR](https://github.com/zed-industries/zed/pull/35657) adding support to run individual Go table sub-tests, I and some other people noticed that it hasn't been working quite as expected, especially for larger table tests. Basically in larger table tests, the detection would only work bottom up, up to a certain point.

After debugging for a while and also confirming that the query seems to work just fine (via [tree-sitter playground](https://tree-sitter.github.io/tree-sitter/7-playground.html)) I realized that the cursor limit is causing it to only find a limited amount of sub-tests.

I made my test example a bit longer to provoke a failure and then bumped the limit to 256 fixed it. Trying it out with some of my real world tests also yielded correct results.

I'm not sure what the golden number could possibly be, but 64 was definitely too low for my day to day use-cases.

If we're worried about performance, I suppose we could also play with `ts_query_cursor_set_timeout_micros` rather than capping the cursor limit at a fixed number.

Release Notes:

- Increased tree-sitter cursor match limit to support more complex queries.
