### PR TITLE
workspace: Fix tab bar drop target height when no unpinned tabs present

### DIFF
--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2997,7 +2997,7 @@ impl Pane {
                             // HACK: This empty child is currently necessary to force the drop target to appear
                             // despite us setting a min width above.
                             .child("")
-                            .h_full()
+                            .h(Tab::container_height(cx))
                             .flex_grow()
                             .drag_over::<DraggedTab>(|bar, _, _, cx| {
                                 bar.bg(cx.theme().colors().drop_target_background)

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2997,6 +2997,7 @@ impl Pane {
                             // HACK: This empty child is currently necessary to force the drop target to appear
                             // despite us setting a min width above.
                             .child("")
+                            // HACK: h_full doesn't occupy the complete height, using fixed height instead
                             .h(Tab::container_height(cx))
                             .flex_grow()
                             .drag_over::<DraggedTab>(|bar, _, _, cx| {


### PR DESCRIPTION
Before:
<img width="846" height="192" alt="Screenshot 2025-09-10 at 4 44 18 AM" src="https://github.com/user-attachments/assets/3c79e140-e2b2-4e50-9fce-cb182e46d878" />

After:
<img width="846" height="192" alt="Screenshot 2025-09-10 at 4 43 13 AM" src="https://github.com/user-attachments/assets/b5fa853d-ce39-4c81-9773-1d84eebc8cbb" />

Release Notes:

- Fixed height of the drop background in the tab bar when no unpinned tabs are present.
