### PR TITLE
inline assist: Fix scroll on first line

### DIFF
--- a/crates/agent_ui/src/inline_assistant.rs
+++ b/crates/agent_ui/src/inline_assistant.rs
@@ -1226,6 +1226,8 @@ impl InlineAssistant {
             scroll_target_top -= editor.vertical_scroll_margin() as f32;
             scroll_target_bottom += editor.vertical_scroll_margin() as f32;
 
+            scroll_target_top = scroll_target_top.max(0.0);
+
             let height_in_lines = editor.visible_line_count().unwrap_or(0.);
             let scroll_top = editor.scroll_position(cx).y;
             let scroll_bottom = scroll_top + height_in_lines;


### PR DESCRIPTION
When opening inline assist on the first line, top portion of the prompt is cut off

PR on the left, current on the right:
<img width="1680" height="1050" alt="image" src="https://github.com/user-attachments/assets/d404d2e6-005c-471b-90e0-21f366b55040" />

Release Notes:

- N/A