### PR TITLE
language_server: Add `textDocument/foldingRange` support

### DIFF
--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -854,6 +854,21 @@ impl LanguageServer {
                     color_provider: Some(DocumentColorClientCapabilities {
                         dynamic_registration: Some(true),
                     }),
+                    folding_range: Some(FoldingRangeClientCapabilities {
+                        dynamic_registration: Some(false),
+                        range_limit: None,
+                        line_folding_only: Some(false),
+                        folding_range_kind: Some(FoldingRangeKindCapability {
+                            value_set: Some(vec![
+                                FoldingRangeKind::Comment,
+                                FoldingRangeKind::Imports,
+                                FoldingRangeKind::Region,
+                            ]),
+                        }),
+                        folding_range: Some(FoldingRangeCapability {
+                            collapsed_text: Some(true),
+                        }),
+                    }),
                     ..TextDocumentClientCapabilities::default()
                 }),
                 experimental: Some(json!({

--- a/crates/lsp/src/lsp.rs
+++ b/crates/lsp/src/lsp.rs
@@ -855,7 +855,7 @@ impl LanguageServer {
                         dynamic_registration: Some(true),
                     }),
                     folding_range: Some(FoldingRangeClientCapabilities {
-                        dynamic_registration: Some(false),
+                        dynamic_registration: Some(true),
                         range_limit: None,
                         line_folding_only: Some(false),
                         folding_range_kind: Some(FoldingRangeKindCapability {

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -3609,6 +3609,7 @@ impl LspStore {
         client.add_entity_request_handler(Self::handle_lsp_command::<PrepareRename>);
         client.add_entity_request_handler(Self::handle_lsp_command::<PerformRename>);
         client.add_entity_request_handler(Self::handle_lsp_command::<LinkedEditingRange>);
+        client.add_entity_request_handler(Self::handle_lsp_command::<GetFoldingRanges>);
 
         client.add_entity_request_handler(Self::handle_lsp_ext_cancel_flycheck);
         client.add_entity_request_handler(Self::handle_lsp_ext_run_flycheck);
@@ -8178,6 +8179,17 @@ impl LspStore {
                     lsp_request_id,
                     get_implementation,
                     position,
+                    cx.clone(),
+                )
+                .await?;
+            }
+            Request::GetFoldingRanges(get_folding_ranges) => {
+                Self::query_lsp_locally::<GetFoldingRanges>(
+                    lsp_store,
+                    sender_id,
+                    lsp_request_id,
+                    get_folding_ranges,
+                    None,
                     cx.clone(),
                 )
                 .await?;

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -18,7 +18,7 @@ pub mod rust_analyzer_ext;
 use crate::{
     CodeAction, ColorPresentation, Completion, CompletionDisplayOptions, CompletionResponse,
     CompletionSource, CoreCompletion, DocumentColor, Hover, InlayHint, LocationLink, LspAction,
-    LspPullDiagnostics, ManifestProvidersStore, Project, ProjectItem, ProjectPath,
+    LspFoldingRange, LspPullDiagnostics, ManifestProvidersStore, Project, ProjectItem, ProjectPath,
     ProjectTransaction, PulledDiagnostics, ResolveState, Symbol,
     buffer_store::{BufferStore, BufferStoreEvent},
     environment::ProjectEnvironment,
@@ -3609,7 +3609,6 @@ impl LspStore {
         client.add_entity_request_handler(Self::handle_lsp_command::<PrepareRename>);
         client.add_entity_request_handler(Self::handle_lsp_command::<PerformRename>);
         client.add_entity_request_handler(Self::handle_lsp_command::<LinkedEditingRange>);
-        client.add_entity_request_handler(Self::handle_lsp_command::<GetFoldingRanges>);
 
         client.add_entity_request_handler(Self::handle_lsp_ext_cancel_flycheck);
         client.add_entity_request_handler(Self::handle_lsp_ext_run_flycheck);

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -850,6 +850,16 @@ impl std::hash::Hash for ColorPresentation {
     }
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LspFoldingRange {
+    pub start_line: u32,
+    pub start_character: Option<u32>,
+    pub end_line: u32,
+    pub end_character: Option<u32>,
+    pub kind: Option<lsp::FoldingRangeKind>,
+    pub collapsed_text: Option<String>,
+}
+
 #[derive(Clone)]
 pub enum DirectoryLister {
     Project(Entity<Project>),
@@ -3639,6 +3649,19 @@ impl Project {
             drop(guard);
             result
         })
+    }
+
+    pub fn folding_ranges(
+        &mut self,
+        buffer: Entity<Buffer>,
+        cx: &mut Context<Self>,
+    ) -> Task<Result<Vec<LspFoldingRange>>> {
+        self.request_lsp(
+            buffer,
+            LanguageServerToQuery::FirstCapable,
+            GetFoldingRanges,
+            cx,
+        )
     }
 
     pub fn document_highlights<T: ToPointUtf16>(

--- a/crates/proto/proto/lsp.proto
+++ b/crates/proto/proto/lsp.proto
@@ -793,6 +793,7 @@ message LspQuery {
         GetDeclaration get_declaration = 11;
         GetTypeDefinition get_type_definition = 12;
         GetImplementation get_implementation = 13;
+        GetFoldingRanges get_folding_ranges = 14;
     }
 }
 
@@ -815,6 +816,7 @@ message LspResponse {
         GetTypeDefinitionResponse get_type_definition_response = 10;
         GetImplementationResponse get_implementation_response = 11;
         GetReferencesResponse get_references_response = 12;
+        GetFoldingRangesResponse get_folding_ranges_response = 13;
     }
     uint64 server_id = 7;
 }
@@ -929,6 +931,26 @@ message PulledDiagnostics {
 message PullWorkspaceDiagnostics {
     uint64 project_id = 1;
     uint64 server_id = 2;
+}
+
+message GetFoldingRanges {
+    uint64 project_id = 1;
+    uint64 buffer_id = 2;
+    repeated VectorClockEntry version = 3;
+}
+
+message GetFoldingRangesResponse {
+    repeated FoldingRange folding_ranges = 1;
+    repeated VectorClockEntry version = 2;
+}
+
+message FoldingRange {
+    uint32 start_line = 1;
+    optional uint32 start_character = 2;
+    uint32 end_line = 3;
+    optional uint32 end_character = 4;
+    optional string kind = 5;
+    optional string collapsed_text = 6;
 }
 
 message ToggleLspLogs {

--- a/crates/proto/proto/zed.proto
+++ b/crates/proto/proto/zed.proto
@@ -415,6 +415,9 @@ message Envelope {
 
         StashDrop stash_drop = 378;
         StashApply stash_apply = 379; // current max
+
+        GetFoldingRanges get_folding_ranges = 380;
+        GetFoldingRangesResponse get_folding_ranges_response = 381;
     }
 
     reserved 87 to 88;

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -550,7 +550,6 @@ entity_messages!(
     GetProjectSymbols,
     GetReferences,
     GetSignatureHelp,
-    GetFoldingRanges,
     OpenUnstagedDiff,
     OpenUncommittedDiff,
     GetTypeDefinition,

--- a/crates/proto/src/proto.rs
+++ b/crates/proto/src/proto.rs
@@ -323,6 +323,8 @@ messages!(
     (ExternalAgentsUpdated, Background),
     (ExternalAgentLoadingStatusUpdated, Background),
     (NewExternalAgentVersionAvailable, Background),
+    (GetFoldingRanges, Background),
+    (GetFoldingRangesResponse, Background)
 );
 
 request_messages!(
@@ -366,6 +368,7 @@ request_messages!(
     (OpenUncommittedDiff, OpenUncommittedDiffResponse),
     (GetSupermavenApiKey, GetSupermavenApiKeyResponse),
     (GetTypeDefinition, GetTypeDefinitionResponse),
+    (GetFoldingRanges, GetFoldingRangesResponse),
     (LinkedEditingRange, LinkedEditingRangeResponse),
     (ListRemoteDirectory, ListRemoteDirectoryResponse),
     (GetUsers, UsersResponse),
@@ -510,6 +513,7 @@ lsp_messages!(
     (GetDeclaration, GetDeclarationResponse, true),
     (GetTypeDefinition, GetTypeDefinitionResponse, true),
     (GetImplementation, GetImplementationResponse, true),
+    (GetFoldingRanges, GetFoldingRangesResponse, true)
 );
 
 entity_messages!(
@@ -546,6 +550,7 @@ entity_messages!(
     GetProjectSymbols,
     GetReferences,
     GetSignatureHelp,
+    GetFoldingRanges,
     OpenUnstagedDiff,
     OpenUncommittedDiff,
     GetTypeDefinition,
@@ -838,6 +843,7 @@ impl LspQuery {
             Some(lsp_query::Request::GetImplementation(_)) => ("GetImplementation", false),
             Some(lsp_query::Request::GetReferences(_)) => ("GetReferences", false),
             Some(lsp_query::Request::GetDocumentColor(_)) => ("GetDocumentColor", false),
+            Some(lsp_query::Request::GetFoldingRanges(_)) => ("GetFoldingRanges", false),
             None => ("<unknown>", true),
         }
     }

--- a/crates/rpc/src/proto_client.rs
+++ b/crates/rpc/src/proto_client.rs
@@ -361,6 +361,9 @@ impl AnyProtoClient {
                             Response::GetImplementationResponse(response) => {
                                 to_any_envelope(&envelope, response)
                             }
+                            Response::GetFoldingRangesResponse(response) => {
+                                to_any_envelope(&envelope, response)
+                            }
                         };
                         Some(proto::ProtoLspResponse {
                             server_id,


### PR DESCRIPTION
Closes #28091

Release Notes:

- Support for `textDocument/foldingRange`, from the LSP specifications.
- [LSP 3.17 specification](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_foldingRange)
- Dynamic registration is set to false.
