### PR TITLE
Allow for additional local settings in .zed/settings.local.json

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1243,6 +1243,7 @@
       "**/.dev.vars",
       "**/secrets.yml",
       "**/.zed/settings.json", // zed project settings
+      "**/.zed/settings.local.json", // zed additional project settings
       "/**/zed/settings.json", // zed user settings
       "/**/zed/keymap.json"
     ],

--- a/crates/paths/src/paths.rs
+++ b/crates/paths/src/paths.rs
@@ -412,6 +412,11 @@ pub fn local_settings_file_relative_path() -> &'static Path {
     Path::new(".zed/settings.json")
 }
 
+/// Returns the relative path to a `settings.local.json` file within a project.
+pub fn additional_local_settings_file_relative_path() -> &'static Path {
+    Path::new(".zed/settings.local.json")
+}
+
 /// Returns the relative path to a `tasks.json` file within a project.
 pub fn local_tasks_file_relative_path() -> &'static Path {
     Path::new(".zed/tasks.json")

--- a/crates/project/src/project_settings.rs
+++ b/crates/project/src/project_settings.rs
@@ -7,7 +7,8 @@ use futures::StreamExt as _;
 use gpui::{App, AsyncApp, BorrowAppContext, Context, Entity, EventEmitter, Subscription, Task};
 use lsp::LanguageServerName;
 use paths::{
-    EDITORCONFIG_NAME, local_debug_file_relative_path, local_settings_file_relative_path,
+    EDITORCONFIG_NAME, additional_local_settings_file_relative_path,
+    local_debug_file_relative_path, local_settings_file_relative_path,
     local_tasks_file_relative_path, local_vscode_launch_file_relative_path,
     local_vscode_tasks_file_relative_path, task_file_name,
 };
@@ -879,6 +880,17 @@ impl SettingsObserver {
                 let settings_dir = Arc::<Path>::from(
                     path.ancestors()
                         .nth(local_settings_file_relative_path().components().count())
+                        .unwrap(),
+                );
+                (settings_dir, LocalSettingsKind::Settings)
+            } else if path.ends_with(additional_local_settings_file_relative_path()) {
+                let settings_dir = Arc::<Path>::from(
+                    path.ancestors()
+                        .nth(
+                            additional_local_settings_file_relative_path()
+                                .components()
+                                .count(),
+                        )
                         .unwrap(),
                 );
                 (settings_dir, LocalSettingsKind::Settings)

--- a/crates/project/src/project_tests.rs
+++ b/crates/project/src/project_tests.rs
@@ -9528,3 +9528,125 @@ async fn test_find_project_path_abs(
         );
     });
 }
