### PR TITLE
git: Add diff view for stash entries

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1269,9 +1269,9 @@
   {
     "context": "StashDiff > Editor",
     "bindings": {
-      "ctrl-space": "git::StashApplyCurrent",
-      "ctrl-shift-space": "git::StashPopCurrent",
-      "ctrl-shift-backspace": "git::StashDropCurrent"
+      "ctrl-space": "git::ApplyCurrentStash",
+      "ctrl-shift-space": "git::PopCurrentStash",
+      "ctrl-shift-backspace": "git::DropCurrentStash"
     }
   },
   {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1267,6 +1267,14 @@
     }
   },
   {
+    "context": "StashDiff > Editor",
+    "bindings": {
+      "ctrl-space": "git::StashApplyCurrent",
+      "ctrl-shift-space": "git::StashPopCurrent",
+      "ctrl-shift-backspace": "git::StashDropCurrent"
+    }
+  },
+  {
     "context": "SettingsWindow > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1080,7 +1080,8 @@
   {
     "context": "StashList || (StashList > Picker > Editor)",
     "bindings": {
-      "ctrl-shift-backspace": "stash_picker::DropStashItem"
+      "ctrl-shift-backspace": "stash_picker::DropStashItem",
+      "ctrl-shift-v": "stash_picker::ShowStashItem"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1375,9 +1375,9 @@
     "context": "StashDiff > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-space": "git::StashApplyCurrent",
-      "ctrl-shift-space": "git::StashPopCurrent",
-      "ctrl-shift-backspace": "git::StashDropCurrent"
+      "ctrl-space": "git::ApplyCurrentStash",
+      "ctrl-shift-space": "git::PopCurrentStash",
+      "ctrl-shift-backspace": "git::DropCurrentStash"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1372,6 +1372,15 @@
     }
   },
   {
+    "context": "StashDiff > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-space": "git::StashApplyCurrent",
+      "ctrl-shift-space": "git::StashPopCurrent",
+      "ctrl-shift-backspace": "git::StashDropCurrent"
+    }
+  },
+  {
     "context": "SettingsWindow > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1153,7 +1153,8 @@
     "context": "StashList || (StashList > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-backspace": "stash_picker::DropStashItem"
+      "ctrl-shift-backspace": "stash_picker::DropStashItem",
+      "ctrl-shift-v": "stash_picker::ShowStashItem"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1291,9 +1291,9 @@
     "context": "StashDiff > Editor",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-space": "git::StashApplyCurrent",
-      "ctrl-shift-space": "git::StashPopCurrent",
-      "ctrl-shift-backspace": "git::StashDropCurrent"
+      "ctrl-space": "git::ApplyCurrentStash",
+      "ctrl-shift-space": "git::PopCurrentStash",
+      "ctrl-shift-backspace": "git::DropCurrentStash"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1106,7 +1106,8 @@
     "context": "StashList || (StashList > Picker > Editor)",
     "use_key_equivalents": true,
     "bindings": {
-      "ctrl-shift-backspace": "stash_picker::DropStashItem"
+      "ctrl-shift-backspace": "stash_picker::DropStashItem",
+      "ctrl-shift-v": "stash_picker::ShowStashItem"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1288,6 +1288,15 @@
     }
   },
   {
+    "context": "StashDiff > Editor",
+    "use_key_equivalents": true,
+    "bindings": {
+      "ctrl-space": "git::StashApplyCurrent",
+      "ctrl-shift-space": "git::StashPopCurrent",
+      "ctrl-shift-backspace": "git::StashDropCurrent"
+    }
+  },
+  {
     "context": "SettingsWindow > NavigationMenu",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -693,10 +693,11 @@ impl GitRepository for RealGitRepository {
                 .args([
                     "--no-optional-locks",
                     "show",
-                    "--format=%P",
+                    "--format=",
                     "-z",
                     "--no-renames",
                     "--name-status",
+                    "--first-parent",
                 ])
                 .arg(&commit)
                 .stdin(Stdio::null())
@@ -707,9 +708,8 @@ impl GitRepository for RealGitRepository {
                 .context("starting git show process")?;
 
             let show_stdout = String::from_utf8_lossy(&show_output.stdout);
-            let mut lines = show_stdout.split('\n');
-            let parent_sha = lines.next().unwrap().trim().trim_end_matches('\0');
-            let changes = parse_git_diff_name_status(lines.next().unwrap_or(""));
+            let changes = parse_git_diff_name_status(&show_stdout);
+            let parent_sha = format!("{}^", commit);
 
             let mut cat_file_process = util::command::new_smol_command(&git_binary_path)
                 .current_dir(&working_directory)

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -102,7 +102,7 @@ impl BlameRenderer for GitBlameRenderer {
                                     blame_entry.sha.to_string(),
                                     repository.downgrade(),
                                     workspace.clone(),
-                                    false,
+                                    None,
                                     window,
                                     cx,
                                 )
@@ -311,10 +311,10 @@ impl BlameRenderer for GitBlameRenderer {
                                                 .icon_position(IconPosition::Start)
                                                 .on_click(move |_, window, cx| {
                                                     CommitView::open(
-                                                        commit_summary.sha.clone(),
+                                                        commit_summary.sha.clone().into(),
                                                         repository.downgrade(),
                                                         workspace.clone(),
-                                                        false,
+                                                        None,
                                                         window,
                                                         cx,
                                                     );
@@ -355,7 +355,7 @@ impl BlameRenderer for GitBlameRenderer {
             blame_entry.sha.to_string(),
             repository.downgrade(),
             workspace,
-            false,
+            None,
             window,
             cx,
         )

--- a/crates/git_ui/src/blame_ui.rs
+++ b/crates/git_ui/src/blame_ui.rs
@@ -99,25 +99,10 @@ impl BlameRenderer for GitBlameRenderer {
                             let workspace = workspace.clone();
                             move |_, window, cx| {
                                 CommitView::open(
-                                    CommitSummary {
-                                        sha: blame_entry.sha.to_string().into(),
-                                        subject: blame_entry
-                                            .summary
-                                            .clone()
-                                            .unwrap_or_default()
-                                            .into(),
-                                        commit_timestamp: blame_entry
-                                            .committer_time
-                                            .unwrap_or_default(),
-                                        author_name: blame_entry
-                                            .committer_name
-                                            .clone()
-                                            .unwrap_or_default()
-                                            .into(),
-                                        has_parent: true,
-                                    },
+                                    blame_entry.sha.to_string(),
                                     repository.downgrade(),
                                     workspace.clone(),
+                                    false,
                                     window,
                                     cx,
                                 )
@@ -326,9 +311,10 @@ impl BlameRenderer for GitBlameRenderer {
                                                 .icon_position(IconPosition::Start)
                                                 .on_click(move |_, window, cx| {
                                                     CommitView::open(
-                                                        commit_summary.clone(),
+                                                        commit_summary.sha.clone(),
                                                         repository.downgrade(),
                                                         workspace.clone(),
+                                                        false,
                                                         window,
                                                         cx,
                                                     );
@@ -366,15 +352,10 @@ impl BlameRenderer for GitBlameRenderer {
         cx: &mut App,
     ) {
         CommitView::open(
-            CommitSummary {
-                sha: blame_entry.sha.to_string().into(),
-                subject: blame_entry.summary.clone().unwrap_or_default().into(),
-                commit_timestamp: blame_entry.committer_time.unwrap_or_default(),
-                author_name: blame_entry.committer_name.unwrap_or_default().into(),
-                has_parent: true,
-            },
+            blame_entry.sha.to_string(),
             repository.downgrade(),
             workspace,
+            false,
             window,
             cx,
         )

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -318,9 +318,10 @@ impl Render for CommitTooltip {
                                             .on_click(
                                                 move |_, window, cx| {
                                                     CommitView::open(
-                                                        commit_summary.clone(),
+                                                        commit_summary.sha.to_string(),
                                                         repo.downgrade(),
                                                         workspace.clone(),
+                                                        false,
                                                         window,
                                                         cx,
                                                     );

--- a/crates/git_ui/src/commit_tooltip.rs
+++ b/crates/git_ui/src/commit_tooltip.rs
@@ -321,7 +321,7 @@ impl Render for CommitTooltip {
                                                         commit_summary.sha.to_string(),
                                                         repo.downgrade(),
                                                         workspace.clone(),
-                                                        false,
+                                                        None,
                                                         window,
                                                         cx,
                                                     );

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -769,20 +769,13 @@ impl ToolbarItemView for CommitViewToolbar {
         _: &mut Window,
         cx: &mut Context<Self>,
     ) -> ToolbarItemLocation {
-        self.commit_view = active_pane_item
-            .and_then(|item| item.act_as::<CommitView>(cx))
-            .map(|entity| entity.downgrade());
-
-        if let Some(commit_view) = self.commit_view(cx) {
-            let is_stash = commit_view.read(cx).stash.is_some();
-            if is_stash {
-                ToolbarItemLocation::PrimaryRight
-            } else {
-                ToolbarItemLocation::Hidden
-            }
-        } else {
-            ToolbarItemLocation::Hidden
+        if let Some(entity) = active_pane_item.and_then(|i| i.act_as::<CommitView>(cx))
+            && entity.read(cx).stash.is_some()
+        {
+            self.commit_view = Some(entity.downgrade());
+            return ToolbarItemLocation::PrimaryRight;
         }
+        ToolbarItemLocation::Hidden
     }
 
     fn pane_focus_update(

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -804,7 +804,6 @@ impl Render for CommitViewToolbar {
             h_group_sm()
                 .child(
                     Button::new("apply-stash", "Apply")
-                        .icon(IconName::ArrowDown)
                         .tooltip(Tooltip::for_action_title_in(
                             "Apply current stash",
                             &ApplyCurrentStash,
@@ -814,7 +813,6 @@ impl Render for CommitViewToolbar {
                 )
                 .child(
                     Button::new("pop-stash", "Pop")
-                        .icon(IconName::ArrowUp)
                         .tooltip(Tooltip::for_action_title_in(
                             "Pop current stash",
                             &PopCurrentStash,

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -34,17 +34,17 @@ use workspace::{
 
 use crate::git_panel::GitPanel;
 
-actions!(git, [StashApplyCurrent, StashPopCurrent, StashDropCurrent,]);
+actions!(git, [ApplyCurrentStash, PopCurrentStash, DropCurrentStash,]);
 
 pub fn init(cx: &mut App) {
     cx.observe_new(|workspace: &mut Workspace, _window, _cx| {
-        register_workspace_action(workspace, |toolbar, _: &StashApplyCurrent, window, cx| {
+        register_workspace_action(workspace, |toolbar, _: &ApplyCurrentStash, window, cx| {
             toolbar.apply_stash(window, cx);
         });
-        register_workspace_action(workspace, |toolbar, _: &StashDropCurrent, window, cx| {
+        register_workspace_action(workspace, |toolbar, _: &DropCurrentStash, window, cx| {
             toolbar.remove_stash(window, cx);
         });
-        register_workspace_action(workspace, |toolbar, _: &StashPopCurrent, window, cx| {
+        register_workspace_action(workspace, |toolbar, _: &PopCurrentStash, window, cx| {
             toolbar.pop_stash(window, cx);
         });
     })
@@ -800,7 +800,7 @@ impl Render for CommitViewToolbar {
                         .icon(IconName::ArrowDown)
                         .tooltip(Tooltip::for_action_title_in(
                             "Apply current stash",
-                            &StashApplyCurrent,
+                            &ApplyCurrentStash,
                             &focus_handle,
                         ))
                         .on_click(cx.listener(|this, _, window, cx| this.apply_stash(window, cx))),
@@ -810,7 +810,7 @@ impl Render for CommitViewToolbar {
                         .icon(IconName::ArrowUp)
                         .tooltip(Tooltip::for_action_title_in(
                             "Pop current stash",
-                            &StashPopCurrent,
+                            &PopCurrentStash,
                             &focus_handle,
                         ))
                         .on_click(cx.listener(|this, _, window, cx| this.pop_stash(window, cx))),
@@ -820,7 +820,7 @@ impl Render for CommitViewToolbar {
                         .icon(IconName::Trash)
                         .tooltip(Tooltip::for_action_title_in(
                             "Remove current stash",
-                            &StashDropCurrent,
+                            &DropCurrentStash,
                             &focus_handle,
                         ))
                         .on_click(cx.listener(|this, _, window, cx| this.remove_stash(window, cx))),

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -595,7 +595,7 @@ impl CommitViewToolbar {
                 let active_pane = workspace.active_pane();
                 let commit_view_id = commit_view.entity_id();
                 active_pane.update(cx, |pane, cx| {
-                    pane.close_item_by_id(commit_view_id, SaveIntent::Close, window, cx)
+                    pane.close_item_by_id(commit_view_id, SaveIntent::Skip, window, cx)
                 })
             })?
             .await?;

--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -637,7 +637,7 @@ impl CommitViewToolbar {
         let Some(stash) = commit_view.read(cx).stash else {
             return;
         };
-        let hash = commit_view.read(cx).commit.sha.clone();
+        let sha = commit_view.read(cx).commit.sha.clone();
 
         let answer = window.prompt(
             PromptLevel::Info,
@@ -661,7 +661,7 @@ impl CommitViewToolbar {
                 return Ok(());
             };
             let result = repo.update(cx, |repo, cx| {
-                if !stash_matches_index(&hash, stash, repo) {
+                if !stash_matches_index(&sha, stash, repo) {
                     return Err(anyhow::anyhow!("Stash has changed, not applying"));
                 }
                 Ok(repo.stash_apply(Some(stash), cx))
@@ -687,7 +687,7 @@ impl CommitViewToolbar {
         let Some(stash) = commit_view.read(cx).stash else {
             return;
         };
-        let hash = commit_view.read(cx).commit.sha.clone();
+        let sha = commit_view.read(cx).commit.sha.clone();
         let answer = window.prompt(
             PromptLevel::Info,
             &format!("Pop stash@{{{}}}?", stash),
@@ -712,7 +712,7 @@ impl CommitViewToolbar {
                 return Ok(());
             };
             let result = repo.update(cx, |repo, cx| {
-                if !stash_matches_index(&hash, stash, repo) {
+                if !stash_matches_index(&sha, stash, repo) {
                     return Err(anyhow::anyhow!("Stash has changed, pop aborted"));
                 }
                 Ok(repo.stash_pop(Some(stash), cx))
@@ -738,7 +738,7 @@ impl CommitViewToolbar {
         let Some(stash) = commit_view.read(cx).stash else {
             return;
         };
-        let hash = commit_view.read(cx).commit.sha.clone();
+        let sha = commit_view.read(cx).commit.sha.clone();
         let answer = window.prompt(
             PromptLevel::Info,
             &format!("Remove stash@{{{}}}?", stash),
@@ -762,7 +762,7 @@ impl CommitViewToolbar {
                 return Ok(());
             };
             let result = repo.update(cx, |repo, cx| {
-                if !stash_matches_index(&hash, stash, repo) {
+                if !stash_matches_index(&sha, stash, repo) {
                     return Err(anyhow::anyhow!("Stash has changed, drop aborted"));
                 }
                 Ok(repo.stash_drop(Some(stash), cx))
@@ -888,7 +888,7 @@ fn register_workspace_action<A: Action>(
     });
 }
 
-fn stash_matches_index(hash: &str, index: usize, repo: &mut Repository) -> bool {
+fn stash_matches_index(sha: &str, index: usize, repo: &mut Repository) -> bool {
     match repo
         .cached_stash()
         .entries
@@ -896,7 +896,7 @@ fn stash_matches_index(hash: &str, index: usize, repo: &mut Repository) -> bool 
         .find(|entry| entry.index == index)
     {
         Some(entry) => {
-            if entry.oid.to_string() != hash {
+            if entry.oid.to_string() != sha {
                 return false;
             }
             true

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3614,7 +3614,7 @@ impl GitPanel {
                                     commit.sha.to_string(),
                                     repo.clone(),
                                     workspace.clone(),
-                                    false,
+                                    None,
                                     window,
                                     cx,
                                 );

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3611,9 +3611,10 @@ impl GitPanel {
                             let repo = active_repository.downgrade();
                             move |_, window, cx| {
                                 CommitView::open(
-                                    commit.clone(),
+                                    commit.sha.to_string(),
                                     repo.clone(),
                                     workspace.clone(),
+                                    false,
                                     window,
                                     cx,
                                 );

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -59,6 +59,7 @@ pub fn init(cx: &mut App) {
     GitPanelSettings::register(cx);
 
     editor::set_blame_renderer(blame_ui::GitBlameRenderer, cx);
+    commit_view::init(cx);
 
     cx.observe_new(|editor: &mut Editor, _, cx| {
         conflict_view::register_editor(editor, editor.buffer().clone(), cx);

--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -34,7 +34,7 @@ mod askpass_modal;
 pub mod branch_picker;
 mod commit_modal;
 pub mod commit_tooltip;
-mod commit_view;
+pub mod commit_view;
 mod conflict_view;
 pub mod file_diff_view;
 pub mod git_panel;

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -264,6 +264,7 @@ impl StashListDelegate {
             return;
         };
         let stash_hash = entry_match.entry.oid.to_string();
+        let stash_index = entry_match.entry.index;
         let Some(repo) = self.repo.clone() else {
             return;
         };
@@ -271,7 +272,7 @@ impl StashListDelegate {
             stash_hash,
             repo.downgrade(),
             self.workspace.clone(),
-            true,
+            Some(stash_index),
             window,
             cx,
         );

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -263,13 +263,13 @@ impl StashListDelegate {
         let Some(entry_match) = self.matches.get(ix) else {
             return;
         };
-        let stash_hash = entry_match.entry.oid.to_string();
+        let stash_sha = entry_match.entry.oid.to_string();
         let stash_index = entry_match.entry.index;
         let Some(repo) = self.repo.clone() else {
             return;
         };
         CommitView::open(
-            stash_hash,
+            stash_sha,
             repo.downgrade(),
             self.workspace.clone(),
             Some(stash_index),

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -4,16 +4,17 @@ use chrono;
 use git::stash::StashEntry;
 use gpui::{
     Action, AnyElement, App, Context, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable,
-    InteractiveElement, IntoElement, Modifiers, ModifiersChangedEvent, MouseButton, MouseUpEvent,
-    ParentElement, Render, SharedString, Styled, Subscription, Task, WeakEntity, Window, actions,
-    rems,
+    InteractiveElement, IntoElement, Modifiers, ModifiersChangedEvent, ParentElement, Render,
+    SharedString, Styled, Subscription, Task, WeakEntity, Window, actions, rems, svg,
 };
 use picker::{Picker, PickerDelegate};
 use project::git_store::{Repository, RepositoryEvent};
 use std::sync::Arc;
 use time::{OffsetDateTime, UtcOffset};
 use time_format;
-use ui::{HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*};
+use ui::{
+    ButtonLike, HighlightedLabel, KeyBinding, ListItem, ListItemSpacing, Tooltip, prelude::*,
+};
 use util::ResultExt;
 use workspace::notifications::DetachAndPromptErr;
 use workspace::{ModalView, Workspace};
@@ -476,17 +477,20 @@ impl PickerDelegate for StashListDelegate {
             );
 
         let show_button = div()
-            .id("show-button")
-            .on_mouse_up(
-                MouseButton::Right,
-                cx.listener(move |picker, _: &MouseUpEvent, window, cx| {
-                    cx.stop_propagation();
-                    picker.delegate.show_stash_at(ix, window, cx);
-                }),
-            )
+            .group("show-button-hover")
             .child(
-                IconButton::new("show_stash", IconName::Eye)
-                    .icon_size(IconSize::Small)
+                ButtonLike::new("show-button")
+                    .child(
+                        svg()
+                            .size(IconSize::Medium.rems())
+                            .flex_none()
+                            .path(IconName::Eye.path())
+                            .text_color(Color::Default.color(cx))
+                            .group_hover("show-button-hover", |this| {
+                                this.text_color(Color::Accent.color(cx))
+                            })
+                            .hover(|this| this.text_color(Color::Accent.color(cx))),
+                    )
                     .tooltip(Tooltip::for_action_title("Show Stash", &ShowStashItem))
                     .on_click(cx.listener(move |picker, _, window, cx| {
                         cx.stop_propagation();

--- a/crates/git_ui/src/stash_picker.rs
+++ b/crates/git_ui/src/stash_picker.rs
@@ -475,11 +475,6 @@ impl PickerDelegate for StashListDelegate {
                     .size(LabelSize::Small),
             );
 
-        let tooltip_text = format!(
-            "stash@{{{}}} created {}",
-            entry_match.entry.index, entry_match.formatted_timestamp
-        );
-
         let show_button = div()
             .id("show-button")
             .on_mouse_up(

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -25,6 +25,7 @@ use feature_flags::{FeatureFlagAppExt, PanicFeatureFlag};
 use fs::Fs;
 use futures::future::Either;
 use futures::{StreamExt, channel::mpsc, select_biased};
+use git_ui::commit_view::CommitViewToolbar;
 use git_ui::git_panel::GitPanel;
 use git_ui::project_diff::ProjectDiffToolbar;
 use gpui::{
@@ -1049,6 +1050,8 @@ fn initialize_pane(
             toolbar.add_item(migration_banner, window, cx);
             let project_diff_toolbar = cx.new(|cx| ProjectDiffToolbar::new(workspace, cx));
             toolbar.add_item(project_diff_toolbar, window, cx);
+            let commit_view_toolbar = cx.new(|cx| CommitViewToolbar::new(workspace, cx));
+            toolbar.add_item(commit_view_toolbar, window, cx);
             let agent_diff_toolbar = cx.new(AgentDiffToolbar::new);
             toolbar.add_item(agent_diff_toolbar, window, cx);
             let basedpyright_banner = cx.new(|cx| BasedPyrightBanner::new(workspace, cx));


### PR DESCRIPTION
Continues the work from #35927 to add a git diff view for stash entries. 

[Screencast From 2025-09-17 19-46-01.webm](https://github.com/user-attachments/assets/ded33782-adef-4696-8e34-3665911c09c7)

Stash entries are [represented as commits](https://git-scm.com/docs/git-stash#_discussion) except they have up to 3 parents: 

```
       .----W (this is the stash entry)
      /    /|
-----H----I |
           \|
            U
```

Where `H` is the `HEAD` commit, `I` is a commit that records the state of the index, and `U` is another commit that records untracked files (when using `git stash -u`). 

Given this, I modified the existing commit view struct to allow loading stash and commits entries with git sha identifier so that we can get a similar git diff view for both of them. 

The stash diff is generated by comparing the stash commit with its parent (`<commit>^` or `H` in the diagram) which generates the same diff as doing `git stash show -p <stash entry>`. This *can* be counter-intuitive since a user may expect the comparison to be made between the stash commit and the current commit (`HEAD`), but given that the default behavior in git cli is to compare with the stash parent, I went for that approach.

Hoping to get some feedback from a Zed team member to see if they agree with this approach. 

Release Notes:

- Add git diff view for stash entries
- Add toolbar on git diff view for stash entries
- Prompt before executing a destructive stash action on diff view
- Fix commit view for merge commits  (see #38289)