### PR TITLE
worktree: Create parent directories on rename

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1775,6 +1775,20 @@ impl LocalWorktree {
             };
             absolutize_path
         };
+
+        if !is_root_entry {
+            // If the parent directory doesn't exist, create it
+            if let Some(parent) = abs_new_path.parent() {
+                if !parent.exists() {
+                    if let Err(e) = std::fs::create_dir_all(parent).with_context(|| {
+                        format!("Creating parent directory {parent:?} for {abs_new_path:?}")
+                    }) {
+                        return Task::ready(Err(anyhow!("error creating parent directory {parent:?}: {e}")));
+                    }
+                }
+            }
+        }
+
         let abs_path = abs_new_path.clone();
         let fs = self.fs.clone();
         let case_sensitive = self.fs_case_sensitive;

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -1782,9 +1782,7 @@ impl LocalWorktree {
 
         let create_dirs = async |fs: &Arc<dyn Fs>, path: &Path| {
             if let Some(parent) = path.parent() {
-                if !fs.is_dir(parent).await {
-                    fs.create_dir(parent).await.with_context(|| format!("Creating parent directory {parent:?}"))?;
-                }
+                fs.create_dir(parent).await.with_context(|| format!("Creating parent directory {parent:?}"))?;
             }
             anyhow::Ok(())
         };


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/37357

Release Notes:

- Allow creating sub-directories when renaming a file in file finder
