### PR TITLE
agent_ui: Put Claude Code button behind feature flag in agent settings

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -15,6 +15,7 @@ use context_server::ContextServerId;
 use editor::{Editor, SelectionEffects, scroll::Autoscroll};
 use extension::ExtensionManifest;
 use extension_host::ExtensionStore;
+use feature_flags::{ClaudeCodeFeatureFlag, FeatureFlagAppExt};
 use fs::Fs;
 use gpui::{
     Action, Animation, AnimationExt as _, AnyView, App, AsyncWindowContext, Corner, Entity,
@@ -1065,12 +1066,14 @@ impl AgentConfiguration {
                         ExternalAgent::Gemini,
                         cx,
                     ))
-                    .child(self.render_agent_server(
-                        IconName::AiClaude,
-                        "Claude Code",
-                        ExternalAgent::ClaudeCode,
-                        cx,
-                    ))
+                    .when(cx.has_flag::<ClaudeCodeFeatureFlag>(), |this| {
+                        this.child(self.render_agent_server(
+                            IconName::AiClaude,
+                            "Claude Code",
+                            ExternalAgent::ClaudeCode,
+                            cx,
+                        ))
+                    })
                     .children(user_defined_agents),
             )
     }


### PR DESCRIPTION
In #37164 the claude code button was made visible inside agent settings UI though clicking on does nothing because I am guessing due to the fact claude code is not yet enabled. So I have put this behind a feature flag, as it might confuse users. In case it was intentional and bound to release this week feel free to close this PR. cc @danilo-leal 

| Before | After |
|--------|--------|
| <img width="768" height="1898" alt="CleanShot 2025-09-01 at 18 40 33@2x" src="https://github.com/user-attachments/assets/48cddccf-f0bd-458e-bb59-f500c3057c1f" /> | <img width="830" height="1954" alt="CleanShot 2025-09-01 at 18 40 46@2x" src="https://github.com/user-attachments/assets/e7dce798-ec66-4db5-8eeb-865b7a3db876" /> | 

Release Notes:

- N/A
