### PR TITLE
Make fallback open picker more intuitive

### DIFF
--- a/crates/file_finder/src/open_path_prompt.rs
+++ b/crates/file_finder/src/open_path_prompt.rs
@@ -522,7 +522,6 @@ impl PickerDelegate for OpenPathDelegate {
         _: &mut Context<Picker<Self>>,
     ) -> Option<String> {
         let candidate = self.get_entry(self.selected_index)?;
-        // TODO kb unit test tab completions for `/` case (also C:\\ on Win) + test the `./` completion
         if candidate.path.string.is_empty() || candidate.path.string == self.current_dir() {
             return None;
         }

--- a/crates/file_finder/src/open_path_prompt_tests.rs
+++ b/crates/file_finder/src/open_path_prompt_tests.rs
@@ -43,12 +43,17 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["root"]);
 
+    #[cfg(not(windows))]
+    let expected_separator = "./";
+    #[cfg(windows)]
+    let expected_separator = ".\\";
+
     // If the query ends with a slash, the picker should show the contents of the directory.
     let query = path!("/root/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["./", "a1", "a2", "a3", "dir1", "dir2"]
+        vec![expected_separator, "a1", "a2", "a3", "dir1", "dir2"]
     );
 
     // Show candidates for the query "a".
@@ -72,7 +77,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["./", "c", "d1", "d2", "d3", "dir3", "dir4"]
+        vec![expected_separator, "c", "d1", "d2", "d3", "dir3", "dir4"]
     );
 
     // Show candidates for the query "d".
@@ -312,7 +317,7 @@ async fn test_open_path_prompt_on_windows_with_remote(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec![".\\", "a", "dir1", "dir2"]
+        vec!["./", "a", "dir1", "dir2"]
     );
     assert_eq!(
         confirm_completion(query, 1, &picker, cx).unwrap(),

--- a/crates/file_finder/src/open_path_prompt_tests.rs
+++ b/crates/file_finder/src/open_path_prompt_tests.rs
@@ -48,7 +48,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["a1", "a2", "a3", "dir1", "dir2"]
+        vec!["./", "a1", "a2", "a3", "dir1", "dir2"]
     );
 
     // Show candidates for the query "a".
@@ -56,7 +56,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["a1", "a2", "a3"]
+        vec!["./", "a1", "a2", "a3"]
     );
 
     // Show candidates for the query "d".

--- a/crates/file_finder/src/open_path_prompt_tests.rs
+++ b/crates/file_finder/src/open_path_prompt_tests.rs
@@ -56,7 +56,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["./", "a1", "a2", "a3"]
+        vec!["a1", "a2", "a3"]
     );
 
     // Show candidates for the query "d".
@@ -72,7 +72,7 @@ async fn test_open_path_prompt(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["c", "d1", "d2", "d3", "dir3", "dir4"]
+        vec!["./", "c", "d1", "d2", "d3", "dir3", "dir4"]
     );
 
     // Show candidates for the query "d".

--- a/crates/file_finder/src/open_path_prompt_tests.rs
+++ b/crates/file_finder/src/open_path_prompt_tests.rs
@@ -116,71 +116,86 @@ async fn test_open_path_prompt_completion(cx: &mut TestAppContext) {
     // Confirm completion for the query "/root", since it's a directory, it should add a trailing slash.
     let query = path!("/root");
     insert_query(query, &picker, cx).await;
-    assert_eq!(confirm_completion(query, 0, &picker, cx), path!("/root/"));
+    assert_eq!(
+        confirm_completion(query, 0, &picker, cx).unwrap(),
+        path!("/root/")
+    );
 
     // Confirm completion for the query "/root/", selecting the first candidate "a", since it's a file, it should not add a trailing slash.
     let query = path!("/root/");
     insert_query(query, &picker, cx).await;
-    assert_eq!(confirm_completion(query, 0, &picker, cx), path!("/root/a"));
+    assert_eq!(
+        confirm_completion(query, 0, &picker, cx),
+        None,
+        "First entry is `./` and when we confirm completion, it is tabbed below"
+    );
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        path!("/root/a"),
+        "Second entry is the first entry of a directory that we want to be completed"
+    );
 
     // Confirm completion for the query "/root/", selecting the second candidate "dir1", since it's a directory, it should add a trailing slash.
     let query = path!("/root/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 1, &picker, cx),
+        confirm_completion(query, 2, &picker, cx).unwrap(),
         path!("/root/dir1/")
     );
 
     let query = path!("/root/a");
     insert_query(query, &picker, cx).await;
-    assert_eq!(confirm_completion(query, 0, &picker, cx), path!("/root/a"));
+    assert_eq!(
+        confirm_completion(query, 0, &picker, cx).unwrap(),
+        path!("/root/a")
+    );
 
     let query = path!("/root/d");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 1, &picker, cx),
+        confirm_completion(query, 1, &picker, cx).unwrap(),
         path!("/root/dir2/")
     );
 
     let query = path!("/root/dir2");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 0, &picker, cx),
+        confirm_completion(query, 0, &picker, cx).unwrap(),
         path!("/root/dir2/")
     );
 
     let query = path!("/root/dir2/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 0, &picker, cx),
+        confirm_completion(query, 1, &picker, cx).unwrap(),
         path!("/root/dir2/c")
     );
 
     let query = path!("/root/dir2/");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 2, &picker, cx),
+        confirm_completion(query, 3, &picker, cx).unwrap(),
         path!("/root/dir2/dir3/")
     );
 
     let query = path!("/root/dir2/d");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 0, &picker, cx),