+
+#[gpui::test]
+async fn test_local_settings_with_local_override(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor().clone());
+
+    // Create a project with both settings.json and settings.local.json
+    fs.insert_tree(
+        "/dir",
+        json!({
+            ".zed": {
+                "settings.json": r#"{
+                    "tab_size": 4,
+                    "soft_wrap": "none",
+                    "preferred_line_length": 100
+                }"#,
+                "settings.local.json": r#"{
+                    "tab_size": 2,
+                    "preferred_line_length": 120
+                }"#
+            },
+            "src": {
+                ".zed": {
+                    "settings.json": r#"{
+                        "tab_size": 8,
+                        "remove_trailing_whitespace_on_save": true
+                    }"#,
+                    "settings.local.json": r#"{
+                        "tab_size": 3
+                    }"#
+                },
+                "file.txt": "content"
+            },
+            "file.txt": "content"
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let worktree = project.read_with(cx, |project, cx| project.worktrees(cx).next().unwrap());
+
+    // Wait for the settings to be loaded
+    cx.executor().run_until_parked();
+    
+    // Give more time for async operations
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    cx.executor().run_until_parked();
+
+    // Test root directory settings - local should override base
+    cx.read(|cx| {
+        let tree = worktree.read(cx);
+        let file_root = File::for_entry(
+            tree.entry_for_path("file.txt").unwrap().clone(),
+            worktree.clone(),
+        ) as _;
+        let settings_root = language_settings(None, Some(&file_root), cx);
+        
+        // tab_size should be 2 from local, not 4 from base
+        assert_eq!(settings_root.tab_size.get(), 2);
+        
+        // preferred_line_length should be 120 from local, not 100 from base
+        assert_eq!(settings_root.preferred_line_length, 120);
+        
+        // soft_wrap should be "none" from base (not overridden in local)
+        assert_eq!(settings_root.soft_wrap, language::language_settings::SoftWrap::None);
+    });
+
+    // Test src directory settings - local should override base  
+    cx.read(|cx| {
+        let tree = worktree.read(cx);
+        let file_src = File::for_entry(
+            tree.entry_for_path("src/file.txt").unwrap().clone(),
+            worktree.clone(),
+        ) as _;
+        let settings_src = language_settings(None, Some(&file_src), cx);
+        
+        // tab_size should be 3 from src/.zed/settings.local.json, not 8 from src/.zed/settings.json
+        assert_eq!(settings_src.tab_size.get(), 3);
+        
+        // remove_trailing_whitespace_on_save should be true from base (not overridden in local)
+        assert_eq!(settings_src.remove_trailing_whitespace_on_save, true);
+    });
+}
+
+#[gpui::test]
+async fn test_simple_local_settings(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor().clone());
+
+    // Test just settings.local.json by itself
+    fs.insert_tree(
+        "/dir",
+        json!({
+            ".zed": {
+                "settings.local.json": r#"{ "tab_size": 2 }"#
+            },
+            "file.txt": "content"
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs, [path!("/dir").as_ref()], cx).await;
+    let worktree = project.read_with(cx, |project, cx| project.worktrees(cx).next().unwrap());
+    
+    cx.executor().run_until_parked();
+    std::thread::sleep(std::time::Duration::from_millis(100));
+    cx.executor().run_until_parked();
+
+    cx.read(|cx| {
+        let tree = worktree.read(cx);
+        let file_root = File::for_entry(
+            tree.entry_for_path("file.txt").unwrap().clone(),
+            worktree.clone(),
+        ) as _;
+        let settings_root = language_settings(None, Some(&file_root), cx);
+        
+        // Should be 2 from settings.local.json (default would be 4)
+        assert_eq!(settings_root.tab_size.get(), 2);
+    });
+}

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -19,6 +19,8 @@ This configuration is merged with any local configuration inside your projects. 
 
 Although most projects will only need one settings file at the root, you can add more local settings files for subdirectories as needed. Not all settings can be set in local files, just those that impact the behavior of the editor and language tooling. For example you can set `tab_size`, `formatter` etc. but not `theme`, `vim_mode` and similar.
 
+You also add an additional local settings in `.zed/settings.local.json` to override settings in the corresponding `.zed/settings.json`. This is useful when you would like the ability to track some settings in version control so they can be shared among people, while ignoring others so that individual can provide their own settings. You can configure the version control system for you project (e.g. git) to ignore `.zed/settings.local.json` but not `.zed/settings.json`.
+
 The syntax for configuration files is a super-set of JSON that allows `//` comments.
 
 ## Default settings


### PR DESCRIPTION
Closes #13300.
Related to #16392 (but does not close it).

This PR adds the local file `.zed/settings.local.json` among the files looked up for settings.

This mainly fulfills the following use case: track some local settings in git so they can be shared with contributors (in `settings.json`), while still allowing them to add there own untracked settings for personal preferences (in `settings.local.json`).

It also fulfills a more niche use case: when having multiple worktrees for the same repository, it is desirable to override Zed's theme for specific worktrees so that one can easily differentiate between them when multiple are open.

I kept things very simple. Other than being read for local settings, the presence of `settings.local.json` does not affect anything else. It cannot be opened from the command palette and is never mentioned across the documentation other than the specific section on local configuration.

This solution and the chosen file name have been inspired, among others, by Claude Code, that reads from both `.claude/settings.json` and `.claude/settings.local.json`.

[The same suggestion was made to VSCode 8 years ago](https://github.com/microsoft/vscode/issues/37519), but they discarded it in favor of decoupling workspace settings from local settings, which Zed does not do. If Zed intends to eventually offer a feature similar to VSCode's workspaces, it may be preferable not to merge this Pull Request. This would save on some complexity.

Release Notes:

- Added the ability to read local settings from `.zed/settings.local.json` in addition to `.zed/settings.json`.
