### PR TITLE
docs: Update TOML docs

### DIFF
--- a/docs/src/languages/toml.md
+++ b/docs/src/languages/toml.md
@@ -1,22 +1,7 @@
 # TOML
 
-TOML support is available through the [TOML extension](https://github.com/zed-extensions/toml).
+TOML support is available through the [TOML extension](https://zed.dev/extensions/toml).
 
 - Tree-sitter: [tree-sitter/tree-sitter-toml](https://github.com/tree-sitter/tree-sitter-toml)
-- Language Server: [tamasfe/taplo](https://github.com/tamasfe/taplo)
 
-## Configuration
-
-You can control the behavior of the Taplo TOML language server by adding a `.taplo.toml` file to the root of your project. See the [Taplo Configuration File](https://taplo.tamasfe.dev/configuration/file.html#configuration-file) and [Taplo Formatter Options](https://taplo.tamasfe.dev/configuration/formatter-options.html) documentation for more.
-
-```toml
-# .taplo.toml
-[formatting]
-align_comments = false
-reorder_keys = true
-
-include = ["Cargo.toml", "some_directory/**/*.toml"]
-# exclude = ["vendor/**/*.toml"]
-```
-
-Note: The taplo language server will not automatically pickup changes to `.taplo.toml`. You must manually trigger {#action editor::RestartLanguageServer} or reload Zed for it to pickup changes.
+A TOML language server is available in the [Tombi extension](https://zed.dev/extensions/tombi).


### PR DESCRIPTION
This PR updates the TOML docs to remove references to Taplo and suggest the Tombi extension for users wanting language server support.

Relates to https://github.com/zed-industries/zed/issues/36766.

Release Notes:

- N/A
