### PR TITLE
Centralize `ZED_STATELESS`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20573,6 +20573,9 @@ dependencies = [
 [[package]]
 name = "zed_env_vars"
 version = "0.1.0"
+dependencies = [
+ "workspace-hack",
+]
 
 [[package]]
 name = "zed_extension_api"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,6 +190,7 @@ dependencies = [
  "uuid",
  "workspace",
  "workspace-hack",
+ "zed_env_vars",
  "zstd",
 ]
 
@@ -278,6 +279,7 @@ dependencies = [
  "web_search",
  "workspace-hack",
  "worktree",
+ "zed_env_vars",
  "zlog",
  "zstd",
 ]
@@ -848,6 +850,7 @@ dependencies = [
  "uuid",
  "workspace",
  "workspace-hack",
+ "zed_env_vars",
 ]
 
 [[package]]
@@ -4489,6 +4492,7 @@ dependencies = [
  "tempfile",
  "util",
  "workspace-hack",
+ "zed_env_vars",
 ]
 
 [[package]]
@@ -20549,6 +20553,7 @@ dependencies = [
  "workspace",
  "workspace-hack",
  "zed_actions",
+ "zed_env_vars",
  "zeta",
  "zlog",
  "zlog_settings",
@@ -20564,6 +20569,10 @@ dependencies = [
  "uuid",
  "workspace-hack",
 ]
+
+[[package]]
+name = "zed_env_vars"
+version = "0.1.0"
 
 [[package]]
 name = "zed_extension_api"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,6 +193,7 @@ members = [
     "crates/x_ai",
     "crates/zed",
     "crates/zed_actions",
+    "crates/zed_env_vars",
     "crates/zeta",
     "crates/zeta_cli",
     "crates/zlog",
@@ -420,6 +421,7 @@ worktree = { path = "crates/worktree" }
 x_ai = { path = "crates/x_ai" }
 zed = { path = "crates/zed" }
 zed_actions = { path = "crates/zed_actions" }
+zed_env_vars = { path = "crates/zed_env_vars" }
 zeta = { path = "crates/zeta" }
 zlog = { path = "crates/zlog" }
 zlog_settings = { path = "crates/zlog_settings" }

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -63,6 +63,7 @@ time.workspace = true
 util.workspace = true
 uuid.workspace = true
 workspace-hack.workspace = true
+zed_env_vars.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]

--- a/crates/agent/src/thread_store.rs
+++ b/crates/agent/src/thread_store.rs
@@ -41,8 +41,7 @@ use std::{
 };
 use util::ResultExt as _;
 
-pub static ZED_STATELESS: std::sync::LazyLock<bool> =
-    std::sync::LazyLock::new(|| std::env::var("ZED_STATELESS").is_ok_and(|v| !v.is_empty()));
+use zed_env_vars::ZED_STATELESS;
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DataType {

--- a/crates/agent2/Cargo.toml
+++ b/crates/agent2/Cargo.toml
@@ -68,6 +68,7 @@ uuid.workspace = true
 watch.workspace = true
 web_search.workspace = true
 workspace-hack.workspace = true
+zed_env_vars.workspace = true
 zstd.workspace = true
 
 [dev-dependencies]

--- a/crates/agent2/src/db.rs
+++ b/crates/agent2/src/db.rs
@@ -18,6 +18,7 @@ use sqlez::{
 };
 use std::sync::Arc;
 use ui::{App, SharedString};
+use zed_env_vars::ZED_STATELESS;
 
 pub type DbMessage = crate::Message;
 pub type DbSummary = DetailedSummaryState;
@@ -200,9 +201,6 @@ impl DbThread {
         })
     }
 }
