### PR TITLE
snippets: Disable `feature_paths` by default

### DIFF
--- a/extensions/snippets/src/snippets.rs
+++ b/extensions/snippets/src/snippets.rs
@@ -120,7 +120,8 @@ impl zed::Extension for SnippetExtension {
                     "snippets_first": true,
                     "feature_words": false,
                     "feature_snippets": true,
-                    "feature_paths": true
+                    // We disable `feature_paths` by default, because it's bad UX to assume that any `/` that is typed is the start of a path.
+                    "feature_paths": false
                 })
             });
         Ok(Some(settings))

--- a/extensions/snippets/src/snippets.rs
+++ b/extensions/snippets/src/snippets.rs
@@ -120,7 +120,8 @@ impl zed::Extension for SnippetExtension {
                     "snippets_first": true,
                     "feature_words": false,
                     "feature_snippets": true,
-                    // We disable `feature_paths` by default, because it's bad UX to assume that any `/` that is typed is the start of a path.
+                    // We disable `feature_paths` by default, because it's bad UX to assume that any `/` that is typed
+                    // is the start of a path.
                     "feature_paths": false
                 })
             });


### PR DESCRIPTION
This PR updates the default configuration of the `snippets` extension to disable suggesting paths (`feature_paths`).

If users want to enable it, it can be done via the settings:

```json
{
  "lsp": {
    "snippet-completion-server": {
      "settings": {
        "feature_paths": true
      }
    }
  }
}
```

Release Notes:

- N/A
