### PR TITLE
gpui: Fix intra rustdoc links

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -2313,7 +2313,7 @@ pub struct AnyDrag {
 }
 
 /// Contains state associated with a tooltip. You'll only need this struct if you're implementing
-/// tooltip behavior on a custom element. Otherwise, use [Div::tooltip].
+/// tooltip behavior on a custom element. Otherwise, use [Div::tooltip](crate::Interactivity::tooltip).
 #[derive(Clone)]
 pub struct AnyTooltip {
     /// The view used to display the tooltip

--- a/crates/gpui/src/app/async_context.rs
+++ b/crates/gpui/src/app/async_context.rs
@@ -218,7 +218,7 @@ impl AsyncApp {
         Some(read(app.try_global()?, &app))
     }
 
-    /// A convenience method for [App::update_global]
+    /// A convenience method for [`App::update_global`](BorrowAppContext::update_global)
     /// for updating the global state of the specified type.
     pub fn update_global<G: Global, R>(
         &self,
@@ -293,7 +293,7 @@ impl AsyncWindowContext {
             .update(self, |_, window, cx| read(cx.global(), window, cx))
     }
 
-    /// A convenience method for [`App::update_global`].
+    /// A convenience method for [`App::update_global`](BorrowAppContext::update_global).
     /// for updating the global state of the specified type.
     pub fn update_global<G, R>(
         &mut self,

--- a/crates/gpui/src/colors.rs
+++ b/crates/gpui/src/colors.rs
@@ -88,9 +88,9 @@ impl Deref for GlobalColors {
 
 impl Global for GlobalColors {}
 
-/// Implement this trait to allow global [Color] access via `cx.default_colors()`.
+/// Implement this trait to allow global [Colors] access via `cx.default_colors()`.
 pub trait DefaultColors {
-    /// Returns the default [`gpui::Colors`]
+    /// Returns the default [`Colors`]
     fn default_colors(&self) -> &Arc<Colors>;
 }
 

--- a/crates/gpui/src/element.rs
+++ b/crates/gpui/src/element.rs
@@ -14,13 +14,13 @@
 //! tree and any callbacks they have registered with GPUI are dropped and the process repeats.
 //!
 //! But some state is too simple and voluminous to store in every view that needs it, e.g.
-//! whether a hover has been started or not. For this, GPUI provides the [`Element::State`], associated type.
+//! whether a hover has been started or not. For this, GPUI provides the [`Element::PrepaintState`], associated type.
 //!
 //! # Implementing your own elements
 //!
 //! Elements are intended to be the low level, imperative API to GPUI. They are responsible for upholding,
 //! or breaking, GPUI's features as they deem necessary. As an example, most GPUI elements are expected
-//! to stay in the bounds that their parent element gives them. But with [`WindowContext::break_content_mask`],
+//! to stay in the bounds that their parent element gives them. But with [`Window::with_content_mask`],
 //! you can ignore this restriction and paint anywhere inside of the window's bounds. This is useful for overlays
 //! and popups and anything else that shows up 'on top' of other elements.
 //! With great power, comes great responsibility.

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -533,7 +533,7 @@ impl Interactivity {
     }
 
     /// Use the given callback to construct a new tooltip view when the mouse hovers over this element.
-    /// The imperative API equivalent to [`InteractiveElement::tooltip`]
+    /// The imperative API equivalent to [`StatefulInteractiveElement::tooltip`]
     pub fn tooltip(&mut self, build_tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static)
     where
         Self: Sized,
@@ -550,7 +550,7 @@ impl Interactivity {
 
     /// Use the given callback to construct a new tooltip view when the mouse hovers over this element.
     /// The tooltip itself is also hoverable and won't disappear when the user moves the mouse into
-    /// the tooltip. The imperative API equivalent to [`InteractiveElement::hoverable_tooltip`]
+    /// the tooltip. The imperative API equivalent to [`StatefulInteractiveElement::hoverable_tooltip`]
     pub fn hoverable_tooltip(
         &mut self,
         build_tooltip: impl Fn(&mut Window, &mut App) -> AnyView + 'static,
@@ -676,7 +676,7 @@ pub trait InteractiveElement: Sized {
 
     #[cfg(any(test, feature = "test-support"))]
     /// Set a key that can be used to look up this element's bounds
-    /// in the [`VisualTestContext::debug_bounds`] map
+    /// in the [`crate::VisualTestContext::debug_bounds`] map
     /// This is a noop in release builds
     fn debug_selector(mut self, f: impl FnOnce() -> String) -> Self {
         self.interactivity().debug_selector = Some(f());
@@ -685,7 +685,7 @@ pub trait InteractiveElement: Sized {
 
     #[cfg(not(any(test, feature = "test-support")))]
     /// Set a key that can be used to look up this element's bounds
-    /// in the [`VisualTestContext::debug_bounds`] map
+    /// in the [`crate::VisualTestContext::debug_bounds`] map
     /// This is a noop in release builds
     #[inline]
     fn debug_selector(self, _: impl FnOnce() -> String) -> Self {
@@ -1087,7 +1087,7 @@ pub trait StatefulInteractiveElement: InteractiveElement {
 
     /// On drag initiation, this callback will be used to create a new view to render the dragged value for a
     /// drag and drop operation. This API should also be used as the equivalent of 'on drag start' with
-    /// the [`Self::on_drag_move`] API.
+    /// the [`InteractiveElement::on_drag_move`] API.
     /// The callback also has access to the offset of triggering click from the origin of parent element.
     /// The fluent API equivalent to [`Interactivity::on_drag`]
     ///

--- a/crates/gpui/src/elements/list.rs
+++ b/crates/gpui/src/elements/list.rs
@@ -5,7 +5,7 @@
 //! In order to minimize re-renders, this element's state is stored intrusively
 //! on your own views, so that your code can coordinate directly with the list element's cached state.
 //!
-//! If all of your elements are the same height, see [`UniformList`] for a simpler API
+//! If all of your elements are the same height, see [`crate::UniformList`] for a simpler API
 
 use crate::{
     AnyElement, App, AvailableSpace, Bounds, ContentMask, DispatchPhase, Edges, Element, EntityId,
@@ -235,7 +235,7 @@ impl ListState {
     }
 
     /// Register with the list state that the items in `old_range` have been replaced
-    /// by new items. As opposed to [`splice`], this method allows an iterator of optional focus handles
+    /// by new items. As opposed to [`Self::splice`], this method allows an iterator of optional focus handles
     /// to be supplied to properly integrate with items in the list that can be focused. If a focused item
     /// is scrolled out of view, the list will continue to render it to allow keyboard interaction.
     pub fn splice_focusable(

--- a/crates/gpui/src/executor.rs
+++ b/crates/gpui/src/executor.rs
@@ -391,7 +391,7 @@ impl BackgroundExecutor {
     }
 
     /// in tests, run all tasks that are ready to run. If after doing so
-    /// the test still has outstanding tasks, this will panic. (See also `allow_parking`)
+    /// the test still has outstanding tasks, this will panic. (See also [`Self::allow_parking`])
     #[cfg(any(test, feature = "test-support"))]
     pub fn run_until_parked(&self) {
         self.dispatcher.as_test().unwrap().run_until_parked()
@@ -405,7 +405,7 @@ impl BackgroundExecutor {
         self.dispatcher.as_test().unwrap().allow_parking();
     }
 
-    /// undoes the effect of [`allow_parking`].
+    /// undoes the effect of [`Self::allow_parking`].
     #[cfg(any(test, feature = "test-support"))]
     pub fn forbid_parking(&self) {
         self.dispatcher.as_test().unwrap().forbid_parking();
@@ -480,7 +480,7 @@ impl ForegroundExecutor {
 /// Variant of `async_task::spawn_local` that includes the source location of the spawn in panics.
 ///
 /// Copy-modified from:
-/// https://github.com/smol-rs/async-task/blob/ca9dbe1db9c422fd765847fa91306e30a6bb58a9/src/runnable.rs#L405
+/// <https://github.com/smol-rs/async-task/blob/ca9dbe1db9c422fd765847fa91306e30a6bb58a9/src/runnable.rs#L405>
 #[track_caller]
 fn spawn_local_with_source_location<Fut, S>(
     future: Fut,

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -24,7 +24,7 @@
 //! - State management and communication with [`Entity`]'s. Whenever you need to store application state
 //!   that communicates between different parts of your application, you'll want to use GPUI's
 //!   entities. Entities are owned by GPUI and are only accessible through an owned smart pointer
-//!   similar to an [`std::rc::Rc`]. See the [`app::context`] module for more information.
+//!   similar to an [`std::rc::Rc`]. See [`app::Context`] for more information.
 //!
 //! - High level, declarative UI with views. All UI in GPUI starts with a view. A view is simply
 //!   a [`Entity`] that can be rendered, by implementing the [`Render`] trait. At the start of each frame, GPUI
@@ -37,7 +37,7 @@
 //!   provide a nice wrapper around an imperative API that provides as much flexibility and control as
 //!   you need. Elements have total control over how they and their child elements are rendered and
 //!   can be used for making efficient views into large lists, implement custom layouting for a code editor,
-//!   and anything else you can think of. See the [`element`] module for more information.
+//!   and anything else you can think of. See the [`elements`] module for more information.
 //!
 //!  Each of these registers has one or more corresponding contexts that can be accessed from all GPUI services.
 //!  This context is your main interface to GPUI, and is used extensively throughout the framework.
@@ -51,9 +51,9 @@
 //!   Use this for implementing keyboard shortcuts, such as cmd-q (See `action` module for more information).
 //! - Platform services, such as `quit the app` or `open a URL` are available as methods on the [`app::App`].
 //! - An async executor that is integrated with the platform's event loop. See the [`executor`] module for more information.,
-//! - The [`gpui::test`](test) macro provides a convenient way to write tests for your GPUI applications. Tests also have their
-//!   own kind of context, a [`TestAppContext`] which provides ways of simulating common platform input. See [`app::test_context`]
-//!   and [`test`] modules for more details.
+//! - The [`gpui::test`](macro@test) macro provides a convenient way to write tests for your GPUI applications. Tests also have their
+//!   own kind of context, a [`TestAppContext`] which provides ways of simulating common platform input. See [`TestAppContext`]
+//!   and [`mod@test`] modules for more details.
 //!
 //! Currently, the best way to learn about these APIs is to read the Zed source code, ask us about it at a fireside hack, or drop
 //! a question in the [Zed Discord](https://zed.dev/community-links). We're working on improving the documentation, creating more examples,
@@ -117,7 +117,7 @@ pub mod private {
 
 mod seal {
     /// A mechanism for restricting implementations of a trait to only those in GPUI.
-    /// See: https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/
+    /// See: <https://predr.ag/blog/definitive-guide-to-sealed-traits-in-rust/>
     pub trait Sealed {}
 }
 

--- a/crates/gpui/src/input.rs
+++ b/crates/gpui/src/input.rs
@@ -72,7 +72,7 @@ pub trait EntityInputHandler: 'static + Sized {
     ) -> Option<usize>;
 }
 
-/// The canonical implementation of [`PlatformInputHandler`]. Call [`Window::handle_input`]
+/// The canonical implementation of [`crate::PlatformInputHandler`]. Call [`Window::handle_input`]
 /// with an instance during your element's paint.
 pub struct ElementInputHandler<V> {
     view: Entity<V>,

--- a/crates/gpui/src/path_builder.rs
+++ b/crates/gpui/src/path_builder.rs
@@ -318,7 +318,7 @@ impl PathBuilder {
         Ok(Self::build_path(buf))
     }
 
-    /// Builds a [`Path`] from a [`lyon::VertexBuffers`].
+    /// Builds a [`Path`] from a [`lyon::tessellation::VertexBuffers`].
     pub fn build_path(buf: VertexBuffers<lyon::math::Point, u16>) -> Path<Pixels> {
         if buf.vertices.is_empty() {
             return Path::new(Point::default());

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -351,7 +351,7 @@ impl WindowTextSystem {
     ///
     /// Note that this method can only shape a single line of text. It will panic
     /// if the text contains newlines. If you need to shape multiple lines of text,
-    /// use `TextLayout::shape_text` instead.
+    /// use [`Self::shape_text`] instead.
     pub fn shape_line(
         &self,
         text: SharedString,
@@ -517,7 +517,7 @@ impl WindowTextSystem {
 
     /// Layout the given line of text, at the given font_size.
     /// Subsets of the line can be styled independently with the `runs` parameter.
-    /// Generally, you should prefer to use `TextLayout::shape_line` instead, which
+    /// Generally, you should prefer to use [`Self::shape_line`] instead, which
     /// can be painted directly.
     pub fn layout_line<Text>(
         &self,
@@ -668,7 +668,7 @@ impl Display for FontStyle {
     }
 }
 
-/// A styled run of text, for use in [`TextLayout`].
+/// A styled run of text, for use in [`crate::TextLayout`].
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TextRun {
     /// A number of utf8 bytes
@@ -694,7 +694,7 @@ impl TextRun {
     }
 }
 
-/// An identifier for a specific glyph, as returned by [`TextSystem::layout_line`].
+/// An identifier for a specific glyph, as returned by [`WindowTextSystem::layout_line`].
 #[derive(Copy, Clone, Debug, Eq, PartialEq, Hash)]
 #[repr(C)]
 pub struct GlyphId(pub(crate) u32);

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -585,7 +585,7 @@ pub enum HitboxBehavior {
     ///     if phase == DispatchPhase::Capture && hitbox.is_hovered(window) {
     ///         cx.stop_propagation();
     ///     }
-    /// }
+    /// })
     /// ```
     ///
     /// This has effects beyond event handling - any use of hitbox checking, such as hover
@@ -605,11 +605,11 @@ pub enum HitboxBehavior {
     /// bubble-phase handler for every mouse event type **except** `ScrollWheelEvent`:
     ///
     /// ```
-    /// window.on_mouse_event(move |_: &EveryMouseEventTypeExceptScroll, phase, window, _cx| {
+    /// window.on_mouse_event(move |_: &EveryMouseEventTypeExceptScroll, phase, window, cx| {
     ///     if phase == DispatchPhase::Bubble && hitbox.should_handle_scroll(window) {
     ///         cx.stop_propagation();
     ///     }
-    /// }
+    /// })
     /// ```
     ///
     /// See the documentation of [`Hitbox::is_hovered`] for details of why `ScrollWheelEvent` is
@@ -1909,7 +1909,7 @@ impl Window {
     }
 
     /// Produces a new frame and assigns it to `rendered_frame`. To actually show
-    /// the contents of the new [Scene], use [present].
+    /// the contents of the new [`Scene`], use [`Self::present`].
     #[profiling::function]
     pub fn draw(&mut self, cx: &mut App) -> ArenaClearNeeded {
         self.invalidate_entities();
@@ -2451,7 +2451,7 @@ impl Window {
     /// Perform prepaint on child elements in a "retryable" manner, so that any side effects
     /// of prepaints can be discarded before prepainting again. This is used to support autoscroll
     /// where we need to prepaint children to detect the autoscroll bounds, then adjust the
-    /// element offset and prepaint again. See [`List`] for an example. This method should only be
+    /// element offset and prepaint again. See [`crate::List`] for an example. This method should only be
     /// called during the prepaint phase of element drawing.
     pub fn transact<T, U>(&mut self, f: impl FnOnce(&mut Self) -> Result<T, U>) -> Result<T, U> {
         self.invalidator.debug_assert_prepaint();
@@ -2476,9 +2476,9 @@ impl Window {
         result
     }
 
-    /// When you call this method during [`prepaint`], containing elements will attempt to
+    /// When you call this method during [`Element::prepaint`], containing elements will attempt to
     /// scroll to cause the specified bounds to become visible. When they decide to autoscroll, they will call
-    /// [`prepaint`] again with a new set of bounds. See [`List`] for an example of an element
+    /// [`Element::prepaint`] again with a new set of bounds. See [`crate::List`] for an example of an element
     /// that supports this method being called on the elements it contains. This method should only be
     /// called during the prepaint phase of element drawing.
     pub fn request_autoscroll(&mut self, bounds: Bounds<Pixels>) {
@@ -2486,8 +2486,8 @@ impl Window {
         self.requested_autoscroll = Some(bounds);
     }
 
-    /// This method can be called from a containing element such as [`List`] to support the autoscroll behavior
-    /// described in [`request_autoscroll`].
+    /// This method can be called from a containing element such as [`crate::List`] to support the autoscroll behavior
+    /// described in [`Self::request_autoscroll`].
     pub fn take_autoscroll(&mut self) -> Option<Bounds<Pixels>> {
         self.invalidator.debug_assert_prepaint();
         self.requested_autoscroll.take()
@@ -2815,7 +2815,7 @@ impl Window {
 
     /// Paint one or more quads into the scene for the next frame at the current stacking context.
     /// Quads are colored rectangular regions with an optional background, border, and corner radius.
-    /// see [`fill`](crate::fill), [`outline`](crate::outline), and [`quad`](crate::quad) to construct this type.
+    /// see [`fill`], [`outline`], and [`quad`] to construct this type.
     ///
     /// This method should only be called as part of the paint phase of element drawing.
     ///
@@ -4821,7 +4821,7 @@ impl HasDisplayHandle for Window {
     }
 }
 
-/// An identifier for an [`Element`](crate::Element).
+/// An identifier for an [`Element`].
 ///
 /// Can be constructed with a string, a number, or both, as well
 /// as other internal representations.

--- a/crates/util/src/schemars.rs
+++ b/crates/util/src/schemars.rs
@@ -7,7 +7,7 @@ const DEFS_PATH: &str = "#/$defs/";
 ///
 /// This asserts that JsonSchema::schema_name() + "2" does not exist because this indicates that
 /// there are multiple types that use this name, and unfortunately schemars APIs do not support
-/// resolving this ambiguity - see https://github.com/GREsau/schemars/issues/449
+/// resolving this ambiguity - see <https://github.com/GREsau/schemars/issues/449>
 ///
 /// This takes a closure for `schema` because some settings types are not available on the remote
 /// server, and so will crash when attempting to access e.g. GlobalThemeRegistry.

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -329,7 +329,7 @@ pub fn load_login_shell_environment() -> Result<()> {
 /// Configures the process to start a new session, to prevent interactive shells from taking control
 /// of the terminal.
 ///
-/// For more details: https://registerspill.thorstenball.com/p/how-to-lose-control-of-your-shell
+/// For more details: <https://registerspill.thorstenball.com/p/how-to-lose-control-of-your-shell>
 pub fn set_pre_exec_to_start_new_session(
     command: &mut std::process::Command,
 ) -> &mut std::process::Command {


### PR DESCRIPTION
The only warnings remaining are links to private modules/items, but I lack knowledge to work out if the referenced modules/items should be made public, or if the links should be rewritten into exposed traits/items.

Links to associated items such as trait implementations have to be written using full markdown format such as:

... [[ `App::update_global` ]](( BorrowAppContext::update_global ))

This is due to https://github.com/rust-lang/rust/issues/74563 which sadly prohibits fully-qualified syntax:

... [[ `<App as BorrowAppContext>::update_global` ]]

Release Notes:

- N/A

Probably related to https://github.com/zed-industries/zed/pull/37072
