### PR TITLE
Revert "Capture `shorthand_field_initializer` and modules in Rust highlights (#35842)"

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -6,9 +6,6 @@
 (self) @variable.special
 (field_identifier) @property
 
-(shorthand_field_initializer
-  (identifier) @property)
-
 (trait_item name: (type_identifier) @type.interface)
 (impl_item trait: (type_identifier) @type.interface)
 (abstract_type trait: (type_identifier) @type.interface)
@@ -41,19 +38,10 @@
     (identifier) @function.special
     (scoped_identifier
       name: (identifier) @function.special)
-  ]
-  "!" @function.special)
+  ])
 
 (macro_definition
   name: (identifier) @function.special.definition)
-
-(mod_item
-  name: (identifier) @module)
-
-(visibility_modifier [
-  (crate) @keyword
-  (super) @keyword
-])
 
 ; Identifier conventions
 
@@ -127,7 +115,9 @@
   "where"
   "while"
   "yield"
+  (crate)
   (mutable_specifier)
+  (super)
 ] @keyword
 
 [
@@ -199,7 +189,6 @@
 operator: "/" @operator
 
 (lifetime) @lifetime
-(lifetime (identifier) @lifetime)
 
 (parameter (identifier) @variable.parameter)
 


### PR DESCRIPTION
This PR reverts https://github.com/zed-industries/zed/pull/35842, as it broke the syntax highlighting for `crate`:

### Before Revert

<img width="367" height="70" alt="Screenshot 2025-08-25 at 11 29 50 AM" src="https://github.com/user-attachments/assets/ce9b8b59-4e89-43ed-84c7-95c0156b9168" />

### After Revert

<img width="353" height="69" alt="Screenshot 2025-08-25 at 11 32 17 AM" src="https://github.com/user-attachments/assets/b6df5a21-64db-4abf-aa76-f085236da0c4" />

This reverts commit 896a35f7befce468427a30489adf88c851b9507d.

Release Notes:

- Reverted https://github.com/zed-industries/zed/pull/35842.
