### PR TITLE
gpui: Fix blending of colors in `HighlightStyle::highlight`

### DIFF
--- a/crates/editor/src/display_map/custom_highlights.rs
+++ b/crates/editor/src/display_map/custom_highlights.rs
@@ -148,11 +148,11 @@ impl<'a> Iterator for CustomHighlightsChunks<'a> {
             ..chunk.clone()
         };
         if !self.active_highlights.is_empty() {
-            let mut highlight_style = HighlightStyle::default();
-            for active_highlight in self.active_highlights.values() {
-                highlight_style.highlight(*active_highlight);
-            }
-            prefix.highlight_style = Some(highlight_style);
+            prefix.highlight_style = self
+                .active_highlights
+                .values()
+                .copied()
+                .reduce(|acc, active_highlight| acc.highlight(active_highlight));
         }
         Some(prefix)
     }

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -385,9 +385,9 @@ impl<'a> Iterator for InlayChunks<'a> {
                         next_inlay_highlight_endpoint = usize::MAX;
                     } else {
                         next_inlay_highlight_endpoint = range.end - offset_in_inlay.0;
-                        highlight_style
-                            .get_or_insert_with(Default::default)
-                            .highlight(*style);
+                        highlight_style = highlight_style
+                            .map(|highlight| highlight.highlight(*style))
+                            .or_else(|| Some(*style));
                     }
                 } else {
                     next_inlay_highlight_endpoint = usize::MAX;

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -23576,8 +23576,7 @@ pub fn styled_runs_for_code_label<'a>(
             } else {
                 return Default::default();
             };
