### PR TITLE
terminal: Fix hyperlink detection for multi-line file paths

### DIFF
--- a/crates/terminal/src/terminal_hyperlinks.rs
+++ b/crates/terminal/src/terminal_hyperlinks.rs
@@ -96,7 +96,10 @@ pub(super) fn find_from_grid_point<T: EventListener>(
             {
                 let next_text = term.bounds_to_string(*next_match.start(), *next_match.end());
                 if next_text.contains('.') && !next_text.contains('/') {
-                    (format!("{}{}", text, next_text), Match::new(*word_match.start(), *next_match.end()))
+                    (
+                        format!("{}{}", text, next_text),
+                        Match::new(*word_match.start(), *next_match.end()),
+                    )
                 } else {
                     (text, word_match)
                 }
@@ -1391,8 +1394,12 @@ mod tests {
             }
         }
 
-        let result = find_from_grid_point(&term, AlacPoint::new(Line(0), Column(15)), &mut regex_searches);
-        
+        let result = find_from_grid_point(
+            &term,
+            AlacPoint::new(Line(0), Column(15)),
+            &mut regex_searches,
+        );
+
         assert!(result.is_some());
         assert!(result.unwrap().0.contains("me.tsx"));
     }

--- a/crates/terminal/src/terminal_hyperlinks.rs
+++ b/crates/terminal/src/terminal_hyperlinks.rs
@@ -252,27 +252,6 @@ fn regex_match_at<T>(term: &Term<T>, point: AlacPoint, regex: &mut RegexSearch) 
     visible_regex_match_iter(term, regex).find(|rm| rm.contains(&point))
 }
 
-fn extend_multiline_path<T: EventListener>(
-    term: &Term<T>,
-    word_match: Match,
-    regex_searches: &mut RegexSearches,
-) -> (String, Match) {
-    let text = term.bounds_to_string(*word_match.start(), *word_match.end());
-    
-    if text.contains('/') && !text.contains('.') && word_match.end().column.0 > 10 {
-        if let Some(next_match) = visible_regex_match_iter(term, &mut regex_searches.word_regex)
-            .find(|m| m.start().line == word_match.end().line + 1 && m.start().column.0 <= 2) 
-        {
-            let next_text = term.bounds_to_string(*next_match.start(), *next_match.end());
-            if next_text.contains('.') && !next_text.contains('/') {
-                return (format!("{}{}", text, next_text), Match::new(*word_match.start(), *next_match.end()));
-            }
-        }
-    }
-    
-    (text, word_match)
-}
-
 /// Copied from alacritty/src/display/hint.rs:
 /// Iterate over all visible regex matches.
 fn visible_regex_match_iter<'a, T>(


### PR DESCRIPTION
Fix terminal hyperlink detection for file paths that wrap across lines.

When file paths in terminal output wrap to multiple lines, only the first part was clickable. This affects build tools, test runners, and compiler errors where users expect to click anywhere on a file path to navigate to it.

The fix adds path reconstruction logic to detect and merge broken paths, making the complete file path navigable from either part.

## Implementation

This implementation follows the feedback from @SomeoneToIgnore on previous PRs (#37967, #37969) by:
- Removing all helper functions and inlining the logic directly
- Eliminating redundant comments
- Using a single, focused test without debug output
- Matching existing code patterns in the repository

While I don't feel this implementation is as readable as the previous versions, I've endeavored to meet @SomeoneToIgnore's requirements. The approach addresses the core user functionality issue while respecting the style preferences indicated. Previous PRs were closed without opportunity for iterative improvement, so this version incorporates all feedback upfront.

Closes #37971

Release Notes:

- Fixed terminal hyperlink detection for file paths that wrap across multiple lines