### PR TITLE
Make project symbols picker entry consistent with outline picker

### DIFF
--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -258,10 +258,7 @@ impl PickerDelegate for ProjectSymbolsDelegate {
             .iter()
             .map(|pos| (*pos..pos + 1, highlight_style));
 
-        let highlights = gpui::combine_highlights(
-            custom_highlights,
-            syntax_runs.map(|(range, highlight)| (range, highlight)),
-        );
+        let highlights = gpui::combine_highlights(custom_highlights, syntax_runs);
 
         Some(
             ListItem::new(ix)

--- a/crates/project_symbols/src/project_symbols.rs
+++ b/crates/project_symbols/src/project_symbols.rs
@@ -270,7 +270,6 @@ impl PickerDelegate for ProjectSymbolsDelegate {
                 .toggle_state(selected)
                 .child(
                     v_flex()
-                        .gap_px()
                         .child(LabelLike::new().child(
                             StyledText::new(label).with_default_highlights(&text_style, highlights),
                         ))


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/36383

The project symbols modal didn't use the buffer font and highlighted matches through modifying the font weight, which is inconsistent with the outline picker, which presents code in list items in a similar way, as well as project _and_ buffer search highlighting design.

Release Notes:

- N/A
