### PR TITLE
Install mold from the OS on Debian 13 (Trixie)

### DIFF
--- a/script/linux
+++ b/script/linux
@@ -47,7 +47,10 @@ if [[ -n $apt ]]; then
     musl-dev
     build-essential
   )
-  if (grep -qP 'PRETTY_NAME="(Linux Mint 22|.+24\.(04|10))' /etc/os-release); then
+  if (grep -qP 'PRETTY_NAME="((Debian|Raspbian).+13|' /etc/os-release); then
+      # libstdc++-14-dev is in build-essential
+      deps+=( mold )
+  elif (grep -qP 'PRETTY_NAME="(Linux Mint 22|.+24\.(04|10))' /etc/os-release); then
     deps+=( mold libstdc++-14-dev )
   elif (grep -qP 'PRETTY_NAME="((Debian|Raspbian).+12|Linux Mint 21|.+22\.04)' /etc/os-release); then
     deps+=( mold libstdc++-12-dev )


### PR DESCRIPTION
I ran `scripts/linux` on Debian Trixie 13. It suggested manually installing Mold, but [mold](http://packages.debian.org/mold) is packaged on Debian and so we could install it automatically.

The version packaged there seems to work well enough for `cargo t` to pass, at least.

## Tested

```
; sudo apt remove mold libstdc++-14-dev
... uninstalls them
; ./script/linux
The following NEW packages will be installed:
  build-essential clang clang-19 clang-tools-19 g++ g++-14 g++-14-x86-64-linux-gnu g++-x86-64-linux-gnu libstdc++-14-dev mold
; cargo t
(passes)
```

Release Notes:

- N/A