### PR TITLE
Enhance syntax highlight for C++20 keywords

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -17182,8 +17182,7 @@ dependencies = [
 [[package]]
 name = "tree-sitter-cpp"
 version = "0.23.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+source = "git+https://github.com/tree-sitter/tree-sitter-cpp?rev=5cb9b693cfd7bfacab1d9ff4acac1a4150700609#5cb9b693cfd7bfacab1d9ff4acac1a4150700609"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -624,7 +624,7 @@ tower-http = "0.4.4"
 tree-sitter = { version = "0.25.6", features = ["wasm"] }
 tree-sitter-bash = "0.25.0"
 tree-sitter-c = "0.23"
-tree-sitter-cpp = "0.23"
+tree-sitter-cpp = { git = "https://github.com/tree-sitter/tree-sitter-cpp", rev = "5cb9b693cfd7bfacab1d9ff4acac1a4150700609" }
 tree-sitter-css = "0.23"
 tree-sitter-diff = "0.1.0"
 tree-sitter-elixir = "0.3"

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -25,15 +25,6 @@
     (module_name
       (identifier) @module)))
 
-(co_await_expression
-  operator: "co_await" @keyword.operator)
-
-(co_return_statement
-  "co_return" @keyword.operator)
-
-(co_yield_statement
-  "co_yield" @keyword.operator)
-
 (call_expression
   function: (qualified_identifier
     name: (identifier) @function))
@@ -119,6 +110,9 @@ type: (primitive_type) @type.builtin
   "case"
   "catch"
   "class"
+  "co_await"
+  "co_return"
+  "co_yield"
   "concept"
   "consteval"
   "constexpr"
@@ -167,12 +161,6 @@ type: (primitive_type) @type.builtin
   (storage_class_specifier)
   (type_qualifier)
 ] @keyword
-
-[
-  "co_await"
-  "co_return"
-  "co_yield"
-] @keyword.operator
 
 [
   "#define"

--- a/crates/languages/src/cpp/highlights.scm
+++ b/crates/languages/src/cpp/highlights.scm
@@ -3,8 +3,36 @@
 (namespace_identifier) @namespace
 
 (concept_definition
-    (identifier) @concept)
+    name: (identifier) @concept)
 
