### PR TITLE
Fix incorrect npm package name in External Agents docs

### DIFF
--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -34,7 +34,7 @@ If you don't yet have Gemini CLI installed, then Zed will install a version for 
 You need to be running at least Gemini version `0.2.0-preview`, and if your version of Gemini is too old you will see an
 error message.
 
-The instructions to upgrade Gemini depend on how you originally installed it, but typically, running `npm install -g gemini-cli@preview` should work.
+The instructions to upgrade Gemini depend on how you originally installed it, but typically, running `npm install -g google@gemini-cli@preview` should work.
 
 #### Authentication
 

--- a/docs/src/ai/external-agents.md
+++ b/docs/src/ai/external-agents.md
@@ -34,7 +34,7 @@ If you don't yet have Gemini CLI installed, then Zed will install a version for 
 You need to be running at least Gemini version `0.2.0-preview`, and if your version of Gemini is too old you will see an
 error message.
 
-The instructions to upgrade Gemini depend on how you originally installed it, but typically, running `npm install -g google@gemini-cli@preview` should work.
+The instructions to upgrade Gemini depend on how you originally installed it, but typically, running `npm install -g @google/gemini-cli@preview` should work.
 
 #### Authentication
 


### PR DESCRIPTION
### Problem Statement

The npm install command in the documentation incorrectly referenced the npm scope/namespace, preventing users from installing Gemini CLI.

### Solution

Updated the npm command to use the correct npm scope/namespace, ensuring users can successfully install or update the Gemini CLI tool. This is a simple documentation fix that prevents installation errors for new users.

Release Notes:

- N/A