### PR TITLE
collab: Add `orb_portal_url` column to `billing_customers` table

### DIFF
--- a/crates/collab/migrations/20250914022147_add_orb_portal_url_to_billing_customers.sql
+++ b/crates/collab/migrations/20250914022147_add_orb_portal_url_to_billing_customers.sql
@@ -1,0 +1,2 @@
+alter table billing_customers
+    add column orb_portal_url text;


### PR DESCRIPTION
This PR adds an `orb_portal_url` column to the `billing_customers` table.

Release Notes:

- N/A
