### PR TITLE
docs: Add Expert to Elixir docs

### DIFF
--- a/docs/src/languages/elixir.md
+++ b/docs/src/languages/elixir.md
@@ -6,15 +6,38 @@ Elixir support is available through the [Elixir extension](https://github.com/ze
   - [elixir-lang/tree-sitter-elixir](https://github.com/elixir-lang/tree-sitter-elixir)
   - [phoenixframework/tree-sitter-heex](https://github.com/phoenixframework/tree-sitter-heex)
 - Language servers:
+  - [elixir-lang/expert](https://github.com/elixir-lang/expert)
   - [elixir-lsp/elixir-ls](https://github.com/elixir-lsp/elixir-ls)
   - [elixir-tools/next-ls](https://github.com/elixir-tools/next-ls)
   - [lexical-lsp/lexical](https://github.com/lexical-lsp/lexical)
 
 ## Choosing a language server
 
-The Elixir extension offers language server support for `elixir-ls`, `next-ls`, and `lexical`.
+The Elixir extension offers language server support for `expert`, `elixir-ls`, `next-ls`, and `lexical`.
 
 `elixir-ls` is enabled by default.
+
+### Expert
+
+To switch to `expert`, add the following to your `settings.json`:
+
+```json
+{
+  "languages": {
+    "Elixir": {
+      "language_servers": [
+        "expert",
+        "!elixir-ls",
+        "!next-ls",
+        "!lexical",
+        "..."
+      ]
+    }
+  }
+}
+```
+
+### Next LS
 
 To switch to `next-ls`, add the following to your `settings.json`:
 
@@ -22,11 +45,19 @@ To switch to `next-ls`, add the following to your `settings.json`:
 {
   "languages": {
     "Elixir": {
-      "language_servers": ["next-ls", "!elixir-ls", "..."]
+      "language_servers": [
+        "next-ls",
+        "!expert",
+        "!elixir-ls",
+        "!lexical",
+        "..."
+      ]
     }
   }
 }
 ```
+
+### Lexical
 
 To switch to `lexical`, add the following to your `settings.json`:
 
@@ -34,7 +65,13 @@ To switch to `lexical`, add the following to your `settings.json`:
 {
   "languages": {
     "Elixir": {
-      "language_servers": ["lexical", "!elixir-ls", "..."]
+      "language_servers": [
+        "lexical",
+        "!expert",
+        "!elixir-ls",
+        "!next-ls",
+        "..."
+      ]
     }
   }
 }


### PR DESCRIPTION
This PR adds documentation for [Expert](https://github.com/elixir-lang/expert) to the Elixir docs.

Also updated the examples for the other language servers to be representative of all the supported language servers.

Release Notes:

- N/A
