### PR TITLE
editor: Unfold buffers with selections on edit + Remove selections on buffer fold

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -18869,7 +18869,8 @@ impl Editor {
             display_map.fold_buffers([buffer_id], cx)
         });
 
-        self.selections.change_with(cx, |selections| {
+        let snapshot = self.display_snapshot(cx);
+        self.selections.change_with(&snapshot, |selections| {
             selections.remove_selections_from_buffer(buffer_id);
         });
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -3457,14 +3457,8 @@ impl Editor {
             .disjoint_anchor_ranges()
             .flat_map(|range| snapshot.buffer_ids_for_range(range))
             .collect();
-        let buffers_to_unfold: Vec<BufferId> = buffer_ids
-            .into_iter()
-            .filter(|buffer_id| self.is_buffer_folded(*buffer_id, cx))
-            .collect();
-        if !buffers_to_unfold.is_empty() {
-            self.display_map.update(cx, |display_map, cx| {
-                display_map.unfold_buffers(buffers_to_unfold, cx);
-            });
+        for buffer_id in buffer_ids {
+            self.unfold_buffer(buffer_id, cx);
         }
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -27333,6 +27333,7 @@ async fn test_next_prev_reference(cx: &mut TestAppContext) {
     cx.assert_editor_state(CYCLE_POSITIONS[1]);
 }
 
+#[gpui::test]
 async fn test_multibuffer_selections_with_folding(cx: &mut TestAppContext) {
     init_test(cx, |_| {});
 

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -487,6 +487,44 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
         self.selections_changed |= changed;
     }
 
+    pub fn remove_selections_from_buffer(&mut self, buffer_id: language::BufferId) {
+        let mut changed = false;
+        let buffer_snapshot = self.buffer.read(self.cx).snapshot(self.cx);
+
+        let filtered_selections: Arc<[Selection<Anchor>]> = {
+            self.disjoint
+                .iter()
+                .filter(|selection| {
+                    if let Some(selection_buffer_id) =
+                        buffer_snapshot.buffer_id_for_anchor(selection.start)
+                    {
+                        let should_remove = selection_buffer_id == buffer_id;
+                        changed |= should_remove;
+                        !should_remove
+                    } else {
+                        true
+                    }
+                })
+                .cloned()
+                .collect()
+        };
+
+        if filtered_selections.is_empty() {
+            let default_anchor = buffer_snapshot.anchor_before(0);
+            self.collection.disjoint = Arc::from([Selection {
+                id: post_inc(&mut self.collection.next_selection_id),
+                start: default_anchor,
+                end: default_anchor,
+                reversed: false,
+                goal: SelectionGoal::None,
+            }]);
+        } else {
+            self.collection.disjoint = filtered_selections;
+        }
+
+        self.selections_changed |= changed;
+    }
+
     pub fn clear_pending(&mut self) {
         if self.collection.pending.is_some() {
             self.collection.pending = None;

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -489,14 +489,13 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
 
     pub fn remove_selections_from_buffer(&mut self, buffer_id: language::BufferId) {
         let mut changed = false;
-        let buffer_snapshot = self.buffer.read(self.cx).snapshot(self.cx);
 
         let filtered_selections: Arc<[Selection<Anchor>]> = {
             self.disjoint
                 .iter()
                 .filter(|selection| {
                     if let Some(selection_buffer_id) =
-                        buffer_snapshot.buffer_id_for_anchor(selection.start)
+                        self.snapshot.buffer_id_for_anchor(selection.start)
                     {
                         let should_remove = selection_buffer_id == buffer_id;
                         changed |= should_remove;
@@ -510,7 +509,7 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
         };
 
         if filtered_selections.is_empty() {
-            let default_anchor = buffer_snapshot.anchor_before(0);
+            let default_anchor = self.snapshot.anchor_before(0);
             self.collection.disjoint = Arc::from([Selection {
                 id: post_inc(&mut self.collection.next_selection_id),
                 start: default_anchor,

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -490,9 +490,6 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
     pub fn remove_selections_from_buffer(&mut self, buffer_id: language::BufferId) {
         let mut changed = false;
 
-        println!("---before---");
-        dbg!(&self.disjoint);
-
         let filtered_selections: Arc<[Selection<Anchor>]> = {
             self.disjoint
                 .iter()
@@ -523,9 +520,6 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
         } else {
             self.collection.disjoint = filtered_selections;
         }
-
-        println!("---after---");
-        dbg!(&self.collection.disjoint);
 
         self.selections_changed |= changed;
     }

--- a/crates/editor/src/selections_collection.rs
+++ b/crates/editor/src/selections_collection.rs
@@ -490,6 +490,9 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
     pub fn remove_selections_from_buffer(&mut self, buffer_id: language::BufferId) {
         let mut changed = false;
 
+        println!("---before---");
+        dbg!(&self.disjoint);
+
         let filtered_selections: Arc<[Selection<Anchor>]> = {
             self.disjoint
                 .iter()
@@ -520,6 +523,9 @@ impl<'snap, 'a> MutableSelectionsCollection<'snap, 'a> {
         } else {
             self.collection.disjoint = filtered_selections;
         }
+
+        println!("---after---");
+        dbg!(&self.collection.disjoint);
 
         self.selections_changed |= changed;
     }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -6619,13 +6619,11 @@ outline: struct OutlineEntryExcerpt
                 format!(
                     r#"frontend-project/
   public/lottie/
-    syntax-tree.json
-      search: {{ "something": "«static»" }}
+    syntax-tree.json  <==== selected
   src/
     app/(site)/
     components/
-      ErrorBoundary.tsx  <==== selected
-        search: «static»"#
+      ErrorBoundary.tsx"#
                 )
             );
         });
@@ -6667,7 +6665,7 @@ outline: struct OutlineEntryExcerpt
                 format!(
                     r#"frontend-project/
   public/lottie/
-    syntax-tree.json
+    syntax-tree.json  <==== selected
       search: {{ "something": "«static»" }}
   src/
     app/(site)/
@@ -6678,7 +6676,7 @@ outline: struct OutlineEntryExcerpt
         page.tsx
           search: «static»
     components/
-      ErrorBoundary.tsx  <==== selected
+      ErrorBoundary.tsx
         search: «static»"#
                 )
             );


### PR DESCRIPTION
Closes #36376 

Problem:
Multi-cursor edits/selections in multi-buffers view were jumping to incorrect locations after toggling buffer folds. When users created multiple selections across different buffers in a multi-buffer view (like project search results) and then folded one of the buffers, subsequent text insertion would either:

1. Insert text at wrong locations (like at the top of the first unfolded buffer)
2. Replace the entire content in some buffers instead of inserting at the intended cursor positions  
3. Create orphaned selections that caused corruption in the editing experience

The issue seems to happen because when a buffer gets folded in a multi-buffer view, the existing selections associated with that buffer become invalid anchor points.

Solution:
1. Selection Cleanup on Buffer Folding
- Added `remove_selections_from_buffer()` method that filters out all selections from a buffer when it gets folded
- This prevents invalid selections from corrupting subsequent editing operations
- Includes edge case handling: if all selections are removed (all buffers folded), it creates a default selection at the start of the first buffer to prevent panics

2. Unfolding buffers before editing  
- Added `unfold_buffers_with_selections()` call in `handle_input()` ensures buffers with active selections are automatically unfolded before editing
- This helps in fixing an edge case (covered in the tests) where, if you fold all buffers in a multi-buffer view, and try to insert text in a selection, it gets unfolded before the edit happens. Without this, the inserted text would override the entire buffer content.
- If we don't care about this edge case, we could remove this method. I find it ok to add since we already trigger buffer unfolding after edits with `Event::ExcerptsEdited`.

Release Notes:

- Fixed multi-cursor edits jumping to incorrect locations after toggling buffer folds in multi-buffer views (e.g, project search)
  - Multi-cursor selections now properly handle buffer folding/unfolding operations
  - Text insertion no longer occurs at the wrong positions when buffers are folded during multi-cursor editing
  - Eliminated content replacement bugs where entire buffer contents were incorrectly overwritten
  - Added safe fallback behavior when all buffers in a multi-buffer view are folded
