### PR TITLE
agent2: Fix terminal tool call content not being shown once truncated

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2646,7 +2646,18 @@ impl AcpThreadView {
                         .bg(cx.theme().colors().editor_background)
                         .rounded_b_md()
                         .text_ui_sm(cx)
-                        .children(terminal_view.clone()),
+                        .h_full()
+                        .children(terminal_view.map(|terminal_view| {
+                            if terminal_view
+                                .read(cx)
+                                .content_mode(window, cx)
+                                .is_scrollable()
+                            {
+                                div().h_72().child(terminal_view).into_any_element()
+                            } else {
+                                terminal_view.into_any_element()
+                            }
+                        })),
                 )
             })
             .into_any()


### PR DESCRIPTION
We render terminals as inline if their content is below a certain line count, and scrollable past that point. In the scrollable case we weren't setting a height for the terminal's container, causing it to be rendered at height 0, which means no lines would be displayed. This PR fixes that by setting an explicit height for the scrollable case, like we do in the agent1 UI code.

Release Notes:

- agent: Fixed a bug that caused terminals in the panel to be empty after their content reached a certain size.