### PR TITLE
windows: Make sure `zed.sh` using the correct line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,4 +2,4 @@
 *.json linguist-language=JSON-with-Comments
 
 # Ensure the WSL script always has LF line endings, even on Windows
-crates/zed/resources/windows/zed text eol=lf
+crates/zed/resources/windows/zed.sh text eol=lf


### PR DESCRIPTION
This got missed in the changes from #37631

Release Notes:

- N/A