### PR TITLE
languages: Add `module` to TS/JS keywords

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -231,6 +231,7 @@
   "implements"
   "interface"
   "keyof"
+  "module"
   "namespace"
   "private"
   "protected"

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -237,6 +237,7 @@
   "implements"
   "interface"
   "keyof"
+  "module"
   "namespace"
   "private"
   "protected"

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -248,6 +248,7 @@
   "is"
   "keyof"
   "let"
+  "module"
   "namespace"
   "new"
   "of"


### PR DESCRIPTION

<img width="376" height="166" alt="image" src="https://github.com/user-attachments/assets/ae32d74c-387b-4809-a0d6-cfa97888347d" />


Release Notes:

- Improved syntax highlights for `module` keyword in TS/JS
