### PR TITLE
extension_host: Replace backslashes with forward slashes for cwd on Windows

### DIFF
--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -667,14 +667,15 @@ impl WasmHost {
         let file_perms = wasi::FilePerms::all();
         let dir_perms = wasi::DirPerms::all();
         let path = SanitizedPath::new(&extension_work_dir);
+        let path = path.to_string().replace('\\', "/");
 
         let mut ctx = wasi::WasiCtxBuilder::new();
         ctx.inherit_stdio()
-            .env("PWD", path.to_string())
+            .env("PWD", &path)
             .env("RUST_BACKTRACE", "full");
 
         ctx.preopened_dir(&path, ".", dir_perms, file_perms)?;
-        ctx.preopened_dir(&path, path.to_string(), dir_perms, file_perms)?;
+        ctx.preopened_dir(&path, &path, dir_perms, file_perms)?;
 
         Ok(ctx.build())
     }

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -666,9 +666,9 @@ impl WasmHost {
 
         let file_perms = wasi::FilePerms::all();
         let dir_perms = wasi::DirPerms::all();
-        let path = SanitizedPath::new(&extension_work_dir);
+        let path = SanitizedPath::new(&extension_work_dir).to_string();
         #[cfg(target_os = "windows")]
-        let path = path.to_string().replace('\\', "/");
+        let path = path.replace('\\', "/");
 
         let mut ctx = wasi::WasiCtxBuilder::new();
         ctx.inherit_stdio()

--- a/crates/extension_host/src/wasm_host.rs
+++ b/crates/extension_host/src/wasm_host.rs
@@ -667,6 +667,7 @@ impl WasmHost {
         let file_perms = wasi::FilePerms::all();
         let dir_perms = wasi::DirPerms::all();
         let path = SanitizedPath::new(&extension_work_dir);
+        #[cfg(target_os = "windows")]
         let path = path.to_string().replace('\\', "/");
 
         let mut ctx = wasi::WasiCtxBuilder::new();

--- a/extensions/test-extension/src/test_extension.rs
+++ b/extensions/test-extension/src/test_extension.rs
@@ -18,6 +18,10 @@ impl TestExtension {
 
         let current_dir = std::env::current_dir().unwrap();
         println!("current_dir: {}", current_dir.display());
+        assert_eq!(
+            current_dir.file_name().unwrap().to_str().unwrap(),
+            "test-extension"
+        );
 
         fs::create_dir_all(current_dir.join("dir-created-with-abs-path")).unwrap();
         fs::create_dir_all("./dir-created-with-rel-path").unwrap();


### PR DESCRIPTION
Instead of passing CWD verbatim from the Windows host with backslashes and all, we now rewrite it into a more POSIX-happy format featuring forward slashes which means `std::path::Path` operations now work within WASI with Windows-style paths.

Release Notes:

- N/A
