### PR TITLE
Add new injections for Go

### DIFF
--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -45,7 +45,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?sql\\s?\\*\\/") ; /* sql */ or /*sql*/
+    (#match? @comment "^\\/\\*\\s*sql\\s*\\*\\/") ; /* sql */ or /*sql*/
     (#set! injection.language "sql")
 )
 
@@ -81,7 +81,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?json\\s?\\*\\/") ; /* json */ or /*json*/
+    (#match? @comment "^\\/\\*\\s*json\\s*\\*\\/") ; /* json */ or /*json*/
     (#set! injection.language "json")
 )
 
@@ -117,7 +117,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?yaml\\s?\\*\\/") ; /* yaml */ or /*yaml*/
+    (#match? @comment "^\\/\\*\\s*yaml\\s*\\*\\/") ; /* yaml */ or /*yaml*/
     (#set! injection.language "yaml")
 )
 
@@ -153,7 +153,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?xml\\s?\\*\\/") ; /* xml */ or /*xml*/
+    (#match? @comment "^\\/\\*\\s*xml\\s*\\*\\/") ; /* xml */ or /*xml*/
     (#set! injection.language "xml")
 )
 
@@ -189,7 +189,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?html\\s?\\*\\/") ; /* html */ or /*html*/
+    (#match? @comment "^\\/\\*\\s*html\\s*\\*\\/") ; /* html */ or /*html*/
     (#set! injection.language "html")
 )
 
@@ -225,7 +225,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?js\\s?\\*\\/") ; /* js */ or /*js*/
+    (#match? @comment "^\\/\\*\\s*js\\s*\\*\\/") ; /* js */ or /*js*/
     (#set! injection.language "javascript")
 )
 
@@ -261,7 +261,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?css\\s?\\*\\/") ; /* css */ or /*css*/
+    (#match? @comment "^\\/\\*\\s*css\\s*\\*\\/") ; /* css */ or /*css*/
     (#set! injection.language "css")
 )
 
@@ -297,7 +297,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?lua\\s?\\*\\/") ; /* lua */ or /*lua*/
+    (#match? @comment "^\\/\\*\\s*lua\\s*\\*\\/") ; /* lua */ or /*lua*/
     (#set! injection.language "lua")
 )
 
@@ -333,7 +333,7 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?bash\\s?\\*\\/") ; /* bash */ or /*bash*/
+    (#match? @comment "^\\/\\*\\s*bash\\s*\\*\\/") ; /* bash */ or /*bash*/
     (#set! injection.language "bash")
 )
 
@@ -369,6 +369,6 @@
         ] @injection.content)
     ]
 
-    (#match? @comment "^\\/\\*\\s?csv\\s?\\*\\/") ; /* csv */ or /*csv*/
+    (#match? @comment "^\\/\\*\\s*csv\\s*\\*\\/") ; /* csv */ or /*csv*/
     (#set! injection.language "csv")
 )

--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -10,4 +10,365 @@
       (raw_string_literal)
       (interpreted_string_literal)
     ] @injection.content
-    (#set! injection.language "regex")))
+    (#set! injection.language "regex")
+    ))
+
+; INJECT SQL
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?sql\\s?\\*\\/") ; /* sql */ or /*sql*/
+    (#set! injection.language "sql")
+)
+
+; INJECT JSON
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?json\\s?\\*\\/") ; /* json */ or /*json*/
+    (#set! injection.language "json")
+)
+
+; INJECT YAML
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?yaml\\s?\\*\\/") ; /* yaml */ or /*yaml*/
+    (#set! injection.language "yaml")
+)
+
+; INJECT XML
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?xml\\s?\\*\\/") ; /* xml */ or /*xml*/
+    (#set! injection.language "xml")
+)
+
+; INJECT HTML
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?html\\s?\\*\\/") ; /* html */ or /*html*/
+    (#set! injection.language "html")
+)
+
+; INJECT JS
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?js\\s?\\*\\/") ; /* js */ or /*js*/
+    (#set! injection.language "javascript")
+)
+
+; INJECT CSS
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?css\\s?\\*\\/") ; /* css */ or /*css*/
+    (#set! injection.language "css")
+)
+
+; INJECT LUA
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?lua\\s?\\*\\/") ; /* lua */ or /*lua*/
+    (#set! injection.language "lua")
+)
+
+; INJECT BASH
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?bash\\s?\\*\\/") ; /* bash */ or /*bash*/
+    (#set! injection.language "bash")
+)
+
+; INJECT CSV
+(
+	[
+		; var, const or short declaration of raw or interpreted string literal
+		((comment) @comment
+  		.
+    	(expression_list
+     	[
+      		(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a literal element (to struct field eg.)
+		((comment) @comment
+        .
+        (literal_element
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content
+        ))
+
+        ; when passing as a function parameter
+        ((comment) @comment
+        .
+        [
+        	(interpreted_string_literal)
+        	(raw_string_literal)
+        ] @injection.content)
+    ]
+
+    (#match? @comment "^\\/\\*\\s?csv\\s?\\*\\/") ; /* csv */ or /*csv*/
+    (#set! injection.language "csv")
+)


### PR DESCRIPTION
support for injecting sql, json, yaml, xml, html, css, js, lua and csv value

if you use `/* lang */` before string literals, highlights them

**Example:**

```go
const sqlQuery = /* sql */ "SELECT * FROM users;" // highlights as SQL code
```

<img width="629" height="46" alt="Screenshot 2025-09-05 at 06 17 49" src="https://github.com/user-attachments/assets/80f404d8-0a47-428d-bdb5-09fbee502cfe" />


Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