+        confirm_completion(query, 0, &picker, cx).unwrap(),
         path!("/root/dir2/d")
     );
 
     let query = path!("/root/dir2/d");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 1, &picker, cx),
+        confirm_completion(query, 1, &picker, cx).unwrap(),
         path!("/root/dir2/dir3/")
     );
 
     let query = path!("/root/dir2/di");
     insert_query(query, &picker, cx).await;
     assert_eq!(
-        confirm_completion(query, 1, &picker, cx),
+        confirm_completion(query, 1, &picker, cx).unwrap(),
         path!("/root/dir2/dir4/")
     );
 }
@@ -211,42 +226,63 @@ async fn test_open_path_prompt_on_windows(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["a", "dir1", "dir2"]
+        vec![".\\", "a", "dir1", "dir2"]
     );
-    assert_eq!(confirm_completion(query, 0, &picker, cx), "C:/root/a");
+    assert_eq!(
+        confirm_completion(query, 0, &picker, cx),
+        None,
+        "First entry is `.\\` and when we confirm completion, it is tabbed below"
+    );
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        "C:/root/a",
+        "Second entry is the first entry of a directory that we want to be completed"
+    );
 
     let query = "C:\\root/";
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["a", "dir1", "dir2"]
+        vec![".\\", "a", "dir1", "dir2"]
     );
-    assert_eq!(confirm_completion(query, 0, &picker, cx), "C:\\root/a");
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        "C:\\root/a"
+    );
 
     let query = "C:\\root\\";
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["a", "dir1", "dir2"]
+        vec![".\\", "a", "dir1", "dir2"]
     );
-    assert_eq!(confirm_completion(query, 0, &picker, cx), "C:\\root\\a");
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        "C:\\root\\a"
+    );
 
     // Confirm completion for the query "C:/root/d", selecting the second candidate "dir2", since it's a directory, it should add a trailing slash.
     let query = "C:/root/d";
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir1", "dir2"]);
-    assert_eq!(confirm_completion(query, 1, &picker, cx), "C:/root/dir2\\");
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        "C:/root/dir2\\"
+    );
 
     let query = "C:\\root/d";
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir1", "dir2"]);
-    assert_eq!(confirm_completion(query, 0, &picker, cx), "C:\\root/dir1\\");
+    assert_eq!(
+        confirm_completion(query, 0, &picker, cx).unwrap(),
+        "C:\\root/dir1\\"
+    );
 
     let query = "C:\\root\\d";
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir1", "dir2"]);
     assert_eq!(
-        confirm_completion(query, 0, &picker, cx),
+        confirm_completion(query, 0, &picker, cx).unwrap(),
         "C:\\root\\dir1\\"
     );
 }
@@ -276,20 +312,29 @@ async fn test_open_path_prompt_on_windows_with_remote(cx: &mut TestAppContext) {
     insert_query(query, &picker, cx).await;
     assert_eq!(
         collect_match_candidates(&picker, cx),
-        vec!["a", "dir1", "dir2"]
+        vec![".\\", "a", "dir1", "dir2"]
     );
-    assert_eq!(confirm_completion(query, 0, &picker, cx), "/root/a");
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        "/root/a"
+    );
 
     // Confirm completion for the query "/root/d", selecting the second candidate "dir2", since it's a directory, it should add a trailing slash.
     let query = "/root/d";
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir1", "dir2"]);
-    assert_eq!(confirm_completion(query, 1, &picker, cx), "/root/dir2/");
+    assert_eq!(
+        confirm_completion(query, 1, &picker, cx).unwrap(),
+        "/root/dir2/"
+    );
 
     let query = "/root/d";
     insert_query(query, &picker, cx).await;
     assert_eq!(collect_match_candidates(&picker, cx), vec!["dir1", "dir2"]);
-    assert_eq!(confirm_completion(query, 0, &picker, cx), "/root/dir1/");
+    assert_eq!(
+        confirm_completion(query, 0, &picker, cx).unwrap(),
+        "/root/dir1/"
+    );
 }
 
 #[gpui::test]
@@ -396,15 +441,13 @@ fn confirm_completion(
     select: usize,
     picker: &Entity<Picker<OpenPathDelegate>>,
     cx: &mut VisualTestContext,
-) -> String {
-    picker
-        .update_in(cx, |f, window, cx| {
-            if f.delegate.selected_index() != select {
-                f.delegate.set_selected_index(select, window, cx);
-            }
-            f.delegate.confirm_completion(query.to_string(), window, cx)
-        })
-        .unwrap()
+) -> Option<String> {
+    picker.update_in(cx, |f, window, cx| {
+        if f.delegate.selected_index() != select {
+            f.delegate.set_selected_index(select, window, cx);
+        }
+        f.delegate.confirm_completion(query.to_string(), window, cx)
+    })
 }
 
 fn collect_match_candidates(


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/34991

Before, the picker did not allow to open the current directory that was just completed:

<img width="553" height="354" alt="image" src="https://github.com/user-attachments/assets/e77793c8-763e-416f-9728-18d5a39b467f" />

pressing `enter` here would open `assets`; pressing `tab` would append the `assets/` segment to the query.
Only backspace, removing `/` would allow to open the current directory.

After:
<img width="574" height="349" alt="image" src="https://github.com/user-attachments/assets/bdbb3e23-7c7a-4e12-8092-51a6a0ea9f87" />

The first item is now a placeholder for opening the current directory with `enter`.
Any time a fuzzy query is appended, the placeholder goes away; `tab` selects the entry below the placeholder.

Release Notes:

- Made fallback open picker more intuitive
