### PR TITLE
Fix overflowing server title in the MCP server section in the agent settings view

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -818,6 +818,8 @@ impl AgentConfiguration {
                     )
                     .child(
                         h_flex()
+                            .flex_1()
+                            .min_w_0()
                             .child(
                                 Disclosure::new(
                                     "tool-list-disclosure",
@@ -846,12 +848,19 @@ impl AgentConfiguration {
                                     .tooltip(Tooltip::text(tooltip_text))
                                     .child(status_indicator),
                             )
-                            .child(Label::new(item_id).ml_0p5())
+                            .child(
+                                div()
+                                    .ml_0p5()
+                                    .overflow_hidden()
+                                    .flex_shrink()
+                                    .child(Label::new(item_id).truncate())
+                            )
                             .child(
                                 div()
                                     .id("extension-source")
                                     .mt_0p5()
                                     .mx_1()
+                                    .flex_none()
                                     .tooltip(Tooltip::text(source_tooltip))
                                     .child(
                                         Icon::new(source_icon)
@@ -861,19 +870,24 @@ impl AgentConfiguration {
                             )
                             .when(is_running, |this| {
                                 this.child(
-                                    Label::new(if tool_count == 1 {
-                                        SharedString::from("1 tool")
-                                    } else {
-                                        SharedString::from(format!("{} tools", tool_count))
-                                    })
-                                    .color(Color::Muted)
-                                    .size(LabelSize::Small),
+                                    div()
+                                        .flex_none()
+                                        .child(
+                                            Label::new(if tool_count == 1 {
+                                                SharedString::from("1 tool")
+                                            } else {
+                                                SharedString::from(format!("{} tools", tool_count))
+                                            })
+                                            .color(Color::Muted)
+                                            .size(LabelSize::Small)
+                                        )
                                 )
                             }),
                     )
                     .child(
                         h_flex()
                             .gap_1()
+                            .flex_none()
                             .child(context_server_configuration_menu)
                             .child(
                                 Switch::new("context-server-switch", is_running.into())

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -843,18 +843,13 @@ impl AgentConfiguration {
                                     .id(SharedString::from(format!("tooltip-{}", item_id)))
                                     .h_full()
                                     .w_3()
-                                    .mx_1()
+                                    .ml_1()
+                                    .mr_1p5()
                                     .justify_center()
                                     .tooltip(Tooltip::text(tooltip_text))
                                     .child(status_indicator),
                             )
-                            .child(
-                                div()
-                                    .ml_0p5()
-                                    .overflow_hidden()
-                                    .flex_shrink()
-                                    .child(Label::new(item_id).truncate())
-                            )
+                            .child(Label::new(item_id).truncate())
                             .child(
                                 div()
                                     .id("extension-source")
@@ -870,23 +865,19 @@ impl AgentConfiguration {
                             )
                             .when(is_running, |this| {
                                 this.child(
-                                    div()
-                                        .flex_none()
-                                        .child(
-                                            Label::new(if tool_count == 1 {
-                                                SharedString::from("1 tool")
-                                            } else {
-                                                SharedString::from(format!("{} tools", tool_count))
-                                            })
-                                            .color(Color::Muted)
-                                            .size(LabelSize::Small)
-                                        )
+                                    Label::new(if tool_count == 1 {
+                                        SharedString::from("1 tool")
+                                    } else {
+                                        SharedString::from(format!("{} tools", tool_count))
+                                    })
+                                    .color(Color::Muted)
+                                    .size(LabelSize::Small),
                                 )
                             }),
                     )
                     .child(
                         h_flex()
-                            .gap_1()
+                            .gap_0p5()
                             .flex_none()
                             .child(context_server_configuration_menu)
                             .child(


### PR DESCRIPTION
Closes #38194

Release Notes:

- Fix overflowing server title in the MCP server section in the agent settings view.

<img width="600" height="738" alt="image" src="https://github.com/user-attachments/assets/86345e57-4fd0-43b8-8b8d-6209dc635dfb" />

