### PR TITLE
git: Fix file changes not loading on merge commit view

### DIFF
--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -645,7 +645,7 @@ impl GitRepository for RealGitRepository {
                 .args([
                     "--no-optional-locks",
                     "show",
-                    "--format=%P%n",
+                    "--format=",
                     "-z",
                     "--no-renames",
                     "--name-status",
@@ -659,8 +659,7 @@ impl GitRepository for RealGitRepository {
                 .context("starting git show process")?;
 
             let show_stdout = String::from_utf8_lossy(&show_output.stdout);
-            let (_, raw_changes) = show_stdout.split_once('\n').unwrap();
-            let changes = parse_git_diff_name_status(raw_changes.trim_start_matches(&['\n', '\0']));
+            let changes = parse_git_diff_name_status(&show_stdout);
             let parent_sha = format!("{}^", commit);
 
             let mut cat_file_process = util::command::new_std_command("git")


### PR DESCRIPTION
Closes #38289 

Dropped parent parsing in favor of just using `<commit>^` to let git figure out the parent of the commit (since in the case of merge commit, multiple parents are returned by the command we are running here) and added `--first-parent` to [properly load the changes of a merge commit](https://stackoverflow.com/questions/49753378/why-is-first-parent-not-the-default-for-git-show) similar to how `git diff` works. 

|Before|After|
|-|-|
|<img width="1044" height="743" alt="image" src="https://github.com/user-attachments/assets/d011adb8-654b-4d0f-a04c-0274de20411f" />|<img width="1103" height="780" alt="image" src="https://github.com/user-attachments/assets/237910d7-5192-4d1c-b1b5-d6c7ad238277" />|



Release Notes:

- Fix diff files not loading on merge commit view.
