### PR TITLE
language_models: Fix GitHub Copilot thread summary by removing unnecessary noop tool logic

### DIFF
--- a/crates/language_models/src/provider/copilot_chat.rs
+++ b/crates/language_models/src/provider/copilot_chat.rs
@@ -475,7 +475,6 @@ fn into_copilot_chat(
         }
     }
 
-    let mut tool_called = false;
     let mut messages: Vec<ChatMessage> = Vec::new();
     for message in request_messages {
         match message.role {
@@ -545,7 +544,6 @@ fn into_copilot_chat(
                 let mut tool_calls = Vec::new();
                 for content in &message.content {
                     if let MessageContent::ToolUse(tool_use) = content {
-                        tool_called = true;
                         tool_calls.push(ToolCall {
                             id: tool_use.id.to_string(),
                             content: copilot::copilot_chat::ToolCallContent::Function {
@@ -590,7 +588,7 @@ fn into_copilot_chat(
         }
     }
 
-    let mut tools = request
+    let tools = request
         .tools
         .iter()
         .map(|tool| Tool::Function {
@@ -601,22 +599,6 @@ fn into_copilot_chat(
             },
         })
         .collect::<Vec<_>>();
-
-    // The API will return a Bad Request (with no error message) when tools
-    // were used previously in the conversation but no tools are provided as
-    // part of this request. Inserting a dummy tool seems to circumvent this
-    // error.
-    if tool_called && tools.is_empty() {
-        tools.push(Tool::Function {
-            function: copilot::copilot_chat::Function {
-                name: "noop".to_string(),
-                description: "No operation".to_string(),
-                parameters: serde_json::json!({
-                    "type": "object"
-                }),
-            },
-        });
-    }
 
     Ok(CopilotChatRequest {
         intent: true,


### PR DESCRIPTION
Closes #37025 

This PR fixes GitHub Copilot thread summary failures by removing the unnecessary `noop` tool insertion logic. The code was originally added as a workaround in https://github.com/zed-industries/zed/pull/30007 for supposed GitHub Copilot API issues when tools were used previously in a conversation but no tools are provided in the current request. However, testing revealed that this scenario works fine without the workaround, and the `noop` tool insertion was actually causing "Invalid schema for function 'noop'" errors that prevented thread summarization from working. Removing this logic eliminates the errors and allows thread summarization to function correctly with GitHub Copilot models.

The best way to see if removing that part of code works is just triggering thread summarisation.

Error Log:
```
2025-08-27T13:47:50-04:00 ERROR [workspace::notifications] "Failed to connect to API: 400 Bad Request {"error":{"message":"Invalid schema for function 'noop': In context=(), object schema missing properties.","code":"invalid_function_parameters"}}\n"
```

Release Notes:

- Fixed GitHub Copilot thread summary failures by removing unnecessary noop tool insertion logic.
