### PR TITLE
snippets: Bump to v0.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20642,7 +20642,7 @@ dependencies = [
 
 [[package]]
 name = "zed_snippets"
-version = "0.0.5"
+version = "0.0.6"
 dependencies = [
  "serde_json",
  "zed_extension_api 0.1.0",

--- a/extensions/snippets/Cargo.toml
+++ b/extensions/snippets/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed_snippets"
-version = "0.0.5"
+version = "0.0.6"
 edition.workspace = true
 publish.workspace = true
 license = "Apache-2.0"

--- a/extensions/snippets/extension.toml
+++ b/extensions/snippets/extension.toml
@@ -1,9 +1,9 @@
 id = "snippets"
 name = "Snippets"
 description = "Support for language-agnostic snippets, provided by simple-completion-language-server"
-version = "0.0.5"
+version = "0.0.6"
 schema_version = 1
-authors = []
+authors = ["Zed Industries <hi@zed.dev>"]
 repository = "https://github.com/zed-industries/zed"
 
 [language_servers.snippet-completion-server]


### PR DESCRIPTION
This PR bumps the snippets extension to v0.0.6.

Changes:

- https://github.com/zed-industries/zed/pull/37565

Release Notes:

- N/A
