### PR TITLE
Consistently map syntax node navigation actions on macOS

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -493,8 +493,8 @@
       "alt-down": "editor::MoveLineDown",
       "ctrl-alt-shift-up": "editor::DuplicateLineUp",
       "ctrl-alt-shift-down": "editor::DuplicateLineDown",
-      "alt-shift-right": "editor::SelectLargerSyntaxNode", // Expand Selection
-      "alt-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
+      "alt-shift-right": "editor::SelectLargerSyntaxNode", // Expand selection
+      "alt-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink selection
       "ctrl-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "ctrl-f2": "editor::SelectAllMatches", // Select all occurrences of current word
       "ctrl-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch  / find_under_expand

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -544,8 +544,10 @@
       "alt-down": "editor::MoveLineDown",
       "alt-shift-up": "editor::DuplicateLineUp",
       "alt-shift-down": "editor::DuplicateLineDown",
-      "ctrl-shift-right": "editor::SelectLargerSyntaxNode", // Expand Selection
-      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
+      "cmd-ctrl-left": "editor::SelectSmallerSyntaxNode", // Shrink selection
+      "cmd-ctrl-right": "editor::SelectLargerSyntaxNode", // Expand selection
+      "cmd-ctrl-up": "editor::SelectPreviousSyntaxNode", // Move selection up
+      "cmd-ctrl-down": "editor::SelectNextSyntaxNode", // Move selection down
       "cmd-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch / find_under_expand
       "cmd-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "cmd-f2": "editor::SelectAllMatches", // Select all occurrences of current word

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -492,8 +492,8 @@
       "alt-down": "editor::MoveLineDown",
       "shift-alt-up": "editor::DuplicateLineUp",
       "shift-alt-down": "editor::DuplicateLineDown",
-      "shift-alt-right": "editor::SelectLargerSyntaxNode", // Expand Selection
-      "shift-alt-left": "editor::SelectSmallerSyntaxNode", // Shrink Selection
+      "shift-alt-right": "editor::SelectLargerSyntaxNode", // Expand selection
+      "shift-alt-left": "editor::SelectSmallerSyntaxNode", // Shrink selection
       "ctrl-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "ctrl-f2": "editor::SelectAllMatches", // Select all occurrences of current word
       "ctrl-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch  / find_under_expand


### PR DESCRIPTION
Skipping Linux and Windows keymaps here, as it's hard to find a consistent base-binding for all 4 actions across all platforms that don't break important actions for each keymap. Someone else can think on that and make a proposal.

Release Notes:

- Added bindings for navigating between sibling nodes in the syntax tree on macOS (`cmd-ctrl-{up/down}` for `SelectPreviousSyntaxNode` and `SelectNextSyntaxNode`). Breaking change: the existing syntax tree parent/child navigation bindings have moved from `ctrl-shift-{left/right}` to `cmd-ctrl-{left/right}` to create a unified four-directional navigation pattern where all syntax tree operations use the same modifier combination. We could not use the previous base modifiers without breaking more bindings.
