### PR TITLE
settings_ui: Add dynamic settings UI item

### DIFF
--- a/crates/settings/src/settings_ui.rs
+++ b/crates/settings/src/settings_ui.rs
@@ -29,6 +29,12 @@ pub enum SettingsUiEntryVariant {
         path: &'static str,
         item: SettingsUiItemSingle,
     },
+    Dynamic {
+        path: &'static str,
+        title: &'static str,
+        options: Vec<SettingsUiEntry>,
+        determine_option: fn(&serde_json::Value, &mut App) -> usize,
+    },
     // todo(settings_ui): remove
     None,
 }
@@ -90,6 +96,11 @@ pub enum SettingsUiItem {
         items: Vec<SettingsUiEntry>,
     },
     Single(SettingsUiItemSingle),
+    Dynamic {
+        title: &'static str,
+        options: Vec<SettingsUiEntry>,
+        determine_option: fn(&serde_json::Value, &mut App) -> usize,
+    },
     None,
 }
 

--- a/crates/settings/src/settings_ui.rs
+++ b/crates/settings/src/settings_ui.rs
@@ -31,7 +31,6 @@ pub enum SettingsUiEntryVariant {
     },
     Dynamic {
         path: &'static str,
-        title: &'static str,
         options: Vec<SettingsUiEntry>,
         determine_option: fn(&serde_json::Value, &mut App) -> usize,
     },
@@ -97,7 +96,6 @@ pub enum SettingsUiItem {
     },
     Single(SettingsUiItemSingle),
     Dynamic {
-        title: &'static str,
         options: Vec<SettingsUiEntry>,
         determine_option: fn(&serde_json::Value, &mut App) -> usize,
     },

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -9,9 +9,7 @@ use command_palette_hooks::CommandPaletteFilter;
 use editor::EditorSettingsControls;
 use feature_flags::{FeatureFlag, FeatureFlagViewExt};
 use gpui::{App, Entity, EventEmitter, FocusHandle, Focusable, ReadGlobal, actions};
-use settings::{
-    SettingsStore, SettingsUiEntry, SettingsUiEntryVariant, SettingsUiItemSingle, SettingsValue,
-};
+use settings::{SettingsStore, SettingsUiEntryVariant, SettingsUiItemSingle, SettingsValue};
 use smallvec::SmallVec;
 use ui::{NumericStepper, SwitchField, ToggleButtonGroup, ToggleButtonSimple, prelude::*};
 use workspace::{
@@ -154,7 +152,7 @@ struct UiEntry {
 }
 
 impl UiEntry {
-    fn first_descendant_index(&self, tree: &[UiEntry]) -> Option<usize> {
+    fn first_descendant_index(&self) -> Option<usize> {
         return self
             .descendant_range
             .is_empty()
@@ -163,7 +161,7 @@ impl UiEntry {
     }
 
     fn nth_descendant_index(&self, tree: &[UiEntry], n: usize) -> Option<usize> {
-        let first_descendant_index = self.first_descendant_index(tree)?;
+        let first_descendant_index = self.first_descendant_index()?;
         let mut current_index = 0;
         let mut current_descendant_index = Some(first_descendant_index);
         while let Some(descendant_index) = current_descendant_index
@@ -229,12 +227,10 @@ fn build_tree_item(
         }
         SettingsUiEntryVariant::Dynamic {
             path,
-            title,
             options,
             determine_option,
         } => {
             tree[index].path = path;
-            tree[index].title = title;
             tree[index].select_descendant = Some(determine_option);
             for option in options {
                 let prev_index = tree[index]
@@ -323,7 +319,7 @@ fn render_content(
     let mut path = smallvec::smallvec![active_entry.path];
     let mut entry_index_queue = VecDeque::new();
 
-    if let Some(child_index) = active_entry.first_descendant_index(&tree.entries) {
+    if let Some(child_index) = active_entry.first_descendant_index() {
         entry_index_queue.push_back(child_index);
         let mut index = child_index;
         while let Some(next_sibling_index) = tree.entries[index].next_sibling {

--- a/crates/settings_ui_macros/src/settings_ui_macros.rs
+++ b/crates/settings_ui_macros/src/settings_ui_macros.rs
@@ -102,6 +102,12 @@ fn map_ui_item_to_render(path: &str, ty: TokenStream) -> TokenStream {
                     path: #path,
                     item,
                 },
+                settings::SettingsUiItem::Dynamic{title, options, determine_option} => settings::SettingsUiEntryVariant::Dynamic {
+                    path: #path,
+                    title,
+                    options,
+                    determine_option,
+                },
                 settings::SettingsUiItem::None => settings::SettingsUiEntryVariant::None,
             }
         }

--- a/crates/settings_ui_macros/src/settings_ui_macros.rs
+++ b/crates/settings_ui_macros/src/settings_ui_macros.rs
@@ -12,7 +12,6 @@ use syn::{Data, DeriveInput, LitStr, Token, parse_macro_input};
 ///
 /// ```
 /// use settings::SettingsUi;
-/// use settings_ui_macros::SettingsUi;
 ///
 /// #[derive(SettingsUi)]
 /// #[settings_ui(group = "Standard")]
@@ -102,9 +101,8 @@ fn map_ui_item_to_render(path: &str, ty: TokenStream) -> TokenStream {
                     path: #path,
                     item,
                 },
-                settings::SettingsUiItem::Dynamic{title, options, determine_option} => settings::SettingsUiEntryVariant::Dynamic {
+                settings::SettingsUiItem::Dynamic{ options, determine_option } => settings::SettingsUiEntryVariant::Dynamic {
                     path: #path,
-                    title,
                     options,
                     determine_option,
                 },


### PR DESCRIPTION
Closes #ISSUE

Adds a first draft of a way for "Dynamic" settings items to be added, where Dynamic means settings where multiple sets of options are possible (i.e. discriminated union, rust enum, etc). The implementation is very similar to that of `Group`, except that instead of rendering all of it's descendants, it contains a function to determine _which_ descendant to render, whether that be a single item or a nested group of items. Currently this is done in a type-unsafe way with indices, a future improvement could be to make the API more type safe, and easier to manually implement correctly.

An example of a "Dynamic" setting is `theme`, where it can either be a string of the desired theme name, or an object with `mode: "light" | "dark" | "system"` as well as theme names for `light` and `dark`. In the system implemented by this PR, this would become a dynamic settings UI item, where option `0` is a single item, the theme name selector, and option `1` is a group, containing items for the `mode`, and `light`/`dark` options.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
