### PR TITLE
editor: APCA contrast

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -226,6 +226,20 @@
   // The debounce delay before querying highlights from the language
   // server based on the current cursor location.
   "lsp_highlight_debounce": 75,
+  // The minimum APCA perceptual contrast between foreground and background colors.
+  // APCA (Accessible Perceptual Contrast Algorithm) is more accurate than WCAG 2.x,
+  // especially for dark mode. Values range from 0 to 106.
+  //
+  // Based on APCA Readability Criterion (ARC) Bronze Simple Mode:
+  // https://readtech.org/ARC/tests/bronze-simple-mode/
+  // - 0: No contrast adjustment
+  // - 45: Minimum for large fluent text (36px+)
+  // - 60: Minimum for other content text
+  // - 75: Minimum for body text
+  // - 90: Preferred for body text
+  //
+  // This only affects text drawn over highlight backgrounds in the editor.
+  "minimum_contrast_for_highlights": 48,
   // Whether to pop the completions menu while typing in an editor without
   // explicitly requesting it.
   "show_completions_on_input": true,

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -239,7 +239,7 @@
   // - 90: Preferred for body text
   //
   // This only affects text drawn over highlight backgrounds in the editor.
-  "minimum_contrast_for_highlights": 48,
+  "minimum_contrast_for_highlights": 45,
   // Whether to pop the completions menu while typing in an editor without
   // explicitly requesting it.
   "show_completions_on_input": true,

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -55,6 +55,7 @@ pub struct EditorSettings {
     pub inline_code_actions: bool,
     pub drag_and_drop_selection: DragAndDropSelection,
     pub lsp_document_colors: DocumentColorsRenderMode,
+    pub minimum_contrast_for_highlights: f32,
 }
 
 /// How to render LSP `textDocument/documentColor` colors in the editor.