-
-pub static ZED_STATELESS: std::sync::LazyLock<bool> =
-    std::sync::LazyLock::new(|| std::env::var("ZED_STATELESS").is_ok_and(|v| !v.is_empty()));
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum DataType {

--- a/crates/assistant_context/Cargo.toml
+++ b/crates/assistant_context/Cargo.toml
@@ -50,8 +50,9 @@ text.workspace = true
 ui.workspace = true
 util.workspace = true
 uuid.workspace = true
-workspace-hack.workspace = true
 workspace.workspace = true
+workspace-hack.workspace = true
+zed_env_vars.workspace = true
 
 [dev-dependencies]
 indoc.workspace = true

--- a/crates/assistant_context/src/context_store.rs
+++ b/crates/assistant_context/src/context_store.rs
@@ -24,6 +24,7 @@ use rpc::AnyProtoClient;
 use std::sync::LazyLock;
 use std::{cmp::Reverse, ffi::OsStr, mem, path::Path, sync::Arc, time::Duration};
 use util::{ResultExt, TryFutureExt};
+use zed_env_vars::ZED_STATELESS;
 
 pub(crate) fn init(client: &AnyProtoClient) {
     client.add_entity_message_handler(ContextStore::handle_advertise_contexts);
@@ -788,8 +789,6 @@ impl ContextStore {
     fn reload(&mut self, cx: &mut Context<Self>) -> Task<Result<()>> {
         let fs = self.fs.clone();
         cx.spawn(async move |this, cx| {
-            pub static ZED_STATELESS: LazyLock<bool> =
-                LazyLock::new(|| std::env::var("ZED_STATELESS").is_ok_and(|v| !v.is_empty()));
             if *ZED_STATELESS {
                 return Ok(());
             }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -27,6 +27,7 @@ sqlez.workspace = true
 sqlez_macros.workspace = true
 util.workspace = true
 workspace-hack.workspace = true
+zed_env_vars.workspace = true
 
 [dev-dependencies]
 gpui = { workspace = true, features = ["test-support"] }

--- a/crates/db/src/db.rs
+++ b/crates/db/src/db.rs
@@ -17,9 +17,10 @@ use sqlez::thread_safe_connection::ThreadSafeConnection;
 use sqlez_macros::sql;
 use std::future::Future;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 use std::sync::{LazyLock, atomic::Ordering};
-use std::{env, sync::atomic::AtomicBool};
 use util::{ResultExt, maybe};
+use zed_env_vars::ZED_STATELESS;
 
 const CONNECTION_INITIALIZE_QUERY: &str = sql!(
     PRAGMA foreign_keys=TRUE;
@@ -35,9 +36,6 @@ const DB_INITIALIZE_QUERY: &str = sql!(
 const FALLBACK_DB_NAME: &str = "FALLBACK_MEMORY_DB";
 
 const DB_FILE_NAME: &str = "db.sqlite";
-
-pub static ZED_STATELESS: LazyLock<bool> =
-    LazyLock::new(|| env::var("ZED_STATELESS").is_ok_and(|v| !v.is_empty()));
 
 pub static ALL_FILE_DB_FAILED: LazyLock<AtomicBool> = LazyLock::new(|| AtomicBool::new(false));
 

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -165,6 +165,7 @@ web_search_providers.workspace = true
 workspace-hack.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
+zed_env_vars.workspace = true
 zeta.workspace = true
 zlog.workspace = true
 zlog_settings.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -288,7 +288,7 @@ pub fn main() {
 
     let (open_listener, mut open_rx) = OpenListener::new();
 
-    let failed_single_instance_check = if *db::ZED_STATELESS
+    let failed_single_instance_check = if *zed_env_vars::ZED_STATELESS
         || *release_channel::RELEASE_CHANNEL == ReleaseChannel::Dev
     {
         false

--- a/crates/zed_env_vars/Cargo.toml
+++ b/crates/zed_env_vars/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "zed_env_vars"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/zed_env_vars.rs"
+
+[features]
+default = []

--- a/crates/zed_env_vars/Cargo.toml
+++ b/crates/zed_env_vars/Cargo.toml
@@ -13,3 +13,6 @@ path = "src/zed_env_vars.rs"
 
 [features]
 default = []
+
+[dependencies]
+workspace-hack.workspace = true

--- a/crates/zed_env_vars/LICENSE-GPL
+++ b/crates/zed_env_vars/LICENSE-GPL
@@ -1,0 +1,1 @@
+../../LICENSE-GPL

--- a/crates/zed_env_vars/src/zed_env_vars.rs
+++ b/crates/zed_env_vars/src/zed_env_vars.rs
@@ -1,0 +1,6 @@
+use std::sync::LazyLock;
+
+/// Whether Zed is running in stateless mode.
+/// When true, Zed will use in-memory databases instead of persistent storage.
+pub static ZED_STATELESS: LazyLock<bool> =
+    LazyLock::new(|| std::env::var("ZED_STATELESS").is_ok_and(|v| !v.is_empty()));

--- a/script/new-crate
+++ b/script/new-crate
@@ -63,6 +63,7 @@ anyhow.workspace = true
 gpui.workspace = true
 ui.workspace = true
 util.workspace = true
+workspace-hack.workspace = true
 
 # Uncomment other workspace dependencies as needed
 # assistant.workspace = true


### PR DESCRIPTION
Closes #ISSUE

Centralizes the references to the `ZED_STATELESS` env var into a single location in a new crate named `zed_env_vars`

Release Notes:

- N/A *or* Added/Fixed/Improved ...
