### PR TITLE
acp: Improve handling of invalid external agent server downloads

### DIFF
--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -101,9 +101,11 @@ impl AgentServerDelegate {
                         continue;
                     };
 
-                    if let Some(version) = file_name
-                        .to_str()
-                        .and_then(|name| semver::Version::from_str(&name).ok())
+                    if let Some(name) = file_name.to_str()
+                        && let Some(version) = semver::Version::from_str(name).ok()
+                        && fs
+                            .is_file(&dir.join(file_name).join(&entrypoint_path))
+                            .await
                     {
                         versions.push((version, file_name.to_owned()));
                     } else {
@@ -146,6 +148,7 @@ impl AgentServerDelegate {
                     cx.background_spawn({
                         let file_name = file_name.clone();
                         let dir = dir.clone();
+                        let fs = fs.clone();
                         async move {
                             let latest_version =
                                 node_runtime.npm_package_latest_version(&package_name).await;
@@ -171,7 +174,7 @@ impl AgentServerDelegate {
                     }
                     let dir = dir.clone();
                     cx.background_spawn(Self::download_latest_version(
-                        fs,
+                        fs.clone(),
                         dir.clone(),
                         node_runtime,
                         package_name,
@@ -179,14 +182,18 @@ impl AgentServerDelegate {
                     .await?
                     .into()
                 };
+
+                let agent_server_path = dir.join(version).join(entrypoint_path);
+                let agent_server_path_exists = fs.is_file(&agent_server_path).await;
+                anyhow::ensure!(
+                    agent_server_path_exists,
+                    "Missing entrypoint path {} after installation",
+                    agent_server_path.to_string_lossy()
+                );
+
                 anyhow::Ok(AgentServerCommand {
                     path: node_path,
-                    args: vec![
-                        dir.join(version)
-                            .join(entrypoint_path)
-                            .to_string_lossy()
-                            .to_string(),
-                    ],
+                    args: vec![agent_server_path.to_string_lossy().to_string()],
                     env: Default::default(),
                 })
             })

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -76,6 +76,7 @@ impl AgentServer for ClaudeCode {
         cx: &mut App,
     ) -> Task<Result<Rc<dyn AgentConnection>>> {
         let root_dir = root_dir.to_path_buf();
+        let fs = delegate.project().read(cx).fs().clone();
         let server_name = self.name();
         let settings = cx.read_global(|settings: &SettingsStore, _| {
             settings.get::<AllAgentServersSettings>(None).claude.clone()
@@ -108,6 +109,13 @@ impl AgentServer for ClaudeCode {
                     .get_or_insert_default()
                     .insert("ANTHROPIC_API_KEY".to_owned(), api_key.key);
             }
+
+            let root_dir_exists = fs.is_dir(&root_dir).await;
+            anyhow::ensure!(
+                root_dir_exists,
+                "Session root {} does not exist or is not a directory",
+                root_dir.to_string_lossy()
+            );
 
             crate::acp::connect(server_name, command.clone(), &root_dir, cx).await
         })


### PR DESCRIPTION
Related to #37213, #37150

When listing previously-downloaded versions of an external agent, don't try to use any downloads that are missing the agent entrypoint (indicating that they're corrupt/unusable), and delete those versions, so that we can attempt to download the latest version again.

Also report clearer errors when failing to start a session due to an agent server entrypoint or root directory not existing.

Release Notes:

- N/A