### PR TITLE
agent2: Always finalize diffs from the edit tool

### DIFF
--- a/crates/agent2/src/thread.rs
+++ b/crates/agent2/src/thread.rs
@@ -2459,6 +2459,30 @@ impl ToolCallEventStreamReceiver {
         }
     }
 
+    pub async fn expect_update_fields(&mut self) -> acp::ToolCallUpdateFields {
+        let event = self.0.next().await;
+        if let Some(Ok(ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateFields(
+            update,
+        )))) = event
+        {
+            update.fields
+        } else {
+            panic!("Expected update fields but got: {:?}", event);
+        }
+    }
+
+    pub async fn expect_diff(&mut self) -> Entity<acp_thread::Diff> {
+        let event = self.0.next().await;
+        if let Some(Ok(ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateDiff(
+            update,
+        )))) = event
+        {
+            update.diff
+        } else {
+            panic!("Expected diff but got: {:?}", event);
+        }
+    }
+
     pub async fn expect_terminal(&mut self) -> Entity<acp_thread::Terminal> {
         let event = self.0.next().await;
         if let Some(Ok(ThreadEvent::ToolCallUpdate(acp_thread::ToolCallUpdate::UpdateTerminal(

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -1580,7 +1580,7 @@ mod tests {
                 tool.run(
                     EditFileToolInput {
                         display_description: "Edit file".into(),
-                        path: "/main.rs".into(),
+                        path: path!("/main.rs").into(),
                         mode: EditFileMode::Edit,
                     },
                     stream_tx,
@@ -1605,7 +1605,7 @@ mod tests {
                 tool.run(
                     EditFileToolInput {
                         display_description: "Edit file".into(),
-                        path: "/main.rs".into(),
+                        path: path!("/main.rs").into(),
                         mode: EditFileMode::Edit,
                     },
                     stream_tx,
@@ -1628,7 +1628,7 @@ mod tests {
                 tool.run(
                     EditFileToolInput {
                         display_description: "Edit file".into(),
-                        path: "/main.rs".into(),
+                        path: path!("/main.rs").into(),
                         mode: EditFileMode::Edit,
                     },
                     stream_tx,

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -272,159 +272,164 @@ impl AgentTool for EditFileTool {
                 .await?;
 
             let diff = cx.new(|cx| Diff::new(buffer.clone(), cx))?;
-            event_stream.update_diff(diff.clone());
+            let result = async {
+                event_stream.update_diff(diff.clone());
 
-            let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
-            let old_text = cx
-                .background_spawn({
-                    let old_snapshot = old_snapshot.clone();
-                    async move { Arc::new(old_snapshot.text()) }
-                })
-                .await;
+                let old_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
+                let old_text = cx
+                    .background_spawn({
+                        let old_snapshot = old_snapshot.clone();
+                        async move { Arc::new(old_snapshot.text()) }
+                    })
+                    .await;
 
 
-            let (output, mut events) = if matches!(input.mode, EditFileMode::Edit) {
-                edit_agent.edit(
-                    buffer.clone(),
-                    input.display_description.clone(),
-                    &request,
-                    cx,
-                )
-            } else {
-                edit_agent.overwrite(
-                    buffer.clone(),
-                    input.display_description.clone(),
-                    &request,
-                    cx,
-                )
-            };
+                let (output, mut events) = if matches!(input.mode, EditFileMode::Edit) {
+                    edit_agent.edit(
+                        buffer.clone(),
+                        input.display_description.clone(),
+                        &request,
+                        cx,
+                    )
+                } else {
+                    edit_agent.overwrite(
+                        buffer.clone(),
+                        input.display_description.clone(),
+                        &request,
+                        cx,
+                    )
+                };
 
-            let mut hallucinated_old_text = false;
-            let mut ambiguous_ranges = Vec::new();
-            let mut emitted_location = false;
-            while let Some(event) = events.next().await {
-                match event {
-                    EditAgentOutputEvent::Edited(range) => {
-                        if !emitted_location {
-                            let line = buffer.update(cx, |buffer, _cx| {
-                                range.start.to_point(&buffer.snapshot()).row
-                            }).ok();
-                            if let Some(abs_path) = abs_path.clone() {
-                                event_stream.update_fields(ToolCallUpdateFields {
-                                    locations: Some(vec![ToolCallLocation { path: abs_path, line }]),
-                                    ..Default::default()
-                                });
+                let mut hallucinated_old_text = false;
+                let mut ambiguous_ranges = Vec::new();
+                let mut emitted_location = false;
+                while let Some(event) = events.next().await {
+                    match event {
+                        EditAgentOutputEvent::Edited(range) => {
+                            if !emitted_location {
+                                let line = buffer.update(cx, |buffer, _cx| {
+                                    range.start.to_point(&buffer.snapshot()).row
+                                }).ok();
+                                if let Some(abs_path) = abs_path.clone() {
+                                    event_stream.update_fields(ToolCallUpdateFields {
+                                        locations: Some(vec![ToolCallLocation { path: abs_path, line }]),
+                                        ..Default::default()
+                                    });
+                                }
+                                emitted_location = true;
                             }
-                            emitted_location = true;
+                        },
+                        EditAgentOutputEvent::UnresolvedEditRange => hallucinated_old_text = true,
+                        EditAgentOutputEvent::AmbiguousEditRange(ranges) => ambiguous_ranges = ranges,
+                        EditAgentOutputEvent::ResolvingEditRange(range) => {
+                            diff.update(cx, |card, cx| card.reveal_range(range.clone(), cx))?;
+                            // if !emitted_location {
+                            //     let line = buffer.update(cx, |buffer, _cx| {
+                            //         range.start.to_point(&buffer.snapshot()).row
+                            //     }).ok();
+                            //     if let Some(abs_path) = abs_path.clone() {
+                            //         event_stream.update_fields(ToolCallUpdateFields {
+                            //             locations: Some(vec![ToolCallLocation { path: abs_path, line }]),
+                            //             ..Default::default()
+                            //         });
+                            //     }
+                            // }
                         }
-                    },
-                    EditAgentOutputEvent::UnresolvedEditRange => hallucinated_old_text = true,
-                    EditAgentOutputEvent::AmbiguousEditRange(ranges) => ambiguous_ranges = ranges,
-                    EditAgentOutputEvent::ResolvingEditRange(range) => {
-                        diff.update(cx, |card, cx| card.reveal_range(range.clone(), cx))?;
-                        // if !emitted_location {
-                        //     let line = buffer.update(cx, |buffer, _cx| {
-                        //         range.start.to_point(&buffer.snapshot()).row
-                        //     }).ok();
-                        //     if let Some(abs_path) = abs_path.clone() {
-                        //         event_stream.update_fields(ToolCallUpdateFields {
-                        //             locations: Some(vec![ToolCallLocation { path: abs_path, line }]),
-                        //             ..Default::default()
-                        //         });
-                        //     }
-                        // }
                     }
                 }
-            }
 
-            // If format_on_save is enabled, format the buffer
-            let format_on_save_enabled = buffer
-                .read_with(cx, |buffer, cx| {
-                    let settings = language_settings::language_settings(
-                        buffer.language().map(|l| l.name()),
-                        buffer.file(),
-                        cx,
-                    );
-                    settings.format_on_save != FormatOnSave::Off
-                })
-                .unwrap_or(false);
+                // If format_on_save is enabled, format the buffer
+                let format_on_save_enabled = buffer
+                    .read_with(cx, |buffer, cx| {
+                        let settings = language_settings::language_settings(
+                            buffer.language().map(|l| l.name()),
+                            buffer.file(),
+                            cx,
+                        );
+                        settings.format_on_save != FormatOnSave::Off
+                    })
+                    .unwrap_or(false);
 
-            let edit_agent_output = output.await?;
+                let edit_agent_output = output.await?;
 
-            if format_on_save_enabled {
+                if format_on_save_enabled {
+                    action_log.update(cx, |log, cx| {
+                        log.buffer_edited(buffer.clone(), cx);
+                    })?;
+
+                    let format_task = project.update(cx, |project, cx| {
+                        project.format(
+                            HashSet::from_iter([buffer.clone()]),
+                            LspFormatTarget::Buffers,
+                            false, // Don't push to history since the tool did it.
+                            FormatTrigger::Save,
+                            cx,
+                        )
+                    })?;
+                    format_task.await.log_err();
+                }
+
+                project
+                    .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))?
+                    .await?;
+
                 action_log.update(cx, |log, cx| {
                     log.buffer_edited(buffer.clone(), cx);
                 })?;
 
-                let format_task = project.update(cx, |project, cx| {
-                    project.format(
-                        HashSet::from_iter([buffer.clone()]),
-                        LspFormatTarget::Buffers,
-                        false, // Don't push to history since the tool did it.
-                        FormatTrigger::Save,
-                        cx,
-                    )
-                })?;
-                format_task.await.log_err();
-            }
+                let new_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
+                let (new_text, unified_diff) = cx
+                    .background_spawn({
+                        let new_snapshot = new_snapshot.clone();
+                        let old_text = old_text.clone();
+                        async move {
+                            let new_text = new_snapshot.text();
+                            let diff = language::unified_diff(&old_text, &new_text);
+                            (new_text, diff)
+                        }
+                    })
+                    .await;
 
-            project
-                .update(cx, |project, cx| project.save_buffer(buffer.clone(), cx))?
-                .await?;
+                let input_path = input.path.display();
+                if unified_diff.is_empty() {
+                    anyhow::ensure!(
+                        !hallucinated_old_text,
+                        formatdoc! {"
+                            Some edits were produced but none of them could be applied.
+                            Read the relevant sections of {input_path} again so that
+                            I can perform the requested edits.
+                        "}
+                    );
+                    anyhow::ensure!(
+                        ambiguous_ranges.is_empty(),
+                        {
+                            let line_numbers = ambiguous_ranges
+                                .iter()
+                                .map(|range| range.start.to_string())
+                                .collect::<Vec<_>>()
+                                .join(", ");
+                            formatdoc! {"
+                                <old_text> matches more than one position in the file (lines: {line_numbers}). Read the
+                                relevant sections of {input_path} again and extend <old_text> so
+                                that I can perform the requested edits.
+                            "}
+                        }
+                    );
+                }
 
-            action_log.update(cx, |log, cx| {
-                log.buffer_edited(buffer.clone(), cx);
-            })?;
-
-            let new_snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot())?;
-            let (new_text, unified_diff) = cx
-                .background_spawn({
-                    let new_snapshot = new_snapshot.clone();
-                    let old_text = old_text.clone();
-                    async move {
-                        let new_text = new_snapshot.text();
-                        let diff = language::unified_diff(&old_text, &new_text);
-                        (new_text, diff)
-                    }
+                Ok(EditFileToolOutput {
+                    input_path: input.path,
+                    new_text,
+                    old_text,
+                    diff: unified_diff,
+                    edit_agent_output,
                 })
-                .await;
+            }.await;
 
+            // Always finalize the diff, regardless of whether the operation succeeded or failed
             diff.update(cx, |diff, cx| diff.finalize(cx)).ok();
 
-            let input_path = input.path.display();
-            if unified_diff.is_empty() {
-                anyhow::ensure!(
-                    !hallucinated_old_text,
-                    formatdoc! {"
-                        Some edits were produced but none of them could be applied.
-                        Read the relevant sections of {input_path} again so that
-                        I can perform the requested edits.
-                    "}
-                );
-                anyhow::ensure!(
-                    ambiguous_ranges.is_empty(),
-                    {
-                        let line_numbers = ambiguous_ranges
-                            .iter()
-                            .map(|range| range.start.to_string())
-                            .collect::<Vec<_>>()
-                            .join(", ");
-                        formatdoc! {"
-                            <old_text> matches more than one position in the file (lines: {line_numbers}). Read the
-                            relevant sections of {input_path} again and extend <old_text> so
-                            that I can perform the requested edits.
-                        "}
-                    }
-                );
-            }
-
-            Ok(EditFileToolOutput {
-                input_path: input.path,
-                new_text,
-                old_text,
-                diff: unified_diff,
-                edit_agent_output,
-            })
+           result
         })
     }
 


### PR DESCRIPTION
Previously, we wouldn't finalize the diff if an error occurred during editing or the tool call was canceled.

Release Notes:

- N/A
