### PR TITLE
settings_ui: Handle enums with fields

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -23,7 +23,7 @@ impl FeatureFlags {
             return true;
         }
 
-        if (cfg!(debug_assertions) || self.staff) && T::enabled_for_staff() {
+        if (cfg!(debug_assertions) || self.staff) && !*ZED_DISABLE_STAFF && T::enabled_for_staff() {
             return true;
         }
 
@@ -211,7 +211,8 @@ impl FeatureFlagAppExt for App {
         self.try_global::<FeatureFlags>()
             .map(|flags| flags.has_flag::<T>())
             .unwrap_or_else(|| {
-                (cfg!(debug_assertions) && T::enabled_for_staff()) || T::enabled_for_all()
+                (cfg!(debug_assertions) && T::enabled_for_staff() && !*ZED_DISABLE_STAFF)
+                    || T::enabled_for_all()
             })
     }
 

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -23,7 +23,7 @@ impl FeatureFlags {
             return true;
         }
 
-        if self.staff && T::enabled_for_staff() {
+        if (cfg!(debug_assertions) || self.staff) && T::enabled_for_staff() {
             return true;
         }
 
@@ -210,7 +210,9 @@ impl FeatureFlagAppExt for App {
     fn has_flag<T: FeatureFlag>(&self) -> bool {
         self.try_global::<FeatureFlags>()
             .map(|flags| flags.has_flag::<T>())
-            .unwrap_or(T::enabled_for_all())
+            .unwrap_or_else(|| {
+                (cfg!(debug_assertions) && T::enabled_for_staff()) || T::enabled_for_all()
+            })
     }
 
     fn is_staff(&self) -> bool {

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -1004,23 +1004,28 @@ impl AsRef<[Formatter]> for FormatterList {
 }
 
 /// Controls which formatter should be used when formatting code. If there are multiple formatters, they are executed in the order of declaration.
-#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, SettingsUi)]
 #[serde(rename_all = "snake_case")]
 pub enum Formatter {
     /// Format code using the current language server.
-    LanguageServer { name: Option<String> },
+    LanguageServer {
+        #[settings_ui(skip)]
+        name: Option<String>,
+    },
     /// Format code using Zed's Prettier integration.
     #[default]
     Prettier,
     /// Format code using an external command.
     External {
         /// The external program to run.
+        #[settings_ui(skip)]
         command: Arc<str>,
         /// The arguments to pass to the program.
+        #[settings_ui(skip)]
         arguments: Option<Arc<[String]>>,
     },
     /// Files should be formatted using code actions executed by language servers.
-    CodeActions(HashMap<String, bool>),
+    CodeActions(#[settings_ui(skip)] HashMap<String, bool>),
 }
 
 /// The settings for indent guides.

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -981,11 +981,17 @@ impl<'de> Deserialize<'de> for SelectedFormatter {
 }
 
 /// Controls which formatters should be used when formatting code.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema, SettingsUi)]
 #[serde(untagged)]
 pub enum FormatterList {
     Single(Formatter),
-    Vec(Vec<Formatter>),
+    Vec(#[settings_ui(skip)] Vec<Formatter>),
+}
+
+impl Default for FormatterList {
+    fn default() -> Self {
+        Self::Single(Formatter::default())
+    }
 }
 
 impl AsRef<[Formatter]> for FormatterList {
@@ -998,12 +1004,13 @@ impl AsRef<[Formatter]> for FormatterList {
 }
 
 /// Controls which formatter should be used when formatting code. If there are multiple formatters, they are executed in the order of declaration.
-#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
+#[derive(Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum Formatter {
     /// Format code using the current language server.
     LanguageServer { name: Option<String> },
     /// Format code using Zed's Prettier integration.
+    #[default]
     Prettier,
     /// Format code using an external command.
     External {

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -108,9 +108,18 @@ impl<T: serde::Serialize> SettingsValue<T> {
 
 #[derive(Clone)]
 pub struct SettingsUiItemUnion {
+    /// Must be the same length as `labels` and `options`
+    pub defaults: Vec<serde_json::Value>,
+    /// Must be the same length as `values` and `options`
+    pub labels: &'static [&'static str],
+    /// Must be the same length as `values` and `labels`
     pub options: Vec<SettingsUiEntry>,
     pub determine_option: fn(&serde_json::Value, &App) -> usize,
 }
+
+// todo(settings_ui): use in ToggleGroup and Dropdown
+#[derive(Clone)]
+pub struct SettingsEnumVariants {}
 
 pub struct SettingsUiEntryMetaData {
     pub title: SharedString,

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -110,10 +110,10 @@ impl<T: serde::Serialize> SettingsValue<T> {
 pub struct SettingsUiItemUnion {
     /// Must be the same length as `labels` and `options`
     pub defaults: Vec<serde_json::Value>,
-    /// Must be the same length as `values` and `options`
+    /// Must be the same length as defaults` and `options`
     pub labels: &'static [&'static str],
-    /// Must be the same length as `values` and `labels`
-    pub options: Vec<SettingsUiEntry>,
+    /// Must be the same length as `defaults` and `labels`
+    pub options: Box<[Option<SettingsUiEntry>]>,
     pub determine_option: fn(&serde_json::Value, &App) -> usize,
 }
 
@@ -145,6 +145,7 @@ pub enum SettingsUiItem {
     Single(SettingsUiItemSingle),
     Union(SettingsUiItemUnion),
     DynamicMap(SettingsUiItemDynamicMap),
+    // Array(SettingsUiItemArray), // code-actions: array of objects, array of string
     None,
 }
 

--- a/crates/settings/src/settings_ui_core.rs
+++ b/crates/settings/src/settings_ui_core.rs
@@ -109,7 +109,7 @@ impl<T: serde::Serialize> SettingsValue<T> {
 #[derive(Clone)]
 pub struct SettingsUiItemUnion {
     /// Must be the same length as `labels` and `options`
-    pub defaults: Vec<serde_json::Value>,
+    pub defaults: Box<[serde_json::Value]>,
     /// Must be the same length as defaults` and `options`
     pub labels: &'static [&'static str],
     /// Must be the same length as `defaults` and `labels`

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -899,10 +899,12 @@ fn render_toggle_button_group_inner(
         on_write: Rc<dyn Fn(usize, &mut App)>,
         labels: &'static [&'static str],
     ) -> AnyElement {
-        let mut labels_array: [&'static str; LEN] = ["unused"; LEN];
-        for i in 0..LEN {
-            labels_array[i] = labels[i];
-        }
+        let labels_array: [&'static str; LEN] = {
+            let mut arr = ["unused"; LEN];
+            arr.copy_from_slice(labels);
+            arr
+        };
+
         let mut idx = 0;
         ToggleButtonGroup::single_row(
             title,

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -375,6 +375,7 @@ fn render_content(
         &mut path,
         content,
         &mut None,
+        true,
         window,
         cx,
     );
@@ -385,8 +386,8 @@ fn render_recursive(
     index: usize,
     path: &mut SmallVec<[SharedString; 1]>,
     mut element: Div,
-    // todo(settings_ui): can this be a ref without cx borrow issues?
     fallback_path: &mut Option<SmallVec<[SharedString; 1]>>,
+    render_next_title: bool,
     window: &mut Window,
     cx: &mut App,
 ) -> Div {
@@ -395,7 +396,9 @@ fn render_recursive(
             .child(Label::new(SharedString::new_static("No settings found")).color(Color::Error));
     };
 
-    element = element.child(Label::new(child.title.clone()).size(LabelSize::Large));
+    if render_next_title {
+        element = element.child(Label::new(child.title.clone()).size(LabelSize::Large));
+    }
 
     // todo(settings_ui): subgroups?
     let mut pushed_path = false;
@@ -452,6 +455,7 @@ fn render_recursive(
                 path,
                 element,
                 fallback_path,
+                false,
                 window,
                 cx,
             );
@@ -494,6 +498,7 @@ fn render_recursive(
                     path,
                     element,
                     &mut Some(defaults_path.clone()),
+                    true,
                     window,
                     cx,
                 );
@@ -516,6 +521,7 @@ fn render_recursive(
                 path,
                 element,
                 fallback_path,
+                true,
                 window,
                 cx,
             );

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -62,7 +62,16 @@ pub fn open_settings_editor(
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _, _| {
         workspace.register_action_renderer(|div, _, _, cx| {
-            if cx.has_flag::<SettingsUiFeatureFlag>() {
+            let settings_ui_actions = [std::any::TypeId::of::<OpenSettingsEditor>()];
+            let has_flag = cx.has_flag::<SettingsUiFeatureFlag>();
+            command_palette_hooks::CommandPaletteFilter::update_global(cx, |filter, _| {
+                if has_flag {
+                    filter.show_action_types(&settings_ui_actions);
+                } else {
+                    filter.hide_action_types(&settings_ui_actions);
+                }
+            });
+            if has_flag {
                 div.on_action(cx.listener(open_settings_editor))
             } else {
                 div

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -435,7 +435,8 @@ fn render_recursive(
                 }
             },
         )));
-        // we don't add descendants for unit options
+        // we don't add descendants for unit options, so we adjust the selected index
+        // by the number of options we didn't add descendants for, to get the descendant index
         let selected_descendant_index = selected_index
             - dynamic_render.options[..selected_index]
                 .iter()

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -216,7 +216,9 @@ fn build_tree_item(
             tree[index].render = Some(item);
         }
         SettingsUiItem::Union(dynamic_render) => {
-            // todo! take from item and store other fields instead of clone
+            // todo(settings_ui) take from item and store other fields instead of clone
+            // will also require replacing usage in render_recursive so it can know
+            // which options were actually rendered
             let options = dynamic_render.options.clone();
             tree[index].dynamic_render = Some(dynamic_render);
             for option in options {

--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -182,6 +182,7 @@ fn build_tree_item(
     depth: usize,
     prev_index: Option<usize>,
 ) {
+    // let tree: HashMap<Path, UiEntry>;
     let index = tree.len();
     tree.push(UiEntry {
         title: entry.title.into(),
@@ -219,6 +220,7 @@ fn build_tree_item(
             let options = dynamic_render.options.clone();
             tree[index].dynamic_render = Some(dynamic_render);
             for option in options {
+                let Some(option) = option else { continue };
                 let prev_index = tree[index]
                     .descendant_range
                     .is_empty()
@@ -433,7 +435,16 @@ fn render_recursive(
                 }
             },
         )));
-        if let Some(descendant_index) = child.nth_descendant_index(tree, selected_index) {
+        // we don't add descendants for unit options
+        let selected_descendant_index = selected_index
+            - dynamic_render.options[..selected_index]
+                .iter()
+                .filter(|option| option.is_none())
+                .count();
+        if dynamic_render.options[selected_index].is_some()
+            && let Some(descendant_index) =
+                child.nth_descendant_index(tree, selected_descendant_index)
+        {
             element = render_recursive(
                 tree,
                 descendant_index,

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -456,7 +456,7 @@ Project panel can be shown/hidden with {#action project_panel::ToggleFocus} ({#k
     "button": true,         // Show/hide the icon in the status bar
     "dock": "right",        // Where to dock: left, right, bottom
     "default_width": 640,   // Default width (left/right docked)
-    "default_height": 320,  // Default height (bottom dockeed)
+    "default_height": 320,  // Default height (bottom docked)
   },
   "agent_font_size": 16
 ```
@@ -471,7 +471,7 @@ See [Zed AI Documentation](./ai/overview.md) for additional non-visual AI settin
     "dock": "bottom",                   // Where to dock: left, right, bottom
     "button": true,                     // Show/hide status bar icon
     "default_width": 640,               // Default width (left/right docked)
-    "default_height": 320,              // Default height (bottom dockeed)
+    "default_height": 320,              // Default height (bottom docked)
 
     // Set the cursor blinking behavior in the terminal (on, off, terminal_controlled)
     "blinking": "terminal_controlled",


### PR DESCRIPTION
Closes #ISSUE

Adds handling for Enums with fields (i.e. not `enum Foo { Yes, No }`) in Settings UI. Accomplished by creating default values for each element with fields (in the derive macro), and rendering a toggle button group with a button for each variant where switching the active variant sets the value in the settings JSON to the default for the new active variant.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
