### PR TITLE
agent: Make assistant panel input size configurable

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -912,7 +912,11 @@
     /// Whether to have terminal cards in the agent panel expanded, showing the whole command output.
     ///
     /// Default: true
-    "expand_terminal_card": true
+    "expand_terminal_card": true,
+    // Minimum number of lines to display in the agent message editor.
+    //
+    // Default: 4
+    "message_editor_min_lines": 4
   },
   // The settings for slash commands.
   "slash_commands": {

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -75,6 +75,8 @@ pub struct AgentSettings {
     pub expand_edit_card: bool,
     pub expand_terminal_card: bool,
     pub use_modifier_to_send: bool,
+    pub input_min_lines: usize,
+    pub input_max_lines: usize,
 }
 
 impl AgentSettings {
@@ -320,6 +322,14 @@ pub struct AgentSettingsContent {
     ///
     /// Default: false
     use_modifier_to_send: Option<bool>,
+    /// Minimum number of lines to display in the agent input area.
+    ///
+    /// Default: 4
+    input_min_lines: Option<usize>,
+    /// Maximum number of lines to display in the agent input area.
+    ///
+    /// Default: 8
+    input_max_lines: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
@@ -413,7 +423,6 @@ impl Settings for AgentSettings {
         _: &mut gpui::App,
     ) -> anyhow::Result<Self> {
         let mut settings = AgentSettings::default();
-
         for value in sources.defaults_and_customizations() {
             merge(&mut settings.enabled, value.enabled);
             merge(&mut settings.button, value.button);
@@ -472,6 +481,8 @@ impl Settings for AgentSettings {
                 &mut settings.use_modifier_to_send,
                 value.use_modifier_to_send,
             );
+            merge(&mut settings.input_min_lines, value.input_min_lines);
+            merge(&mut settings.input_max_lines, value.input_max_lines);
 
             settings
                 .model_parameters

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -325,7 +325,7 @@ pub struct AgentSettingsContent {
     ///
     /// Default: false
     use_modifier_to_send: Option<bool>,
-    /// Minimum number of lines to display in the agent message editor.
+    /// Minimum number of lines of height the agent message editor should have.
     ///
     /// Default: 4
     message_editor_min_lines: Option<usize>,

--- a/crates/agent_settings/src/agent_settings.rs
+++ b/crates/agent_settings/src/agent_settings.rs
@@ -75,8 +75,7 @@ pub struct AgentSettings {
     pub expand_edit_card: bool,
     pub expand_terminal_card: bool,
     pub use_modifier_to_send: bool,
-    pub input_min_lines: usize,
-    pub input_max_lines: usize,
+    pub message_editor_min_lines: usize,
 }
 
 impl AgentSettings {
@@ -108,6 +107,10 @@ impl AgentSettings {
             provider: provider.into(),
             model,
         });
+    }
+
+    pub fn set_message_editor_max_lines(&self) -> usize {
+        self.message_editor_min_lines * 2
     }
 }
 
@@ -322,14 +325,10 @@ pub struct AgentSettingsContent {
     ///
     /// Default: false
     use_modifier_to_send: Option<bool>,
-    /// Minimum number of lines to display in the agent input area.
+    /// Minimum number of lines to display in the agent message editor.
     ///
     /// Default: 4
-    input_min_lines: Option<usize>,
-    /// Maximum number of lines to display in the agent input area.
-    ///
-    /// Default: 8
-    input_max_lines: Option<usize>,
+    message_editor_min_lines: Option<usize>,
 }
 
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, JsonSchema, PartialEq, Default)]
@@ -423,6 +422,7 @@ impl Settings for AgentSettings {
         _: &mut gpui::App,
     ) -> anyhow::Result<Self> {
         let mut settings = AgentSettings::default();
+
         for value in sources.defaults_and_customizations() {
             merge(&mut settings.enabled, value.enabled);
             merge(&mut settings.button, value.button);
@@ -481,8 +481,10 @@ impl Settings for AgentSettings {
                 &mut settings.use_modifier_to_send,
                 value.use_modifier_to_send,
             );
-            merge(&mut settings.input_min_lines, value.input_min_lines);
-            merge(&mut settings.input_max_lines, value.input_max_lines);
+            merge(
+                &mut settings.message_editor_min_lines,
+                value.message_editor_min_lines,
+            );
 
             settings
                 .model_parameters

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -356,8 +356,8 @@ impl AcpThreadView {
                 agent.name(),
                 &placeholder,
                 editor::EditorMode::AutoHeight {
-                    min_lines: AgentSettings::get_global(cx).input_min_lines,
-                    max_lines: Some(AgentSettings::get_global(cx).input_max_lines),
+                    min_lines: AgentSettings::get_global(cx).message_editor_min_lines,
+                    max_lines: Some(AgentSettings::get_global(cx).set_message_editor_max_lines()),
                 },
                 window,
                 cx,
@@ -860,8 +860,8 @@ impl AcpThreadView {
                 let agent_settings = AgentSettings::get_global(cx);
                 editor.set_mode(
                     EditorMode::AutoHeight {
-                        min_lines: agent_settings.input_min_lines,
-                        max_lines: Some(agent_settings.input_max_lines),
+                        min_lines: agent_settings.message_editor_min_lines,
+                        max_lines: Some(agent_settings.set_message_editor_max_lines()),
                     },
                     cx,
                 )

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -72,9 +72,6 @@ use crate::{
     RejectOnce, ToggleBurnMode, ToggleProfileSelector,
 };
 
-pub const MIN_EDITOR_LINES: usize = 4;
-pub const MAX_EDITOR_LINES: usize = 8;
-
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 enum ThreadFeedback {
     Positive,
@@ -359,8 +356,8 @@ impl AcpThreadView {
                 agent.name(),
                 &placeholder,
                 editor::EditorMode::AutoHeight {
-                    min_lines: MIN_EDITOR_LINES,
-                    max_lines: Some(MAX_EDITOR_LINES),
+                    min_lines: AgentSettings::get_global(cx).input_min_lines,
+                    max_lines: Some(AgentSettings::get_global(cx).input_max_lines),
                 },
                 window,
                 cx,
@@ -860,10 +857,11 @@ impl AcpThreadView {
                     cx,
                 )
             } else {
+                let agent_settings = AgentSettings::get_global(cx);
                 editor.set_mode(
                     EditorMode::AutoHeight {
-                        min_lines: MIN_EDITOR_LINES,
-                        max_lines: Some(MAX_EDITOR_LINES),
+                        min_lines: agent_settings.input_min_lines,
+                        max_lines: Some(agent_settings.input_max_lines),
                     },
                     cx,
                 )

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -183,6 +183,8 @@ It is set to `4` by default, and the max number of lines is always double of the
 }
 ```
 
+> This setting is currently available only in Preview.
+
 ### Modifier to Send
 
 Make a modifier (`cmd` on macOS, `ctrl` on Linux) required to send messages.

--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -170,6 +170,19 @@ The default value is `false`.
 
 > This setting is available via the Agent Panel's settings UI.
 
+### Message Editor Size
+
+Use the `message_editor_min_lines` setting to control minimum number of lines of height the agent message editor should have.
+It is set to `4` by default, and the max number of lines is always double of the minimum.
+
+```json
+{
+  "agent": {
+    "message_editor_min_lines": 4
+  }
+}
+```
+
 ### Modifier to Send
 
 Make a modifier (`cmd` on macOS, `ctrl` on Linux) required to send messages.


### PR DESCRIPTION
Release Notes:

- Added the `agent. message_editor_min_lines `setting to allow users to customize the agent panel message editor default size by using a different minimum number of lines.

<img width="800" height="1316" alt="Screenshot 2025-09-11 at 5 47 18 pm" src="https://github.com/user-attachments/assets/20990b90-c4f9-4f5c-af59-76358642a273" />
