### PR TITLE
collab: Add Orb cancellation date to `billing_subscriptions` table

### DIFF
--- a/crates/collab/migrations/20250913035238_add_orb_cancellation_date_to_billing_subscriptions.sql
+++ b/crates/collab/migrations/20250913035238_add_orb_cancellation_date_to_billing_subscriptions.sql
@@ -1,0 +1,2 @@
+alter table billing_subscriptions
+    add column orb_cancellation_date timestamp without time zone;


### PR DESCRIPTION
This PR adds an `orb_cancellation_date` column to the `billing_subscriptions` table.

Release Notes:

- N/A
