### PR TITLE
Add support for remote MCP servers via npx snippet

### DIFF
--- a/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_modal.rs
@@ -245,6 +245,7 @@ fn context_server_input_template(server_type: ServerType) -> String {
     "command": "npx",
     /// The arguments to pass to the MCP server
     "args": [
+        "-y",
         "mcp-remote",
         "https://mcp.atlassian.com/v1/sse",
         "--header",


### PR DESCRIPTION
Closes #37770

Release Notes:

- Introduce functionality to add remote mcp servers through the UI via an example snippet


Introduce server type selection and template switching for context server configuration. This update allows users to choose between local and remote server templates, improving flexibility in server setup. The editor content updates dynamically based on the selected template type.


btw i can confirm that the server command is run twice when adding a server causing 2 browser auth tabs to open (notice in the video below how 2 tabs are opened after adding the server entry) which is different from the behavior in the latest Zed 0.203.5 release which correctly only opens one auth tab



<img width="1294" height="1332" alt="image" src="https://github.com/user-attachments/assets/1cd21779-c3f9-4b78-a65e-7c83c1be7210" />


https://github.com/user-attachments/assets/09a1ec59-1081-4f3a-9791-2776f36cbb92

