### PR TITLE
windows: Skip `AppendCategory` call when there are no shell links

### DIFF
--- a/crates/gpui/src/platform/windows/destination_list.rs
+++ b/crates/gpui/src/platform/windows/destination_list.rs
@@ -171,7 +171,9 @@ fn add_recent_folders(
             )?)?;
         }
 
-        list.AppendCategory(&HSTRING::from("Recent Folders"), &tasks)?;
+        if tasks.GetCount().unwrap_or(0) > 0 {
+            list.AppendCategory(&HSTRING::from("Recent Folders"), &tasks)?;
+        }
         Ok(())
     }
 }


### PR DESCRIPTION
`ICustomDestinationList::AppendCategory` rejects an empty `IObjectArray` and returns an `E_INVALIDARG` error. Error propagated and caused an early-return from `update_jump_list()`.
<img width="1628" height="540" alt="image" src="https://github.com/user-attachments/assets/f8143297-c71e-42a1-a505-66cd77dfa599" />

Release Notes:

- N/A