### PR TITLE
language_models: Fix tool calling for `x-ai/grok-code-fast-1` model via OpenRouter

### DIFF
--- a/crates/language_models/src/provider/open_router.rs
+++ b/crates/language_models/src/provider/open_router.rs
@@ -381,7 +381,7 @@ impl LanguageModel for OpenRouterLanguageModel {
 
     fn tool_input_format(&self) -> LanguageModelToolSchemaFormat {
         let model_id = self.model.id().trim().to_lowercase();
-        if model_id.contains("gemini") || model_id.contains("grok-4") {
+        if model_id.contains("gemini") || model_id.contains("grok") {
             LanguageModelToolSchemaFormat::JsonSchemaSubset
         } else {
             LanguageModelToolSchemaFormat::JsonSchema


### PR DESCRIPTION
Closes #37022
Closes #36994

This update ensures all Grok models use the JsonSchemaSubset format for tool schemas.

A previous fix for this issue was too specific, only targeting grok-4 models. This caused other variants, like grok-code-fast-1, to be missed. We've now broadened the logic to correctly apply the setting to the entire Grok model family.

Release Notes:

- Fix tool calling for `x-ai/grok-code-fast-1` model via OpenRouter.
