### PR TITLE
tests: Fix doctests in crates/component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3515,6 +3515,7 @@ name = "component"
 version = "0.1.0"
 dependencies = [
  "collections",
+ "documented",
  "gpui",
  "inventory",
  "parking_lot",

--- a/crates/component/Cargo.toml
+++ b/crates/component/Cargo.toml
@@ -20,5 +20,8 @@ strum.workspace = true
 theme.workspace = true
 workspace-hack.workspace = true
 
+[dev-dependencies]
+documented.workspace = true
+
 [features]
 default = []

--- a/crates/component/src/component.rs
+++ b/crates/component/src/component.rs
@@ -227,6 +227,8 @@ pub trait Component {
     /// Example:
     ///
     /// ```
+    /// use documented::Documented;
+    ///
     /// /// This is a doc comment.
     /// #[derive(Documented)]
     /// struct MyComponent;


### PR DESCRIPTION
Previously, `cargo test --package component` failed due to missing imports for a doctest:


```

   Doc-tests component

running 1 test
test crates/component/src/component.rs - Component::description (line 229) ... FAILED

failures:

---- crates/component/src/component.rs - Component::description (line 229) stdout ----
error: cannot find derive macro `Documented` in this scope
 --> crates/component/src/component.rs:231:10
  |
4 | #[derive(Documented)]
  |          ^^^^^^^^^^

error[E0599]: no associated item named `DOCS` found for struct `MyComponent` in the current scope
 --> crates/component/src/component.rs:236:20
  |
5 | struct MyComponent;
  | ------------------ associated item `DOCS` not found for this struct
...
9 |         Some(Self::DOCS)
  |                    ^^^^ associated item not found in `MyComponent`

error: aborting due to 2 previous errors

For more information about this error, try `rustc --explain E0599`.
Couldn't compile the test.

failures:
    crates/component/src/component.rs - Component::description (line 229)

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.29s

error: doctest failed, to rerun pass `-p component --doc`
bobcat ~/src/zed (doctests) 18:33

``` 

This might be unnoticed if you mostly run nextest, as it does not run doctests.

Release Notes:

- N/A 
