### PR TITLE
Bump xcb dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20136,9 +20136,9 @@ dependencies = [
 
 [[package]]
 name = "xcb"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1e2f212bb1a92cd8caac8051b829a6582ede155ccb60b5d5908b81b100952be"
+checksum = "f07c123b796139bfe0603e654eaf08e132e52387ba95b252c78bad3640ba37ea"
 dependencies = [
  "bitflags 1.3.2",
  "libc",


### PR DESCRIPTION
Deals with https://github.com/zed-industries/zed/security/dependabot/65

Release Notes:

- N/A
