### PR TITLE
languages: Highlights for `defer` keyword TS/JS

### DIFF
--- a/crates/languages/src/javascript/highlights.scm
+++ b/crates/languages/src/javascript/highlights.scm
@@ -226,6 +226,7 @@
 
 [ "abstract"
   "declare"
+  "defer"
   "enum"
   "export"
   "implements"

--- a/crates/languages/src/tsx/highlights.scm
+++ b/crates/languages/src/tsx/highlights.scm
@@ -232,6 +232,7 @@
 
 [ "abstract"
   "declare"
+  "defer"
   "enum"
   "export"
   "implements"

--- a/crates/languages/src/typescript/highlights.scm
+++ b/crates/languages/src/typescript/highlights.scm
@@ -226,6 +226,7 @@
   "continue"
   "debugger"
   "declare"
+  "defer"
   "default"
   "delete"
   "do"


### PR DESCRIPTION
- this keyword is in tc39 Stage 3 https://github.com/tc39/proposal-defer-import-eval/ for JS 
- it has official support in TS as of release 5.9

Release Notes:

- Improved TS/JS syntax highlighting of `import defer` syntax
