### PR TITLE
Instruct the model not to specify the path when creating a file

### DIFF
--- a/crates/assistant_tools/src/templates/create_file_prompt.hbs
+++ b/crates/assistant_tools/src/templates/create_file_prompt.hbs
@@ -4,7 +4,7 @@ You MUST respond with the file's content wrapped in triple backticks (```).
 The backticks should be on their own line.
 The text you output will be saved verbatim as the content of the file.
 Tool calls have been disabled.
-Don't specify the path, start your response with ```
+Start your response with ``` and the code.
 
 <file_path>
 {{path}}

--- a/crates/assistant_tools/src/templates/create_file_prompt.hbs
+++ b/crates/assistant_tools/src/templates/create_file_prompt.hbs
@@ -4,7 +4,7 @@ You MUST respond with the file's content wrapped in triple backticks (```).
 The backticks should be on their own line.
 The text you output will be saved verbatim as the content of the file.
 Tool calls have been disabled.
-Start your response with ```.
+Don't specify the path, start your response with ```
 
 <file_path>
 {{path}}


### PR DESCRIPTION
Add the shortest instruction possible to prevent some models from adding the pah before the backticks (gpt4-o for example)

Closes #34466

I did not have enough time and knowledge about the codebase to check that the prompt is evaluated better. than the previous one.

Before:
At least, I have a before / after screenshot, and it was very consistent for me:
<img width="674" height="556" alt="image" src="https://github.com/user-attachments/assets/12e6a807-966b-4234-9918-e2d6a06261ed" />

After:
<img width="684" height="521" alt="image" src="https://github.com/user-attachments/assets/4f0c98c3-41af-4505-acf7-76150c5b93c4" />


Release Notes:

- Fixed a bug where gpt-4o and other models would append the path in the first line of an edit.