### PR TITLE
editor: Allow no context for the `excerpt_context_lines` setting

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -24418,5 +24418,5 @@ pub fn multibuffer_context_lines(cx: &App) -> u32 {
     EditorSettings::try_get(cx)
         .map(|settings| settings.excerpt_context_lines)
         .unwrap_or(2)
-        .clamp(1, 32)
+        .min(32)
 }


### PR DESCRIPTION
Closes #37980

There seems to be no reason to hard limit this to 1, and we even have existing UX for this case already:

<img width="1530" height="748" alt="Bildschirmfoto 2025-09-11 um 11 22 57" src="https://github.com/user-attachments/assets/d6498318-c905-4d3c-90ab-60e4f2bb6c48" />

(Notice the different arrows in the gutter area for single lines)

Hence, allowing the value to honor the request from the issue

Release Notes:

- Allowed `0` as a value for the `excerpt_context_lines` setting
