### PR TITLE
gpui: Remove `http_client` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -299,9 +299,7 @@ git_hosting_providers = { path = "crates/git_hosting_providers" }
 git_ui = { path = "crates/git_ui" }
 go_to_line = { path = "crates/go_to_line" }
 google_ai = { path = "crates/google_ai" }
-gpui = { path = "crates/gpui", default-features = false, features = [
-    "http_client",
-] }
+gpui = { path = "crates/gpui", default-features = false }
 gpui_macros = { path = "crates/gpui_macros" }
 gpui_tokio = { path = "crates/gpui_tokio" }
 html_to_markdown = { path = "crates/html_to_markdown" }

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -12,13 +12,13 @@ license = "Apache-2.0"
 workspace = true
 
 [features]
-default = ["http_client", "font-kit", "wayland", "x11", "windows-manifest"]
+default = ["font-kit", "wayland", "x11", "windows-manifest"]
 test-support = [
     "leak-detection",
     "collections/test-support",
     "rand",
     "util/test-support",
-    "http_client?/test-support",
+    "http_client/test-support",
     "wayland",
     "x11",
 ]
@@ -91,7 +91,7 @@ derive_more.workspace = true
 etagere = "0.2"
 futures.workspace = true
 gpui_macros.workspace = true
-http_client = { optional = true, workspace = true }
+http_client.workspace = true
 image.workspace = true
 inventory.workspace = true
 itertools.workspace = true


### PR DESCRIPTION
This PR removes the `http_client` feature from the `gpui` crate, as it wasn't really doing anything.

It only controlled whether we depend on the `http_client` crate, but from what I can tell we always depended on it anyways.

Obviates https://github.com/zed-industries/zed/pull/36615.

Release Notes:

- N/A
