### PR TITLE
agent: Fix mention completion sometimes not dismissing on space

### DIFF
--- a/crates/agent_ui/src/acp/completion_provider.rs
+++ b/crates/agent_ui/src/acp/completion_provider.rs
@@ -1108,6 +1108,10 @@ impl MentionCompletion {
             match rest_of_line[mode_text.len()..].find(|c: char| !c.is_whitespace()) {
                 Some(whitespace_count) => {
                     if let Some(argument_text) = parts.next() {
+                        if mode.is_none() && !argument_text.is_empty() {
+                            return None;
+                        }
+
                         argument = Some(argument_text.to_string());
                         end += whitespace_count + argument_text.len();
                     }
@@ -1265,6 +1269,17 @@ mod tests {
             })
         );
 
+        assert_eq!(
+            MentionCompletion::try_parse(true, "Lorem @main ", 0),
+            Some(MentionCompletion {
+                source_range: 6..12,
+                mode: None,
+                argument: Some("main".to_string()),
+            })
+        );
+
+        assert_eq!(MentionCompletion::try_parse(true, "Lorem @main m", 0), None);
+
         assert_eq!(MentionCompletion::try_parse(true, "test@", 0), None);
 
         // Allowed non-file mentions
@@ -1279,14 +1294,9 @@ mod tests {
         );
 
         // Disallowed non-file mentions
-
         assert_eq!(
             MentionCompletion::try_parse(false, "Lorem @symbol main", 0),
-            Some(MentionCompletion {
-                source_range: 6..18,
-                mode: None,
-                argument: Some("main".to_string()),
-            })
+            None
         );
 
         assert_eq!(

--- a/crates/agent_ui/src/acp/completion_provider.rs
+++ b/crates/agent_ui/src/acp/completion_provider.rs
@@ -1108,6 +1108,8 @@ impl MentionCompletion {
             match rest_of_line[mode_text.len()..].find(|c: char| !c.is_whitespace()) {
                 Some(whitespace_count) => {
                     if let Some(argument_text) = parts.next() {
+                        // If mode wasn't recognized but we have an argument, don't suggest completions
+                        // (e.g. '@something word')
                         if mode.is_none() && !argument_text.is_empty() {
                             return None;
                         }


### PR DESCRIPTION
Previously we would still show a completion menu even when the user typed an unrecognised mode with an argument,
e.g. `@something word`.
This PR ensures that we only show the completion menu, when the part after the `@` is a known mode (e.g. `file`/`symbol`/`rule`/...)

Release Notes:

- Fix an issue where completions for `@mentions` in the agent panel would sometimes not be dismissed when typing a space
