### PR TITLE
agent_servers: Set proxy env for all ACP agents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,7 @@ dependencies = [
  "futures 0.3.31",
  "gpui",
  "gpui_tokio",
+ "http_client",
  "indoc",
  "language",
  "language_model",

--- a/crates/agent_servers/Cargo.toml
+++ b/crates/agent_servers/Cargo.toml
@@ -30,6 +30,7 @@ fs.workspace = true
 futures.workspace = true
 gpui.workspace = true
 gpui_tokio = { workspace = true, optional = true }
+http_client.workspace = true
 indoc.workspace = true
 language.workspace = true
 language_model.workspace = true

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -1,5 +1,6 @@
 use agent_client_protocol as acp;
 use fs::Fs;
+use http_client::read_no_proxy_from_env;
 use settings::{SettingsStore, update_settings_file};
 use std::path::Path;
 use std::rc::Rc;
@@ -7,6 +8,8 @@ use std::sync::Arc;
 use std::{any::Any, path::PathBuf};
 
 use anyhow::{Context as _, Result};
+use client::ProxySettings;
+use collections::HashMap;
 use gpui::{App, AppContext as _, SharedString, Task};
 use project::agent_server_store::{AllAgentServersSettings, CLAUDE_CODE_NAME};
 
@@ -60,9 +63,27 @@ impl AgentServer for ClaudeCode {
         let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().to_string());
         let is_remote = delegate.project.read(cx).is_via_remote_server();
         let store = delegate.store.downgrade();
+        let proxy_url = cx.read_global(|settings: &SettingsStore, _| {
+            settings.get::<ProxySettings>(None).proxy_url()
+        });
         let default_mode = self.default_mode(cx);
 
         cx.spawn(async move |cx| {
+            let mut extra_env = HashMap::default();
+
+            if let Some(proxy_url) = &proxy_url {
+                let env_var = if proxy_url.scheme() == "https" {
+                    "HTTPS_PROXY"
+                } else {
+                    "HTTP_PROXY"
+                };
+                extra_env.insert(env_var.to_owned(), proxy_url.to_string());
+            }
+
+            if let Some(no_proxy) = read_no_proxy_from_env() {
+                extra_env.insert("NO_PROXY".to_owned(), no_proxy);
+            }
+
             let (command, root_dir, login) = store
                 .update(cx, |store, cx| {
                     let agent = store
@@ -70,7 +91,7 @@ impl AgentServer for ClaudeCode {
                         .context("Claude Code is not registered")?;
                     anyhow::Ok(agent.get_command(
                         root_dir.as_deref(),
-                        Default::default(),
+                        extra_env,
                         delegate.status_tx,
                         delegate.new_version_available,
                         &mut cx.to_async(),

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -1,4 +1,4 @@
-use crate::AgentServerDelegate;
+use crate::{AgentServerDelegate, load_proxy_env};
 use acp_thread::AgentConnection;
 use agent_client_protocol as acp;
 use anyhow::{Context as _, Result};
@@ -65,6 +65,7 @@ impl crate::AgentServer for CustomAgentServer {
         let is_remote = delegate.project.read(cx).is_via_remote_server();
         let default_mode = self.default_mode(cx);
         let store = delegate.store.downgrade();
+        let extra_env = load_proxy_env(cx);
 
         cx.spawn(async move |cx| {
             let (command, root_dir, login) = store
@@ -76,7 +77,7 @@ impl crate::AgentServer for CustomAgentServer {
                         })?;
                     anyhow::Ok(agent.get_command(
                         root_dir.as_deref(),
-                        Default::default(),
+                        extra_env,
                         delegate.status_tx,
                         delegate.new_version_available,
                         &mut cx.to_async(),

--- a/crates/http_client/src/http_client.rs
+++ b/crates/http_client/src/http_client.rs
@@ -318,6 +318,12 @@ pub fn read_proxy_from_env() -> Option<Url> {
         .and_then(|env| env.parse().ok())
 }
 
+pub fn read_no_proxy_from_env() -> Option<String> {
+    const ENV_VARS: &[&str] = &["NO_PROXY", "no_proxy"];
+
+    ENV_VARS.iter().find_map(|var| std::env::var(var).ok())
+}
+
 pub struct BlockedHttpClient;
 
 impl BlockedHttpClient {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -19,7 +19,6 @@ use git::GitHostingProviderRegistry;
 use gpui::{App, AppContext, Application, AsyncApp, Focusable as _, UpdateGlobal as _};
 
 use gpui_tokio::Tokio;
-use http_client::{Url, read_proxy_from_env};
 use language::LanguageRegistry;
 use onboarding::{FIRST_OPEN, show_onboarding_view};
 use prompt_store::PromptBuilder;
@@ -398,16 +397,7 @@ pub fn main() {
             std::env::consts::OS,
             std::env::consts::ARCH
         );
-        let proxy_str = ProxySettings::get_global(cx).proxy.to_owned();
-        let proxy_url = proxy_str
-            .as_ref()
-            .and_then(|input| {
-                input
-                    .parse::<Url>()
-                    .inspect_err(|e| log::error!("Error parsing proxy settings: {}", e))
-                    .ok()
-            })
-            .or_else(read_proxy_from_env);
+        let proxy_url = ProxySettings::get_global(cx).proxy_url();
         let http = {
             let _guard = Tokio::handle(cx).enter();
 


### PR DESCRIPTION
- Use ProxySettings::proxy_url to read from settings or env 
- Export HTTP(S)_PROXY and NO_PROXY for agent CLIs 
- Add read_no_proxy_from_env and move parsing from main

Closes https://github.com/zed-industries/claude-code-acp/issues/46

Release Notes:

- acp: Pass proxy settings through to all ACP agents
