### PR TITLE
Make fields of `AiUpsellCard` private

### DIFF
--- a/crates/ai_onboarding/src/ai_upsell_card.rs
+++ b/crates/ai_onboarding/src/ai_upsell_card.rs
@@ -12,11 +12,11 @@ use crate::{SignInStatus, YoungAccountBanner, plan_definitions::PlanDefinitions}
 
 #[derive(IntoElement, RegisterComponent)]
 pub struct AiUpsellCard {
-    pub sign_in_status: SignInStatus,
-    pub sign_in: Arc<dyn Fn(&mut Window, &mut App)>,
-    pub account_too_young: bool,
-    pub user_plan: Option<Plan>,
-    pub tab_index: Option<isize>,
+    sign_in_status: SignInStatus,
+    sign_in: Arc<dyn Fn(&mut Window, &mut App)>,
+    account_too_young: bool,
+    user_plan: Option<Plan>,
+    tab_index: Option<isize>,
 }
 
 impl AiUpsellCard {
@@ -42,6 +42,11 @@ impl AiUpsellCard {
             account_too_young: store.account_too_young(),
             tab_index: None,
         }
+    }
+
+    pub fn tab_index(mut self, tab_index: Option<isize>) -> Self {
+        self.tab_index = tab_index;
+        self
     }
 }
 

--- a/crates/onboarding/src/ai_setup_page.rs
+++ b/crates/onboarding/src/ai_setup_page.rs
@@ -283,17 +283,13 @@ pub(crate) fn render_ai_setup_page(
             v_flex()
                 .mt_2()
                 .gap_6()
-                .child({
-                    let mut ai_upsell_card =
-                        AiUpsellCard::new(client, &user_store, user_store.read(cx).plan(), cx);
-
-                    ai_upsell_card.tab_index = Some({
-                        tab_index += 1;
-                        tab_index - 1
-                    });
-
-                    ai_upsell_card
-                })
+                .child(
+                    AiUpsellCard::new(client, &user_store, user_store.read(cx).plan(), cx)
+                        .tab_index(Some({
+                            tab_index += 1;
+                            tab_index - 1
+                        })),
+                )
                 .child(render_llm_provider_section(
                     &mut tab_index,
                     workspace,


### PR DESCRIPTION
This PR makes the fields of the `AiUpsellCard` private, for better encapsulation.

Release Notes:

- N/A
