### PR TITLE
reqwest_client: Fix a panic in the example

### DIFF
--- a/crates/reqwest_client/examples/client.rs
+++ b/crates/reqwest_client/examples/client.rs
@@ -20,14 +20,19 @@ fn main() {
             ];
             let mut requests = requests.into_iter().collect::<FuturesUnordered<_>>();
             while let Some(response) = requests.next().await {
+                let unwrapped_response = response.unwrap();
+                println!("Status: {}", unwrapped_response.status());
+                println!("Headers: {:#?}", unwrapped_response.headers());
+
                 let mut body = String::new();
-                response
-                    .unwrap()
+                match unwrapped_response
                     .into_body()
                     .read_to_string(&mut body)
                     .await
-                    .unwrap();
-                println!("{}", &body.len());
+                {
+                    Ok(body) => println!("{}", body),
+                    Err(e) => println!("Failed to get text: {}", e),
+                }
             }
             println!("{:?}", start.elapsed());
 


### PR DESCRIPTION
The method read_into_string throws an error if the response body is not valid utf-8. This commit prints an error instead of panicing. Output before:
```
     Running `target/debug/examples/client`
566244

thread 'main' panicked at crates/reqwest_client/examples/client.rs:29:22:
called `Result::unwrap()` on an `Err` value: Custom { kind: InvalidData, error: "stream did not contain valid UTF-8" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Output after:
```
Status: 200 OK
Headers: {
    ...
}
Failed to get text: stream did not contain valid UTF-8
Status: 200 OK
Headers: {
    ...
}
17219
Status: 200 OK
Headers: {
    ...
}
566244
549.769283ms
```
Release Notes:

- N/A
