### PR TITLE
editor: Add "Wrap Selections in Tag" action

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -754,7 +754,7 @@ actions!(
         /// Removes duplicate lines (case-sensitive).
         UniqueLinesCaseSensitive,
         UnwrapSyntaxNode,
-        /// Wraps in an HTML tag.
-        WrapInTag
+        /// Wraps selections in tag specified by language.
+        WrapSelectionsInTag
     ]
 );

--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -753,6 +753,8 @@ actions!(
         UniqueLinesCaseInsensitive,
         /// Removes duplicate lines (case-sensitive).
         UniqueLinesCaseSensitive,
-        UnwrapSyntaxNode
+        UnwrapSyntaxNode,
+        /// Wraps in an HTML tag.
+        WrapInTag
     ]
 );

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -10447,15 +10447,18 @@ impl Editor {
         })
     }
 
-    fn supports_wrap_in_tag(&self, cx: &App) -> bool {
-        let Some((_, buffer, _)) = self.active_excerpt(cx) else {
-            return false;
-        };
-
-        let Some(language) = buffer.read(cx).language() else {
-            return false;
-        };
-        language.config().wrap_characters.is_some()
+    fn enable_wrap_selections_in_tag(&self, cx: &App) -> bool {
+        let snapshot = self.buffer.read(cx).snapshot(cx);
+        for selection in self.selections.disjoint_anchors().iter() {
+            if snapshot
+                .language_at(selection.start)
+                .and_then(|lang| lang.config().wrap_characters.as_ref())
+                .is_some()
+            {
+                return true;
+            }
+        }
+        false
     }
 
     fn wrap_selections_in_tag(
@@ -10464,9 +10467,6 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if !self.supports_wrap_in_tag(cx) {
-            return;
-        }
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
 
         let snapshot = self.buffer.read(cx).snapshot(cx);

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4404,6 +4404,109 @@ async fn test_unique_lines_single_selection(cx: &mut TestAppContext) {
 }
 
 #[gpui::test]
+async fn test_wrap_in_tag_single_selection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let js_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "JavaScript".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(js_language), cx));
+
+    cx.set_state(indoc! {"
+        «testˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.assert_editor_state(indoc! {"
+        <«ˇ»>test</«ˇ»>
+    "});
+
+    cx.set_state(indoc! {"
+        «test
+         testˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.assert_editor_state(indoc! {"
+        <«ˇ»>test
+         test</«ˇ»>
+    "});
+}
+
+#[gpui::test]
+async fn test_wrap_in_tag_multi_selection(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let js_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "JavaScript".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(js_language), cx));
+
+    cx.set_state(indoc! {"
+        «testˇ»
+        «testˇ» «testˇ»
+        «testˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.assert_editor_state(indoc! {"
+        <«ˇ»>test</«ˇ»>
+        <«ˇ»>test</«ˇ»> <«ˇ»>test</«ˇ»>
+        <«ˇ»>test</«ˇ»>
+    "});
+
+    cx.set_state(indoc! {"
+        «test
+         testˇ»
+        «test
+         testˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.assert_editor_state(indoc! {"
+        <«ˇ»>test
+         test</«ˇ»>
+        <«ˇ»>test
+         test</«ˇ»>
+    "});
+}
+
+#[gpui::test]
+async fn test_wrap_in_tag_does_nothing_in_unsupported_languages(cx: &mut TestAppContext) {
+    init_test(cx, |_| {});
+
+    let mut cx = EditorTestContext::new(cx).await;
+
+    let plaintext_language = Arc::new(Language::new(
+        LanguageConfig {
+            name: "Plain Text".into(),
+            ..LanguageConfig::default()
+        },
+        None,
+    ));
+
+    cx.update_buffer(|buffer, cx| buffer.set_language(Some(plaintext_language), cx));
+
+    cx.set_state(indoc! {"
+        «testˇ»
+    "});
+    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.assert_editor_state(indoc! {"
+      «testˇ»
+    "});
+}
+
+#[gpui::test]
 async fn test_manipulate_immutable_lines_with_multi_selection(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4412,6 +4412,12 @@ async fn test_wrap_in_tag_single_selection(cx: &mut TestAppContext) {
     let js_language = Arc::new(Language::new(
         LanguageConfig {
             name: "JavaScript".into(),
+            wrap_characters: Some(language::WrapCharactersConfig {
+                start_prefix: "<".into(),
+                start_suffix: ">".into(),
+                end_prefix: "</".into(),
+                end_suffix: ">".into(),
+            }),
             ..LanguageConfig::default()
         },
         None,
@@ -4422,7 +4428,7 @@ async fn test_wrap_in_tag_single_selection(cx: &mut TestAppContext) {
     cx.set_state(indoc! {"
         «testˇ»
     "});
-    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.update_editor(|e, window, cx| e.wrap_selections_in_tag(&WrapSelectionsInTag, window, cx));
     cx.assert_editor_state(indoc! {"
         <«ˇ»>test</«ˇ»>
     "});
@@ -4431,7 +4437,7 @@ async fn test_wrap_in_tag_single_selection(cx: &mut TestAppContext) {
         «test
          testˇ»
     "});
-    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.update_editor(|e, window, cx| e.wrap_selections_in_tag(&WrapSelectionsInTag, window, cx));
     cx.assert_editor_state(indoc! {"
         <«ˇ»>test
          test</«ˇ»>
@@ -4447,6 +4453,12 @@ async fn test_wrap_in_tag_multi_selection(cx: &mut TestAppContext) {
     let js_language = Arc::new(Language::new(
         LanguageConfig {
             name: "JavaScript".into(),
+            wrap_characters: Some(language::WrapCharactersConfig {
+                start_prefix: "<".into(),
+                start_suffix: ">".into(),
+                end_prefix: "</".into(),
+                end_suffix: ">".into(),
+            }),
             ..LanguageConfig::default()
         },
         None,
@@ -4459,7 +4471,7 @@ async fn test_wrap_in_tag_multi_selection(cx: &mut TestAppContext) {
         «testˇ» «testˇ»
         «testˇ»
     "});
-    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.update_editor(|e, window, cx| e.wrap_selections_in_tag(&WrapSelectionsInTag, window, cx));
     cx.assert_editor_state(indoc! {"
         <«ˇ»>test</«ˇ»>
         <«ˇ»>test</«ˇ»> <«ˇ»>test</«ˇ»>
@@ -4472,7 +4484,7 @@ async fn test_wrap_in_tag_multi_selection(cx: &mut TestAppContext) {
         «test
          testˇ»
     "});
-    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.update_editor(|e, window, cx| e.wrap_selections_in_tag(&WrapSelectionsInTag, window, cx));
     cx.assert_editor_state(indoc! {"
         <«ˇ»>test
          test</«ˇ»>
@@ -4500,7 +4512,7 @@ async fn test_wrap_in_tag_does_nothing_in_unsupported_languages(cx: &mut TestApp
     cx.set_state(indoc! {"
         «testˇ»
     "});
-    cx.update_editor(|e, window, cx| e.wrap_in_tag(&WrapInTag, window, cx));
+    cx.update_editor(|e, window, cx| e.wrap_selections_in_tag(&WrapSelectionsInTag, window, cx));
     cx.assert_editor_state(indoc! {"
       «testˇ»
     "});

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -4442,6 +4442,14 @@ async fn test_wrap_in_tag_single_selection(cx: &mut TestAppContext) {
         <«ˇ»>test
          test</«ˇ»>
     "});
+
+    cx.set_state(indoc! {"
+        teˇst
+    "});
+    cx.update_editor(|e, window, cx| e.wrap_selections_in_tag(&WrapSelectionsInTag, window, cx));
+    cx.assert_editor_state(indoc! {"
+        te<«ˇ»></«ˇ»>st
+    "});
 }
 
 #[gpui::test]

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -585,7 +585,7 @@ impl EditorElement {
         register_action(editor, window, Editor::edit_log_breakpoint);
         register_action(editor, window, Editor::enable_breakpoint);
         register_action(editor, window, Editor::disable_breakpoint);
-        if editor.read(cx).supports_wrap_in_tag(cx) {
+        if editor.read(cx).enable_wrap_selections_in_tag(cx) {
             register_action(editor, window, Editor::wrap_selections_in_tag);
         }
     }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -586,7 +586,7 @@ impl EditorElement {
         register_action(editor, window, Editor::enable_breakpoint);
         register_action(editor, window, Editor::disable_breakpoint);
         if editor.read(cx).supports_wrap_in_tag(cx) {
-            register_action(editor, window, Editor::wrap_in_tag);
+            register_action(editor, window, Editor::wrap_selections_in_tag);
         }
     }
 

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -585,6 +585,9 @@ impl EditorElement {
         register_action(editor, window, Editor::edit_log_breakpoint);
         register_action(editor, window, Editor::enable_breakpoint);
         register_action(editor, window, Editor::disable_breakpoint);
+        if editor.read(cx).supports_wrap_in_tag(cx) {
+            register_action(editor, window, Editor::wrap_in_tag);
+        }
     }
 
     fn register_key_listeners(&self, window: &mut Window, _: &mut App, layout: &EditorLayout) {

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -720,6 +720,9 @@ pub struct LanguageConfig {
     /// How to soft-wrap long lines of text.
     #[serde(default)]
     pub soft_wrap: Option<SoftWrap>,
+    /// When set, selections can be wrapped using prefix/suffix pairs on both sides.
+    #[serde(default)]
+    pub wrap_characters: Option<WrapCharactersConfig>,
     /// The name of a Prettier parser that will be used for this language when no file path is available.
     /// If there's a parser name in the language settings, that will be used instead.
     #[serde(default)]
@@ -923,6 +926,7 @@ impl Default for LanguageConfig {
             hard_tabs: None,
             tab_size: None,
             soft_wrap: None,
+            wrap_characters: None,
             prettier_parser_name: None,
             hidden: false,
             jsx_tag_auto_close: None,
@@ -930,6 +934,18 @@ impl Default for LanguageConfig {
             debuggers: Default::default(),
         }
     }
+}
+
+#[derive(Clone, Debug, Deserialize, JsonSchema)]
+pub struct WrapCharactersConfig {
+    /// Opening token split into a prefix and suffix. The first caret goes
+    /// after the prefix (i.e., between prefix and suffix).
+    pub start_prefix: String,
+    pub start_suffix: String,
+    /// Closing token split into a prefix and suffix. The second caret goes
+    /// after the prefix (i.e., between prefix and suffix).
+    pub end_prefix: String,
+    pub end_suffix: String,
 }
 
 fn auto_indent_using_last_non_empty_line_default() -> bool {

--- a/crates/languages/src/javascript/config.toml
+++ b/crates/languages/src/javascript/config.toml
@@ -6,6 +6,7 @@ first_line_pattern = '^#!.*\b(?:[/ ]node|deno run.*--ext[= ]js)\b'
 line_comments = ["// "]
 block_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }
 documentation_comment = { start = "/**", prefix = "* ", end = "*/", tab_size = 1 }
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/tsx/config.toml
+++ b/crates/languages/src/tsx/config.toml
@@ -4,6 +4,7 @@ path_suffixes = ["tsx"]
 line_comments = ["// "]
 block_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }
 documentation_comment = { start = "/**", prefix = "* ", end = "*/", tab_size = 1 }
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/crates/languages/src/typescript/config.toml
+++ b/crates/languages/src/typescript/config.toml
@@ -5,6 +5,7 @@ first_line_pattern = '^#!.*\b(?:deno run|ts-node|bun|tsx|[/ ]node)\b'
 line_comments = ["// "]
 block_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }
 documentation_comment = { start = "/**", prefix = "* ", end = "*/", tab_size = 1 }
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },

--- a/extensions/html/languages/html/config.toml
+++ b/extensions/html/languages/html/config.toml
@@ -3,6 +3,7 @@ grammar = "html"
 path_suffixes = ["html", "htm", "shtml"]
 autoclose_before = ">})"
 block_comment = { start = "<!--", prefix = "", end = "-->", tab_size = 0 }
+wrap_characters = { start_prefix = "<", start_suffix = ">", end_prefix = "</", end_suffix = ">" }
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
     { start = "[", end = "]", close = true, newline = true },


### PR DESCRIPTION
This PR adds the ability for a user to select one or more blocks of text and wrap each selection in an HTML tag — which works by placing multiple cursors inside the open and close tags so the appropriate element name can be typed in to all places simultaneously.

This is similar to the emmet "Wrap with Abbreviation" functionality discussed in #15588 but is a simpler version that does not rely on Emmet's language server.

Here's a preview of the feature in action:

https://github.com/user-attachments/assets/1931e717-136c-4766-a585-e4ba939d9adf


Some notes and questions:
- The current implementation is a hardcoded with regards to supported languages. I'd love some direction on how much of this information to push into the relevant language structs.
- I can see this feature as something that languages added by an extension would want to enable support for — is this something you'd want?
- The syntax is hardcoded to support HTML/XML/JSX-like languages. I don't suppose this is a problem but figured I'd point it out anyway.
- I called it "Wrap in tag" but open to whatever naming you feel is appropriate.
- The implementation doesn't use `manipulate_lines` — I wasn't sure how make use of that without extra overhead / bookkeeping — does this seem fine?
- I could also investigate adding wrap in abbreviation support by communicating with the Emmet language server but I think I'll need some direction on how to handle Emmet's custom LSP message. I could do this either in addition to or instead of this feature — though imo this feature is a nice "shortcut" regardless.

Release Notes:

- Added a new "Wrap Selections in Tag" action that lets you wrap one or more selections in tags based on language. Works in HTML, JSX, and similar languages, and places cursors inside both opening and closing tags so you can type the tag name once and apply it everywhere.