### PR TITLE
git_ui: Fix disappearing AI button

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -40,8 +40,7 @@ use gpui::{
 use itertools::Itertools;
 use language::{Buffer, File};
 use language_model::{
-    ConfiguredModel, LanguageModel, LanguageModelRegistry, LanguageModelRequest,
-    LanguageModelRequestMessage, Role,
+    LanguageModel, LanguageModelRegistry, LanguageModelRequest, LanguageModelRequestMessage, Role,
 };
 use menu::{Confirm, SecondaryConfirm, SelectFirst, SelectLast, SelectNext, SelectPrevious};
 use multi_buffer::ExcerptInfo;

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4454,14 +4454,13 @@ fn current_language_model(cx: &Context<'_, GitPanel>) -> Option<Arc<dyn Language
     let is_enabled = agent_settings::AgentSettings::get_global(cx).enabled
         && !DisableAiSettings::get_global(cx).disable_ai;
 
-    is_enabled
-        .then(|| {
-            let ConfiguredModel { provider, model } =
-                LanguageModelRegistry::read_global(cx).commit_message_model()?;
+    if !is_enabled {
+        return None;
+    }
 
-            provider.is_authenticated(cx).then(|| model)
-        })
-        .flatten()
+    LanguageModelRegistry::read_global(cx)
+        .authenticated_commit_message_model(cx)
+        .map(|m| m.model)
 }
 
 impl Render for GitPanel {

--- a/crates/language_model/src/registry.rs
+++ b/crates/language_model/src/registry.rs
@@ -366,6 +366,33 @@ impl LanguageModelRegistry {
             .or_else(|| self.default_model.clone())
     }
 
+    pub fn authenticated_commit_message_model(&self, cx: &App) -> Option<ConfiguredModel> {
+        #[cfg(debug_assertions)]
+        if std::env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {
+            return None;
+        }
+
+        if let Some(model) = &self.commit_message_model {
+            if model.provider.is_authenticated(cx) {
+                return Some(model.clone());
+            }
+        }
+
+        if let Some(model) = &self.default_fast_model {
+            if model.provider.is_authenticated(cx) {
+                return Some(model.clone());
+            }
+        }
+
+        if let Some(model) = &self.default_model {
+            if model.provider.is_authenticated(cx) {
+                return Some(model.clone());
+            }
+        }
+
+        None
+    }
+
     pub fn thread_summary_model(&self) -> Option<ConfiguredModel> {
         #[cfg(debug_assertions)]
         if std::env::var("ZED_SIMULATE_NO_LLM_PROVIDER").is_ok() {


### PR DESCRIPTION
Closes #37462

Release Notes:

- Fix bug where the git commit `render_generate_commit_message_button` would not display when model settings and ACP agent was last used. Adding additional check for backup models to display button. If the models settings don't function correctly.

#37462 explains it a bit more. Where the ai button would not know how to load once the acp server was in there. Somehow breaking the auth when zed would open for the first time.

I used AI to help with this gpt-5-mini. This is not the first answer. That one was trash but more of a guide along the way.

I found there was a problem with the fallback mechanism when my settings were

```json
    "commit_message_model": {
      "provider": "anthropic",
      "model": "claude-3-7-sonnet-latest"
    },
```

When they were removed. Or even different. There was no problem. This solution just checks if all of the other values are set. That will act as a fallback as well.