### PR TITLE
docs: Update settings in diagnostics.md

### DIFF
--- a/docs/src/diagnostics.md
+++ b/docs/src/diagnostics.md
@@ -51,7 +51,7 @@ To configure, use
 
 ```json5
 "project_panel": {
-  "diagnostics": "all",
+  "show_diagnostics": "all",
 }
 ```
 


### PR DESCRIPTION
For project_panel, the diagnostics key seems to be `show_diagnostics` not `diagnostics` ([source](https://github.com/zed-industries/zed/blob/main/crates/project_panel/src/project_panel_settings.rs#L149-L152)). Updating the docs accordingly

Release Notes:

- N/A