### PR TITLE
git_ui: Add tooltip for branch picker items

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -521,6 +521,14 @@ impl PickerDelegate for BranchListDelegate {
                 .inset(true)
                 .spacing(ListItemSpacing::Sparse)
                 .toggle_state(selected)
+                .tooltip({
+                    let branch_name = entry.branch.name().to_string();
+                    if entry.is_new {
+                        Tooltip::text(format!("Create branch \"{}\"", branch_name))
+                    } else {
+                        Tooltip::text(branch_name)
+                    }
+                })
                 .child(
                     v_flex()
                         .w_full()


### PR DESCRIPTION
Closes #38256

<img width="300" alt="image" src="https://github.com/user-attachments/assets/5018951f-0f1b-4d5d-b59d-5b5266380e43" />


Release Notes:

- Added tooltip to Git branch picker items, making it easier to distinguish long branch names.