### PR TITLE
Fix external agent authentication with spaces in paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -416,7 +416,6 @@ dependencies = [
  "serde_json",
  "serde_json_lenient",
  "settings",
- "shlex",
  "smol",
  "streaming_diff",
  "task",

--- a/crates/agent_ui/Cargo.toml
+++ b/crates/agent_ui/Cargo.toml
@@ -80,7 +80,6 @@ serde.workspace = true
 serde_json.workspace = true
 serde_json_lenient.workspace = true
 settings.workspace = true
-shlex.workspace = true
 smol.workspace = true
 streaming_diff.workspace = true
 task.workspace = true


### PR DESCRIPTION
This fixes terminal-based authentication for external ACP agents (Claude Code, Gemini CLI) when file paths contain spaces, like "Application Support" on macOS and "Program Files" on Windows.

When users click authentication buttons or type `/login`, they get errors like `Cannot find module '/Users/username/Library/Application'` because the path gets split at the space.

The fix removes redundant `shlex::try_quote` calls from `spawn_external_agent_login`. These were causing double-quoting since the terminal spawning code already handles proper shell escaping.

Added a test to verify paths with spaces aren't pre-quoted.

Release Notes:

- Fixed external agent authentication failures when file paths contain spaces