### PR TITLE
agent: Make it so delete_path tool needs user confirmation

### DIFF
--- a/crates/assistant_tools/src/delete_path_tool.rs
+++ b/crates/assistant_tools/src/delete_path_tool.rs
@@ -35,7 +35,7 @@ impl Tool for DeletePathTool {
     }
 
     fn needs_confirmation(&self, _: &serde_json::Value, _: &Entity<Project>, _: &App) -> bool {
-        false
+        true
     }
 
     fn may_perform_edits(&self) -> bool {


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/37048

Release Notes:

- agent: Make delete_path tool require user confirmation by default
