### PR TITLE
Fix Sqlite newline syntax in workspace migration

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -553,7 +553,7 @@ impl Domain for WorkspaceDb {
                             WHEN workspaces.local_paths_array IS NULL OR workspaces.local_paths_array = "" THEN
                                 NULL
                             ELSE
-                                replace(workspaces.local_paths_array, ',', "\n")
+                                replace(workspaces.local_paths_array, ',', CHAR(10))
                         END
                 END as paths,
 


### PR DESCRIPTION
Fixes one more case where I incorrectly tried to use a `\n` escape sequence for a newline in sqlite.

Release Notes:

- N/A
