### PR TITLE
windows: Don’t skip the typo check for the windows folder

### DIFF
--- a/crates/gpui/src/platform/windows/directx_renderer.rs
+++ b/crates/gpui/src/platform/windows/directx_renderer.rs
@@ -1760,7 +1760,7 @@ mod amd {
                 anyhow::bail!("Failed to initialize AMD AGS, error code: {}", result);
             }
 
-            // Vulkan acctually returns this as the driver version
+            // Vulkan actually returns this as the driver version
             let software_version = if !gpu_info.radeon_software_version.is_null() {
                 std::ffi::CStr::from_ptr(gpu_info.radeon_software_version)
                     .to_string_lossy()

--- a/crates/gpui/src/platform/windows/events.rs
+++ b/crates/gpui/src/platform/windows/events.rs
@@ -708,7 +708,7 @@ impl WindowsWindowInner {
                 .system_settings
                 .auto_hide_taskbar_position
         {
-            // Fot the auto-hide taskbar, adjust in by 1 pixel on taskbar edge,
+            // For the auto-hide taskbar, adjust in by 1 pixel on taskbar edge,
             // so the window isn't treated as a "fullscreen app", which would cause
             // the taskbar to disappear.
             match taskbar_position {

--- a/crates/gpui/src/platform/windows/vsync.rs
+++ b/crates/gpui/src/platform/windows/vsync.rs
@@ -94,7 +94,7 @@ impl VSyncProvider {
         // DwmFlush and DCompositionWaitForCompositorClock returns very early
         // instead of waiting until vblank when the monitor goes to sleep or is
         // unplugged (nothing to present due to desktop occlusion). We use 1ms as
-        // a threshhold for the duration of the wait functions and fallback to
+        // a threshold for the duration of the wait functions and fallback to
         // Sleep() if it returns before that. This could happen during normal
         // operation for the first call after the vsync thread becomes non-idle,
         // but it shouldn't happen often.

--- a/typos.toml
+++ b/typos.toml
@@ -35,8 +35,6 @@ extend-exclude = [
     "crates/rpc/src/auth.rs",
     # glsl isn't recognized by this tool.
     "extensions/glsl/languages/glsl/",
-    # Windows likes its abbreviations.
-    "crates/gpui/src/platform/windows/",
     # Some typos in the base mdBook CSS.
     "docs/theme/css/",
     # Spellcheck triggers on `|Fixe[sd]|` regex part.

--- a/typos.toml
+++ b/typos.toml
@@ -35,6 +35,11 @@ extend-exclude = [
     "crates/rpc/src/auth.rs",
     # glsl isn't recognized by this tool.
     "extensions/glsl/languages/glsl/",
+    # Windows likes its abbreviations.
+    "crates/gpui/src/platform/windows/directx_renderer.rs",
+    "crates/gpui/src/platform/windows/events.rs",
+    "crates/gpui/src/platform/windows/direct_write.rs",
+    "crates/gpui/src/platform/windows/window.rs",
     # Some typos in the base mdBook CSS.
     "docs/theme/css/",
     # Spellcheck triggers on `|Fixe[sd]|` regex part.


### PR DESCRIPTION
Try to narrow down the scope of typo checking


Release Notes:

- N/A