### PR TITLE
extension_host: Fix operation status whilst installing dev extension

### DIFF
--- a/crates/extension_host/src/extension_host.rs
+++ b/crates/extension_host/src/extension_host.rs
@@ -937,7 +937,7 @@ impl ExtensionStore {
             if !this.update(cx, |this, cx| {
                 match this.outstanding_operations.entry(extension_id.clone()) {
                     btree_map::Entry::Occupied(_) => return false,
-                    btree_map::Entry::Vacant(e) => e.insert(ExtensionOperation::Remove),
+                    btree_map::Entry::Vacant(e) => e.insert(ExtensionOperation::Install),
                 };
                 cx.notify();
                 true


### PR DESCRIPTION
This fixes a minor issue where we would show "Removing extension ..." in the status bar when we would actually be installing it.

Release Notes:

- Fixed an issue where installing a dev extension would show the installation status as "removing" in the activity indicator.
