### PR TITLE
onboarding: Fix font loading frame delay

### DIFF
--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{sync::Arc, time::Instant};
 
 use editor::{EditorSettings, ShowMinimap};
 use fs::Fs;
@@ -449,11 +449,16 @@ impl FontPickerDelegate {
     ) -> Self {
         let font_family_cache = FontFamilyCache::global(cx);
 
+        // 1. Load font families in a task on tab open
+        // 2. Store state of that in the onboarding page
+        // 3. When rendering the editing page, use that state (whether it's empty or not)
+        // 4. Don't re-create these pickers every frame.
+        let start_time = Instant::now();
         let fonts: Vec<SharedString> = font_family_cache
             .list_font_families(cx)
             .into_iter()
             .collect();
-
+        dbg!(start_time.elapsed());
         let selected_index = fonts
             .iter()
             .position(|font| *font == current_font)

--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -1,4 +1,4 @@
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 
 use editor::{EditorSettings, ShowMinimap};
 use fs::Fs;

--- a/crates/onboarding/src/editing_page.rs
+++ b/crates/onboarding/src/editing_page.rs
@@ -449,7 +449,9 @@ impl FontPickerDelegate {
     ) -> Self {
         let font_family_cache = FontFamilyCache::global(cx);
 
-        let fonts = font_family_cache.list_font_families(cx);
+        let fonts = font_family_cache
+            .try_list_font_families()
+            .unwrap_or_else(|| vec![current_font.clone()]);
         let selected_index = fonts
             .iter()
             .position(|font| *font == current_font)

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -12,7 +12,7 @@ use notifications::status_toast::{StatusToast, ToastIcon};
 use schemars::JsonSchema;
 use serde::Deserialize;
 use settings::{SettingsStore, VsCodeSettingsSource};
-use std::{sync::Arc, time::Instant};
+use std::sync::Arc;
 use ui::{
     Avatar, ButtonLike, FluentBuilder, Headline, KeyBinding, ParentElement as _,
     StatefulInteractiveElement, Vector, VectorName, prelude::*, rems_from_px,

--- a/crates/onboarding/src/onboarding.rs
+++ b/crates/onboarding/src/onboarding.rs
@@ -244,7 +244,7 @@ impl Onboarding {
     fn new(workspace: &Workspace, cx: &mut App) -> Entity<Self> {
         let font_family_cache = theme::FontFamilyCache::global(cx);
         cx.spawn(async move |cx| {
-            font_family_cache.fetch_font_names(cx).await;
+            font_family_cache.prefetch(cx).await;
         })
         .detach();
 
@@ -253,7 +253,6 @@ impl Onboarding {
             focus_handle: cx.focus_handle(),
             selected_page: SelectedPage::Basics,
             user_store: workspace.user_store().clone(),
-            last_frame_time: Instant::now(),
             _settings_subscription: cx.observe_global::<SettingsStore>(move |_, cx| cx.notify()),
         })
     }
@@ -519,7 +518,6 @@ impl Onboarding {
         match self.selected_page {
             SelectedPage::Basics => crate::basics_page::render_basics_page(cx).into_any_element(),
             SelectedPage::Editing => {
-                // div().into_any_element()
                 crate::editing_page::render_editing_page(window, cx).into_any_element()
             }
             SelectedPage::AiSetup => crate::ai_setup_page::render_ai_setup_page(
@@ -536,7 +534,7 @@ impl Onboarding {
 
 impl Render for Onboarding {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let result = h_flex()
+        h_flex()
             .image_cache(gpui::retain_all("onboarding-page"))
             .key_context({
                 let mut ctx = KeyContext::new_with_defaults();
@@ -590,8 +588,7 @@ impl Render for Onboarding {
                             .overflow_y_scroll()
                             .child(self.render_page(window, cx)),
                     ),
-            );
-        result
+            )
     }
 }
 

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -78,6 +78,7 @@ impl SettingsValue<serde_json::Value> {
         let fs = <dyn Fs>::global(cx);
 
         let rx = settings_store.update_settings_file_at_path(fs.clone(), path.as_slice(), value);
+
         let path = path.clone();
         cx.background_spawn(async move {
             rx.await?

--- a/crates/theme/src/font_family_cache.rs
+++ b/crates/theme/src/font_family_cache.rs
@@ -62,7 +62,6 @@ impl FontFamilyCache {
         {
             return;
         }
-        let mut lock = self.state.write();
 
         let Ok(text_system) = cx.update(|cx| App::text_system(cx).clone()) else {
             return;
@@ -81,6 +80,7 @@ impl FontFamilyCache {
             })
             .await;
 
+        let mut lock = self.state.write();
         lock.font_families = task;
         lock.loaded_at = Some(Instant::now());
     }

--- a/crates/theme/src/font_family_cache.rs
+++ b/crates/theme/src/font_family_cache.rs
@@ -53,8 +53,8 @@ impl FontFamilyCache {
         lock.font_families.clone()
     }
 
-    /// Prefetch all font names
-    pub async fn fetch_font_names(&self, cx: &gpui::AsyncApp) {
+    /// Prefetch all font names in the background
+    pub async fn prefetch(&self, cx: &gpui::AsyncApp) {
         if self
             .state
             .try_read()

--- a/crates/theme/src/font_family_cache.rs
+++ b/crates/theme/src/font_family_cache.rs
@@ -16,7 +16,7 @@ struct FontFamilyCacheState {
 /// so we do it once and then use the cached values each render.
 #[derive(Default)]
 pub struct FontFamilyCache {
-    state: RwLock<FontFamilyCacheState>,
+    state: Arc<RwLock<FontFamilyCacheState>>,
 }
 
 #[derive(Default)]
@@ -53,6 +53,14 @@ impl FontFamilyCache {
         lock.font_families.clone()
     }
 
+    /// Returns the list of font families if they have been loaded
+    pub fn try_list_font_families(&self) -> Option<Vec<SharedString>> {
+        self.state
+            .try_read()
+            .filter(|state| state.loaded_at.is_some())
+            .map(|state| state.font_families.clone())
+    }
+
     /// Prefetch all font names in the background
     pub async fn prefetch(&self, cx: &gpui::AsyncApp) {
         if self
@@ -67,21 +75,21 @@ impl FontFamilyCache {
             return;
         };
 
-        // We take the lock early to block any synchronous calls to `list_font_families` to this struct until fonts are loaded
-        // this won't affect performance because the struct would have to load the font families anyway
-        let task = cx
-            .background_executor()
+        let state = self.state.clone();
+
+        cx.background_executor()
             .spawn(async move {
-                text_system
+                // We take this lock in the background executor to ensure that synchronous calls to `list_font_families` are blocked while we are prefetching,
+                // while not blocking the main thread and risking deadlocks
+                let mut lock = state.write();
+                let all_font_names = text_system
                     .all_font_names()
                     .into_iter()
                     .map(SharedString::from)
-                    .collect()
+                    .collect();
+                lock.font_families = all_font_names;
+                lock.loaded_at = Some(Instant::now());
             })
             .await;
-
-        let mut lock = self.state.write();
-        lock.font_families = task;
-        lock.loaded_at = Some(Instant::now());
     }
 }


### PR DESCRIPTION
Closes #ISSUE

Fixed an issue where the first frame of the `Editing` page in onboarding would have a slight delay before rendering the first time it was navigated to. This was caused by listing the OS fonts on the main thread, blocking rendering. This PR fixes the issue by adding a new method to the font family cache to prefill the cache on a background thread.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
