### PR TITLE
acp: Upgrade errors

### DIFF
--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -39,7 +39,7 @@ impl AgentServer for Gemini {
     }
 
     fn install_command(&self) -> Option<&'static str> {
-        Some("npm install -g @google/gemini-cli@latest")
+        Some("npm install --engine-strict -g @google/gemini-cli@latest")
     }
 
     fn connect(
@@ -141,7 +141,7 @@ impl Gemini {
     }
 
     pub fn install_command() -> &'static str {
-        "npm install -g @google/gemini-cli@latest"
+        "npm install --engine-strict -g @google/gemini-cli@latest"
     }
 
     pub fn upgrade_command() -> &'static str {

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2975,7 +2975,7 @@ impl AcpThreadView {
             ))
             .when_some(existing_version, |el, (path, _)| {
                 el.child(
-                    Label::new(format!("If this does not work; you will need to upgrade manualy, or uninstall your existing version from {}", path))
+                    Label::new(format!("If this does not work you will need to upgrade manually, or uninstall your existing version from {}", path))
                         .size(LabelSize::Small)
                         .color(Color::Muted),
                 )

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2913,10 +2913,17 @@ impl AcpThreadView {
             if let Some((path, version)) = existing_version {
                 (
                     format!("Upgrade {} to work with Zed", self.agent.name()),
-                    format!(
-                        "Currently using {}, which is only version {}",
-                        path, version
-                    ),
+                    if version.is_empty() {
+                        format!(
+                            "Currently using {}, which does not report a valid --version",
+                            path,
+                        )
+                    } else {
+                        format!(
+                            "Currently using {}, which is only version {}",
+                            path, version
+                        )
+                    },
                     format!("Upgrade {}", self.agent.name()),
                 )
             } else {
@@ -2966,6 +2973,13 @@ impl AcpThreadView {
                 self.install_command_markdown.clone(),
                 default_markdown_style(false, false, window, cx),
             ))
+            .when_some(existing_version, |el, (path, _)| {
+                el.child(
+                    Label::new(format!("If this does not work; you will need to upgrade manualy, or uninstall your existing version from {}", path))
+                        .size(LabelSize::Small)
+                        .color(Color::Muted),
+                )
+            })
             .into_any_element()
     }
 


### PR DESCRIPTION
- **Pass --engine-strict to gemini install command**
- **Make it clearer that if upgrading fails, you need to fix i**

Closes #ISSUE

Release Notes:

- N/A
