### PR TITLE
Don't send contents of large `@mention`-ed files

### DIFF
--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -191,7 +191,6 @@ impl FileContextHandle {
         let buffer = self.buffer.clone();
 
         cx.spawn(async move |cx| {
-            // Get content or outline based on file size
             let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
                 .await
                 .unwrap_or_else(|_| outline::BufferContent {

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -191,12 +191,13 @@ impl FileContextHandle {
         let buffer = self.buffer.clone();
 
         cx.spawn(async move |cx| {
-            let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
-                .await
-                .unwrap_or_else(|_| outline::BufferContent {
-                    text: rope.to_string(),
-                    is_outline: false,
-                });
+            let buffer_content =
+                outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
+                    .await
+                    .unwrap_or_else(|_| outline::BufferContent {
+                        text: rope.to_string(),
+                        is_outline: false,
+                    });
 
             let context = AgentContext::File(FileContext {
                 handle: self,

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -192,17 +192,18 @@ impl FileContextHandle {
 
         cx.spawn(async move |cx| {
             // Get content or outline based on file size
-            let content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
+            let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
                 .await
-                .unwrap_or_else(|_| rope.to_string());
-
-            let is_outline = rope.len() > outline::AUTO_OUTLINE_SIZE;
+                .unwrap_or_else(|_| outline::BufferContent {
+                    text: rope.to_string(),
+                    is_outline: false,
+                });
 
             let context = AgentContext::File(FileContext {
                 handle: self,
                 full_path,
-                text: content.into(),
-                is_outline,
+                text: buffer_content.text.into(),
+                is_outline: buffer_content.is_outline,
             });
             Some((context, vec![buffer]))
         })

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -6,7 +6,7 @@ use futures::future;
 use futures::{FutureExt, future::Shared};
 use gpui::{App, AppContext as _, ElementId, Entity, SharedString, Task};
 use icons::IconName;
-use language::{Buffer, ParseStatus};
+use language::Buffer;
 use language_model::{LanguageModelImage, LanguageModelRequestMessage, MessageContent};
 use project::{Project, ProjectEntryId, ProjectPath, Worktree};
 use prompt_store::{PromptStore, UserPromptId};

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -225,11 +225,9 @@ impl AgentTool for ReadFileTool {
                 Ok(result.into())
             } else {
                 // No line ranges specified, so check file size to see if it's too big.
-                let buffer_content = outline::get_buffer_content_or_outline(
-                    buffer.clone(),
-                    Some(&abs_path),
-                    cx
-                ).await?;
+                let buffer_content =
+                    outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), cx)
+                        .await?;
 
                 action_log.update(cx, |log, cx| {
                     log.buffer_read(buffer.clone(), cx);

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -224,7 +224,7 @@ impl AgentTool for ReadFileTool {
 
                 Ok(result.into())
             } else {
-                // No line ranges specified, so use shared function to get content or outline
+                // No line ranges specified, so check file size to see if it's too big.
                 let buffer_content = outline::get_buffer_content_or_outline(
                     buffer.clone(),
                     Some(&abs_path),
@@ -235,7 +235,6 @@ impl AgentTool for ReadFileTool {
                     log.buffer_read(buffer.clone(), cx);
                 })?;
 
-                // Check if we returned an outline or full content
                 if buffer_content.is_outline {
                     Ok(formatdoc! {"
                         This file was too big to read all at once.

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -147,7 +147,7 @@ impl AgentTool for ReadFileTool {
 
         event_stream.update_fields(ToolCallUpdateFields {
             locations: Some(vec![acp::ToolCallLocation {
-                path: abs_path,
+                path: abs_path.clone(),
                 line: input.start_line.map(|line| line.saturating_sub(1)),
             }]),
             ..Default::default()
@@ -227,7 +227,7 @@ impl AgentTool for ReadFileTool {
                 // No line ranges specified, so use shared function to get content or outline
                 let content = outline::get_buffer_content_or_outline(
                     buffer.clone(),
-                    Some(&path_buf),
+                    Some(&abs_path),
                     cx
                 ).await?;
 

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -225,7 +225,7 @@ impl AgentTool for ReadFileTool {
                 Ok(result.into())
             } else {
                 // No line ranges specified, so use shared function to get content or outline
-                let content = outline::get_buffer_content_or_outline(
+                let buffer_content = outline::get_buffer_content_or_outline(
                     buffer.clone(),
                     Some(&abs_path),
                     cx
@@ -235,8 +235,8 @@ impl AgentTool for ReadFileTool {
                     log.buffer_read(buffer.clone(), cx);
                 })?;
 
-                // Check if we returned an outline (file was too large)
-                if content.starts_with("# File outline") {
+                // Check if we returned an outline or full content
+                if buffer_content.is_outline {
                     Ok(formatdoc! {"
                         This file was too big to read all at once.
 
@@ -247,11 +247,11 @@ impl AgentTool for ReadFileTool {
                         implementations of symbols in the outline.
 
                         Alternatively, you can fall back to the `grep` tool (if available)
-                        to search the file for specific content.", content
+                        to search the file for specific content.", buffer_content.text
                     }
                     .into())
                 } else {
-                    Ok(content.into())
+                    Ok(buffer_content.text.into())
                 }
             };
 

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -224,39 +224,34 @@ impl AgentTool for ReadFileTool {
 
                 Ok(result.into())
             } else {
-                // No line ranges specified, so check file size to see if it's too big.
-                let file_size = buffer.read_with(cx, |buffer, _cx| buffer.text().len())?;
+                // No line ranges specified, so use shared function to get content or outline
+                let content = outline::get_buffer_content_or_outline(
+                    buffer.clone(),
+                    Some(&path_buf),
+                    cx
+                ).await?;
 
-                if file_size <= outline::AUTO_OUTLINE_SIZE {
-                    // File is small enough, so return its contents.
-                    let result = buffer.read_with(cx, |buffer, _cx| buffer.text())?;
+                action_log.update(cx, |log, cx| {
+                    log.buffer_read(buffer.clone(), cx);
+                })?;
 
-                    action_log.update(cx, |log, cx| {
-                        log.buffer_read(buffer.clone(), cx);
-                    })?;
-
-                    Ok(result.into())
-                } else {
-                    // File is too big, so return the outline
-                    // and a suggestion to read again with line numbers.
-                    let outline =
-                        outline::file_outline(project.clone(), file_path, action_log, None, cx)
-                            .await?;
+                // Check if we returned an outline (file was too large)
+                if content.starts_with("# File outline") {
                     Ok(formatdoc! {"
                         This file was too big to read all at once.
 
-                        Here is an outline of its symbols:
-
-                        {outline}
+                        {}
 
                         Using the line numbers in this outline, you can call this tool again
                         while specifying the start_line and end_line fields to see the
                         implementations of symbols in the outline.
 
                         Alternatively, you can fall back to the `grep` tool (if available)
-                        to search the file for specific content."
+                        to search the file for specific content.", content
                     }
                     .into())
+                } else {
+                    Ok(content.into())
                 }
             };
 

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -457,8 +457,6 @@ impl MessageEditor {
             .update(cx, |project, cx| project.open_buffer(project_path, cx));
         cx.spawn(async move |_, cx| {
             let buffer = buffer.await?;
-
-            // Use shared function to get content or outline based on file size
             let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), &cx).await?;
 
             Ok(Mention::Text {
@@ -526,8 +524,6 @@ impl MessageEditor {
 
                     cx.spawn(async move |cx| {
                         let buffer = open_task.await.log_err()?;
-
-                        // Use shared function to get content or outline based on file size
                         let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
                             .await
                             .ok()?;

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -459,10 +459,10 @@ impl MessageEditor {
             let buffer = buffer.await?;
 
             // Use shared function to get content or outline based on file size
-            let content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), &cx).await?;
+            let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), &cx).await?;
 
             Ok(Mention::Text {
-                content,
+                content: buffer_content.text,
                 tracked_buffers: vec![buffer],
             })
         })
@@ -528,11 +528,11 @@ impl MessageEditor {
                         let buffer = open_task.await.log_err()?;
 
                         // Use shared function to get content or outline based on file size
-                        let content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
+                        let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
                             .await
                             .ok()?;
 
-                        Some((rel_path, full_path, content, buffer))
+                        Some((rel_path, full_path, buffer_content.text, buffer))
                     })
                 }))
             })?;

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -2649,9 +2649,14 @@ mod tests {
         });
 
         // Test large file mention
-        let large_file_path = PathBuf::from("/project/large_file.rs");
+        // Get the absolute path using the project's worktree
+        let large_file_abs_path = project.read_with(cx, |project, cx| {
+            let worktree = project.worktrees(cx).next().unwrap();
+            let worktree_root = worktree.read(cx).abs_path();
+            worktree_root.join("large_file.rs")
+        });
         let large_file_task = message_editor.update(cx, |editor, cx| {
-            editor.confirm_mention_for_file(large_file_path, cx)
+            editor.confirm_mention_for_file(large_file_abs_path, cx)
         });
 
         let large_file_mention = large_file_task.await.unwrap();
@@ -2667,9 +2672,14 @@ mod tests {
         }
 
         // Test small file mention
-        let small_file_path = PathBuf::from("/project/small_file.rs");
+        // Get the absolute path using the project's worktree
+        let small_file_abs_path = project.read_with(cx, |project, cx| {
+            let worktree = project.worktrees(cx).next().unwrap();
+            let worktree_root = worktree.read(cx).abs_path();
+            worktree_root.join("small_file.rs")
+        });
         let small_file_task = message_editor.update(cx, |editor, cx| {
-            editor.confirm_mention_for_file(small_file_path, cx)
+            editor.confirm_mention_for_file(small_file_abs_path, cx)
         });
 
         let small_file_mention = small_file_task.await.unwrap();

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1574,7 +1574,7 @@ mod tests {
     use std::{
         cell::{Cell, RefCell},
         ops::Range,
-        path::{Path, PathBuf},
+        path::Path,
         rc::Rc,
         sync::Arc,
     };

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -457,7 +457,9 @@ impl MessageEditor {
             .update(cx, |project, cx| project.open_buffer(project_path, cx));
         cx.spawn(async move |_, cx| {
             let buffer = buffer.await?;
-            let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), &cx).await?;
+            let buffer_content =
+                outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), &cx)
+                    .await?;
 
             Ok(Mention::Text {
                 content: buffer_content.text,
@@ -524,9 +526,13 @@ impl MessageEditor {
 
                     cx.spawn(async move |cx| {
                         let buffer = open_task.await.log_err()?;
-                        let buffer_content = outline::get_buffer_content_or_outline(buffer.clone(), Some(&full_path), &cx)
-                            .await
-                            .ok()?;
+                        let buffer_content = outline::get_buffer_content_or_outline(
+                            buffer.clone(),
+                            Some(&full_path),
+                            &cx,
+                        )
+                        .await
+                        .ok()?;
 
                         Some((rel_path, full_path, buffer_content.text, buffer))
                     })

--- a/crates/assistant_tool/src/outline.rs
+++ b/crates/assistant_tool/src/outline.rs
@@ -6,7 +6,6 @@ use project::Project;
 use regex::Regex;
 use std::fmt::Write;
 use std::path::Path;
-use std::sync::Arc;
 use text::Point;
 
 /// For files over this size, instead of reading them (or including them in context),

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -262,11 +262,9 @@ impl Tool for ReadFileTool {
             } else {
                 // No line ranges specified, so check file size to see if it's too big.
                 let path_buf = std::path::PathBuf::from(&file_path);
-                let buffer_content = outline::get_buffer_content_or_outline(
-                    buffer.clone(),
-                    Some(&path_buf),
-                    cx
-                ).await?;
+                let buffer_content =
+                    outline::get_buffer_content_or_outline(buffer.clone(), Some(&path_buf), cx)
+                        .await?;
 
                 action_log.update(cx, |log, cx| {
                     log.buffer_read(buffer, cx);

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -260,9 +260,9 @@ impl Tool for ReadFileTool {
 
                 Ok(result)
             } else {
-                // No line ranges specified, so use shared function to get content or outline
+                // No line ranges specified
                 let path_buf = std::path::PathBuf::from(&file_path);
-                let content = outline::get_buffer_content_or_outline(
+                let buffer_content = outline::get_buffer_content_or_outline(
                     buffer.clone(),
                     Some(&path_buf),
                     cx
@@ -272,8 +272,8 @@ impl Tool for ReadFileTool {
                     log.buffer_read(buffer, cx);
                 })?;
 
-                // Check if we returned an outline (file was too large)
-                if content.starts_with("# File outline") {
+                // Check if we returned an outline or full content
+                if buffer_content.is_outline {
                     Ok(formatdoc! {"
                         This file was too big to read all at once.
 
@@ -284,11 +284,11 @@ impl Tool for ReadFileTool {
                         implementations of symbols in the outline.
 
                         Alternatively, you can fall back to the `grep` tool (if available)
-                        to search the file for specific content.", content
+                        to search the file for specific content.", buffer_content.text
                     }
                     .into())
                 } else {
-                    Ok(content.into())
+                    Ok(buffer_content.text.into())
                 }
             }
         })

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -260,7 +260,7 @@ impl Tool for ReadFileTool {
 
                 Ok(result)
             } else {
-                // No line ranges specified
+                // No line ranges specified, so check file size to see if it's too big.
                 let path_buf = std::path::PathBuf::from(&file_path);
                 let buffer_content = outline::get_buffer_content_or_outline(
                     buffer.clone(),
@@ -272,7 +272,6 @@ impl Tool for ReadFileTool {
                     log.buffer_read(buffer, cx);
                 })?;
 
-                // Check if we returned an outline or full content
                 if buffer_content.is_outline {
                     Ok(formatdoc! {"
                         This file was too big to read all at once.


### PR DESCRIPTION
<img width="598" height="311" alt="Screenshot 2025-09-11 at 9 39 12 PM" src="https://github.com/user-attachments/assets/b526e648-37cf-4412-83a0-42037b9fc94d" />

This is for both ACP and the regular agent. Previously we would always include the whole file, which can easily blow the context window on huge files.

Release Notes:

- When `@mention`ing large files, the Agent Panel now send an outline of the file instead of the whole thing.
