### PR TITLE
agent2: Kill terminal task when tool call is cancelled

### DIFF
--- a/crates/agent2/src/tools/terminal_tool.rs
+++ b/crates/agent2/src/tools/terminal_tool.rs
@@ -201,7 +201,7 @@ impl AgentTool for TerminalTool {
                 let exit_status = terminal
                     .update(cx, |terminal, cx| terminal.wait_for_completed_task(cx))?
                     .await;
-                guard.update(cx, |cancelled, _| *cancelled = true);
+                guard.update(cx, |cancelled, _| *cancelled = true)?;
                 let (content, content_line_count) = terminal.read_with(cx, |terminal, _| {
                     (terminal.get_content(), terminal.total_lines())
                 })?;


### PR DESCRIPTION
This PR makes it so that when a terminal tool call in an agent2 thread is cancelled by sending another message in the thread, we kill the terminal's main process.

Release Notes:

- agent2: Running processes in terminals are now killed if their tool call is cancelled by sending another message.