### PR TITLE
terminal: Fix not able to select text during continuous output

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1141,13 +1141,6 @@ impl Terminal {
         }
     }
 
-    pub fn clear_matches(&mut self) {
-        if !self.matches.is_empty() {
-            self.matches.clear();
-            self.set_selection(None);
-        }
-    }
-
     pub fn select_matches(&mut self, matches: &[RangeInclusive<AlacPoint>]) {
         let matches_to_select = self
             .matches

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1142,8 +1142,10 @@ impl Terminal {
     }
 
     pub fn clear_matches(&mut self) {
-        self.matches.clear();
-        self.set_selection(None);
+        if !self.matches.is_empty() {
+            self.matches.clear();
+            self.set_selection(None);
+        }
     }
 
     pub fn select_matches(&mut self, matches: &[RangeInclusive<AlacPoint>]) {

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1523,7 +1523,7 @@ impl SearchableItem for TerminalView {
 
     /// Clear stored matches
     fn clear_matches(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
-        self.terminal().update(cx, |term, _| term.clear_matches())
+        self.terminal().update(cx, |term, _| term.matches.clear())
     }
 
     /// Store matches returned from find_matches somewhere for rendering


### PR DESCRIPTION
Closes #37211

Regressed in https://github.com/zed-industries/zed/pull/33305

Every time the terminal updates, we emit `SearchEvent::MatchesInvalidated` to trigger a re-run of the buffer search, which calls `clear_matches` to drop stale results. https://github.com/zed-industries/zed/pull/33305 PR also cleared the selection when clearing matches, which caused this issue. We could fix it by only clearing matches and selection when they’re non-empty, but it’s better to not clear the selection at all. This matches how the editor behaves and keeps it consistent. This PR reverts that part of code.


Release Notes:

- Fixed an issue where text selection was lost during continuous terminal output.