### PR TITLE
docs: Add configuration example for `simple-completion-language-server`

### DIFF
--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -40,4 +40,20 @@ To create JSX snippets you have to use `javascript.json` snippets file, instead 
 
 ## See also
 
+The `feature_paths` option in `simple-completion-language-server` is disabled by default.
+
+If you want to enable it you can add the following to your `settings.json`:
+
+```json
+{
+  "lsp": {
+    "snippet-completion-server": {
+      "settings": {
+        "feature_paths": true
+      }
+    }
+  }
+}
+```
+
 For more configuration information, see the [`simple-completion-language-server` instructions](https://github.com/zed-industries/simple-completion-language-server/tree/main).


### PR DESCRIPTION
This PR adds a configuration example for the `simple-completion-language-server`.

We show the user how to re-enable the `feature_paths` option, as we're now disabling it by default (https://github.com/zed-industries/zed/pull/37565).

Release Notes:

- N/A