-            let mut muted_style = style;
-            muted_style.highlight(fade_out);
+            let muted_style = style.highlight(fade_out);
 
             let mut runs = SmallVec::<[(Range<usize>, HighlightStyle); 3]>::new();
             if range.start >= label.filter_range.end {

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -1311,7 +1311,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_highlight_style_combination() {
+    fn test_basic_highlight_style_combination() {
         let mut style_a = HighlightStyle::default();
         let style_b = HighlightStyle::default();
         style_a.highlight(style_b);
@@ -1322,18 +1322,18 @@ mod tests {
         );
 
         let mut style_b = HighlightStyle {
-            color: Some(crate::red()),
+            color: Some(red()),
             strikethrough: Some(StrikethroughStyle {
                 thickness: px(2.),
-                color: Some(crate::blue()),
+                color: Some(blue()),
             }),
             fade_out: Some(0.),
             font_style: Some(FontStyle::Italic),
             font_weight: Some(FontWeight(300.)),
-            background_color: Some(crate::yellow()),
+            background_color: Some(yellow()),
             underline: Some(UnderlineStyle {
                 thickness: px(2.),
-                color: Some(crate::red()),
+                color: Some(red()),
                 wavy: true,
             }),
         };
@@ -1354,7 +1354,7 @@ mod tests {
         let mut style_c = expected_style;
 
         let style_d = HighlightStyle {
-            color: Some(crate::blue().alpha(0.7)),
+            color: Some(blue().alpha(0.7)),
             strikethrough: Some(StrikethroughStyle {
                 thickness: px(4.),
                 color: Some(crate::red()),
@@ -1362,7 +1362,7 @@ mod tests {
             fade_out: Some(0.),
             font_style: Some(FontStyle::Oblique),
             font_weight: Some(FontWeight(800.)),
-            background_color: Some(crate::green()),
+            background_color: Some(green()),
             underline: Some(UnderlineStyle {
                 thickness: px(4.),
                 color: None,
@@ -1371,16 +1371,16 @@ mod tests {
         };
 
         let expected_style = HighlightStyle {
-            color: Some(crate::red().blend(crate::blue().alpha(0.7))),
+            color: Some(red().blend(blue().alpha(0.7))),
             strikethrough: Some(StrikethroughStyle {
                 thickness: px(4.),
-                color: Some(crate::red()),
+                color: Some(red()),
             }),
             // TODO this does not seem right
             fade_out: Some(0.),
             font_style: Some(FontStyle::Oblique),
             font_weight: Some(FontWeight(800.)),
-            background_color: Some(crate::green()),
+            background_color: Some(green()),
             underline: Some(UnderlineStyle {
                 thickness: px(4.),
                 color: None,
@@ -1422,14 +1422,14 @@ mod tests {
                 (
                     1..2,
                     HighlightStyle {
-                        color: Some(green()),
+                        color: Some(blue()),
                         ..Default::default()
                     }
                 ),
                 (
                     2..3,
                     HighlightStyle {
-                        color: Some(green()),
+                        color: Some(blue()),
                         font_style: Some(FontStyle::Italic),
                         ..Default::default()
                     }

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -1337,7 +1337,7 @@ mod tests {
                 wavy: true,
             }),
         };
-        let expected_style = style_b.clone();
+        let expected_style = style_b;
 
         style_a.highlight(style_b);
         assert_eq!(

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -429,23 +429,36 @@ impl Default for TextStyle {
 
 impl TextStyle {
     /// Create a new text style with the given highlighting applied.
-    pub fn highlight(self, style: impl Into<HighlightStyle>) -> Self {
+    pub fn highlight(mut self, style: impl Into<HighlightStyle>) -> Self {
         let style = style.into();
-        Self {
-            font_weight: style.font_weight.unwrap_or(self.font_weight),
-            font_style: style.font_style.unwrap_or(self.font_style),
-            color: style.color.map_or(self.color, |color| {
-                let mut new_color = self.color.blend(color);
-                if let Some(fade_out) = style.fade_out {
-                    new_color.fade_out(fade_out);
-                }
-                new_color
-            }),
-            background_color: style.background_color.or(self.background_color),
-            underline: style.underline.or(self.underline),
-            strikethrough: style.strikethrough.or(self.strikethrough),
-            ..self
+        if let Some(weight) = style.font_weight {
+            self.font_weight = weight;
         }
+        if let Some(style) = style.font_style {
+            self.font_style = style;
+        }
+
+        if let Some(color) = style.color {
+            self.color = self.color.blend(color);
+        }
+
+        if let Some(factor) = style.fade_out {
+            self.color.fade_out(factor);
+        }
+
+        if let Some(background_color) = style.background_color {
+            self.background_color = Some(background_color);
+        }
+
+        if let Some(underline) = style.underline {
+            self.underline = Some(underline);
+        }
+
+        if let Some(strikethrough) = style.strikethrough {
+            self.strikethrough = Some(strikethrough);
+        }
+
+        self
     }
 
     /// Get the font configured for this text style.

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -889,7 +889,7 @@ impl HighlightStyle {
     pub fn highlight(&mut self, other: HighlightStyle) {
         match (self.color, other.color) {
             (Some(self_color), Some(other_color)) => {
-                self.color = Some(Hsla::blend(self_color, other_color));
+                self.color = Some(self_color.blend(other_color));
             }
             (None, Some(other_color)) => {
                 self.color = Some(other_color);

--- a/crates/gpui/src/style.rs
+++ b/crates/gpui/src/style.rs
@@ -889,7 +889,7 @@ impl HighlightStyle {
     pub fn highlight(&mut self, other: HighlightStyle) {
         match (self.color, other.color) {
             (Some(self_color), Some(other_color)) => {
-                self.color = Some(Hsla::blend(other_color, self_color));
+                self.color = Some(Hsla::blend(self_color, other_color));
             }
             (None, Some(other_color)) => {
                 self.color = Some(other_color);

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -635,13 +635,13 @@ impl HighlightedTextBuilder {
             self.text.push_str(chunk.text);
             let end = self.text.len();
 
-            if let Some(mut highlight_style) = chunk
+            if let Some(highlight_style) = chunk
                 .syntax_highlight_id
                 .and_then(|id| id.style(syntax_theme))
             {
-                if let Some(override_style) = override_style {
-                    highlight_style.highlight(override_style);
-                }
+                let highlight_style = override_style.map_or(highlight_style, |override_style| {
+                    highlight_style.highlight(override_style)
+                });
                 self.highlights.push((start..end, highlight_style));
             } else if let Some(override_style) = override_style {
                 self.highlights.push((start..end, override_style));


### PR DESCRIPTION
Whilst looking into adding support for RainbowBrackes, we stumbled upon this: Whereas for all properties during this blending, we take the value of `other` if it is set, for the color we actually take `self.color` instead of `other.color` if `self.color` is at full opacity.  `Hsla::blend` returns the latter color if it is at full opacity, which seems wrong for this case. Hence, this PR swaps these.

Will not merge before the next release, to ensure that we don't break something somewhere unexpected.

Release Notes:

- N/A