### PR TITLE
Remove some unused events

### DIFF
--- a/crates/activity_indicator/src/activity_indicator.rs
+++ b/crates/activity_indicator/src/activity_indicator.rs
@@ -84,7 +84,6 @@ impl ActivityIndicator {
     ) -> Entity<ActivityIndicator> {
         let project = workspace.project().clone();
         let auto_updater = AutoUpdater::get(cx);
-        let workspace_handle = cx.entity();
         let this = cx.new(|cx| {
             let mut status_events = languages.language_server_binary_statuses();
             cx.spawn(async move |this, cx| {
@@ -100,20 +99,6 @@ impl ActivityIndicator {
                 }
                 anyhow::Ok(())
             })
-            .detach();
-
-            cx.subscribe_in(
-                &workspace_handle,
-                window,
-                |activity_indicator, _, event, window, cx| {
-                    if let workspace::Event::ClearActivityIndicator = event
-                        && activity_indicator.statuses.pop().is_some()
-                    {
-                        activity_indicator.dismiss_error_message(&DismissErrorMessage, window, cx);
-                        cx.notify();
-                    }
-                },
-            )
             .detach();
 
             cx.subscribe(

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -13,11 +13,8 @@ use anyhow::{Context as _, Result, anyhow};
 use collections::IndexMap;
 use dap::adapters::DebugAdapterName;
 use dap::debugger_settings::DebugPanelDockPosition;
-use dap::{
-    ContinuedEvent, LoadedSourceEvent, ModuleEvent, OutputEvent, StoppedEvent, ThreadEvent,
-    client::SessionId, debugger_settings::DebuggerSettings,
-};
 use dap::{DapRegistry, StartDebuggingRequestArguments};
+use dap::{client::SessionId, debugger_settings::DebuggerSettings};
 use editor::Editor;
 use gpui::{
     Action, App, AsyncWindowContext, ClipboardItem, Context, DismissEvent, Entity, EntityId,
@@ -45,23 +42,6 @@ use workspace::{
     dock::{DockPosition, Panel, PanelEvent},
 };
 use zed_actions::ToggleFocus;
-
-pub enum DebugPanelEvent {
-    Exited(SessionId),
-    Terminated(SessionId),
-    Stopped {
-        client_id: SessionId,
-        event: StoppedEvent,
-        go_to_stack_frame: bool,
-    },
-    Thread((SessionId, ThreadEvent)),
-    Continued((SessionId, ContinuedEvent)),
-    Output((SessionId, OutputEvent)),
-    Module((SessionId, ModuleEvent)),
-    LoadedSource((SessionId, LoadedSourceEvent)),
-    ClientShutdown(SessionId),
-    CapabilitiesChanged(SessionId),
-}
 
 pub struct DebugPanel {
     size: Pixels,
@@ -1407,7 +1387,6 @@ async fn register_session_inner(
 }
 
 impl EventEmitter<PanelEvent> for DebugPanel {}
-impl EventEmitter<DebugPanelEvent> for DebugPanel {}
 
 impl Focusable for DebugPanel {
     fn focus_handle(&self, _: &App) -> FocusHandle {

--- a/crates/debugger_ui/src/session.rs
+++ b/crates/debugger_ui/src/session.rs
@@ -2,9 +2,7 @@ pub mod running;
 
 use crate::{StackTraceView, persistence::SerializedLayout, session::running::DebugTerminal};
 use dap::client::SessionId;
-use gpui::{
-    App, Axis, Entity, EventEmitter, FocusHandle, Focusable, Subscription, Task, WeakEntity,
-};
+use gpui::{App, Axis, Entity, EventEmitter, FocusHandle, Focusable, Task, WeakEntity};
 use project::debugger::session::Session;
 use project::worktree_store::WorktreeStore;
 use project::{Project, debugger::session::SessionQuirks};
@@ -24,13 +22,6 @@ pub struct DebugSession {
     stack_trace_view: OnceCell<Entity<StackTraceView>>,
     _worktree_store: WeakEntity<WorktreeStore>,
     workspace: WeakEntity<Workspace>,
-    _subscriptions: [Subscription; 1],
-}
-
-#[derive(Debug)]
-pub enum DebugPanelItemEvent {
-    Close,
-    Stopped { go_to_stack_frame: bool },
 }
 
 impl DebugSession {
@@ -59,9 +50,6 @@ impl DebugSession {
         let quirks = session.read(cx).quirks();
 
         cx.new(|cx| Self {
-            _subscriptions: [cx.subscribe(&running_state, |_, _, _, cx| {
-                cx.notify();
-            })],
             remote_id: None,
             running_state,
             quirks,
@@ -133,7 +121,7 @@ impl DebugSession {
     }
 }
 
-impl EventEmitter<DebugPanelItemEvent> for DebugSession {}
+impl EventEmitter<()> for DebugSession {}
 
 impl Focusable for DebugSession {
     fn focus_handle(&self, cx: &App) -> FocusHandle {
@@ -142,7 +130,7 @@ impl Focusable for DebugSession {
 }
 
 impl Item for DebugSession {
-    type Event = DebugPanelItemEvent;
+    type Event = ();
     fn tab_content_text(&self, _detail: usize, _cx: &App) -> SharedString {
         "Debugger".into()
     }

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -14,7 +14,6 @@ use crate::{
     session::running::memory_view::MemoryView,
 };
 
-use super::DebugPanelItemEvent;
 use anyhow::{Context as _, Result, anyhow};
 use breakpoint_list::BreakpointList;
 use collections::{HashMap, IndexMap};
@@ -1825,8 +1824,6 @@ impl RunningState {
         self.panes.invert_axies();
     }
 }
-
-impl EventEmitter<DebugPanelItemEvent> for RunningState {}
 
 impl Focusable for RunningState {
     fn focus_handle(&self, _: &App) -> FocusHandle {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20310,7 +20310,6 @@ impl Editor {
             multi_buffer::Event::FileHandleChanged
             | multi_buffer::Event::Reloaded
             | multi_buffer::Event::BufferDiffChanged => cx.emit(EditorEvent::TitleChanged),
-            multi_buffer::Event::Closed => cx.emit(EditorEvent::Closed),
             multi_buffer::Event::DiagnosticsUpdated => {
                 self.update_diagnostics_state(window, cx);
             }
@@ -23008,7 +23007,6 @@ pub enum EditorEvent {
     DirtyChanged,
     Saved,
     TitleChanged,
-    DiffBaseChanged,
     SelectionsChanged {
         local: bool,
     },
@@ -23016,14 +23014,12 @@ pub enum EditorEvent {
         local: bool,
         autoscroll: bool,
     },
-    Closed,
     TransactionUndone {
         transaction_id: clock::Lamport,
     },
     TransactionBegun {
         transaction_id: clock::Lamport,
     },
-    Reloaded,
     CursorShapeChanged,
     BreadcrumbsChanged,
     PushedToNavHistory {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -775,12 +775,6 @@ impl Item for Editor {
         self.nav_history = Some(history);
     }
 
-    fn discarded(&self, _project: Entity<Project>, _: &mut Window, cx: &mut Context<Self>) {
-        for buffer in self.buffer().clone().read(cx).all_buffers() {
-            buffer.update(cx, |buffer, cx| buffer.discarded(cx))
-        }
-    }
-
     fn on_removed(&self, cx: &App) {
         self.report_editor_event(ReportEditorEvent::Closed, None, cx);
     }
@@ -1022,8 +1016,6 @@ impl Item for Editor {
 
     fn to_item_events(event: &EditorEvent, mut f: impl FnMut(ItemEvent)) {
         match event {
-            EditorEvent::Closed => f(ItemEvent::CloseItem),
-
             EditorEvent::Saved | EditorEvent::TitleChanged => {
                 f(ItemEvent::UpdateTab);
                 f(ItemEvent::UpdateBreadcrumbs);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -315,10 +315,6 @@ pub enum BufferEvent {
     DiagnosticsUpdated,
     /// The buffer gained or lost editing capabilities.
     CapabilityChanged,
-    /// The buffer was explicitly requested to close.
-    Closed,
-    /// The buffer was discarded when closing.
-    Discarded,
 }
 
 /// The file associated with a buffer.
@@ -1246,8 +1242,10 @@ impl Buffer {
 
     /// Assign the buffer a new [`Capability`].
     pub fn set_capability(&mut self, capability: Capability, cx: &mut Context<Self>) {
-        self.capability = capability;
-        cx.emit(BufferEvent::CapabilityChanged)
+        if self.capability != capability {
+            self.capability = capability;
+            cx.emit(BufferEvent::CapabilityChanged)
+        }
     }
 
     /// This method is called to signal that the buffer has been saved.
@@ -1264,12 +1262,6 @@ impl Buffer {
         self.saved_mtime = mtime;
         self.was_changed();
         cx.emit(BufferEvent::Saved);
-        cx.notify();
-    }
-
-    /// This method is called to signal that the buffer has been discarded.
-    pub fn discarded(&self, cx: &mut Context<Self>) {
-        cx.emit(BufferEvent::Discarded);
         cx.notify();
     }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -113,15 +113,10 @@ pub enum Event {
         transaction_id: TransactionId,
     },
     Reloaded,
-    ReloadNeeded,
-
     LanguageChanged(BufferId),
-    CapabilityChanged,
     Reparsed(BufferId),
     Saved,
     FileHandleChanged,
-    Closed,
-    Discarded,
     DirtyChanged,
     DiagnosticsUpdated,
     BufferDiffChanged,
@@ -2433,28 +2428,24 @@ impl MultiBuffer {
         event: &language::BufferEvent,
         cx: &mut Context<Self>,
     ) {
+        use language::BufferEvent;
         cx.emit(match event {
-            language::BufferEvent::Edited => Event::Edited {
+            BufferEvent::Edited => Event::Edited {
                 singleton_buffer_edited: true,
                 edited_buffer: Some(buffer),
             },
-            language::BufferEvent::DirtyChanged => Event::DirtyChanged,
-            language::BufferEvent::Saved => Event::Saved,
-            language::BufferEvent::FileHandleChanged => Event::FileHandleChanged,
-            language::BufferEvent::Reloaded => Event::Reloaded,
-            language::BufferEvent::ReloadNeeded => Event::ReloadNeeded,
-            language::BufferEvent::LanguageChanged => {
-                Event::LanguageChanged(buffer.read(cx).remote_id())
-            }
-            language::BufferEvent::Reparsed => Event::Reparsed(buffer.read(cx).remote_id()),
-            language::BufferEvent::DiagnosticsUpdated => Event::DiagnosticsUpdated,
-            language::BufferEvent::Closed => Event::Closed,
-            language::BufferEvent::Discarded => Event::Discarded,
-            language::BufferEvent::CapabilityChanged => {
+            BufferEvent::DirtyChanged => Event::DirtyChanged,
+            BufferEvent::Saved => Event::Saved,
+            BufferEvent::FileHandleChanged => Event::FileHandleChanged,
+            BufferEvent::Reloaded => Event::Reloaded,
+            BufferEvent::LanguageChanged => Event::LanguageChanged(buffer.read(cx).remote_id()),
+            BufferEvent::Reparsed => Event::Reparsed(buffer.read(cx).remote_id()),
+            BufferEvent::DiagnosticsUpdated => Event::DiagnosticsUpdated,
+            BufferEvent::CapabilityChanged => {
                 self.capability = buffer.read(cx).capability();
-                Event::CapabilityChanged
+                return;
             }
-            language::BufferEvent::Operation { .. } => return,
+            BufferEvent::Operation { .. } | BufferEvent::ReloadNeeded => return,
         });
     }
 

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -541,7 +541,6 @@ pub trait ItemHandle: 'static + Send {
         cx: &mut Context<Workspace>,
     );
     fn deactivated(&self, window: &mut Window, cx: &mut App);
-    fn discarded(&self, project: Entity<Project>, window: &mut Window, cx: &mut App);
     fn on_removed(&self, cx: &App);
     fn workspace_deactivated(&self, window: &mut Window, cx: &mut App);
     fn navigate(&self, data: Box<dyn Any>, window: &mut Window, cx: &mut App) -> bool;
@@ -973,10 +972,6 @@ impl<T: Item> ItemHandle for Entity<T> {
         cx.defer_in(window, |workspace, window, cx| {
             workspace.serialize_workspace(window, cx);
         });
-    }
-
-    fn discarded(&self, project: Entity<Project>, window: &mut Window, cx: &mut App) {
-        self.update(cx, |this, cx| this.discarded(project, window, cx));
     }
 
     fn deactivated(&self, window: &mut Window, cx: &mut App) {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -254,9 +254,6 @@ pub enum Event {
     Remove {
         focus_on_pane: Option<Entity<Pane>>,
     },
-    RemoveItem {
-        idx: usize,
-    },
     RemovedItem {
         item: Box<dyn ItemHandle>,
     },
@@ -287,7 +284,6 @@ impl fmt::Debug for Event {
                 .field("local", local)
                 .finish(),
             Event::Remove { .. } => f.write_str("Remove"),
-            Event::RemoveItem { idx } => f.debug_struct("RemoveItem").field("idx", idx).finish(),
             Event::RemovedItem { item } => f
                 .debug_struct("RemovedItem")
                 .field("item", &item.item_id())
@@ -2096,11 +2092,10 @@ impl Pane {
                             Ok(0) => {}
                             Ok(1) => {
                                 // Don't save this file
-                                pane.update_in(cx, |pane, window, cx| {
+                                pane.update_in(cx, |pane, _, cx| {
                                     if pane.is_tab_pinned(item_ix) && !item.can_save(cx) {
                                         pane.pinned_tab_count -= 1;
                                     }
-                                    item.discarded(project, window, cx)
                                 })
                                 .log_err();
                                 return Ok(true);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1030,7 +1030,6 @@ pub enum Event {
     ItemAdded {
         item: Box<dyn ItemHandle>,
     },
-    ItemRemoved,
     ActiveItemChanged,
     UserSavedItem {
         pane: WeakEntity<Pane>,
@@ -3939,7 +3938,6 @@ impl Workspace {
                 }
                 serialize_workspace = false;
             }
-            pane::Event::RemoveItem { .. } => {}
             pane::Event::RemovedItem { item } => {
                 cx.emit(Event::ActiveItemChanged);
                 self.update_window_edited(window, cx);

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -1045,7 +1045,6 @@ pub enum Event {
     },
     ZoomChanged,
     ModalOpened,
-    ClearActivityIndicator,
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This PR cleans up some emitted events around the codebase. These events are either never emitted or never listened for. 

It seems better to re-implement these at some point should they again be needed - this ensures that they will actually be fired in the cases where they are needed as opposed to being there and getting unreliable and stale (which is already the case for the majority of the events removed here).

Lastly, this ensures the `CapabilitiesChanged` event is not fired too often.

Release Notes:

- N/A
