### PR TITLE
agent2: Use inline enums in `now` and `edit_file` tools JSON schema

### DIFF
--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -83,6 +83,7 @@ struct EditFileToolPartialInput {
 
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
+#[schemars(inline)]
 pub enum EditFileMode {
     Edit,
     Create,

--- a/crates/agent2/src/tools/now_tool.rs
+++ b/crates/agent2/src/tools/now_tool.rs
@@ -11,6 +11,7 @@ use crate::{AgentTool, ToolCallEventStream};
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
+#[schemars(inline)]
 pub enum Timezone {
     /// Use UTC for the datetime.
     Utc,


### PR DESCRIPTION
Added schemars annotations to generate inline enums instead of references ($ref) in the JSON schema passed to LLMs.

Concerns :
- "timezeone" parameter for "now" tool function
- "mode" parameter for "edit_file" tool function

Should be the same for futures tools/functions enums. This is easier for LLMs to understand the schema since many of them don't use JSON references correctly.

Tested with :
- local GPT-OSS-120b with llama.cpp server (openai compatible)
- remote Claude Sonnet 4.0 with Zed pro subscription

Thanks in advance for the merge.
(notice this is my first PR ever on Github, I hope I'm doing things well, please let me know if you have any comment - edit: just noticed my username/email were not correctly setup on my local git, sorry, it's been 5 years I've not used git)

Closes #37389

Release Notes:

- agent: Improve "now" and "edit_file" tool schemas to work with more models.
