### PR TITLE
extension_host: Sanitize cwd path for ResolvedTask

### DIFF
--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -309,7 +309,14 @@ impl TryFrom<SpawnInTerminal> for ResolvedTask {
             command: value.command.context("missing command")?,
             args: value.args,
             env: value.env.into_iter().collect(),
-            cwd: value.cwd.map(|s| s.to_string_lossy().into_owned()),
+            cwd: value.cwd.map(|s| {
+                let s = s.to_string_lossy();
+                if cfg!(target_os = "windows") {
+                    s.replace('\\', "/")
+                } else {
+                    s.into_owned()
+                }
+            }),
         })
     }
 }


### PR DESCRIPTION
Ensures build task's CWD paths use POSIX-friendly path separator on Windows host so that `std::path::Path` ops work as expected within the Wasm guest.

Release Notes:

- N/A
