### PR TITLE
Allow wrapping markdown text into `*` by selecting text and writing the `*`

### DIFF
--- a/crates/languages/src/markdown/config.toml
+++ b/crates/languages/src/markdown/config.toml
@@ -12,6 +12,7 @@ brackets = [
     { start = "\"", end = "\"", close = false, newline = false },
     { start = "'", end = "'", close = false, newline = false },
     { start = "`", end = "`", close = false, newline = false },
+    { start = "*", end = "*", close = false, newline = false, surround = true },
 ]
 rewrap_prefixes = [
     "[-*+]\\s+",


### PR DESCRIPTION
Release Notes:

- Allowed wrapping markdown text into `*` by selecting text and writing the `*`
