### PR TITLE
gpui: Fix typo in Windows alpha correction shader

### DIFF
--- a/crates/gpui/src/platform/windows/alpha_correction.hlsl
+++ b/crates/gpui/src/platform/windows/alpha_correction.hlsl
@@ -1,5 +1,5 @@
 float color_brightness(float3 color) {
-    // REC. 601 luminance coefficients for percieved brightness
+    // REC. 601 luminance coefficients for perceived brightness
     return dot(color, float3(0.30f, 0.59f, 0.11f));
 }
 


### PR DESCRIPTION
This PR fixes a typo in the Windows alpha correction shader that is now caught by https://github.com/zed-industries/zed/pull/37314.

Another case that could be addressed by Bors.

Release Notes:

- N/A
