### PR TITLE
Fix lost notifications during modal loop on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -264,13 +264,12 @@ impl WindowsWindowInner {
             callback();
         }
         unsafe {
-            PostThreadMessageW(
-                self.main_thread_id_win32,
+            SendMessageW(
+                self.main_thread_message_window,
                 WM_GPUI_CLOSE_ONE_WINDOW,
-                WPARAM(self.validation_number),
-                LPARAM(handle.0 as isize),
-            )
-            .log_err();
+                None,
+                Some(LPARAM(handle.0 as isize)),
+            );
         }
         Some(0)
     }
@@ -1147,10 +1146,13 @@ impl WindowsWindowInner {
     }
 
     fn handle_input_language_changed(&self, lparam: LPARAM) -> Option<isize> {
-        let thread = self.main_thread_id_win32;
-        let validation = self.validation_number;
         unsafe {
-            PostThreadMessageW(thread, WM_INPUTLANGCHANGE, WPARAM(validation), lparam).log_err();
+            SendMessageW(
+                self.main_thread_message_window,
+                WM_INPUTLANGCHANGE,
+                None,
+                Some(lparam),
+            );
         }
         Some(0)
     }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -124,13 +124,13 @@ impl WindowsPlatform {
             main_thread_message_window: Default::default(),
         });
 
-        let hwnd = create_message_window(&inner)?;
+        let hwnd = create_message_window(&mut inner)?;
         inner.main_thread_message_window = hwnd;
 
         let dispatcher = Arc::new(WindowsDispatcher::new(main_sender, hwnd));
 
         let background_executor = BackgroundExecutor::new(dispatcher.clone());
-        let foreground_executor = ForegroundExecutor::new(dispatcher.clone());
+        let foreground_executor = ForegroundExecutor::new(dispatcher);
 
         Ok(Self(inner, background_executor, foreground_executor))
     }
@@ -701,7 +701,7 @@ pub(crate) struct WindowCreationInfo {
     pub(crate) disable_direct_composition: bool,
 }
 
-fn create_message_window(inner: &Box<WindowsPlatformInner>) -> Result<HWND> {
+fn create_message_window(inner: &mut WindowsPlatformInner) -> Result<HWND> {
     let class_name = w!("Zed::MessageOnlyWindow");
     let hinstance = get_module_handle();
 
@@ -727,7 +727,7 @@ fn create_message_window(inner: &Box<WindowsPlatformInner>) -> Result<HWND> {
             Some(HWND_MESSAGE),
             None,
             Some(hinstance.into()),
-            Some(&*(*inner) as *const _ as _),
+            Some(&*inner as *const _ as _),
         )?)
     }
 }

--- a/crates/gpui/src/platform/windows/window.rs
+++ b/crates/gpui/src/platform/windows/window.rs
@@ -71,9 +71,8 @@ pub(crate) struct WindowsWindowInner {
     pub(crate) is_movable: bool,
     pub(crate) executor: ForegroundExecutor,
     pub(crate) windows_version: WindowsVersion,
-    pub(crate) validation_number: usize,
     pub(crate) main_receiver: flume::Receiver<Runnable>,
-    pub(crate) main_thread_id_win32: u32,
+    pub(crate) main_thread_message_window: HWND,
 }
 
 impl WindowsWindowState {
@@ -226,9 +225,8 @@ impl WindowsWindowInner {
             is_movable: context.is_movable,
             executor: context.executor.clone(),
             windows_version: context.windows_version,
-            validation_number: context.validation_number,
             main_receiver: context.main_receiver.clone(),
-            main_thread_id_win32: context.main_thread_id_win32,
+            main_thread_message_window: context.main_thread_message_window,
         }))
     }
 
@@ -340,9 +338,8 @@ struct WindowCreateContext {
     current_cursor: Option<HCURSOR>,
     windows_version: WindowsVersion,
     drop_target_helper: IDropTargetHelper,
-    validation_number: usize,
     main_receiver: flume::Receiver<Runnable>,
-    main_thread_id_win32: u32,
+    main_thread_message_window: HWND,
     appearance: WindowAppearance,
     disable_direct_composition: bool,
 }
@@ -359,9 +356,8 @@ impl WindowsWindow {
             current_cursor,
             windows_version,
             drop_target_helper,
-            validation_number,
             main_receiver,
-            main_thread_id_win32,
+            main_thread_message_window,
             disable_direct_composition,
         } = creation_info;
         register_window_class(icon);
@@ -417,9 +413,8 @@ impl WindowsWindow {
             current_cursor,
             windows_version,
             drop_target_helper,
-            validation_number,
             main_receiver,
-            main_thread_id_win32,
+            main_thread_message_window,
             appearance,
             disable_direct_composition,
         };
@@ -1197,7 +1192,7 @@ pub(crate) fn window_from_hwnd(hwnd: HWND) -> Option<Rc<WindowsWindowInner>> {
     }
 }
 
