### PR TITLE
Remove trailing newline in `TerminalOutput::full_text`

### DIFF
--- a/crates/repl/src/outputs/plain.rs
+++ b/crates/repl/src/outputs/plain.rs
@@ -233,8 +233,7 @@ impl TerminalOutput {
             }
         }
 
-        // Trim any trailing newlines
-        full_text.trim_end().to_string()
+        full_text
     }
 }
 


### PR DESCRIPTION
Closes #30678

This is caused by `TerminalOutput::full_text` triming trailing newline when creating the "REPL Output" buffer.

Release Notes:

- fix: Remove trailing newline in `TerminalOutput::full_text`
