### PR TITLE
acp: Add SSH remote support

### DIFF
--- a/crates/agent2/src/native_agent_server.rs
+++ b/crates/agent2/src/native_agent_server.rs
@@ -1,4 +1,4 @@
-use std::{any::Any, path::Path, rc::Rc, sync::Arc};
+use std::{any::Any, rc::Rc, sync::Arc};
 
 use agent_servers::{AgentServer, AgentServerDelegate};
 use anyhow::Result;
@@ -35,14 +35,10 @@ impl AgentServer for NativeAgentServer {
 
     fn connect(
         &self,
-        _root_dir: &Path,
         delegate: AgentServerDelegate,
         cx: &mut App,
     ) -> Task<Result<Rc<dyn acp_thread::AgentConnection>>> {
-        log::debug!(
-            "NativeAgentServer::connect called for path: {:?}",
-            _root_dir
-        );
+        log::debug!("NativeAgentServer::connect called");
         let project = delegate.project().clone();
         let fs = self.fs.clone();
         let history = self.history.clone();

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -1,6 +1,5 @@
 use language_models::provider::anthropic::AnthropicLanguageModelProvider;
 use settings::SettingsStore;
-use std::path::Path;
 use std::rc::Rc;
 use std::{any::Any, path::PathBuf};
 
@@ -71,11 +70,10 @@ impl AgentServer for ClaudeCode {
 
     fn connect(
         &self,
-        root_dir: &Path,
         delegate: AgentServerDelegate,
         cx: &mut App,
     ) -> Task<Result<Rc<dyn AgentConnection>>> {
-        let root_dir = root_dir.to_path_buf();
+        let project = delegate.project().clone();
         let server_name = self.name();
         let settings = cx.read_global(|settings: &SettingsStore, _| {
             settings.get::<AllAgentServersSettings>(None).claude.clone()
@@ -105,11 +103,10 @@ impl AgentServer for ClaudeCode {
             {
                 command
                     .env
-                    .get_or_insert_default()
                     .insert("ANTHROPIC_API_KEY".to_owned(), api_key.key);
             }
 
-            crate::acp::connect(server_name, command.clone(), &root_dir, cx).await
+            crate::acp::connect(server_name, command.clone(), &project, cx).await
         })
     }
 

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -2,7 +2,7 @@ use crate::{AgentServerCommand, AgentServerDelegate};
 use acp_thread::AgentConnection;
 use anyhow::Result;
 use gpui::{App, SharedString, Task};
-use std::{path::Path, rc::Rc};
+use std::rc::Rc;
 use ui::IconName;
 
 /// A generic agent server implementation for custom user-defined agents
@@ -32,14 +32,13 @@ impl crate::AgentServer for CustomAgentServer {
 
     fn connect(
         &self,
-        root_dir: &Path,
-        _delegate: AgentServerDelegate,
+        delegate: AgentServerDelegate,
         cx: &mut App,
     ) -> Task<Result<Rc<dyn AgentConnection>>> {
         let server_name = self.name();
         let command = self.command.clone();
-        let root_dir = root_dir.to_path_buf();
-        cx.spawn(async move |cx| crate::acp::connect(server_name, command, &root_dir, cx).await)
+        let project = delegate.project().clone();
+        cx.spawn(async move |cx| crate::acp::connect(server_name, command, &project, cx).await)
     }
 
     fn into_any(self: Rc<Self>) -> Rc<dyn std::any::Any> {

--- a/crates/agent_servers/src/e2e_tests.rs
+++ b/crates/agent_servers/src/e2e_tests.rs
@@ -477,7 +477,7 @@ pub async fn init_test(cx: &mut TestAppContext) -> Arc<FakeFs> {
                     command: AgentServerCommand {
                         path: "claude-code-acp".into(),
                         args: vec![],
-                        env: None,
+                        env: Default::default(),
                     },
                 }),
                 gemini: Some(crate::gemini::tests::local_command().into()),
@@ -500,10 +500,7 @@ pub async fn new_test_thread(
 ) -> Entity<AcpThread> {
     let delegate = AgentServerDelegate::new(project.clone(), None);
 
-    let connection = cx
-        .update(|cx| server.connect(current_dir.as_ref(), delegate, cx))
-        .await
-        .unwrap();
+    let connection = cx.update(|cx| server.connect(delegate, cx)).await.unwrap();
 
     cx.update(|cx| connection.new_thread(project.clone(), current_dir.as_ref(), cx))
         .await

--- a/crates/agent_servers/src/settings.rs
+++ b/crates/agent_servers/src/settings.rs
@@ -52,7 +52,7 @@ impl BuiltinAgentServerSettings {
         self.path.map(|path| AgentServerCommand {
             path,
             args: self.args.unwrap_or_default(),
-            env: self.env,
+            env: self.env.unwrap_or_default(),
         })
     }
 }
@@ -62,7 +62,7 @@ impl From<AgentServerCommand> for BuiltinAgentServerSettings {
         BuiltinAgentServerSettings {
             path: Some(value.path),
             args: Some(value.args),
-            env: value.env,
+            env: Some(value.env),
             ..Default::default()
         }
     }

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -701,7 +701,7 @@ impl MessageEditor {
             self.history_store.clone(),
         ));
         let delegate = AgentServerDelegate::new(self.project.clone(), None);
-        let connection = server.connect(Path::new(""), delegate, cx);
+        let connection = server.connect(delegate, cx);
         cx.spawn(async move |_, cx| {
             let agent = connection.await?;
             let agent = agent.downcast::<agent2::NativeAgentConnection>().unwrap();

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -449,7 +449,7 @@ impl AcpThreadView {
         let (tx, mut rx) = watch::channel("Loading…".into());
         let delegate = AgentServerDelegate::new(project.clone(), Some(tx));
 
-        let connect_task = agent.connect(&root_dir, delegate, cx);
+        let connect_task = agent.connect(delegate, cx);
         let load_task = cx.spawn_in(window, async move |this, cx| {
             let connection = match connect_task.await {
                 Ok(connection) => connection,
@@ -5634,7 +5634,6 @@ pub(crate) mod tests {
 
         fn connect(
             &self,
-            _root_dir: &Path,
             _delegate: AgentServerDelegate,
             _cx: &mut App,
         ) -> Task<gpui::Result<Rc<dyn AgentConnection>>> {

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -1298,7 +1298,7 @@ async fn open_new_agent_servers_entry_in_settings_editor(
                             command: AgentServerCommand {
                                 path: "path_to_executable".into(),
                                 args: vec![],
-                                env: Some(HashMap::default()),
+                                env: HashMap::default(),
                             },
                         },
                     );


### PR DESCRIPTION
runs the acp server on remote

what doesn't work:

- auto installation
- login via UI
  - xdg-open doesn't work on remote, having acp client request to open a url during auth would be nice

works if you have already logged into gemini cli on remote

Closes #37011 

Release Notes:

- Added external agents support for ssh remote projects
