### PR TITLE
Fix docs for `tabs.close_position` in `default.json`

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -962,7 +962,7 @@
     // Show git status colors in the editor tabs.
     "git_status": false,
     // Position of the close button on the editor tabs.
-    // One of: ["right", "left", "hidden"]
+    // One of: ["right", "left"]
     "close_position": "right",
     // Whether to show the file icon for a tab.
     "file_icons": false,


### PR DESCRIPTION
Minor docs fix.
Seems like 0a4ff2f47536c872ebd1ac3e672538a6251832e8 accidentally added "hidden" to the docs of both – `close_position` and `show_close_button`.

Release Notes:

- N/A