### PR TITLE
feature_flags: Remove unused `llm-closed-beta` feature flag

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -61,10 +61,6 @@ impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";
 }
 
-pub struct LlmClosedBetaFeatureFlag {}
-impl FeatureFlag for LlmClosedBetaFeatureFlag {
-    const NAME: &'static str = "llm-closed-beta";
-}
 
 pub struct BillingV2FeatureFlag {}
 

--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -61,7 +61,6 @@ impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
     const NAME: &'static str = "predict-edits-rate-completions";
 }
 
-
 pub struct BillingV2FeatureFlag {}
 
 impl FeatureFlag for BillingV2FeatureFlag {


### PR DESCRIPTION
This PR removes the `llm-closed-beta` feature flag, as it is no longer used.

Release Notes:

- N/A
