### PR TITLE
rope: Prevent integer overflow in peek_with_bitmaps

### DIFF
--- a/crates/rope/src/rope.rs
+++ b/crates/rope/src/rope.rs
@@ -784,7 +784,15 @@ impl<'a> Chunks<'a> {
             slice_start..slice_end
         };
 
-        let bitmask = (1u128 << slice_range.end as u128).saturating_sub(1);
+        // Ensure slice_range.end doesn't exceed valid bitmap positions
+        // Find the highest set bit in chunk.chars to determine valid bitmap range
+        let max_bit_position = if chunk.chars() == 0 {
+            0
+        } else {
+            128 - chunk.chars().leading_zeros() as usize
+        };
+        let end = cmp::min(slice_range.end, max_bit_position);
+        let bitmask = (1u128 << end).wrapping_sub(1);
 
         let chars = (chunk.chars() & bitmask) >> slice_range.start;
         let tabs = (chunk.tabs & bitmask) >> slice_range.start;


### PR DESCRIPTION
Fixes integer overflow bug in Chunks::peak_with_bitmaps() when slice_range.end >= 128, which caused panic when processing text chunks with 128 or more characters.

The overflow occurred in the bitmask calculation:
(1u128 << slice_range.end as u128).saturating_sub(1)

Release Notes:

- N/A
