### PR TITLE
Disable Expert language server by default for Elixir

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1585,7 +1585,7 @@
       "ensure_final_newline_on_save": false
     },
     "Elixir": {
-      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."]
     },
     "Elm": {
       "tab_size": 4
@@ -1610,7 +1610,7 @@
       }
     },
     "HEEX": {
-      "language_servers": ["elixir-ls", "!next-ls", "!lexical", "..."]
+      "language_servers": ["elixir-ls", "!expert", "!next-ls", "!lexical", "..."]
     },
     "HTML": {
       "prettier": {


### PR DESCRIPTION
This PR updates the language server configuration for Elixir and HEEx to not start the [Expert](https://github.com/elixir-lang/expert) language server by default.

While Expert is the official Elixir language server, it is still early, so we don't want to make it the default just yet.

Release Notes:

- Updated the default Elixir and HEEx language server settings to not start the Expert language server.
