### PR TITLE
project: Add dynamic capabilities registration for "workspace/didChangeWorkspaceFolders"

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -1383,7 +1383,8 @@ impl LanguageServer {
             self.notify::<DidChangeWorkspaceFolders>(&params).ok();
         }
     }
-    /// Add new workspace folder to the list.
+
+    /// Remove existing workspace folder from the list.
     pub fn remove_workspace_folder(&self, uri: Url) {
         if self
             .capabilities()

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11703,18 +11703,16 @@ impl LspStore {
                     // Ignore payload since we notify clients of setting changes unconditionally, relying on them pulling the latest settings.
                 }
                 "workspace/didChangeWorkspaceFolders" => {
-                    dbg!(&reg);
-                    let options = parse_register_capabilities(reg)?;
+                    // in this case register options as empty object, we can ignore it
+                    let caps = lsp::WorkspaceFoldersServerCapabilities {
+                        supported: Some(true),
+                        change_notifications: Some(OneOf::Right(reg.id)),
+                    };
                     server.update_capabilities(|capabilities| {
                         capabilities
                             .workspace
                             .get_or_insert_default()
-                            .workspace_folders
-                            .get_or_insert_with(|| lsp::WorkspaceFoldersServerCapabilities {
-                                supported: Some(true),
-                                change_notifications: None,
-                            })
-                            .change_notifications = Some(options);
+                            .workspace_folders = Some(caps);
                     });
                     notify_server_capabilities_updated(&server, cx);
                 }

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -11703,7 +11703,7 @@ impl LspStore {
                     // Ignore payload since we notify clients of setting changes unconditionally, relying on them pulling the latest settings.
                 }
                 "workspace/didChangeWorkspaceFolders" => {
-                    // in this case register options as empty object, we can ignore it
+                    // In this case register options is an empty object, we can ignore it
                     let caps = lsp::WorkspaceFoldersServerCapabilities {
                         supported: Some(true),
                         change_notifications: Some(OneOf::Right(reg.id)),


### PR DESCRIPTION
Fixes missing capability registration for "workspace/didChangeWorkspaceFolders".

```
WARN  [project::lsp_store] unhandled capability registration: Registration { id: "e288546c-4458-401a-a029-bbba759d5a71", method: "workspace/didChangeWorkspaceFolders", register_options: Some(Object {}) }
```

We already correctly send back events to server on workspace add and remove by checking this capability. https://github.com/zed-industries/zed/blob/cf89691b85e4652093548c0bf8b79d881e26562b/crates/lsp/src/lsp.rs#L1353

https://github.com/zed-industries/zed/blob/cf89691b85e4652093548c0bf8b79d881e26562b/crates/lsp/src/lsp.rs#L1388

Release Notes:

- N/A
