### PR TITLE
editor: Don't pull diagnostics on excerpts change in diagnostics editors

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -20549,7 +20549,9 @@ impl Editor {
                     )
                     .detach();
                 }
-                self.update_lsp_data(false, Some(buffer_id), window, cx);
+                if self.active_diagnostics != ActiveDiagnostic::All {
+                    self.update_lsp_data(false, Some(buffer_id), window, cx);
+                }
                 cx.emit(EditorEvent::ExcerptsAdded {
                     buffer: buffer.clone(),
                     predecessor: *predecessor,


### PR DESCRIPTION
This can lead to an infinite regress when using a language server that supports pull diagnostics, since the excerpts for the diagnostics editor are set based on the project's diagnostics.

Closes #36772

Release Notes:

- Fixed a bug that could cause duplicated diagnostics with some language servers.