### PR TITLE
Hide BasedPyright banner in toolbar when dismissed

### DIFF
--- a/crates/language_onboarding/src/python.rs
+++ b/crates/language_onboarding/src/python.rs
@@ -30,6 +30,10 @@ impl BasedPyrightBanner {
             _subscriptions: [subscription],
         }
     }
+
+    fn onboarding_banner_enabled(&self) -> bool {
+        !self.dismissed && self.have_basedpyright
+    }
 }
 
 impl EventEmitter<ToolbarItemEvent> for BasedPyrightBanner {}
@@ -38,7 +42,7 @@ impl Render for BasedPyrightBanner {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         div()
             .id("basedpyright-banner")
-            .when(!self.dismissed && self.have_basedpyright, |el| {
+            .when(self.onboarding_banner_enabled(), |el| {
                 el.child(
                     Banner::new()
                         .child(
@@ -81,6 +85,9 @@ impl ToolbarItemView for BasedPyrightBanner {
         _window: &mut ui::Window,
         cx: &mut Context<Self>,
     ) -> ToolbarItemLocation {
+        if !self.onboarding_banner_enabled() {
+            return ToolbarItemLocation::Hidden;
+        }
         if let Some(item) = active_pane_item
             && let Some(editor) = item.act_as::<Editor>(cx)
             && let Some(path) = editor.update(cx, |editor, cx| editor.target_file_abs_path(cx))


### PR DESCRIPTION
This PR fixes the `BasedPyrightBanner`, making sure the banner is completely hidden in the toolbar, when it was dismissed, or it's not installed.

Without the fix, the banner still occupies some space in the toolbar, making the UI looks inconsistent when editing a Python file. The bug is **especially prominent** when the toolbar is hidden in the user's settings (see below).

_Banner is shown_
<img width="1470" height="254" alt="Screenshot 2025-09-14 at 11 36 37" src="https://github.com/user-attachments/assets/1415b075-0660-41ed-8069-c2318ac3a7cf" />

_Banner dismissed_
<img width="1470" height="207" alt="Screenshot 2025-09-14 at 11 36 44" src="https://github.com/user-attachments/assets/828a3fba-5c50-4aba-832c-3e0cc6ed464b" />

_Banner dismissed (and the toolbar is hidden)_
<img width="1470" height="177" alt="Screenshot 2025-09-14 at 12 07 25" src="https://github.com/user-attachments/assets/41aa5861-87df-491f-ac7e-09fc1558dd84" />

Closes n/a

Release Notes:

- Fixed the basedpyright onboarding banner
