### PR TITLE
Fix auto update not defaulting to true

### DIFF
--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -564,6 +564,7 @@ impl AutoUpdater {
 
         this.update(&mut cx, |this, cx| {
             this.status = AutoUpdateStatus::Checking;
+            log::info!("Auto Update: checking for updates");
             cx.notify();
         })?;
 

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -119,9 +119,11 @@ struct AutoUpdateSetting(bool);
 ///
 /// Default: true
 #[derive(Clone, Copy, Default, JsonSchema, Deserialize, Serialize, SettingsUi, SettingsKey)]
-#[serde(transparent)]
-#[settings_key(key = "auto_update")]
-struct AutoUpdateSettingContent(bool);
+#[settings_key(None)]
+#[settings_ui(group = "Auto Update")]
+struct AutoUpdateSettingContent {
+    pub auto_update: Option<bool>,
+}
 
 impl Settings for AutoUpdateSetting {
     type FileContent = AutoUpdateSettingContent;
@@ -134,17 +136,22 @@ impl Settings for AutoUpdateSetting {
             sources.user,
         ]
         .into_iter()
-        .find_map(|value| value.copied())
-        .unwrap_or(*sources.default);
+        .find_map(|value| value.and_then(|val| val.auto_update))
+        .or(sources.default.auto_update)
+        .ok_or_else(Self::missing_default)?;
 
-        Ok(Self(auto_update.0))
+        Ok(Self(auto_update))
     }
 
     fn import_from_vscode(vscode: &settings::VsCodeSettings, current: &mut Self::FileContent) {
         let mut cur = &mut Some(*current);
         vscode.enum_setting("update.mode", &mut cur, |s| match s {
-            "none" | "manual" => Some(AutoUpdateSettingContent(false)),
-            _ => Some(AutoUpdateSettingContent(true)),
+            "none" | "manual" => Some(AutoUpdateSettingContent {
+                auto_update: Some(false),
+            }),
+            _ => Some(AutoUpdateSettingContent {
+                auto_update: Some(true),
+            }),
         });
         *current = cur.unwrap();
     }


### PR DESCRIPTION
 #37337 Made `AutoUpdateSetting` `FileContent = AutoUpdateSettingsContent` which caused a deserialization bug to occur because the field it was wrapping wasn't optional. Thus serde would deserialize the wrapped type `bool` to its default value `false` stopping the settings load function from reading the correct default value from `default.json`

I also added a log message that states when the auto updater struct is checking for updates to make this easier to test. 

Release Notes:

- fix auto update defaulting to false
