### PR TITLE
Fix crash when opening inspector on Windows debug build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8467,6 +8467,7 @@ dependencies = [
  "theme",
  "ui",
  "util",
+ "util_macros",
  "workspace",
  "workspace-hack",
  "zed_actions",

--- a/crates/inspector_ui/Cargo.toml
+++ b/crates/inspector_ui/Cargo.toml
@@ -24,6 +24,7 @@ serde_json_lenient.workspace = true
 theme.workspace = true
 ui.workspace = true
 util.workspace = true
+util_macros.workspace = true
 workspace-hack.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true

--- a/crates/inspector_ui/src/div_inspector.rs
+++ b/crates/inspector_ui/src/div_inspector.rs
@@ -25,10 +25,7 @@ use util::split_str_with_ranges;
 
 /// Path used for unsaved buffer that contains style json. To support the json language server, this
 /// matches the name used in the generated schemas.
-#[cfg(target_os = "windows")]
-const ZED_INSPECTOR_STYLE_JSON: &str = r"C:\zed-inspector-style.json";
-#[cfg(not(target_os = "windows"))]
-const ZED_INSPECTOR_STYLE_JSON: &str = "/zed-inspector-style.json";
+const ZED_INSPECTOR_STYLE_JSON: &str = util_macros::path!("/zed-inspector-style.json");
 
 pub(crate) struct DivInspector {
     state: State,

--- a/crates/inspector_ui/src/div_inspector.rs
+++ b/crates/inspector_ui/src/div_inspector.rs
@@ -25,6 +25,9 @@ use util::split_str_with_ranges;
 
 /// Path used for unsaved buffer that contains style json. To support the json language server, this
 /// matches the name used in the generated schemas.
+#[cfg(target_os = "windows")]
+const ZED_INSPECTOR_STYLE_JSON: &str = r"C:\zed-inspector-style.json";
+#[cfg(not(target_os = "windows"))]
 const ZED_INSPECTOR_STYLE_JSON: &str = "/zed-inspector-style.json";
 
 pub(crate) struct DivInspector {


### PR DESCRIPTION
Closes #36811

Release Notes:

- N/A 

---


`lsp::Url::from_file_path` failed to parse the path and panicked. 
`/zed-inspector-style.json` is not a valid path on Windows and it returns `Err`.

https://github.com/zed-industries/zed/blob/40e34a31220fd1fbb40204f03a3187be1f08bf40/crates/project/src/lsp_store.rs#L7174-L7175

### Changes

- Added a valid path for Windows
