### PR TITLE
language_models: Prevent sending the tools object to unsupported models for Ollama

### DIFF
--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -347,7 +347,11 @@ impl OllamaLanguageModel {
                 .model
                 .supports_thinking
                 .map(|supports_thinking| supports_thinking && request.thinking_allowed),
-            tools: request.tools.into_iter().map(tool_into_ollama).collect(),
+            tools: if self.model.supports_tools.unwrap_or(false) {
+                request.tools.into_iter().map(tool_into_ollama).collect()
+            } else {
+                vec![]
+            },
         }
     }
 }


### PR DESCRIPTION
Closes #32758

Release Notes:

- Resolved an issue with the Ollama provider that caused requests to fail with a 400 error for models that don't support tools. The tools object is now only sent to compatible models to ensure successful requests.
