### PR TITLE
lsp: Use effective capabilities instead of overwriting static ones with dynamic

### DIFF
--- a/crates/lsp/src/capabilities.rs
+++ b/crates/lsp/src/capabilities.rs
@@ -1,8 +1,9 @@
-use super::DynamicCapabilities;
 use lsp_types::{
     ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncSaveOptions,
 };
+
+use super::DynamicCapabilities;
 
 pub mod cap {
     pub struct DidChangeTextDocument;
@@ -30,11 +31,11 @@ impl EffectiveCapability for cap::DidChangeTextDocument {
                     return None;
                 }
                 let mut has_incremental = false;
-                for &kind in id_to_sync_kind_map.values() {
-                    if kind == TextDocumentSyncKind::FULL {
+                for data in id_to_sync_kind_map.values() {
+                    if data.sync_kind == TextDocumentSyncKind::FULL {
                         return Some(TextDocumentSyncKind::FULL);
                     }
-                    if kind == TextDocumentSyncKind::INCREMENTAL {
+                    if data.sync_kind == TextDocumentSyncKind::INCREMENTAL {
                         has_incremental = true;
                     }
                 }
@@ -73,7 +74,7 @@ impl EffectiveCapability for cap::DidSaveTextDocument {
                     Some(
                         id_to_save_options_map
                             .values()
-                            .any(|opts| opts.include_text.unwrap_or(false)),
+                            .any(|data| data.include_text),
                     )
                 }
             })

--- a/crates/lsp/src/capabilities.rs
+++ b/crates/lsp/src/capabilities.rs
@@ -32,10 +32,16 @@ impl EffectiveCapability for cap::DidChangeTextDocument {
                 }
                 let mut has_incremental = false;
                 for data in id_to_sync_kind_map.values() {
-                    if data.sync_kind == TextDocumentSyncKind::FULL {
+                    let sync_kind = match data.sync_kind {
+                        0 => Some(TextDocumentSyncKind::NONE),
+                        1 => Some(TextDocumentSyncKind::FULL),
+                        2 => Some(TextDocumentSyncKind::INCREMENTAL),
+                        _ => None,
+                    };
+                    if sync_kind == Some(TextDocumentSyncKind::FULL) {
                         return Some(TextDocumentSyncKind::FULL);
                     }
-                    if data.sync_kind == TextDocumentSyncKind::INCREMENTAL {
+                    if sync_kind == Some(TextDocumentSyncKind::INCREMENTAL) {
                         has_incremental = true;
                     }
                 }

--- a/crates/lsp/src/capabilities.rs
+++ b/crates/lsp/src/capabilities.rs
@@ -80,7 +80,7 @@ impl EffectiveCapability for cap::DidSaveTextDocument {
                     Some(
                         id_to_save_options_map
                             .values()
-                            .any(|data| data.include_text),
+                            .any(|data| data.include_text.unwrap_or(false)),
                     )
                 }
             })

--- a/crates/lsp/src/capabilities.rs
+++ b/crates/lsp/src/capabilities.rs
@@ -1,0 +1,90 @@
+use super::DynamicCapabilities;
+use lsp_types::{
+    ServerCapabilities, TextDocumentSyncCapability, TextDocumentSyncKind,
+    TextDocumentSyncSaveOptions,
+};
+
+pub mod cap {
+    pub struct DidChangeTextDocument;
+    pub struct DidSaveTextDocument;
+}
+
+pub trait EffectiveCapability {
+    type Value;
+    fn compute(static_caps: &ServerCapabilities, dynamic_caps: &DynamicCapabilities)
+    -> Self::Value;
+}
+
+impl EffectiveCapability for cap::DidChangeTextDocument {
+    type Value = Option<TextDocumentSyncKind>;
+
+    fn compute(
+        static_caps: &ServerCapabilities,
+        dynamic_caps: &DynamicCapabilities,
+    ) -> Self::Value {
+        dynamic_caps
+            .text_document_sync_did_change
+            .as_ref()
+            .and_then(|id_to_sync_kind_map| {
+                if id_to_sync_kind_map.is_empty() {
+                    None
+                } else {
+                    let mut best: Option<TextDocumentSyncKind> = None;
+                    for kind in id_to_sync_kind_map.values() {
+                        best = Some(match (best, kind) {
+                            (None, kind) => *kind,
+                            (
+                                Some(TextDocumentSyncKind::FULL),
+                                &TextDocumentSyncKind::INCREMENTAL,
+                            ) => TextDocumentSyncKind::INCREMENTAL,
+                            (Some(kind), _) => kind,
+                        });
+                    }
+                    best
+                }
+            })
+            .or_else(|| {
+                static_caps
+                    .text_document_sync
+                    .as_ref()
+                    .and_then(|sync| match sync {
+                        TextDocumentSyncCapability::Kind(kind) => Some(*kind),
+                        TextDocumentSyncCapability::Options(opts) => opts.change,
+                    })
+            })
+    }
+}
+
+impl EffectiveCapability for cap::DidSaveTextDocument {
+    type Value = Option<bool>;
+
+    fn compute(
+        static_caps: &ServerCapabilities,
+        dynamic_caps: &DynamicCapabilities,
+    ) -> Self::Value {
+        dynamic_caps
+            .text_document_sync_did_save
+            .as_ref()
+            .and_then(|id_to_save_options_map| {
+                if id_to_save_options_map.is_empty() {
+                    None
+                } else {
+                    Some(
+                        id_to_save_options_map
+                            .values()
+                            .any(|opts| opts.include_text.unwrap_or(false)),
+                    )
+                }
+            })
+            .or_else(|| match static_caps.text_document_sync.as_ref()? {
+                TextDocumentSyncCapability::Options(opts) => match opts.save.as_ref()? {
+                    TextDocumentSyncSaveOptions::Supported(true) => Some(false),
+                    TextDocumentSyncSaveOptions::Supported(false) => None,
+                    TextDocumentSyncSaveOptions::SaveOptions(save_opts) => {
+                        Some(save_opts.include_text.unwrap_or(false))
+                    }
+                },
+                TextDocumentSyncCapability::Kind(_) => None,
+            })
+    }
+}

--- a/crates/lsp/src/capabilities.rs
+++ b/crates/lsp/src/capabilities.rs
@@ -27,20 +27,21 @@ impl EffectiveCapability for cap::DidChangeTextDocument {
             .as_ref()
             .and_then(|id_to_sync_kind_map| {
                 if id_to_sync_kind_map.is_empty() {
-                    None
-                } else {
-                    let mut best: Option<TextDocumentSyncKind> = None;
-                    for kind in id_to_sync_kind_map.values() {
-                        best = Some(match (best, kind) {
-                            (None, kind) => *kind,
-                            (
-                                Some(TextDocumentSyncKind::FULL),
-                                &TextDocumentSyncKind::INCREMENTAL,
-                            ) => TextDocumentSyncKind::INCREMENTAL,
-                            (Some(kind), _) => kind,
-                        });
+                    return None;
+                }
+                let mut has_incremental = false;
+                for &kind in id_to_sync_kind_map.values() {
+                    if kind == TextDocumentSyncKind::FULL {
+                        return Some(TextDocumentSyncKind::FULL);
                     }
-                    best
+                    if kind == TextDocumentSyncKind::INCREMENTAL {
+                        has_incremental = true;
+                    }
+                }
+                if has_incremental {
+                    Some(TextDocumentSyncKind::INCREMENTAL)
+                } else {
+                    None
                 }
             })
             .or_else(|| {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -307,8 +307,9 @@ pub struct AdapterServerCapabilities {
 
 #[derive(Debug, Default, Clone)]
 pub struct DynamicCapabilities {
-    pub text_document_sync_did_change: Option<HashMap<String, TextDocumentSyncKind>>,
-    pub text_document_sync_did_save: Option<HashMap<String, SaveOptions>>,
+    pub text_document_sync_did_change:
+        Option<HashMap<String, TextDocumentChangeRegistrationOptions>>,
+    pub text_document_sync_did_save: Option<HashMap<String, TextDocumentSaveRegistrationOptions>>,
 }
 
 impl LanguageServer {

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1148,6 +1148,7 @@ impl LanguageServer {
         update(self.dynamic_capabilities.write().deref_mut());
     }
 
+    /// Get effective capabilities by combining static and dynamic capabilities.
     pub fn effective_capability<Cap: EffectiveCapability>(&self) -> Cap::Value {
         let static_capabilities = self.capabilities();
         let dynamic_capabilities = self.dynamic_capabilities.read().clone();

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1,4 +1,7 @@
+mod capabilities;
 mod input_handler;
+
+pub use capabilities::{EffectiveCapability, cap};
 
 pub use lsp_types::request::*;
 pub use lsp_types::*;
@@ -306,15 +309,6 @@ pub struct AdapterServerCapabilities {
 pub struct DynamicCapabilities {
     pub text_document_sync_did_change: Option<HashMap<String, TextDocumentSyncKind>>,
     pub text_document_sync_did_save: Option<HashMap<String, SaveOptions>>,
-}
-
-/// Effective text document synchronization behavior, merging static and dynamic capabilities.
-#[derive(Debug, Default, Clone)]
-pub struct EffectiveTextDocumentSync {
-    /// Effective change sync kind (FULL or INCREMENTAL), if any.
-    pub change: Option<TextDocumentSyncKind>,
-    /// Whether to include text on didSave, or None if didSave is not supported.
-    pub save_include_text: Option<bool>,
 }
 
 impl LanguageServer {
@@ -1150,74 +1144,14 @@ impl LanguageServer {
         self.static_capabilities.read().clone()
     }
 
-    pub fn dynamic_capabilities(&self) -> DynamicCapabilities {
-        self.dynamic_capabilities.read().clone()
-    }
-
     pub fn update_dynamic_capabilities(&self, update: impl FnOnce(&mut DynamicCapabilities)) {
         update(self.dynamic_capabilities.write().deref_mut());
     }
 
-    pub fn effective_text_document_sync(&self) -> EffectiveTextDocumentSync {
-        let static_caps = self.capabilities();
-        let dyn_caps = self.dynamic_capabilities();
-
-        let change = dyn_caps
-            .text_document_sync_did_change
-            .as_ref()
-            .and_then(|m| {
-                if m.is_empty() {
-                    None
-                } else {
-                    let mut best: Option<TextDocumentSyncKind> = None;
-                    for kind in m.values() {
-                        best = Some(match (best, kind) {
-                            (None, k) => *k,
-                            (
-                                Some(TextDocumentSyncKind::FULL),
-                                &TextDocumentSyncKind::INCREMENTAL,
-                            ) => TextDocumentSyncKind::INCREMENTAL,
-                            (Some(curr), _) => curr,
-                        });
-                    }
-                    best
-                }
-            })
-            .or_else(|| {
-                static_caps
-                    .text_document_sync
-                    .as_ref()
-                    .and_then(|sync| match sync {
-                        TextDocumentSyncCapability::Kind(kind) => Some(*kind),
-                        TextDocumentSyncCapability::Options(options) => options.change,
-                    })
-            });
-
-        let save_include_text = dyn_caps
-            .text_document_sync_did_save
-            .as_ref()
-            .and_then(|m| {
-                if m.is_empty() {
-                    None
-                } else {
-                    Some(m.values().any(|opts| opts.include_text.unwrap_or(false)))
-                }
-            })
-            .or_else(|| match static_caps.text_document_sync.as_ref()? {
-                TextDocumentSyncCapability::Options(opts) => match opts.save.as_ref()? {
-                    TextDocumentSyncSaveOptions::Supported(true) => Some(false),
-                    TextDocumentSyncSaveOptions::Supported(false) => None,
-                    TextDocumentSyncSaveOptions::SaveOptions(save_opts) => {
-                        Some(save_opts.include_text.unwrap_or(false))
-                    }
-                },
-                TextDocumentSyncCapability::Kind(_) => None,
-            });
-
-        EffectiveTextDocumentSync {
-            change,
-            save_include_text,
-        }
+    pub fn effective_capability<Cap: EffectiveCapability>(&self) -> Cap::Value {
+        let static_capabilities = self.capabilities();
+        let dynamic_capabilities = self.dynamic_capabilities.read().clone();
+        Cap::compute(&static_capabilities, &dynamic_capabilities)
     }
 
     /// Get the reported capabilities of the running language server and

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11706,12 +11706,11 @@ impl LspStore {
                     // Ignore payload since we notify clients of setting changes unconditionally, relying on them pulling the latest settings.
                 }
                 "workspace/symbol" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.workspace_symbol_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.workspace_symbol_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "workspace/fileOperations" => {
                     if let Some(options) = reg.register_options {
@@ -11735,12 +11734,11 @@ impl LspStore {
                     }
                 }
                 "textDocument/rangeFormatting" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.document_range_formatting_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.document_range_formatting_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "textDocument/onTypeFormatting" => {
                     if let Some(options) = reg
@@ -11755,36 +11753,32 @@ impl LspStore {
                     }
                 }
                 "textDocument/formatting" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.document_formatting_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.document_formatting_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "textDocument/rename" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.rename_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.rename_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "textDocument/inlayHint" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.inlay_hint_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.inlay_hint_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "textDocument/documentSymbol" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.document_symbol_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.document_symbol_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "textDocument/codeAction" => {
                     if let Some(options) = reg
@@ -11800,12 +11794,11 @@ impl LspStore {
                     }
                 }
                 "textDocument/definition" => {
-                    if let Some(options) = parse_register_capabilities(reg)? {
-                        server.update_capabilities(|capabilities| {
-                            capabilities.definition_provider = Some(options);
-                        });
-                        notify_server_capabilities_updated(&server, cx);
-                    }
+                    let options = parse_register_capabilities(reg)?;
+                    server.update_capabilities(|capabilities| {
+                        capabilities.definition_provider = Some(options);
+                    });
+                    notify_server_capabilities_updated(&server, cx);
                 }
                 "textDocument/completion" => {
                     if let Some(caps) = reg
@@ -12184,10 +12177,10 @@ impl LspStore {
 // https://github.com/microsoft/vscode-languageserver-node/blob/d90a87f9557a0df9142cfb33e251cfa6fe27d970/client/src/common/client.ts#L2133
 fn parse_register_capabilities<T: serde::de::DeserializeOwned>(
     reg: lsp::Registration,
-) -> anyhow::Result<Option<OneOf<bool, T>>> {
+) -> Result<OneOf<bool, T>> {
     Ok(match reg.register_options {
-        Some(options) => Some(OneOf::Right(serde_json::from_value::<T>(options)?)),
-        None => Some(OneOf::Left(true)),
+        Some(options) => OneOf::Right(serde_json::from_value::<T>(options)?),
+        None => OneOf::Left(true),
     })
 }
 

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -12140,20 +12140,6 @@ impl LspStore {
         Ok(())
     }
 
-    fn take_text_document_sync_options(
-        capabilities: &mut lsp::ServerCapabilities,
-    ) -> lsp::TextDocumentSyncOptions {
-        match capabilities.text_document_sync.take() {
-            Some(lsp::TextDocumentSyncCapability::Options(sync_options)) => sync_options,
-            Some(lsp::TextDocumentSyncCapability::Kind(sync_kind)) => {
-                let mut sync_options = lsp::TextDocumentSyncOptions::default();
-                sync_options.change = Some(sync_kind);
-                sync_options
-            }
-            None => lsp::TextDocumentSyncOptions::default(),
-        }
-    }
-
     #[cfg(any(test, feature = "test-support"))]
     pub fn forget_code_lens_task(&mut self, buffer_id: BufferId) -> Option<CodeLensTask> {
         let data = self.lsp_code_lens.get_mut(&buffer_id)?;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11832,42 +11832,27 @@ impl LspStore {
                     }
                 }
                 "textDocument/didChange" => {
-                    if let Some(sync_kind) = reg
-                        .register_options
-                        .and_then(|opts| opts.get("syncKind").cloned())
-                        .map(serde_json::from_value::<lsp::TextDocumentSyncKind>)
-                        .transpose()?
-                    {
+                    if let Some(options) = reg.register_options {
+                        let options: lsp::TextDocumentChangeRegistrationOptions =
+                            serde_json::from_value(options)?;
                         server.update_dynamic_capabilities(|dyn_caps| {
                             let map = dyn_caps
                                 .text_document_sync_did_change
                                 .get_or_insert_with(HashMap::default);
-                            map.insert(reg.id, sync_kind);
+                            map.insert(reg.id, options);
                         });
                         notify_server_capabilities_updated(&server, cx);
                     }
                 }
                 "textDocument/didSave" => {
-                    if let Some(include_text) = reg
-                        .register_options
-                        .map(|opts| {
-                            let transpose = opts
-                                .get("includeText")
-                                .cloned()
-                                .map(serde_json::from_value::<Option<bool>>)
-                                .transpose();
-                            match transpose {
-                                Ok(value) => Ok(value.flatten()),
-                                Err(e) => Err(e),
-                            }
-                        })
-                        .transpose()?
-                    {
+                    if let Some(options) = reg.register_options {
+                        let options: lsp::TextDocumentSaveRegistrationOptions =
+                            serde_json::from_value(options)?;
                         server.update_dynamic_capabilities(|dyn_caps| {
                             let map = dyn_caps
                                 .text_document_sync_did_save
                                 .get_or_insert_with(HashMap::default);
-                            map.insert(reg.id, lsp::SaveOptions { include_text });
+                            map.insert(reg.id, options);
                         });
                         notify_server_capabilities_updated(&server, cx);
                     }


### PR DESCRIPTION
WIP, idea is to store both static and dynamic caps in map with ids (id for static is created on client side), then use effective caps logic to figure out how to use them. Benefit for this is, when language server unregisters the caps, we don't loose static caps like we currently do.

This also builds base for storing `documentSelector` which we don't do currently.  

Release Notes:

- N/A
