### PR TITLE
Fix hover element on ACP thread mode selector

### DIFF
--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -106,18 +106,21 @@ impl ModeSelector {
                                         .gap_0p5()
                                         .text_sm()
                                         .text_color(Color::Muted.color(cx))
-                                        .child(h_flex().children(ui::render_modifiers(
-                                            &gpui::Modifiers::secondary_key(),
-                                            PlatformStyle::platform(),
-                                            None,
-                                            Some(ui::TextSize::Default.rems(cx).into()),
-                                            true,
-                                        )))
+                                        .child("Hold")
+                                        .child(h_flex().flex_shrink_0().children(
+                                            ui::render_modifiers(
+                                                &gpui::Modifiers::secondary_key(),
+                                                PlatformStyle::Windows,
+                                                None,
+                                                Some(ui::TextSize::Default.rems(cx).into()),
+                                                true,
+                                            ),
+                                        ))
                                         .child(div().map(|this| {
                                             if is_default {
-                                                this.child("click to also unset as default")
+                                                this.child("to also unset as default")
                                             } else {
-                                                this.child("click to also set as default")
+                                                this.child("to also set as default")
                                             }
                                         })),
                                 )

--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -106,8 +106,7 @@ impl ModeSelector {
                                         .gap_0p5()
                                         .text_sm()
                                         .text_color(Color::Muted.color(cx))
-                                        .child("Hold")
-                                        .child(div().pt_0p5().children(ui::render_modifiers(
+                                        .child(h_flex().children(ui::render_modifiers(
                                             &gpui::Modifiers::secondary_key(),
                                             PlatformStyle::platform(),
                                             None,
@@ -116,9 +115,9 @@ impl ModeSelector {
                                         )))
                                         .child(div().map(|this| {
                                             if is_default {
-                                                this.child("to also unset as default")
+                                                this.child("click to also unset as default")
                                             } else {
-                                                this.child("to also set as default")
+                                                this.child("click to also set as default")
                                             }
                                         })),
                                 )

--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -110,7 +110,7 @@ impl ModeSelector {
                                         .child(h_flex().flex_shrink_0().children(
                                             ui::render_modifiers(
                                                 &gpui::Modifiers::secondary_key(),
-                                                PlatformStyle::Windows,
+                                                PlatformStyle::platform(),
                                                 None,
                                                 Some(ui::TextSize::Default.rems(cx).into()),
                                                 true,


### PR DESCRIPTION
Closes #38197

This will render `^ click to also ...` on MacOS and `Ctrl + click to also ...` on Windows and Linux. 

|Before|After|
|-|-|
| <img width="683" height="197" alt="image" src="https://github.com/user-attachments/assets/09909f1b-3163-40d1-b025-4eb9b159fbf3" /> | <img width="683" height="197" alt="image" src="https://github.com/user-attachments/assets/47d0290d-afa2-4b1b-a588-adfe3130d0b1" />|

On Mac: 

<img width="683" height="197" alt="image" src="https://github.com/user-attachments/assets/f63103b5-1ceb-4193-ae6c-be55b97106e0" />

Release Notes:

- Fixed broken keybinding display when hovering over mode selector menu items.
