### PR TITLE
cli: Fix WSL path conversion

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -156,11 +156,12 @@ fn parse_path_in_wsl(source: &str, wsl: &str) -> Result<String> {
         command.arg("--user").arg(user);
     }
 
+    // NOTE: due to the nature of this wslpath, when running cli.exe in WSL, ~ will expand to the home directory of whichever filesystem it is run in (e.g. /mnt/c/Users/username or /home/username)
     let output = command
         .arg("--distribution")
         .arg(distro_name)
         .arg("wslpath")
-        .arg("-au")
+        .arg("-au") // -a make output absolute -u convert windows path to wsl path (even if running the .exe from wsl the arg will always be a windows path)
         .arg(source)
         .output()?;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -160,18 +160,15 @@ fn parse_path_in_wsl(source: &str, wsl: &str) -> Result<String> {
         .arg("--distribution")
         .arg(distro_name)
         .arg("wslpath")
-        .arg("-m")
+        .arg("-au")
         .arg(source)
         .output()?;
 
     let result = String::from_utf8_lossy(&output.stdout);
+    let result = result.strip_suffix("\\").unwrap_or(&result).trim();
     let prefix = format!("//wsl.localhost/{}", distro_name);
 
-    Ok(result
-        .trim()
-        .strip_prefix(&prefix)
-        .unwrap_or(&result)
-        .to_string())
+    Ok(result.strip_prefix(&prefix).unwrap_or(&result).to_string())
 }
 
 fn main() -> Result<()> {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -165,10 +165,12 @@ fn parse_path_in_wsl(source: &str, wsl: &str) -> Result<String> {
         .output()?;
 
     let result = String::from_utf8_lossy(&output.stdout);
-    let result = result.strip_suffix("\\").unwrap_or(&result).trim();
-    let prefix = format!("//wsl.localhost/{}", distro_name);
 
-    Ok(result.strip_prefix(&prefix).unwrap_or(&result).to_string())
+    Ok(result
+        .strip_suffix("\\")
+        .unwrap_or(&result)
+        .trim()
+        .to_string())
 }
 
 fn main() -> Result<()> {


### PR DESCRIPTION
This is quite a simple fix that properly uses `wslpath` to convert the Windows path to a WSL path so that Zed can properly open (before I'd get an error).

Some notes:
- I know you can't install the CLI yet (out of curiosity why?) from Zed on Windows. However, I'm just compiling from source and linking it into ~/.local/bin/cli.exe and ~/.local/zed.exe.
- It works well for me so if anyone wants to have a similar setup I recommend creating an alias in WSL's `.zshrc`: `alias zed=cli.exe --wsl <distro>`.
- Due to the nature of `wslpath` if you are in WSL and try launching Zed with a path that includes a `~` or even `$HOME`, it will expand into the home directory of whichever file system you are currently in (e.g. `/mnt/c/Users/username` or `/home/username`)

Release Notes:

- N/A
