### PR TITLE
Highlight labels in Go

### DIFF
--- a/crates/languages/src/go/highlights.scm
+++ b/crates/languages/src/go/highlights.scm
@@ -4,6 +4,8 @@
 (field_identifier) @property
 (package_identifier) @namespace
 
+(label_name) @label
+
 (keyed_element
   .
   (literal_element


### PR DESCRIPTION
Release Notes:

- Highlight labels in Go

| Zed 0.202.7 | With this PR |
| --- | --- |
| <img width="160" height="50" alt="go-0 202 7" src="https://github.com/user-attachments/assets/1a1b3b3c-52ae-41e3-a52b-c2a9bb7589d2" /> | <img width="160" height="50" alt="go-pr" src="https://github.com/user-attachments/assets/29020b9f-ed03-4298-aa5b-0201a81fd5e6" /> |

