### PR TITLE
ollama: Add button for refreshing available models

### DIFF
--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -913,6 +913,17 @@ impl Render for ConfigurationView {
                                             .child(Icon::new(IconName::Check).color(Color::Success))
                                             .child(Label::new("Connected"))
                                             .into_any_element(),
+                                    )
+                                    .child(
+                                        Button::new("reload-models", "")
+                                            .icon(IconName::RotateCcw)
+                                            .icon_size(IconSize::XSmall)
+                                            .on_click(cx.listener(|this, _, _, cx| {
+                                                this.state.update(cx, |state, _| {
+                                                    state.fetched_models.clear();
+                                                });
+                                                this.retry_connection(cx);
+                                            })),
                                     ),
                             )
                         } else {

--- a/crates/language_models/src/provider/ollama.rs
+++ b/crates/language_models/src/provider/ollama.rs
@@ -915,9 +915,8 @@ impl Render for ConfigurationView {
                                             .into_any_element(),
                                     )
                                     .child(
-                                        Button::new("reload-models", "")
-                                            .icon(IconName::RotateCcw)
-                                            .icon_size(IconSize::XSmall)
+                                        IconButton::new("refresh-models", IconName::RotateCcw)
+                                            .tooltip(Tooltip::text("Refresh models"))
                                             .on_click(cx.listener(|this, _, _, cx| {
                                                 this.state.update(cx, |state, _| {
                                                     state.fetched_models.clear();


### PR DESCRIPTION
Closes #17524

This PR adds a button to the bottom right corner of the ollama settings ui. It resets the available ollama models, also resets the "Connected" state in the process. This means it can be used to check if the connection is still valid as well. It's a question whether we should clear the available models on ALL `fetch_models` calls, since these only happen during auth anyway.

Ollama is a local model provider which means clicking the refresh button often only flashes the "not connected" state because the latency of the request is so low. This accentuates changes in the UI, however I don't think there's a way around this without adding some rather cumbersome deferred ui updates.

I've attached the refresh button to the "Connected" `ButtonLike`, since I don't think automatic UI spacing should separate these elements. I think this is okay because the "Connected" isn't actually something that the user can interact with.

Before: 
<img width="211" height="245" alt="image" src="https://github.com/user-attachments/assets/ea90e24a-b603-4ee2-9212-2917e1695774" />

After: 
<img width="211" height="250" alt="image" src="https://github.com/user-attachments/assets/be9af950-86a2-4067-87a0-52034a80a823" />


Alternative approach: There was also a suggestion to simply add a entry to the command palette, however none of the other providers have this ability currently either so I went with this approach. The current approach also makes it more discoverable to the user.

Release Notes:

- Added a button for refreshing available ollama models
