### PR TITLE
kotlin: Specify default language server

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1629,6 +1629,9 @@
         "allowed": true
       }
     },
+    "Kotlin": {
+      "language_servers": ["kotlin-language-server", "!kotlin-lsp", "..."]
+    },
     "LaTeX": {
       "formatter": "language_server",
       "language_servers": ["texlab", "..."],


### PR DESCRIPTION
As of https://github.com/zed-extensions/kotlin/commit/db52fc3655df8594a89b3a6b539274f23dfa2f28, the Kotlin extension has two language servers. However, following that change, no default language server for Kotlin was configured within this repo, which led to two language servers being activated for Kotlin by default. 

This PR makes `kotlin-language-server` the default language server for the extension. This also ensures that the [documentation within the repository](https://github.com/zed-extensions/kotlin?tab=readme-ov-file#kotlin-lsp) matches what is actually the case.


Release Notes:

- kotlin: Made `kotlin-language-server` the default language server.