### PR TITLE
Fix line indicator format setting

### DIFF
--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -303,8 +303,10 @@ pub(crate) enum LineIndicatorFormat {
 
 #[derive(Clone, Copy, Default, JsonSchema, Deserialize, Serialize, SettingsUi, SettingsKey)]
 #[serde(transparent)]
-#[settings_key(key = "line_indicator_format")]
-pub(crate) struct LineIndicatorFormatContent(LineIndicatorFormat);
+#[settings_key(None)]
+pub(crate) struct LineIndicatorFormatContent {
+    line_indicator_format: Option<LineIndicatorFormat>,
+}
 
 impl Settings for LineIndicatorFormat {
     type FileContent = LineIndicatorFormatContent;
@@ -312,14 +314,17 @@ impl Settings for LineIndicatorFormat {
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut App) -> anyhow::Result<Self> {
         let format = [
             sources.release_channel,
+            sources.profile,
             sources.operating_system,
             sources.user,
         ]
         .into_iter()
         .find_map(|value| value.copied())
-        .unwrap_or(*sources.default);
+        .unwrap_or(*sources.default)
+        .line_indicator_format
+        .ok_or_else(Self::missing_default)?;
 
-        Ok(format.0)
+        Ok(format)
     }
 
     fn import_from_vscode(_vscode: &settings::VsCodeSettings, _current: &mut Self::FileContent) {}

--- a/crates/go_to_line/src/cursor_position.rs
+++ b/crates/go_to_line/src/cursor_position.rs
@@ -293,7 +293,7 @@ impl StatusItemView for CursorPosition {
     }
 }
 
-#[derive(Clone, Copy, Default, PartialEq, JsonSchema, Deserialize, Serialize)]
+#[derive(Clone, Copy, Default, PartialEq, Debug, JsonSchema, Deserialize, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub(crate) enum LineIndicatorFormat {
     Short,
@@ -301,8 +301,9 @@ pub(crate) enum LineIndicatorFormat {
     Long,
 }
 
-#[derive(Clone, Copy, Default, JsonSchema, Deserialize, Serialize, SettingsUi, SettingsKey)]
-#[serde(transparent)]
+#[derive(
+    Clone, Copy, Default, Debug, JsonSchema, Deserialize, Serialize, SettingsUi, SettingsKey,
+)]
 #[settings_key(None)]
 pub(crate) struct LineIndicatorFormatContent {
     line_indicator_format: Option<LineIndicatorFormat>,
@@ -315,13 +316,14 @@ impl Settings for LineIndicatorFormat {
         let format = [
             sources.release_channel,
             sources.profile,
-            sources.operating_system,
             sources.user,
+            sources.operating_system,
+            Some(sources.default),
         ]
         .into_iter()
-        .find_map(|value| value.copied())
-        .unwrap_or(*sources.default)
-        .line_indicator_format
+        .flatten()
+        .filter_map(|val| val.line_indicator_format)
+        .next()
         .ok_or_else(Self::missing_default)?;
 
         Ok(format)

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1012,6 +1012,8 @@ impl settings::Settings for DisableAiSettings {
             .iter()
             .chain(sources.user.iter())
             .chain(sources.server.iter())
+            .chain(sources.release_channel.iter())
+            .chain(sources.profile.iter())
             .any(|disabled| disabled.disable_ai == Some(true));
 
         Ok(Self { disable_ai })

--- a/crates/vim_mode_setting/src/vim_mode_setting.rs
+++ b/crates/vim_mode_setting/src/vim_mode_setting.rs
@@ -52,8 +52,8 @@ impl Settings for VimModeSetting {
             ]
             .into_iter()
             .flatten()
+            .filter_map(|mode| mode.vim_mode)
             .next()
-            .and_then(|mode| mode.vim_mode)
             .ok_or_else(Self::missing_default)?,
         ))
     }
@@ -101,8 +101,8 @@ impl Settings for HelixModeSetting {
             ]
             .into_iter()
             .flatten()
+            .filter_map(|mode| mode.helix_mode)
             .next()
-            .and_then(|mode| mode.helix_mode)
             .ok_or_else(Self::missing_default)?,
         ))
     }

--- a/crates/vim_mode_setting/src/vim_mode_setting.rs
+++ b/crates/vim_mode_setting/src/vim_mode_setting.rs
@@ -43,12 +43,18 @@ impl Settings for VimModeSetting {
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut App) -> Result<Self> {
         Ok(Self(
-            sources
-                .user
-                .and_then(|mode| mode.vim_mode)
-                .or(sources.server.and_then(|mode| mode.vim_mode))
-                .or(sources.default.vim_mode)
-                .ok_or_else(Self::missing_default)?,
+            [
+                sources.profile,
+                sources.release_channel,
+                sources.user,
+                sources.server,
+                Some(sources.default),
+            ]
+            .into_iter()
+            .flatten()
+            .next()
+            .and_then(|mode| mode.vim_mode)
+            .ok_or_else(Self::missing_default)?,
         ))
     }
 
@@ -86,12 +92,18 @@ impl Settings for HelixModeSetting {
 
     fn load(sources: SettingsSources<Self::FileContent>, _: &mut App) -> Result<Self> {
         Ok(Self(
-            sources
-                .user
-                .and_then(|mode| mode.helix_mode)
-                .or(sources.server.and_then(|mode| mode.helix_mode))
-                .or(sources.default.helix_mode)
-                .ok_or_else(Self::missing_default)?,
+            [
+                sources.profile,
+                sources.release_channel,
+                sources.user,
+                sources.server,
+                Some(sources.default),
+            ]
+            .into_iter()
+            .flatten()
+            .next()
+            .and_then(|mode| mode.helix_mode)
+            .ok_or_else(Self::missing_default)?,
         ))
     }
 


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- Fixed an issue where the `line_indicator_format` setting would not update based on the value in `settings.json`