### PR TITLE
gpui: Fix choppy scrolling on macOS 26

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -304,6 +304,10 @@ unsafe fn build_classes() {
                     sel!(inlinePredictionType),
                     inline_prediction_type_none as extern "C" fn(&Object, Sel) -> NSInteger,
                 );
+                decl.add_method(
+                    sel!(textContentType),
+                    return_nil as extern "C" fn(&Object, Sel) -> id,
+                );
             }
             decl.register()
         };
@@ -1665,6 +1669,10 @@ extern "C" fn autocorrection_type_no(_: &Object, _: Sel) -> NSInteger {
 
 extern "C" fn inline_prediction_type_none(_: &Object, _: Sel) -> NSInteger {
     NSTextInlinePredictionTypeNone
+}
+
+extern "C" fn return_nil(_: &Object, _: Sel) -> id {
+    nil
 }
 
 extern "C" fn dealloc_window(this: &Object, _: Sel) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -84,6 +84,10 @@ type NSDragOperation = NSUInteger;
 const NSDragOperationNone: NSDragOperation = 0;
 #[allow(non_upper_case_globals)]
 const NSDragOperationCopy: NSDragOperation = 1;
+#[allow(non_upper_case_globals)]
+const NSTextAutocorrectionTypeNo: NSInteger = 1;
+#[allow(non_upper_case_globals)]
+const NSTextInlinePredictionTypeNone: NSInteger = 1;
 #[derive(PartialEq)]
 pub enum UserTabbingPreference {
     Never,
@@ -279,6 +283,26 @@ unsafe fn build_classes() {
                 decl.add_method(
                     sel!(isAutomaticTextReplacementEnabled),
                     no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isContinuousSpellCheckingEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isGrammarCheckingEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isSmartInsertDeleteEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(autocorrectionType),
+                    autocorrection_type_no as extern "C" fn(&Object, Sel) -> NSInteger,
+                );
+                decl.add_method(
+                    sel!(inlinePredictionType),
+                    inline_prediction_type_none as extern "C" fn(&Object, Sel) -> NSInteger,
                 );
             }
             decl.register()
@@ -1633,6 +1657,14 @@ extern "C" fn yes(_: &Object, _: Sel) -> BOOL {
 
 extern "C" fn no(_: &Object, _: Sel) -> BOOL {
     NO
+}
+
+extern "C" fn autocorrection_type_no(_: &Object, _: Sel) -> NSInteger {
+    NSTextAutocorrectionTypeNo
+}
+
+extern "C" fn inline_prediction_type_none(_: &Object, _: Sel) -> NSInteger {
+    NSTextInlinePredictionTypeNone
 }
 
 extern "C" fn dealloc_window(this: &Object, _: Sel) {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -249,6 +249,37 @@ unsafe fn build_classes() {
                     sel!(characterIndexForPoint:),
                     character_index_for_point as extern "C" fn(&Object, Sel, NSPoint) -> u64,
                 );
+
+                // Disable automatic text substitutions and services, which cause
+                // performance issues by constantly running heuristics on macOS 26.
+                decl.add_method(
+                    sel!(isAutomaticTextCompletionEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isAutomaticQuoteSubstitutionEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isAutomaticDashSubstitutionEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isAutomaticLinkDetectionEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isAutomaticDataDetectionEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isAutomaticSpellingCorrectionEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
+                decl.add_method(
+                    sel!(isAutomaticTextReplacementEnabled),
+                    no as extern "C" fn(&Object, Sel) -> BOOL,
+                );
             }
             decl.register()
         };
@@ -1598,6 +1629,10 @@ unsafe fn drop_window_state(object: &Object) {
 
 extern "C" fn yes(_: &Object, _: Sel) -> BOOL {
     YES
+}
+
+extern "C" fn no(_: &Object, _: Sel) -> BOOL {
+    NO
 }
 
 extern "C" fn dealloc_window(this: &Object, _: Sel) {


### PR DESCRIPTION
Closes #33182

This only happened to me once after extended use of Zed Nightly on macOS 26 Beta. The trace shows it’s caused by the built-in Autofill feature, specifically `NSAutoFillHeuristicController` and `showOrHideAutoFillForCurrentTextInputContextIfAppropriate`, which likely checks the current text field and decides whether autofill is relevant. Disabling autofill is a straightforward fix, and I don’t think we need it in Zed.
 
I haven’t been able to fully test if this resolves the issue since it happens so rarely.

Trace:
<img width="500" alt="trace" src="https://github.com/user-attachments/assets/342c45f9-d447-42ef-be63-2fe65b952b63" />

Docs:

macOS 10.12.2+

- [isAutomaticTextCompletionEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomatictextcompletionenabled?language=objc)
- [isAutomaticQuoteSubstitutionEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomaticquotesubstitutionenabled?language=objc)
- [isAutomaticDashSubstitutionEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomaticdashsubstitutionenabled?language=objc)
- [isAutomaticLinkDetectionEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomaticlinkdetectionenabled?language=objc)
- [isAutomaticDataDetectionEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomaticdatadetectionenabled?language=objc)
- [isAutomaticSpellingCorrectionEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomaticspellingcorrectionenabled?language=objc)
- [isAutomaticTextReplacementEnabled](https://developer.apple.com/documentation/appkit/nstextview/isautomatictextreplacementenabled?language=objc)

Release Notes:

- Fixed an issue where scrolling could sometimes feel choppy on macOS 26 Beta.