### PR TITLE
Rename from `create_ssh_worktree` to `create_remote_worktree`

### DIFF
--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -228,7 +228,7 @@ impl WorktreeStore {
                         Task::ready(Err(Arc::new(anyhow!("cannot create worktrees via collab"))))
                     } else {
                         let abs_path = RemotePathBuf::new(abs_path.to_path_buf(), *path_style);
-                        self.create_ssh_worktree(upstream_client.clone(), abs_path, visible, cx)
+                        self.create_remote_worktree(upstream_client.clone(), abs_path, visible, cx)
                     }
                 }
                 WorktreeStoreState::Local { fs } => {
@@ -251,7 +251,7 @@ impl WorktreeStore {
         })
     }
 
-    fn create_ssh_worktree(
+    fn create_remote_worktree(
         &mut self,
         client: AnyProtoClient,
         abs_path: RemotePathBuf,


### PR DESCRIPTION
This is a left-over issue of #37035

Release Notes:

- N/A
