### PR TITLE
Update Markdown selectors

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -236,6 +236,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#bfbdb6ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#628b80ff",
             "font_style": null,
@@ -251,12 +256,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fe8f40ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#aad84cff",
             "font_style": null,
             "font_weight": null
@@ -311,11 +316,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#a6a5a0ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#a6a5a0ff",
             "font_style": null,
@@ -326,12 +326,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#fe8f40ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#d2a6ffff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#5ac1feff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#5ac1feff",
             "font_style": null,
             "font_weight": null
@@ -363,11 +373,6 @@
           },
           "tag": {
             "color": "#5ac1feff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#fe8f40ff",
             "font_style": null,
             "font_weight": null
           },
@@ -627,6 +632,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#5c6166ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8ca7c2ff",
             "font_style": null,
@@ -642,12 +652,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#f98d3fff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#85b304ff",
             "font_style": null,
             "font_weight": null
@@ -702,11 +712,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#73777bff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#73777bff",
             "font_style": null,
@@ -717,12 +722,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#f98d3fff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#a37accff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#3b9ee5ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#3b9ee5ff",
             "font_style": null,
             "font_weight": null
@@ -754,11 +769,6 @@
           },
           "tag": {
             "color": "#3b9ee5ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#f98d3fff",
             "font_style": null,
             "font_weight": null
           },
@@ -1018,6 +1028,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#cccac2ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#7399a3ff",
             "font_style": null,
@@ -1033,12 +1048,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#fead66ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d5fe80ff",
             "font_style": null,
             "font_weight": null
@@ -1093,11 +1108,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#b4b3aeff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#b4b3aeff",
             "font_style": null,
@@ -1108,12 +1118,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#fead66ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#dfbfffff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#72cffeff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#72cffeff",
             "font_style": null,
             "font_weight": null
@@ -1145,11 +1165,6 @@
           },
           "tag": {
             "color": "#72cffeff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#fead66ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -245,6 +245,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -260,12 +265,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -320,11 +325,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#83a598ff",
             "font_style": null,
@@ -335,12 +335,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
@@ -372,11 +382,6 @@
           },
           "tag": {
             "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -650,6 +655,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -665,12 +675,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -725,11 +735,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#83a598ff",
             "font_style": null,
@@ -740,12 +745,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
@@ -777,11 +792,6 @@
           },
           "tag": {
             "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1055,6 +1065,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#b8bb25ff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
@@ -1070,12 +1085,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#8ec07cff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#d3869bff",
             "font_style": null,
             "font_weight": null
@@ -1130,11 +1145,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#ebdbb2ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#83a598ff",
             "font_style": null,
@@ -1145,12 +1155,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#fabd2eff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#83a598ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
@@ -1182,11 +1202,6 @@
           },
           "tag": {
             "color": "#8ec07cff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#83a598ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1460,6 +1475,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1475,12 +1495,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -1535,11 +1555,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#066578ff",
             "font_style": null,
@@ -1550,12 +1565,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
@@ -1587,11 +1612,6 @@
           },
           "tag": {
             "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -1865,6 +1885,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -1880,12 +1905,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -1940,11 +1965,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#066578ff",
             "font_style": null,
@@ -1955,12 +1975,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
@@ -1992,11 +2022,6 @@
           },
           "tag": {
             "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },
@@ -2270,6 +2295,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#79740eff",
+            "font_style": null,
+            "font_weight": 700
+          },
           "hint": {
             "color": "#677562ff",
             "font_style": null,
@@ -2285,12 +2315,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#427b58ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#8f3e71ff",
             "font_style": null,
             "font_weight": null
@@ -2345,11 +2375,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#282828ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#066578ff",
             "font_style": null,
@@ -2360,12 +2385,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#066578ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#b57613ff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#0b6678ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#0b6678ff",
             "font_style": null,
             "font_weight": null
@@ -2397,11 +2432,6 @@
           },
           "tag": {
             "color": "#427b58ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#066578ff",
             "font_style": null,
             "font_weight": null
           },

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -241,6 +241,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d07277ff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#788ca6ff",
             "font_style": null,
@@ -256,12 +261,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#73ade9ff",
             "font_style": "normal",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#6eb4bfff",
             "font_style": null,
             "font_weight": null
@@ -316,11 +321,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#d07277ff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#d07277ff",
             "font_style": null,
@@ -331,12 +331,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#a1c181ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#dfc184ff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#74ade8ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#74ade8ff",
             "font_style": null,
             "font_weight": null
@@ -368,11 +378,6 @@
           },
           "tag": {
             "color": "#74ade8ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#a1c181ff",
             "font_style": null,
             "font_weight": null
           },
@@ -640,6 +645,11 @@
             "font_style": null,
             "font_weight": null
           },
+          "heading": {
+            "color": "#d3604fff",
+            "font_style": null,
+            "font_weight": 400
+          },
           "hint": {
             "color": "#7274a7ff",
             "font_style": null,
@@ -655,12 +665,12 @@
             "font_style": null,
             "font_weight": null
           },
