### PR TITLE
Add debug methods for visually annotating ranges 

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20204,6 +20204,64 @@ impl Editor {
                 results.push((start..end, color))
             }
         }
+
+        #[cfg(debug_assertions)]
+        {
+            text::debug::GlobalDebugRanges::with_locked(|debug_ranges| {
+                if debug_ranges.0.is_empty() {
+                    return;
+                }
+                let buffer_snapshot = display_snapshot.buffer_snapshot.clone();
+                for (buffer, buffer_range, excerpt_id) in
+                    buffer_snapshot.range_to_buffer_ranges(search_range)
+                {
+                    let buffer_range = buffer.anchor_after(buffer_range.start)
+                        ..buffer.anchor_before(buffer_range.end);
+                    let buffer_snapshot = &buffer_snapshot;
+                    results.extend(
+                        debug_ranges
+                            .0
+                            .iter()
+                            .filter_map(|debug_range| {
+                                let ranges = debug_range
+                                    .ranges
+                                    .iter()
+                                    .filter(|range| {
+                                        range.start.buffer_id == Some(buffer.remote_id())
+                                    })
+                                    .collect::<Vec<_>>();
+                                if ranges.is_empty() {
+                                    None
+                                } else {
+                                    Some(ranges)
+                                }
+                            })
+                            .enumerate()
+                            .flat_map(|(ix, ranges)| {
+                                let color =
+                                    gpui::hsla(((ix + 2) % 6) as f32 / 6.0, 0.75, 0.5, 0.05);
+                                ranges.into_iter().filter_map(move |range| {
+                                    let clipped_start =
+                                        range.start.max(&buffer_range.start, buffer);
+                                    let clipped_end = range.end.min(&buffer_range.end, buffer);
+                                    if clipped_start.cmp(&clipped_end, buffer) == Ordering::Greater
+                                    {
+                                        return None;
+                                    }
+                                    let range = buffer_snapshot
+                                        .anchor_in_excerpt(excerpt_id, clipped_start)?
+                                        ..buffer_snapshot
+                                            .anchor_in_excerpt(excerpt_id, clipped_end)?;
+                                    let start = range.start.to_display_point(display_snapshot);
+                                    let end = range.end.to_display_point(display_snapshot);
+                                    Some((start..end, color.clone()))
+                                })
+                            }),
+                    );
+                }
+            });
+        }
+
         results
     }
 

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20233,13 +20233,18 @@ impl Editor {
                                 if ranges.is_empty() {
                                     None
                                 } else {
-                                    Some(ranges)
+                                    let color = if let Some(color) =
+                                        debug_range.value.downcast_ref::<gpui::Hsla>()
+                                    {
+                                        color.alpha(0.25)
+                                    } else {
+                                        log::error!("expected Hsla value in debug_range value in call at {:?}", debug_range.caller);
+                                        gpui::hsla(0.97, 1.00, 0.88, 0.5)
+                                    };
+                                    Some((ranges, color))
                                 }
                             })
