### PR TITLE
anthropic: Remove logging when no credentials are available

### DIFF
--- a/crates/language_models/src/provider/anthropic.rs
+++ b/crates/language_models/src/provider/anthropic.rs
@@ -197,7 +197,7 @@ impl AnthropicLanguageModelProvider {
         })
     }
 
-    pub fn api_key(cx: &mut App) -> Task<Result<ApiKey>> {
+    pub fn api_key(cx: &mut App) -> Task<Result<ApiKey, AuthenticateError>> {
         let credentials_provider = <dyn CredentialsProvider>::global(cx);
         let api_url = AllLanguageModelSettings::get_global(cx)
             .anthropic


### PR DESCRIPTION
Removes excess log which got through on each start of Zed
```
ERROR [agent_ui::language_model_selector] Failed to authenticate provider: Anthropic: credentials not found
```

The `AnthropicLanguageModelProvider::api_key` method returned a `anyhow::Result` which would convert `AuthenticateError::CredentialsNotFound` into a generic error because of the implicit `Into` when using the `?` operator. This would then get converted into a `AuthenticateError::Other` later.

By specifying the error type as `AuthenticateError`, we remove this implicit conversion and the log gets removed.

Release Notes:

- N/A
