### PR TITLE
Add support for JSONL (JSON Lines) file format

### DIFF
--- a/crates/languages/src/jsonl/brackets.scm
+++ b/crates/languages/src/jsonl/brackets.scm
@@ -1,0 +1,3 @@
+("[" @open "]" @close)
+("{" @open "}" @close)
+("\"" @open "\"" @close)

--- a/crates/languages/src/jsonl/config.toml
+++ b/crates/languages/src/jsonl/config.toml
@@ -1,0 +1,19 @@
+# JSONL (JSON Lines) language configuration
+# This configuration is derived from the JSON language configuration
+# and should be kept in sync with crates/languages/src/json/config.toml
+# The main differences are:
+# - name: "JSONL" instead of "JSON"  
+# - path_suffixes: ["jsonl", "ndjson"] instead of ["json", "flake.lock"]
+# - No prettier_parser_name or debuggers (JSONL-specific)
+
+name = "JSONL"
+grammar = "json"
+path_suffixes = ["jsonl", "ndjson"]
+line_comments = ["// "]
+autoclose_before = ",]}"
+brackets = [
+    { start = "{", end = "}", close = true, newline = true },
+    { start = "[", end = "]", close = true, newline = true },
+    { start = "\"", end = "\"", close = true, newline = false, not_in = ["string"] },
+]
+tab_size = 2

--- a/crates/languages/src/jsonl/embedding.scm
+++ b/crates/languages/src/jsonl/embedding.scm
@@ -1,0 +1,19 @@
+; JSONL (JSON Lines) embedding configuration  
+; This file is derived from crates/languages/src/json/embedding.scm
+; and should be kept in sync with the JSON embedding rules
+
+; Produce one embedding for the entire document, with selective collapsing
+; to reduce noise while preserving structure for semantic search
+(document) @item
+
+; Collapse arrays, except for the first object.
+(array
+  "[" @keep
+  .
+  (object)? @keep
+  "]" @keep) @collapse
+
+; Collapse string values (but not keys).
+(pair value: (string
+  "\"" @keep
+  "\"" @keep) @collapse)

--- a/crates/languages/src/jsonl/highlights.scm
+++ b/crates/languages/src/jsonl/highlights.scm
@@ -1,0 +1,32 @@
+; JSONL (JSON Lines) syntax highlighting
+; This file is derived from crates/languages/src/json/highlights.scm
+; and should be kept in sync with the JSON highlighting rules
+
+(comment) @comment
+
+(string) @string
+(escape_sequence) @string.escape
+
+(pair
+  key: (string) @property.json_key)
+
+(number) @number
+
+[
+  (true)
+  (false)
+] @boolean
+
+(null) @constant.builtin
+
+[
+  ","
+  ":"
+] @punctuation.delimiter
+
+[
+  "{"
+  "}"
+  "["
+  "]"
+] @punctuation.bracket

--- a/crates/languages/src/jsonl/indents.scm
+++ b/crates/languages/src/jsonl/indents.scm
@@ -1,0 +1,2 @@
+(array "]" @end) @indent
+(object "}" @end) @indent

--- a/crates/languages/src/jsonl/outline.scm
+++ b/crates/languages/src/jsonl/outline.scm
@@ -1,0 +1,2 @@
+(pair
+  key: (string (string_content) @name)) @item

--- a/crates/languages/src/jsonl/overrides.scm
+++ b/crates/languages/src/jsonl/overrides.scm
@@ -1,0 +1,1 @@
+(string) @string

--- a/crates/languages/src/jsonl/redactions.scm
+++ b/crates/languages/src/jsonl/redactions.scm
@@ -1,0 +1,4 @@
+(pair value: (number) @redact)
+(pair value: (string) @redact)
+(array (number) @redact)
+(array (string) @redact)

--- a/crates/languages/src/jsonl/textobjects.scm
+++ b/crates/languages/src/jsonl/textobjects.scm
@@ -1,0 +1,1 @@
+(comment)+ @comment.around

--- a/crates/languages/src/lib.rs
+++ b/crates/languages/src/lib.rs
@@ -67,6 +67,7 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
         ("jsdoc", tree_sitter_jsdoc::LANGUAGE),
         ("json", tree_sitter_json::LANGUAGE),
         ("jsonc", tree_sitter_json::LANGUAGE),
+        ("jsonl", tree_sitter_json::LANGUAGE),
         ("markdown", tree_sitter_md::LANGUAGE),
         ("markdown-inline", tree_sitter_md::INLINE_LANGUAGE),
         ("python", tree_sitter_python::LANGUAGE),
@@ -153,6 +154,11 @@ pub fn init(languages: Arc<LanguageRegistry>, node: NodeRuntime, cx: &mut App) {
             name: "jsonc",
             adapters: vec![json_lsp_adapter],
             context: Some(json_context_provider),
+            ..Default::default()
+        },
+        LanguageInfo {
+            name: "jsonl",
+            adapters: vec![],
             ..Default::default()
         },
         LanguageInfo {

--- a/crates/theme/src/icon_theme.rs
+++ b/crates/theme/src/icon_theme.rs
@@ -150,7 +150,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     ),
     ("java", &["java"]),
     ("javascript", &["cjs", "js", "mjs"]),
-    ("json", &["json"]),
+    ("json", &["json", "jsonc", "jsonl", "ndjson"]),
     ("julia", &["jl"]),
     ("kdl", &["kdl"]),
     ("kotlin", &["kt"]),
@@ -197,7 +197,7 @@ const FILE_SUFFIXES_BY_ICON_KEY: &[(&str, &[&str])] = &[
     (
         "storage",
         &[
-            "accdb", "csv", "dat", "db", "dbf", "dll", "fmp", "fp7", "frm", "gdb", "ib", "jsonc",
+            "accdb", "csv", "dat", "db", "dbf", "dll", "fmp", "fp7", "frm", "gdb", "ib",
             "ldf", "mdb", "mdf", "myd", "myi", "pdb", "RData", "rdata", "sav", "sdf", "sql",
             "sqlite", "tsv",
         ],


### PR DESCRIPTION
## Summary
- Adds support for JSONL (JSON Lines) format in Zed
- Resolves "End of file expected" errors when working with JSONL files  
- Supports both `.jsonl` and `.ndjson` file extensions

## Implementation Details
- Created dedicated JSONL language configuration without language server integration
- Reuses existing JSON tree-sitter grammar for consistent syntax highlighting
- Added proper icon support for JSONL files matching JSON icon
- Fixed JSONC icon categorization to use JSON icon instead of storage

## Changes
- **New language**: `/crates/languages/src/jsonl/` with complete configuration
- **Language registration**: Added JSONL to language registry without LSP adapters
- **Icon support**: Updated icon theme to handle `.jsonl`, `.ndjson`, and fixed `.jsonc`

## Code Quality Improvements
- Added sync comments to all JSONL configuration files referencing JSON origins
- Removed unnecessary `runnables.scm` (package.json scripts not relevant for JSONL)
- Fixed `embedding.scm` comment to clarify selective collapsing behavior
- Removed redundant icon definition (handled by file suffix mapping)

## Test plan
- [x] Create `.jsonl` files with multiple JSON objects per line
- [x] Verify syntax highlighting works correctly  
- [x] Confirm no "End of file expected" validation errors
- [x] Check file icons display consistently with JSON files
- [x] Test both `.jsonl` and `.ndjson` extensions

🤖 Generated with [Claude Code](https://claude.ai/code)