### PR TITLE
html: Add outline

### DIFF
--- a/extensions/html/languages/html/outline.scm
+++ b/extensions/html/languages/html/outline.scm
@@ -1,1 +1,5 @@
 (comment) @annotation
+
+(element
+  (start_tag
+    (tag_name) @name)) @item


### PR DESCRIPTION
We were missing an outline definition for HTML flies, hence this PR adds one for that

<img width="255" height="726" alt="image" src="https://github.com/user-attachments/assets/ae59cb8d-6c69-4019-966a-d5baf744329d" />

Release Notes:

- N/A
