### PR TITLE
cargo: Remove unused -fuse-ld=lld flag from Win config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,8 +19,6 @@ rustflags = [
     "windows_slim_errors",        # This cfg will reduce the size of `windows::core::Error` from 16 bytes to 4 bytes
     "-C",
     "target-feature=+crt-static", # This fixes the linking issue when compiling livekit on Windows
-    "-C",
-    "link-arg=-fuse-ld=lld",
 ]
 
 [env]


### PR DESCRIPTION
It is unused and generates a warning

```
 LINK : warning LNK4044: unrecognized option '/fuse-ld=lld'; ignored
```

If in the future we want to give `lld-link.exe` a try, we can set

```toml
linker = "lld-link.exe"
```

instead. At the time of writing, my tests have shown that there is no real difference between `lld-link` and `link` in terms of linking speed.

Release Notes:

- N/A
