### PR TITLE
Fix small errors preventing WSL support from working 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 # Prevent GitHub from displaying comments within JSON files as errors.
 *.json linguist-language=JSON-with-Comments
+
+# Ensure the WSL script always has LF line endings, even on Windows
+crates/zed/resources/windows/zed-wsl text eol=lf

--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -164,10 +164,7 @@ impl WslRemoteConnection {
         delegate.set_status(Some("Installing remote server"), cx);
 
         let wanted_version = match release_channel {
-            ReleaseChannel::Nightly => None,
-            ReleaseChannel::Dev => {
-                return Err(anyhow!("Dev builds require manual installation"));
-            }
+            ReleaseChannel::Nightly | ReleaseChannel::Dev => None,
             _ => Some(cx.update(|cx| AppVersion::global(cx))?),
         };
 
@@ -176,7 +173,7 @@ impl WslRemoteConnection {
             .await?;
 
         let tmp_path = RemotePathBuf::new(
-            PathBuf::from(format!("{}.{}.tmp", dst_path, std::process::id())),
+            PathBuf::from(format!("{}.{}.gz", dst_path, std::process::id())),
             PathStyle::Posix,
         );
 


### PR DESCRIPTION
On nightly, when I run `zed` under WSL, I get an error parsing the shebang line

```
/usr/bin/env: ‘sh\r’: No such file or directory
```

I believe that this is because in CI, Git checks out the file with CRLF line endings, and that is how it is copied into the installer.

Also, the file extension was incorrect when downloading the production remote server (a gzipped binary), preventing extraction from working properly.

Release Notes:

- N/A
