### PR TITLE
Add xAI to supported language model providers

### DIFF
--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -352,19 +352,19 @@ impl JsonSchema for LanguageModelProviderSetting {
     fn json_schema(_: &mut schemars::SchemaGenerator) -> schemars::Schema {
         json_schema!({
             "enum": [
-                "anthropic",
                 "amazon-bedrock",
-                "google",
-                "lmstudio",
-                "ollama",
-                "openai",
-                "zed.dev",
+                "anthropic",
                 "copilot_chat",
                 "deepseek",
-                "openrouter",
+                "google",
+                "lmstudio",
                 "mistral",
+                "ollama",
+                "openai",
+                "openrouter",
                 "vercel",
-                "x_ai"
+                "x_ai",
+                "zed.dev"
             ]
         })
     }

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -363,7 +363,8 @@ impl JsonSchema for LanguageModelProviderSetting {
                 "deepseek",
                 "openrouter",
                 "mistral",
-                "vercel"
+                "vercel",
+                "x_ai"
             ]
         })
     }


### PR DESCRIPTION
After setting a `grok` model via the agent panel, the settings complains that it doesn't recognize the language model provider:

<img width="1005" height="188" alt="SCR-20250829-tqqd" src="https://github.com/user-attachments/assets/a25fc7e0-60f0-44fd-96d2-b1cb316d06b6" />

Also, sorted the list, in the follow-up commit.

Release Notes:

- N/A
