### PR TITLE
vim: Add `:[range]w {file}` command

### DIFF
--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -170,6 +170,7 @@ pub struct VimSet {
 #[derive(Clone, PartialEq, Action)]
 #[action(namespace = vim, no_json, no_register)]
 struct VimSave {
+    pub range: Option<CommandRange>,
     pub save_intent: Option<SaveIntent>,
     pub filename: String,
 }
@@ -298,6 +299,83 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
     });
 
     Vim::action(editor, cx, |vim, action: &VimSave, window, cx| {
+        if let Some(range) = &action.range {
+            vim.update_editor(cx, |vim, editor, cx| {
+                let Some(range) = range.buffer_range(vim, editor, window, cx).ok() else {
+                    return;
+                };
+                let Some((line_ending, text)) = editor.buffer().update(cx, |multi, cx| {
+                    Some(multi.as_singleton()?.update(cx, |buffer, _| {
+                        (
+                            buffer.line_ending(),
+                            buffer.as_rope().slice_rows(range.start.0..range.end.0 + 1),
+                        )
+                    }))
+                }) else {
+                    return;
+                };
+
+                let filename = action.filename.clone();
+                let filename = if filename.is_empty() {
+                    let Some(filename ) = editor.buffer().read(cx).
+                         as_singleton().and_then(|buffer|
+                            buffer.read(cx).file()
+                        ) else {
+                            return;
+                        };
+                    filename.path().to_string_lossy().to_string()
+
+                } else {filename};
+
+                editor.project().unwrap().update(cx, |project, cx| {
+                    let worktree = project.visible_worktrees(cx).next().unwrap();
+
+                    worktree.update(cx, |worktree, cx| {
+                        let path = Path::new(&filename);
+                        let rx = (worktree.entry_for_path(path).is_some() && Some(SaveIntent::Overwrite) != action.save_intent).then(|| {
+                            window.prompt(
+                                gpui::PromptLevel::Warning,
+                                &format!("{path:?} already exists. Do you want to replace it?"),
+                                Some(
+                                    "A file or folder with the same name already exists. Replacing it will overwrite its current contents.",
+                                ),
+                                &["Replace", "Cancel"],
+                                cx
+                            )
+                        });
+                        let filename = filename.clone();
+                        cx.spawn_in(window, async move |this, cx| {
+                            if let Some(rx) = rx && Ok(0) != rx.await {
+                                return;
+                            }
+
+                            let _ = this.update_in(cx, |worktree, window, cx| {
+                                let path = Path::new(&filename);
+                                worktree
+                                    .write_file(path, text.clone(), line_ending, cx)
+                                    .detach_and_prompt_err("Failed to write lines", window, cx, |_, _, _| None);
+                            });
+                        })
+                        .detach();
+                    });
+                });
+            });
+            return;
+        }
+        if action.filename.is_empty() {
+            if let Some(workspace) = vim.workspace(window) {
+                workspace.update(cx, |workspace, cx| {
+                    workspace
+                        .save_active_item(
+                            action.save_intent.unwrap_or(SaveIntent::Save),
+                            window,
+                            cx,
+                        )
+                        .detach_and_prompt_err("Failed to save", window, cx, |_, _, _| None);
+                });
+            }
+            return;
+        }
         vim.update_editor(cx, |_, editor, cx| {
             let Some(project) = editor.project().cloned() else {
                 return;
@@ -312,7 +390,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 
             if project.read(cx).entry_for_path(&project_path, cx).is_some() && action.save_intent != Some(SaveIntent::Overwrite) {
                 let answer = window.prompt(
-                    gpui::PromptLevel::Critical,
+                    gpui::PromptLevel::Warning,
                     &format!("{} already exists. Do you want to replace it?", project_path.path.to_string_lossy()),
                     Some(
                         "A file or folder with the same name already exists. Replacing it will overwrite its current contents.",
@@ -652,7 +730,7 @@ pub fn register(editor: &mut Editor, cx: &mut Context<Vim>) {
 
     Vim::action(editor, cx, |vim, action: &ShellExec, window, cx| {
         action.run(vim, window, cx)
-    })
+    });
 }
 
 #[derive(Default)]
@@ -998,24 +1076,34 @@ fn generate_commands(_: &App) -> Vec<VimCommand> {
     vec![
         VimCommand::new(
             ("w", "rite"),
-            workspace::Save {
+            VimSave {
                 save_intent: Some(SaveIntent::Save),
+                filename: "".to_string(),
+                range: None,
             },
         )
-        .bang(workspace::Save {
+        .bang(VimSave {
             save_intent: Some(SaveIntent::Overwrite),
+            filename: "".to_string(),
+            range: None,
         })
         .args(|action, args| {
             Some(
                 VimSave {
                     save_intent: action
                         .as_any()
-                        .downcast_ref::<workspace::Save>()
+                        .downcast_ref::<VimSave>()
                         .and_then(|action| action.save_intent),
                     filename: args,
+                    range: None,
                 }
                 .boxed_clone(),
             )
+        })
+        .range(|action, range| {
+            let mut action: VimSave = action.as_any().downcast_ref::<VimSave>().unwrap().clone();
+            action.range.replace(range.clone());
+            Some(Box::new(action))
         }),
         VimCommand::new(
             ("q", "uit"),
@@ -2011,7 +2099,7 @@ impl ShellExec {
 
 #[cfg(test)]
 mod test {
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     use crate::{
         VimAddon,
@@ -2022,7 +2110,7 @@ mod test {
     use gpui::{Context, TestAppContext};
     use indoc::indoc;
     use util::path;
-    use workspace::Workspace;
+    use workspace::{OpenOptions, Workspace};
 
     #[gpui::test]
     async fn test_command_basics(cx: &mut TestAppContext) {
@@ -2323,6 +2411,48 @@ mod test {
 
         cx.workspace(|workspace, _, cx| {
             assert_active_item(workspace, path!("/root/other.rs"), "", cx);
+        });
+    }
+
+    #[gpui::test]
+    async fn test_range_w_command(cx: &mut TestAppContext) {
+        let mut cx = VimTestContext::new(cx, true).await;
+
+        cx.workspace(|workspace, _, cx| {
+            assert_active_item(workspace, path!("/root/dir/file.rs"), "", cx);
+        });
+
+        cx.set_state(
+            indoc! {"
+                The quick
+                brown« fox
+                jumpsˇ» over
+                the lazy dog
+            "},
+            Mode::Visual,
+        );
+
+        cx.simulate_keystrokes(": w space dir/other.rs");
+        cx.simulate_keystrokes("enter");
+
+        let other = path!("/root/dir/other.rs");
+
+        let _ = cx
+            .workspace(|workspace, window, cx| {
+                workspace.open_abs_path(PathBuf::from(other), OpenOptions::default(), window, cx)
+            })
+            .await;
+
+        cx.workspace(|workspace, _, cx| {
+            assert_active_item(
+                workspace,
+                other,
+                indoc! {"
+                    brown fox
+                    jumps over
+                "},
+                cx,
+            );
         });
     }
 


### PR DESCRIPTION
Release Notes:

- Adds support for `:[range]w {file}`
  - This writes the lines in the range to the specified
- Adds support for `:[range]w`
  - This replaces the current file with the selected lines