### PR TITLE
Fix watching for git changes

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1221,6 +1221,11 @@ impl LocalWorktree {
         self.scan_requests_tx = scan_requests_tx;
         self.path_prefixes_to_scan_tx = path_prefixes_to_scan_tx;
 
+        // Because starting a new background scanner drops all the watcher
+        // registrations we have to register ".git" again
+        self.snapshot.git_repositories = Default::default();
+        self.snapshot.ignores_by_parent_abs_path = Default::default();
+
         self.start_background_scanner(scan_requests_rx, path_prefixes_to_scan_rx, cx);
         let always_included_entries = mem::take(&mut self.snapshot.always_included_entries);
         log::debug!(
@@ -2094,8 +2099,6 @@ impl LocalWorktree {
         cx: &Context<Worktree>,
     ) {
         if let Some(new_path) = new_path {
-            self.snapshot.git_repositories = Default::default();
-            self.snapshot.ignores_by_parent_abs_path = Default::default();
             let root_name = new_path
                 .as_path()
                 .file_name()


### PR DESCRIPTION
After adding the `Drop` implementation for `FsWatcher` in https://github.com/zed-industries/zed/commit/d705585a2e566a0399673303deb8a934e7ae058c everytime the background scanner is restarted all the watchers must be registered again, but `insert_git_repository_for_path` skips registering a watcher for ".git" when restarting because it checks `self.snapshot.git_repositories.get(&work_dir_entry.id).is_some()`, not if the watcher for ".git" is actually registered. It means, effectively Zed losses ability to track branch change of other git related actions if the background scanner was restarted.

The easiest way to test this is to create a simple git repo with `.zed/settings.json`. The file must contain some setting overrides, so Zed restarts the background scanner when it opens this repo. Then it looses the ability to react on git changes, e.g. switching the branch.

This patch ensures ".git" watcher is registered every time the background scanner is restated.

Closes #36492

Release Notes:

- Fixed ability to track git branch change and other git actions [#36492]
