### PR TITLE
editor: Ensure placeholder text wraps properly after font size change

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -18911,14 +18911,15 @@ impl Editor {
         // so that wrapping is not recalculated and stays consistent for the editor
         // and its linked minimap.
         if !self.mode.is_minimap() {
-            let rem_size = window.rem_size();
-            self.display_map.update(cx, |map, cx| {
-                map.set_font(
-                    style.text.font(),
-                    style.text.font_size.to_pixels(rem_size),
-                    cx,
-                )
-            });
+            let font = style.text.font();
+            let font_size = style.text.font_size.to_pixels(window.rem_size());
+            let display_map = self
+                .placeholder_display_map
+                .as_ref()
+                .filter(|_| self.is_empty(cx))
+                .unwrap_or(&self.display_map);
+
+            display_map.update(cx, |map, cx| map.set_font(font, font_size, cx));
         }
         self.style = Some(style);
     }


### PR DESCRIPTION
Follow-up of https://github.com/zed-industries/zed/pull/37919

This fixes an issue where the placeholder text in editors would not wrap properly in cases where the font size was changed.

Before:

https://github.com/user-attachments/assets/479c919f-5815-4164-b46d-75f31b5dc56f 

After:

https://github.com/user-attachments/assets/9f63ab9f-eac2-4f3e-864c-2b96b58f2d71 


Release Notes:

- N/A
