### PR TITLE
Use serde 1.0.221 instead of serde_derive hackery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2646,7 +2646,6 @@ dependencies = [
  "project",
  "schemars",
  "serde",
- "serde_derive",
  "settings",
  "telemetry",
  "util",
@@ -3357,7 +3356,6 @@ dependencies = [
  "semantic_version",
  "semver",
  "serde",
- "serde_derive",
  "serde_json",
  "session",
  "settings",
@@ -3413,7 +3411,6 @@ dependencies = [
  "rpc",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "settings",
  "smallvec",
@@ -4826,7 +4823,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5783,7 +5780,6 @@ dependencies = [
  "schemars",
  "search",
  "serde",
- "serde_derive",
  "serde_json",
  "settings",
  "text",
@@ -6503,7 +6499,6 @@ dependencies = [
  "project",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "settings",
  "strum 0.27.1",
@@ -7474,7 +7469,6 @@ dependencies = [
  "seahash",
  "semantic_version",
  "serde",
- "serde_derive",
  "serde_json",
  "slotmap",
  "smallvec",
@@ -12706,7 +12700,6 @@ dependencies = [
  "schemars",
  "search",
  "serde",
- "serde_derive",
  "serde_json",
  "settings",
  "smallvec",
@@ -13623,7 +13616,6 @@ dependencies = [
  "runtimelib",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "settings",
  "smol",
@@ -14730,18 +14722,28 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
+checksum = "341877e04a22458705eb4e131a1508483c877dca2792b3781d4e5d8a6019ec43"
+dependencies = [
+ "serde_core",
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.221"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c459bc0a14c840cb403fc14b148620de1e0778c96ecd6e0c8c3cacb6d8d00fe"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.219"
+version = "1.0.221"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+checksum = "d6185cf75117e20e62b1ff867b9518577271e58abe0037c40bb4794969355ab0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -14770,15 +14772,15 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.144"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "56177480b00303e689183f110b4e727bb4211d692c62d4fcd16d02be93077d40"
 dependencies = [
  "indexmap",
  "itoa",
  "memchr",
  "ryu",
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -14878,7 +14880,6 @@ dependencies = [
  "rust-embed",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "serde_json_lenient",
  "serde_path_to_error",
@@ -16465,7 +16466,6 @@ dependencies = [
  "release_channel",
  "schemars",
  "serde",
- "serde_derive",
  "settings",
  "smol",
  "sysinfo",
@@ -16568,7 +16568,6 @@ dependencies = [
  "refineable",
  "schemars",
  "serde",
- "serde_derive",
  "serde_json",
  "serde_json_lenient",
  "serde_repr",
@@ -18068,7 +18067,6 @@ dependencies = [
  "schemars",
  "search",
  "serde",
- "serde_derive",
  "serde_json",
  "settings",
  "task",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4823,7 +4823,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users 0.5.0",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -20140,6 +20140,7 @@ dependencies = [
  "windows-sys 0.48.0",
  "windows-sys 0.52.0",
  "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "winnow",
  "zeroize",
  "zvariant",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20096,7 +20096,7 @@ dependencies = [
  "security-framework-sys",
  "semver",
  "serde",
- "serde_derive",
+ "serde_core",
  "serde_json",
  "sha1",
  "simd-adler32",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20140,7 +20140,6 @@ dependencies = [
  "windows-sys 0.48.0",
  "windows-sys 0.52.0",
  "windows-sys 0.59.0",
- "windows-sys 0.60.2",
  "winnow",
  "zeroize",
  "zvariant",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -617,9 +617,8 @@ rustls-platform-verifier = "0.5.0"
 scap = { git = "https://github.com/zed-industries/scap", rev = "808aa5c45b41e8f44729d02e38fd00a2fe2722e7", default-features = false }
 schemars = { version = "1.0", features = ["indexmap2"] }
 semver = "1.0"
-serde = { version = "1.0", features = ["derive", "rc"] }
-serde_derive = { version = "1.0", features = ["deserialize_in_place"] }
-serde_json = { version = "1.0", features = ["preserve_order", "raw_value"] }
+serde = { version = "1.0.221", features = ["derive", "rc"] }
+serde_json = { version = "1.0.144", features = ["preserve_order", "raw_value"] }
 serde_json_lenient = { version = "0.2", features = [
     "preserve_order",
     "raw_value",

--- a/crates/auto_update_ui/src/auto_update_ui.rs
+++ b/crates/auto_update_ui/src/auto_update_ui.rs
@@ -31,6 +31,10 @@ pub fn init(cx: &mut App) {
 
 #[derive(Deserialize)]
 struct ReleaseNotesBody {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     title: String,
     release_notes: String,
 }

--- a/crates/call/Cargo.toml
+++ b/crates/call/Cargo.toml
@@ -37,7 +37,6 @@ postage.workspace = true
 project.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 settings.workspace = true
 telemetry.workspace = true
 util.workspace = true

--- a/crates/call/src/call_settings.rs
+++ b/crates/call/src/call_settings.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use gpui::App;
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsKey, SettingsSources, SettingsUi};
 
 #[derive(Deserialize, Debug)]

--- a/crates/collab/Cargo.toml
+++ b/crates/collab/Cargo.toml
@@ -52,7 +52,6 @@ sea-orm = { version = "1.1.0-rc.1", features = ["sqlx-postgres", "postgres-array
 semantic_version.workspace = true
 semver.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 sqlx = { version = "0.8", features = ["runtime-tokio-rustls", "postgres", "json", "time", "uuid", "any"] }

--- a/crates/collab/src/tests/random_channel_buffer_tests.rs
+++ b/crates/collab/src/tests/random_channel_buffer_tests.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 use async_trait::async_trait;
 use gpui::{BackgroundExecutor, SharedString, TestAppContext};
 use rand::prelude::*;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use std::{
     ops::{Deref, DerefMut, Range},
     rc::Rc,

--- a/crates/collab/src/user_backfiller.rs
+++ b/crates/collab/src/user_backfiller.rs
@@ -157,5 +157,9 @@ impl UserBackfiller {
 struct GithubUser {
     id: i32,
     created_at: DateTime<Utc>,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     name: Option<String>,
 }

--- a/crates/collab_ui/Cargo.toml
+++ b/crates/collab_ui/Cargo.toml
@@ -49,7 +49,6 @@ release_channel.workspace = true
 rpc.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smallvec.workspace = true

--- a/crates/collab_ui/src/collab_panel.rs
+++ b/crates/collab_ui/src/collab_panel.rs
@@ -24,7 +24,7 @@ use rpc::{
     ErrorCode, ErrorExt,
     proto::{self, ChannelVisibility, PeerId},
 };
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use settings::Settings;
 use smallvec::SmallVec;
 use std::{mem, sync::Arc};

--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -127,6 +127,10 @@ struct Notification<'a, T> {
 
 #[derive(Debug, Clone, Deserialize)]
 struct AnyNotification<'a> {
+    #[expect(
+        unused,
+        reason = "Part of the JSON-RPC protocol - we expect the field to be present in a valid JSON-RPC notification"
+    )]
     jsonrpc: &'a str,
     method: String,
     #[serde(default)]

--- a/crates/eval/src/examples/mod.rs
+++ b/crates/eval/src/examples/mod.rs
@@ -115,6 +115,10 @@ pub struct ExampleToml {
     pub url: String,
     pub revision: String,
     pub language_extension: Option<String>,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub insert_id: Option<String>,
     #[serde(default = "default_true")]
     pub require_lsp: bool,

--- a/crates/file_finder/Cargo.toml
+++ b/crates/file_finder/Cargo.toml
@@ -27,7 +27,6 @@ schemars.workspace = true
 search.workspace = true
 settings.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 text.workspace = true
 theme.workspace = true
 ui.workspace = true

--- a/crates/file_finder/src/file_finder_settings.rs
+++ b/crates/file_finder/src/file_finder_settings.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsKey, SettingsSources, SettingsUi};
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq)]

--- a/crates/git_hosting_providers/src/providers/codeberg.rs
+++ b/crates/git_hosting_providers/src/providers/codeberg.rs
@@ -16,25 +16,53 @@ use git::{
 
 #[derive(Debug, Deserialize)]
 struct CommitDetails {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     commit: Commit,
     author: Option<User>,
 }
 
 #[derive(Debug, Deserialize)]
 struct Commit {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     author: Author,
 }
 
 #[derive(Debug, Deserialize)]
 struct Author {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     name: String,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     email: String,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     date: String,
 }
 
 #[derive(Debug, Deserialize)]
 struct User {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub login: String,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub id: u64,
     pub avatar_url: String,
 }

--- a/crates/git_hosting_providers/src/providers/github.rs
+++ b/crates/git_hosting_providers/src/providers/github.rs
@@ -25,22 +25,38 @@ fn pull_request_number_regex() -> &'static Regex {
 
 #[derive(Debug, Deserialize)]
 struct CommitDetails {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     commit: Commit,
     author: Option<User>,
 }
 
 #[derive(Debug, Deserialize)]
 struct Commit {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     author: Author,
 }
 
 #[derive(Debug, Deserialize)]
 struct Author {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     email: String,
 }
 
 #[derive(Debug, Deserialize)]
 struct User {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub id: u64,
     pub avatar_url: String,
 }

--- a/crates/git_ui/Cargo.toml
+++ b/crates/git_ui/Cargo.toml
@@ -48,7 +48,6 @@ postage.workspace = true
 project.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 strum.workspace = true

--- a/crates/git_ui/src/git_panel_settings.rs
+++ b/crates/git_ui/src/git_panel_settings.rs
@@ -1,7 +1,7 @@
 use editor::EditorSettings;
 use gpui::Pixels;
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsKey, SettingsSources, SettingsUi};
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
 use workspace::dock::DockPosition;

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -114,7 +114,6 @@ schemars.workspace = true
 seahash = "4.1"
 semantic_version.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 slotmap = "1.0.6"
 smallvec.workspace = true

--- a/crates/gpui/src/gpui.rs
+++ b/crates/gpui/src/gpui.rs
@@ -112,7 +112,6 @@ pub mod private {
     pub use inventory;
     pub use schemars;
     pub use serde;
-    pub use serde_derive;
     pub use serde_json;
 }
 

--- a/crates/gpui/src/text_system/font_fallbacks.rs
+++ b/crates/gpui/src/text_system/font_fallbacks.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 /// The fallback fonts that can be configured for a given font.
 /// Fallback fonts family names are stored here.

--- a/crates/gpui/tests/action_macros.rs
+++ b/crates/gpui/tests/action_macros.rs
@@ -1,7 +1,7 @@
 use gpui::{Action, actions};
 use gpui_macros::register_action;
 use schemars::JsonSchema;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 #[test]
 fn test_action_macros() {
@@ -19,7 +19,7 @@ fn test_action_macros() {
     #[serde(deny_unknown_fields)]
     struct AnotherAction;
 
-    #[derive(PartialEq, Clone, gpui::private::serde_derive::Deserialize)]
+    #[derive(PartialEq, Clone, gpui::private::serde::Deserialize)]
     #[serde(deny_unknown_fields)]
     struct RegisterableAction {}
 

--- a/crates/project_panel/Cargo.toml
+++ b/crates/project_panel/Cargo.toml
@@ -29,7 +29,6 @@ project.workspace = true
 schemars.workspace = true
 search.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smallvec.workspace = true

--- a/crates/project_panel/src/project_panel_settings.rs
+++ b/crates/project_panel/src/project_panel_settings.rs
@@ -1,7 +1,7 @@
 use editor::EditorSettings;
 use gpui::Pixels;
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsKey, SettingsSources, SettingsUi};
 use ui::scrollbars::{ScrollbarVisibility, ShowScrollbar};
 

--- a/crates/repl/Cargo.toml
+++ b/crates/repl/Cargo.toml
@@ -40,7 +40,6 @@ project.workspace = true
 runtimelib.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 smol.workspace = true

--- a/crates/repl/src/repl_settings.rs
+++ b/crates/repl/src/repl_settings.rs
@@ -1,6 +1,6 @@
 use gpui::App;
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 use settings::{Settings, SettingsKey, SettingsSources, SettingsUi};
 
 /// Settings for configuring REPL display and behavior.

--- a/crates/settings/Cargo.toml
+++ b/crates/settings/Cargo.toml
@@ -29,7 +29,6 @@ release_channel.workspace = true
 rust-embed.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 settings_ui_macros.workspace = true
 serde_json_lenient.workspace = true

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -2232,7 +2232,9 @@ mod tests {
 
     #[derive(Debug, Deserialize)]
     struct JournalSettings {
+        #[expect(unused)]
         pub path: String,
+        #[expect(unused)]
         pub hour_format: HourFormat,
     }
 

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1588,7 +1588,7 @@ mod tests {
     use super::*;
     // This is so the SettingsUi macro can still work properly
     use crate as settings;
-    use serde_derive::Deserialize;
+    use serde::Deserialize;
     use settings_ui_macros::{SettingsKey, SettingsUi};
     use unindent::Unindent;
 

--- a/crates/supermaven_api/src/supermaven_api.rs
+++ b/crates/supermaven_api/src/supermaven_api.rs
@@ -56,7 +56,15 @@ pub struct SupermavenDownloadResponse {
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SupermavenUser {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     id: String,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     email: String,
     api_key: String,
 }

--- a/crates/terminal/Cargo.toml
+++ b/crates/terminal/Cargo.toml
@@ -29,7 +29,6 @@ libc.workspace = true
 release_channel.workspace = true
 schemars.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 settings.workspace = true
 sysinfo.workspace = true
 smol.workspace = true

--- a/crates/terminal/src/terminal_settings.rs
+++ b/crates/terminal/src/terminal_settings.rs
@@ -4,7 +4,7 @@ use alacritty_terminal::vte::ansi::{
 use collections::HashMap;
 use gpui::{AbsoluteLength, App, FontFallbacks, FontFeatures, FontWeight, Pixels, px};
 use schemars::JsonSchema;
-use serde_derive::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize};
 
 use settings::{SettingsKey, SettingsSources, SettingsUi};
 use std::path::PathBuf;

--- a/crates/theme/Cargo.toml
+++ b/crates/theme/Cargo.toml
@@ -31,7 +31,6 @@ parking_lot.workspace = true
 refineable.workspace = true
 schemars = { workspace = true, features = ["indexmap2"] }
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
 serde_repr.workspace = true

--- a/crates/theme/src/styles/accents.rs
+++ b/crates/theme/src/styles/accents.rs
@@ -1,5 +1,5 @@
 use gpui::Hsla;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 use crate::{
     AccentContent, amber, blue, cyan, gold, grass, indigo, iris, jade, lime, orange, pink, purple,

--- a/crates/theme/src/styles/players.rs
+++ b/crates/theme/src/styles/players.rs
@@ -1,7 +1,7 @@
 #![allow(missing_docs)]
 
 use gpui::Hsla;
-use serde_derive::Deserialize;
+use serde::Deserialize;
 
 use crate::{
     PlayerColorContent, amber, blue, jade, lime, orange, pink, purple, red, try_parse_color,

--- a/crates/theme_importer/src/main.rs
+++ b/crates/theme_importer/src/main.rs
@@ -21,8 +21,20 @@ const ZED_THEME_SCHEMA_URL: &str = "https://zed.dev/schema/themes/v0.2.0.json";
 
 #[derive(Debug, Deserialize)]
 struct FamilyMetadata {
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub name: String,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub author: String,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub themes: Vec<ThemeMetadata>,
 
     /// Overrides for specific syntax tokens.
@@ -31,6 +43,10 @@ struct FamilyMetadata {
     /// to an exact set of scopes when it is not otherwise possible
     /// to rely on the default mappings in the theme importer.
     #[serde(default)]
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub syntax: IndexMap<String, Vec<String>>,
 }
 

--- a/crates/theme_importer/src/vscode/theme.rs
+++ b/crates/theme_importer/src/vscode/theme.rs
@@ -6,12 +6,32 @@ use crate::vscode::VsCodeTokenColor;
 #[derive(Deserialize, Debug)]
 pub struct VsCodeTheme {
     #[serde(rename = "$schema")]
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub schema: Option<String>,
     pub name: Option<String>,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub author: Option<String>,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub maintainers: Option<Vec<String>>,
     #[serde(rename = "semanticClass")]
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     pub semantic_class: Option<String>,
+    #[expect(
+        unused,
+        reason = "This field was found to be unused with serde library bump; it's left as is due to insufficient context on PO's side, but it *may* be fine to remove"
+    )]
     #[serde(rename = "semanticHighlighting")]
     pub semantic_highlighting: Option<bool>,
     pub colors: Colors,

--- a/crates/vim/Cargo.toml
+++ b/crates/vim/Cargo.toml
@@ -38,7 +38,6 @@ regex.workspace = true
 schemars.workspace = true
 search.workspace = true
 serde.workspace = true
-serde_derive.workspace = true
 serde_json.workspace = true
 settings.workspace = true
 task.workspace = true

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -3,7 +3,7 @@ use gpui::{Action, Context, Window, actions};
 use language::Point;
 use schemars::JsonSchema;
 use search::{BufferSearchBar, SearchOptions, buffer_search};
-use serde_derive::Deserialize;
+use serde::Deserialize;
 use settings::Settings;
 use std::{iter::Peekable, str::Chars};
 use util::serde::default_true;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -38,7 +38,7 @@ use normal::search::SearchSubmit;
 use object::Object;
 use schemars::JsonSchema;
 use serde::Deserialize;
-use serde_derive::Serialize;
+use serde::Serialize;
 use settings::{
     Settings, SettingsKey, SettingsSources, SettingsStore, SettingsUi, update_settings_file,
 };

--- a/tooling/workspace-hack/Cargo.toml
+++ b/tooling/workspace-hack/Cargo.toml
@@ -114,6 +114,7 @@ sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres", 
 sea-query-binder = { version = "0.7", default-features = false, features = ["postgres-array", "sqlx-postgres", "sqlx-sqlite", "with-bigdecimal", "with-chrono", "with-json", "with-rust_decimal", "with-time", "with-uuid"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
+serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
 serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value", "unbounded_depth"] }
 sha1 = { version = "0.10", features = ["compress"] }
 simd-adler32 = { version = "0.3" }
@@ -249,7 +250,7 @@ sea-orm = { version = "1", features = ["runtime-tokio-rustls", "sqlx-postgres", 
 sea-query-binder = { version = "0.7", default-features = false, features = ["postgres-array", "sqlx-postgres", "sqlx-sqlite", "with-bigdecimal", "with-chrono", "with-json", "with-rust_decimal", "with-time", "with-uuid"] }
 semver = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["alloc", "derive", "rc"] }
-serde_derive = { version = "1", features = ["deserialize_in_place"] }
+serde_core = { version = "1", default-features = false, features = ["alloc", "rc", "result", "std"] }
 serde_json = { version = "1", features = ["alloc", "preserve_order", "raw_value", "unbounded_depth"] }
 sha1 = { version = "0.10", features = ["compress"] }
 simd-adler32 = { version = "0.3" }


### PR DESCRIPTION
serde 1.0.221 introduced serde_core into the build graph, which should render explicitly depending on serde_derive for faster build times an obsolote method.

Besides, I'm not even sure if that worked for us. My hunch is that at least one of our deps would have `serde` with derive feature enabled.. and then, most of the crates using `serde_derive` explicitly were also depending on gpui, which depended on `serde`.. thus, we wouldn't have gained anything from explicit dep on `serde_derive`

Release Notes:

- N/A
