### PR TITLE
language_models: Skip empty delta text content in OpenAI and OpenAI compatible provider

### DIFF
--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -586,7 +586,9 @@ impl OpenAiEventMapper {
         };
 
         if let Some(content) = choice.delta.content.clone() {
-            events.push(Ok(LanguageModelCompletionEvent::Text(content)));
+            if !content.is_empty() {
+                events.push(Ok(LanguageModelCompletionEvent::Text(content)));
+            }
         }
 
         if let Some(tool_calls) = choice.delta.tool_calls.as_ref() {


### PR DESCRIPTION
Closes #37302 

Related: #37614 

In case of open_ai_compatible providers like Zhipu AI and z.ai they return empty content along with usage data. below is the example json captured from z.ai. We now ignore empty content returned by providers now to avoid this issue where we would return the same empty content back to provider which would error out.

```
OpenAI Stream Response JSON:
{
  "id": "2025090518465610d80dc21e66426d",
  "created": 1757069216,
  "model": "glm-4.5",
  "choices": [
    {
      "index": 0,
      "finish_reason": "tool_calls",
      "delta": {
        "role": "assistant",
        "content": ""
      }
    }
  ],
  "usage": {
    "prompt_tokens": 7882,
    "completion_tokens": 150,
    "total_tokens": 8032,
    "prompt_tokens_details": {
      "cached_tokens": 7881
    }
  }
}
```

Release Notes:

- Skip empty delta text content in OpenAI and OpenAI compatible provider
