### PR TITLE
html: Bump to v0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20590,7 +20590,7 @@ dependencies = [
 
 [[package]]
 name = "zed_html"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "zed_extension_api 0.1.0",
 ]

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_html"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/html/extension.toml
+++ b/extensions/html/extension.toml
@@ -1,7 +1,7 @@
 id = "html"
 name = "HTML"
 description = "HTML support."
-version = "0.2.1"
+version = "0.2.2"
 schema_version = 1
 authors = ["Isaac Clayton <slightknack@gmail.com>"]
 repository = "https://github.com/zed-industries/zed"


### PR DESCRIPTION
This PR bumps the HTML extension to v0.2.2.

Changes:

- https://github.com/zed-industries/zed/pull/28184
- https://github.com/zed-industries/zed/pull/36948
- https://github.com/zed-industries/zed/pull/37098

Release Notes:

- N/A
