### PR TITLE
Require authorization for MCP tools

### DIFF
--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -950,6 +950,7 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
         paths::settings_file(),
         json!({
             "agent": {
+                "always_allow_tool_actions": true,
                 "profiles": {
                     "test": {
                         "name": "Test Profile",

--- a/crates/agent2/src/tools/context_server_registry.rs
+++ b/crates/agent2/src/tools/context_server_registry.rs
@@ -169,15 +169,18 @@ impl AnyAgentTool for ContextServerTool {
     fn run(
         self: Arc<Self>,
         input: serde_json::Value,
-        _event_stream: ToolCallEventStream,
+        event_stream: ToolCallEventStream,
         cx: &mut App,
     ) -> Task<Result<AgentToolOutput>> {
         let Some(server) = self.store.read(cx).get_running_server(&self.server_id) else {
             return Task::ready(Err(anyhow!("Context server not found")));
         };
         let tool_name = self.tool.name.clone();
+        let authorize = event_stream.authorize(self.initial_title(input.clone()), cx);
 
         cx.spawn(async move |_cx| {
+            authorize.await?;
+
             let Some(protocol) = server.client() else {
                 bail!("Context server not initialized");
             };


### PR DESCRIPTION
Fixes #37154 

Release Notes:

- Fixed a regression that caused MCP tools to run without requesting authorization first.
