### PR TITLE
ci: Skip Nix for commits on release branches and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
             echo "run_license=false" >> "$GITHUB_OUTPUT"
 
           echo "$CHANGED_FILES" | grep -qP '^(nix/|flake\.|Cargo\.|rust-toolchain.toml|\.cargo/config.toml)' && \
+            echo "$GITHUB_REF_NAME" | grep -qvP '^v[0-9]+\.[0-9]+\.[0-9x](-pre)?$' && \
             echo "run_nix=true" >> "$GITHUB_OUTPUT" || \
             echo "run_nix=false" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
When doing stable/preview releases simultaneously there are two tags and two branches pushed.  Previously nix was attempting 1 job for each.  Our current mac parallelism is 4.
 
Can't easily test this. 🤷 

Release Notes:

- N/A
