### PR TITLE
dap_adapters: Define `buildFlags` for Go

### DIFF
--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -383,7 +383,8 @@ impl DebugAdapter for GoDebugAdapter {
                     "program": launch_config.program,
                     "cwd": launch_config.cwd,
                     "args": launch_config.args,
-                    "env": launch_config.env_json()
+                    "env": launch_config.env_json(),
+                    "buildFlags": ""
                 })
             }
         };


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed empty buildFlags error in Go