### PR TITLE
Always enable acp accept/reject buttons for now

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -279,14 +279,6 @@ impl ToolCall {
         }
     }
 
-    pub fn has_pending_edits(&self) -> bool {
-        self.kind == acp::ToolKind::Edit
-            || self
-                .content
-                .iter()
-                .any(|content| matches!(content, ToolCallContent::Diff(_)))
-    }
-
     pub fn diffs(&self) -> impl Iterator<Item = &Entity<Diff>> {
         self.content.iter().filter_map(|content| match content {
             ToolCallContent::Diff(diff) => Some(diff),
@@ -768,7 +760,6 @@ pub struct AcpThread {
     session_id: acp::SessionId,
     token_usage: Option<TokenUsage>,
     prompt_capabilities: acp::PromptCapabilities,
-    pending_edit_calls: collections::HashSet<acp::ToolCallId>,
     _observe_prompt_capabilities: Task<anyhow::Result<()>>,
 }
 
@@ -865,7 +856,6 @@ impl AcpThread {
             session_id,
             token_usage: None,
             prompt_capabilities,
-            pending_edit_calls: Default::default(),
             _observe_prompt_capabilities: task,
         }
     }
@@ -914,10 +904,6 @@ impl AcpThread {
         self.token_usage.as_ref()
     }
 
-    pub fn has_active_edit_tool_calls(&self) -> bool {
-        !self.pending_edit_calls.is_empty()
-    }
-
     pub fn has_pending_edit_tool_calls(&self) -> bool {
         for entry in self.entries.iter().rev() {
             match entry {
@@ -956,8 +942,6 @@ impl AcpThread {
     ) -> Result<(), acp::Error> {
         match update {
             acp::SessionUpdate::UserMessageChunk { content } => {
-                // New user message starts a new turn; clear pending edit calls.
-                self.pending_edit_calls.clear();
                 self.push_user_content_block(None, content, cx);
             }
             acp::SessionUpdate::AgentMessageChunk { content } => {
@@ -1150,24 +1134,6 @@ impl AcpThread {
             current_call.update_fields(tool_call_update.fields, language_registry, cx);
             current_call.status = status;
 
-            // Maintain pending edit call IDs based on status transitions.
-            match current_call.status {
-                ToolCallStatus::WaitingForConfirmation { .. }
-                | ToolCallStatus::Pending
-                | ToolCallStatus::InProgress
-                    if current_call.has_pending_edits() =>
-                {
-                    self.pending_edit_calls.insert(id.clone());
-                }
-                ToolCallStatus::Completed
-                | ToolCallStatus::Failed
-                | ToolCallStatus::Rejected
-                | ToolCallStatus::Canceled => {
-                    self.pending_edit_calls.remove(&id);
-                }
-                _ => {}
-            }
-
             cx.emit(AcpThreadEvent::EntryUpdated(ix));
         } else {
             let call =
@@ -1303,17 +1269,6 @@ impl AcpThread {
             respond_tx.send(option_id).log_err();
         } else if cfg!(debug_assertions) {
             panic!("tried to authorize an already authorized tool call");
-        }
-
-        // Maintain pending edit call IDs based on the new status.
-        match call.status {
-            ToolCallStatus::InProgress if call.has_pending_edits() => {
-                self.pending_edit_calls.insert(id.clone());
-            }
-            ToolCallStatus::Rejected | ToolCallStatus::Failed | ToolCallStatus::Canceled => {
-                self.pending_edit_calls.remove(&id);
-            }
-            _ => {}
         }
 
         cx.emit(AcpThreadEvent::EntryUpdated(ix));

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3071,7 +3071,7 @@ impl AcpThreadView {
         let active_color = cx.theme().colors().element_selected;
         let bg_edit_files_disclosure = editor_bg_color.blend(active_color.opacity(0.3));
 
-        let pending_edits = thread.has_active_edit_tool_calls();
+        let pending_edits = thread.has_pending_edit_tool_calls();
 
         v_flex()
             .mt_1()

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3071,7 +3071,12 @@ impl AcpThreadView {
         let active_color = cx.theme().colors().element_selected;
         let bg_edit_files_disclosure = editor_bg_color.blend(active_color.opacity(0.3));
 
-        let pending_edits = thread.has_pending_edit_tool_calls();
+        // Temporarily always enable ACP edit controls. This is temporary, to lessen the
+        // impact of a nasty bug that causes them to sometimes be disabled when they shouldn't
+        // be, which blocks you from being able to accept or reject edits. This switches the
+        // bug to be that sometimes it's enabled when it shouldn't be, which at least doesn't
+        // block you from using the panel.
+        let pending_edits = false;
 
         v_flex()
             .mt_1()

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3071,45 +3071,7 @@ impl AcpThreadView {
         let active_color = cx.theme().colors().element_selected;
         let bg_edit_files_disclosure = editor_bg_color.blend(active_color.opacity(0.3));
 
-        let pending_edits = {
-            use std::path::PathBuf;
-
-            // Collect paths for buffers with unreviewed edits
-            let mut changed_paths = HashSet::default();
-            for (buffer, _diff) in &changed_buffers {
-                if let Some(file) = buffer.read(cx).file() {
-                    changed_paths.insert(file.path().to_path_buf());
-                }
-            }
-
-            // Only consider pending edit tool calls that touch one of the changed files
-            let mut pending = false;
-            for entry in thread.entries().iter().rev() {
-                match entry {
-                    AgentThreadEntry::UserMessage(_) => break, // stop scanning at last user message
-                    AgentThreadEntry::ToolCall(call)
-                        if matches!(
-                            call.status,
-                            ToolCallStatus::InProgress | ToolCallStatus::Pending
-                        ) && call.diffs().next().is_some() =>
-                    {
-                        // If the tool call reports locations, gate only when those overlap changed files.
-                        if !call.locations.is_empty()
-                            && call
-                                .locations
-                                .iter()
-                                .any(|loc| changed_paths.contains(&loc.path))
-                        {
-                            pending = true;
-                            break;
-                        }
-                        // If there are no locations, ignore for gating ACP buttons to match buffer controls behavior.
-                    }
-                    _ => {}
-                }
-            }
-            pending
-        };
+        let pending_edits = thread.has_pending_edit_tool_calls();
 
         v_flex()
             .mt_1()

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3071,7 +3071,7 @@ impl AcpThreadView {
         let active_color = cx.theme().colors().element_selected;
         let bg_edit_files_disclosure = editor_bg_color.blend(active_color.opacity(0.3));
 
-        let pending_edits = thread.has_pending_edit_tool_calls();
+        let pending_edits = thread.has_active_edit_tool_calls();
 
         v_flex()
             .mt_1()


### PR DESCRIPTION
We have a bug in our ACP implementation where sometimes the Accept/Reject buttons are disabled (and stay disabled even after the thread has finished). I haven't found a complete fix for this yet, so in the meantime I'm putting out the fire by making it so those buttons are always enabled. That way you're never blocked, and the only consequence of the bug is that sometimes they should be disabled but are enabled instead.

Release Notes:

- N/A
