### PR TITLE
Add ';' and '*' to word_chars to improve softwrap

### DIFF
--- a/crates/gpui/src/text_system/line_wrapper.rs
+++ b/crates/gpui/src/text_system/line_wrapper.rs
@@ -181,7 +181,7 @@ impl LineWrapper {
         matches!(c, '\u{0400}'..='\u{04FF}') ||
         // Some other known special characters that should be treated as word characters,
         // e.g. `a-b`, `var_name`, `I'm`, '@mention`, `#hashtag`, `100%`, `3.1415`, `2^3`, `a~b`, etc.
-        matches!(c, '-' | '_' | '.' | '\'' | '$' | '%' | '@' | '#' | '^' | '~' | ',' | '!') ||
+        matches!(c, '-' | '_' | '.' | '\'' | '$' | '%' | '@' | '#' | '^' | '~' | ',' | '!' | ';' | '*') ||
         // Characters that used in URL, e.g. `https://github.com/zed-industries/zed?a=1&b=2` for better wrapping a long URL.
         matches!(c,  '/' | ':' | '?' | '&' | '=') ||
         // `⋯` character is special used in Zed, to keep this at the end of the line.


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/37019
See also: https://github.com/zed-industries/zed/issues/37010

Before/After:
<img width="418" height="402" alt="Screenshot 2025-08-27 at 13 54 52" src="https://github.com/user-attachments/assets/1b2e02dd-c216-4372-b23e-5a3a619d2b77" />


Release Notes:

- N/A