### PR TITLE
Add whitespace_map setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -361,6 +361,11 @@
   // - It is adjacent to an edge (start or end)
   // - It is adjacent to a whitespace (left or right)
   "show_whitespaces": "selection",
+  // Visible characters used to render whitespace when show_whitespaces is enabled.
+  "whitespace_map": {
+    "space": "•",
+    "tab": "→"
+  },
   // Settings related to calls in Zed
   "calls": {
     // Join calls with the microphone live by default

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9252,11 +9252,21 @@ impl Element for EditorElement {
                     });
 
                     let invisible_symbol_font_size = font_size / 2.;
+                    let whitespace_map = &self
+                        .editor
+                        .read(cx)
+                        .buffer
+                        .read(cx)
+                        .language_settings(cx)
+                        .whitespace_map;
+
+                    let tab_char = whitespace_map.tab.clone();
+                    let tab_len = tab_char.len();
                     let tab_invisible = window.text_system().shape_line(
-                        "→".into(),
+                        tab_char.into(),
                         invisible_symbol_font_size,
                         &[TextRun {
-                            len: "→".len(),
+                            len: tab_len,
                             font: self.style.text.font(),
                             color: cx.theme().colors().editor_invisible,
                             background_color: None,
@@ -9265,11 +9275,14 @@ impl Element for EditorElement {
                         }],
                         None,
                     );
+
+                    let space_char = whitespace_map.space.clone();
+                    let space_len = space_char.len();
                     let space_invisible = window.text_system().shape_line(
-                        "•".into(),
+                        space_char.into(),
                         invisible_symbol_font_size,
                         &[TextRun {
-                            len: "•".len(),
+                            len: space_len,
                             font: self.style.text.font(),
                             color: cx.theme().colors().editor_invisible,
                             background_color: None,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9263,7 +9263,7 @@ impl Element for EditorElement {
                     let tab_char = whitespace_map.tab();
                     let tab_len = tab_char.len();
                     let tab_invisible = window.text_system().shape_line(
-                        tab_char.into(),
+                        tab_char,
                         invisible_symbol_font_size,
                         &[TextRun {
                             len: tab_len,
@@ -9279,7 +9279,7 @@ impl Element for EditorElement {
                     let space_char = whitespace_map.space();
                     let space_len = space_char.len();
                     let space_invisible = window.text_system().shape_line(
-                        space_char.into(),
+                        space_char,
                         invisible_symbol_font_size,
                         &[TextRun {
                             len: space_len,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9260,7 +9260,7 @@ impl Element for EditorElement {
                         .language_settings(cx)
                         .whitespace_map;
 
-                    let tab_char = whitespace_map.tab.clone();
+                    let tab_char = whitespace_map.tab();
                     let tab_len = tab_char.len();
                     let tab_invisible = window.text_system().shape_line(
                         tab_char.into(),
@@ -9276,7 +9276,7 @@ impl Element for EditorElement {
                         None,
                     );
 
-                    let space_char = whitespace_map.space.clone();
+                    let space_char = whitespace_map.space();
                     let space_len = space_char.len();
                     let space_invisible = window.text_system().shape_line(
                         space_char.into(),

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -123,6 +123,8 @@ pub struct LanguageSettings {
     pub edit_predictions_disabled_in: Vec<String>,
     /// Whether to show tabs and spaces in the editor.
     pub show_whitespaces: ShowWhitespaceSetting,
+    /// Visible characters used to render whitespace when show_whitespaces is enabled.
+    pub whitespace_map: WhitespaceMap,
     /// Whether to start a new line with a comment when a previous line is a comment as well.
     pub extend_comment_on_newline: bool,
     /// Inlay hint related settings.
@@ -542,6 +544,9 @@ pub struct LanguageSettingsContent {
     /// Whether to show tabs and spaces in the editor.
     #[serde(default)]
     pub show_whitespaces: Option<ShowWhitespaceSetting>,
+    /// Visible characters used to render whitespace when show_whitespaces is enabled.
+    #[serde(default)]
+    pub whitespace_map: Option<WhitespaceMap>,
     /// Whether to start a new line with a comment when a previous line is a comment as well.
     ///
     /// Default: true
@@ -813,6 +818,15 @@ pub enum ShowWhitespaceSetting {
     Boundary,
     /// Draw whitespaces only after non-whitespace characters.
     Trailing,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, SettingsUi)]
+pub struct WhitespaceMap {
+    #[serde(default)]
+    pub space: String,
+
+    #[serde(default)]
+    pub tab: String,
 }
 
 /// Controls which formatter should be used when formatting code.
@@ -1603,6 +1617,7 @@ fn merge_settings(settings: &mut LanguageSettings, src: &LanguageSettingsContent
         src.edit_predictions_disabled_in.clone(),
     );
     merge(&mut settings.show_whitespaces, src.show_whitespaces);
+    merge(&mut settings.whitespace_map, src.whitespace_map.clone());
     merge(
         &mut settings.extend_comment_on_newline,
         src.extend_comment_on_newline,

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -8,7 +8,7 @@ use ec4rs::{
     property::{FinalNewline, IndentSize, IndentStyle, MaxLineLen, TabWidth, TrimTrailingWs},
 };
 use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
-use gpui::{App, Modifiers};
+use gpui::{App, Modifiers, SharedString};
 use itertools::{Either, Itertools};
 use schemars::{JsonSchema, json_schema};
 use serde::{
@@ -545,6 +545,8 @@ pub struct LanguageSettingsContent {
     #[serde(default)]
     pub show_whitespaces: Option<ShowWhitespaceSetting>,
     /// Visible characters used to render whitespace when show_whitespaces is enabled.
+    ///
+    /// Default: "•" for spaces, "→" for tabs.
     #[serde(default)]
     pub whitespace_map: Option<WhitespaceMap>,
     /// Whether to start a new line with a comment when a previous line is a comment as well.
@@ -823,10 +825,23 @@ pub enum ShowWhitespaceSetting {
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, PartialEq, SettingsUi)]
 pub struct WhitespaceMap {
     #[serde(default)]
-    pub space: String,
-
+    pub space: Option<String>,
     #[serde(default)]
-    pub tab: String,
+    pub tab: Option<String>,
+}
+
+impl WhitespaceMap {
+    pub fn space(&self) -> SharedString {
+        self.space
+            .as_ref()
+            .map_or_else(|| SharedString::from("•"), |s| SharedString::from(s))
+    }
+
+    pub fn tab(&self) -> SharedString {
+        self.tab
+            .as_ref()
+            .map_or_else(|| SharedString::from("→"), |s| SharedString::from(s))
+    }
 }
 
 /// Controls which formatter should be used when formatting code.


### PR DESCRIPTION
This setting controls which visible characters are used to render whitespace when the show_whitespace setting is enabled. Apart from more customization, the primary motivation for me is to allow hiding the default whitespace character. For example, our projects use tabs for indentation. I'd like to hide tabs but show spaces so that it's obvious when the indentation is wrong, without having to look at all rendered tabs.

<img width="712" height="222" alt="image" src="https://github.com/user-attachments/assets/25bb6be5-458d-4970-a580-b87cd59e533e" />

Release Notes:

- Added `whitespace_map` setting to control which visible characters are used to render whitespace when the `show_whitespace` setting is enabled.