### PR TITLE
cloud_llm_client: Add another `Plan` variant

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -5010,7 +5010,9 @@ impl AcpThreadView {
             cloud_llm_client::Plan::ZedProTrial | cloud_llm_client::Plan::ZedFree => {
                 "Upgrade to Zed Pro for more prompts."
             }
-            cloud_llm_client::Plan::ZedProV2 | cloud_llm_client::Plan::ZedProTrialV2 => "",
+            cloud_llm_client::Plan::ZedProV2
+            | cloud_llm_client::Plan::ZedProTrialV2
+            | cloud_llm_client::Plan::ZedFreeV2 => "",
         };
 
         Callout::new()

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -515,7 +515,7 @@ impl AgentConfiguration {
                 .blend(cx.theme().colors().text_accent.opacity(0.2));
 
             let (plan_name, label_color, bg_color) = match plan {
-                Plan::ZedFree => ("Free", Color::Default, free_chip_bg),
+                Plan::ZedFree | Plan::ZedFreeV2 => ("Free", Color::Default, free_chip_bg),
                 Plan::ZedProTrial | Plan::ZedProTrialV2 => {
                     ("Pro Trial", Color::Accent, pro_chip_bg)
                 }

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -3066,6 +3066,8 @@ impl AgentPanel {
             return None;
         }
 
+        let plan = self.user_store.read(cx).plan()?;
+
         Some(
             v_flex()
                 .absolute()
@@ -3074,15 +3076,18 @@ impl AgentPanel {
                 .bg(cx.theme().colors().panel_background)
                 .opacity(0.85)
                 .block_mouse_except_scroll()
-                .child(EndTrialUpsell::new(Arc::new({
-                    let this = cx.entity();
-                    move |_, cx| {
-                        this.update(cx, |_this, cx| {
-                            TrialEndUpsell::set_dismissed(true, cx);
-                            cx.notify();
-                        });
-                    }
-                }))),
+                .child(EndTrialUpsell::new(
+                    plan,
+                    Arc::new({
+                        let this = cx.entity();
+                        move |_, cx| {
+                            this.update(cx, |_this, cx| {
+                                TrialEndUpsell::set_dismissed(true, cx);
+                                cx.notify();
+                            });
+                        }
+                    }),
+                )),
         )
     }
 
@@ -3518,7 +3523,7 @@ impl AgentPanel {
         let error_message = match plan {
             Plan::ZedPro => "Upgrade to usage-based billing for more prompts.",
             Plan::ZedProTrial | Plan::ZedFree => "Upgrade to Zed Pro for more prompts.",
-            Plan::ZedProV2 | Plan::ZedProTrialV2 => "",
+            Plan::ZedProV2 | Plan::ZedProTrialV2 | Plan::ZedFreeV2 => "",
         };
 
         Callout::new()

--- a/crates/agent_ui/src/ui/end_trial_upsell.rs
+++ b/crates/agent_ui/src/ui/end_trial_upsell.rs
@@ -2,18 +2,22 @@ use std::sync::Arc;
 
 use ai_onboarding::{AgentPanelOnboardingCard, PlanDefinitions};
 use client::zed_urls;
-use feature_flags::{BillingV2FeatureFlag, FeatureFlagAppExt as _};
+use cloud_llm_client::Plan;
 use gpui::{AnyElement, App, IntoElement, RenderOnce, Window};
 use ui::{Divider, Tooltip, prelude::*};
 
 #[derive(IntoElement, RegisterComponent)]
 pub struct EndTrialUpsell {
+    plan: Plan,
     dismiss_upsell: Arc<dyn Fn(&mut Window, &mut App)>,
 }
 
 impl EndTrialUpsell {
-    pub fn new(dismiss_upsell: Arc<dyn Fn(&mut Window, &mut App)>) -> Self {
-        Self { dismiss_upsell }
+    pub fn new(plan: Plan, dismiss_upsell: Arc<dyn Fn(&mut Window, &mut App)>) -> Self {
+        Self {
+            plan,
+            dismiss_upsell,
+        }
     }
 }
 
@@ -32,7 +36,7 @@ impl RenderOnce for EndTrialUpsell {
                     )
                     .child(Divider::horizontal()),
             )
-            .child(PlanDefinitions.pro_plan(cx.has_flag::<BillingV2FeatureFlag>(), false))
+            .child(PlanDefinitions.pro_plan(self.plan.is_v2(), false))
             .child(
                 Button::new("cta-button", "Upgrade to Zed Pro")
                     .full_width()
@@ -63,7 +67,7 @@ impl RenderOnce for EndTrialUpsell {
                     )
                     .child(Divider::horizontal()),
             )
-            .child(PlanDefinitions.free_plan(cx.has_flag::<BillingV2FeatureFlag>()));
+            .child(PlanDefinitions.free_plan(self.plan.is_v2()));
 
         AgentPanelOnboardingCard::new()
             .child(Headline::new("Your Zed Pro Trial has expired"))
@@ -108,6 +112,7 @@ impl Component for EndTrialUpsell {
         Some(
             v_flex()
                 .child(EndTrialUpsell {
+                    plan: Plan::ZedFree,
                     dismiss_upsell: Arc::new(|_, _| {}),
                 })
                 .into_any_element(),

--- a/crates/agent_ui/src/ui/preview/usage_callouts.rs
+++ b/crates/agent_ui/src/ui/preview/usage_callouts.rs
@@ -38,7 +38,7 @@ impl RenderOnce for UsageCallout {
 
         let (title, message, button_text, url) = if is_limit_reached {
             match self.plan {
-                Plan::ZedFree => (
+                Plan::ZedFree | Plan::ZedFreeV2 => (
                     "Out of free prompts",
                     "Upgrade to continue, wait for the next reset, or switch to API key."
                         .to_string(),

--- a/crates/cloud_llm_client/src/cloud_llm_client.rs
+++ b/crates/cloud_llm_client/src/cloud_llm_client.rs
@@ -80,6 +80,7 @@ pub enum Plan {
     #[default]
     #[serde(alias = "Free")]
     ZedFree,
+    ZedFreeV2,
     #[serde(alias = "ZedPro")]
     ZedPro,
     ZedProV2,
@@ -88,14 +89,23 @@ pub enum Plan {
     ZedProTrialV2,
 }
 
+impl Plan {
+    pub fn is_v2(&self) -> bool {
+        matches!(self, Plan::ZedFreeV2 | Plan::ZedProV2 | Plan::ZedProTrialV2)
+    }
+}
+
 impl FromStr for Plan {
     type Err = anyhow::Error;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         match value {
             "zed_free" => Ok(Plan::ZedFree),
+            "zed_free_v2" => Ok(Plan::ZedFreeV2),
             "zed_pro" => Ok(Plan::ZedPro),
+            "zed_pro_v2" => Ok(Plan::ZedProV2),
             "zed_pro_trial" => Ok(Plan::ZedProTrial),
+            "zed_pro_trial_v2" => Ok(Plan::ZedProTrialV2),
             plan => Err(anyhow::anyhow!("invalid plan: {plan:?}")),
         }
     }

--- a/crates/language_model/src/model/cloud_model.rs
+++ b/crates/language_model/src/model/cloud_model.rs
@@ -36,7 +36,9 @@ impl fmt::Display for ModelRequestLimitReachedError {
             Plan::ZedProTrial => {
                 "Model request limit reached. Upgrade to Zed Pro for more requests."
             }
-            Plan::ZedProV2 | Plan::ZedProTrialV2 => "Model request limit reached.",
+            Plan::ZedFreeV2 | Plan::ZedProV2 | Plan::ZedProTrialV2 => {
+                "Model request limit reached."
+            }
         };
 
         write!(f, "{message}")

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -659,7 +659,9 @@ impl TitleBar {
                         let user_login = user.github_login.clone();
 
                         let (plan_name, label_color, bg_color) = match plan {
-                            None | Some(Plan::ZedFree) => ("Free", Color::Default, free_chip_bg),
+                            None | Some(Plan::ZedFree | Plan::ZedFreeV2) => {
+                                ("Free", Color::Default, free_chip_bg)
+                            }
                             Some(Plan::ZedProTrial | Plan::ZedProTrialV2) => {
                                 ("Pro Trial", Color::Accent, pro_chip_bg)
                             }


### PR DESCRIPTION
This PR adds a corresponding `FreeV2` variant to the `Plan`.

Release Notes:

- N/A
