### PR TITLE
Fix typo in default settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1844,7 +1844,7 @@
     //    "typescript": "deno"
     // }
   },
-  // Repl settings.
+  // REPL settings.
   "repl": {
     // Maximum number of columns to keep in REPL's scrollback buffer.
     // Clamped with [20, 512] range.


### PR DESCRIPTION
This PR fixes a typo in the default settings file.

Release Notes:

- N/A
