### PR TITLE
agent_servers: Fix proxy configuration for Gemini

### DIFF
--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -23,7 +23,7 @@ action_log.workspace = true
 agent-client-protocol.workspace = true
 agent_settings.workspace = true
 anyhow.workspace = true
-client = { workspace = true, optional = true }
+client.workspace = true
 collections.workspace = true
 env_logger = { workspace = true, optional = true }
 fs.workspace = true


### PR DESCRIPTION
Closes #37487 

Proxy settings are now taken from the Zed configuration and passed to Gemini via the "--proxy" flag.

Release Notes:

- acp: Gemini ACP server now uses proxy settings from Zed configuration.
