### PR TITLE
vim: Fix cursor position being set to end of line in normal mode

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -2524,6 +2524,10 @@ impl Editor {
         key_context
     }
 
+    pub fn last_bounds(&self) -> Option<&Bounds<Pixels>> {
+        self.last_bounds.as_ref()
+    }
+
     fn show_mouse_cursor(&mut self, cx: &mut Context<Self>) {
         if self.mouse_cursor_hidden {
             self.mouse_cursor_hidden = false;

--- a/crates/vim/src/test.rs
+++ b/crates/vim/src/test.rs
@@ -7,8 +7,8 @@ use std::time::Duration;
 use collections::HashMap;
 use command_palette::CommandPalette;
 use editor::{
-    AnchorRangeExt, DisplayPoint, Editor, EditorMode, MultiBuffer, SelectionEffects,
-    actions::DeleteLine, code_context_menus::CodeContextMenu, display_map::DisplayRow,
+    AnchorRangeExt, DisplayPoint, Editor, EditorMode, MultiBuffer, actions::DeleteLine,
+    code_context_menus::CodeContextMenu, display_map::DisplayRow,
     test::editor_test_context::EditorTestContext,
 };
 use futures::StreamExt;
@@ -16,7 +16,6 @@ use gpui::{KeyBinding, Modifiers, MouseButton, TestAppContext, px};
 use language::Point;
 pub use neovim_backed_test_context::*;
 use settings::SettingsStore;
-use text::SelectionGoal;
 use ui::Pixels;
 use util::test::marked_text_ranges;
 pub use vim_test_context::*;

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -1092,6 +1092,8 @@ impl Vim {
                         let mut point = selection.head();
                         if !selection.reversed && !selection.is_empty() {
                             point = movement::left(map, selection.head());
+                        } else if selection.is_empty() {
+                            point = map.clip_point(point, Bias::Left);
                         }
                         selection.collapse_to(point, selection.goal)
                     } else if !last_mode.is_visual() && mode.is_visual() && selection.is_empty() {
@@ -1607,7 +1609,7 @@ impl Vim {
             && !is_multicursor
             && [Mode::Visual, Mode::VisualLine, Mode::VisualBlock].contains(&self.mode)
         {
-            self.switch_mode(Mode::Normal, true, window, cx);
+            self.switch_mode(Mode::Normal, false, window, cx);
         }
     }
 


### PR DESCRIPTION
Address an issue where, in Vim mode, clicking past the end of a line after selecting the entire line would place the cursor on the newline character instead of the last character of the line, which is inconsistent with Vim's normal mode expectations.

I believe the root cause was that the cursor’s position was updated to the end of the line before the mode switch from Visual to Normal, at which point `DisplayMap.clip_at_line_ends` was still set to `false`. As a result, the cursor could end up in an invalid position for Normal mode. The fix ensures that when switching between these two modes, and if the selection is empty, the selection point is properly clipped, preventing the cursor from being placed past the end of the line.

Related #38049 

Release Notes:

- Fixed issue in Vim mode where switching from any mode to normal mode could end up with the cursor in the newline character
