### PR TITLE
search: Preserve `SearchOptions` across dismisses

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -2816,6 +2816,28 @@ mod tests {
                 "After a settings update and toggling the search bar, configured options should be used"
             );
         });
+
+        update_search_settings(
+            SearchSettings {
+                button: true,
+                whole_word: true,
+                case_sensitive: true,
+                include_ignored: false,
+                regex: false,
+            },
+            cx,
+        );
+
+        search_bar.update_in(cx, |search_bar, window, cx| {
+            search_bar.deploy(&deploy, window, cx);
+            search_bar.dismiss(&Dismiss, window, cx);
+            search_bar.show(window, cx);
+            assert_eq!(
+                search_bar.search_options,
+                SearchOptions::CASE_SENSITIVE | SearchOptions::WHOLE_WORD,
+                "Calling deploy on an already deployed search bar should not prevent settings updates from being detected"
+            );
+        });
     }
 
     fn update_search_settings(search_settings: SearchSettings, cx: &mut TestAppContext) {

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -2748,20 +2748,52 @@ mod tests {
             search_bar.deploy(&deploy, window, cx);
             assert_eq!(
                 search_bar.search_options,
-                SearchOptions::WHOLE_WORD,
-                "After hiding and showing the search bar, options should be preserved"
+                SearchOptions::NONE,
+                "After hiding and showing the search bar, default options should be used"
             );
 
             search_bar.toggle_search_option(SearchOptions::REGEX, window, cx);
             search_bar.toggle_search_option(SearchOptions::WHOLE_WORD, window, cx);
             assert_eq!(
                 search_bar.search_options,
-                SearchOptions::REGEX,
+                SearchOptions::REGEX | SearchOptions::WHOLE_WORD,
                 "Should enable the options toggled"
             );
             assert!(
                 !search_bar.dismissed,
                 "Search bar should be present and visible"
+            );
+        });
+
+        update_search_settings(
+            SearchSettings {
+                button: true,
+                whole_word: false,
+                case_sensitive: true,
+                include_ignored: false,
+                regex: false,
+            },
+            cx,
+        );
+        search_bar.update_in(cx, |search_bar, window, cx| {
+            assert_eq!(
+                search_bar.search_options,
+                SearchOptions::REGEX | SearchOptions::WHOLE_WORD,
+                "Should have no search options enabled by default"
+            );
+
+            search_bar.deploy(&deploy, window, cx);
+            assert_eq!(
+                search_bar.search_options,
+                SearchOptions::REGEX | SearchOptions::WHOLE_WORD,
+                "Toggling a non-dismissed search bar with custom options should not change the default options"
+            );
+            search_bar.dismiss(&Dismiss, window, cx);
+            search_bar.deploy(&deploy, window, cx);
+            assert_eq!(
+                search_bar.search_options,
+                SearchOptions::CASE_SENSITIVE,
+                "After hiding and showing the search bar, default options should be used"
             );
         });
     }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -754,6 +754,7 @@ impl BufferSearchBar {
         let settings_changed = configured_options != self.configured_options;
 
         if self.dismissed && settings_changed {
+            self.configured_options = configured_options;
             self.search_options = configured_options;
             self.default_options = configured_options;
         }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -2804,9 +2804,14 @@ mod tests {
             search_bar.dismiss(&Dismiss, window, cx);
             search_bar.deploy(&deploy, window, cx);
             assert_eq!(
+                search_bar.configured_options,
+                SearchOptions::CASE_SENSITIVE,
+                "After a settings update, dismissing the bar should update the configured options"
+            );
+            assert_eq!(
                 search_bar.search_options,
                 SearchOptions::CASE_SENSITIVE,
-                "After a settings update, dismissing the bar should update the search options"
+                "After a settings update, dismissing the bar should update the active search options"
             );
         });
     }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -111,7 +111,6 @@ pub struct BufferSearchBar {
     pending_search: Option<Task<()>>,
     search_options: SearchOptions,
     default_options: SearchOptions,
-    configured_options: SearchOptions,
     query_error: Option<String>,
     dismissed: bool,
     search_history: SearchHistory,
@@ -653,7 +652,6 @@ impl BufferSearchBar {
             active_match_index: None,
             searchable_items_with_matches: Default::default(),
             default_options: search_options,
-            configured_options: search_options,
             search_options,
             pending_search: None,
             query_error: None,
@@ -748,16 +746,6 @@ impl BufferSearchBar {
         let Some(handle) = self.active_searchable_item.as_ref() else {
             return false;
         };
-
-        self.configured_options =
-            SearchOptions::from_settings(&EditorSettings::get_global(cx).search);
-        if self.dismissed
-            && (self.configured_options != self.default_options
-                || self.configured_options != self.search_options)
-        {
-            self.search_options = self.configured_options;
-            self.default_options = self.configured_options;
-        }
 
         self.dismissed = false;
         self.adjust_query_regex_language(cx);
@@ -2751,11 +2739,6 @@ mod tests {
             );
             search_bar.deploy(&deploy, window, cx);
             assert_eq!(
-                search_bar.configured_options,
-                SearchOptions::NONE,
-                "Should have configured search options matching the settings"
-            );
-            assert_eq!(
                 search_bar.search_options,
                 SearchOptions::WHOLE_WORD,
                 "After (re)deploying, the option should still be enabled"
@@ -2800,11 +2783,6 @@ mod tests {
             );
 
             search_bar.deploy(&deploy, window, cx);
-            assert_eq!(
-                search_bar.configured_options,
-                SearchOptions::CASE_SENSITIVE,
-                "Should have configured search options matching the settings"
-            );
             assert_eq!(
                 search_bar.search_options,
                 SearchOptions::REGEX | SearchOptions::WHOLE_WORD,

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -2748,52 +2748,20 @@ mod tests {
             search_bar.deploy(&deploy, window, cx);
             assert_eq!(
                 search_bar.search_options,
-                SearchOptions::NONE,
-                "After hiding and showing the search bar, default options should be used"
+                SearchOptions::WHOLE_WORD,
+                "After hiding and showing the search bar, options should be preserved"
             );
 
             search_bar.toggle_search_option(SearchOptions::REGEX, window, cx);
             search_bar.toggle_search_option(SearchOptions::WHOLE_WORD, window, cx);
             assert_eq!(
                 search_bar.search_options,
-                SearchOptions::REGEX | SearchOptions::WHOLE_WORD,
+                SearchOptions::REGEX,
                 "Should enable the options toggled"
             );
             assert!(
                 !search_bar.dismissed,
                 "Search bar should be present and visible"
-            );
-        });
-
-        update_search_settings(
-            SearchSettings {
-                button: true,
-                whole_word: false,
-                case_sensitive: true,
-                include_ignored: false,
-                regex: false,
-            },
-            cx,
-        );
-        search_bar.update_in(cx, |search_bar, window, cx| {
-            assert_eq!(
-                search_bar.search_options,
-                SearchOptions::REGEX | SearchOptions::WHOLE_WORD,
-                "Should have no search options enabled by default"
-            );
-
-            search_bar.deploy(&deploy, window, cx);
-            assert_eq!(
-                search_bar.search_options,
-                SearchOptions::REGEX | SearchOptions::WHOLE_WORD,
-                "Toggling a non-dismissed search bar with custom options should not change the default options"
-            );
-            search_bar.dismiss(&Dismiss, window, cx);
-            search_bar.deploy(&deploy, window, cx);
-            assert_eq!(
-                search_bar.search_options,
-                SearchOptions::CASE_SENSITIVE,
-                "After hiding and showing the search bar, default options should be used"
             );
         });
     }

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -754,6 +754,8 @@ impl BufferSearchBar {
         let settings_changed = configured_options != self.configured_options;
 
         if self.dismissed && settings_changed {
+            // Only update configuration options when search bar is dismissed,
+            // so we don't miss updates even after calling show twice
             self.configured_options = configured_options;
             self.search_options = configured_options;
             self.default_options = configured_options;

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -2806,12 +2806,12 @@ mod tests {
             assert_eq!(
                 search_bar.configured_options,
                 SearchOptions::CASE_SENSITIVE,
-                "After a settings update, dismissing the bar should update the configured options"
+                "After a settings update and toggling the search bar, configured options should be updated"
             );
             assert_eq!(
                 search_bar.search_options,
                 SearchOptions::CASE_SENSITIVE,
-                "After a settings update, dismissing the bar should update the active search options"
+                "After a settings update and toggling the search bar, configured options should be used"
             );
         });
     }

--- a/crates/web_search_providers/src/web_search_providers.rs
+++ b/crates/web_search_providers/src/web_search_providers.rs
@@ -1,4 +1,5 @@
 mod cloud;
+mod serpapi;
 
 use client::Client;
 use gpui::{App, Context, Entity};
@@ -22,6 +23,11 @@ fn register_web_search_providers(
         registry,
         client.clone(),
         &LanguageModelRegistry::global(cx),
+        cx,
+    );
+
+    registry.register_provider(
+        serpapi::SerpApiWebSearchProvider::new(client.http_client()),
         cx,
     );
 

--- a/crates/web_search_providers/src/web_search_providers.rs
+++ b/crates/web_search_providers/src/web_search_providers.rs
@@ -1,5 +1,4 @@
 mod cloud;
-mod serpapi;
 
 use client::Client;
 use gpui::{App, Context, Entity};
@@ -23,11 +22,6 @@ fn register_web_search_providers(
         registry,
         client.clone(),
         &LanguageModelRegistry::global(cx),
-        cx,
-    );
-
-    registry.register_provider(
-        serpapi::SerpApiWebSearchProvider::new(client.http_client()),
         cx,
     );
 


### PR DESCRIPTION
Closes #36931 and #21956

Preserves `SearchOptions` across dismisses of the buffer search bar. This behavior is consistent with VSCode, which seems reasonable. The `configured_options` field is then no longer being used. The configuration is still read during initialization of the `BufferSearchBar`, but not after.

Something to consider is that there are other elements in the search bar which are not kept across dismisses such as replace status. However these are visually separated in the UI, leading me to believe this is a okay change to make.

Release Notes:

- Preserve search options between buffer search dismisses
