### PR TITLE
remote: Properly quote `cd` argument in ssh remote commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9262,6 +9262,7 @@ dependencies = [
  "serde_json_lenient",
  "settings",
  "sha2",
+ "shlex",
  "smol",
  "snippet_provider",
  "task",

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -93,6 +93,7 @@ tree-sitter-typescript = { workspace = true, optional = true }
 tree-sitter-yaml = { workspace = true, optional = true }
 util.workspace = true
 workspace-hack.workspace = true
+shlex.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -932,7 +932,9 @@ impl ToolchainLister for PythonToolchainProvider {
                     };
                     let path = prefix.join(BINARY_DIR).join(activate_script_name);
                     if fs.is_file(&path).await {
-                        activation_script.push(format!("{activate_keyword} {}", path.display()));
+                        let path = path.to_string_lossy();
+                        let path = shlex::try_quote(&path).unwrap();
+                        activation_script.push(format!("{activate_keyword} {}", path));
                     }
                 }
             }
@@ -942,7 +944,8 @@ impl ToolchainLister for PythonToolchainProvider {
                 };
                 let version = toolchain.version.as_deref().unwrap_or("system");
                 let pyenv = manager.executable;
-                let pyenv = pyenv.display();
+                let path = pyenv.to_string_lossy();
+                let pyenv = shlex::try_quote(&path).unwrap();
                 activation_script.extend(match shell {
                     ShellKind::Fish => Some(format!("{pyenv} shell - fish {version}")),
                     ShellKind::Posix => Some(format!("{pyenv} shell - sh {version}")),

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -125,12 +125,18 @@ impl RemoteConnection for SshRemoteConnection {
             // shlex will wrap the command in single quotes (''), disabling ~ expansion,
             // replace ith with something that works
             const TILDE_PREFIX: &'static str = "~/";
-            if working_dir.starts_with(TILDE_PREFIX) {
+            let working_dir = if working_dir.starts_with(TILDE_PREFIX) {
                 let working_dir = working_dir.trim_start_matches("~").trim_start_matches("/");
-                write!(&mut script, "cd \"$HOME/{working_dir}\"; ").unwrap();
+                format!("$HOME/{working_dir}")
             } else {
-                write!(&mut script, "cd \"{working_dir}\"; ").unwrap();
-            }
+                working_dir
+            };
+            write!(
+                &mut script,
+                "cd {}; ",
+                shlex::try_quote(&working_dir).context("invalid working directory")?
+            )
+            .unwrap();
         } else {
             write!(&mut script, "cd; ").unwrap();
         };


### PR DESCRIPTION
Closes  https://github.com/zed-industries/zed/issues/33459, Closes https://github.com/zed-industries/zed/issues/36569
Release Notes:

- Fixed `cd` arguments in ssh commands not being correctly quoted
