### PR TITLE
docs: Link glossary

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -157,5 +157,6 @@
   - [FreeBSD](./development/freebsd.md)
   - [Local Collaboration](./development/local-collaboration.md)
   - [Using Debuggers](./development/debuggers.md)
+  - [Glossary](./development/glossary.md)
 - [Release Process](./development/releases.md)
 - [Debugging Crashes](./development/debugging-crashes.md)

--- a/docs/src/development/glossary.md
+++ b/docs/src/development/glossary.md
@@ -1,9 +1,17 @@
-These are some terms and structures frequently used throughout the zed codebase. This is a best effort list.
+# Zed Development: Glossary
+
+These are some terms and structures frequently used throughout the zed codebase.
+
+This is a best effort list and a work in progress.
+
+<!--
+TBD: Glossary Improvement
 
 Questions:
 
 - Can we generate this list from doc comments throughout zed?
 - We should have a section that shows the various UI parts and their names. (Can't do that in the channel.)
+-->
 
 ## Naming conventions
 


### PR DESCRIPTION
Follow-up to: https://github.com/zed-industries/zed/pull/37360

Add glossary.md to SUMMARY.md so it's linked to the public documentation.

Release Notes:

- N/A
