### PR TITLE
project_panel: Make rest of the project panel drag and drop target

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5609,15 +5609,16 @@ impl Render for ProjectPanel {
                                                             drag_state.active_selection.entry_id,
                                                             cx,
                                                         )
-                                                        .map(|e| e.path.parent())
-                                                        .flatten()
+                                                        .and_then(|e| {
+                                                            e.path.parent().map(|p| p.to_path_buf())
+                                                        })
                                                     {
                                                         let project = this.project.read(cx);
                                                         project
                                                             .path_for_entry(last_root_id, cx)
                                                             .is_some_and(|p| {
                                                                 p.path.as_ref()
-                                                                    == active_parent_path
+                                                                    == active_parent_path.as_path()
                                                             })
                                                     } else {
                                                         false

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5612,9 +5612,18 @@ impl Render for ProjectPanel {
                                 .block_mouse_except_scroll()
                                 .flex_grow()
                                 .when(
-                                    self.drag_target_entry.as_ref().is_some_and(|entry| {
-                                        matches!(entry, DragTarget::Background)
-                                    }),
+                                    self.drag_target_entry.as_ref().is_some_and(
+                                        |entry| match entry {
+                                            DragTarget::Background => true,
+                                            DragTarget::Entry {
+                                                highlight_entry_id, ..
+                                            } => {
+                                                self.last_worktree_root_id.is_some_and(|root_id| {
+                                                    *highlight_entry_id == root_id
+                                                })
+                                            }
+                                        },
+                                    ),
                                     |div| div.bg(cx.theme().colors().drop_target_background),
                                 )
                                 .on_drag_move::<DraggedSelection>(cx.listener(

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5651,43 +5651,49 @@ impl Render for ProjectPanel {
                                         };
                                         if event.bounds.contains(&event.event.position) {
                                             let drag_state = event.drag(cx);
+                                            let mut should_highlight = false;
 
                                             // Always highlight for multiple entries
                                             if drag_state.items().count() > 1 {
-                                                this.drag_target_entry =
-                                                    Some(DragTarget::Background);
-                                                return;
+                                                should_highlight = true;
                                             }
 
                                             // Since root will always have empty relative path
-                                            if let Some(entry_path) =
-                                                this.project.read(cx).path_for_entry(
-                                                    drag_state.active_selection.entry_id,
-                                                    cx,
-                                                )
-                                            {
-                                                if let Some(parent_path) = entry_path.path.parent()
+                                            if !should_highlight {
+                                                if let Some(entry_path) =
+                                                    this.project.read(cx).path_for_entry(
+                                                        drag_state.active_selection.entry_id,
+                                                        cx,
+                                                    )
                                                 {
-                                                    if !parent_path.as_os_str().is_empty() {
-                                                        this.drag_target_entry =
-                                                            Some(DragTarget::Background);
-                                                        return;
+                                                    if let Some(parent_path) =
+                                                        entry_path.path.parent()
+                                                    {
+                                                        if !parent_path.as_os_str().is_empty() {
+                                                            should_highlight = true;
+                                                        }
                                                     }
                                                 }
                                             }
 
                                             // If parent is empty, check if different worktree
-                                            if let Some(last_root_worktree_id) = this
-                                                .project
-                                                .read(cx)
-                                                .worktree_id_for_entry(last_root_id, cx)
-                                            {
-                                                if drag_state.active_selection.worktree_id
-                                                    != last_root_worktree_id
+                                            if !should_highlight {
+                                                if let Some(last_root_worktree_id) = this
+                                                    .project
+                                                    .read(cx)
+                                                    .worktree_id_for_entry(last_root_id, cx)
                                                 {
-                                                    this.drag_target_entry =
-                                                        Some(DragTarget::Background);
+                                                    if drag_state.active_selection.worktree_id
+                                                        != last_root_worktree_id
+                                                    {
+                                                        should_highlight = true;
+                                                    }
                                                 }
+                                            }
+
+                                            if should_highlight {
+                                                this.drag_target_entry =
+                                                    Some(DragTarget::Background);
                                             }
                                         } else {
                                             if this.drag_target_entry.as_ref().is_some_and(|e| {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5601,9 +5601,12 @@ impl Render for ProjectPanel {
                                         if event.bounds.contains(&event.event.position) {
                                             let should_highlight = {
                                                 let drag_state = event.drag(cx);
-                                                if drag_state.items().count() == 1 {
-                                                    if let Some(active_parent_path) = this
-                                                        .project
+                                                if drag_state.items().count() > 1 {
+                                                    // Always highlight for multiple entries
+                                                    true
+                                                } else {
+                                                    // For single entry check if parent matches root
+                                                    this.project
                                                         .read(cx)
                                                         .path_for_entry(
                                                             drag_state.active_selection.entry_id,
@@ -5612,20 +5615,15 @@ impl Render for ProjectPanel {
                                                         .and_then(|e| {
                                                             e.path.parent().map(|p| p.to_path_buf())
                                                         })
-                                                    {
-                                                        let project = this.project.read(cx);
-                                                        project
-                                                            .path_for_entry(last_root_id, cx)
-                                                            .is_some_and(|p| {
-                                                                p.path.as_ref()
-                                                                    == active_parent_path.as_path()
-                                                            })
-                                                    } else {
-                                                        false
-                                                    }
-                                                } else {
-                                                    // If multiple entries are dragged, always highlight
-                                                    true
+                                                        .is_some_and(|parent_path| {
+                                                            this.project
+                                                                .read(cx)
+                                                                .path_for_entry(last_root_id, cx)
+                                                                .is_some_and(|p| {
+                                                                    p.path.as_ref()
+                                                                        == parent_path.as_path()
+                                                                })
+                                                        })
                                                 }
                                             };
                                             if should_highlight {

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -3971,7 +3971,9 @@ impl ProjectPanel {
 
         // In case of single item drag, we do not highlight existing
         // directory which item belongs too
-        if drag_state.items().count() == 1 {
+        if drag_state.items().count() == 1
+            && drag_state.active_selection.worktree_id == target_worktree.id()
+        {
             let active_entry_path = self
                 .project
                 .read(cx)

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5587,12 +5587,6 @@ impl Render for ProjectPanel {
                             div()
                                 .block_mouse_except_scroll()
                                 .flex_grow()
-                                .drag_over::<DraggedSelection>(|style, _, _, cx| {
-                                    style.bg(cx.theme().colors().drop_target_background)
-                                })
-                                .drag_over::<ExternalPaths>(|style, _, _, cx| {
-                                    style.bg(cx.theme().colors().drop_target_background)
-                                })
                                 .on_drag_move::<DraggedSelection>(cx.listener(
                                     move |this, event: &DragMoveEvent<DraggedSelection>, _, cx| {
                                         let Some(last_root_id) = this.last_worktree_root_id else {
@@ -5621,7 +5615,7 @@ impl Render for ProjectPanel {
                                                                 .path_for_entry(last_root_id, cx)
                                                                 .is_some_and(|p| {
                                                                     p.path.as_ref()
-                                                                        == parent_path.as_path()
+                                                                        != parent_path.as_path()
                                                                 })
                                                         })
                                                 }

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5704,6 +5704,16 @@ impl Render for ProjectPanel {
                                         }
                                         cx.stop_propagation();
                                     },
+                                ))
+                                .on_drop(cx.listener(
+                                    move |this, selections: &DraggedSelection, window, cx| {
+                                        this.drag_target_entry = None;
+                                        this.hover_scroll_task.take();
+                                        if let Some(entry_id) = this.last_worktree_root_id {
+                                            this.drag_onto(selections, entry_id, false, window, cx);
+                                        }
+                                        cx.stop_propagation();
+                                    },
                                 )),
                         )
                         .size_full(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5611,6 +5611,12 @@ impl Render for ProjectPanel {
                             div()
                                 .block_mouse_except_scroll()
                                 .flex_grow()
+                                .when(
+                                    self.drag_target_entry.as_ref().is_some_and(|entry| {
+                                        matches!(entry, DragTarget::Background)
+                                    }),
+                                    |div| div.bg(cx.theme().colors().drop_target_background),
+                                )
                                 .on_drag_move::<DraggedSelection>(cx.listener(
                                     move |this, event: &DragMoveEvent<DraggedSelection>, _, cx| {
                                         let Some(last_root_id) = this.last_worktree_root_id else {

--- a/crates/project_panel/src/project_panel_tests.rs
+++ b/crates/project_panel/src/project_panel_tests.rs
@@ -5725,6 +5725,160 @@ async fn test_highlight_entry_for_selection_drag_cross_worktree(cx: &mut gpui::T
 }
 
 #[gpui::test]
+async fn test_should_highlight_background_for_selection_drag(cx: &mut gpui::TestAppContext) {
+    init_test(cx);
+
+    let fs = FakeFs::new(cx.executor());
+    fs.insert_tree(
+        "/root1",
+        json!({
+            "parent_dir": {
+                "child_file.txt": "",
+                "nested_dir": {
+                    "nested_file.txt": ""
+                }
+            },
+            "root_file.txt": ""
+        }),
+    )
+    .await;
+
+    fs.insert_tree(
+        "/root2",
+        json!({
+            "other_dir": {
+                "other_file.txt": ""
+            }
+        }),
+    )
+    .await;
+
+    let project = Project::test(fs.clone(), ["/root1".as_ref(), "/root2".as_ref()], cx).await;
+    let workspace = cx.add_window(|window, cx| Workspace::test_new(project.clone(), window, cx));
+    let cx = &mut VisualTestContext::from_window(*workspace, cx);
+    let panel = workspace.update(cx, ProjectPanel::new).unwrap();
+
+    panel.update(cx, |panel, cx| {
+        let project = panel.project.read(cx);
+        let worktrees: Vec<_> = project.visible_worktrees(cx).collect();
+        let worktree1 = worktrees[0].read(cx);
+        let worktree2 = worktrees[1].read(cx);
+        let worktree1_id = worktree1.id();
+        let _worktree2_id = worktree2.id();
+
+        let root1_entry = worktree1.root_entry().unwrap();
+        let root2_entry = worktree2.root_entry().unwrap();
+        let _parent_dir = worktree1.entry_for_path("parent_dir").unwrap();
+        let child_file = worktree1
+            .entry_for_path("parent_dir/child_file.txt")
+            .unwrap();
+        let nested_file = worktree1
+            .entry_for_path("parent_dir/nested_dir/nested_file.txt")
+            .unwrap();
+        let root_file = worktree1.entry_for_path("root_file.txt").unwrap();
+
+        // Test 1: Multiple entries - should always highlight background
+        let multiple_dragged_selection = DraggedSelection {
+            active_selection: SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: child_file.id,
+            },
+            marked_selections: Arc::new([
+                SelectedEntry {
+                    worktree_id: worktree1_id,
+                    entry_id: child_file.id,
+                },
+                SelectedEntry {
+                    worktree_id: worktree1_id,
+                    entry_id: nested_file.id,
+                },
+            ]),
+        };
+
+        let result = panel.should_highlight_background_for_selection_drag(
+            &multiple_dragged_selection,
+            root1_entry.id,
+            cx,
+        );
+        assert!(result, "Should highlight background for multiple entries");
+
+        // Test 2: Single entry with non-empty parent path - should highlight background
+        let nested_dragged_selection = DraggedSelection {
+            active_selection: SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: nested_file.id,
+            },
+            marked_selections: Arc::new([SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: nested_file.id,
+            }]),
+        };
+
+        let result = panel.should_highlight_background_for_selection_drag(
+            &nested_dragged_selection,
+            root1_entry.id,
+            cx,
+        );
+        assert!(result, "Should highlight background for nested file");
+
+        // Test 3: Single entry at root level, same worktree - should NOT highlight background
+        let root_file_dragged_selection = DraggedSelection {
+            active_selection: SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: root_file.id,
+            },
+            marked_selections: Arc::new([SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: root_file.id,
+            }]),
+        };
+
+        let result = panel.should_highlight_background_for_selection_drag(
+            &root_file_dragged_selection,
+            root1_entry.id,
+            cx,
+        );
+        assert!(
+            !result,
+            "Should NOT highlight background for root file in same worktree"
+        );
+
+        // Test 4: Single entry at root level, different worktree - should highlight background
+        let result = panel.should_highlight_background_for_selection_drag(
+            &root_file_dragged_selection,
+            root2_entry.id,
+            cx,
+        );
+        assert!(
+            result,
+            "Should highlight background for root file from different worktree"
+        );
+
+        // Test 5: Single entry in subdirectory - should highlight background
+        let child_file_dragged_selection = DraggedSelection {
+            active_selection: SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: child_file.id,
+            },
+            marked_selections: Arc::new([SelectedEntry {
+                worktree_id: worktree1_id,
+                entry_id: child_file.id,
+            }]),
+        };
+
+        let result = panel.should_highlight_background_for_selection_drag(
+            &child_file_dragged_selection,
+            root1_entry.id,
+            cx,
+        );
+        assert!(
+            result,
+            "Should highlight background for file with non-empty parent path"
+        );
+    });
+}
+
+#[gpui::test]
 async fn test_hide_root(cx: &mut gpui::TestAppContext) {
     init_test(cx);
 


### PR DESCRIPTION
Closes #25854

You can now drag-and-drop on the remaining space in the project panel to drop entries/external paths in the last worktree.

https://github.com/user-attachments/assets/a7e14518-6065-4b0f-ba2c-823c70f154f4

Release Notes:

- Added support for drag-and-drop files and external paths into the empty space of the project panel, placing them in the last folder you have added to the project.
