### PR TITLE
language_models: Fix OpenAI API key leakage when changing provider API URL setting

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -63,7 +63,6 @@ pub struct State {
 const OPENAI_API_KEY_VAR: &str = "OPENAI_API_KEY";
 
 impl State {
-    //
     fn is_authenticated(&self) -> bool {
         self.api_key.is_some()
     }

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -143,7 +143,9 @@ impl OpenAiLanguageModelProvider {
         let state = cx.new(|cx| State {
             api_key: None,
             api_key_from_env: false,
-            _subscription: cx.observe_global::<SettingsStore>(|_this: &mut State, cx| {
+            _subscription: cx.observe_global::<SettingsStore>(|this: &mut State, cx| {
+                this.api_key = None;
+                this.api_key_from_env = false;
                 cx.notify();
             }),
         });

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -164,6 +164,11 @@ impl OpenAiCompatibleLanguageModelProvider {
                     return;
                 };
                 if &this.settings != settings {
+                    if settings.api_url != this.settings.api_url {
+                        this.api_key = None;
+                        this.api_key_from_env = false;
+                    }
+
                     this.settings = settings.clone();
                     cx.notify();
                 }


### PR DESCRIPTION
Closes #37093

Fixed a security vulnerability in the OpenAI language model provider where changing the `api_url` setting from the default OpenAI endpoint to a custom server would inadvertently send the user's stored OpenAI API key to the custom server. The issue occurred because the provider cached authentication state across settings changes, so when users modified their API URL configuration, the provider retained the previously authenticated OpenAI key and sent it to the new endpoint. The fix ensures that cached authentication is cleared whenever language model settings change, forcing re-authentication with the new API URL and preventing accidental credential leakage to third-party servers.

Release Notes:

- Fixed OpenAI API keys being sent to custom servers when changing the OpenAI provider's API URL setting. Authentication is now properly invalidated when settings change.
