### PR TITLE
Add Cerebras, Groq and Hugging Face to supported language model providers

### DIFF
--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -354,9 +354,11 @@ impl JsonSchema for LanguageModelProviderSetting {
             "enum": [
                 "amazon-bedrock",
                 "anthropic",
+                "cerebras",
                 "copilot_chat",
                 "deepseek",
                 "google",
+                "groq",
                 "lmstudio",
                 "mistral",
                 "ollama",

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -359,6 +359,7 @@ impl JsonSchema for LanguageModelProviderSetting {
                 "deepseek",
                 "google",
                 "groq",
+                "huggingface",
                 "lmstudio",
                 "mistral",
                 "ollama",


### PR DESCRIPTION
After setting `cerebras` or `groq` or `huggingface` models via the agent panel, the settings complains that it doesn't recognize the language model provider:

<img width="735" height="136" alt="Screenshot_20250830_081157" src="https://github.com/user-attachments/assets/a304410e-5970-4397-88e7-d37ab75e3bf7" />



Release Notes:

- N/A