### PR TITLE
vim: Fix `NormalBefore` with completions shown

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -324,7 +324,7 @@
     }
   },
   {
-    "context": "vim_mode == insert && !menu",
+    "context": "vim_mode == insert",
     "bindings": {
       "ctrl-c": "vim::NormalBefore",
       "ctrl-[": "vim::NormalBefore",


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/35985

The `!menu` is actually not needed and breaks other keybinds from that context. 

Release Notes:

- N/A
