### PR TITLE
Fix watching of Git repo in presence of scanner restarts

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -3151,16 +3151,6 @@ impl BackgroundScannerState {
             .work_directory_abs_path(&work_directory)
             .log_err()?;
 
-        if self
-            .snapshot
-            .git_repositories
-            .get(&work_dir_entry.id)
-            .is_some()
-        {
-            log::trace!("existing git repository for {work_directory:?}");
-            return None;
-        }
-
         let dot_git_abs_path: Arc<Path> = self
             .snapshot
             .abs_path


### PR DESCRIPTION
The scanner is restarted after loading initial settings, and there was an optimization to not re-discover and re-watch git repositories if they already exist in the snapshot. #35865 added cleanup of watches that occurred when the scanner restarts, and so in some cases repos were no longer watched.

Release Notes:

- Linux: Fixed a case where Git repositories might not be watched for changes, causing branch switching to not update the UI.