### PR TITLE
lsp: Fix overnotifying about open buffers for unrelated servers

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -100,7 +100,6 @@ use std::{
     borrow::Cow,
     cell::RefCell,
     cmp::{Ordering, Reverse},
-    collections::HashMap,
     convert::TryInto,
     ffi::OsStr,
     future::ready,
@@ -10541,7 +10540,10 @@ impl LspStore {
             for (worktree_id, servers) in &local.lsp_tree.instances {
                 if *worktree_id != key.worktree_id {
                     for server_map in servers.roots.values() {
-                        if server_map.contains_key(&key.name) {
+                        if server_map
+                            .values()
+                            .any(|(node, _)| node.id() == Some(server_id))
+                        {
                             worktrees_using_server.push(*worktree_id);
                         }
                     }

--- a/crates/project/src/manifest_tree/server_tree.rs
+++ b/crates/project/src/manifest_tree/server_tree.rs
@@ -114,6 +114,10 @@ impl InnerTreeNode {
             }),
         }
     }
+
+    pub(crate) fn id(&self) -> Option<LanguageServerId> {
+        self.id.get().copied()
+    }
 }
 
 impl LanguageServerTree {


### PR DESCRIPTION
Do not report all open buffers to new instances of the same language server, as they can respond with ~spurious errors.

This regressed in  https://github.com/zed-industries/zed/pull/34142

Closes https://github.com/zed-industries/zed/issues/35017

Release Notes:

- Fixed Zed overly notifying language servers about open buffers, which could've resulted in confusing errors in multi-language projects (in e.g. Go).