@@ -544,6 +545,12 @@ pub struct EditorSettingsContent {
     ///
     /// Default: false
     pub show_signature_help_after_edits: Option<bool>,
+    /// The minimum APCA perceptual contrast to maintain when
+    /// rendering text over highlight backgrounds in the editor.
+    ///
+    /// Values range from 0 to 106. Set to 0 to disable adjustments.
+    /// Default: 48
+    pub minimum_contrast_for_highlights: Option<f32>,
 
     /// Whether to follow-up empty go to definition responses from the language server or not.
     /// `FindAllReferences` allows to look up references of the same symbol instead.

--- a/crates/editor/src/editor_settings.rs
+++ b/crates/editor/src/editor_settings.rs
@@ -549,7 +549,7 @@ pub struct EditorSettingsContent {
     /// rendering text over highlight backgrounds in the editor.
     ///
     /// Values range from 0 to 106. Set to 0 to disable adjustments.
-    /// Default: 48
+    /// Default: 45
     pub minimum_contrast_for_highlights: Option<f32>,
 
     /// Whether to follow-up empty go to definition responses from the language server or not.

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3421,6 +3421,7 @@ impl EditorElement {
         style: &EditorStyle,
         editor_width: Pixels,
         is_row_soft_wrapped: impl Copy + Fn(usize) -> bool,
+        bg_segments_per_row: &[Vec<(Range<DisplayPoint>, Hsla)>],
         window: &mut Window,
         cx: &mut App,
     ) -> Vec<LineWithInvisibles> {
@@ -3476,6 +3477,7 @@ impl EditorElement {
                 &snapshot.mode,
                 editor_width,
                 is_row_soft_wrapped,
+                bg_segments_per_row,
                 window,
                 cx,
             )
@@ -7495,6 +7497,7 @@ impl LineWithInvisibles {
         editor_mode: &EditorMode,
         text_width: Pixels,
         is_row_soft_wrapped: impl Copy + Fn(usize) -> bool,
+        bg_segments_per_row: &[Vec<(Range<DisplayPoint>, Hsla)>],
         window: &mut Window,
         cx: &mut App,
     ) -> Vec<Self> {
@@ -8607,7 +8610,11 @@ impl Element for EditorElement {
                         cx,
                     );
 
-                    Self::bg_segments_per_row(start_row..end_row, &selections, &highlighted_ranges);
+                    let bg_segments_per_row = Self::bg_segments_per_row(
+                        start_row..end_row,
+                        &selections,
+                        &highlighted_ranges,
+                    );
 
                     let mut line_layouts = Self::layout_lines(
                         start_row..end_row,
@@ -8615,6 +8622,7 @@ impl Element for EditorElement {
                         &self.style,
                         editor_width,
                         is_row_soft_wrapped,
+                        &bg_segments_per_row,
                         window,
                         cx,
                     );
@@ -9974,6 +9982,7 @@ pub fn layout_line(
         &snapshot.mode,
         text_width,
         is_row_soft_wrapped,
+        &[],
         window,
         cx,
     )

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3281,10 +3281,10 @@ impl EditorElement {
                 }
             }
         }
-        Self::clamped_highlight_ranges_per_row(rows, &all_ranges);
+        Self::clamped_ranges_per_row(rows, &all_ranges);
     }
 
-    fn clamped_highlight_ranges_per_row(
+    fn clamped_ranges_per_row(
         rows: Range<DisplayRow>,
         ranges: &[(Range<DisplayPoint>, Hsla)],
     ) -> Vec<Vec<(Range<DisplayPoint>, Hsla)>> {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -95,8 +95,6 @@ use workspace::{
     item::Item, notifications::NotifyTaskExt,
 };
 
-const MIN_APCA_CONTRAST_FOR_HIGHLIGHTS: f32 = 60.0;
-
 /// Determines what kinds of highlights should be applied to a lines background.
 #[derive(Clone, Copy, Default)]
 struct LineHighlightSpec {
@@ -7518,7 +7516,7 @@ impl LineWithInvisibles {
             if let Some(replacement) = highlighted_chunk.replacement {
                 if !line.is_empty() {
                     let segments = bg_segments_per_row.get(row).map(|v| &v[..]).unwrap_or(&[]);
-                    let text_runs = Self::split_runs_by_bg_segments(&styles, segments);
+                    let text_runs = Self::split_runs_by_bg_segments(&styles, segments, cx);
                     let shaped_line = window.text_system().shape_line(
                         line.clone().into(),
                         font_size,
@@ -7601,7 +7599,7 @@ impl LineWithInvisibles {
                 for (ix, mut line_chunk) in highlighted_chunk.text.split('\n').enumerate() {
                     if ix > 0 {
                         let segments = bg_segments_per_row.get(row).map(|v| &v[..]).unwrap_or(&[]);
-                        let text_runs = Self::split_runs_by_bg_segments(&styles, segments);
+                        let text_runs = Self::split_runs_by_bg_segments(&styles, segments, cx);
                         let shaped_line = window.text_system().shape_line(
                             line.clone().into(),
                             font_size,
@@ -7698,6 +7696,7 @@ impl LineWithInvisibles {
     fn split_runs_by_bg_segments(
         text_runs: &[TextRun],
         bg_segments: &[(Range<DisplayPoint>, Hsla)],
+        cx: &mut App,
     ) -> Vec<TextRun> {
         let mut output_runs: Vec<TextRun> = Vec::with_capacity(text_runs.len());
         let mut line_col = 0usize;
@@ -7737,7 +7736,7 @@ impl LineWithInvisibles {
                     let new_text_color = ensure_minimum_contrast(
                         text_run.color,
                         *segment_color,
-                        MIN_APCA_CONTRAST_FOR_HIGHLIGHTS,
+                        EditorSettings::get_global(cx).minimum_contrast_for_highlights,
                     );
                     output_runs.push(TextRun {
                         len: segment_slice_end_col - cursor_col,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3307,6 +3307,9 @@ impl EditorElement {
             }
         }
         for row_segments in per_row_map.iter_mut() {
+            if row_segments.is_empty() {
+                continue;
+            }
             let segments = mem::take(row_segments);
             let merged = Self::merge_overlapping_ranges(segments, base_background);
             *row_segments = merged;

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3318,6 +3318,98 @@ impl EditorElement {
         buckets
     }
 
+    /// Merge overlapping ranges by splitting at all range boundaries and blending colors where
+    /// multiple ranges overlap. The result contains non-overlapping ranges ordered from left to right.
+    fn merge_overlapping_ranges(ranges: Vec<(Range<u32>, Hsla)>) -> Vec<(Range<u32>, Hsla)> {
+        struct Boundary {
+            pos: u32,
+            is_start: bool,
+            index: usize,
+            color: Hsla,
+        }
+
+        let mut boundaries: Vec<Boundary> = Vec::with_capacity(ranges.len() * 2);
+        for (index, (range, color)) in ranges.iter().enumerate() {
+            if range.start < range.end {
+                boundaries.push(Boundary {
+                    pos: range.start,
+                    is_start: true,
+                    index,
+                    color: *color,
+                });
+                boundaries.push(Boundary {
+                    pos: range.end,
+                    is_start: false,
+                    index,
+                    color: *color,
+                });
+            }
+        }
+
+        if boundaries.is_empty() {
+            return Vec::new();
+        }
+
+        boundaries.sort_by(|a, b| a.pos.cmp(&b.pos).then_with(|| a.is_start.cmp(&b.is_start)));
+
+        let blended_color = |active: &[(usize, Hsla)]| -> Hsla {
+            if active.is_empty() {
+                return Hsla::transparent_black();
+            }
+            let mut sorted = active.to_vec();
+            sorted.sort_by_key(|(idx, _)| *idx);
+            let mut acc = Hsla::transparent_black();
+            for &(_, c) in &sorted {
+                acc = Hsla::blend(acc, c);
+            }
+            acc
+        };
+
+        let mut processed_ranges: Vec<(Range<u32>, Hsla)> = Vec::new();
+        let mut active_ranges: Vec<(usize, Hsla)> = Vec::new();
+
+        let mut i = 0;
+        let mut start_pos = boundaries[0].pos;
+
+        let boundaries_len = boundaries.len();
+        while i < boundaries_len {
+            let current_boundary_pos = boundaries[i].pos;
+            if start_pos < current_boundary_pos {
+                if !active_ranges.is_empty() {
+                    let color = blended_color(&active_ranges);
+                    if color.a > 0.0 {
+                        if let Some((last_range, last_color)) = processed_ranges.last_mut() {
+                            if *last_color == color && last_range.end == start_pos {
+                                last_range.end = current_boundary_pos;
+                            } else {
+                                processed_ranges.push((start_pos..current_boundary_pos, color));
+                            }
+                        } else {
+                            processed_ranges.push((start_pos..current_boundary_pos, color));
+                        }
+                    }
+                }
+            }
+            while i < boundaries_len && boundaries[i].pos == current_boundary_pos {
+                let active_range = &boundaries[i];
+                if active_range.is_start {
+                    active_ranges.push((active_range.index, active_range.color));
+                } else {
+                    if let Some(j) = active_ranges
+                        .iter()
+                        .position(|(idx, _)| *idx == active_range.index)
+                    {
+                        active_ranges.swap_remove(j);
+                    }
+                }
+                i += 1;
+            }
+            start_pos = current_boundary_pos;
+        }
+
+        processed_ranges
+    }
+
     fn layout_lines(
         rows: Range<DisplayRow>,
         snapshot: &EditorSnapshot,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -11219,5 +11219,36 @@ mod tests {
         assert_eq!(out[0].color, text_color);
         assert_eq!(out[1].color, adjusted);
         assert_eq!(out[2].color, adjusted);
+
+        // Case C: multi-byte characters
+        // for text: "Hello 🌍 世界!"
+        let runs = vec![
+            generate_test_run(5, text_color), // "Hello"
+            generate_test_run(6, text_color), // " 🌍 "
+            generate_test_run(6, text_color), // "世界"
+            generate_test_run(1, text_color), // "!"
+        ];
+        // selecting "🌍 世"
+        let segs = vec![(
+            DisplayPoint::new(DisplayRow(0), 6)..DisplayPoint::new(DisplayRow(0), 14),
+            bg1,
+        )];
+        let out = LineWithInvisibles::split_runs_by_bg_segments(&runs, &segs, min_contrast);
+        // "Hello" | " " | "🌍 " | "世" | "界" | "!"
+        assert_eq!(
+            out.iter().map(|r| r.len).collect::<Vec<_>>(),
+            vec![5, 1, 5, 3, 3, 1]
+        );
+        assert_eq!(out[0].color, text_color); // "Hello"
+        assert_eq!(
+            out[2].color,
+            ensure_minimum_contrast(text_color, bg1, min_contrast)
+        ); // "🌍 "
+        assert_eq!(
+            out[3].color,
+            ensure_minimum_contrast(text_color, bg1, min_contrast)
+        ); // "世"
+        assert_eq!(out[4].color, text_color); // "界"
+        assert_eq!(out[5].color, text_color); // "!"
     }
 }

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3312,7 +3312,7 @@ impl EditorElement {
                 let seg_end = if row == range.end.row() && range.end.column() != 0 {
                     range.end
                 } else {
-                    DisplayPoint::new(row.next_row(), 0)
+                    DisplayPoint::new(row, u32::MAX)
                 };
                 let ix = row.minus(rows.start) as usize;
                 debug_assert!(row >= rows.start && row < rows.end);


### PR DESCRIPTION
Closes #35787
Closes #17890
Closes #28789
Closes #36495

How it works:

For highlights (and selections) within the visible rows of the editor, we split them row by row. This is efficient since the number of visible rows is constant. For each row, all highlights and selections, which may overlap, are flattened using a line sweep. This produces non-overlapping consecutive segments for each row, each with a blended background color.  

Next, for each row, we split text runs into smaller runs to adjust its color using APCA contrast. Since both text runs and segment are non-overlapping and consecutive, we can use two-pointer on them to do this. 

For example, a text run for the variable red might be split into two runs if a highlight partially covers it. As a result, one part may appear as red, while the other appears as a lighter red, depending on the background behind it.


Result:

<img width="1458" height="949" alt="image" src="https://github.com/user-attachments/assets/4814c93d-12e7-4b4d-8542-d912acccfb8e" />

<img width="1459" height="952" alt="image" src="https://github.com/user-attachments/assets/9e497b6c-3e66-43e8-8e5b-f634dd5ee8d3" />

<img width="1457" height="621" alt="image" src="https://github.com/user-attachments/assets/8dfa6ce5-f46b-45b9-8008-66169d5aecd4" />

Release Notes:

- Improved text contrast when selected or highlighted in the editor.
