### PR TITLE
Fix typo in development docs for Windows and Linux

### DIFF
--- a/docs/src/development/linux.md
+++ b/docs/src/development/linux.md
@@ -18,7 +18,7 @@ Clone down the [Zed repository](https://github.com/zed-industries/zed).
 
 ### Backend Dependencies (optional) {#backend-dependencies}
 
-If you are looking to develop Zed collaboration features using a local collabortation server, please see: [Local Collaboration](./local-collaboration.md) docs.
+If you are looking to develop Zed collaboration features using a local collaboration server, please see: [Local Collaboration](./local-collaboration.md) docs.
 
 ## Building from source
 

--- a/docs/src/development/windows.md
+++ b/docs/src/development/windows.md
@@ -68,7 +68,7 @@ The list can be obtained as follows:
 
 ### Backend Dependencies (optional) {#backend-dependencies}
 
-If you are looking to develop Zed collaboration features using a local collabortation server, please see: [Local Collaboration](./local-collaboration.md) docs.
+If you are looking to develop Zed collaboration features using a local collaboration server, please see: [Local Collaboration](./local-collaboration.md) docs.
 
 ### Notes
 


### PR DESCRIPTION
Fixes same typo ("collabortation") as #37607 but for the Windows and Linux dev docs.

Release Notes:

- N/A
