### PR TITLE
Pane tabs: Scroll entire new tab into view

### DIFF
--- a/crates/collab/src/tests/integration_tests.rs
+++ b/crates/collab/src/tests/integration_tests.rs
@@ -6498,13 +6498,7 @@ async fn test_right_click_menu_behind_collab_panel(cx: &mut TestAppContext) {
     cx.simulate_keystrokes("cmd-n cmd-n cmd-n");
     cx.update(|window, _cx| window.refresh());
 
-    let tab_bounds = cx.debug_bounds("TAB-2").unwrap();
     let new_tab_button_bounds = cx.debug_bounds("ICON-Plus").unwrap();
-
-    assert!(
-        tab_bounds.intersects(&new_tab_button_bounds),
-        "Tab should overlap with the new tab button, if this is failing check if there's been a redesign!"
-    );
 
     cx.simulate_event(MouseDownEvent {
         button: MouseButton::Right,

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -2991,7 +2991,7 @@ struct ScrollHandleState {
     active_item: ActiveItem,
 }
 
-/// Tracking if a child item needs to be scrolled to 
+/// Tracking if a child item needs to be scrolled to
 /// Having it here ensures that [ScrollHandleState] is in sync
 #[derive(Default, Debug)]
 pub enum ActiveItem {
@@ -3092,13 +3092,9 @@ impl ScrollHandle {
                     }
                     ActiveItem::Current
                 }
-                None => {
-                    ActiveItem::Stale(ix)
-                }
+                None => ActiveItem::Stale(ix),
             },
-            ActiveItem::Current => {
-                ActiveItem::Current
-            }
+            ActiveItem::Current => ActiveItem::Current,
         };
         state.active_item = active_item;
     }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3079,6 +3079,8 @@ impl ScrollHandle {
             return;
         };
 
