### PR TITLE
feature_flags: Move feature flag definitions to their own module

### DIFF
--- a/crates/feature_flags/src/feature_flags.rs
+++ b/crates/feature_flags/src/feature_flags.rs
@@ -1,11 +1,16 @@
-use futures::channel::oneshot;
-use futures::{FutureExt, select_biased};
-use gpui::{App, Context, Global, Subscription, Task, Window};
+mod flags;
+
 use std::cell::RefCell;
 use std::rc::Rc;
 use std::sync::LazyLock;
 use std::time::Duration;
 use std::{future::Future, pin::Pin, task::Poll};
+
+use futures::channel::oneshot;
+use futures::{FutureExt, select_biased};
+use gpui::{App, Context, Global, Subscription, Task, Window};
+
+pub use flags::*;
 
 #[derive(Default)]
 struct FeatureFlags {
@@ -53,60 +58,6 @@ pub trait FeatureFlag {
     /// without needing to remove all of the call sites.
     fn enabled_for_all() -> bool {
         false
-    }
-}
-
-pub struct PredictEditsRateCompletionsFeatureFlag;
-impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
-    const NAME: &'static str = "predict-edits-rate-completions";
-}
-
-pub struct BillingV2FeatureFlag {}
-
-impl FeatureFlag for BillingV2FeatureFlag {
-    const NAME: &'static str = "billing-v2";
-}
-
-pub struct NotebookFeatureFlag;
-
-impl FeatureFlag for NotebookFeatureFlag {
-    const NAME: &'static str = "notebooks";
-}
-
-pub struct PanicFeatureFlag;
-
-impl FeatureFlag for PanicFeatureFlag {
-    const NAME: &'static str = "panic";
-}
-
-pub struct JjUiFeatureFlag {}
-
-impl FeatureFlag for JjUiFeatureFlag {
-    const NAME: &'static str = "jj-ui";
-}
-
-pub struct GeminiAndNativeFeatureFlag;
-
-impl FeatureFlag for GeminiAndNativeFeatureFlag {
-    // This was previously called "acp".
-    //
-    // We renamed it because existing builds used it to enable the Claude Code
-    // integration too, and we'd like to turn Gemini/Native on in new builds
-    // without enabling Claude Code in old builds.
-    const NAME: &'static str = "gemini-and-native";
-
-    fn enabled_for_all() -> bool {
-        true
-    }
-}
-
-pub struct ClaudeCodeFeatureFlag;
-
-impl FeatureFlag for ClaudeCodeFeatureFlag {
-    const NAME: &'static str = "claude-code";
-
-    fn enabled_for_all() -> bool {
-        true
     }
 }
 

--- a/crates/feature_flags/src/flags.rs
+++ b/crates/feature_flags/src/flags.rs
@@ -1,0 +1,56 @@
+use crate::FeatureFlag;
+
+pub struct PredictEditsRateCompletionsFeatureFlag;
+
+impl FeatureFlag for PredictEditsRateCompletionsFeatureFlag {
+    const NAME: &'static str = "predict-edits-rate-completions";
+}
+
+pub struct BillingV2FeatureFlag {}
+
+impl FeatureFlag for BillingV2FeatureFlag {
+    const NAME: &'static str = "billing-v2";
+}
+
+pub struct NotebookFeatureFlag;
+
+impl FeatureFlag for NotebookFeatureFlag {
+    const NAME: &'static str = "notebooks";
+}
+
+pub struct PanicFeatureFlag;
+
+impl FeatureFlag for PanicFeatureFlag {
+    const NAME: &'static str = "panic";
+}
+
+pub struct JjUiFeatureFlag {}
+
+impl FeatureFlag for JjUiFeatureFlag {
+    const NAME: &'static str = "jj-ui";
+}
+
+pub struct GeminiAndNativeFeatureFlag;
+
+impl FeatureFlag for GeminiAndNativeFeatureFlag {
+    // This was previously called "acp".
+    //
+    // We renamed it because existing builds used it to enable the Claude Code
+    // integration too, and we'd like to turn Gemini/Native on in new builds
+    // without enabling Claude Code in old builds.
+    const NAME: &'static str = "gemini-and-native";
+
+    fn enabled_for_all() -> bool {
+        true
+    }
+}
+
+pub struct ClaudeCodeFeatureFlag;
+
+impl FeatureFlag for ClaudeCodeFeatureFlag {
+    const NAME: &'static str = "claude-code";
+
+    fn enabled_for_all() -> bool {
+        true
+    }
+}


### PR DESCRIPTION
This PR moves the feature flag definitions to their own module so that they aren't intermingled with the feature flag infrastructure itself.

Release Notes:

- N/A
