### PR TITLE
go: Stop running ghost tests, fix broken `go test -run` for suites

### DIFF
--- a/crates/languages/src/go/runnables.scm
+++ b/crates/languages/src/go/runnables.scm
@@ -1,22 +1,28 @@
 ; Functions names start with `Test`
 (
-  [
+  (
     (function_declaration name: (_) @run
       (#match? @run "^Test.*"))
+  ) @_
+  (#set! tag go-test)
+)
+
+; Suite test methods (testify/suite)
+(
     (method_declaration
       receiver: (parameter_list
         (parameter_declaration
-          name: (identifier) @_receiver_name
-          type: [
-            (pointer_type (type_identifier) @_receiver_type)
-            (type_identifier) @_receiver_type
-          ]
+            type: [
+                (pointer_type (type_identifier) @_suite_name)
+                (type_identifier) @_suite_name
+            ]
         )
       )
-      name: (field_identifier) @run @_method_name
-      (#match? @_method_name "^Test.*"))
-  ] @_
-  (#set! tag go-test)
+      name: (field_identifier) @run @_subtest_name
+      (#match? @_subtest_name "^Test.*")
+      (#match? @_suite_name ".*Suite")
+    ) @_
+    (#set! tag go-testify-suite)
 )
 
 ; `go:generate` comments


### PR DESCRIPTION
Closed #33759
Closed #38166

### Summary

This PR fixes the way `go test` commands are generated for **testify suite test methods**.
Previously, only the method name was included in the `-run` flag, which caused Go’s test runner to fail to find suite test cases.

---

### Problem

https://github.com/user-attachments/assets/e6f80a77-bcf3-457c-8bfb-a7286d44ff71

1. **Incorrect command** was generated for suite tests:

   ```bash
   go test -run TestSomething_Success
   ```

   This results in:

   ```
   testing: warning: no tests to run
   ```

2. The correct format requires the **suite name + method name**:

   ```bash
   go test -run ^TestFooSuite$/TestSomething_Success$
   ```

Without the suite prefix (`TestFooSuite`), Go cannot locate test methods defined on a suite struct.

---

### Changes Made

* **Updated `runnables.scm`**:

  * Added a new query rule for suite methods (`.*Suite` receiver types).
  * Ensures only methods on suite structs (e.g., `FooSuite`) are matched.
  * Tagged these with `go-testify-suite` in addition to `go-test`.

* **Extended task template generation**:

  * Introduced `GO_SUITE_NAME_TASK_VARIABLE` to capture the suite name.
  * Create a `TaskTemplate` for the testify suite.

* **Improved labeling**:

  * Labels now show the full path (`go test ./pkg -v -run TestFooSuite/TestSomething_Success`) for clarity.

* **Added a test** `test_testify_suite_detection`:

  * Covered testify suite cases to ensure correct detection and command generation.

---

### Impact

https://github.com/user-attachments/assets/ef509183-534a-4aa4-9dc7-01402ac32260

* **Before**: Running a suite test method produced “no tests to run.”
* **After**: Suite test methods are runnable individually with the correct `-run` command, and full suites can still be executed as before.

### Release Notes

* Fixed generation of `go test` commands for **testify suite test methods**.
  Suite methods now include both the suite name and the method name in the `-run` flag (e.g., `^TestFooSuite$/TestSomething_Success$`), ensuring they are properly detected and runnable individually.