### PR TITLE
Handle negative tool call index from Z.ai API

### DIFF
--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -522,7 +522,7 @@ pub async fn stream_completion(
             error: OpenAiError,
         }
 
-        match from_str::<OpenAiResponse>(&body) {
+        match serde_json::from_str::<OpenAiResponse>(&body) {
             Ok(response) if !response.error.message.is_empty() => Err(anyhow!(
                 "API request to {} failed: {}",
                 api_url,

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -480,7 +480,6 @@ pub async fn stream_completion(
 
     let request = request_builder.body(AsyncBody::from(serde_json::to_string(&request)?))?;
     let mut response = client.send(request).await?;
-
     if response.status().is_success() {
         let reader = BufReader::new(response.into_body());
         Ok(reader

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -84,7 +84,8 @@ pub enum Model {
     #[serde(rename = "custom")]
     Custom {
         name: String,
-        /// The name displayed in the UI, such as in the assistant panel model dropdown menu.
+        /// The name displayed in the UI, such as in the assistant panel model
+        /// dropdown menu.
         display_name: Option<String>,
         max_tokens: u64,
         max_output_tokens: Option<u64>,
@@ -217,11 +218,9 @@ impl Model {
         }
     }
 
-    /// Returns whether the given model supports the `parallel_tool_calls`
-    /// parameter.
+    /// Returns whether the given model supports the `parallel_tool_calls` parameter.
     ///
-    /// If the model does not support the parameter, do not pass it up, or the
-    /// API will return an error.
+    /// If the model does not support the parameter, do not pass it up, or the API will return an error.
     pub fn supports_parallel_tool_calls(&self) -> bool {
         match self {
             Self::ThreePointFiveTurbo
@@ -438,12 +437,10 @@ pub struct Usage {
     pub prompt_tokens: u64,
     pub completion_tokens: u64,
     pub total_tokens: u64,
-    pub prompt_tokens_details: Option<Value>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ChoiceDelta {
-    // This field's type is already correct, no change needed.
     pub index: u32,
     pub delta: ResponseMessageDelta,
     pub finish_reason: Option<String>,
@@ -492,22 +489,22 @@ pub async fn stream_completion(
                     Ok(line) => {
                         let line = line.strip_prefix("data: ").or_else(|| line.strip_prefix("data:"))?;
                         if line == "[DONE]" {
-                            return None;
-                        }
-
-                        match from_str::<ResponseStreamResult>(&line) {
-                            Ok(ResponseStreamResult::Ok(response)) => Some(Ok(response)),
-                            Ok(ResponseStreamResult::Err { error }) => {
-                                Some(Err(anyhow!(error.message)))
-                            }
-                            Err(error) => {
-                                log::error!(
-                                    "Failed to parse OpenAI response into ResponseStreamResult: `{}`\n\
-                                    Original Response: `{}`",
-                                    error,
-                                    line,
-                                );
-                                Some(Err(anyhow!(error)))
+                            None
+                        } else {
+                            match serde_json::from_str(line) {
+                                Ok(ResponseStreamResult::Ok(response)) => Some(Ok(response)),
+                                Ok(ResponseStreamResult::Err { error }) => {
+                                    Some(Err(anyhow!(error.message)))
+                                }
+                                Err(error) => {
+                                    log::error!(
+                                        "Failed to parse OpenAI response into ResponseStreamResult: `{}`\n\
+                                        Response: `{}`",
+                                        error,
+                                        line,
+                                    );
+                                    Some(Err(anyhow!(error)))
+                                }
                             }
                         }
                     }

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::{Value, from_str};
+use serde_json::Value;
 use std::{convert::TryFrom, future::Future};
 use strum::EnumIter;
 

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -218,9 +218,11 @@ impl Model {
         }
     }
 
-    /// Returns whether the given model supports the `parallel_tool_calls` parameter.
+    /// Returns whether the given model supports the `parallel_tool_calls`
+    /// parameter.
     ///
-    /// If the model does not support the parameter, do not pass it up, or the API will return an error.
+    /// If the model does not support the parameter, do not pass it up, or the
+    /// API will return an error.
     pub fn supports_parallel_tool_calls(&self) -> bool {
         match self {
             Self::ThreePointFiveTurbo
@@ -415,7 +417,6 @@ where
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct ToolCallChunk {
-    // The key change is here: use the custom deserializer to handle the index.
     #[serde(deserialize_with = "normalize_tool_call_index")]
     pub index: usize,
     pub id: Option<String>,
@@ -477,7 +478,7 @@ pub async fn stream_completion(
         .header("Content-Type", "application/json")
         .header("Authorization", format!("Bearer {}", api_key.trim()));
 
-    let request = request_builder.body(AsyncBody::from(to_string(&request)?))?;
+    let request = request_builder.body(AsyncBody::from(serde_json::to_string(&request)?))?;
     let mut response = client.send(request).await?;
 
     if response.status().is_success() {

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -2,7 +2,7 @@ use anyhow::{Context as _, Result, anyhow};
 use futures::{AsyncBufReadExt, AsyncReadExt, StreamExt, io::BufReader, stream::BoxStream};
 use http_client::{AsyncBody, HttpClient, Method, Request as HttpRequest};
 use serde::{Deserialize, Deserializer, Serialize};
-use serde_json::{Value, from_str, to_string};
+use serde_json::{Value, from_str};
 use std::{convert::TryFrom, future::Future};
 use strum::EnumIter;
 


### PR DESCRIPTION
Address a specific cause of the "Error data did not match any variant of untagged enum ResponseStreamResult" as reported in relation to #36775 .

# Problem

When using the Z.ai model provider, the API's streaming response occasionally returns a tool_calls object with an index value of -1. This violates the standard and causes a deserialization error in the client, as the index field is typed as a usize (unsigned integer).

Here is a typical example of the problematic JSON line:
`{"id": "20250911221307ba7635b1a8f948fc", "created":1757599987, "model": "glm-4.5-flash", "choices":[{"index":0, "finish_reason": "tool_calls", "delta":{"tool_calls":[{"id": "call_w2Fk3IB9T6OjeSbeF5-xSw", "index":-1," type": "function", "function":{"name": "read_file", "arguments":"{\"path\": \"/home/ease/Desktop/RustDevelopment/Abstrust/Cargo.toml\"}"}}]}}]} `

# Solution

This change implements a custom serde deserializer, normalize_tool_call_index, to handle the invalid -1 value. This deserializer converts the negative index to 0 during parsing, allowing the rest of the stream to be processed correctly. This approach is more robust than a simple string replacement and gracefully handles the API's non-standard behavior without affecting other providers.