### PR TITLE
Compress minidumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4068,6 +4068,7 @@ dependencies = [
  "smol",
  "system_specs",
  "workspace-hack",
+ "zstd",
 ]
 
 [[package]]

--- a/crates/crashes/Cargo.toml
+++ b/crates/crashes/Cargo.toml
@@ -17,6 +17,7 @@ serde.workspace = true
 serde_json.workspace = true
 system_specs.workspace = true
 workspace-hack.workspace = true
+zstd.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]
 mach2.workspace = true

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -60,7 +60,9 @@ pub fn init_panic_hook(
             .or_else(|| info.payload().downcast_ref::<String>().cloned())
             .unwrap_or_else(|| "Box<Any>".to_string());
 
-        if *release_channel::RELEASE_CHANNEL != ReleaseChannel::Dev {
+        if *release_channel::RELEASE_CHANNEL != ReleaseChannel::Dev
+            || env::var("ZED_GENERATE_MINIDUMPS").is_ok()
+        {
             crashes::handle_panic(payload.clone(), info.location());
         }
 


### PR DESCRIPTION
@notpeter this should fix that issue you were seeing where a generated minidump was too big to upload with the sentry api.

Release Notes:

- N/A