### PR TITLE
linux: Support ctrl-insert in markdown previews

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -170,7 +170,7 @@
     "context": "Markdown",
     "bindings": {
       "copy": "markdown::Copy",
-      "ctrl-insert": "markdown::CopyAs",
+      "ctrl-insert": "markdown::Copy",
       "ctrl-c": "markdown::Copy"
     }
   },

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -170,6 +170,7 @@
     "context": "Markdown",
     "bindings": {
       "copy": "markdown::Copy",
+      "ctrl-insert": "markdown::CopyAs",
       "ctrl-c": "markdown::Copy"
     }
   },
@@ -258,6 +259,7 @@
     "context": "AgentPanel > Markdown",
     "bindings": {
       "copy": "markdown::CopyAsMarkdown",
+      "ctrl-insert": "markdown::CopyAsMarkdown",
       "ctrl-c": "markdown::CopyAsMarkdown"
     }
   },


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/37240

Release Notes:

- Added support for copying in Markdown preview using `ctrl-insert` on Linux/Windows