### PR TITLE
prompts: Improve inline assist prompt to reduce garbage from smaller models

### DIFF
--- a/assets/prompts/content_prompt.hbs
+++ b/assets/prompts/content_prompt.hbs
@@ -29,7 +29,9 @@ Generate {{content_type}} based on the following prompt:
 
 Match the indentation in the original file in the inserted {{content_type}}, don't include any indentation on blank lines.
 
-Immediately start with the following format with no remarks:
+Return ONLY the {{content_type}} to insert. Do NOT include any XML tags like <document>, <insert_here>, or any surrounding markup from the input.
+
+Respond with a code block containing the {{content_type}} to insert. Replace \{{INSERTED_CODE}} with your actual {{content_type}}:
 
 ```
 \{{INSERTED_CODE}}
@@ -66,7 +68,9 @@ Only make changes that are necessary to fulfill the prompt, leave everything els
 
 Start at the indentation level in the original file in the rewritten {{content_type}}. Don't stop until you've rewritten the entire section, even if you have no more changes to make, always write out the whole section with no unnecessary elisions.
 
-Immediately start with the following format with no remarks:
+Return ONLY the rewritten {{content_type}}. Do NOT include any XML tags like <document>, <rewrite_this>, or any surrounding markup from the input.
+
+Respond with a code block containing the rewritten {{content_type}}. Replace \{{REWRITTEN_CODE}} with your actual rewritten {{content_type}}:
 
 ```
 \{{REWRITTEN_CODE}}


### PR DESCRIPTION
Closes #24412 and #19471

I tested both insertion and replacing with o3-mini and it failed with the current prompt. With the updated prompt it does no longer return `<document><rewrite_this>` or `{{REWRITTEN_CODE}}`

I have ensured the LLM Worker works with these prompt changes.

Release Notes:

- Improved prompting for the inline assistant
