### PR TITLE
editor: Do not show edit prediction during in-progress IME composition

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7744,6 +7744,11 @@ impl Editor {
             return None;
         }
 
+        if self.ime_transaction.is_some() {
+            self.discard_edit_prediction(false, cx);
+            return None;
+        }
+
         let selection = self.selections.newest_anchor();
         let cursor = selection.head();
         let multibuffer = self.buffer.read(cx).snapshot(cx);


### PR DESCRIPTION
Closes #37249

We no longer show edit prediction when composing IME since it isn't useful for unfinished alphabet.

Release Notes:

- Fixed edit predictions showing up during partial IME composition.

