### PR TITLE
settings_ui: Improve case handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14921,6 +14921,7 @@ dependencies = [
 name = "settings_ui_macros"
 version = "0.1.0"
 dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -24,7 +24,6 @@ pub trait SettingsUi {
 }
 
 pub struct SettingsUiEntry {
-    // todo(settings_ui): move this back here once there isn't a None variant
     /// The path in the settings JSON file for this setting. Relative to parent
     /// None implies `#[serde(flatten)]` or `Settings::KEY.is_none()` for top level settings
     pub path: Option<&'static str>,

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -36,9 +36,19 @@ pub enum SettingsUiItemSingle {
     SwitchField,
     /// A numeric stepper for a specific type of number
     NumericStepper(NumType),
-    ToggleGroup(&'static [&'static str]),
+    ToggleGroup {
+        /// Must be the same length as `labels`
+        variants: &'static [&'static str],
+        /// Must be the same length as `variants`
+        labels: &'static [&'static str],
+    },
     /// This should be used when toggle group size > 6
-    DropDown(&'static [&'static str]),
+    DropDown {
+        /// Must be the same length as `labels`
+        variants: &'static [&'static str],
+        /// Must be the same length as `variants`
+        labels: &'static [&'static str],
+    },
     Custom(Box<dyn Fn(SettingsValue<serde_json::Value>, &mut Window, &mut App) -> AnyElement>),
 }
 

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -329,6 +329,7 @@ fn render_content(
         }
         let settings_value = settings_value_from_settings_and_path(
             path.clone(),
+            child.title,
             // PERF: how to structure this better? There feels like there's a way to avoid the clone
             // and every value lookup
             SettingsStore::global(cx).raw_user_settings(),
@@ -671,6 +672,7 @@ fn render_toggle_button_group(
 
 fn settings_value_from_settings_and_path(
     path: SmallVec<[&'static str; 1]>,
+    title: &'static str,
     user_settings: &serde_json::Value,
     default_settings: &serde_json::Value,
 ) -> SettingsValue<serde_json::Value> {
@@ -684,8 +686,8 @@ fn settings_value_from_settings_and_path(
         default_value,
         value,
         path: path.clone(),
-        // todo(settings_ui) title for items
-        title: path.last().expect("path non empty"),
+        // todo(settings_ui) is title required inside SettingsValue?
+        title,
     };
     return settings_value;
 }

--- a/crates/settings_ui_macros/Cargo.toml
+++ b/crates/settings_ui_macros/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 default = []
 
 [dependencies]
+heck.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true
 syn.workspace = true

--- a/crates/settings_ui_macros/src/settings_ui_macros.rs
+++ b/crates/settings_ui_macros/src/settings_ui_macros.rs
@@ -1,4 +1,4 @@
-use heck::ToTitleCase as _;
+use heck::{ToSnakeCase as _, ToTitleCase as _};
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{Data, DeriveInput, LitStr, Token, parse_macro_input};
@@ -182,20 +182,24 @@ fn generate_ui_item_body(
             let variants = data_enum.variants.iter().map(|variant| {
                 let string = variant.ident.clone().to_string();
 
-                if lowercase {
+                let title = string.to_title_case();
+                let string = if lowercase {
                     string.to_lowercase()
                 } else {
                     string
-                }
+                };
+                (string, title)
             });
+
+            let (variants, labels): (Vec<_>, Vec<_>) = variants.unzip();
 
             if length > 6 {
                 quote! {
-                    settings::SettingsUiItem::Single(settings::SettingsUiItemSingle::DropDown(&[#(#variants),*]))
+                    settings::SettingsUiItem::Single(settings::SettingsUiItemSingle::DropDown{ variants: &[#(#variants),*], labels: &[#(#labels),*] })
                 }
             } else {
                 quote! {
-                    settings::SettingsUiItem::Single(settings::SettingsUiItemSingle::ToggleGroup(&[#(#variants),*]))
+                    settings::SettingsUiItem::Single(settings::SettingsUiItemSingle::ToggleGroup{ variants: &[#(#variants),*], labels: &[#(#labels),*] })
                 }
             }
         }

--- a/crates/settings_ui_macros/src/settings_ui_macros.rs
+++ b/crates/settings_ui_macros/src/settings_ui_macros.rs
@@ -163,14 +163,15 @@ fn generate_ui_item_body(
         }
         (None, _, Data::Enum(data_enum)) => {
             let mut lowercase = false;
+            let mut snake_case = false;
             for attr in &input.attrs {
                 if attr.path().is_ident("serde") {
                     attr.parse_nested_meta(|meta| {
                         if meta.path.is_ident("rename_all") {
                             meta.input.parse::<Token![=]>()?;
                             let lit = meta.input.parse::<LitStr>()?.value();
-                            // todo(settings_ui) snake case
-                            lowercase = lit == "lowercase" || lit == "snake_case";
+                            lowercase = lit == "lowercase";
+                            snake_case = lit == "snake_case";
                         }
                         Ok(())
                     })
@@ -185,9 +186,12 @@ fn generate_ui_item_body(
                 let title = string.to_title_case();
                 let string = if lowercase {
                     string.to_lowercase()
+                } else if snake_case {
+                    string.to_snake_case()
                 } else {
                     string
                 };
+
                 (string, title)
             });
 

--- a/crates/settings_ui_macros/src/settings_ui_macros.rs
+++ b/crates/settings_ui_macros/src/settings_ui_macros.rs
@@ -60,8 +60,7 @@ pub fn derive_settings_ui(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 
     let ui_item_fn_body = generate_ui_item_body(group_name.as_ref(), path_name.as_ref(), &input);
 
-    // todo(settings_ui): Reformat title to be title case with spaces if group name not present,
-    // and make group name optional, repurpose group as tag indicating item is group
+    // todo(settings_ui): make group name optional, repurpose group as tag indicating item is group, and have "title" tag for custom title
     let title = group_name.unwrap_or(input.ident.to_string().to_title_case());
 
     let ui_entry_fn_body = map_ui_item_to_entry(path_name.as_deref(), &title, quote! { Self });

--- a/crates/settings_ui_macros/src/settings_ui_macros.rs
+++ b/crates/settings_ui_macros/src/settings_ui_macros.rs
@@ -1,3 +1,4 @@
+use heck::ToTitleCase as _;
 use proc_macro2::TokenStream;
 use quote::{ToTokens, quote};
 use syn::{Data, DeriveInput, LitStr, Token, parse_macro_input};
@@ -61,7 +62,7 @@ pub fn derive_settings_ui(input: proc_macro::TokenStream) -> proc_macro::TokenSt
 
     // todo(settings_ui): Reformat title to be title case with spaces if group name not present,
     // and make group name optional, repurpose group as tag indicating item is group
-    let title = group_name.unwrap_or(input.ident.to_string());
+    let title = group_name.unwrap_or(input.ident.to_string().to_title_case());
 
     let ui_entry_fn_body = map_ui_item_to_entry(path_name.as_deref(), &title, quote! { Self });
 
@@ -154,7 +155,7 @@ fn generate_ui_item_body(
                     )
                 })
                 // todo(settings_ui): Re-format field name as nice title, and support setting different title with attr
-                .map(|(name, ty)| map_ui_item_to_entry(Some(&name), &name, ty));
+                .map(|(name, ty)| map_ui_item_to_entry(Some(&name), &name.to_title_case(), ty));
 
             quote! {
                 settings::SettingsUiItem::Group(settings::SettingsUiItemGroup{ items: vec![#(#fields),*] })


### PR DESCRIPTION
Closes #ISSUE

Improves the derive macro for `SettingsUi` so that titles generated from struct and field names are shown in title case, and toggle button groups use title case for rendering, while using lower case/snake case in JSON 

Release Notes:

- N/A *or* Added/Fixed/Improved ...
