### PR TITLE
html: Remove Windows workaround

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20687,6 +20687,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "zed_extension_api"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
+dependencies = [
+ "serde",
+ "serde_json",
+ "wit-bindgen 0.41.0",
+]
+
+[[package]]
 name = "zed_glsl"
 version = "0.1.0"
 dependencies = [
@@ -20697,7 +20708,7 @@ dependencies = [
 name = "zed_html"
 version = "0.2.2"
 dependencies = [
- "zed_extension_api 0.7.0",
+ "zed_extension_api 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20697,7 +20697,7 @@ dependencies = [
 name = "zed_html"
 version = "0.2.2"
 dependencies = [
- "zed_extension_api 0.1.0",
+ "zed_extension_api 0.7.0",
 ]
 
 [[package]]

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/html.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = { path = "../../crates/extension_api" }
+zed_extension_api = "0.7.0"

--- a/extensions/html/Cargo.toml
+++ b/extensions/html/Cargo.toml
@@ -13,4 +13,4 @@ path = "src/html.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-zed_extension_api = "0.1.0"
+zed_extension_api = { path = "../../crates/extension_api" }

--- a/extensions/html/src/html.rs
+++ b/extensions/html/src/html.rs
@@ -77,7 +77,8 @@ impl zed::Extension for HtmlExtension {
         Ok(zed::Command {
             command: zed::node_binary_path()?,
             args: vec![
-                zed_ext::sanitize_windows_path(env::current_dir().unwrap())
+                env::current_dir()
+                    .unwrap()
                     .join(&server_path)
                     .to_string_lossy()
                     .to_string(),
@@ -110,24 +111,3 @@ impl zed::Extension for HtmlExtension {
 }
 
 zed::register_extension!(HtmlExtension);
-
-mod zed_ext {
-    /// Sanitizes the given path to remove the leading `/` on Windows.
-    ///
-    /// On macOS and Linux this is a no-op.
-    ///
-    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
-    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
-        use zed_extension_api::{Os, current_platform};
-
-        let (os, _arch) = current_platform();
-        match os {
-            Os::Mac | Os::Linux => path,
-            Os::Windows => path
-                .to_string_lossy()
-                .to_string()
-                .trim_start_matches('/')
-                .into(),
-        }
-    }
-}


### PR DESCRIPTION
⚠️ Don't merge until Zed 0.205.x is on stable ⚠️ 

See https://github.com/zed-industries/zed/pull/37811

This PR updates the HTML extension, bumping the zed extension API to the latest version, which removes the need to work around a bug where `current_dir()` returned an invalid path on windows.

Release Notes:

- N/A