### PR TITLE
cfg-out musl-incompatible workspace parts

### DIFF
--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -13,6 +13,10 @@ path = "src/editor.rs"
 doctest = false
 
 [features]
+default = ["workspace-full"]
+workspace-full = ["workspace/call", "workspace/sqlez"]
+workspace-minimal = []
+
 test-support = [
     "text/test-support",
     "language/test-support",
@@ -116,6 +120,6 @@ tree-sitter-yaml.workspace = true
 tree-sitter-bash.workspace = true
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
-workspace = { workspace = true, features = ["test-support"] }
+workspace = { path = "../workspace", default-features = false, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 zlog.workspace = true

--- a/crates/language_tools/Cargo.toml
+++ b/crates/language_tools/Cargo.toml
@@ -17,7 +17,7 @@ anyhow.workspace = true
 client.workspace = true
 collections.workspace = true
 copilot.workspace = true
-editor.workspace = true
+editor = { path = "../editor", default-features = false }
 futures.workspace = true
 gpui.workspace = true
 itertools.workspace = true
@@ -36,7 +36,7 @@ zed_actions.workspace = true
 workspace-hack.workspace = true
 
 [dev-dependencies]
-editor = { workspace = true, features = ["test-support"] }
+editor = { path = "../editor", default-features = false, features = ["test-support"] }
 release_channel.workspace = true
 gpui = { workspace = true, features = ["test-support"] }
 util = { workspace = true, features = ["test-support"] }

--- a/crates/workspace/Cargo.toml
+++ b/crates/workspace/Cargo.toml
@@ -13,7 +13,7 @@ path = "src/workspace.rs"
 doctest = false
 
 [features]
-default = ["call"]
+default = ["call", "sqlez"]
 test-support = [
     "call/test-support",
     "client/test-support",
@@ -55,7 +55,7 @@ serde_json.workspace = true
 session.workspace = true
 settings.workspace = true
 smallvec.workspace = true
-sqlez.workspace = true
+sqlez = { workspace = true, optional = true }
 strum.workspace = true
 task.workspace = true
 telemetry.workspace = true

--- a/crates/workspace/src/dock.rs
+++ b/crates/workspace/src/dock.rs
@@ -1,4 +1,6 @@
+#[cfg(feature = "sqlez")]
 use crate::persistence::model::DockData;
+
 use crate::{DraggedDock, Event, ModalLayer, Pane};
 use crate::{Workspace, status_bar::StatusItemView};
 use anyhow::Context as _;
@@ -198,6 +200,7 @@ pub struct Dock {
     is_open: bool,
     active_panel_index: Option<usize>,
     focus_handle: FocusHandle,
+    #[cfg(feature = "sqlez")]
     pub(crate) serialized_dock: Option<DockData>,
     zoom_layer_open: bool,
     modal_layer: Entity<ModalLayer>,
@@ -275,6 +278,7 @@ impl Dock {
                 is_open: false,
                 focus_handle: focus_handle.clone(),
                 _subscriptions: [focus_subscription, zoom_subscription],
+                #[cfg(feature = "sqlez")]
                 serialized_dock: None,
                 zoom_layer_open: false,
                 modal_layer,
@@ -553,7 +557,10 @@ impl Dock {
             },
         );
 
-        self.restore_state(window, cx);
+        #[cfg(feature = "sqlez")]
+        {
+            self.restore_state(window, cx);
+        }
         if panel.read(cx).starts_open(window, cx) {
             self.activate_panel(index, window, cx);
             self.set_open(true, window, cx);
@@ -563,6 +570,7 @@ impl Dock {
         index
     }
 
+    #[cfg(feature = "sqlez")]
     pub fn restore_state(&mut self, window: &mut Window, cx: &mut Context<Self>) -> bool {
         if let Some(serialized) = self.serialized_dock.clone() {
             if let Some(active_panel) = serialized.active_panel.filter(|_| serialized.visible)

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -1,9 +1,8 @@
 use crate::{
-    CollaboratorId, DelayedDebouncedEditAction, FollowableViewRegistry, ItemNavHistory,
+    CollaboratorId, DelayedDebouncedEditAction, FollowableViewRegistry, ItemId, ItemNavHistory,
     SerializableItemRegistry, ToolbarItemLocation, ViewId, Workspace, WorkspaceId,
     invalid_buffer_view::InvalidBufferView,
     pane::{self, Pane},
-    persistence::model::ItemId,
     searchable::SearchableItemHandle,
     workspace_settings::{AutosaveSetting, WorkspaceSettings},
 };


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/36709 

This requires editor to be updated in a similar way, so that language_tools crate can depend on nothing that causes problems with musl builds of the remote headless server.

There's definitely more work better be done later to split things better.
The main requirement is to be able to track new workspace ideas added in the `lsp_log.rs`: https://github.com/zed-industries/zed/blob/46504fcc26cea65ff2e4fbcac1a01eccf21e9d32/crates/language_tools/src/lsp_log.rs#L260-L264

as those are needed for the remote headless server to properly react on LSP-related events and manage the server logs storage and sharing with the client.

Release Notes:

- N/A
