### PR TITLE
acp: Add keybindings for authorizing tool calls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,6 +355,7 @@ dependencies = [
  "agent_settings",
  "ai_onboarding",
  "anyhow",
+ "arrayvec",
  "assistant_context",
  "assistant_slash_command",
  "assistant_slash_commands",

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -247,7 +247,10 @@
       "ctrl-shift-e": "project_panel::ToggleFocus",
       "ctrl-shift-enter": "agent::ContinueThread",
       "super-ctrl-b": "agent::ToggleBurnMode",
-      "alt-enter": "agent::ContinueWithBurnMode"
+      "alt-enter": "agent::ContinueWithBurnMode",
+      "ctrl-y": "agent::AllowOnce",
+      "ctrl-alt-y": "agent::AllowAlways",
+      "ctrl-d": "agent::RejectOnce"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -289,7 +289,7 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "cmd-y": "agent::AllowOnce",
       "cmd-alt-y": "agent::AllowAlways",
-      "cmd-r": "agent::RejectOnce"
+      "cmd-d": "agent::RejectOnce"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -218,7 +218,7 @@
     }
   },
   {
-    "context": "Editor && !agent_diff",
+    "context": "Editor && !agent_diff && !AgentPanel",
     "use_key_equivalents": true,
     "bindings": {
       "cmd-alt-z": "git::Restore",
@@ -286,7 +286,10 @@
       "cmd-shift-e": "project_panel::ToggleFocus",
       "cmd-ctrl-b": "agent::ToggleBurnMode",
       "cmd-shift-enter": "agent::ContinueThread",
-      "alt-enter": "agent::ContinueWithBurnMode"
+      "alt-enter": "agent::ContinueWithBurnMode",
+      "cmd-y": "agent::AllowOnce",
+      "cmd-alt-y": "agent::AllowAlways",
+      "cmd-r": "agent::RejectOnce"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -249,7 +249,10 @@
       "ctrl-shift-e": "project_panel::ToggleFocus",
       "ctrl-shift-enter": "agent::ContinueThread",
       "super-ctrl-b": "agent::ToggleBurnMode",
-      "alt-enter": "agent::ContinueWithBurnMode"
+      "alt-enter": "agent::ContinueWithBurnMode",
+      "ctrl-y": "agent::AllowOnce",
+      "ctrl-alt-y": "agent::AllowAlways",
+      "ctrl-d": "agent::RejectOnce"
     }
   },
   {

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -25,6 +25,7 @@ agent_servers.workspace = true
 agent_settings.workspace = true
 ai_onboarding.workspace = true
 anyhow.workspace = true
+arrayvec.workspace = true
 assistant_context.workspace = true
 assistant_slash_command.workspace = true
 assistant_slash_commands.workspace = true

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2481,12 +2481,17 @@ impl AcpThreadView {
                 .is_some_and(|call| call.id == tool_call_id)
         });
         let mut seen_kinds: ArrayVec<acp::PermissionOptionKind, 3> = ArrayVec::new();
-        let buttons = div()
+
+        div()
+            .p_1()
+            .border_t_1()
+            .border_color(self.tool_card_border_color(cx))
+            .w_full()
             .map(|this| {
                 if kind == acp::ToolKind::SwitchMode {
-                    this.w_full().v_flex()
+                    this.v_flex()
                 } else {
-                    this.h_flex()
+                    this.h_flex().justify_end().flex_wrap()
                 }
             })
             .gap_0p5()
@@ -2544,24 +2549,7 @@ impl AcpThreadView {
                             );
                         }
                     }))
-            }));
-
-        h_flex()
-            .py_1()
-            .px_1()
-            .gap_1()
-            .justify_between()
-            .flex_wrap()
-            .border_t_1()
-            .border_color(self.tool_card_border_color(cx))
-            .when(kind != acp::ToolKind::SwitchMode, |this| {
-                this.pl_2().child(
-                    div().min_w(rems_from_px(145.)).child(
-                        LoadingLabel::new("Waiting for Confirmation").size(LabelSize::Small),
-                    ),
-                )
-            })
-            .child(buttons)
+            }))
     }
 
     fn render_diff_loading(&self, cx: &Context<Self>) -> AnyElement {

--- a/crates/agent_ui/src/agent_ui.rs
+++ b/crates/agent_ui/src/agent_ui.rs
@@ -116,6 +116,12 @@ actions!(
         RejectAll,
         /// Keeps all suggestions or changes.
         KeepAll,
+        /// Allow this operation only this time.
+        AllowOnce,
+        /// Allow this operation and remember the choice.
+        AllowAlways,
+        /// Reject this operation only this time.
+        RejectOnce,
         /// Follows the agent's suggestions.
         Follow,
         /// Resets the trial upsell notification.


### PR DESCRIPTION
- [x] Double-check if we like the naming of the new actions
- [x] Only show keybinding hint once per option (e.g. if there are two `allow_once` buttons only show it on the first one)
- [x] If there are multiple tool calls that need authorisation, only show keybindings on the first tool call
- [x] Figure out which keybindings to use
- [x] Add linux keybindings
- [x] Add windows keybindings
- [x] Bug: long keybindings can make the buttons overflow


Release Notes:

- Add keybindings for authorizing tool calls (`agent: Allow once`, `agent: Allow always`, `agent: Reject once`) in the agent panel