-          "link_text": {
+          "link": {
             "color": "#5b79e3ff",
             "font_style": "italic",
             "font_weight": null
           },
-          "link_uri": {
+          "link.uri": {
             "color": "#3882b7ff",
             "font_style": null,
             "font_weight": null
@@ -715,11 +725,6 @@
             "font_style": null,
             "font_weight": null
           },
-          "punctuation.list_marker": {
-            "color": "#d3604fff",
-            "font_style": null,
-            "font_weight": null
-          },
           "punctuation.markup": {
             "color": "#d3604fff",
             "font_style": null,
@@ -730,12 +735,22 @@
             "font_style": null,
             "font_weight": null
           },
+          "raw": {
+            "color": "#649f57ff",
+            "font_style": null,
+            "font_weight": null
+          },
           "selector": {
             "color": "#669f59ff",
             "font_style": null,
             "font_weight": null
           },
           "selector.pseudo": {
+            "color": "#5c78e2ff",
+            "font_style": null,
+            "font_weight": null
+          },
+          "strikethrough": {
             "color": "#5c78e2ff",
             "font_style": null,
             "font_weight": null
@@ -767,11 +782,6 @@
           },
           "tag": {
             "color": "#5c78e2ff",
-            "font_style": null,
-            "font_weight": null
-          },
-          "text.literal": {
-            "color": "#649f57ff",
             "font_style": null,
             "font_weight": null
           },

--- a/crates/languages/src/gitcommit/highlights.scm
+++ b/crates/languages/src/gitcommit/highlights.scm
@@ -1,8 +1,8 @@
-(subject) @markup.heading
+(subject) @heading.markup
 (path) @string.special.path
 (branch) @string.special.symbol
 (commit) @constant
-(item) @markup.link.url
+(item) @link.uri.markup
 (header) @tag
 (comment) @comment
 

--- a/crates/languages/src/markdown-inline/highlights.scm
+++ b/crates/languages/src/markdown-inline/highlights.scm
@@ -1,6 +1,6 @@
 (emphasis) @emphasis.markup
 (strong_emphasis) @emphasis.strong.markup
-(code_span) @text.literal.markup
+(code_span) @raw.markup
 (strikethrough) @strikethrough.markup
 
 [
@@ -10,13 +10,14 @@
   (full_reference_link)
   (image)
   (link_text)
-  (link_label)
-] @link_text.markup
+] @link.markup
 
-(inline_link ["(" ")"] @link_uri.markup)
-(image ["(" ")"] @link_uri.markup)
+(link_label) @link.label.markup
+
+(inline_link ["(" ")"] @link.uri.markup)
+(image ["(" ")"] @link.uri.markup)
 [
   (link_destination)
   (uri_autolink)
   (email_autolink)
-] @link_uri.markup
+] @link.uri.markup

--- a/crates/languages/src/markdown/highlights.scm
+++ b/crates/languages/src/markdown/highlights.scm
@@ -8,8 +8,8 @@
   (atx_heading)
   (setext_heading)
   (thematic_break)
-] @title.markup
-(setext_heading (paragraph) @title.markup)
+] @heading.markup
+(setext_heading (paragraph) @heading.markup)
 
 [
   (list_marker_plus)
@@ -17,7 +17,7 @@
   (list_marker_star)
   (list_marker_dot)
   (list_marker_parenthesis)
-] @punctuation.list_marker.markup
+] @punctuation.list.markup
 
 (block_quote_marker) @punctuation.markup
 (pipe_table_header "|" @punctuation.markup)
@@ -30,5 +30,6 @@
   (info_string)
 ] @punctuation.embedded.markup
 
-(link_reference_definition) @link_text.markup
-(link_destination) @link_uri.markup
+(link_reference_definition) @link.markup
+(link_label) @link.label.markup
+(link_destination) @link.uri.markup


### PR DESCRIPTION
Release Notes:

  - Introduced new Markdown selectors
  
This PR depends on PR #37669 and introduces new Markdown selectors.

| Zed 0.202.7 | With this PR |
| --- | --- |
| <img width="800" height="1080" alt="md-0 202 7" src="https://github.com/user-attachments/assets/6566f1e5-2ff4-4024-bbf4-6fbde49ce99a" /> | <img width="800" height="1080" alt="md-pr-v2" src="https://github.com/user-attachments/assets/b925e6b8-0d4e-4064-91bf-b40eb82ecb19" /> |

Changes to Markdown selectors:

- `# Heading`: `title.markup` -> `heading.markup`
- `-`, `1.`: `punctuation.list_marker.markup` -> `punctuation.list.markup`
- `[1]: url.com`, `[link](url.com)`: `link_text.markup` -> `link.markup`
- `url.com`: `link_uri.markup` -> `link.uri.markup`
- `[1]`: `link.label.markup`
- ``` `raw` ```: `text.literal.markup` -> `raw.markup`

````md

# Heading

Some stylized text:
- `raw`
- *italic*
- ~strike~
- **strong**

> quoted

```python
print("some code")
```

1. Here is an ![image](image.jpg)
2. A [link](https://github.com/zed-industries)
3. And even a [referenced link][1]

[1]: https://zed.dev

| tables | are |
| --- | --- |
| properly | scoped |

````
