### PR TITLE
docs: Fix typos in language configurations

### DIFF
--- a/docs/src/languages/c.md
+++ b/docs/src/languages/c.md
@@ -8,14 +8,14 @@ C support is available natively in Zed.
 
 ## Clangd: Force detect as C
 
-Clangd out of the box assumes mixed C++/C projects. If you have a C-only project you may wish to instruct clangd to all files as C using the `-xc` flag. To do this, create a `.clangd` file in the root of your project with the following:
+Clangd out of the box assumes mixed C++/C projects. If you have a C-only project you may wish to instruct clangd to treat all files as C using the `-xc` flag. To do this, create a `.clangd` file in the root of your project with the following:
 
 ```yaml
 CompileFlags:
   Add: [-xc]
 ```
 
-By default clang and gcc by will recognize `*.C` and `*.H` (uppercase extensions) as C++ and not C and so Zed too follows this convention. If you are working with a C-only project (perhaps one with legacy uppercase pathing like `FILENAME.C`) you can override this behavior by adding this to your settings:
+By default clang and gcc will recognize `*.C` and `*.H` (uppercase extensions) as C++ and not C and so Zed too follows this convention. If you are working with a C-only project (perhaps one with legacy uppercase pathing like `FILENAME.C`) you can override this behavior by adding this to your settings:
 
 ```json
 {

--- a/docs/src/languages/cpp.md
+++ b/docs/src/languages/cpp.md
@@ -44,7 +44,7 @@ If you want to use a binary in a custom location, you can specify a `path` and o
 ```json
 {
   "lsp": {
-    "cangd": {
+    "clangd": {
       "binary": {
         "path": "/path/to/clangd",
         "arguments": []

--- a/docs/src/languages/rust.md
+++ b/docs/src/languages/rust.md
@@ -112,7 +112,7 @@ This `"path"` has to be an absolute path.
 
 ## Alternate Targets
 
-If want rust-analyzer to provide diagnostics for a target other than you current platform (e.g. for windows when running on macOS) you can use the following Zed lsp settings:
+If you want rust-analyzer to provide diagnostics for a target other than your current platform (e.g. for windows when running on macOS) you can use the following Zed lsp settings:
 
 ```json
 {
@@ -128,7 +128,7 @@ If want rust-analyzer to provide diagnostics for a target other than you current
 }
 ```
 
-If you are using `rustup` and you can find a list of available target triples (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, etc) by running:
+If you are using `rustup`, you can find a list of available target triples (`aarch64-apple-darwin`, `x86_64-unknown-linux-gnu`, etc) by running:
 
 ```sh
 rustup target list --installed
@@ -239,7 +239,7 @@ you can list them in `linkedProjects` in the local project settings:
 
 ### Snippets
 
-There's a way get custom completion items from rust-analyzer, that will transform the code according to the snippet body:
+There's a way to get custom completion items from rust-analyzer, that will transform the code according to the snippet body:
 
 ```json
 {


### PR DESCRIPTION
Fixes several typos in the docs. I think there are more but I have only read what I actually needed :)

Release Notes:

- N/A