### PR TITLE
multi_buffer: Pre-allocate IDs when editing

### DIFF
--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -835,7 +835,7 @@ impl MultiBuffer {
                 this.convert_edits_to_buffer_edits(edits, &snapshot, &original_indent_columns);
             drop(snapshot);
 
-            let mut buffer_ids = Vec::new();
+            let mut buffer_ids = Vec::with_capacity(buffer_edits.len());
             for (buffer_id, mut edits) in buffer_edits {
                 buffer_ids.push(buffer_id);
                 edits.sort_by_key(|edit| edit.range.start);


### PR DESCRIPTION
Something I came across when looking at `edit_internal`. Potentially saves multiple re-allocations on an edit

Release Notes:

- N/A
