### PR TITLE
language_models: Pass `AuthenticateError::CredentialsNotFound` from Anthropic provider

### DIFF
--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -197,7 +197,7 @@ impl AnthropicLanguageModelProvider {
         })
     }
 
-    pub fn api_key(cx: &mut App) -> Task<Result<ApiKey>> {
+    pub fn api_key(cx: &mut App) -> Task<Result<ApiKey, AuthenticateError>> {
         let credentials_provider = <dyn CredentialsProvider>::global(cx);
         let api_url = AllLanguageModelSettings::get_global(cx)
             .anthropic


### PR DESCRIPTION
This PR suppresses noisy error logs that appear when Anthropic credentials are not found.

A previous change (#36995) was intended to ignore these logs, as they are not actionable errors. However, the specific AuthenticateError::CredentialsNotFound was being wrapped inside a generic error type for anthropic provider. This wrapping prevented our check from correctly identifying and skipping the error, causing it to spam the logs. This fix ensures the error is properly identified and suppressed as intended.
Release Notes:

- N/A
