### PR TITLE
project_panel: Allow dragging folded directories onto other items

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4340,14 +4340,12 @@ impl ProjectPanel {
                 .on_drag(
                     dragged_selection,
                     {
-                        let weak = cx.weak_entity();
+                        let active_component = self.ancestors.get(&entry_id).and_then(|ancestors| ancestors.active_component(&details.filename));
                         move |selection, click_offset, _window, cx| {
-                            let filename = weak.update(cx, |this, _| {
-                                this.ancestors.get(&entry_id).and_then(|ancestors| ancestors.active_component(&details.filename))
-                            }).ok().and_then(|active_component| active_component).unwrap_or_else(|| details.filename.clone());
+                            let filename = active_component.as_ref().unwrap_or_else(|| &details.filename);
                             cx.new(|_| DraggedProjectEntryView {
                                 icon: details.icon.clone(),
-                                filename,
+                                filename: filename.clone(),
                                 click_offset,
                                 selection: selection.active_selection,
                                 selections: selection.marked_selections.clone(),

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -393,7 +393,8 @@ struct SerializedProjectPanel {
 
 struct DraggedProjectEntryView {
     selection: SelectedEntry,
-    details: EntryDetails,
+    icon: Option<SharedString>,
+    filename: String,
     click_offset: Point<Pixels>,
     selections: Arc<[SelectedEntry]>,
 }
@@ -4322,7 +4323,8 @@ impl ProjectPanel {
                     dragged_selection,
                     move |selection, click_offset, _window, cx| {
                         cx.new(|_| DraggedProjectEntryView {
-                            details: details.clone(),
+                            icon: details.icon.clone(),
+                            filename: details.filename.clone(),
                             click_offset,
                             selection: selection.active_selection,
                             selections: selection.marked_selections.clone(),
@@ -5849,12 +5851,12 @@ impl Render for DraggedProjectEntryView {
                         if self.selections.len() > 1 && self.selections.contains(&self.selection) {
                             this.child(Label::new(format!("{} entries", self.selections.len())))
                         } else {
-                            this.child(if let Some(icon) = &self.details.icon {
+                            this.child(if let Some(icon) = &self.icon {
                                 div().child(Icon::from_path(icon.clone()))
                             } else {
                                 div()
                             })
-                            .child(Label::new(self.details.filename.clone()))
+                            .child(Label::new(self.filename.clone()))
                         }
                     }),
             )

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4643,16 +4643,19 @@ impl ProjectPanel {
                                                     }))
                                                 })
                                             })
-                                            .on_click(cx.listener(move |this, _, _, cx| {
-                                                if index != active_index
-                                                    && let Some(folds) =
-                                                        this.ancestors.get_mut(&entry_id)
-                                                    {
-                                                        folds.current_ancestor_depth =
-                                                            components_len - 1 - index;
-                                                        cx.notify();
-                                                    }
-                                            }))
+                                            .on_mouse_down(
+                                                MouseButton::Left,
+                                                cx.listener(move |this, _, _, cx| {
+                                                    if index != active_index
+                                                        && let Some(folds) =
+                                                            this.ancestors.get_mut(&entry_id)
+                                                        {
+                                                            folds.current_ancestor_depth =
+                                                                components_len - 1 - index;
+                                                            cx.notify();
+                                                        }
+                                                }),
+                                            )
                                             .child(
                                                 Label::new(component)
                                                     .single_line()


### PR DESCRIPTION
In https://github.com/zed-industries/zed/pull/22983 we made it possible to drag items onto folded directories. 

This PR handles the reverse: dragging folded directories onto other items.

Release Notes:

- Improved drag-and-drop support by allowing folded directories to be dragged onto other items in Project Panel.

