### PR TITLE
open_ai: Remove `model` field from ResponseStreamEvent

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -446,7 +446,6 @@ pub enum ResponseStreamResult {
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ResponseStreamEvent {
-    pub model: String,
     pub choices: Vec<ChoiceDelta>,
     pub usage: Option<Usage>,
 }


### PR DESCRIPTION
Closes #36901

Release Notes:

- Fixed use of Open WebUI as an LLM provider.