### PR TITLE
Fix filled button hover background

### DIFF
--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -217,7 +217,7 @@ impl ButtonStyle {
         match self {
             ButtonStyle::Filled => {
                 let mut filled_background = element_bg_from_elevation(elevation, cx);
-                filled_background.fade_out(0.92);
+                filled_background.fade_out(0.5);
 
                 ButtonLikeStyles {
                     background: filled_background,

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -217,7 +217,7 @@ impl ButtonStyle {
         match self {
             ButtonStyle::Filled => {
                 let mut filled_background = element_bg_from_elevation(elevation, cx);
-                filled_background.fade_out(0.5);
+                filled_background.fade_out(0.2);
 
                 ButtonLikeStyles {
                     background: filled_background,

--- a/crates/ui/src/components/button/button_like.rs
+++ b/crates/ui/src/components/button/button_like.rs
@@ -217,7 +217,7 @@ impl ButtonStyle {
         match self {
             ButtonStyle::Filled => {
                 let mut filled_background = element_bg_from_elevation(elevation, cx);
-                filled_background.fade_out(0.2);
+                filled_background.fade_out(0.5);
 
                 ButtonLikeStyles {
                     background: filled_background,


### PR DESCRIPTION
Release Notes:

- Fixed filled button hover background.

## Before

https://github.com/user-attachments/assets/fbc75890-d1a4-4a0c-b54e-ca2c7e63a661

## After

https://github.com/user-attachments/assets/a3595b01-e143-4cd0-8bc4-90db9ccfbf74


This appears to be a minor calculation error, not an intentional use of this value.

If we pass `0.92` to `fade_out`, the calculated will be `alpha: 0.08`.
