### PR TITLE
gpui: Fix Windows rendering inconsistencies

### DIFF
--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -278,9 +278,15 @@ mod windows {
     fn compile_shaders() {
         let shader_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
             .join("src/platform/windows/shaders.hlsl");
+        let color_text_raster_path = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap())
+            .join("src/platform/windows/color_text_raster.hlsl");
         let out_dir = std::env::var("OUT_DIR").unwrap();
 
         println!("cargo:rerun-if-changed={}", shader_path.display());
+        println!(
+            "cargo:rerun-if-changed={}",
+            color_text_raster_path.display()
+        );
 
         // Check if fxc.exe is available
         let fxc_path = find_fxc_compiler();

--- a/crates/gpui/src/platform/test/platform.rs
+++ b/crates/gpui/src/platform/test/platform.rs
@@ -15,11 +15,6 @@ use std::{
     rc::{Rc, Weak},
     sync::Arc,
 };
-#[cfg(target_os = "windows")]
-use windows::Win32::{
-    Graphics::Imaging::{CLSID_WICImagingFactory, IWICImagingFactory},
-    System::Com::{CLSCTX_INPROC_SERVER, CoCreateInstance},
-};
 
 /// TestPlatform implements the Platform trait for use in tests.
 pub(crate) struct TestPlatform {
@@ -36,8 +31,6 @@ pub(crate) struct TestPlatform {
     screen_capture_sources: RefCell<Vec<TestScreenCaptureSource>>,
     pub opened_url: RefCell<Option<String>>,
     pub text_system: Arc<dyn PlatformTextSystem>,
-    #[cfg(target_os = "windows")]
-    bitmap_factory: std::mem::ManuallyDrop<IWICImagingFactory>,
     weak: Weak<Self>,
 }
 
@@ -92,16 +85,6 @@ pub(crate) struct TestPrompts {
 
 impl TestPlatform {
     pub fn new(executor: BackgroundExecutor, foreground_executor: ForegroundExecutor) -> Rc<Self> {
-        #[cfg(target_os = "windows")]
-        let bitmap_factory = unsafe {
-            windows::Win32::System::Ole::OleInitialize(None)
-                .expect("unable to initialize Windows OLE");
-            std::mem::ManuallyDrop::new(
-                CoCreateInstance(&CLSID_WICImagingFactory, None, CLSCTX_INPROC_SERVER)
-                    .expect("Error creating bitmap factory."),
-            )
-        };
-
         let text_system = Arc::new(NoopTextSystem);
 
         Rc::new_cyclic(|weak| TestPlatform {
@@ -117,8 +100,6 @@ impl TestPlatform {
             current_primary_item: Mutex::new(None),
             weak: weak.clone(),
             opened_url: Default::default(),
-            #[cfg(target_os = "windows")]
-            bitmap_factory,
             text_system,
         })
     }
@@ -437,16 +418,6 @@ impl TestScreenCaptureSource {
     /// Create a fake screen capture source, for testing.
     pub fn new() -> Self {
         Self {}
-    }
-}
-
-#[cfg(target_os = "windows")]
-impl Drop for TestPlatform {
-    fn drop(&mut self) {
-        unsafe {
-            std::mem::ManuallyDrop::drop(&mut self.bitmap_factory);
-            windows::Win32::System::Ole::OleUninitialize();
-        }
     }
 }
 

--- a/crates/gpui/src/platform/windows/color_text_raster.hlsl
+++ b/crates/gpui/src/platform/windows/color_text_raster.hlsl
@@ -23,7 +23,7 @@ struct Bounds {
     int2 size;
 };
 
-Texture2D<float4> t_layer : register(t0);
+Texture2D<float> t_layer : register(t0);
 SamplerState s_layer : register(s0);
 
 cbuffer GlyphLayerTextureParams : register(b0) {
@@ -32,8 +32,9 @@ cbuffer GlyphLayerTextureParams : register(b0) {
 };
 
 float4 emoji_rasterization_fragment(PixelInput input): SV_Target {
-    float3 sampled = t_layer.Sample(s_layer, input.texcoord.xy).rgb;
-    float alpha = (sampled.r + sampled.g + sampled.b) / 3;
+    float sampled = t_layer.Sample(s_layer, input.texcoord.xy);
+    float alpha = sampled * run_color.a;
 
-    return float4(run_color.rgb, alpha);
+    float3 color_linear = lerp(run_color.rgb / 12.92, pow((run_color.rgb + 0.055) / 1.055, 2.4), step(0.04045, run_color.rgb));
+    return float4(color_linear * alpha, alpha);
 }

--- a/crates/gpui/src/platform/windows/directx_atlas.rs
+++ b/crates/gpui/src/platform/windows/directx_atlas.rs
@@ -172,7 +172,7 @@ impl DirectXAtlasState {
                 bytes_per_pixel = 1;
             }
             AtlasTextureKind::Polychrome => {
-                pixel_format = DXGI_FORMAT_B8G8R8A8_UNORM;
+                pixel_format = DXGI_FORMAT_B8G8R8A8_UNORM_SRGB;
                 bind_flag = D3D11_BIND_SHADER_RESOURCE;
                 bytes_per_pixel = 4;
             }

--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1171,7 +1171,20 @@ fn create_render_target_and_its_view(
 )> {
     let render_target: ID3D11Texture2D = unsafe { swap_chain.GetBuffer(0) }?;
     let mut render_target_view = None;
-    unsafe { device.CreateRenderTargetView(&render_target, None, Some(&mut render_target_view))? };
+    let rtv_desc = D3D11_RENDER_TARGET_VIEW_DESC {
+        Format: DXGI_FORMAT_B8G8R8A8_UNORM_SRGB,
+        ViewDimension: D3D11_RTV_DIMENSION_TEXTURE2D,
+        Anonymous: D3D11_RENDER_TARGET_VIEW_DESC_0 {
+            Texture2D: D3D11_TEX2D_RTV { MipSlice: 0 },
+        },
+    };
+    unsafe {
+        device.CreateRenderTargetView(
+            &render_target,
+            Some(&rtv_desc),
+            Some(&mut render_target_view),
+        )?
+    };
     Ok((
         ManuallyDrop::new(render_target),
         [Some(render_target_view.unwrap())],
@@ -1295,7 +1308,7 @@ fn create_blend_state(device: &ID3D11Device) -> Result<ID3D11BlendState> {
     desc.RenderTarget[0].SrcBlend = D3D11_BLEND_SRC_ALPHA;
     desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
     desc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
-    desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
+    desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
     desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8;
     unsafe {
         let mut state = None;
@@ -1335,7 +1348,7 @@ fn create_blend_state_for_path_sprite(device: &ID3D11Device) -> Result<ID3D11Ble
     desc.RenderTarget[0].SrcBlend = D3D11_BLEND_ONE;
     desc.RenderTarget[0].SrcBlendAlpha = D3D11_BLEND_ONE;
     desc.RenderTarget[0].DestBlend = D3D11_BLEND_INV_SRC_ALPHA;
-    desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_ONE;
+    desc.RenderTarget[0].DestBlendAlpha = D3D11_BLEND_INV_SRC_ALPHA;
     desc.RenderTarget[0].RenderTargetWriteMask = D3D11_COLOR_WRITE_ENABLE_ALL.0 as u8;
     unsafe {
         let mut state = None;


### PR DESCRIPTION
Switch from ClearType to grayscale antialiasing for DirectWrite glyph atlas generation. ClearType requires knowledge of text/background colors for proper subpixel rendering, which isn't available when generating a reusable atlas.

Changes:
- Use grayscale antialiasing with flat pixel geometry
- Remove WIC dependency; get grayscale directly from DirectWrite
- Fix blend modes for correct alpha compositing
- Add proper sRGB<->linear color conversions in shaders
- Use SRGB render target view for automatic output conversion
- Fix render DPI to ensure we get grid alignment
- Fix missing build check for dirty color text shader

This ensures consistent font rendering across all color combinations and fixes excess alpha/blending issues in the DirectX pipeline. In particular this fixes a lot of render problems with light on dark content.

Closes #36023

Release Notes:

- N/A

Supersedes #36903
Supersedes #37167