### PR TITLE
acp: Improve error reporting and log more information when failing to launch gemini

### DIFF
--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -120,6 +120,7 @@ impl AgentServerDelegate {
                 } else {
                     None
                 };
+                log::debug!("existing version of {package_name}: {newest_version:?}");
                 to_delete.extend(versions.into_iter().map(|(_, file_name)| file_name));
 
                 cx.background_spawn({
@@ -185,7 +186,6 @@ impl AgentServerDelegate {
                             .join(entrypoint_path)
                             .to_string_lossy()
                             .to_string(),
-                        "--".into(),
                     ],
                     env: Default::default(),
                 })
@@ -201,6 +201,8 @@ impl AgentServerDelegate {
         node_runtime: NodeRuntime,
         package_name: SharedString,
     ) -> Result<String> {
+        log::debug!("downloading latest version of {package_name}");
+
         let tmp_dir = tempfile::tempdir_in(&dir)?;
 
         node_runtime

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -113,7 +113,7 @@ impl AgentServerDelegate {
 
                 versions.sort();
                 let newest_version = if let Some((version, file_name)) = versions.last().cloned()
-                    && minimum_version.is_none_or(|minimum_version| version > minimum_version)
+                    && minimum_version.is_none_or(|minimum_version| version >= minimum_version)
                 {
                     versions.pop();
                     Some(file_name)

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -185,6 +185,7 @@ impl AgentServerDelegate {
                             .join(entrypoint_path)
                             .to_string_lossy()
                             .to_string(),
+                        "--".into(),
                     ],
                     env: Default::default(),
                 })

--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -105,14 +105,14 @@ impl AgentServerDelegate {
                         .to_str()
                         .and_then(|name| semver::Version::from_str(&name).ok())
                     {
-                        versions.push((file_name.to_owned(), version));
+                        versions.push((version, file_name.to_owned()));
                     } else {
                         to_delete.push(file_name.to_owned())
                     }
                 }
 
                 versions.sort();
-                let newest_version = if let Some((file_name, version)) = versions.last().cloned()
+                let newest_version = if let Some((version, file_name)) = versions.last().cloned()
                     && minimum_version.is_none_or(|minimum_version| version > minimum_version)
                 {
                     versions.pop();
@@ -120,7 +120,7 @@ impl AgentServerDelegate {
                 } else {
                     None
                 };
-                to_delete.extend(versions.into_iter().map(|(file_name, _)| file_name));
+                to_delete.extend(versions.into_iter().map(|(_, file_name)| file_name));
 
                 cx.background_spawn({
                     let fs = fs.clone();

--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -1,5 +1,4 @@
 use std::rc::Rc;
-use std::str::FromStr as _;
 use std::{any::Any, path::Path};
 
 use crate::acp::AcpConnection;
@@ -114,13 +113,19 @@ impl AgentServer for Gemini {
 
                     let (version_output, help_output) =
                         futures::future::join(version_fut, help_fut).await;
+                    let Some(version_output) = version_output.ok().and_then(|output| String::from_utf8(output.stdout).ok()) else {
+                        return result;
+                    };
+                    let Some((help_stdout, help_stderr)) = help_output.ok().and_then(|output| String::from_utf8(output.stdout).ok().zip(String::from_utf8(output.stderr).ok())) else  {
+                        return result;
+                    };
 
-                    let current_version = std::str::from_utf8(&version_output?.stdout)?
-                        .trim()
-                        .to_string();
-                    let supported = String::from_utf8(help_output?.stdout)?.contains(ACP_ARG) || semver::Version::from_str(&current_version).is_ok_and(|version| version >= Self::MINIMUM_VERSION.parse().unwrap());
+                    let current_version = version_output.trim().to_string();
+                    let supported = help_stdout.contains(ACP_ARG) || current_version.parse::<semver::Version>().is_ok_and(|version| version >= Self::MINIMUM_VERSION.parse::<semver::Version>().unwrap());
 
                     log::error!("failed to create ACP connection to gemini (version is {current_version}, supported: {supported}): {e}");
+                    log::debug!("gemini --help stdout: {help_stdout:?}");
+                    log::debug!("gemini --help stderr: {help_stderr:?}");
                     if !supported {
                         return Err(LoadError::Unsupported {
                             current_version: current_version.into(),

--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -86,14 +86,12 @@ impl AgentServer for Gemini {
                             .await;
                         let current_version =
                             String::from_utf8(version_output?.stdout)?.trim().to_owned();
-                        if !connection.prompt_capabilities().image {
-                            return Err(LoadError::Unsupported {
-                                current_version: current_version.into(),
-                                command: command.path.to_string_lossy().to_string().into(),
-                                minimum_version: Self::MINIMUM_VERSION.into(),
-                            }
-                            .into());
+                        return Err(LoadError::Unsupported {
+                            current_version: current_version.into(),
+                            command: command.path.to_string_lossy().to_string().into(),
+                            minimum_version: Self::MINIMUM_VERSION.into(),
                         }
+                        .into());
                     }
                 }
                 Err(_) => {


### PR DESCRIPTION
In the case where we fail to create an ACP connection to Gemini, only report the "unsupported version" error if the version for the found binary is at least our minimum version. That means we'll surface the real error in this situation.

This also fixes incorrect sorting of downloaded Gemini versions--as @kpe pointed out we were effectively using the version string as a key. Now we'll correctly use the parsed semver::Version instead.

Release Notes:

- N/A