### PR TITLE
Fix SQL error in recent projects query

### DIFF
--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -1112,11 +1112,11 @@ impl WorkspaceDb {
 
     query! {
         fn recent_workspaces_query() -> Result<Vec<(WorkspaceId, String, String, Option<u64>)>> {
-            SELECT workspace_id, paths, paths_order, ssh_connection_id
+            SELECT workspace_id, paths, paths_order, remote_connection_id
             FROM workspaces
             WHERE
                 paths IS NOT NULL OR
-                ssh_connection_id IS NOT NULL
+                remote_connection_id IS NOT NULL
             ORDER BY timestamp DESC
         }
     }
@@ -1128,11 +1128,11 @@ impl WorkspaceDb {
         Ok(self
             .session_workspaces_query(session_id)?
             .into_iter()
-            .map(|(paths, order, window_id, ssh_connection_id)| {
+            .map(|(paths, order, window_id, remote_connection_id)| {
                 (
                     PathList::deserialize(&SerializedPathList { paths, order }),
                     window_id,
-                    ssh_connection_id.map(RemoteConnectionId),
+                    remote_connection_id.map(RemoteConnectionId),
                 )
             })
             .collect())


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/37035

In the WSL PR, `ssh_connection_id` was renamed to `remote_connection_id`. However, that was not accounted for within the `recent_workspaces_query`. This caused a query fail:

```
2025-08-30T14:45:44+02:00 ERROR [recent_projects] Prepare call failed for query:
SELECT
  workspace_id,
  paths,
  paths_order,
  ssh_connection_id
FROM
  workspaces
WHERE
  paths IS NOT NULL
  OR ssh_connection_id IS NOT NULL
ORDER BY
  timestamp DESC

Caused by:
    Sqlite call failed with code 1 and message: Some("no such column: ssh_connection_id")
```

and resulted in no recent workspaces being shown within the recent projects picker.

This change updates the column name to the new name and thus fixes the error.

Release Notes:

- N/A
