### PR TITLE
helix: Fix `buffer search: deploy` reset to normal mode

### DIFF
--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -203,7 +203,10 @@ impl Vim {
 
     // hook into the existing to clear out any vim search state on cmd+f or edit -> find.
     fn search_deploy(&mut self, _: &buffer_search::Deploy, _: &mut Window, cx: &mut Context<Self>) {
+        // Preserve the current mode when resetting search state
+        let current_mode = self.mode;
         self.search = Default::default();
+        self.search.prior_mode = current_mode;
         cx.propagate();
     }
 


### PR DESCRIPTION
## Fix: Preserve Helix mode when using  search

### Problem
When using `buffer search: deploy` in Helix mode, pressing Enter to dismiss the search incorrectly returned to Vim NORMAL mode instead of Helix NORMAL mode.

### Root Cause
The `search_deploy` function was resetting the entire `SearchState` to default values when buffer search: deploy was activated. Since the default `Mode` is `Normal`, this caused `prior_mode` to be set to Vim's Normal mode regardless of the actual mode before search.

### Solution
Modified `search_deploy` to preserve the current mode when resetting search state:
- Store the current mode before resetting
- Reset search state to default
- Restore the saved mode to `prior_mode`

This ensures the editor returns to the correct mode (Helix NORMAL or Vim NORMAL) after dismissing buffer search.

### Settings

I was able to reproduce and then test the fix was successful with the following config and have also tested with vim: default_mode commented out to ensure that's not influencing the mode selection flow: 

```
  "helix_mode": true,
  "vim_mode": true,
  "vim": {
    "default_mode": "helix_normal"
  },
```

This is on Kubuntu 24.04.

The following test combinations pass locally:

- `cargo test -p search`
- `cargo test -p vim` 
- `cargo test -p editor`
- `cargo test -p workspace`
- `cargo test -p gpui -- vim`
- `cargo test -p gpui -- helix`

Release Notes:

- Fixed Helix mode switching to Vim normal mode after using `buffer search: deploy` to search

Closes #36872 