### PR TITLE
Set an environment variable when spawning a login shell

### DIFF
--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -15,6 +15,7 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
 
     let mut command_string = String::new();
     let mut command = std::process::Command::new(&shell_path);
+    command.env("ZED_CAPTURE_ENVIRONMENT", "1");
     // In some shells, file descriptors greater than 2 cannot be used in interactive mode,
     // so file descriptor 0 (stdin) is used instead. This impacts zsh, old bash; perhaps others.
     // See: https://github.com/zed-industries/zed/pull/32136#issuecomment-2999645482


### PR DESCRIPTION
Set an environment variable to allow running some scripts when launched by Zed. 

```bash
# ~/.profile
if [ "$ZED_CAPTURE_ENVIRONMENT" = "1" ]; then
  ...
fi
```

Visual Studio Code uses `VSCODE_RESOLVING_ENVIRONMENT `
https://code.visualstudio.com/docs/configure/command-line#_how-do-i-detect-when-a-shell-was-launched-by-vs-code

JetBrains IDEs uses `INTELLIJ_ENVIRONMENT_READER `
https://youtrack.jetbrains.com/articles/SUPPORT-A-1727/Shell-Environment-Loading#how-to-fix-it