### PR TITLE
agent2: Fix model deduplication to use provider ID and model ID

### DIFF
--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -93,7 +93,7 @@ impl LanguageModels {
         let mut recommended = Vec::new();
         for provider in &providers {
             for model in provider.recommended_models(cx) {
-                recommended_models.insert(model.id());
+                recommended_models.insert((model.provider_id(), model.id()));
                 recommended.push(Self::map_language_model_to_info(&model, provider));
             }
         }
@@ -110,7 +110,7 @@ impl LanguageModels {
             for model in provider.provided_models(cx) {
                 let model_info = Self::map_language_model_to_info(&model, &provider);
                 let model_id = model_info.id.clone();
-                if !recommended_models.contains(&model.id()) {
+                if !recommended_models.contains(&(model.provider_id(), model.id())) {
                     provider_models.push(model_info);
                 }
                 models.insert(model_id, model);


### PR DESCRIPTION
Closes #37043

Previously claude sonnet 4 was missing from copilot as it was colliding with zed's claude-sonnet-4 model id. Now we do deduplication based upon model and provider id both.

| Before | After |
|--------|--------|
| <img width="784" height="950" alt="CleanShot 2025-08-28 at 18 31 28@2x" src="https://github.com/user-attachments/assets/d49d5a17-7271-417d-bb5e-bc380071e810" />  | <img width="720" height="876" alt="CleanShot 2025-08-28 at 18 31 42@2x" src="https://github.com/user-attachments/assets/a5100c05-994e-4e19-ab20-34c0258b977c" /> | 

Release Notes:

- Fixed an issue where models with the same ID from different providers (such as Claude Sonnet 4 from both Zed and Copilot) were incorrectly deduplicated in the model selector—now all variants are shown.
