### PR TITLE
Add a test that would have caught the bug last week

### DIFF
--- a/crates/auto_update/Cargo.toml
+++ b/crates/auto_update/Cargo.toml
@@ -32,3 +32,6 @@ workspace-hack.workspace = true
 
 [target.'cfg(not(target_os = "windows"))'.dependencies]
 which.workspace = true
+
+[dev-dependencies]
+gpui = { workspace = true, "features" = ["test-support"] }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -1008,11 +1008,7 @@ mod tests {
                 .set_user_settings("{}", cx)
                 .expect("Unable to set user settings");
             cx.set_global(store);
-        });
-        cx.update(|cx| {
             AutoUpdateSetting::register(cx);
-        });
-        cx.update(|cx| {
             assert!(AutoUpdateSetting::get_global(cx).0);
         });
     }

--- a/crates/auto_update/src/auto_update.rs
+++ b/crates/auto_update/src/auto_update.rs
@@ -992,7 +992,30 @@ pub fn finalize_auto_update_on_quit() {
 
 #[cfg(test)]
 mod tests {
+    use gpui::TestAppContext;
+    use settings::default_settings;
+
     use super::*;
+
+    #[gpui::test]
+    fn test_auto_update_defaults_to_true(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let mut store = SettingsStore::new(cx);
+            store
+                .set_default_settings(&default_settings(), cx)
+                .expect("Unable to set default settings");
+            store
+                .set_user_settings("{}", cx)
+                .expect("Unable to set user settings");
+            cx.set_global(store);
+        });
+        cx.update(|cx| {
+            AutoUpdateSetting::register(cx);
+        });
+        cx.update(|cx| {
+            assert!(AutoUpdateSetting::get_global(cx).0);
+        });
+    }
 
     #[test]
     fn test_stable_does_not_update_when_fetched_version_is_not_higher() {

--- a/crates/project/src/direnv.rs
+++ b/crates/project/src/direnv.rs
@@ -65,7 +65,7 @@ pub async fn load_direnv_environment(
     let output = String::from_utf8_lossy(&direnv_output.stdout);
     if output.is_empty() {
         // direnv outputs nothing when it has no changes to apply to environment variables
-        return Ok(HashMap::new());
+        return Ok(HashMap::default());
     }
 
     match serde_json::from_str(&output) {


### PR DESCRIPTION
This adds a test to make sure that the default value of the auto update setting is always true. We manually re-applied the broken code from last week, and confirmed that this test fails with that code.

Release Notes:

- N/A
