### PR TITLE
Highlight shorthand fields in Rust

### DIFF
--- a/crates/languages/src/rust/highlights.scm
+++ b/crates/languages/src/rust/highlights.scm
@@ -5,6 +5,7 @@
 (primitive_type) @type.builtin
 (self) @variable.special
 (field_identifier) @property
+(shorthand_field_identifier) @property
 
 (trait_item name: (type_identifier) @type.interface)
 (impl_item trait: (type_identifier) @type.interface)


### PR DESCRIPTION
Release Notes:

- Highlight shorthand fields in Rust

| Zed 0.202.7 | With this PR |
| --- | --- |
| <img width="370" height="50" alt="rust-0 202 7" src="https://github.com/user-attachments/assets/856a4d82-3ad0-4248-ad51-0472a0b6531a" /> | <img width="370" height="50" alt="rust-pr" src="https://github.com/user-attachments/assets/25b8e357-8519-4533-9026-3f2874b42ddb" /> |