### PR TITLE
gpui: Move Option -> Result conversion out of closure in App::update_window_id

### DIFF
--- a/crates/gpui/src/app.rs
+++ b/crates/gpui/src/app.rs
@@ -1358,12 +1358,7 @@ impl App {
         F: FnOnce(AnyView, &mut Window, &mut App) -> T,
     {
         self.update(|cx| {
-            let mut window = cx
-                .windows
-                .get_mut(id)
-                .context("window not found")?
-                .take()
-                .context("window not found")?;
+            let mut window = cx.windows.get_mut(id)?.take()?;
 
             let root_view = window.root.clone().unwrap();
 
@@ -1380,15 +1375,14 @@ impl App {
                     true
                 });
             } else {
-                cx.windows
-                    .get_mut(id)
-                    .context("window not found")?
-                    .replace(window);
+                cx.windows.get_mut(id)?.replace(window);
             }
 
-            Ok(result)
+            Some(result)
         })
+        .context("window not found")
     }
+
     /// Creates an `AsyncApp`, which can be cloned and has a static lifetime
     /// so it can be held across `await` points.
     pub fn to_async(&self) -> AsyncApp {


### PR DESCRIPTION
Doesn't fix anything, but it seems that we do not need to assert and convert into an error until after the closure run to completion, especially since this is the only error we throw.

Release Notes:

- N/A
