### PR TITLE
terminal: Fix COLORTERM regression for true color support

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -364,6 +364,7 @@ impl TerminalBuilder {
         env.insert("ZED_TERM".to_string(), "true".to_string());
         env.insert("TERM_PROGRAM".to_string(), "zed".to_string());
         env.insert("TERM".to_string(), "xterm-256color".to_string());
+        env.insert("COLORTERM".to_string(), "truecolor".to_string());
         env.insert(
             "TERM_PROGRAM_VERSION".to_string(),
             release_channel::AppVersion::global(cx).to_string(),


### PR DESCRIPTION
Closes #38304 

Release Notes:

- Fixed true color detection regression by setting `COLORTERM=truecolor`

---

Reason:

The regression is possibly introduced in [pr#36576: Inject venv environment via the toolchain](https://github.com/zed-industries/zed/pull/36576/files#diff-6f30387876b79f1de44f8193401d6c8fb49a2156479c4f2e32bc922ec5d54d76), where `alacritty_terminal::tty::setup_env();` is removed.

The `alacritty_terminal::tty::setup_env();` does 2 things, which sets `TERM` & `COLORTERM` envvar.
```rs
/// Setup environment variables.
pub fn setup_env() {
    // Default to 'alacritty' terminfo if it is available, otherwise
    // default to 'xterm-256color'. May be overridden by user's config
    // below.
    let terminfo = if terminfo_exists("alacritty") { "alacritty" } else { "xterm-256color" };
    unsafe { env::set_var("TERM", terminfo) };

    // Advertise 24-bit color support.
    unsafe { env::set_var("COLORTERM", "truecolor") };
}
```