### PR TITLE
cli: Refactor URL prefix checks

### DIFF
--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -309,13 +309,9 @@ fn main() -> Result<()> {
     #[cfg(not(target_os = "windows"))]
     let wsl = None;
 
+    let prefixes = ["zed://", "http://", "https://", "file://", "ssh://"];
     for path in args.paths_with_position.iter() {
-        if path.starts_with("zed://")
-            || path.starts_with("http://")
-            || path.starts_with("https://")
-            || path.starts_with("file://")
-            || path.starts_with("ssh://")
-        {
+        if prefixes.iter().any(|&prefix| path.starts_with(prefix)) {
             urls.push(path.to_string());
         } else if path == "-" && args.paths_with_position.len() == 1 {
             let file = NamedTempFile::new()?;


### PR DESCRIPTION
Use slice to refactor URL prefix checks.

Release Notes:

- N/A