### PR TITLE
extension: Enable optimizations in extension builds

### DIFF
--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -158,7 +158,7 @@ impl ExtensionBuilder {
             .arg(extension_dir.join("target"))
             // WASI builds do not work with sccache and just stuck, so disable it.
             .env("RUSTC_WRAPPER", "")
-            // Enable additional optimizations in extensions
+            // Enable additional optimizations in extensions.
             .env("CARGO_PROFILE_RELEASE_LTO", "true")
             .env("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", "1")
             .current_dir(extension_dir)

--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -158,6 +158,9 @@ impl ExtensionBuilder {
             .arg(extension_dir.join("target"))
             // WASI builds do not work with sccache and just stuck, so disable it.
             .env("RUSTC_WRAPPER", "")
+            // Enable additional optimizations in extensions
+            .env("CARGO_PROFILE_RELEASE_LTO", "true")
+            .env("CARGO_PROFILE_RELEASE_CODEGEN_UNITS", "1")
             .current_dir(extension_dir)
             .output()
             .context("failed to run `cargo`")?;


### PR DESCRIPTION
Enable FullLTO and `codegen-units = 1` optimizations for extensions

I didn't test the changes locally - just made the changes via GitHub UI. However, the changes are pretty straightforward. If the team can suggest me an easy way to test the changes - I think I can do the testing part too.

A full discussion about this feature is available [here](https://github.com/zed-industries/zed/discussions/21450). @ConradIrwin friendly pinging you here since you were active in the original discussion ;)

Closes https://github.com/zed-industries/zed/discussions/21450

Release Notes:

- Added FullLTO and `codegen-units = 1` optimizations for Zed extensions in a central place
