### PR TITLE
Fix Wayland crash on AMD GPUs by updating Blade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2291,7 +2291,7 @@ dependencies = [
 [[package]]
 name = "blade-graphics"
 version = "0.6.0"
-source = "git+https://github.com/kvark/blade?rev=e0ec4e720957edd51b945b64dd85605ea54bcfe5#e0ec4e720957edd51b945b64dd85605ea54bcfe5"
+source = "git+https://github.com/kvark/blade?rev=bfa594e#bfa594ea697d4b6326ea29f747525c85ecf933b9"
 dependencies = [
  "ash",
  "ash-window",
@@ -2324,7 +2324,7 @@ dependencies = [
 [[package]]
 name = "blade-macros"
 version = "0.3.0"
-source = "git+https://github.com/kvark/blade?rev=e0ec4e720957edd51b945b64dd85605ea54bcfe5#e0ec4e720957edd51b945b64dd85605ea54bcfe5"
+source = "git+https://github.com/kvark/blade?rev=bfa594e#bfa594ea697d4b6326ea29f747525c85ecf933b9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2334,7 +2334,7 @@ dependencies = [
 [[package]]
 name = "blade-util"
 version = "0.2.0"
-source = "git+https://github.com/kvark/blade?rev=e0ec4e720957edd51b945b64dd85605ea54bcfe5#e0ec4e720957edd51b945b64dd85605ea54bcfe5"
+source = "git+https://github.com/kvark/blade?rev=bfa594e#bfa594ea697d4b6326ea29f747525c85ecf933b9"
 dependencies = [
  "blade-graphics",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -459,9 +459,9 @@ aws-smithy-types = { version = "1.3.0", features = ["http-body-1-x"] }
 base64 = "0.22"
 bincode = "1.2.1"
 bitflags = "2.6.0"
-blade-graphics = { git = "https://github.com/kvark/blade", rev = "e0ec4e720957edd51b945b64dd85605ea54bcfe5" }
-blade-macros = { git = "https://github.com/kvark/blade", rev = "e0ec4e720957edd51b945b64dd85605ea54bcfe5" }
-blade-util = { git = "https://github.com/kvark/blade", rev = "e0ec4e720957edd51b945b64dd85605ea54bcfe5" }
+blade-graphics = { git = "https://github.com/kvark/blade", rev = "bfa594e" }
+blade-macros = { git = "https://github.com/kvark/blade", rev = "bfa594e" }
+blade-util = { git = "https://github.com/kvark/blade", rev = "bfa594e" }
 blake3 = "1.5.3"
 bytes = "1.0"
 cargo_metadata = "0.19"

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -369,9 +369,9 @@ impl BladeRenderer {
             .ok()
             .and_then(|v| v.parse().ok())
             .or_else(|| {
-                [4, 2, 1]
-                    .into_iter()
-                    .find(|count| context.gpu.supports_texture_sample_count(*count))
+                [4, 2, 1].into_iter().find(|count| {
+                    context.gpu.capabilities().sample_count_mask & (1 << (*count - 1)) != 0
+                })
             })
             .unwrap_or(1);
         let pipelines = BladePipelines::new(&context.gpu, surface.info(), path_sample_count);

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -369,9 +369,9 @@ impl BladeRenderer {
             .ok()
             .and_then(|v| v.parse().ok())
             .or_else(|| {
-                [4, 2, 1].into_iter().find(|count| {
-                    context.gpu.capabilities().sample_count_mask & (1 << (*count - 1)) != 0
-                })
+                [4, 2, 1]
+                    .into_iter()
+                    .find(|&n| (context.gpu.capabilities().sample_count_mask & n) != 0)
             })
             .unwrap_or(1);
         let pipelines = BladePipelines::new(&context.gpu, surface.info(), path_sample_count);


### PR DESCRIPTION
Updates blade-graphics from e0ec4e7 to bfa594e to fix GPU crashes on Wayland with AMD graphics cards.

The crash was caused by incorrect BLAS scratch buffer alignment - the old version hardcoded 256-byte alignment, but AMD GPUs require different alignment values. The newer Blade version uses the GPU's actual alignment requirements instead of hardcoding.

Closes #37448

Release Notes:

- Migrate to newer version of Blade upstream
