### PR TITLE
Don't let `ctrl-g` clobber git panel keybindings in Emacs keymap

### DIFF
--- a/assets/keymaps/macos/emacs.json
+++ b/assets/keymaps/macos/emacs.json
@@ -4,6 +4,7 @@
 // from the command palette.
 [
   {
+    "context": "!GitPanel",
     "bindings": {
       "ctrl-g": "menu::Cancel"
     }


### PR DESCRIPTION
i'm testing out zed, coming from emacs, and so i'm trying out the base keymap for it. i noticed though that zed's default git keybindings don't work when the gitpanel is open though, because of the top-level binding of `ctrl-g` to cancel. my expectation is that the emacs-like keybindings would work insofar as they don't clobber zed's defaults (which would take precedence), but obviously i'll defer to others on this!

another option could be to use the `C-x v` keymap prefix that the emacs built-in `vc` package uses, but it doesn't contain the same set of bindings for git commands that zed has.