### PR TITLE
gpui: Improve the "Window" menu on macOS

### DIFF
--- a/crates/gpui/examples/set_menus.rs
+++ b/crates/gpui/examples/set_menus.rs
@@ -26,14 +26,20 @@ fn main() {
         // Register the `quit` function so it can be referenced by the `MenuItem::action` in the menu bar
         cx.on_action(quit);
         // Add menu items
-        cx.set_menus(vec![Menu {
-            name: "set_menus".into(),
-            items: vec![
-                MenuItem::os_submenu("Services", SystemMenuType::Services),
-                MenuItem::separator(),
-                MenuItem::action("Quit", Quit),
-            ],
-        }]);
+        cx.set_menus(vec![
+            Menu {
+                name: "set_menus".into(),
+                items: vec![
+                    MenuItem::os_submenu("Services", SystemMenuType::Services),
+                    MenuItem::separator(),
+                    MenuItem::action("Quit", Quit),
+                ],
+            },
+            Menu {
+                name: "Window".into(),
+                items: vec![MenuItem::os_submenu("", SystemMenuType::Window)],
+            },
+        ]);
         cx.open_window(WindowOptions::default(), |_, cx| cx.new(|_| SetMenus {}))
             .unwrap();
     });

--- a/crates/gpui/src/platform/app_menu.rs
+++ b/crates/gpui/src/platform/app_menu.rs
@@ -46,6 +46,15 @@ impl OsMenu {
 pub enum SystemMenuType {
     /// The 'Services' menu in the Application menu on macOS
     Services,
+
+    /// The 'Window' menu on macOS.
+    ///
+    /// This item is a marker and will not display as a menu item.
+    /// If a menu begins with this item, it will be treated as the Window menu.
+    ///
+    /// macOS will add window management items to this menu, such as
+    /// 'Fill', 'Center', 'Move to [Display]', and a list of windows.
+    Window,
 }
 
 /// The different kinds of items that can be in a menu

--- a/crates/gpui/src/platform/mac/platform.rs
+++ b/crates/gpui/src/platform/mac/platform.rs
@@ -254,9 +254,9 @@ impl MacPlatform {
                 menu.setDelegate_(delegate);
 
                 // Check the first item to see if it is window menu
-                if let Some(i) = menu_config.items.first()
+                if let Some(menu_item) = menu_config.items.first()
                     && matches!(
-                        i,
+                        menu_item,
                         MenuItem::SystemMenu(OsMenu {
                             menu_type: SystemMenuType::Window,
                             ..

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -281,6 +281,9 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
         Menu {
             name: "Window".into(),
             items: vec![
+                #[cfg(target_os = "macos")]
+                MenuItem::os_submenu("", gpui::SystemMenuType::Window),
+                MenuItem::separator(),
                 MenuItem::action("Minimize", super::Minimize),
                 MenuItem::action("Zoom", super::Zoom),
                 MenuItem::separator(),


### PR DESCRIPTION
Release Notes:

- N/A

---

The "Window" menu on macOS depended on a hardcoded menu name, not allowing i18n of the menu name.

Inspired by #34115, this PR adds `Window` to `SystemMenuType`. If a menu begins with a `OsSubMenu` item with this type, it will be treated as the Window menu. The `Window` item is treated as a marker and will not be displayed as a common item.

Since adding fields to `Menu` struct will introduce breaking changes, this PR is compatible with existing code.

Example `set_menus` is also updated.
