### PR TITLE
Require confirmation for fetch tool

### DIFF
--- a/crates/agent2/src/tools/fetch_tool.rs
+++ b/crates/agent2/src/tools/fetch_tool.rs
@@ -136,12 +136,17 @@ impl AgentTool for FetchTool {
     fn run(
         self: Arc<Self>,
         input: Self::Input,
-        _event_stream: ToolCallEventStream,
+        event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<Self::Output>> {
+        let authorize = event_stream.authorize(input.url.clone(), cx);
+
         let text = cx.background_spawn({
             let http_client = self.http_client.clone();
-            async move { Self::build_message(http_client, &input.url).await }
+            async move {
+                authorize.await?;
+                Self::build_message(http_client, &input.url).await
+            }
         });
 
         cx.foreground_executor().spawn(async move {

--- a/crates/assistant_tools/src/fetch_tool.rs
+++ b/crates/assistant_tools/src/fetch_tool.rs
@@ -118,7 +118,7 @@ impl Tool for FetchTool {
     }
 
     fn needs_confirmation(&self, _: &serde_json::Value, _: &Entity<Project>, _: &App) -> bool {
-        false
+        true
     }
 
     fn may_perform_edits(&self) -> bool {


### PR DESCRIPTION
Using prompt injection, the agent may be tricked into making a fetch
request that includes unexpected data from the conversation in the URL.

As agent conversations may contain sensitive information (like private code, or
potentially even API keys), this seems bad.

The easiest way to prevent this is to require the user to look at the URL
before the model is allowed to fetch it.

Thanks to @ant4g0nist for bringing this to our attention.

Release Notes:

- agent panel: The fetch tool now requires confirmation.
