### PR TITLE
acp: Model-specific prompt capabilities for 1PA

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -756,6 +756,8 @@ pub struct AcpThread {
     connection: Rc<dyn AgentConnection>,
     session_id: acp::SessionId,
     token_usage: Option<TokenUsage>,
+    prompt_capabilities: acp::PromptCapabilities,
+    _observe_prompt_capabilities: Task<anyhow::Result<()>>,
 }
 
 #[derive(Debug)]
@@ -770,6 +772,7 @@ pub enum AcpThreadEvent {
     Stopped,
     Error,
     LoadError(LoadError),
+    PromptCapabilitiesUpdated,
 }
 
 impl EventEmitter<AcpThreadEvent> for AcpThread {}
@@ -821,7 +824,20 @@ impl AcpThread {
         project: Entity<Project>,
         action_log: Entity<ActionLog>,
         session_id: acp::SessionId,
+        mut prompt_capabilities_rx: watch::Receiver<acp::PromptCapabilities>,
+        cx: &mut Context<Self>,
     ) -> Self {
+        let prompt_capabilities = prompt_capabilities_rx.borrow().clone();
+        let task = cx.spawn::<_, anyhow::Result<()>>(async move |this, cx| {
+            loop {
+                let caps = prompt_capabilities_rx.recv().await?;
+                this.update(cx, |this, cx| {
+                    this.prompt_capabilities = caps;
+                    cx.emit(AcpThreadEvent::PromptCapabilitiesUpdated);
+                })?;
+            }
+        });
+
         Self {
             action_log,
             shared_buffers: Default::default(),
@@ -833,7 +849,13 @@ impl AcpThread {
             connection,
             session_id,
             token_usage: None,
+            prompt_capabilities,
+            _observe_prompt_capabilities: task,
         }
+    }
+
+    pub fn prompt_capabilities(&self) -> acp::PromptCapabilities {
+        self.prompt_capabilities
     }
 
     pub fn connection(&self) -> &Rc<dyn AgentConnection> {
@@ -2599,13 +2621,19 @@ mod tests {
                     .into(),
             );
             let action_log = cx.new(|_| ActionLog::new(project.clone()));
-            let thread = cx.new(|_cx| {
+            let thread = cx.new(|cx| {
                 AcpThread::new(
                     "Test",
                     self.clone(),
                     project,
                     action_log,
                     session_id.clone(),
+                    watch::Receiver::constant(acp::PromptCapabilities {
+                        image: true,
+                        audio: true,
+                        embedded_context: true,
+                    }),
+                    cx,
                 )
             });
             self.sessions.lock().insert(session_id, thread.downgrade());
@@ -2636,18 +2664,6 @@ mod tests {
                 Task::ready(Ok(acp::PromptResponse {
                     stop_reason: acp::StopReason::EndTurn,
                 }))
-            }
-        }
-
-        fn prompt_capabilities(
-            &self,
-            _session: &acp::SessionId,
-            _cx: &mut App,
-        ) -> acp::PromptCapabilities {
-            acp::PromptCapabilities {
-                image: true,
-                audio: true,
-                embedded_context: true,
             }
         }
 

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -827,7 +827,7 @@ impl AcpThread {
         mut prompt_capabilities_rx: watch::Receiver<acp::PromptCapabilities>,
         cx: &mut Context<Self>,
     ) -> Self {
-        let prompt_capabilities = prompt_capabilities_rx.borrow().clone();
+        let prompt_capabilities = *prompt_capabilities_rx.borrow();
         let task = cx.spawn::<_, anyhow::Result<()>>(async move |this, cx| {
             loop {
                 let caps = prompt_capabilities_rx.recv().await?;

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2639,7 +2639,11 @@ mod tests {
             }
         }
 
-        fn prompt_capabilities(&self) -> acp::PromptCapabilities {
+        fn prompt_capabilities(
+            &self,
+            _session: &acp::SessionId,
+            _cx: &mut App,
+        ) -> acp::PromptCapabilities {
             acp::PromptCapabilities {
                 image: true,
                 audio: true,

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -38,7 +38,11 @@ pub trait AgentConnection {
         cx: &mut App,
     ) -> Task<Result<acp::PromptResponse>>;
 
-    fn prompt_capabilities(&self) -> acp::PromptCapabilities;
+    fn prompt_capabilities(
+        &self,
+        session: &acp::SessionId,
+        cx: &mut App,
+    ) -> acp::PromptCapabilities;
 
     fn resume(
         &self,
@@ -348,7 +352,11 @@ mod test_support {
             Task::ready(Ok(thread))
         }
 
-        fn prompt_capabilities(&self) -> acp::PromptCapabilities {
+        fn prompt_capabilities(
+            &self,
+            _session: &acp::SessionId,
+            _cx: &mut App,
+        ) -> acp::PromptCapabilities {
             acp::PromptCapabilities {
                 image: true,
                 audio: true,

--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -26,7 +26,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::rc::Rc;
 use std::sync::Arc;
-use util::{ResultExt, maybe};
+use util::ResultExt;
 
 const RULES_FILE_NAMES: [&str; 9] = [
     ".rules",
@@ -240,13 +240,16 @@ impl NativeAgent {
         let title = thread.title();
         let project = thread.project.clone();
         let action_log = thread.action_log.clone();
-        let acp_thread = cx.new(|_cx| {
+        let prompt_capabilities_rx = thread.prompt_capabilities_rx.clone();
+        let acp_thread = cx.new(|cx| {
             acp_thread::AcpThread::new(
                 title,
                 connection,
                 project.clone(),
                 action_log.clone(),
                 session_id.clone(),
+                prompt_capabilities_rx,
+                cx,
             )
         });
         let subscriptions = vec![
@@ -923,28 +926,6 @@ impl acp_thread::AgentConnection for NativeAgentConnection {
 
             thread.update(cx, |thread, cx| thread.send(id, content, cx))
         })
-    }
-
-    fn prompt_capabilities(
-        &self,
-        session: &acp::SessionId,
-        cx: &mut App,
-    ) -> acp::PromptCapabilities {
-        let model = maybe!({
-            let thread = self
-                .0
-                .read(cx)
-                .sessions
-                .get(session)
-                .map(|session| session.thread.clone())?;
-            thread.read(cx).model().cloned()
-        });
-        let image = model.map_or(true, |model| model.supports_images());
-        acp::PromptCapabilities {
-            image,
-            audio: false,
-            embedded_context: true,
-        }
     }
 
     fn resume(

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -279,7 +279,12 @@ impl AgentConnection for AcpConnection {
         })
     }
 
-    fn prompt_capabilities(&self) -> acp::PromptCapabilities {
+    fn prompt_capabilities(
+        &self,
+        _session: &acp::SessionId,
+        _cx: &mut App,
+    ) -> acp::PromptCapabilities {
+        // TODO: support ACP sending prompt capabilities per session?
         self.prompt_capabilities
     }
 

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -193,7 +193,7 @@ impl AgentConnection for AcpConnection {
                     action_log,
                     session_id.clone(),
                     // ACP doesn't currently support per-session prompt capabilities or changing capabilities dynamically.
-                    watch::Receiver::constant(self.prompt_capabilities.clone()),
+                    watch::Receiver::constant(self.prompt_capabilities),
                     cx,
                 )
             })?;

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -185,13 +185,16 @@ impl AgentConnection for AcpConnection {
 
             let session_id = response.session_id;
             let action_log = cx.new(|_| ActionLog::new(project.clone()))?;
-            let thread = cx.new(|_cx| {
+            let thread = cx.new(|cx| {
                 AcpThread::new(
                     self.server_name.clone(),
                     self.clone(),
                     project,
                     action_log,
                     session_id.clone(),
+                    // ACP doesn't currently support per-session prompt capabilities or changing capabilities dynamically.
+                    watch::Receiver::constant(self.prompt_capabilities.clone()),
+                    cx,
                 )
             })?;
 
@@ -277,15 +280,6 @@ impl AgentConnection for AcpConnection {
                 }
             }
         })
-    }
-
-    fn prompt_capabilities(
-        &self,
-        _session: &acp::SessionId,
-        _cx: &mut App,
-    ) -> acp::PromptCapabilities {
-        // TODO: support ACP sending prompt capabilities per session?
-        self.prompt_capabilities
     }
 
     fn cancel(&self, session_id: &acp::SessionId, cx: &mut App) {

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -319,7 +319,11 @@ impl AgentConnection for ClaudeAgentConnection {
         cx.foreground_executor().spawn(async move { end_rx.await? })
     }
 
-    fn prompt_capabilities(&self) -> acp::PromptCapabilities {
+    fn prompt_capabilities(
+        &self,
+        _session: &acp::SessionId,
+        _cx: &mut App,
+    ) -> acp::PromptCapabilities {
         acp::PromptCapabilities {
             image: true,
             audio: false,

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -249,13 +249,19 @@ impl AgentConnection for ClaudeAgentConnection {
             });
 
             let action_log = cx.new(|_| ActionLog::new(project.clone()))?;
-            let thread = cx.new(|_cx| {
+            let thread = cx.new(|cx| {
                 AcpThread::new(
                     "Claude Code",
                     self.clone(),
                     project,
                     action_log,
                     session_id.clone(),
+                    watch::Receiver::constant(acp::PromptCapabilities {
+                        image: true,
+                        audio: false,
+                        embedded_context: true,
+                    }),
+                    cx,
                 )
             })?;
 
@@ -317,18 +323,6 @@ impl AgentConnection for ClaudeAgentConnection {
         }
 
         cx.foreground_executor().spawn(async move { end_rx.await? })
-    }
-
-    fn prompt_capabilities(
-        &self,
-        _session: &acp::SessionId,
-        _cx: &mut App,
-    ) -> acp::PromptCapabilities {
-        acp::PromptCapabilities {
-            image: true,
-            audio: false,
-            embedded_context: true,
-        }
     }
 
     fn cancel(&self, session_id: &acp::SessionId, _cx: &mut App) {

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -373,7 +373,7 @@ impl MessageEditor {
 
         if Img::extensions().contains(&extension) && !extension.contains("svg") {
             if !self.prompt_capabilities.get().image {
-                return Task::ready(Err(anyhow!("This agent does not support images yet")));
+                return Task::ready(Err(anyhow!("This model does not support images yet")));
             }
             let task = self
                 .project

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -471,8 +471,9 @@ impl AcpThreadView {
                     Ok(thread) => {
                         let action_log = thread.read(cx).action_log().clone();
 
+                        let session = thread.read(cx).session_id().clone();
                         this.prompt_capabilities
-                            .set(connection.prompt_capabilities());
+                            .set(connection.prompt_capabilities(&session, cx));
 
                         let count = thread.read(cx).entries().len();
                         this.list_state.splice(0..0, count);
@@ -5316,7 +5317,11 @@ pub(crate) mod tests {
             &[]
         }
 
-        fn prompt_capabilities(&self) -> acp::PromptCapabilities {
+        fn prompt_capabilities(
+            &self,
+            _session: &acp::SessionId,
+            _cx: &mut App,
+        ) -> acp::PromptCapabilities {
             acp::PromptCapabilities {
                 image: true,
                 audio: true,

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1529,6 +1529,7 @@ impl AgentDiff {
             | AcpThreadEvent::TokenUsageUpdated
             | AcpThreadEvent::EntriesRemoved(_)
             | AcpThreadEvent::ToolAuthorizationRequired
+            | AcpThreadEvent::PromptCapabilitiesUpdated
             | AcpThreadEvent::Retry(_) => {}
         }
     }

--- a/crates/watch/src/watch.rs
+++ b/crates/watch/src/watch.rs
@@ -162,6 +162,19 @@ impl<T> Receiver<T> {
             pending_waker_id: None,
         }
     }
+
+    /// Creates a new [`Receiver`] holding an initial value that will never change.
+    pub fn constant(value: T) -> Self {
+        let state = Arc::new(RwLock::new(State {
+            value,
+            wakers: BTreeMap::new(),
+            next_waker_id: WakerId::default(),
+            version: 0,
+            closed: false,
+        }));
+
+        Self { state, version: 0 }
+    }
 }
 
 impl<T: Clone> Receiver<T> {


### PR DESCRIPTION
Adds support for per-session prompt capabilities and capability changes on the Zed side (ACP itself still only has per-connection static capabilities for now), and uses it to reflect image support accurately in 1PA threads based on the currently-selected model.

Release Notes:

- N/A