### PR TITLE
open_ai: Trim newline before "data:" prefix and account for the possibility of no space after ":"

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -473,7 +473,7 @@ pub async fn stream_completion(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = line.strip_prefix("data: ")?;
+                        let line = line.trim().strip_prefix("data:")?;
                         if line == "[DONE]" {
                             None
                         } else {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -473,7 +473,7 @@ pub async fn stream_completion(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = line.trim().strip_prefix("data:")?;
+                        let line = line.strip_prefix("data:")?;
                         if line == "[DONE]" {
                             None
                         } else {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -473,10 +473,7 @@ pub async fn stream_completion(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let mut line = line.strip_prefix("data:")?;
-                        if line.starts_with(" ") {
-                            line = &line[1..]
-                        }
+                        let line = line.strip_prefix("data: ").or_else(|| line.strip_prefix("data:"))?;
                         if line == "[DONE]" {
                             None
                         } else {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -473,7 +473,7 @@ pub async fn stream_completion(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = line.strip_prefix("data:")?;
+                        let line = line.strip_prefix("data:")?.trim_start();
                         if line == "[DONE]" {
                             None
                         } else {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -473,7 +473,10 @@ pub async fn stream_completion(
             .filter_map(|line| async move {
                 match line {
                     Ok(line) => {
-                        let line = line.strip_prefix("data:")?.trim_start();
+                        let mut line = line.strip_prefix("data:")?;
+                        if line.starts_with(" ") {
+                            line = &line[1..]
+                        }
                         if line == "[DONE]" {
                             None
                         } else {


### PR DESCRIPTION
I'am using an openai compatible model, but got nothing in agent thread panel, and Zed log has "Model generated an empty summary" line.

I add one log to open_ai.rs:
<img width="2454" height="626" alt="图片" src="https://github.com/user-attachments/assets/85354c7d-a0cc-4bba-86fd-2a640038a13e" />

and got:

<img width="3456" height="278" alt="图片" src="https://github.com/user-attachments/assets/7746aedd-5d76-44b5-90f2-e129a1507178" />

It appear that `let line = line.strip_prefix("data: ")?;` can not handle correctly.

Release Notes:

- N/A
