### PR TITLE
ci: Move doctests to a separate parallel job

### DIFF
--- a/.github/actions/run_tests/action.yml
+++ b/.github/actions/run_tests/action.yml
@@ -21,8 +21,3 @@ runs:
     - name: Run tests
       shell: bash -euxo pipefail {0}
       run: cargo nextest run --workspace --no-fail-fast
-
-    - name: Run doctests
-      shell: bash -euxo pipefail {0}
-      # Nextest currently doesn't support doctests
-      run: cargo test --workspace --doc --no-fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -373,6 +373,46 @@ jobs:
         if: always()
         run: rm -rf ./../.cargo
 
+  doctests:
+    # Nextest currently doesn't support doctests, so run them separately and in parallel.
+    timeout-minutes: 60
+    name: (Linux) Run doctests
+    needs: [job_spec]
+    if: |
+      github.repository_owner == 'zed-industries' &&
+      needs.job_spec.outputs.run_tests == 'true'
+    runs-on:
+      - namespace-profile-16x32-ubuntu-2204
+    steps:
+      - name: Add Rust to the PATH
+        run: echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Checkout repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+        with:
+          clean: false
+
+      - name: Cache dependencies
+        uses: swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # v2
+        with:
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+          # cache-provider: "buildjet"
+
+      - name: Install Linux dependencies
+        run: ./script/linux
+
+      - name: Configure CI
+        run: |
+          mkdir -p ./../.cargo
+          cp ./.cargo/ci-config.toml ./../.cargo/config.toml
+
+      - name: Run doctests
+        run: cargo test --workspace --doc --no-fail-fast
+
+      - name: Clean CI config file
+        if: always()
+        run: rm -rf ./../.cargo
+
   build_remote_server:
     timeout-minutes: 60
     name: (Linux) Build Remote Server


### PR DESCRIPTION
Follow on from #37851 

This may reduce CI time by running doctests in parallel with other tests. It also makes it easier to find the results.

Example output: https://github.com/zed-industries/zed/actions/runs/17698218116/job/50300398669?pr=38111

At least on this run, the doctests finished before the main Linux tests, which makes sense because there are many fewer doctests. So they should not be on the critical path.

Thanks @maxdeviant for the prompt.

<img width="615" height="513" alt="image" src="https://github.com/user-attachments/assets/bcafa636-a68c-4602-97f4-61f7904e6a7b" />


Release Notes:

- N/A