### PR TITLE
Allow outline modal toggling

### DIFF
--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -81,8 +81,14 @@ impl ModalView for OutlineView {
 }
 
 impl Render for OutlineView {
-    fn render(&mut self, _window: &mut Window, _cx: &mut Context<Self>) -> impl IntoElement {
-        v_flex().w(rems(34.)).child(self.picker.clone())
+    fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        v_flex()
+            .w(rems(34.))
+            .on_action(cx.listener(|_this: &mut OutlineView, _: &zed_actions::outline::ToggleOutline, _window: &mut Window, cx: &mut Context<OutlineView>| {
+                // When outline::Toggle is triggered while the outline is open, dismiss it
+                cx.emit(DismissEvent);
+            }))
+            .child(self.picker.clone())
     }
 }
 

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -84,10 +84,15 @@ impl Render for OutlineView {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         v_flex()
             .w(rems(34.))
-            .on_action(cx.listener(|_this: &mut OutlineView, _: &zed_actions::outline::ToggleOutline, _window: &mut Window, cx: &mut Context<OutlineView>| {
-                // When outline::Toggle is triggered while the outline is open, dismiss it
-                cx.emit(DismissEvent);
-            }))
+            .on_action(cx.listener(
+                |_this: &mut OutlineView,
+                 _: &zed_actions::outline::ToggleOutline,
+                 _window: &mut Window,
+                 cx: &mut Context<OutlineView>| {
+                    // When outline::Toggle is triggered while the outline is open, dismiss it
+                    cx.emit(DismissEvent);
+                },
+            ))
             .child(self.picker.clone())
     }
 }


### PR DESCRIPTION
Closes #37511 

The outline modal seems to have a bug where if it's open and the `outline::Toggle` is triggered, it would not close if there was another command with the same keybind. So instead, if the outline modal is open and an `outline::Toggle` is triggered, we dismiss the modal.

Release Notes:

- Fixed a bug where `outline::Toggle` would sometimes not close outline modal
