### PR TITLE
Set usePlaceholders to match Go default

### DIFF
--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -204,7 +204,7 @@ impl super::LspAdapter for GoLspAdapter {
         _: &Arc<dyn LspAdapterDelegate>,
     ) -> Result<Option<serde_json::Value>> {
         Ok(Some(json!({
-            "usePlaceholders": true,
+            "usePlaceholders": false,
             "hints": {
                 "assignVariableTypes": true,
                 "compositeLiteralFields": true,


### PR DESCRIPTION
Closes #33629

Release Notes:

- changed gopls default to match what Go specifies https://github.com/golang/tools/blob/master/gopls/doc/settings.md#useplaceholders-bool
