### PR TITLE
editor: Fix inconsistent search behavior for untitled/temporary tabs

### DIFF
--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -651,7 +651,8 @@ impl Item for Editor {
         if let Some(path) = path_for_buffer(&self.buffer, detail, true, cx) {
             path.to_string_lossy().to_string().into()
         } else {
-            "untitled".into()
+            // Use the same logic as the displayed title for consistency
+            self.buffer.read(cx).title(cx).to_string().into()
         }
     }
 


### PR DESCRIPTION
Closes #37597 

Release Notes:

- Fix inconsistent search behavior for untitled/temporary files in Tab Switcher

---


## Problem

When using "Tab Switcher: Toggle All", temporary files (untitled buffers without associated file paths) cannot be searched by their displayed content. This creates an inconsistent user experience where:

- **UI Display**: Shows dynamic titles based on the first line of content (up to 40 characters)
- **Search Text**: Only searches for the static text "untitled"

### Example
- A temporary file containing `Hello World` is displayed as "Hello World" in the tab
- However, searching for "Hello" in Tab Switcher returns no results
- Only searching for "untitled" will find this temporary file

## Root Cause

The issue stems from inconsistent title generation logic between display and search:

1. **Display Title** (`items.rs:724`): Uses `self.title(cx)` → `MultiBuffer::title()` → `buffer_content_title()` 
   - Returns the first line of content (max 40 chars) for temporary files
   
2. **Search Text** (`items.rs:650-656`): Uses `tab_content_text()` method
   - Returns hardcoded "untitled" for files without paths

## Solution

Modified the `tab_content_text()` method in `crates/editor/src/items.rs` to use the same logic as the displayed title for consistency:

```rust
fn tab_content_text(&self, detail: usize, cx: &App) -> SharedString {
    if let Some(path) = path_for_buffer(&self.buffer, detail, true, cx) {
        path.to_string_lossy().to_string().into()
    } else {
        // Use the same logic as the displayed title for consistency
        self.buffer.read(cx).title(cx).to_string().into()
    }
}
```
