### PR TITLE
docs: Fix casing on mentions to some brand names

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -294,7 +294,7 @@ Define extensions which should be installed (`true`) or never installed (`false`
 
 **Options**
 
-1. VSCode
+1. VS Code
 
 ```json
 {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -178,7 +178,7 @@ Note: This setting has no effect in Vim mode, as rewrap is already allowed every
 
 You can find the names of your currently installed extensions by listing the subfolders under the [extension installation location](./extensions/installing-extensions.md#installation-location):
 
-On MacOS:
+On macOS:
 
 ```sh
 ls ~/Library/Application\ Support/Zed/extensions/installed/
@@ -2699,7 +2699,7 @@ Positive `integer` values or `null` for unlimited tabs
 
 **Options**
 
-1. Maps to `Alt` on Linux and Windows and to `Option` on MacOS:
+1. Maps to `Alt` on Linux and Windows and to `Option` on macOS:
 
 ```json
 {
@@ -2707,7 +2707,7 @@ Positive `integer` values or `null` for unlimited tabs
 }
 ```
 
-2. Maps `Control` on Linux and Windows and to `Command` on MacOS:
+2. Maps `Control` on Linux and Windows and to `Command` on macOS:
 
 ```json
 {
@@ -2829,7 +2829,6 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
-
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2829,6 +2829,7 @@ Configuration object for defining settings profiles. Example:
 - Description:
   Preview tabs allow you to open files in preview mode, where they close automatically when you switch to another file unless you explicitly pin them. This is useful for quickly viewing files without cluttering your workspace. Preview tabs display their file names in italics. \
    There are several ways to convert a preview tab into a regular tab:
+
   - Double-clicking on the file
   - Double-clicking on the tab header
   - Using the {#action project_panel::OpenPermanent} action

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -326,7 +326,7 @@ Define extensions which should be installed (`true`) or never installed (`false`
 }
 ```
 
-5. SublimeText
+5. Sublime Text
 
 ```json
 {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -2469,7 +2469,7 @@ The following languages have inlay hints preconfigured by Zed:
 - [Go](https://docs.zed.dev/languages/go)
 - [Rust](https://docs.zed.dev/languages/rust)
 - [Svelte](https://docs.zed.dev/languages/svelte)
-- [Typescript](https://docs.zed.dev/languages/typescript)
+- [TypeScript](https://docs.zed.dev/languages/typescript)
 
 Use the `lsp` section for the server configuration. Examples are provided in the corresponding language documentation.
 

--- a/docs/src/development/debuggers.md
+++ b/docs/src/development/debuggers.md
@@ -93,9 +93,9 @@ rust-lldb -p <pid>
 
 Where `<pid>` is the process ID of the Zed instance you want to attach to.
 
-To get the process ID of a running Zed instance, you can use your systems process management tools such as `Task Manager` on windows or `Activity Monitor` on MacOS.
+To get the process ID of a running Zed instance, you can use your systems process management tools such as `Task Manager` on windows or `Activity Monitor` on macOS.
 
-Alternatively, you can run the `ps aux | grep zed` command on MacOS and Linux or `Get-Process | Select-Object Id, ProcessName` in an instance of PowerShell on Windows.
+Alternatively, you can run the `ps aux | grep zed` command on macOS and Linux or `Get-Process | Select-Object Id, ProcessName` in an instance of PowerShell on Windows.
 
 #### Debugging Panics and Crashes
 

--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -269,7 +269,7 @@ The `textobjects.scm` file defines rules for navigating by text objects. This wa
 
 Vim provides two levels of granularity for navigating around files. Section-by-section with `[]` etc., and method-by-method with `]m` etc. Even languages that don't support functions and classes can work well by defining similar concepts. For example CSS defines a rule-set as a method, and a media-query as a class.
 
-For languages with closures, these typically should not count as functions in Zed. This is best-effort however, as languages like Javascript do not syntactically differentiate syntactically between closures and top-level function declarations.
+For languages with closures, these typically should not count as functions in Zed. This is best-effort however, as languages like JavaScript do not syntactically differentiate syntactically between closures and top-level function declarations.
 
 For languages with declarations like C, provide queries that match `@class.around` or `@function.around`. The `if` and `ic` text objects will default to these if there is no inside.
 

--- a/docs/src/globs.md
+++ b/docs/src/globs.md
@@ -43,7 +43,7 @@ If you wanted to only search Markdown files add `*.md` to the "Include" search f
 
 ### Case insensitive matching
 
-Globs in Zed are case-sensitive, so `*.c` will not match `main.C` (even on case-insensitive filesystems like HFS+/APFS on MacOS). Instead use brackets to match characters. So instead of `*.c` use `*.[cC]`.
+Globs in Zed are case-sensitive, so `*.c` will not match `main.C` (even on case-insensitive filesystems like HFS+/APFS on macOS). Instead use brackets to match characters. So instead of `*.c` use `*.[cC]`.
 
 ### Matching directories
 
@@ -70,7 +70,7 @@ Alternatively, if in your Zed settings you wanted a [`file_types`](./configuring
 
 While globs in Zed are implemented as described above, when writing code using globs in other languages, please reference your platform's glob documentation:
 
-- [MacOS fnmatch](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fnmatch.3.html) (BSD C Standard Library)
+- [macOS fnmatch](https://developer.apple.com/library/archive/documentation/System/Conceptual/ManPages_iPhoneOS/man3/fnmatch.3.html) (BSD C Standard Library)
 - [Linux fnmatch](https://www.gnu.org/software/libc/manual/html_node/Wildcard-Matching.html) (GNU C Standard Library)
 - [POSIX fnmatch](https://pubs.opengroup.org/onlinepubs/9699919799/functions/fnmatch.html) (POSIX Specification)
 - [node-glob](https://github.com/isaacs/node-glob) (Node.js `glob` package)

--- a/docs/src/languages/deno.md
+++ b/docs/src/languages/deno.md
@@ -54,7 +54,7 @@ To use the Deno Language Server with TypeScript and TSX files, you will likely w
 See [Configuring supported languages](../configuring-languages.md) in the Zed documentation for more information.
 
 <!--
-TBD: Deno Typescript REPL instructions [docs/repl#typescript-deno](../repl.md#typescript-deno)
+TBD: Deno TypeScript REPL instructions [docs/repl#typescript-deno](../repl.md#typescript-deno)
 -->
 
 ## DAP support

--- a/docs/src/languages/gdscript.md
+++ b/docs/src/languages/gdscript.md
@@ -8,7 +8,7 @@ Report issues to: [https://github.com/grndctrl/zed-gdscript/issues](https://gith
 
 ## Setup
 
-1. Download and install [Godot for MacOS](https://godotengine.org/download/macos/).
+1. Download and install [Godot for macOS](https://godotengine.org/download/macos/).
 2. Unzip the Godot.app and drag it into your /Applications folder.
 3. Open Godot.app and open your project (an example project is fine)
 4. In Godot, Editor Menu -> Editor Settings; scroll down the left sidebar to `Text Editor -> External`

--- a/docs/src/languages/java.md
+++ b/docs/src/languages/java.md
@@ -10,7 +10,7 @@ Java language support in Zed is provided by:
 
 You will need to install a Java runtime (OpenJDK).
 
-- MacOS: `brew install openjdk`
+- macOS: `brew install openjdk`
 - Ubuntu: `sudo add-apt-repository ppa:openjdk-23 && sudo apt-get install openjdk-23`
 - Windows: `choco install openjdk`
 - Arch Linux: `sudo pacman -S jre-openjdk-headless`
@@ -154,7 +154,7 @@ There are also many more options you can pass directly to the language server, f
 
 If you prefer, you can install JDTLS yourself and the extension can be configured to use that instead.
 
-- MacOS: `brew install jdtls`
+- macOS: `brew install jdtls`
 - Arch: [`jdtls` from AUR](https://aur.archlinux.org/packages/jdtls)
 
 Or manually download install:

--- a/docs/src/languages/lua.md
+++ b/docs/src/languages/lua.md
@@ -18,7 +18,7 @@ To configure LuaLS you can create a `.luarc.json` file in the root of your works
 }
 ```
 
