### PR TITLE
Revert "workspace: Disable padding on zoomed panels"

### DIFF
--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -6622,15 +6622,25 @@ impl Render for Workspace {
                                     }
                                 })
                                 .children(self.zoomed.as_ref().and_then(|view| {
-                                    Some(div()
+                                    let zoomed_view = view.upgrade()?;
+                                    let div = div()
                                         .occlude()
                                         .absolute()
                                         .overflow_hidden()
                                         .border_color(colors.border)
                                         .bg(colors.background)
-                                        .child(view.upgrade()?)
+                                        .child(zoomed_view)
                                         .inset_0()
-                                        .shadow_lg())
+                                        .shadow_lg();
+
+                                    Some(match self.zoomed_position {
+                                        Some(DockPosition::Left) => div.right_2().border_r_1(),
+                                        Some(DockPosition::Right) => div.left_2().border_l_1(),
+                                        Some(DockPosition::Bottom) => div.top_2().border_t_1(),
+                                        None => {
+                                            div.top_2().bottom_2().left_2().right_2().border_1()
+                                        }
+                                    })
                                 }))
                                 .children(self.render_notifications(window, cx)),
                         )


### PR DESCRIPTION
Reverts zed-industries/zed#36012

We thought we didn't need this UI, but it turns out it was load bearing :)

Release Notes:

- Restored the zoomed panel padding