-fn get_module_handle() -> HMODULE {
+pub(crate) fn get_module_handle() -> HMODULE {
     unsafe {
         let mut h_module = std::mem::zeroed();
         GetModuleHandleExW(

--- a/crates/gpui/src/platform/windows/wrapper.rs
+++ b/crates/gpui/src/platform/windows/wrapper.rs
@@ -2,7 +2,7 @@ use std::ops::Deref;
 
 use windows::Win32::{Foundation::HWND, UI::WindowsAndMessaging::HCURSOR};
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct SafeCursor {
     raw: HCURSOR,
 }
@@ -24,7 +24,7 @@ impl Deref for SafeCursor {
     }
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct SafeHwnd {
     raw: HWND,
 }


### PR DESCRIPTION
Fix the issue mentioned in https://github.com/zed-industries/zed/pull/36779#issuecomment-3215852440.

I couldn't find an easy way to demonstrate the issue in Zed, so I confirmed the fix with the following patch to `hello_world.rs`:
<details>

```diff
diff --git a/crates/gpui/examples/hello_world.rs b/crates/gpui/examples/hello_world.rs
index 7011093474..3c69216b51 100644
--- a/crates/gpui/examples/hello_world.rs
+++ b/crates/gpui/examples/hello_world.rs
@@ -2,13 +2,21 @@ use gpui::{
     App, Application, Bounds, Context, SharedString, Window, WindowBounds, WindowOptions, div,
     prelude::*, px, rgb, size,
 };
+use std::time::Duration;
 
 struct HelloWorld {
     text: SharedString,
+    lines: Vec<SharedString>,
 }
 
 impl Render for HelloWorld {
     fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
+        let lines = self
+            .lines
+            .iter()
+            .cloned()
+            .map(|line| div().text_sm().text_color(rgb(0xffffff)).child(line));
+
         div()
             .flex()
             .flex_col()
@@ -22,7 +30,18 @@ impl Render for HelloWorld {
             .border_color(rgb(0x0000ff))
             .text_xl()
             .text_color(rgb(0xffffff))
+            .id("root")
+            .on_click(|_, window, cx| {
+                let _ = window.prompt(
+                    gpui::PromptLevel::Info,
+                    "Clicked!",
+                    Some("You clicked the window. ForegroundExecutor demo continues in the background."),
+                    &["OK"],
+                    cx,
+                );
+            })
             .child(format!("Hello, {}!", &self.text))
+            .child(div().flex().flex_col().gap_1().children(lines))
             .child(
                 div()
                     .flex()
@@ -89,18 +108,48 @@ impl Render for HelloWorld {
 fn main() {
     Application::new().run(|cx: &mut App| {
         let bounds = Bounds::centered(None, size(px(500.), px(500.0)), cx);
-        cx.open_window(
-            WindowOptions {
-                window_bounds: Some(WindowBounds::Windowed(bounds)),
-                ..Default::default()
-            },
-            |_, cx| {
-                cx.new(|_| HelloWorld {
-                    text: "World".into(),
-                })
-            },
-        )
-        .unwrap();
+        let window = cx
+            .open_window(
+                WindowOptions {
+                    window_bounds: Some(WindowBounds::Windowed(bounds)),
+                    ..Default::default()
+                },
+                |_, cx| {
+                    cx.new(|_| HelloWorld {
+                        text: "World".into(),
+                        lines: Vec::new(),
+                    })
+                },
+            )
+            .unwrap();
+
+        // Demo: use ForegroundExecutor::spawn to schedule periodic UI updates on the main thread.
+        let mut async_cx = cx.to_async();
+        let window_handle = window;
+        cx.foreground_executor()
+            .spawn(async move {
+                let mut i: usize = 1;
+                loop {
+                    // Wait on a background timer, then update UI on the main thread.
+                    async_cx
+                        .background_executor()
+                        .timer(Duration::from_secs(1))
+                        .await;
+
+                    let _ = window_handle.update(&mut async_cx, |state, _window, _cx| {
+                        state.text = format!("World {}", i).into();
+                        state
+                            .lines
+                            .push(format!("Tick {}: queued on main thread", i).into());
+                    });
+
+                    // Schedule a redraw safely outside the paint/prepaint phases.
+                    let _ = async_cx.refresh();
+
+                    i = i.saturating_add(1);
+                }
+            })
+            .detach();
         cx.activate(true);
     });
 }
```

</details>

The patch changes the example so that, each second, a new line of text is added to the window. Clicking on the window also opens a dialog box.

Before this patch, opening the dialog box causes the timer notifications to be dropped:

https://github.com/user-attachments/assets/124a0247-b176-45db-9573-598e4f892dd9

After this patch, the timer keeps firing as expected:

https://github.com/user-attachments/assets/e2463dbc-3b19-4b57-b8a1-1e58ca2204d5




Release Notes:

- N/A
