### PR TITLE
go: Fix highlighting of fields

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -764,6 +764,7 @@ mod tests {
         let highlight_type = grammar.highlight_id_for_name("type").unwrap();
         let highlight_keyword = grammar.highlight_id_for_name("keyword").unwrap();
         let highlight_number = grammar.highlight_id_for_name("number").unwrap();
+        let highlight_field = grammar.highlight_id_for_name("property").unwrap();
 
         assert_eq!(
             adapter
@@ -828,7 +829,7 @@ mod tests {
             Some(CodeLabel {
                 text: "two.Three a.Bcd".to_string(),
                 filter_range: 0..9,
-                runs: vec![(12..15, highlight_type)],
+                runs: vec![(4..9, highlight_field), (12..15, highlight_type)],
             })
         );
     }

--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -1,13 +1,13 @@
 (identifier) @variable
 
 (type_identifier) @type
-(field_identifier) @variable.member
+(field_identifier) @property
 (package_identifier) @namespace
 
 (keyed_element
   .
   (literal_element
-    (identifier) @variable.member))
+    (identifier) @property))
 
 (call_expression
   function: (identifier) @function)


### PR DESCRIPTION
Closes #36420

## Synopsis

The issue in #36420 is caused by #7276, which bound the appropriate tree-sitter queries to the `@variable.member` color. However, I have found neither this color's declaration nor its other usages in the codebase (neither on the latest `main` nor on 79c1003b344ee513cf97ee8313c38c7c3f02c916).

Other languages use for such situations the `@property` color.


## Solution

Just change the used `@variable.member` color to the `@property` one.

Seems fully inline with the changes illustrated in #7276.


## Screenshots

<img width="856" height="465" alt="Screenshot 2025-08-28 at 13 18 38" src="https://github.com/user-attachments/assets/9d1f3542-8749-421f-864f-959c1242cc64" />

<img width="837" height="462" alt="Screenshot 2025-08-28 at 13 20 08" src="https://github.com/user-attachments/assets/36a80c22-9de9-46b1-87e3-7fdeaa62978f" />


## Changelog

Release Notes:

- go: Fixed highlighting of fields.
