### PR TITLE
Swap `NewlineBelow` and `NewlineAbove` bindings for default linux keymap

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -130,8 +130,8 @@
     "bindings": {
       "shift-enter": "editor::Newline",
       "enter": "editor::Newline",
-      "ctrl-enter": "editor::NewlineAbove",
-      "ctrl-shift-enter": "editor::NewlineBelow",
+      "ctrl-enter": "editor::NewlineBelow",
+      "ctrl-shift-enter": "editor::NewlineAbove",
       "ctrl-k ctrl-z": "editor::ToggleSoftWrap",
       "ctrl-k z": "editor::ToggleSoftWrap",
       "find": "buffer_search::Deploy",

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -134,8 +134,8 @@
     "bindings": {
       "shift-enter": "editor::Newline",
       "enter": "editor::Newline",
-      "ctrl-enter": "editor::NewlineAbove",
-      "ctrl-shift-enter": "editor::NewlineBelow",
+      "ctrl-enter": "editor::NewlineBelow",
+      "ctrl-shift-enter": "editor::NewlineAbove",
       "ctrl-k ctrl-z": "editor::ToggleSoftWrap",
       "ctrl-k z": "editor::ToggleSoftWrap",
       "find": "buffer_search::Deploy",


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/33725

The default bindings for the `editor::NewlineAbove` and `editor::NewlineBelow` actions in the default keymap were accidentally swapped some time ago. This causes confusion, as normally these are the other way around. 

This PR fixes this by swapping these back, which also matches what [VSCode does by default](https://code.visualstudio.com/shortcuts/keyboard-shortcuts-linux.pdf). 

Release Notes:

- Swapped the default bindings for `editor::NewlineBelow` and `editor::NewlineAbove` for Linux and Windows to align more with other editors.