### PR TITLE
Add open WSL shortcut

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -90,6 +90,18 @@ pub fn init(cx: &mut App) {
         });
     });
 
+    #[cfg(target_os = "windows")]
+    cx.on_action(|open_wsl: &zed_actions::wsl_actions::OpenWsl, cx| {
+        let create_new_window = open_wsl.create_new_window;
+        with_active_or_new_workspace(cx, move |workspace, window, cx| {
+            let handle = cx.entity().downgrade();
+            let fs = workspace.project().read(cx).fs().clone();
+            workspace.toggle_modal(window, cx, |window, cx| {
+                RemoteServerProjects::wsl(create_new_window, fs, window, handle, cx)
+            });
+        });
+    });
+
     cx.on_action(|open_recent: &OpenRecent, cx| {
         let create_new_window = open_recent.create_new_window;
         with_active_or_new_workspace(cx, move |workspace, window, cx| {

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -522,7 +522,42 @@ impl Mode {
 }
 
 impl RemoteServerProjects {
+    pub fn wsl(
+        create_new_window: bool,
+        fs: Arc<dyn Fs>,
+        window: &mut Window,
+        workspace: WeakEntity<Workspace>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::new_inner(
+            Mode::AddWslDistro(AddWslDistro::new(window, cx)),
+            create_new_window,
+            fs,
+            window,
+            workspace,
+            cx,
+        )
+    }
+
     pub fn new(
+        create_new_window: bool,
+        fs: Arc<dyn Fs>,
+        window: &mut Window,
+        workspace: WeakEntity<Workspace>,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self::new_inner(
+            Mode::default_mode(&BTreeSet::new(), cx),
+            create_new_window,
+            fs,
+            window,
+            workspace,
+            cx,
+        )
+    }
+
+    fn new_inner(
+        mode: Mode,
         create_new_window: bool,
         fs: Arc<dyn Fs>,
         window: &mut Window,
@@ -558,7 +593,7 @@ impl RemoteServerProjects {
             });
 
         Self {
-            mode: Mode::default_mode(&BTreeSet::new(), cx),
+            mode,
             focus_handle,
             workspace,
             retained_connections: Vec::new(),

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -522,6 +522,7 @@ impl Mode {
 }
 
 impl RemoteServerProjects {
+    #[cfg(target_os = "windows")]
     pub fn wsl(
         create_new_window: bool,
         fs: Arc<dyn Fs>,

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -512,4 +512,13 @@ pub mod wsl_actions {
         #[serde(default)]
         pub create_new_window: bool,
     }
+
+    /// Open a wsl distro.
+    #[derive(PartialEq, Clone, Deserialize, Default, JsonSchema, Action)]
+    #[action(namespace = projects)]
+    #[serde(deny_unknown_fields)]
+    pub struct OpenWsl {
+        #[serde(default)]
+        pub create_new_window: bool,
+    }
 }


### PR DESCRIPTION
Adds a shortcut to add a WSL distro for better wsl feature discoverability.

- [x] Open wsl from open remote
- [x] Open local folder in wsl action
- [x] Open wsl shortcut (shortcuts to open remote)

Release Notes:

- N/A