-See [LuaLS Settings Documentation](https://luals.github.io/wiki/settings/) for all available configuration options, or when editing this file in Zed available settings options will autocomplete, (e.g `runtime.version` will show `"Lua 5.1"`, `"Lua 5.2"`, `"Lua 5.3"`, `"Lua 5.4"` and `"LuaJIT"` as allowed values). Note when importing settings options from VSCode, remove the `Lua.` prefix. (e.g. `runtime.version` instead of `Lua.runtime.version`).
+See [LuaLS Settings Documentation](https://luals.github.io/wiki/settings/) for all available configuration options, or when editing this file in Zed available settings options will autocomplete, (e.g `runtime.version` will show `"Lua 5.1"`, `"Lua 5.2"`, `"Lua 5.3"`, `"Lua 5.4"` and `"LuaJIT"` as allowed values). Note when importing settings options from VS Code, remove the `Lua.` prefix. (e.g. `runtime.version` instead of `Lua.runtime.version`).
 
 ### LuaCATS Definitions
 

--- a/docs/src/languages/yarn.md
+++ b/docs/src/languages/yarn.md
@@ -5,5 +5,5 @@
 ## Setup
 
 1. Run `yarn dlx @yarnpkg/sdks base` to generate a `.yarn/sdks` directory.
-2. Set your language server (e.g. VTSLS) to use Typescript SDK from `.yarn/sdks/typescript/lib` directory in [LSP initialization options](../configuring-zed.md#lsp). The actual setting for that depends on language server; for example, for VTSLS you should set [`typescript.tsdk`](https://github.com/yioneko/vtsls/blob/6adfb5d3889ad4b82c5e238446b27ae3ee1e3767/packages/service/configuration.schema.json#L5).
+2. Set your language server (e.g. VTSLS) to use TypeScript SDK from `.yarn/sdks/typescript/lib` directory in [LSP initialization options](../configuring-zed.md#lsp). The actual setting for that depends on language server; for example, for VTSLS you should set [`typescript.tsdk`](https://github.com/yioneko/vtsls/blob/6adfb5d3889ad4b82c5e238446b27ae3ee1e3767/packages/service/configuration.schema.json#L5).
 3. Voilla! Language server functionalities such as Go to Definition, Code Completions and On Hover documentation should work.

--- a/docs/src/repl.md
+++ b/docs/src/repl.md
@@ -114,7 +114,7 @@ ark --install
 TBD: Improve R REPL (Ark Kernel) instructions
 -->
 
-### Typescript: Deno {#typescript-deno}
+### TypeScript: Deno {#typescript-deno}
 
 - [Install Deno](https://docs.deno.com/runtime/manual/getting_started/installation/) and then install the Deno jupyter kernel:
 

--- a/docs/src/snippets.md
+++ b/docs/src/snippets.md
@@ -31,7 +31,7 @@ The scope is determined by the language name in lowercase e.g. `python.json` for
 | JSX        | javascript.json |
 | Plain Text | plaintext.json  |
 
-To create JSX snippets you have to use `javascript.json` snippets file, instead of `jsx.json`, but this does not apply to TSX and Typescript which follow the above rule.
+To create JSX snippets you have to use `javascript.json` snippets file, instead of `jsx.json`, but this does not apply to TSX and TypeScript which follow the above rule.
 
 ## Known Limitations
 


### PR DESCRIPTION
- MacOS → macOS
- VSCode → VS Code
- SublimeText → Sublime Text
- Javascript/Typescript → JavaScript/TypeScript

Release Notes:

- N/A
