### PR TITLE
agent_servers: Let Gemini CLI know it is running in Zed

### DIFF
--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -44,6 +44,7 @@ impl AgentServer for Gemini {
 
         cx.spawn(async move |cx| {
             let mut extra_env = HashMap::default();
+            extra_env.insert("SURFACE".to_owned(), "zed".to_owned());
             if let Some(api_key) = cx
                 .update(GoogleLanguageModelProvider::api_key_for_gemini_cli)?
                 .await


### PR DESCRIPTION
By passing through Zed as the surface, Gemini can know which editor it is running in.

Release Notes:

- N/A
