### PR TITLE
gpui: Skip `test` attribute expansion for rust-analyzer

### DIFF
--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -121,6 +121,14 @@ mod seal {
     pub trait Sealed {}
 }
 
+// This allows r-a to skip expanding the gpui test macro which should
+// reduce resource usage a bit as the test attribute is special cased
+// to be treated as a no-op.
+#[cfg(rust_analyzer)]
+pub use core::prelude::v1::test;
+#[cfg(not(rust_analyzer))]
+pub use gpui_macros::test;
+
 pub use action::*;
 pub use anyhow::Result;
 pub use app::*;
@@ -134,7 +142,7 @@ pub use elements::*;
 pub use executor::*;
 pub use geometry::*;
 pub use global::*;
-pub use gpui_macros::{AppContext, IntoElement, Render, VisualContext, register_action, test};
+pub use gpui_macros::{AppContext, IntoElement, Render, VisualContext, register_action};
 pub use http_client;
 pub use input::*;
 pub use inspector::*;


### PR DESCRIPTION
The `test` attribute doesn't really matter to rust-analyzer, so we can make use of its cfg to have it think its just the standard test attribute which should make rust-analyzer slightly less resource intensive in zed. It also should prevent some IDE features from possibly failing within tests.

Notably this has no effect outside of this repo, as the `rust-analyzer` cfg only takes effect on workspace member crates.

Ideally we'd use the ignored proc macro config here but rust-analyzer still doesn't have toml configs working unfortunately.

Release Notes:

- N/A 