### PR TITLE
Check if virtual environment is in worktree root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9271,6 +9271,7 @@ dependencies = [
  "pet-fs",
  "pet-poetry",
  "pet-reporter",
+ "pet-virtualenv",
  "pretty_assertions",
  "project",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -580,6 +580,7 @@ pet-fs = { git = "https://github.com/microsoft/python-environment-tools.git", re
 pet-pixi = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "845945b830297a50de0e24020b980a65e4820559" }
 pet-poetry = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "845945b830297a50de0e24020b980a65e4820559" }
 pet-reporter = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "845945b830297a50de0e24020b980a65e4820559" }
+pet-virtualenv = { git = "https://github.com/microsoft/python-environment-tools.git", rev = "845945b830297a50de0e24020b980a65e4820559" }
 portable-pty = "0.9.0"
 postage = { version = "0.5", features = ["futures-traits"] }
 pretty_assertions = { version = "1.3.0", features = ["unstable"] }

--- a/crates/languages/Cargo.toml
+++ b/crates/languages/Cargo.toml
@@ -56,6 +56,7 @@ pet-core.workspace = true
 pet-fs.workspace = true
 pet-poetry.workspace = true
 pet-reporter.workspace = true
+pet-virtualenv.workspace = true
 pet.workspace = true
 project.workspace = true
 regex.workspace = true

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -763,7 +763,7 @@ fn get_venv_parent_dir(env: &PythonEnvironment) -> Option<PathBuf> {
         .as_ref()
         .and_then(|p| p.parent())
         .and_then(|p| p.parent())
-        .filter(|p| is_virtualenv_dir(*p))?;
+        .filter(|p| is_virtualenv_dir(p))?;
 
     venv.parent().map(|parent| parent.to_path_buf())
 }
@@ -828,16 +828,8 @@ impl ToolchainLister for PythonToolchainProvider {
 
             // Compare project paths against worktree root
             let proj_ordering = || {
-                let lhs_project = lhs
-                    .project
-                    .clone()
-                    .or_else(|| get_venv_parent_dir(lhs))
-                    .map(|p| p.to_path_buf());
-                let rhs_project = rhs
-                    .project
-                    .clone()
-                    .or_else(|| get_venv_parent_dir(rhs))
-                    .map(|p| p.to_path_buf());
+                let lhs_project = lhs.project.clone().or_else(|| get_venv_parent_dir(lhs));
+                let rhs_project = rhs.project.clone().or_else(|| get_venv_parent_dir(rhs));
                 match (&lhs_project, &rhs_project) {
                     (Some(l), Some(r)) => (r == &wr).cmp(&(l == &wr)),
                     (Some(l), None) if l == &wr => Ordering::Less,

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -830,14 +830,12 @@ impl ToolchainLister for PythonToolchainProvider {
             let proj_ordering = || {
                 let lhs_project = lhs
                     .project
-                    .as_ref()
-                    .map(|p| p.to_path_buf())
+                    .clone()
                     .or_else(|| get_venv_parent_dir(lhs))
                     .map(|p| p.to_path_buf());
                 let rhs_project = rhs
                     .project
-                    .as_ref()
-                    .map(|p| p.to_path_buf())
+                    .clone()
                     .or_else(|| get_venv_parent_dir(rhs))
                     .map(|p| p.to_path_buf());
                 match (&lhs_project, &rhs_project) {


### PR DESCRIPTION
The problem from issue #37509 comes from local virtual environments created with certain approaches (including the 'simple' way of `python -m venv`) not having a `.project` file with the path to the project's root directory. When the toolchains are sorted, a virtual environment in the project is not treated as being for that project and therefore is not prioritized.

With this change, if a toolchain does not have a `project` associated with it, we check to see if it is a virtual environment, and if it is we use its parent directory as the `project`. This will make it the top priority (i.e. the default) if there are no other virtual environments for a project, which is what should be expected.

Closes #37509

Release Notes:

- Improved python toolchain prioritization of local virtual environments.
