### PR TITLE
rust: Fix `block_comment` and `documentation_comment`

### DIFF
--- a/crates/languages/src/rust/config.toml
+++ b/crates/languages/src/rust/config.toml
@@ -2,6 +2,8 @@ name = "Rust"
 grammar = "rust"
 path_suffixes = ["rs"]
 line_comments = ["// ", "/// ", "//! "]
+block_comment = { start = "/*", prefix = "", end = "*/", tab_size = 1 }
+documentation_comment = { start = "/**", prefix = "", end = "*/", tab_size = 1 }
 autoclose_before = ";:.,=}])>"
 brackets = [
     { start = "{", end = "}", close = true, newline = true },
@@ -16,4 +18,3 @@ brackets = [
 ]
 collapsed_placeholder = " /* ... */ "
 debuggers = ["CodeLLDB", "GDB"]
-documentation_comment = { start = "/*", prefix = "* ", end = "*/", tab_size = 1 }


### PR DESCRIPTION
Solves unnecessary asterisk (`*`) placement for each next line in the block comment if `languages.Rust.extend_comment_on_newline` is enabled.

### `block_comment`

Before fix:
```
/*
 * <- this `*` is unnecessary and harmful, despite that the code is valid
 */
```

After fix:
```
/*
 <- no star
 */
```


### `documentation_comment`

Before fix:
```
/**
 * <- this `*` is unnecessary and harmful, despite that the code is valid
 */
```

After fix:
```
/**
 <- no star
 */
```


https://github.com/user-attachments/assets/0a52f565-bcfc-47ec-9a05-df4ed02973fb




- - -

_Also could be great to set inner token-set of `documentation_comment` to that it is Markdown (rustdoc's flawor) somehow._

__Also__ need to add second `documentation_comment`:
```rust
/*!
 comment
*/
```
_but I don't know how_ 🤷🏻‍♂️


- - -

Release Notes:

- Fixed unnecessary asterisk (`*`) placement for each next line in the block comments (`block_comment ` & `documentation_comment `) if `languages.Rust.extend_comment_on_newline` is enabled.

- - -

I will answer a possible question in advance. 
Why is it clearly _harmful_? 
Because it wastes the user's time and nerves on removing the asterisk. Doc comments in Rust are in Markdown, and the asterisk is a list.