### PR TITLE
terminal_view: Fix focusing of center-pane terminals

### DIFF
--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -249,6 +249,7 @@ where
                 if tasks.is_empty() { None } else { Some(()) }
             })?
             .is_some();
+
         if !did_spawn {
             workspace
                 .update_in(cx, |workspace, window, cx| {

--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -249,7 +249,6 @@ where
                 if tasks.is_empty() { None } else { Some(()) }
             })?
             .is_some();
-
         if !did_spawn {
             workspace
                 .update_in(cx, |workspace, window, cx| {

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -41,7 +41,7 @@ use workspace::{
     ui::IconName,
 };
 
-use anyhow::{Context as _, Result, anyhow};
+use anyhow::{Result, anyhow};
 use zed_actions::assistant::InlineAssist;
 
 const TERMINAL_PANEL_KEY: &str = "TerminalPanel";

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -913,9 +913,7 @@ impl TerminalPanel {
                                 cx,
                             );
 
-                            if !did_activate {
-                                anyhow::bail!("Failed retrieve terminal pane")
-                            }
+                            anyhow::ensure!(did_activate, "Failed to retrieve terminal pane");
 
                             anyhow::Ok(())
                         })??;

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -905,11 +905,18 @@ impl TerminalPanel {
                 RevealStrategy::Always => match reveal_target {
                     RevealTarget::Center => {
                         task_workspace.update_in(cx, |workspace, window, cx| {
-                            workspace
-                                .active_item(cx)
-                                .context("retrieving active terminal item in the workspace")?
-                                .item_focus_handle(cx)
-                                .focus(window);
+                            let did_activate = workspace.activate_item(
+                                &terminal_to_replace,
+                                true,
+                                true,
+                                window,
+                                cx,
+                            );
+
+                            if !did_activate {
+                                anyhow::bail!("Failed retrieve terminal pane")
+                            }
+
                             anyhow::Ok(())
                         })??;
                     }


### PR DESCRIPTION
With `reveal_stragegy=always` + `reveal_target=center`, `TerminalPanel::spawn_task` activates & focuses the pane of the task. This works fine in the terminal pane but doesn't for `reveal_target=center`.

Please note: I'm not verified familiar with the architecture and internal APIs of zed. If there's a better way or if this fix is a bad idea, I'm fine with adapting this 😃 

Closes #35908

Release Notes:

- Fixed task focus when re-spawning a task with `reveal_target=center`
