### PR TITLE
Revert "gpui: Skip `test` attribute expansion for rust-analyzer (#37611)"

### DIFF
--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -121,14 +121,6 @@ mod seal {
     pub trait Sealed {}
 }
 
-// This allows r-a to skip expanding the gpui test macro which should
-// reduce resource usage a bit as the test attribute is special cased
-// to be treated as a no-op.
-#[cfg(rust_analyzer)]
-pub use core::prelude::v1::test;
-#[cfg(not(rust_analyzer))]
-pub use gpui_macros::test;
-
 pub use action::*;
 pub use anyhow::Result;
 pub use app::*;
@@ -142,7 +134,7 @@ pub use elements::*;
 pub use executor::*;
 pub use geometry::*;
 pub use global::*;
-pub use gpui_macros::{AppContext, IntoElement, Render, VisualContext, register_action};
+pub use gpui_macros::{AppContext, IntoElement, Render, VisualContext, register_action, test};
 pub use http_client;
 pub use input::*;
 pub use inspector::*;


### PR DESCRIPTION
This reverts commit 4124bedab796d2ac0a1e57f8b94f72500969797a.

With the new annotation, r-a starts to skip the tasks that are marked with `gpui::test` and when it fully loads, it starts to return module-only tasks:

https://github.com/user-attachments/assets/5af3e3e4-91b7-4f19-aab0-ed7f186e5f74


Release Notes:

- N/A
