### PR TITLE
docs: Add link to msys2 docs page

### DIFF
--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -116,6 +116,8 @@ cargo test --workspace
 
 Zed does not support unofficial MSYS2 Zed packages built for Mingw-w64. Please report any issues you may have with [mingw-w64-zed](https://packages.msys2.org/base/mingw-w64-zed) to [msys2/MINGW-packages/issues](https://github.com/msys2/MINGW-packages/issues?q=is%3Aissue+is%3Aopen+zed).
 
+Please refer to [MSYS2 documentation](https://www.msys2.org/docs/ides-editors/#zed) first.
+
 ## Troubleshooting
 
 ### Setting `RUSTFLAGS` env var breaks builds


### PR DESCRIPTION
it was removed earlier. better to keep this link because the page contains some useful information

Release Notes:

- N/A
