### PR TITLE
editor: Fix fold placeholder hover width smaller than marker

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -1794,7 +1794,7 @@ impl Editor {
         let font_size = style.font_size.to_pixels(window.rem_size());
         let editor = cx.entity().downgrade();
         let fold_placeholder = FoldPlaceholder {
-            constrain_width: true,
+            constrain_width: false,
             render: Arc::new(move |fold_id, fold_range, cx| {
                 let editor = editor.clone();
                 div()


### PR DESCRIPTION
Bug:
<img width="196" height="95" alt="Screenshot 2025-09-06 at 1 21 39 AM" src="https://github.com/user-attachments/assets/66ec0fc9-961e-4289-bd75-68b24dad485e" />

The fold marker we use, `⋯`, isn’t rendered at the same size as the editor’s font. Notice how the fold marker appears larger than the same character typed directly in the editor buffer.

<img width="146" height="82" alt="image" src="https://github.com/user-attachments/assets/a059d221-6b55-4cf9-bc1e-898ff5444006" />

When we shape the line, we use the editor’s font size, and it ends up determining the element’s width. To fix this, we should treat the ellipsis as a UI element rather than a buffer character, since current visual size looks good to me.

<img width="196" height="95" alt="Screenshot 2025-09-06 at 1 29 28 AM" src="https://github.com/user-attachments/assets/1b766d46-00ab-40c7-b98a-95ea2d4b29bf" />

Release Notes:

- Fixed an issue where the fold placeholder’s hover area was smaller than the marker.
