### PR TITLE
Set StartupWMClass correctly in zed.desktop.in

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -12,6 +12,7 @@ Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
 MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;
 Actions=NewWorkspace;
+StartupWMClass=dev.zed.Zed
 
 [Desktop Action NewWorkspace]
 Exec=$APP_CLI --new $APP_ARGS


### PR DESCRIPTION
Adds the `StartupWMClass` field to the `zed.desktop.in` template, so window managers can identify the appropriate desktop file to look up the icon in.

**Missing:**
<img width="479" height="288" alt="zed-icon-missing" src="https://github.com/user-attachments/assets/968aab1e-b476-4c00-871e-1facb3580cc0" />

**Fixed:**
<img width="353" height="291" alt="zed-icon-fixed" src="https://github.com/user-attachments/assets/cc2ef5d6-84ac-434f-85e9-5082957884c8" />



Closes #37961
Likely will solve #30644 as well - would want confirmation from the original reporter.

Release Notes:

N/A
