### PR TITLE
agent: Re-add workaround for language model behavior with empty tool result

### DIFF
--- a/crates/agent2/src/thread.rs
+++ b/crates/agent2/src/thread.rs
@@ -484,11 +484,15 @@ impl AgentMessage {
         };
 
         for tool_result in self.tool_results.values() {
+            let mut tool_result = tool_result.clone();
+            // Surprisingly, the API fails if we return an empty string here.
+            // It thinks we are sending a tool use without a tool result.
+            if tool_result.content.is_empty() {
+                tool_result.content = "<Tool returned an empty string>".into();
+            }
             user_message
                 .content
-                .push(language_model::MessageContent::ToolResult(
-                    tool_result.clone(),
-                ));
+                .push(language_model::MessageContent::ToolResult(tool_result));
         }
 
         let mut messages = Vec::new();


### PR DESCRIPTION
This is just copying over the same workaround here:

https://github.com/zed-industries/zed/blob/a790e514af4d6957aa1a14cc8190b2ff24a0484c/crates/agent/src/thread.rs#L1455-L1459

Into the agent2 code.

Release Notes:

- agent: Fixed an issue where some tool calls in the Zed agent could return an error like "`tool_use` ids were found without `tool_result` blocks immediately after"