+        dbg!(ix, state.child_bounds.len(), bounds, state.child_bounds.clone());
+
         let mut scroll_offset = state.offset.borrow_mut();
 
         if state.overflow.y == Overflow::Scroll {

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3059,7 +3059,9 @@ impl ScrollHandle {
     fn scroll_to_active_item(&self) {
         let mut state = self.0.borrow_mut();
 
-        let Some(active_item_index) = state.active_item else { return; }; 
+        let Some(active_item_index) = state.active_item else { 
+            return; 
+        }; 
         let active_item = match state.child_bounds.get(active_item_index) {
             Some(bounds) => {
                 let mut scroll_offset = state.offset.borrow_mut();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3059,31 +3059,29 @@ impl ScrollHandle {
     fn scroll_to_active_item(&self) {
         let mut state = self.0.borrow_mut();
 
-        let active_item = match state.active_item {
-            Some(ix) => match state.child_bounds.get(ix) {
-                Some(bounds) => {
-                    let mut scroll_offset = state.offset.borrow_mut();
+        let Some(active_item_index) = state.active_item else { return; }; 
+        let active_item = match state.child_bounds.get(active_item_index) {
+            Some(bounds) => {
+                let mut scroll_offset = state.offset.borrow_mut();
 
-                    if state.overflow.y == Overflow::Scroll {
-                        if bounds.top() + scroll_offset.y < state.bounds.top() {
-                            scroll_offset.y = state.bounds.top() - bounds.top();
-                        } else if bounds.bottom() + scroll_offset.y > state.bounds.bottom() {
-                            scroll_offset.y = state.bounds.bottom() - bounds.bottom();
-                        }
+                if state.overflow.y == Overflow::Scroll {
+                    if bounds.top() + scroll_offset.y < state.bounds.top() {
+                        scroll_offset.y = state.bounds.top() - bounds.top();
+                    } else if bounds.bottom() + scroll_offset.y > state.bounds.bottom() {
+                        scroll_offset.y = state.bounds.bottom() - bounds.bottom();
                     }
-
-                    if state.overflow.x == Overflow::Scroll {
-                        if bounds.left() + scroll_offset.x < state.bounds.left() {
-                            scroll_offset.x = state.bounds.left() - bounds.left();
-                        } else if bounds.right() + scroll_offset.x > state.bounds.right() {
-                            scroll_offset.x = state.bounds.right() - bounds.right();
-                        }
-                    }
-                    None
                 }
-                None => Some(ix),
-            },
-            None => None,
+
+                if state.overflow.x == Overflow::Scroll {
+                    if bounds.left() + scroll_offset.x < state.bounds.left() {
+                        scroll_offset.x = state.bounds.left() - bounds.left();
+                    } else if bounds.right() + scroll_offset.x > state.bounds.right() {
+                        scroll_offset.x = state.bounds.right() - bounds.right();
+                    }
+                }
+                None
+            }
+            None => Some(active_item_index),
         };
         state.active_item = active_item;
     }

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3059,9 +3059,9 @@ impl ScrollHandle {
     fn scroll_to_active_item(&self) {
         let mut state = self.0.borrow_mut();
 
-        let Some(active_item_index) = state.active_item else { 
-            return; 
-        }; 
+        let Some(active_item_index) = state.active_item else {
+            return;
+        };
         let active_item = match state.child_bounds.get(active_item_index) {
             Some(bounds) => {
                 let mut scroll_offset = state.offset.borrow_mut();

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3110,7 +3110,9 @@ impl ScrollHandle {
 #[cfg(test)]
 mod test {
     use crate::{
-        self as gpui, div, point, px, size, AppContext, Context, InteractiveElement, IntoElement, ParentElement, Render, ScrollHandle, StatefulInteractiveElement, Styled, TestAppContext, Window
+        self as gpui, AppContext, Context, InteractiveElement, IntoElement, ParentElement, Render,
+        ScrollHandle, StatefulInteractiveElement, Styled, TestAppContext, Window, div, point, px,
+        size,
     };
 
     #[gpui::test]
@@ -3125,21 +3127,21 @@ mod test {
             // simple horizontal flex grid with 5 boxes
             fn render(&mut self, _: &mut Window, _: &mut Context<Self>) -> impl IntoElement {
                 div()
-                    .child(div()
-                        // create a parent div less wide than all the children
-                        .w(px(200.))
-                        .child(
-                            div()
-                                .flex()
-                                .flex_row()
-                                .items_center()
-                                .id("unpinned tabs")
-                                // make it scrollable
-                                .overflow_x_scroll()
-                                .w_full()
-                                .track_scroll(&self.scroll_handle)
-                                .children(
-                                    (0..5).map(|i| {
+                    .child(
+                        div()
+                            // create a parent div less wide than all the children
+                            .w(px(200.))
+                            .child(
+                                div()
+                                    .flex()
+                                    .flex_row()
+                                    .items_center()
+                                    .id("unpinned tabs")
+                                    // make it scrollable
+                                    .overflow_x_scroll()
+                                    .w_full()
+                                    .track_scroll(&self.scroll_handle)
+                                    .children((0..5).map(|_| {
                                         div()
                                             .id("tab_bar_drop_target")
                                             .min_w(px(60.))
@@ -3148,10 +3150,10 @@ mod test {
                                             .h_full()
                                             .flex_grow()
                                             .bg(gpui::blue())
-                                    })
-                                )
-                        )).into_element()
-
+                                    })),
+                            ),
+                    )
+                    .into_element()
             }
         }
 
@@ -3160,9 +3162,7 @@ mod test {
             scroll_handle: scrollable_handle.clone(),
         });
 
-        cx.draw(point(px(0.), px(0.)), size(px(200.), px(100.)), |_, cx| {
-            view
-        });
+        cx.draw(point(px(0.), px(0.)), size(px(200.), px(100.)), |_, _| view);
 
         // act: go to the third child which is already partially visible
         scrollable_handle.scroll_to_item(2);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -1279,7 +1279,7 @@ impl Pane {
     fn update_active_tab(&mut self, index: usize) {
         if !self.is_tab_pinned(index) {
             self.suppress_scroll = false;
-            self.tab_bar_scroll_handle.update_active_item(index);
+            self.tab_bar_scroll_handle.scroll_to_item(index);
         }
     }
 

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4065,11 +4065,11 @@ mod tests {
 
     use super::*;
     use crate::item::test::{TestItem, TestProjectItem};
-    use gpui::{TestAppContext, VisualTestContext, size, ScrollWheelEvent, point, ScrollDelta};
+    use gpui::{TestAppContext, VisualTestContext, size};
     use project::FakeFs;
     use settings::SettingsStore;
     use theme::LoadThemes;
-    use util::{default, TryFutureExt};
+    use util::{TryFutureExt};
 
     #[gpui::test]
     async fn test_add_item_capped_to_max_tabs(cx: &mut TestAppContext) {
@@ -6302,7 +6302,7 @@ mod tests {
         add_labeled_item(&pane, "untitled", false, cx);
         
         // Assert
-        let mut tab_bar_scroll_handle = pane.update_in(cx, |pane, window, cx| {
+        let tab_bar_scroll_handle = pane.update_in(cx, |pane, _window, _cx| {
             pane.tab_bar_scroll_handle.clone()
         });
         assert_eq!(tab_bar_scroll_handle.children_count(), 6);

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -4069,7 +4069,7 @@ mod tests {
     use project::FakeFs;
     use settings::SettingsStore;
     use theme::LoadThemes;
-    use util::{TryFutureExt};
+    use util::TryFutureExt;
 
     #[gpui::test]
     async fn test_add_item_capped_to_max_tabs(cx: &mut TestAppContext) {
@@ -6287,11 +6287,9 @@ mod tests {
 
         let project = Project::test(fs, None, cx).await;
         let (workspace, cx) =
-            cx.add_window_view(|window, cx| {
-                Workspace::test_new(project, window, cx)
-            });
+            cx.add_window_view(|window, cx| Workspace::test_new(project, window, cx));
         let pane = workspace.read_with(cx, |workspace, _| workspace.active_pane().clone());
-        
+
         cx.simulate_resize(size(px(300.), px(300.)));
 
         add_labeled_item(&pane, "untitled", false, cx);
@@ -6300,28 +6298,22 @@ mod tests {
         add_labeled_item(&pane, "untitled", false, cx);
         // Act: this should trigger a scroll
         add_labeled_item(&pane, "untitled", false, cx);
-        
         // Assert
-        let tab_bar_scroll_handle = pane.update_in(cx, |pane, _window, _cx| {
-            pane.tab_bar_scroll_handle.clone()
-        });
+        let tab_bar_scroll_handle =
+            pane.update_in(cx, |pane, _window, _cx| pane.tab_bar_scroll_handle.clone());
         assert_eq!(tab_bar_scroll_handle.children_count(), 6);
-        
         let tab_bounds = cx.debug_bounds("TAB-3").unwrap();
         let new_tab_button_bounds = cx.debug_bounds("ICON-Plus").unwrap();
-        
         let scroll_bounds = tab_bar_scroll_handle.bounds();
         let scroll_offset = tab_bar_scroll_handle.offset();
-        
         assert!(tab_bounds.right() <= scroll_bounds.right() + scroll_offset.x);
         // -39.75 is the magic number for this setup
         assert_eq!(scroll_offset.x, px(-39.75));
         assert!(
             !tab_bounds.intersects(&new_tab_button_bounds),
-            "Tab should overlap with the new tab button, if this is failing check if there's been a redesign!"
+            "Tab should not overlap with the new tab button, if this is failing check if there's been a redesign!"
         );
     }
-
 
     #[gpui::test]
     async fn test_close_all_items_including_pinned(cx: &mut TestAppContext) {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -566,10 +566,8 @@ impl Pane {
         if !self.was_focused {
             self.was_focused = true;
             self.update_history(self.active_item_index);
-            if self.active_item().is_some() {
-                if self.active_item_index() == self.active_item_index && !self.suppress_scroll {
-                    self.update_active_tab(self.active_item_index);
-                }
+            if !self.suppress_scroll && self.items.get(self.active_item_index).is_some() {
+                self.update_active_tab(self.active_item_index);
             }
             cx.emit(Event::Focus);
             cx.notify();


### PR DESCRIPTION
The state of the child bounds is not up-to-date when `scroll_to_item` gets triggered, causing the new tab to not scroll completely into view.

Closes #36317 

Release Notes:

- Fix an issue where a new tab is only partially visible on creation.
