### PR TITLE
feat: Searchable description on Extensions

### DIFF
--- a/crates/collab/src/db/tests/extension_tests.rs
+++ b/crates/collab/src/db/tests/extension_tests.rs
@@ -421,3 +421,199 @@ async fn test_extensions_by_id(db: &Arc<Database>) {
         }]
     );
 }
+
+test_both_dbs!(
+    test_extension_search_by_name,
+    test_extension_search_by_name_postgres,
+    test_extension_search_by_name_sqlite
+);
+
+async fn test_extension_search_by_name(db: &Arc<Database>) {
+    let t0 = time::OffsetDateTime::from_unix_timestamp_nanos(0).unwrap();
+    let t0 = time::PrimitiveDateTime::new(t0.date(), t0.time());
+
+    let t0_chrono = convert_time_to_chrono(t0);
+
+    db.insert_extension_versions(
+        &[
+            (
+                "ext1",
+                vec![NewExtensionVersion {
+                    name: "Framework A".into(),
+                    version: semver::Version::parse("0.0.1").unwrap(),
+                    description: "Framework A that suits Language X".into(),
+                    authors: vec!["max".into(), "lucas".into()],
+                    repository: "ext1/repo".into(),
+                    schema_version: 1,
+                    wasm_api_version: Some("0.0.4".into()),
+                    provides: BTreeSet::from_iter([
+                        ExtensionProvides::Grammars,
+                        ExtensionProvides::Languages,
+                        ExtensionProvides::LanguageServers,
+                    ]),
+                    published_at: t0,
+                }],
+            ),
+            (
+                "ext2",
+                vec![NewExtensionVersion {
+                    name: "Extension Two".into(),
+                    version: semver::Version::parse("0.2.0").unwrap(),
+                    description: "a great extension".into(),
+                    authors: vec!["marshall".into()],
+                    repository: "ext2/repo".into(),
+                    schema_version: 0,
+                    wasm_api_version: None,
+                    provides: BTreeSet::default(),
+                    published_at: t0,
+                }],
+            ),
+            (
+                "ext3",
+                vec![NewExtensionVersion {
+                    name: "Some Extension".into(),
+                    version: semver::Version::parse("0.2.0").unwrap(),
+                    description: "a great extension".into(),
+                    authors: vec!["marshall".into()],
+                    repository: "ext2/repo".into(),
+                    schema_version: 0,
+                    wasm_api_version: None,
+                    provides: BTreeSet::default(),
+                    published_at: t0,
+                }],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    )
+    .await
+    .unwrap();
+
+    let extensions = db
+        .get_extensions(Some("Framework A"), None, 1, 5)
+        .await
+        .unwrap();
+
+    assert_eq!(1, extensions.len());
+
+    assert_eq!(
+        extensions,
+        &[ExtensionMetadata {
+            id: "ext1".into(),
+            manifest: rpc::ExtensionApiManifest {
+                name: "Framework A".into(),
+                version: "0.0.1".into(),
+                authors: vec!["max".into(), "lucas".into()],
+                description: Some("Framework A that suits Language X".into()),
+                repository: "ext1/repo".into(),
+                schema_version: Some(1),
+                wasm_api_version: Some("0.0.4".into()),
+                provides: BTreeSet::from_iter([
+                    ExtensionProvides::Grammars,
+                    ExtensionProvides::Languages,
+                    ExtensionProvides::LanguageServers,
+                ]),
+            },
+            published_at: t0_chrono,
+            download_count: 0,
+        }]
+    );
+}
+
+test_both_dbs!(
+    test_extension_search_by_description,
+    test_extension_search_by_description_postgres,
+    test_extension_search_by_description_sqlite
+);
+
+async fn test_extension_search_by_description(db: &Arc<Database>) {
+    let t0 = time::OffsetDateTime::from_unix_timestamp_nanos(0).unwrap();
+    let t0 = time::PrimitiveDateTime::new(t0.date(), t0.time());
+
+    let t0_chrono = convert_time_to_chrono(t0);
+
+    db.insert_extension_versions(
+        &[
+            (
+                "ext1",
+                vec![NewExtensionVersion {
+                    name: "Framework A".into(),
+                    version: semver::Version::parse("0.0.1").unwrap(),
+                    description: "Framework A that suits Language X".into(),
+                    authors: vec!["max".into(), "lucas".into()],
+                    repository: "ext1/repo".into(),
+                    schema_version: 1,
+                    wasm_api_version: Some("0.0.4".into()),
+                    provides: BTreeSet::from_iter([
+                        ExtensionProvides::Grammars,
+                        ExtensionProvides::Languages,
+                        ExtensionProvides::LanguageServers,
+                    ]),
+                    published_at: t0,
+                }],
+            ),
+            (
+                "ext2",
+                vec![NewExtensionVersion {
+                    name: "Extension Two".into(),
+                    version: semver::Version::parse("0.2.0").unwrap(),
+                    description: "a great extension".into(),
+                    authors: vec!["marshall".into()],
+                    repository: "ext2/repo".into(),
+                    schema_version: 0,
+                    wasm_api_version: None,
+                    provides: BTreeSet::default(),
+                    published_at: t0,
+                }],
+            ),
+            (
+                "ext3",
+                vec![NewExtensionVersion {
+                    name: "Some Extension".into(),
+                    version: semver::Version::parse("0.2.0").unwrap(),
+                    description: "a great extension".into(),
+                    authors: vec!["marshall".into()],
+                    repository: "ext2/repo".into(),
+                    schema_version: 0,
+                    wasm_api_version: None,
+                    provides: BTreeSet::default(),
+                    published_at: t0,
+                }],
+            ),
+        ]
+        .into_iter()
+        .collect(),
+    )
+    .await
+    .unwrap();
+
+    let extensions = db
+        .get_extensions(Some("Language X"), None, 1, 5)
+        .await
+        .unwrap();
+
+    assert_eq!(1, extensions.len());
+
+    assert_eq!(
+        extensions,
+        &[ExtensionMetadata {
+            id: "ext1".into(),
+            manifest: rpc::ExtensionApiManifest {
+                name: "Framework A".into(),
+                version: "0.0.1".into(),
+                authors: vec!["max".into(), "lucas".into()],
+                description: Some("Framework A that suits Language X".into()),
+                repository: "ext1/repo".into(),
+                schema_version: Some(1),
+                wasm_api_version: Some("0.0.4".into()),
+                provides: BTreeSet::from_iter([
+                    ExtensionProvides::Grammars,
+                    ExtensionProvides::Languages,
+                    ExtensionProvides::LanguageServers,
+                ]),
+            },
+            published_at: t0_chrono,
+            download_count: 0,
+        }]
+    );
+}


### PR DESCRIPTION
# Summary
Extensions: Making searches by Description field

### Use case I found
I found out this use case while I tried to search for Godot(Game engine) extension, and our Zed extension is called GDScript, which is basically GoDotScript. That's probably the best name to technically call that extension, however, it would also make sense to try to do it via "Godot"

Then, I figured we could add `description` as a searchable field.
That increases the odds of having a better search experience. However, it might have search results less relevant. Thus, the decision on whether to merge it or not is somewhat subjective. Overall, I believe it might make sense to move forward with the change. Let me know your thoughts on this.

---

# Query Changes (Postgres)
SQL-wise, we would be going from this to that:
- From:
```sql
WHERE
    "extensions"."latest_version" = "extension_versions"."version"
    AND "extension_versions"."schema_version" <= 1
    AND (name ILIKE '%g%o%d%o%t%')
```
- To:
```sql
WHERE
    "extensions"."latest_version" = "extension_versions"."version"
    AND "extension_versions"."schema_version" <= 1
    AND (name ILIKE '%g%o%d%o%t%' or extension_versions.description ILIKE '%godot%')
```
# Tests
- [x] Created `test_extension_search_by_name` (This one could be there even before)
- [x] Created `test_extension_search_by_description`


# Screenshots
## Currently:
<img width="945" height="328" alt="current_production" src="https://github.com/user-attachments/assets/e0923310-095e-4467-8d71-281d6369e207" />
## Pull Request:
<img width="1098" height="414" alt="local_env" src="https://github.com/user-attachments/assets/3121c047-b64e-461e-aaa4-b4a4189a8077" />

-------

## Other Example:
### This Python linter called Ruff has "Python" in its description (+60k downloads):
<img width="1126" height="652" alt="ruff_showing" src="https://github.com/user-attachments/assets/e670c4cb-f00a-40ac-811b-ee42086dc73b" />

### In production, it doesn't show up when user queries Python:
<img width="817" height="643" alt="prod_python" src="https://github.com/user-attachments/assets/eaf61818-1237-419d-b929-28c87e1ef334" />


# Local Environment Setup
FYI,
How local environment has been set up to tackle this task:
- Used `docker-compose up -d` to get my postgres instance up and running, had the migrations applied
- Extracted this JSON from dev: `https://api.zed.dev/extensions?max_schema_version=1`
- Created the INSERT queries for both `extensions` and `extension_versions` tables (Got around 730 records in extensions)
- Then, I ran the Collab API locally, pointing to my local postgres instance by using `crates/collab/.env.toml`
- Then ran Zed locally, pointing to my local API
