### PR TITLE
debugger: Add ability to only show stack frame entries from visible work trees

### DIFF
--- a/assets/icons/list_filter.svg
+++ b/assets/icons/list_filter.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-list-filter-icon lucide-list-filter"><path d="M3 6h18"/><path d="M7 12h10"/><path d="M10 18h4"/></svg>

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -234,6 +234,7 @@ impl PythonDebugAdapter {
                     .await
                     .map_err(|e| format!("{e:#?}"))?
                     .success();
+
                 if !did_succeed {
                     return Err("Failed to create base virtual environment".into());
                 }

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -283,7 +283,7 @@ pub fn init(cx: &mut App) {
                             .ok();
                     }
                 })
-                .on_action(move |_: &ToggleUserFrames, window, cx| {
+                .on_action(move |_: &ToggleUserFrames, _, cx| {
                     if let Some((thread_status, stack_frame_list)) = active_item
                         .read_with(cx, |item, cx| {
                             (item.thread_status(cx), item.stack_frame_list().clone())
@@ -291,7 +291,7 @@ pub fn init(cx: &mut App) {
                         .ok()
                     {
                         stack_frame_list.update(cx, |stack_frame_list, cx| {
-                            stack_frame_list.toggle_frame_filter(thread_status, window, cx);
+                            stack_frame_list.toggle_frame_filter(thread_status, cx);
                         })
                     }
                 })

--- a/crates/debugger_ui/src/debugger_ui.rs
+++ b/crates/debugger_ui/src/debugger_ui.rs
@@ -85,6 +85,10 @@ actions!(
         Rerun,
         /// Toggles expansion of the selected item in the debugger UI.
         ToggleExpandItem,
+        /// Toggle the user frame filter in the stack frame list
+        /// When toggled on, only frames from the user's code are shown
+        /// When toggled off, all frames are shown
+        ToggleUserFrames,
     ]
 );
 
@@ -272,10 +276,23 @@ pub fn init(cx: &mut App) {
                     }
                 })
                 .on_action({
+                    let active_item = active_item.clone();
                     move |_: &ToggleIgnoreBreakpoints, _, cx| {
                         active_item
                             .update(cx, |item, cx| item.toggle_ignore_breakpoints(cx))
                             .ok();
+                    }
+                })
+                .on_action(move |_: &ToggleUserFrames, window, cx| {
+                    if let Some((thread_status, stack_frame_list)) = active_item
+                        .read_with(cx, |item, cx| {
+                            (item.thread_status(cx), item.stack_frame_list().clone())
+                        })
+                        .ok()
+                    {
+                        stack_frame_list.update(cx, |stack_frame_list, cx| {
+                            stack_frame_list.toggle_frame_filter(thread_status, window, cx);
+                        })
                     }
                 })
             });

--- a/crates/debugger_ui/src/persistence.rs
+++ b/crates/debugger_ui/src/persistence.rs
@@ -270,12 +270,9 @@ pub(crate) fn deserialize_pane_layout(
                 .children
                 .iter()
                 .map(|child| match child {
-                    DebuggerPaneItem::Frames => Box::new(SubView::new(
-                        stack_frame_list.focus_handle(cx),
-                        stack_frame_list.clone().into(),
-                        DebuggerPaneItem::Frames,
-                        cx,
-                    )),
+                    DebuggerPaneItem::Frames => {
+                        Box::new(SubView::stack_frame_list(stack_frame_list.clone(), cx))
+                    }
                     DebuggerPaneItem::Variables => Box::new(SubView::new(
                         variable_list.focus_handle(cx),
                         variable_list.clone().into(),

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -158,6 +158,29 @@ impl SubView {
         })
     }
 
+    pub(crate) fn stack_frame_list(
+        stack_frame_list: Entity<StackFrameList>,
+        cx: &mut App,
+    ) -> Entity<Self> {
+        let weak_list = stack_frame_list.downgrade();
+        let this = Self::new(
+            stack_frame_list.focus_handle(cx),
+            stack_frame_list.into(),
+            DebuggerPaneItem::Frames,
+            cx,
+        );
+
+        this.update(cx, |this, _| {
+            this.with_actions(Box::new(move |_, cx| {
+                weak_list
+                    .update(cx, |this, _| this.render_control_strip())
+                    .unwrap_or_else(|_| div().into_any_element())
+            }));
+        });
+
+        this
+    }
+
     pub(crate) fn console(console: Entity<Console>, cx: &mut App) -> Entity<Self> {
         let weak_console = console.downgrade();
         let this = Self::new(

--- a/crates/debugger_ui/src/session/running/stack_frame_list.rs
+++ b/crates/debugger_ui/src/session/running/stack_frame_list.rs
@@ -881,7 +881,7 @@ impl StackFrameList {
             .child(
                 IconButton::new(
                     "filter-by-visible-worktree-stack-frame-list",
-                    IconName::FolderSearch,
+                    IconName::ListFilter,
                 )
                 .tooltip(move |window, cx| {
                     Tooltip::for_action(tooltip_title, &ToggleUserFrames, window, cx)

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -145,6 +145,7 @@ pub enum IconName {
     Library,
     LineHeight,
     ListCollapse,
+    ListFilter,
     ListTodo,
     ListTree,
     ListX,


### PR DESCRIPTION
This PR adds a toggleable filter to the stack frame list that filters out entries that don't exist within a user's project (visible work trees). This works by keeping a vector of entry indices that exist within a user's project and updates the list state based on these entries when filtering the list.

I went with this approach so the stack frame list wouldn't have to rebuild itself whenever the filter is toggled and it could persist its state across toggles (uncollapsing a collapse list). It was also easier to keep track of selected entries on toggle using the vector as well.

### Preview
https://github.com/user-attachments/assets/d86c7485-c885-4bbb-bebb-2f6385674925



Release Notes:

- debugger: Add option to only show stack frames from user's project in stack frame list
