### PR TITLE
Fix experimental audio volume being significantly too low

### DIFF
--- a/crates/audio/src/audio.rs
+++ b/crates/audio/src/audio.rs
@@ -161,7 +161,7 @@ impl Audio {
             .default_device()?
             .default_config()?
             .prefer_sample_rates([SAMPLE_RATE, SAMPLE_RATE.saturating_mul(nz!(2))])
-            .prefer_channel_counts([nz!(1), nz!(2)])
+            // .prefer_channel_counts([nz!(1), nz!(2)])
             .prefer_buffer_sizes(512..)
             .open_stream()?;
         info!("Opened microphone: {:?}", stream.config());


### PR DESCRIPTION
The rodio channelcount convertor halves the volume. This addresses that in most cases by using the default channelcount for the system microphone which is usually 2.

A proper fix will follow later as part of the de-noising PR

Release Notes:

- N/A 
