### PR TITLE
Make scrollbars auto-hide by default

### DIFF
--- a/crates/ui/src/components/scrollbar.rs
+++ b/crates/ui/src/components/scrollbar.rs
@@ -35,11 +35,11 @@ pub mod scrollbars {
     pub enum ShowScrollbar {
         /// Show the scrollbar if there's important information or
         /// follow the system's configured behavior.
+        #[default]
         Auto,
         /// Match the system's configured behavior.
         System,
         /// Always show the scrollbar.
-        #[default]
         Always,
         /// Never show the scrollbar.
         Never,


### PR DESCRIPTION
With this, scrollbars across the app will now auto-hide unless it is specified that they should follow a specific setting.

Optimally, we would just track the user preference by default. However, this is currently not possible. because the setting we would need to read lives in `editor` and we cannot read that from within the `ui` crate.

Release Notes:

- N/A
