### PR TITLE
acp: Receive available commands over notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,9 +195,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "603941db1d130ee275840c465b73a2312727d4acef97449550ccf033de71301f"
+checksum = "6d02292efd75080932b6466471d428c70e2ac06908ae24792fc7c36ecbaf67ca"
 dependencies = [
  "anyhow",
  "async-broadcast",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -428,7 +428,7 @@ zlog_settings = { path = "crates/zlog_settings" }
 # External crates
 #
 
-agent-client-protocol = { version = "0.2.0-alpha.4", features = ["unstable"]}
+agent-client-protocol = { version = "0.2.0-alpha.6", features = ["unstable"]}
 aho-corasick = "1.1"
 alacritty_terminal = { git = "https://github.com/zed-industries/alacritty.git", branch = "add-hush-login-flag" }
 any_vec = "0.14"

--- a/crates/acp_thread/src/connection.rs
+++ b/crates/acp_thread/src/connection.rs
@@ -338,7 +338,6 @@ mod test_support {
                         audio: true,
                         embedded_context: true,
                     }),
-                    vec![],
                     cx,
                 )
             });

--- a/crates/agent2/src/agent.rs
+++ b/crates/agent2/src/agent.rs
@@ -292,7 +292,6 @@ impl NativeAgent {
                 action_log.clone(),
                 session_id.clone(),
                 prompt_capabilities_rx,
-                vec![],
                 cx,
             )
         });

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -224,7 +224,6 @@ impl AgentConnection for AcpConnection {
                     session_id.clone(),
                     // ACP doesn't currently support per-session prompt capabilities or changing capabilities dynamically.
                     watch::Receiver::constant(self.agent_capabilities.prompt_capabilities),
-                    response.available_commands,
                     cx,
                 )
             })?;

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -40,7 +40,7 @@ impl ClaudeCode {
                         Self::PACKAGE_NAME.into(),
                         "node_modules/@anthropic-ai/claude-code/cli.js".into(),
                         true,
-                        None,
+                        Some("0.2.5".parse().unwrap()),
                         cx,
                     )
                 })?

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -430,6 +430,7 @@ impl AcpThreadView {
             window,
             cx,
         );
+        self.available_commands.replace(vec![]);
         self.new_server_version_available.take();
         cx.notify();
     }
@@ -534,26 +535,6 @@ impl AcpThreadView {
                 match result {
                     Ok(thread) => {
                         let action_log = thread.read(cx).action_log().clone();
-
-                        let mut available_commands = thread.read(cx).available_commands();
-
-                        if connection
-                            .auth_methods()
-                            .iter()
-                            .any(|method| method.id.0.as_ref() == "claude-login")
-                        {
-                            available_commands.push(acp::AvailableCommand {
-                                name: "login".to_owned(),
-                                description: "Authenticate".to_owned(),
-                                input: None,
-                            });
-                            available_commands.push(acp::AvailableCommand {
-                                name: "logout".to_owned(),
-                                description: "Authenticate".to_owned(),
-                                input: None,
-                            });
-                        }
-                        this.available_commands.replace(available_commands);
 
                         this.prompt_capabilities
                             .set(thread.read(cx).prompt_capabilities());
@@ -1343,6 +1324,30 @@ impl AcpThreadView {
                     .set(thread.read(cx).prompt_capabilities());
             }
             AcpThreadEvent::TokenUsageUpdated => {}
+            AcpThreadEvent::AvailableCommandsUpdated(available_commands) => {
+                let mut available_commands = available_commands.clone();
+
+                if thread
+                    .read(cx)
+                    .connection()
+                    .auth_methods()
+                    .iter()
+                    .any(|method| method.id.0.as_ref() == "claude-login")
+                {
+                    available_commands.push(acp::AvailableCommand {
+                        name: "login".to_owned(),
+                        description: "Authenticate".to_owned(),
+                        input: None,
+                    });
+                    available_commands.push(acp::AvailableCommand {
+                        name: "logout".to_owned(),
+                        description: "Authenticate".to_owned(),
+                        input: None,
+                    });
+                }
+
+                self.available_commands.replace(available_commands);
+            }
         }
         cx.notify();
     }
@@ -5745,7 +5750,6 @@ pub(crate) mod tests {
                         audio: true,
                         embedded_context: true,
                     }),
-                    vec![],
                     cx,
                 )
             })))
@@ -5805,7 +5809,6 @@ pub(crate) mod tests {
                         audio: true,
                         embedded_context: true,
                     }),
-                    Vec::new(),
                     cx,
                 )
             })))

--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -1528,6 +1528,7 @@ impl AgentDiff {
             | AcpThreadEvent::EntriesRemoved(_)
             | AcpThreadEvent::ToolAuthorizationRequired
             | AcpThreadEvent::PromptCapabilitiesUpdated
+            | AcpThreadEvent::AvailableCommandsUpdated(_)
             | AcpThreadEvent::Retry(_) => {}
         }
     }


### PR DESCRIPTION
See: https://github.com/zed-industries/agent-client-protocol/pull/62

Release Notes:

- Agent Panel: Fixes an issue where Claude Code would timeout waiting for slash commands to be loaded
