### PR TITLE
Implement Vim's tag stack

### DIFF
--- a/crates/agent_ui/src/agent_diff.rs
+++ b/crates/agent_ui/src/agent_diff.rs
@@ -523,7 +523,7 @@ impl Item for AgentDiffPane {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/agent_ui/src/text_thread_editor.rs
+++ b/crates/agent_ui/src/text_thread_editor.rs
@@ -47,7 +47,7 @@ use settings::{
     update_settings_file,
 };
 use std::{
-    any::TypeId,
+    any::{Any, TypeId},
     cmp,
     ops::Range,
     path::{Path, PathBuf},
@@ -2531,7 +2531,7 @@ impl Item for TextThreadEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn std::any::Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/collab_ui/src/channel_view.rs
+++ b/crates/collab_ui/src/channel_view.rs
@@ -510,7 +510,7 @@ impl Item for ChannelView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/debugger_ui/src/stack_trace_view.rs
+++ b/crates/debugger_ui/src/stack_trace_view.rs
@@ -1,4 +1,7 @@
-use std::any::{Any, TypeId};
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
 
 use collections::HashMap;
 use dap::StackFrameId;
@@ -330,7 +333,7 @@ impl Item for StackTraceView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/diagnostics/src/buffer_diagnostics.rs
+++ b/crates/diagnostics/src/buffer_diagnostics.rs
@@ -732,7 +732,7 @@ impl Item for BufferDiagnosticsEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/diagnostics/src/diagnostics.rs
+++ b/crates/diagnostics/src/diagnostics.rs
@@ -649,7 +649,7 @@ impl Item for ProjectDiagnosticsEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -16735,6 +16735,11 @@ impl Editor {
                                     )
                                 });
                             target_editor.update(cx, |target_editor, cx| {
+                                if target_editor.nav_history().is_none() {
+                                    let nav_history =
+                                        pane.read(cx).nav_history_for_item(&cx.entity());
+                                    target_editor.set_nav_history(Some(nav_history));
+                                }
                                 // When selecting a definition in a different buffer, disable the nav history
                                 // to avoid creating a history entry at the previous cursor location.
                                 pane.update(cx, |pane, _| pane.disable_history());
@@ -16777,12 +16782,14 @@ impl Editor {
                     target_buffer.anchor_after(target_start)
                         ..target_buffer.anchor_before(target_end)
                 })?;
+
+                let location = Location {
+                    buffer: target_buffer_handle,
+                    range,
+                };
                 LocationLink {
-                    origin: None,
-                    target: Location {
-                        buffer: target_buffer_handle,
-                        range,
-                    },
+                    origin: Some(location.clone()),
+                    target: location,
                 }
             });
             Ok(location)

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -799,7 +799,7 @@ async fn test_navigation_history(cx: &mut TestAppContext) {
             invalid_anchor.text_anchor.buffer_id = BufferId::new(999).ok();
             let invalid_point = Point::new(9999, 0);
             editor.navigate(
-                Box::new(NavigationData {
+                Arc::new(NavigationData {
                     cursor_anchor: invalid_anchor,
                     cursor_position: invalid_point,
                     scroll_anchor: ScrollAnchor {

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -28,7 +28,7 @@ use project::{
 use rpc::proto::{self, update_view};
 use settings::Settings;
 use std::{
-    any::TypeId,
+    any::{Any, TypeId},
     borrow::Cow,
     cmp::{self, Ordering},
     iter,
@@ -590,11 +590,11 @@ impl Item for Editor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn std::any::Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {
-        if let Ok(data) = data.downcast::<NavigationData>() {
+        if let Some(data) = data.downcast_ref::<NavigationData>() {
             let newest_selection = self.selections.newest::<Point>(cx);
             let buffer = self.buffer.read(cx).read(cx);
             let offset = if buffer.can_resolve(&data.cursor_anchor) {

--- a/crates/editor/src/proposed_changes_editor.rs
+++ b/crates/editor/src/proposed_changes_editor.rs
@@ -7,7 +7,13 @@ use language::{Buffer, BufferEvent, Capability};
 use multi_buffer::{ExcerptRange, MultiBuffer};
 use project::Project;
 use smol::stream::StreamExt;
-use std::{any::TypeId, ops::Range, rc::Rc, time::Duration};
+use std::{
+    any::{Any, TypeId},
+    ops::Range,
+    rc::Rc,
+    sync::Arc,
+    time::Duration,
+};
 use text::ToOffset;
 use ui::{ButtonLike, KeyBinding, prelude::*};
 use workspace::{
@@ -317,7 +323,7 @@ impl Item for ProposedChangesEditor {
 
     fn navigate(
         &mut self,
-        data: Box<dyn std::any::Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -492,7 +492,7 @@ impl Item for CommitView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/file_diff_view.rs
+++ b/crates/git_ui/src/file_diff_view.rs
@@ -303,7 +303,7 @@ impl Item for FileDiffView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/project_diff.rs
+++ b/crates/git_ui/src/project_diff.rs
@@ -30,8 +30,11 @@ use project::{
     git_store::{GitStore, GitStoreEvent, Repository},
 };
 use settings::{Settings, SettingsStore};
-use std::any::{Any, TypeId};
 use std::ops::Range;
+use std::{
+    any::{Any, TypeId},
+    sync::Arc,
+};
 use theme::ActiveTheme;
 use ui::{KeyBinding, Tooltip, prelude::*, vertical_divider};
 use util::ResultExt as _;
@@ -567,7 +570,7 @@ impl Item for ProjectDiff {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -364,7 +364,7 @@ impl Item for TextDiffView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -602,7 +602,7 @@ impl Item for ProjectSearchView {
 
     fn navigate(
         &mut self,
-        data: Box<dyn Any>,
+        data: Arc<dyn Any + Send>,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> bool {

--- a/crates/workspace/src/item.rs
+++ b/crates/workspace/src/item.rs
@@ -252,7 +252,12 @@ pub trait Item: Focusable + EventEmitter<Self::Event> + Render + Sized {
     fn discarded(&self, _project: Entity<Project>, _window: &mut Window, _cx: &mut Context<Self>) {}
     fn on_removed(&self, _cx: &App) {}
     fn workspace_deactivated(&mut self, _window: &mut Window, _: &mut Context<Self>) {}
-    fn navigate(&mut self, _: Box<dyn Any>, _window: &mut Window, _: &mut Context<Self>) -> bool {
+    fn navigate(
+        &mut self,
+        _: Arc<dyn Any + Send>,
+        _window: &mut Window,
+        _: &mut Context<Self>,
+    ) -> bool {
         false
     }
 
@@ -492,7 +497,7 @@ pub trait ItemHandle: 'static + Send {
     fn deactivated(&self, window: &mut Window, cx: &mut App);
     fn on_removed(&self, cx: &App);
     fn workspace_deactivated(&self, window: &mut Window, cx: &mut App);
-    fn navigate(&self, data: Box<dyn Any>, window: &mut Window, cx: &mut App) -> bool;
+    fn navigate(&self, data: Arc<dyn Any + Send>, window: &mut Window, cx: &mut App) -> bool;
     fn item_id(&self) -> EntityId;
     fn to_any(&self) -> AnyView;
     fn is_dirty(&self, cx: &App) -> bool;
@@ -935,7 +940,7 @@ impl<T: Item> ItemHandle for Entity<T> {
         self.update(cx, |this, cx| this.workspace_deactivated(window, cx));
     }
 
-    fn navigate(&self, data: Box<dyn Any>, window: &mut Window, cx: &mut App) -> bool {
+    fn navigate(&self, data: Arc<dyn Any + Send>, window: &mut Window, cx: &mut App) -> bool {
         self.update(cx, |this, cx| this.navigate(data, window, cx))
     }
 
@@ -1308,7 +1313,7 @@ pub mod test {
         InteractiveElement, IntoElement, Render, SharedString, Task, WeakEntity, Window,
     };
     use project::{Project, ProjectEntryId, ProjectPath, WorktreeId};
-    use std::{any::Any, cell::Cell};
+    use std::{any::Any, cell::Cell, sync::Arc};
     use util::rel_path::rel_path;
 
     pub struct TestProjectItem {
@@ -1541,14 +1546,18 @@ pub mod test {
 
         fn navigate(
             &mut self,
-            state: Box<dyn Any>,
+            state: Arc<dyn Any + Send>,
             _window: &mut Window,
             _: &mut Context<Self>,
         ) -> bool {
-            let state = *state.downcast::<String>().unwrap_or_default();
-            if state != self.state {
-                self.state = state;
-                true
+            if let Some(state) = state.downcast_ref::<Box<String>>() {
+                let state = *state.clone();
+                if state != self.state {
+                    false
+                } else {
+                    self.state = state;
+                    true
+                }
             } else {
                 false
             }

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -468,8 +468,8 @@ impl Default for NavigationMode {
 
 #[derive(Clone)]
 pub struct NavigationEntry {
-    pub item: Arc<dyn WeakItemHandle>,
-    pub data: Option<Arc<dyn Any + Send>>,
+    pub item: Arc<dyn WeakItemHandle + Send + Sync>,
+    pub data: Option<Arc<dyn Any + Send + Sync>>,
     pub timestamp: usize,
     pub is_preview: bool,
     pub is_deleted: bool,
@@ -4046,7 +4046,7 @@ impl Render for Pane {
 }
 
 impl ItemNavHistory {
-    pub fn push<D: 'static + Any + Send>(&mut self, data: Option<D>, cx: &mut App) {
+    pub fn push<D: 'static + Any + Send + Sync>(&mut self, data: Option<D>, cx: &mut App) {
         if self
             .item
             .upgrade()
@@ -4057,7 +4057,11 @@ impl ItemNavHistory {
         }
     }
 
-    pub fn push_tag<D: 'static + Any + Send>(&mut self, tag: Option<String>, data: Option<D>) {
+    pub fn push_tag<D: 'static + Any + Send + Sync>(
+        &mut self,
+        tag: Option<String>,
+        data: Option<D>,
+    ) {
         if self
             .item
             .upgrade()
@@ -4149,10 +4153,10 @@ impl NavHistory {
         }
     }
 
-    pub fn push<D: 'static + Any + Send>(
+    pub fn push<D: 'static + Any + Send + Sync>(
         &mut self,
         data: Option<D>,
-        item: Arc<dyn WeakItemHandle>,
+        item: Arc<dyn WeakItemHandle + Send + Sync>,
         is_preview: bool,
         cx: &mut App,
     ) {
@@ -4165,18 +4169,18 @@ impl NavHistory {
             | NavigationMode::GoingBack(_)
             | NavigationMode::GoingForward(_)
             | NavigationMode::ClosingItem => {
-                let data = data.map(|item| Arc::new(item) as Arc<dyn Any + Send>);
+                let data = data.map(|item| Arc::new(item) as Arc<dyn Any + Send + Sync>);
                 state.push(mode, data, item, is_preview);
             }
         }
         state.did_update(cx);
     }
 
-    pub fn push_tag<D: 'static + Any + Send>(
+    pub fn push_tag<D: 'static + Any + Send + Sync>(
         &mut self,
         tag: Option<String>,
         data: Option<D>,
-        item: Arc<dyn WeakItemHandle>,
+        item: Arc<dyn WeakItemHandle + Send + Sync>,
         is_preview: bool,
     ) {
         let mut state = self.0.lock();
@@ -4185,7 +4189,7 @@ impl NavHistory {
         };
         let dst = NavigationEntry {
             item,
-            data: data.map(|item| Arc::new(item) as Arc<dyn Any + Send>),
+            data: data.map(|item| Arc::new(item) as Arc<dyn Any + Send + Sync>),
             timestamp: src.timestamp,
             is_preview,
             is_deleted: false,
@@ -4239,8 +4243,8 @@ impl NavHistoryState {
     fn push(
         &mut self,
         mode: NavigationMode,
-        data: Option<Arc<dyn Any + Send>>,
-        item: Arc<dyn WeakItemHandle>,
+        data: Option<Arc<dyn Any + Send + Sync>>,
+        item: Arc<dyn WeakItemHandle + Send + Sync>,
         is_preview: bool,
     ) {
         match mode {

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -402,6 +402,7 @@ pub struct ActivationHistoryEntry {
     pub timestamp: usize,
 }
 
+#[derive(Clone)]
 pub struct ItemNavHistory {
     history: NavHistory,
     item: Arc<dyn WeakItemHandle>,
@@ -411,6 +412,7 @@ pub struct ItemNavHistory {
 #[derive(Clone)]
 pub struct NavHistory(Arc<Mutex<NavHistoryState>>);
 
+#[derive(Clone)]
 struct NavHistoryState {
     mode: NavigationMode,
     backward_stack: VecDeque<NavigationEntry>,
@@ -437,9 +439,10 @@ impl Default for NavigationMode {
     }
 }
 
+#[derive(Clone)]
 pub struct NavigationEntry {
     pub item: Arc<dyn WeakItemHandle>,
-    pub data: Option<Box<dyn Any + Send>>,
+    pub data: Option<Arc<dyn Any + Send>>,
     pub timestamp: usize,
     pub is_preview: bool,
 }
@@ -3939,7 +3942,7 @@ impl Render for Pane {
 }
 
 impl ItemNavHistory {
-    pub fn push<D: 'static + Send + Any>(&mut self, data: Option<D>, cx: &mut App) {
+    pub fn push<D: 'static + Any + Send>(&mut self, data: Option<D>, cx: &mut App) {
         if self
             .item
             .upgrade()
@@ -4017,7 +4020,7 @@ impl NavHistory {
         entry
     }
 
-    pub fn push<D: 'static + Send + Any>(
+    pub fn push<D: 'static + Any + Send>(
         &mut self,
         data: Option<D>,
         item: Arc<dyn WeakItemHandle>,
@@ -4033,7 +4036,7 @@ impl NavHistory {
                 }
                 state.backward_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });
@@ -4045,7 +4048,7 @@ impl NavHistory {
                 }
                 state.forward_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });
@@ -4056,7 +4059,7 @@ impl NavHistory {
                 }
                 state.backward_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });
@@ -4067,7 +4070,7 @@ impl NavHistory {
                 }
                 state.closed_stack.push_back(NavigationEntry {
                     item,
-                    data: data.map(|data| Box::new(data) as Box<dyn Any + Send>),
+                    data: data.map(|data| Arc::new(data) as Arc<dyn Any + Send>),
                     timestamp: state.next_timestamp.fetch_add(1, Ordering::SeqCst),
                     is_preview,
                 });

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -805,6 +805,16 @@ impl Pane {
         &mut self.nav_history
     }
 
+    pub fn fork_nav_history(&self) -> NavHistory {
+        let history = self.nav_history.0.lock().clone();
+        NavHistory(Arc::new(Mutex::new(history)))
+    }
+
+    pub fn set_nav_history(&mut self, history: NavHistory, cx: &Context<Self>) {
+        self.nav_history = history;
+        self.nav_history().0.lock().pane = cx.entity().downgrade();
+    }
+
     pub fn disable_history(&mut self) {
         self.nav_history.disable();
     }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -4115,8 +4115,10 @@ impl Workspace {
         let maybe_pane_handle =
             if let Some(clone) = item.clone_on_split(self.database_id(), window, cx) {
                 let new_pane = self.add_pane(window, cx);
+                let nav_history = pane.read(cx).fork_nav_history();
                 new_pane.update(cx, |pane, cx| {
-                    pane.add_item(clone, true, true, None, window, cx)
+                    pane.set_nav_history(nav_history, cx);
+                    pane.add_item(clone, true, true, None, window, cx);
                 });
                 self.center.split(&pane, &new_pane, direction).unwrap();
                 cx.notify();


### PR DESCRIPTION
cc @ConradIrwin @AidanV (thank you for pairing with me!)

Gosh, this turned out to be harder than I thought! But I'm really happy with how things turned out—it's a much better solution than what I had on Tuesday.

I'd recommend reading this commit-by-commit. I tried to leave nice commit messages to make it easier to follow along.

At a high level:
- This ~exactly implements Vim's tag stack behavior, at least as I understand and use it. We're missing (1) a UI, and (2) some stuff like navigating between ambiguous choices, which Zed has a different solve for anyways
- I've integrated it tightly with Zed's navigation history (forwards/back). You can think of navigating to older and newer tags like "super-back" and "super-forward"
- Nothing about this implementation is Vim specific. Anyone can use it!
- Except for the fact that splits now fork navigation (and tag) history, and the exact details of which navigations result in history items, I am not aware of behavior differences for folks who don't use the feature.

One thing I haven't looked into: Making `<C-t>` in Vim use `pane: Go to older tag` instead of `pane: Go back`. 

Closes #14206

Release Notes:
- ??? I don't know what to write here! Suggestions welcome (or Just Fix It™)
