### PR TITLE
rust: Improve highlighting in derive macros

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -196,12 +196,12 @@ operator: "/" @operator
   (identifier) @attribute
   (scoped_identifier name: (identifier) @attribute)
   (token_tree (identifier) @attribute (#match? @attribute "^[a-z\\d_]*$"))
-  (token_tree (identifier) @variable "::" (identifier) @type (#match? @type "^[A-Z]"))
+  (token_tree (identifier) @none "::" (#match? @none "^[a-z\\d_]*$"))
 ]))
 
 (inner_attribute_item (attribute [
   (identifier) @attribute
   (scoped_identifier name: (identifier) @attribute)
   (token_tree (identifier) @attribute (#match? @attribute "^[a-z\\d_]*$"))
-  (token_tree (identifier) @variable "::" (identifier) @type (#match? @type "^[A-Z]"))
+  (token_tree (identifier) @none "::" (#match? @none "^[a-z\\d_]*$"))
 ]))


### PR DESCRIPTION
Follow-up to https://github.com/zed-industries/zed/pull/37049

This fixes an issue where we would lose highlighting in derive macros if one of the names was qualified.

| Before | After |
| --- | --- |
| <img width="886" height="398" alt="Bildschirmfoto 2025-09-03 um 10 39 25" src="https://github.com/user-attachments/assets/dbc680e3-6ce3-4059-9934-9daa4c59d4a0" /> | <img width="886" height="398" alt="Bildschirmfoto 2025-09-03 um 10 38 14" src="https://github.com/user-attachments/assets/6e10df6f-5158-4bfd-81ab-8f2b384f1e99" />  |


Release Notes:

- N/A
