### PR TITLE
Change move to end of line to behave like the other move to end movements

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13242,17 +13242,14 @@ impl Editor {
 
     pub fn select_to_end_of_line(
         &mut self,
-        action: &SelectToEndOfLine,
+        _: &SelectToEndOfLine,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.change_selections(Default::default(), window, cx, |s| {
             s.move_heads_with(|map, head, _| {
-                (
-                    movement::line_end(map, head, action.stop_at_soft_wraps),
-                    SelectionGoal::None,
-                )
+                (movement::line_end(map, head, false), SelectionGoal::None)
             });
         })
     }
@@ -13265,13 +13262,7 @@ impl Editor {
     ) {
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
         self.transact(window, cx, |this, window, cx| {
-            this.select_to_end_of_line(
-                &SelectToEndOfLine {
-                    stop_at_soft_wraps: false,
-                },
-                window,
-                cx,
-            );
+            this.select_to_end_of_line(&Default::default(), window, cx);
             this.delete(&Delete, window, cx);
         });
     }
@@ -13284,13 +13275,7 @@ impl Editor {
     ) {
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
         self.transact(window, cx, |this, window, cx| {
-            this.select_to_end_of_line(
-                &SelectToEndOfLine {
-                    stop_at_soft_wraps: false,
-                },
-                window,
-                cx,
-            );
+            this.select_to_end_of_line(&Default::default(), window, cx);
             this.cut(&Cut, window, cx);
         });
     }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -248,10 +248,7 @@ pub fn line_end(
     stop_at_soft_boundaries: bool,
 ) -> DisplayPoint {
     if stop_at_soft_boundaries {
-        map.clip_point(
-            DisplayPoint::new(display_point.row(), map.line_len(display_point.row())),
-            Bias::Left,
-        )
+        DisplayPoint::new(display_point.row(), map.line_len(display_point.row()))
     } else {
         map.next_line_boundary(display_point.to_point(map)).1
     }

--- a/crates/editor/src/movement.rs
+++ b/crates/editor/src/movement.rs
@@ -247,12 +247,11 @@ pub fn line_end(
     display_point: DisplayPoint,
     stop_at_soft_boundaries: bool,
 ) -> DisplayPoint {
-    let soft_line_end = map.clip_point(
-        DisplayPoint::new(display_point.row(), map.line_len(display_point.row())),
-        Bias::Left,
-    );
-    if stop_at_soft_boundaries && display_point != soft_line_end {
-        soft_line_end
+    if stop_at_soft_boundaries {
+        map.clip_point(
+            DisplayPoint::new(display_point.row(), map.line_len(display_point.row())),
+            Bias::Left,
+        )
     } else {
         map.next_line_boundary(display_point.to_point(map)).1
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/36677

Get the `editor: move to end of line` to move the cursor to beyond the end of the line, similar to what `editor: move to end` and `editor: move to end of paragraph` do. Also changed the behavior of `editor: select to end of line` so that it selects to the end of the line instead of the previous behavior of selecting to end of the line except the last character.

Release Notes:

- Editor: Change end of line movements to work the same as the other end movements such as end and end of paragraph.