-                            .enumerate()
-                            .flat_map(|(ix, ranges)| {
-                                let color =
-                                    gpui::hsla(((ix + 2) % 6) as f32 / 6.0, 0.75, 0.5, 0.05);
+                            .flat_map(|(ranges, color)| {
                                 ranges.into_iter().filter_map(move |range| {
                                     let clipped_start =
                                         range.start.max(&buffer_range.start, buffer);

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1505,6 +1505,15 @@ impl EditorElement {
                 selections.push((player, layouts));
             }
         });
+
+        #[cfg(debug_assertions)]
+        Self::layout_debug_ranges(
+            &mut selections,
+            start_anchor..end_anchor,
+            &snapshot.display_snapshot,
+            cx,
+        );
+
         (selections, active_rows, newest_selection_head)
     }
 
@@ -7293,6 +7302,54 @@ impl EditorElement {
             .is_some_and(|style| matches!(style, GitHunkStyleSetting::UnstagedHollow));
 
         unstaged == unstaged_hollow
+    }
+
+    #[cfg(debug_assertions)]
+    fn layout_debug_ranges(
+        selections: &mut Vec<(PlayerColor, Vec<SelectionLayout>)>,
+        anchor_range: Range<Anchor>,
+        display_snapshot: &DisplaySnapshot,
+        cx: &App,
+    ) {
+        let theme = cx.theme();
+        text::debug::GlobalDebugRanges::with_locked(|debug_ranges| {
+            if debug_ranges.ranges.is_empty() {
+                return;
+            }
+            let buffer_snapshot = &display_snapshot.buffer_snapshot;
+            for (buffer, buffer_range, excerpt_id) in
+                buffer_snapshot.range_to_buffer_ranges(anchor_range)
+            {
+                let buffer_range =
+                    buffer.anchor_after(buffer_range.start)..buffer.anchor_before(buffer_range.end);
+                selections.extend(debug_ranges.ranges.iter().flat_map(|debug_range| {
+                    let player_color = theme
+                        .players()
+                        .color_for_participant(debug_range.occurrence_index as u32 + 1);
+                    debug_range.ranges.iter().filter_map(move |range| {
+                        if range.start.buffer_id != Some(buffer.remote_id()) {
+                            return None;
+                        }
+                        let clipped_start = range.start.max(&buffer_range.start, buffer);
+                        let clipped_end = range.end.min(&buffer_range.end, buffer);
+                        let range = buffer_snapshot.anchor_in_excerpt(excerpt_id, clipped_start)?
+                            ..buffer_snapshot.anchor_in_excerpt(excerpt_id, clipped_end)?;
+                        let start = range.start.to_display_point(display_snapshot);
+                        let end = range.end.to_display_point(display_snapshot);
+                        let selection_layout = SelectionLayout {
+                            head: start,
+                            range: start..end,
+                            cursor_shape: CursorShape::Bar,
+                            is_newest: false,
+                            is_local: false,
+                            active_rows: start.row()..end.row(),
+                            user_name: Some(SharedString::new(debug_range.value.clone())),
+                        };
+                        Some((player_color, vec![selection_layout]))
+                    })
+                }));
+            }
+        });
     }
 }
 

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -8089,11 +8089,7 @@ pub mod debug {
             snapshot: &MultiBufferSnapshot,
         ) -> Vec<Range<usize>> {
             self.iter()
-                .map(|range| {
-                    let start = range.start.to_offset(snapshot);
-                    let end = range.end.to_offset(snapshot);
-                    start..end
-                })
+                .map(|range| range.start.to_offset(snapshot)..range.end.to_offset(snapshot))
                 .collect()
         }
     }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6410,7 +6410,7 @@ impl MultiBufferSnapshot {
     pub fn debug<V, R>(&self, value: V, range: &R)
     where
         V: std::fmt::Debug,
-        R: ToMultiBufferDebugRanges,
+        R: debug::ToMultiBufferDebugRanges,
     {
         self.debug_with_key(std::panic::Location::caller(), value, range);
     }
@@ -6423,7 +6423,7 @@ impl MultiBufferSnapshot {
     where
         K: std::hash::Hash + 'static,
         V: std::fmt::Debug,
-        R: ToMultiBufferDebugRanges,
+        R: debug::ToMultiBufferDebugRanges,
     {
         let caller = std::panic::Location::caller();
         let text_ranges = range
@@ -8024,60 +8024,77 @@ impl From<ExcerptId> for EntityId {
 }
 
 #[cfg(debug_assertions)]
-pub trait ToMultiBufferDebugRanges {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>>;
-}
+pub mod debug {
+    use super::*;
 
-#[cfg(debug_assertions)]
-impl<T: ToOffset> ToMultiBufferDebugRanges for T {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
-        [self.to_offset(snapshot)].to_multi_buffer_debug_ranges(snapshot)
+    pub trait ToMultiBufferDebugRanges {
+        fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot)
+        -> Vec<Range<usize>>;
     }
-}
 
-#[cfg(debug_assertions)]
-impl<T: ToOffset> ToMultiBufferDebugRanges for Range<T> {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
-        [self.start.to_offset(snapshot)..self.end.to_offset(snapshot)]
-            .to_multi_buffer_debug_ranges(snapshot)
+    impl<T: ToOffset> ToMultiBufferDebugRanges for T {
+        fn to_multi_buffer_debug_ranges(
+            &self,
+            snapshot: &MultiBufferSnapshot,
+        ) -> Vec<Range<usize>> {
+            [self.to_offset(snapshot)].to_multi_buffer_debug_ranges(snapshot)
+        }
     }
-}
 
-#[cfg(debug_assertions)]
-impl<T: ToOffset> ToMultiBufferDebugRanges for Vec<T> {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
-        self.as_slice().to_multi_buffer_debug_ranges(snapshot)
+    impl<T: ToOffset> ToMultiBufferDebugRanges for Range<T> {
+        fn to_multi_buffer_debug_ranges(
+            &self,
+            snapshot: &MultiBufferSnapshot,
+        ) -> Vec<Range<usize>> {
+            [self.start.to_offset(snapshot)..self.end.to_offset(snapshot)]
+                .to_multi_buffer_debug_ranges(snapshot)
+        }
     }
-}
 
-#[cfg(debug_assertions)]
-impl<T: ToOffset> ToMultiBufferDebugRanges for Vec<Range<T>> {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
-        self.as_slice().to_multi_buffer_debug_ranges(snapshot)
+    impl<T: ToOffset> ToMultiBufferDebugRanges for Vec<T> {
+        fn to_multi_buffer_debug_ranges(
+            &self,
+            snapshot: &MultiBufferSnapshot,
+        ) -> Vec<Range<usize>> {
+            self.as_slice().to_multi_buffer_debug_ranges(snapshot)
+        }
     }
-}
 
-#[cfg(debug_assertions)]
-impl<T: ToOffset> ToMultiBufferDebugRanges for [T] {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
-        self.iter()
-            .map(|item| {
-                let offset = item.to_offset(snapshot);
-                offset..offset
-            })
-            .collect()
+    impl<T: ToOffset> ToMultiBufferDebugRanges for Vec<Range<T>> {
+        fn to_multi_buffer_debug_ranges(
+            &self,
+            snapshot: &MultiBufferSnapshot,
+        ) -> Vec<Range<usize>> {
+            self.as_slice().to_multi_buffer_debug_ranges(snapshot)
+        }
     }
-}
 
-#[cfg(debug_assertions)]
-impl<T: ToOffset> ToMultiBufferDebugRanges for [Range<T>] {
-    fn to_multi_buffer_debug_ranges(&self, snapshot: &MultiBufferSnapshot) -> Vec<Range<usize>> {
-        self.iter()
-            .map(|range| {
-                let start = range.start.to_offset(snapshot);
-                let end = range.end.to_offset(snapshot);
-                start..end
-            })
-            .collect()
+    impl<T: ToOffset> ToMultiBufferDebugRanges for [T] {
+        fn to_multi_buffer_debug_ranges(
+            &self,
+            snapshot: &MultiBufferSnapshot,
+        ) -> Vec<Range<usize>> {
+            self.iter()
+                .map(|item| {
+                    let offset = item.to_offset(snapshot);
+                    offset..offset
+                })
+                .collect()
+        }
+    }
+
+    impl<T: ToOffset> ToMultiBufferDebugRanges for [Range<T>] {
+        fn to_multi_buffer_debug_ranges(
+            &self,
+            snapshot: &MultiBufferSnapshot,
+        ) -> Vec<Range<usize>> {
+            self.iter()
+                .map(|range| {
+                    let start = range.start.to_offset(snapshot);
+                    let end = range.end.to_offset(snapshot);
+                    start..end
+                })
+                .collect()
+        }
     }
 }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6407,12 +6407,12 @@ impl MultiBufferSnapshot {
     /// callsite of this function is used as a key - previous annotations will be removed.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug<V, R>(&self, value: V, range: &R)
+    pub fn debug<V, R>(&self, range: &R, value: V)
     where
-        V: std::fmt::Debug,
         R: debug::ToMultiBufferDebugRanges,
+        V: std::fmt::Debug,
     {
-        self.debug_with_key(std::panic::Location::caller(), value, range);
+        self.debug_with_key(std::panic::Location::caller(), range, value);
     }
 
     /// Visually annotates a position or range with the `Debug` representation of a value. Previous
@@ -6420,11 +6420,11 @@ impl MultiBufferSnapshot {
     /// annotation's color.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug_with_key<K, V, R>(&self, key: &K, value: V, range: &R)
+    pub fn debug_with_key<K, R, V>(&self, key: &K, range: &R, value: V)
     where
         K: std::hash::Hash + 'static,
-        V: std::fmt::Debug,
         R: debug::ToMultiBufferDebugRanges,
+        V: std::fmt::Debug,
     {
         let caller = std::panic::Location::caller();
         let text_ranges = range
@@ -6439,7 +6439,7 @@ impl MultiBufferSnapshot {
             })
             .collect();
         text::debug::GlobalDebugRanges::with_locked(|debug_ranges| {
-            debug_ranges.insert(key, format!("{value:?}").into(), text_ranges, caller)
+            debug_ranges.insert(key, text_ranges, format!("{value:?}").into(), caller)
         });
     }
 }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6403,8 +6403,8 @@ impl MultiBufferSnapshot {
         self.diffs.get(&buffer_id)
     }
 
-    /// Debugging helper to highlight a range. Only one highlight will be shown per callsite. The
-    /// `value` argument is an `Hsla` color for the highlight (alpha will be set to 0.25).
+    /// Visually annotates a position or range with the `Debug` representation of a value. The
+    /// callsite of this function is used as a key - previous annotations will be removed.
     #[cfg(debug_assertions)]
     #[track_caller]
     pub fn debug<V, R>(&self, value: V, range: &R)
@@ -6415,8 +6415,9 @@ impl MultiBufferSnapshot {
         self.debug_with_key(std::panic::Location::caller(), value, range);
     }
 
-    /// Debugging helper to highlight a range. Replaces the highlights associated with the provided
-    /// key. The `value` argument is an `Hsla` color for the highlight (alpha will be set to 0.25).
+    /// Visually annotates a position or range with the `Debug` representation of a value. Previous
+    /// debug annotations with the same key will be removed. The key is also used to determine the
+    /// annotation's color.
     #[cfg(debug_assertions)]
     #[track_caller]
     pub fn debug_with_key<K, V, R>(&self, key: &K, value: V, range: &R)

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6407,12 +6407,12 @@ impl MultiBufferSnapshot {
     /// callsite of this function is used as a key - previous annotations will be removed.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug<V, R>(&self, range: &R, value: V)
+    pub fn debug<V, R>(&self, ranges: &R, value: V)
     where
         R: debug::ToMultiBufferDebugRanges,
         V: std::fmt::Debug,
     {
-        self.debug_with_key(std::panic::Location::caller(), range, value);
+        self.debug_with_key(std::panic::Location::caller(), ranges, value);
     }
 
     /// Visually annotates a position or range with the `Debug` representation of a value. Previous
@@ -6420,14 +6420,14 @@ impl MultiBufferSnapshot {
     /// annotation's color.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug_with_key<K, R, V>(&self, key: &K, range: &R, value: V)
+    pub fn debug_with_key<K, R, V>(&self, key: &K, ranges: &R, value: V)
     where
         K: std::hash::Hash + 'static,
         R: debug::ToMultiBufferDebugRanges,
         V: std::fmt::Debug,
     {
         let caller = std::panic::Location::caller();
-        let text_ranges = range
+        let text_ranges = ranges
             .to_multi_buffer_debug_ranges(self)
             .into_iter()
             .flat_map(|range| {

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6409,7 +6409,7 @@ impl MultiBufferSnapshot {
     #[track_caller]
     pub fn debug_range<V, R>(&self, value: V, range: &R)
     where
-        V: std::any::Any + Send,
+        V: std::fmt::Debug,
         R: ToMultiBufferDebugRange,
     {
         self.debug_range_with_key(std::panic::Location::caller(), value, range);
@@ -6422,7 +6422,7 @@ impl MultiBufferSnapshot {
     pub fn debug_range_with_key<K, V, R>(&self, key: &K, value: V, range: &R)
     where
         K: std::hash::Hash + 'static,
-        V: std::any::Any + Send,
+        V: std::fmt::Debug,
         R: ToMultiBufferDebugRange,
     {
         let caller = std::panic::Location::caller();
@@ -6435,7 +6435,7 @@ impl MultiBufferSnapshot {
             })
             .collect();
         text::debug::GlobalDebugRanges::with_locked(|debug_ranges| {
-            debug_ranges.insert(key, value, text_ranges, caller)
+            debug_ranges.insert(key, format!("{value:?}").into(), text_ranges, caller)
         });
     }
 }

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -6426,7 +6426,6 @@ impl MultiBufferSnapshot {
         R: debug::ToMultiBufferDebugRanges,
         V: std::fmt::Debug,
     {
-        let caller = std::panic::Location::caller();
         let text_ranges = ranges
             .to_multi_buffer_debug_ranges(self)
             .into_iter()
@@ -6439,7 +6438,7 @@ impl MultiBufferSnapshot {
             })
             .collect();
         text::debug::GlobalDebugRanges::with_locked(|debug_ranges| {
-            debug_ranges.insert(key, text_ranges, format!("{value:?}").into(), caller)
+            debug_ranges.insert(key, text_ranges, format!("{value:?}").into())
         });
     }
 }

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2598,12 +2598,12 @@ impl BufferSnapshot {
     /// callsite of this function is used as a key - previous annotations will be removed.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug<R, V>(&self, range: &R, value: V)
+    pub fn debug<R, V>(&self, ranges: &R, value: V)
     where
         R: debug::ToDebugRanges,
         V: std::fmt::Debug,
     {
-        self.debug_with_key(std::panic::Location::caller(), range, value);
+        self.debug_with_key(std::panic::Location::caller(), ranges, value);
     }
 
     /// Visually annotates a position or range with the `Debug` representation of a value. Previous
@@ -2611,14 +2611,14 @@ impl BufferSnapshot {
     /// annotation's color.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug_with_key<K, R, V>(&self, key: &K, range: &R, value: V)
+    pub fn debug_with_key<K, R, V>(&self, key: &K, ranges: &R, value: V)
     where
         K: std::hash::Hash + 'static,
         R: debug::ToDebugRanges,
         V: std::fmt::Debug,
     {
         let caller = std::panic::Location::caller();
-        let ranges = range
+        let ranges = ranges
             .to_debug_ranges(self)
             .into_iter()
             .map(|range| self.anchor_after(range.start)..self.anchor_before(range.end))

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2594,8 +2594,8 @@ impl BufferSnapshot {
         })
     }
 
-    /// Debugging helper to highlight a range. Only one highlight will be shown per callsite. The
-    /// `value` argument is an `Hsla` color for the highlight (alpha will be set to 0.25).
+    /// Visually annotates a position or range with the `Debug` representation of a value. The
+    /// callsite of this function is used as a key - previous annotations will be removed.
     #[cfg(debug_assertions)]
     #[track_caller]
     pub fn debug<V, R>(&self, value: V, range: &R)
@@ -2603,14 +2603,15 @@ impl BufferSnapshot {
         V: std::fmt::Debug,
         R: debug::ToDebugRanges,
     {
-        self.debug_ranges_with_key(std::panic::Location::caller(), value, range);
+        self.debug_with_key(std::panic::Location::caller(), value, range);
     }
 
-    /// Debugging helper to highlight a range. Replaces the highlights associated with the provided
-    /// key. The `value` argument is an `Hsla` color for the highlight (alpha will be set to 0.25).
+    /// Visually annotates a position or range with the `Debug` representation of a value. Previous
+    /// debug annotations with the same key will be removed. The key is also used to determine the
+    /// annotation's color.
     #[cfg(debug_assertions)]
     #[track_caller]
-    pub fn debug_ranges_with_key<K, V, R>(&self, key: &K, value: V, range: &R)
+    pub fn debug_with_key<K, V, R>(&self, key: &K, value: V, range: &R)
     where
         K: std::hash::Hash + 'static,
         V: std::fmt::Debug,

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -3431,11 +3431,7 @@ pub mod debug {
     impl<T: ToOffset> ToDebugRanges for [Range<T>] {
         fn to_debug_ranges(&self, snapshot: &BufferSnapshot) -> Vec<Range<usize>> {
             self.iter()
-                .map(|range| {
-                    let start = range.start.to_offset(snapshot);
-                    let end = range.end.to_offset(snapshot);
-                    start..end
-                })
+                .map(|range| range.start.to_offset(snapshot)..range.end.to_offset(snapshot))
                 .collect()
         }
     }

--- a/crates/text/src/text.rs
+++ b/crates/text/src/text.rs
@@ -2610,21 +2610,19 @@ impl BufferSnapshot {
     /// debug annotations with the same key will be removed. The key is also used to determine the
     /// annotation's color.
     #[cfg(debug_assertions)]
-    #[track_caller]
     pub fn debug_with_key<K, R, V>(&self, key: &K, ranges: &R, value: V)
     where
         K: std::hash::Hash + 'static,
         R: debug::ToDebugRanges,
         V: std::fmt::Debug,
     {
-        let caller = std::panic::Location::caller();
         let ranges = ranges
             .to_debug_ranges(self)
             .into_iter()
             .map(|range| self.anchor_after(range.start)..self.anchor_before(range.end))
             .collect();
         debug::GlobalDebugRanges::with_locked(|debug_ranges| {
-            debug_ranges.insert(key, ranges, format!("{value:?}").into(), caller);
+            debug_ranges.insert(key, ranges, format!("{value:?}").into());
         });
     }
 }
@@ -3301,7 +3299,6 @@ pub mod debug {
         key: Key,
         pub ranges: Vec<Range<Anchor>>,
         pub value: Arc<str>,
-        pub caller: &'static std::panic::Location<'static>,
         pub occurrence_index: usize,
     }
 
@@ -3333,7 +3330,6 @@ pub mod debug {
             key: &K,
             ranges: Vec<Range<Anchor>>,
             value: Arc<str>,
-            caller: &'static std::panic::Location<'static>,
         ) {
             let occurrence_index = *self
                 .key_to_occurrence_index
@@ -3356,7 +3352,6 @@ pub mod debug {
                 ranges,
                 key,
                 value,
-                caller,
                 occurrence_index,
             });
         }


### PR DESCRIPTION
This allows you to write `buffer_snapshot.debug(ranges, value)` and it will be displayed in the buffer (or multibuffer!) until that callsite runs again.  `ranges` can be any position (`usize`, `Anchor`, etc), any range, or a slice or vec of those.  `value` just needs a `Debug` impl.  These are stored in a mutable global for convenience, and this is only available in debug builds.

For example, using this to visualize the captures of the brackets Tree-sitter query:

<img width="1215" height="480" alt="image" src="https://github.com/user-attachments/assets/c1878fc7-f6b3-4e27-949e-ecf67a7906b9" />

Release Notes:

- N/A