### PR TITLE
Remove extra brace in rules template

### DIFF
--- a/assets/prompts/assistant_system_prompt.hbs
+++ b/assets/prompts/assistant_system_prompt.hbs
@@ -172,7 +172,7 @@ The user has specified the following rules that should be applied:
 Rules title: {{title}}
 {{/if}}
 ``````
-{{contents}}}
+{{contents}}
 ``````
 {{/each}}
 {{/if}}


### PR DESCRIPTION
Release Notes:

- Fixed: remove extra brace in rules template
