### PR TITLE
agent_ui: Clear model selector query on dismiss

### DIFF
--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -193,15 +193,9 @@ impl PickerDelegate for AcpModelPickerDelegate {
     }
 
     fn dismissed(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) {
-        cx.emit(DismissEvent);
-        cx.spawn_in(window, async move |handle, cx| {
-            handle
-                .update_in(cx, |picker, window, cx| {
-                    picker.set_query("", window, cx);
-                })
-                .ok();
-        })
-        .detach();
+        cx.defer_in(window, |picker, window, cx| {
+            picker.set_query("", window, cx);
+        });
     }
 
     fn render_match(

--- a/crates/agent_ui/src/acp/model_selector.rs
+++ b/crates/agent_ui/src/acp/model_selector.rs
@@ -192,8 +192,16 @@ impl PickerDelegate for AcpModelPickerDelegate {
         }
     }
 
-    fn dismissed(&mut self, _: &mut Window, cx: &mut Context<Picker<Self>>) {
+    fn dismissed(&mut self, window: &mut Window, cx: &mut Context<Picker<Self>>) {
         cx.emit(DismissEvent);
+        cx.spawn_in(window, async move |handle, cx| {
+            handle
+                .update_in(cx, |picker, window, cx| {
+                    picker.set_query("", window, cx);
+                })
+                .ok();
+        })
+        .detach();
     }
 
     fn render_match(


### PR DESCRIPTION
Closes #36756

| Before | After |
|--------|--------|
| <video src ="https://github.com/user-attachments/assets/1d022ac6-0aea-4e98-a717-9988420c9683"/> | <video src="https://github.com/user-attachments/assets/78d19012-1224-4c92-a6c8-47ae4c13ca31"/> | 

Release Notes:

- Clear model selector query on dismiss in agent panel
