### PR TITLE
gpui: Add `box-sizing` API to style

### DIFF
--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -251,6 +251,9 @@ pub struct Style {
     /// Box shadow of the element
     pub box_shadow: Vec<BoxShadow>,
 
+    /// Box Sizing of the element
+    pub box_sizing: BoxSizing,
+
     /// The text style of this element
     pub text: TextStyleRefinement,
 
@@ -314,6 +317,18 @@ pub struct BoxShadow {
     pub blur_radius: Pixels,
     /// How much should the shadow spread?
     pub spread_radius: Pixels,
+}
+
+/// The box-sizing property, similar to the CSS property `box-sizing`, defaults to `ContentBox`
+///
+/// https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
+#[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub enum BoxSizing {
+    /// Excluding borders and paddings.
+    #[default]
+    ContentBox,
+    /// Including borders and paddings.
+    BorderBox,
 }
 
 /// How to handle whitespace in text
@@ -737,6 +752,7 @@ impl Style {
 impl Default for Style {
     fn default() -> Self {
         Style {
+            box_sizing: BoxSizing::default(),
             display: Display::Block,
             visibility: Visibility::Visible,
             overflow: Point {
@@ -1300,6 +1316,15 @@ impl From<Position> for taffy::style::Position {
         match value {
             Position::Relative => Self::Relative,
             Position::Absolute => Self::Absolute,
+        }
+    }
+}
+
+impl From<BoxSizing> for taffy::style::BoxSizing {
+    fn from(value: BoxSizing) -> Self {
+        match value {
+            BoxSizing::ContentBox => Self::ContentBox,
+            BoxSizing::BorderBox => Self::BorderBox,
         }
     }
 }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -319,16 +319,16 @@ pub struct BoxShadow {
     pub spread_radius: Pixels,
 }
 
-/// The box-sizing property, similar to the CSS property `box-sizing`, defaults to `ContentBox`
+/// The box-sizing property, similar to the CSS property `box-sizing`, defaults to `BorderBox`
 ///
 /// https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
 #[derive(Default, Copy, Clone, Debug, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub enum BoxSizing {
-    /// Excluding borders and paddings.
-    #[default]
-    ContentBox,
     /// Including borders and paddings.
+    #[default]
     BorderBox,
+    /// Excluding borders and paddings.
+    ContentBox,
 }
 
 /// How to handle whitespace in text

--- a/crates/gpui/src/styled.rs
+++ b/crates/gpui/src/styled.rs
@@ -1,5 +1,5 @@
 use crate::{
-    self as gpui, AbsoluteLength, AlignContent, AlignItems, BorderStyle, CursorStyle,
+    self as gpui, AbsoluteLength, AlignContent, AlignItems, BorderStyle, BoxSizing, CursorStyle,
     DefiniteLength, Display, Fill, FlexDirection, FlexWrap, Font, FontStyle, FontWeight,
     GridPlacement, Hsla, JustifyContent, Length, SharedString, StrikethroughStyle, StyleRefinement,
     TextAlign, TextOverflow, TextStyleRefinement, UnderlineStyle, WhiteSpace, px, relative, rems,
@@ -740,6 +740,32 @@ pub trait Styled: Sized {
     fn row_span_full(mut self) -> Self {
         let grid_location = self.style().grid_location_mut();
         grid_location.row = GridPlacement::Line(1)..GridPlacement::Line(-1);
+        self
+    }
+
+    /// Set the box-sizing of the element.
+    fn box_sizing(mut self, box_sizing: BoxSizing) -> Self {
+        self.style().box_sizing = Some(box_sizing);
+        self
+    }
+
+    /// Set use `content-box` for box-sizing of the element.
+    ///
+    /// Excluding borders and paddings.
+    ///
+    /// See also: https://tailwindcss.com/docs/box-sizing#excluding-borders-and-padding
+    fn box_content(mut self) -> Self {
+        self.style().box_sizing = Some(BoxSizing::ContentBox);
+        self
+    }
+
+    /// Set use `border-box` for box-sizing of the element.
+    ///
+    /// Including borders and paddings.
+    ///
+    /// See also: https://tailwindcss.com/docs/box-sizing#including-borders-and-padding
+    fn box_border(mut self) -> Self {
+        self.style().box_sizing = Some(BoxSizing::BorderBox);
         self
     }
 

--- a/crates/gpui/src/taffy.rs
+++ b/crates/gpui/src/taffy.rs
@@ -275,6 +275,7 @@ impl ToTaffy<taffy::style::Style> for Style {
         }
 
         taffy::style::Style {
+            box_sizing: self.box_sizing.into(),
             display: self.display.into(),
             overflow: self.overflow.into(),
             scrollbar_width: self.scrollbar_width,


### PR DESCRIPTION
Release Notes:

- N/A

~~Since Taffy 0.6.0, the default behavior for `box-sizing` has changed from `border-box` (previously) to `content-box` (now).~~

I was mistaken, it was always `border-box`.

cc @osiewicz

Ref links:

- https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing
- https://tailwindcss.com/docs/box-sizing
- https://github.com/DioxusLabs/taffy/pull/666
- https://github.com/DioxusLabs/taffy/releases/tag/v0.6.0

---

About AI: No use, some doc by AI tab complete.