### PR TITLE
languages: Invoke conda activate in conda environments

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -902,6 +902,13 @@ impl ToolchainLister for PythonToolchainProvider {
                 let env = toolchain.name.as_deref().unwrap_or("default");
                 activation_script.push(format!("pixi shell -e {env}"))
             }
+            Some(PythonEnvironmentKind::Conda) => {
+                if let Some(name) = &toolchain.name {
+                    activation_script.push(format!("conda activate {name}"));
+                } else {
+                    activation_script.push("conda activate".to_string());
+                }
+            }
             Some(PythonEnvironmentKind::Venv | PythonEnvironmentKind::VirtualEnv) => {
                 if let Some(prefix) = &toolchain.prefix {
                     let activate_keyword = match shell {


### PR DESCRIPTION
This isn't quite right, but using the env manager path causes conda to scream and I am not yet sure why, either way this is an improvement over the status quo

Release Notes:

- N/A
