### PR TITLE
zeta: Show update required notification on appropriate window(s)

### DIFF
--- a/crates/zed/src/zed/edit_prediction_registry.rs
+++ b/crates/zed/src/zed/edit_prediction_registry.rs
@@ -8,7 +8,6 @@ use settings::SettingsStore;
 use std::{cell::RefCell, rc::Rc, sync::Arc};
 use supermaven::{Supermaven, SupermavenCompletionProvider};
 use ui::Window;
-use workspace::Workspace;
 use zeta::{ProviderDataCollection, ZetaEditPredictionProvider};
 
 pub fn init(client: Arc<Client>, user_store: Entity<UserStore>, cx: &mut App) {
@@ -204,13 +203,7 @@ fn assign_edit_prediction_provider(
                     }
                 }
 
-                let workspace = window
-                    .root::<Workspace>()
-                    .flatten()
-                    .map(|workspace| workspace.downgrade());
-
-                let zeta =
-                    zeta::Zeta::register(workspace, worktree, client.clone(), user_store, cx);
+                let zeta = zeta::Zeta::register(worktree, client.clone(), user_store, cx);
 
                 if let Some(buffer) = &singleton_buffer
                     && buffer.read(cx).file().is_some()


### PR DESCRIPTION
To show these notifications, Zeta was being initialized with the initial workspace it's used on - which may not even still exist! This removes a confusing/misleading workspace field from Zeta.

Release Notes:

- N/A