+(requires_clause
+    constraint: (template_type
+        name: (type_identifier) @concept))
+
+(module_name
+  (identifier) @module)
+
+(module_declaration
+  name: (module_name
+    (identifier) @module))
+
+(import_declaration
+  name: (module_name
+    (identifier) @module))
+
+(import_declaration
+  partition: (module_partition
+    (module_name
+      (identifier) @module)))
+
+(co_await_expression
+  operator: "co_await" @keyword.operator)
+
+(co_return_statement
+  "co_return" @keyword.operator)
+
+(co_yield_statement
+  "co_yield" @keyword.operator)
 
 (call_expression
   function: (qualified_identifier
@@ -61,6 +89,9 @@
 (operator_name
   (identifier)? @operator) @function
 
+(operator_name
+  "<=>" @operator.spaceship)
+
 (destructor_name (identifier) @function)
 
 ((namespace_identifier) @type
@@ -68,21 +99,17 @@
 
 (auto) @type
 (type_identifier) @type
-type :(primitive_type) @type.primitive
-(sized_type_specifier) @type.primitive
-
-(requires_clause
-    constraint: (template_type
-        name: (type_identifier) @concept))
+type: (primitive_type) @type.builtin
+(sized_type_specifier) @type.builtin
 
 (attribute
-    name: (identifier) @keyword)
+    name: (identifier) @attribute)
 
-((identifier) @constant
- (#match? @constant "^_*[A-Z][A-Z\\d_]*$"))
+((identifier) @constant.builtin
+ (#match? @constant.builtin "^_*[A-Z][A-Z\\d_]*$"))
 
 (statement_identifier) @label
-(this) @variable.special
+(this) @variable.builtin
 ("static_assert") @function.builtin
 
 [
@@ -92,11 +119,10 @@ type :(primitive_type) @type.primitive
   "case"
   "catch"
   "class"
-  "co_await"
-  "co_return"
-  "co_yield"
   "concept"
+  "consteval"
   "constexpr"
+  "constinit"
   "continue"
   "decltype"
   "default"
@@ -105,15 +131,20 @@ type :(primitive_type) @type.primitive
   "else"
   "enum"
   "explicit"
+  "export"
   "extern"
   "final"
   "for"
   "friend"
+  "goto"
   "if"
+  "import"
   "inline"
+  "module"
   "namespace"
   "new"
   "noexcept"
+  "operator"
   "override"
   "private"
   "protected"
@@ -124,6 +155,7 @@ type :(primitive_type) @type.primitive
   "struct"
   "switch"
   "template"
+  "thread_local"
   "throw"
   "try"
   "typedef"
@@ -137,6 +169,12 @@ type :(primitive_type) @type.primitive
 ] @keyword
 
 [
+  "co_await"
+  "co_return"
+  "co_yield"
+] @keyword.operator
+
+[
   "#define"
   "#elif"
   "#else"
@@ -146,7 +184,7 @@ type :(primitive_type) @type.primitive
   "#ifndef"
   "#include"
   (preproc_directive)
-] @keyword
+] @keyword.directive
 
 (comment) @comment
 
@@ -224,10 +262,24 @@ type :(primitive_type) @type.primitive
   ">"
   "<="
   ">="
-  "<=>"
-  "||"
   "?"
+  "and"
+  "and_eq"
+  "bitand"
+  "bitor"
+  "compl"
+  "not"
+  "not_eq"
+  "or"
+  "or_eq"
+  "xor"
+  "xor_eq"
 ] @operator
+
+"<=>" @operator.spaceship
+
+(binary_expression
+  operator: "<=>" @operator.spaceship)
 
 (conditional_expression ":" @operator)
 (user_defined_literal (literal_suffix) @operator)


### PR DESCRIPTION
Closes #36439 and #32999 

## C++20 modules:
Before (Zed Preview v0.201.3):
<img width="1048" height="704" alt="image" src="https://github.com/user-attachments/assets/8eaaf77f-4e27-4a5a-9e87-4e5ba7293990" />
After:
<img width="1048" height="704" alt="image" src="https://github.com/user-attachments/assets/df8d0b2c-f2d0-4b0e-9a52-495e6be5a8c0" />

## C++20 coroutines:
Before (Zed Preview v0.201.3):
<img width="1048" height="704" alt="image" src="https://github.com/user-attachments/assets/652191ec-a653-444d-a239-da3e4e4b661e" />
After:
<img width="1048" height="704" alt="image" src="https://github.com/user-attachments/assets/36947eb5-8997-483a-b36c-8af84872b158" />

## Logical operators:
Before (Zed Preview v0.201.3):
<img width="511" height="102" alt="image" src="https://github.com/user-attachments/assets/9bf95bac-b076-4edd-a1f3-c3dfee98c2fd" />

After:
<img width="511" height="102" alt="image" src="https://github.com/user-attachments/assets/82c7564d-b94d-41f5-9c48-e39fe3ba3b3e" />

## Operator keyword:
Before (Zed Preview v0.201.3):
<img width="591" height="381" alt="image" src="https://github.com/user-attachments/assets/1d9dad05-2d86-4566-97f4-aff440dcd1df" />

After:
<img width="591" height="381" alt="image" src="https://github.com/user-attachments/assets/a1ca289a-8a5d-4ffd-96db-0d511405da4b" />

## Goto:
Before (Zed Preview v0.201.3):
<img width="610" height="430" alt="image" src="https://github.com/user-attachments/assets/2d00382b-d1ad-4e36-a3ee-88e06ec528ed" />

After:
<img width="610" height="430" alt="image" src="https://github.com/user-attachments/assets/de887b21-66f0-4a70-9ed2-e18dbb3c81c9" />

Release Notes:

- Enhance keyword highlighting for C++
