### PR TITLE
Change DeepSeek max token count to 128k

### DIFF
--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -104,7 +104,7 @@ impl Model {
     pub fn max_output_tokens(&self) -> Option<u64> {
         match self {
             Self::Chat => Some(8_192),
-            Self::Reasoner => Some(8_192),
+            Self::Reasoner => Some(64_000),
             Self::Custom {
                 max_output_tokens, ..
             } => *max_output_tokens,

--- a/crates/deepseek/src/deepseek.rs
+++ b/crates/deepseek/src/deepseek.rs
@@ -96,7 +96,7 @@ impl Model {
 
     pub fn max_token_count(&self) -> u64 {
         match self {
-            Self::Chat | Self::Reasoner => 64_000,
+            Self::Chat | Self::Reasoner => 128_000,
             Self::Custom { max_tokens, .. } => *max_tokens,
         }
     }


### PR DESCRIPTION
https://api-docs.deepseek.com/zh-cn/news/news250821

Now the official API supports 128k token content

and have modify the name to v3.1/v3.1 thinking

Release Notes:

- N/A
