### PR TITLE
editor: Fix select to end of line when Vim mode is enabled

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5099,6 +5099,7 @@ dependencies = [
  "url",
  "util",
  "uuid",
+ "vim_mode_setting",
  "workspace",
  "workspace-hack",
  "zed_actions",

--- a/crates/editor/Cargo.toml
+++ b/crates/editor/Cargo.toml
@@ -117,6 +117,7 @@ tree-sitter-yaml.workspace = true
 tree-sitter-bash.workspace = true
 unindent.workspace = true
 util = { workspace = true, features = ["test-support"] }
+vim_mode_setting.workspace = true
 workspace = { workspace = true, features = ["test-support"] }
 http_client = { workspace = true, features = ["test-support"] }
 zlog.workspace = true

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -13451,6 +13451,15 @@ impl Editor {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
+        // If the user has Vim mode enabled, we'll update the
+        // `clip_at_line_ends` field to `false`, as Vim mode can set this to
+        // `true` when in NORMAL mode, which makes it so that , without this
+        // call, the selection ends up being until the penultimate character of
+        // the line, instead of the last.
+        if vim_enabled(cx) {
+            self.set_clip_at_line_ends(false, cx);
+        };
+
         self.hide_mouse_cursor(HideMouseCursorOrigin::MovementAction, cx);
         self.change_selections(Default::default(), window, cx, |s| {
             s.move_heads_with(|map, head, _| {


### PR DESCRIPTION
This commit updates the `Editor.select_to_end_of_line` method in order to ensure that, if the user has vim enabled, it always sets the display map's `clip_at_line_ends` to `false` ensuring that, regardless of the the current vim mode, the selection is always the same.

Closes #37190 

Release Notes:

- Fixed `editor: select to end of line` when in vim's normal mode
