### PR TITLE
Implement perceptual gamma / contrast correction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -691,6 +691,7 @@ features = [
     "Win32_Graphics_Dxgi_Common",
     "Win32_Graphics_Gdi",
     "Win32_Graphics_Imaging",
+    "Win32_Graphics_Hlsl",
     "Win32_Networking_WinSock",
     "Win32_Security",
     "Win32_Security_Credentials",

--- a/crates/gpui/src/platform/windows/alpha_correction.hlsl
+++ b/crates/gpui/src/platform/windows/alpha_correction.hlsl
@@ -1,0 +1,28 @@
+float color_brightness(float3 color) {
+    // REC. 601 luminance coefficients for percieved brightness
+    return dot(color, float3(0.30f, 0.59f, 0.11f));
+}
+
+float light_on_dark_contrast(float enhancedContrast, float3 color) {
+    float brightness = color_brightness(color);
+    float multiplier = saturate(4.0f * (0.75f - brightness));
+    return enhancedContrast * multiplier;
+}
+
+float enhance_contrast(float alpha, float k) {
+    return alpha * (k + 1.0f) / (alpha * k + 1.0f);
+}
+
+float apply_alpha_correction(float a, float b, float4 g) {
+    float brightness_adjustment = g.x * b + g.y;
+    float correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0f - a) * correction;
+}
+
+float apply_contrast_and_gamma_correction(float sample, float3 color, float enhanced_contrast_factor, float4 gamma_ratios) {
+    float enhanced_contrast = light_on_dark_contrast(enhanced_contrast_factor, color);
+    float brightness = color_brightness(color);
+
+    float contrasted = enhance_contrast(sample, enhanced_contrast);
+    return apply_alpha_correction(contrasted, brightness, gamma_ratios);
+}

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -10,11 +10,8 @@ use windows::{
         Foundation::*,
         Globalization::GetUserDefaultLocaleName,
         Graphics::{
-            Direct3D::D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP,
-            Direct3D11::*,
-            DirectWrite::*,
-            Dxgi::Common::*,
-            Gdi::{IsRectEmpty, LOGFONTW},
+            Direct3D::D3D_PRIMITIVE_TOPOLOGY_TRIANGLESTRIP, Direct3D11::*, DirectWrite::*,
+            Dxgi::Common::*, Gdi::LOGFONTW,
         },
         System::SystemServices::LOCALE_NAME_MAX_LENGTH,
         UI::WindowsAndMessaging::*,

--- a/crates/gpui/src/platform/windows/direct_write.rs
+++ b/crates/gpui/src/platform/windows/direct_write.rs
@@ -736,9 +736,9 @@ impl DirectWriteState {
         unsafe {
             font.font_face.GetRecommendedRenderingMode(
                 params.font_size.0,
-                // The dpi here seems that it has the same effect with `Some(&transform)`
-                1.0,
-                1.0,
+                // Using 96 as scale is applied by the transform
+                96.0,
+                96.0,
                 Some(&transform),
                 false,
                 DWRITE_OUTLINE_THRESHOLD_ANTIALIASED,

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -3,16 +3,12 @@ use std::{mem::ManuallyDrop, sync::Arc};
 use ::util::ResultExt;
 use anyhow::{Context, Result};
 use windows::{
-    Win32::{
+    core::Interface, Win32::{
         Foundation::{HMODULE, HWND},
         Graphics::{
-            Direct3D::*,
-            Direct3D11::*,
-            DirectComposition::*,
-            Dxgi::{Common::*, *},
+            Direct3D::*, Direct3D11::*, DirectComposition::*, DirectWrite::*, Dxgi::{Common::*, *}
         },
-    },
-    core::Interface,
+    }
 };
 
 use crate::{
@@ -27,6 +23,11 @@ const RENDER_TARGET_FORMAT: DXGI_FORMAT = DXGI_FORMAT_B8G8R8A8_UNORM;
 // This configuration is used for MSAA rendering on paths only, and it's guaranteed to be supported by DirectX 11.
 const PATH_MULTISAMPLE_COUNT: u32 = 4;
 
+struct FontInfo {
+    gamma_ratios: [f32; 4],
+    grayscale_enhanced_contrast: f32,
+}
+
 pub(crate) struct DirectXRenderer {
     hwnd: HWND,
     atlas: Arc<DirectXAtlas>,
@@ -35,6 +36,7 @@ pub(crate) struct DirectXRenderer {
     globals: DirectXGlobalElements,
     pipelines: DirectXRenderPipelines,
     direct_composition: Option<DirectComposition>,
+    font_info: FontInfo,
 }
 
 /// Direct3D objects
@@ -163,6 +165,15 @@ impl DirectXRenderer {
             Some(composition)
         };
 
+        let rasterization_info = unsafe {
+            let factory: IDWriteFactory5 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
+            let render_params: IDWriteRenderingParams1 = factory.CreateRenderingParams()?.cast()?;
+            FontInfo {
+                gamma_ratios: Self::get_gamma_ratios(render_params.GetGamma()),
+                grayscale_enhanced_contrast: render_params.GetGrayscaleEnhancedContrast(),
+            }
+        };
+
         Ok(DirectXRenderer {
             hwnd,
             atlas,
@@ -171,6 +182,7 @@ impl DirectXRenderer {
             globals,
             pipelines,
             direct_composition,
+            font_info: rasterization_info,
         })
     }
 
@@ -183,10 +195,12 @@ impl DirectXRenderer {
             &self.devices.device_context,
             self.globals.global_params_buffer[0].as_ref().unwrap(),
             &[GlobalParams {
+                gamma_ratios: self.font_info.gamma_ratios,
                 viewport_size: [
                     self.resources.viewport[0].Width,
                     self.resources.viewport[0].Height,
                 ],
+                grayscale_enhanced_contrast: self.font_info.grayscale_enhanced_contrast,
                 _pad: 0,
             }],
         )?;
@@ -617,6 +631,35 @@ impl DirectXRenderer {
             driver_info: driver_version,
         })
     }
+
+    // Gamma ratios for brightening/darkening edges for better contrast
+    // https://github.com/microsoft/terminal/blob/1283c0f5b99a2961673249fa77c6b986efb5086c/src/renderer/atlas/dwrite.cpp#L50
+    fn get_gamma_ratios(gamma: f32) -> [f32; 4] {
+        const GAMMA_INCORRECT_TARGET_RATIOS: [[f32; 4]; 13] = [
+            [ 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0 ], // gamma = 1.0
+            [ 0.0166 / 4.0, -0.0807 / 4.0, 0.2227 / 4.0, -0.0751 / 4.0 ], // gamma = 1.1
+            [ 0.0350 / 4.0, -0.1760 / 4.0, 0.4325 / 4.0, -0.1370 / 4.0 ], // gamma = 1.2
+            [ 0.0543 / 4.0, -0.2821 / 4.0, 0.6302 / 4.0, -0.1876 / 4.0 ], // gamma = 1.3
+            [ 0.0739 / 4.0, -0.3963 / 4.0, 0.8167 / 4.0, -0.2287 / 4.0 ], // gamma = 1.4
+            [ 0.0933 / 4.0, -0.5161 / 4.0, 0.9926 / 4.0, -0.2616 / 4.0 ], // gamma = 1.5
+            [ 0.1121 / 4.0, -0.6395 / 4.0, 1.1588 / 4.0, -0.2877 / 4.0 ], // gamma = 1.6
+            [ 0.1300 / 4.0, -0.7649 / 4.0, 1.3159 / 4.0, -0.3080 / 4.0 ], // gamma = 1.7
+            [ 0.1469 / 4.0, -0.8911 / 4.0, 1.4644 / 4.0, -0.3234 / 4.0 ], // gamma = 1.8
+            [ 0.1627 / 4.0, -1.0170 / 4.0, 1.6051 / 4.0, -0.3347 / 4.0 ], // gamma = 1.9
+            [ 0.1773 / 4.0, -1.1420 / 4.0, 1.7385 / 4.0, -0.3426 / 4.0 ], // gamma = 2.0
+            [ 0.1908 / 4.0, -1.2652 / 4.0, 1.8650 / 4.0, -0.3476 / 4.0 ], // gamma = 2.1
+            [ 0.2031 / 4.0, -1.3864 / 4.0, 1.9851 / 4.0, -0.3501 / 4.0 ], // gamma = 2.2
+        ];
+
+        const NORM13: f32 = ((0x10000 as f64) / (255.0 * 255.0) * 4.0) as f32;
+        const NORM24: f32 = ((0x100 as f64) / (255.0) * 4.0) as f32;
+
+        let index = ((gamma * 10.0).round() as usize).clamp(10, 22) - 10;
+        let ratios = GAMMA_INCORRECT_TARGET_RATIOS[index];
+
+        [ratios[0] * NORM13, ratios[1] * NORM24, ratios[2] * NORM13, ratios[3] * NORM24]
+    }
+
 }
 
 impl DirectXResources {
@@ -822,8 +865,10 @@ impl DirectXGlobalElements {
 #[derive(Debug, Default)]
 #[repr(C)]
 struct GlobalParams {
+    gamma_ratios: [f32; 4],
     viewport_size: [f32; 2],
-    _pad: u64,
+    grayscale_enhanced_contrast: f32,
+    _pad: u32,
 }
 
 struct PipelineState<T> {

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1638,8 +1638,9 @@ pub(crate) mod shader_resources {
             let target_cstr = PCSTR::from_raw(target.as_ptr());
 
             // really dirty trick because winapi bindings are unhappy otherwise
-            let include_handler =
-                std::mem::transmute::<_, &ID3DInclude>(&D3D_COMPILE_STANDARD_FILE_INCLUDE);
+            let include_handler = std::mem::transmute::<&usize, &ID3DInclude>(
+                &(D3D_COMPILE_STANDARD_FILE_INCLUDE as usize),
+            );
 
             let ret = D3DCompileFromFile(
                 &HSTRING::from(shader_path.to_str().unwrap()),

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1,14 +1,22 @@
-use std::{mem::ManuallyDrop, sync::Arc};
+use std::{
+    mem::ManuallyDrop,
+    sync::{Arc, OnceLock},
+};
 
 use ::util::ResultExt;
 use anyhow::{Context, Result};
 use windows::{
-    core::Interface, Win32::{
+    Win32::{
         Foundation::{HMODULE, HWND},
         Graphics::{
-            Direct3D::*, Direct3D11::*, DirectComposition::*, DirectWrite::*, Dxgi::{Common::*, *}
+            Direct3D::*,
+            Direct3D11::*,
+            DirectComposition::*,
+            DirectWrite::*,
+            Dxgi::{Common::*, *},
         },
-    }
+    },
+    core::Interface,
 };
 
 use crate::{
@@ -23,9 +31,9 @@ const RENDER_TARGET_FORMAT: DXGI_FORMAT = DXGI_FORMAT_B8G8R8A8_UNORM;
 // This configuration is used for MSAA rendering on paths only, and it's guaranteed to be supported by DirectX 11.
 const PATH_MULTISAMPLE_COUNT: u32 = 4;
 
-struct FontInfo {
-    gamma_ratios: [f32; 4],
-    grayscale_enhanced_contrast: f32,
+pub(crate) struct FontInfo {
+    pub gamma_ratios: [f32; 4],
+    pub grayscale_enhanced_contrast: f32,
 }
 
 pub(crate) struct DirectXRenderer {
@@ -36,7 +44,7 @@ pub(crate) struct DirectXRenderer {
     globals: DirectXGlobalElements,
     pipelines: DirectXRenderPipelines,
     direct_composition: Option<DirectComposition>,
-    font_info: FontInfo,
+    font_info: &'static FontInfo,
 }
 
 /// Direct3D objects
@@ -165,15 +173,6 @@ impl DirectXRenderer {
             Some(composition)
         };
 
-        let rasterization_info = unsafe {
-            let factory: IDWriteFactory5 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED)?;
-            let render_params: IDWriteRenderingParams1 = factory.CreateRenderingParams()?.cast()?;
-            FontInfo {
-                gamma_ratios: Self::get_gamma_ratios(render_params.GetGamma()),
-                grayscale_enhanced_contrast: render_params.GetGrayscaleEnhancedContrast(),
-            }
-        };
-
         Ok(DirectXRenderer {
             hwnd,
             atlas,
@@ -182,7 +181,7 @@ impl DirectXRenderer {
             globals,
             pipelines,
             direct_composition,
-            font_info: rasterization_info,
+            font_info: Self::get_font_info(),
         })
     }
 
@@ -632,23 +631,36 @@ impl DirectXRenderer {
         })
     }
 
+    pub(crate) fn get_font_info() -> &'static FontInfo {
+        static CACHED_FONT_INFO: OnceLock<FontInfo> = OnceLock::new();
+        CACHED_FONT_INFO.get_or_init(|| unsafe {
+            let factory: IDWriteFactory5 = DWriteCreateFactory(DWRITE_FACTORY_TYPE_SHARED).unwrap();
+            let render_params: IDWriteRenderingParams1 =
+                factory.CreateRenderingParams().unwrap().cast().unwrap();
+            FontInfo {
+                gamma_ratios: Self::get_gamma_ratios(render_params.GetGamma()),
+                grayscale_enhanced_contrast: render_params.GetGrayscaleEnhancedContrast(),
+            }
+        })
+    }
+
     // Gamma ratios for brightening/darkening edges for better contrast
     // https://github.com/microsoft/terminal/blob/1283c0f5b99a2961673249fa77c6b986efb5086c/src/renderer/atlas/dwrite.cpp#L50
     fn get_gamma_ratios(gamma: f32) -> [f32; 4] {
         const GAMMA_INCORRECT_TARGET_RATIOS: [[f32; 4]; 13] = [
-            [ 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0 ], // gamma = 1.0
-            [ 0.0166 / 4.0, -0.0807 / 4.0, 0.2227 / 4.0, -0.0751 / 4.0 ], // gamma = 1.1
-            [ 0.0350 / 4.0, -0.1760 / 4.0, 0.4325 / 4.0, -0.1370 / 4.0 ], // gamma = 1.2
-            [ 0.0543 / 4.0, -0.2821 / 4.0, 0.6302 / 4.0, -0.1876 / 4.0 ], // gamma = 1.3
-            [ 0.0739 / 4.0, -0.3963 / 4.0, 0.8167 / 4.0, -0.2287 / 4.0 ], // gamma = 1.4
-            [ 0.0933 / 4.0, -0.5161 / 4.0, 0.9926 / 4.0, -0.2616 / 4.0 ], // gamma = 1.5
-            [ 0.1121 / 4.0, -0.6395 / 4.0, 1.1588 / 4.0, -0.2877 / 4.0 ], // gamma = 1.6
-            [ 0.1300 / 4.0, -0.7649 / 4.0, 1.3159 / 4.0, -0.3080 / 4.0 ], // gamma = 1.7
-            [ 0.1469 / 4.0, -0.8911 / 4.0, 1.4644 / 4.0, -0.3234 / 4.0 ], // gamma = 1.8
-            [ 0.1627 / 4.0, -1.0170 / 4.0, 1.6051 / 4.0, -0.3347 / 4.0 ], // gamma = 1.9
-            [ 0.1773 / 4.0, -1.1420 / 4.0, 1.7385 / 4.0, -0.3426 / 4.0 ], // gamma = 2.0
-            [ 0.1908 / 4.0, -1.2652 / 4.0, 1.8650 / 4.0, -0.3476 / 4.0 ], // gamma = 2.1
-            [ 0.2031 / 4.0, -1.3864 / 4.0, 1.9851 / 4.0, -0.3501 / 4.0 ], // gamma = 2.2
+            [0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0, 0.0000 / 4.0], // gamma = 1.0
+            [0.0166 / 4.0, -0.0807 / 4.0, 0.2227 / 4.0, -0.0751 / 4.0], // gamma = 1.1
+            [0.0350 / 4.0, -0.1760 / 4.0, 0.4325 / 4.0, -0.1370 / 4.0], // gamma = 1.2
+            [0.0543 / 4.0, -0.2821 / 4.0, 0.6302 / 4.0, -0.1876 / 4.0], // gamma = 1.3
+            [0.0739 / 4.0, -0.3963 / 4.0, 0.8167 / 4.0, -0.2287 / 4.0], // gamma = 1.4
+            [0.0933 / 4.0, -0.5161 / 4.0, 0.9926 / 4.0, -0.2616 / 4.0], // gamma = 1.5
+            [0.1121 / 4.0, -0.6395 / 4.0, 1.1588 / 4.0, -0.2877 / 4.0], // gamma = 1.6
+            [0.1300 / 4.0, -0.7649 / 4.0, 1.3159 / 4.0, -0.3080 / 4.0], // gamma = 1.7
+            [0.1469 / 4.0, -0.8911 / 4.0, 1.4644 / 4.0, -0.3234 / 4.0], // gamma = 1.8
+            [0.1627 / 4.0, -1.0170 / 4.0, 1.6051 / 4.0, -0.3347 / 4.0], // gamma = 1.9
+            [0.1773 / 4.0, -1.1420 / 4.0, 1.7385 / 4.0, -0.3426 / 4.0], // gamma = 2.0
+            [0.1908 / 4.0, -1.2652 / 4.0, 1.8650 / 4.0, -0.3476 / 4.0], // gamma = 2.1
+            [0.2031 / 4.0, -1.3864 / 4.0, 1.9851 / 4.0, -0.3501 / 4.0], // gamma = 2.2
         ];
 
         const NORM13: f32 = ((0x10000 as f64) / (255.0 * 255.0) * 4.0) as f32;
@@ -657,9 +669,13 @@ impl DirectXRenderer {
         let index = ((gamma * 10.0).round() as usize).clamp(10, 22) - 10;
         let ratios = GAMMA_INCORRECT_TARGET_RATIOS[index];
 
-        [ratios[0] * NORM13, ratios[1] * NORM24, ratios[2] * NORM13, ratios[3] * NORM24]
+        [
+            ratios[0] * NORM13,
+            ratios[1] * NORM24,
+            ratios[2] * NORM13,
+            ratios[3] * NORM24,
+        ]
     }
-
 }
 
 impl DirectXResources {

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1638,8 +1638,8 @@ pub(crate) mod shader_resources {
             let target_cstr = PCSTR::from_raw(target.as_ptr());
 
             // really dirty trick because winapi bindings are unhappy otherwise
-            let include_handler = std::mem::transmute::<&usize, &ID3DInclude>(
-                &(D3D_COMPILE_STANDARD_FILE_INCLUDE as usize),
+            let include_handler = &std::mem::transmute::<usize, ID3DInclude>(
+                D3D_COMPILE_STANDARD_FILE_INCLUDE as usize,
             );
 
             let ret = D3DCompileFromFile(

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -17,9 +17,7 @@ use windows::{
     UI::ViewManagement::UISettings,
     Win32::{
         Foundation::*,
-        Graphics::{
-            Gdi::*,
-        },
+        Graphics::Gdi::*,
         Security::Credentials::*,
         System::{Com::*, LibraryLoader::*, Ole::*, SystemInformation::*, Threading::*},
         UI::{Input::KeyboardAndMouse::*, Shell::*, WindowsAndMessaging::*},

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -1,7 +1,6 @@
 use std::{
     cell::RefCell,
     ffi::OsStr,
-    mem::ManuallyDrop,
     path::{Path, PathBuf},
     rc::Rc,
     sync::Arc,
@@ -20,7 +19,6 @@ use windows::{
         Foundation::*,
         Graphics::{
             Gdi::*,
-            Imaging::{CLSID_WICImagingFactory, IWICImagingFactory},
         },
         Security::Credentials::*,
         System::{Com::*, LibraryLoader::*, Ole::*, SystemInformation::*, Threading::*},
@@ -41,7 +39,6 @@ pub(crate) struct WindowsPlatform {
     foreground_executor: ForegroundExecutor,
     text_system: Arc<DirectWriteTextSystem>,
     windows_version: WindowsVersion,
-    bitmap_factory: ManuallyDrop<IWICImagingFactory>,
     drop_target_helper: IDropTargetHelper,
     validation_number: usize,
     main_thread_id_win32: u32,
@@ -101,12 +98,8 @@ impl WindowsPlatform {
         let foreground_executor = ForegroundExecutor::new(dispatcher);
         let directx_devices = DirectXDevices::new(disable_direct_composition)
             .context("Unable to init directx devices.")?;
-        let bitmap_factory = ManuallyDrop::new(unsafe {
-            CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
-                .context("Error creating bitmap factory.")?
-        });
         let text_system = Arc::new(
-            DirectWriteTextSystem::new(&directx_devices, &bitmap_factory)
+            DirectWriteTextSystem::new(&directx_devices)
                 .context("Error creating DirectWriteTextSystem")?,
         );
         let drop_target_helper: IDropTargetHelper = unsafe {
@@ -128,7 +121,6 @@ impl WindowsPlatform {
             text_system,
             disable_direct_composition,
             windows_version,
-            bitmap_factory,
             drop_target_helper,
             validation_number,
             main_thread_id_win32,
@@ -716,7 +708,6 @@ impl Platform for WindowsPlatform {
 impl Drop for WindowsPlatform {
     fn drop(&mut self) {
         unsafe {
-            ManuallyDrop::drop(&mut self.bitmap_factory);
             OleUninitialize();
         }
     }

--- a/crates/gpui/src/platform/windows/shaders.hlsl
+++ b/crates/gpui/src/platform/windows/shaders.hlsl
@@ -1,6 +1,8 @@
 cbuffer GlobalParams: register(b0) {
+    float4 gamma_ratios;
     float2 global_viewport_size;
-    uint2 _pad;
+    float grayscale_enhanced_contrast;
+    uint _pad;
 };
 
 Texture2D<float4> t_sprite: register(t0);
@@ -1096,9 +1098,36 @@ MonochromeSpriteVertexOutput monochrome_sprite_vertex(uint vertex_id: SV_VertexI
     return output;
 }
 
+float color_brightness(float3 color) {
+    // REC. 601 luminance coefficients for percieved brightness
+    return dot(color, float3(0.30f, 0.59f, 0.11f));
+}
+
+float light_on_dark_contrast(float enhancedContrast, float3 color) {
+    float brightness = color_brightness(color);
+    float multiplier = saturate(4.0f * (0.75f - brightness));
+    return enhancedContrast * multiplier;
+}
+
+float enhance_contrast(float alpha, float k) {
+    return alpha * (k + 1.0f) / (alpha * k + 1.0f);
+}
+
+float apply_alpha_correction(float a, float b, float4 g) {
+    float brightness_adjustment = g.x * b + g.y;
+    float correction = brightness_adjustment * a + (g.z * b + g.w);
+    return a + a * (1.0f - a) * correction;
+}
+
 float4 monochrome_sprite_fragment(MonochromeSpriteFragmentInput input): SV_Target {
+    float enhanced_contrast = light_on_dark_contrast(grayscale_enhanced_contrast, input.color.rgb);
+    float brightness = color_brightness(input.color.rgb);
+
     float sample = t_sprite.Sample(s_sprite, input.tile_position).r;
-    return float4(input.color.rgb, input.color.a * sample);
+    float contrasted = enhance_contrast(sample, enhanced_contrast);
+    float alpha_corrected = apply_alpha_correction(contrasted, brightness, gamma_ratios);
+
+    return float4(input.color.rgb, input.color.a * alpha_corrected);
 }
 
 /*


### PR DESCRIPTION
Closes #36023 

This improves font rendering quality by doing perceptual gamma+contrast correction which makes font edges look nicer and more legible.

A comparison image: (left is old, right is new)
<img width="1638" height="854" alt="Screenshot 2025-08-29 140015" src="https://github.com/user-attachments/assets/85ca9818-0d55-4af0-a796-19e8cf9ed36b" />

This is most noticeable on smaller fonts / low-dpi displays

Release Notes:

- Improved font rendering quality
