### PR TITLE
gpui: Set initial window title on Wayland

### DIFF
--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -155,6 +155,12 @@ impl WaylandWindowState {
             BladeRenderer::new(gpu_context, &raw_window, config)?
         };
 
+        if let Some(titlebar) = options.titlebar {
+            if let Some(title) = titlebar.title {
+               toplevel.set_title(title.to_string());
+            }
+        }
+
         Ok(Self {
             xdg_surface,
             acknowledged_first_configure: false,

--- a/crates/gpui/src/platform/linux/wayland/window.rs
+++ b/crates/gpui/src/platform/linux/wayland/window.rs
@@ -157,7 +157,7 @@ impl WaylandWindowState {
 
         if let Some(titlebar) = options.titlebar {
             if let Some(title) = titlebar.title {
-               toplevel.set_title(title.to_string());
+                toplevel.set_title(title.to_string());
             }
         }
 


### PR DESCRIPTION
Closes #36843 

Release Notes:

- Fixed: set the initial window title correctly on startup in Wayland.
