### PR TITLE
diagnostics: Fix diagnostics pane clearing up too eagerly on typing

### DIFF
--- a/crates/diagnostics/src/items.rs
+++ b/crates/diagnostics/src/items.rs
@@ -32,49 +32,38 @@ impl Render for DiagnosticIndicator {
         }
 
         let diagnostic_indicator = match (self.summary.error_count, self.summary.warning_count) {
-            (0, 0) => h_flex().map(|this| {
-                this.child(
-                    Icon::new(IconName::Check)
-                        .size(IconSize::Small)
-                        .color(Color::Default),
-                )
-            }),
-            (0, warning_count) => h_flex()
-                .gap_1()
-                .child(
-                    Icon::new(IconName::Warning)
-                        .size(IconSize::Small)
-                        .color(Color::Warning),
-                )
-                .child(Label::new(warning_count.to_string()).size(LabelSize::Small)),
-            (error_count, 0) => h_flex()
-                .gap_1()
-                .child(
-                    Icon::new(IconName::XCircle)
-                        .size(IconSize::Small)
-                        .color(Color::Error),
-                )
-                .child(Label::new(error_count.to_string()).size(LabelSize::Small)),
+            (0, 0) => h_flex().child(
+                Icon::new(IconName::Check)
+                    .size(IconSize::Small)
+                    .color(Color::Default),
+            ),
             (error_count, warning_count) => h_flex()
                 .gap_1()
-                .child(
-                    Icon::new(IconName::XCircle)
-                        .size(IconSize::Small)
-                        .color(Color::Error),
-                )
-                .child(Label::new(error_count.to_string()).size(LabelSize::Small))
-                .child(
-                    Icon::new(IconName::Warning)
-                        .size(IconSize::Small)
-                        .color(Color::Warning),
-                )
-                .child(Label::new(warning_count.to_string()).size(LabelSize::Small)),
+                .when(error_count > 0, |this| {
+                    this.child(
+                        Icon::new(IconName::XCircle)
+                            .size(IconSize::Small)
+                            .color(Color::Error),
+                    )
+                    .child(Label::new(error_count.to_string()).size(LabelSize::Small))
+                })
+                .when(warning_count > 0, |this| {
+                    this.child(
+                        Icon::new(IconName::Warning)
+                            .size(IconSize::Small)
+                            .color(Color::Warning),
+                    )
+                    .child(Label::new(warning_count.to_string()).size(LabelSize::Small))
+                }),
         };
 
         let status = if let Some(diagnostic) = &self.current_diagnostic {
-            let message = diagnostic.message.split('\n').next().unwrap().to_string();
+            let message = diagnostic
+                .message
+                .split_once('\n')
+                .map_or(&*diagnostic.message, |(first, _)| first);
             Some(
-                Button::new("diagnostic_message", message)
+                Button::new("diagnostic_message", SharedString::new(message))
                     .label_size(LabelSize::Small)
                     .tooltip(|window, cx| {
                         Tooltip::for_action(


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/30494

Release Notes:

- Fixed diagnostics pane closing buffers too eagerly when typing inside it
