### PR TITLE
Work around duplicate ssh projects in workspace migration

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -599,6 +599,13 @@ impl Domain for WorkspaceDb {
                 ssh_projects ON
                 workspaces.ssh_project_id = ssh_projects.id;
 
+            DELETE FROM workspaces_2
+            WHERE workspace_id NOT IN (
+                SELECT MAX(workspace_id)
+                FROM workspaces_2
+                GROUP BY ssh_connection_id, paths
+            );
+
             DROP TABLE ssh_projects;
             DROP TABLE workspaces;
             ALTER TABLE workspaces_2 RENAME TO workspaces;


### PR DESCRIPTION
Fixes another case where the sqlite migration could fail, reported by @SomeoneToIgnore.

Release Notes:

- N/A
