### PR TITLE
remote: Remove excess quoting in WSL `build_command`

### DIFF
--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -400,7 +400,7 @@ impl RemoteConnection for WslRemoteConnection {
                 "--".to_string(),
                 self.shell.clone(),
                 "-c".to_string(),
-                shlex::try_quote(&script)?.to_string(),
+                script,
             ]
         } else {
             vec![
@@ -411,7 +411,7 @@ impl RemoteConnection for WslRemoteConnection {
                 "--".to_string(),
                 self.shell.clone(),
                 "-c".to_string(),
-                shlex::try_quote(&script)?.to_string(),
+                script,
             ]
         };
 


### PR DESCRIPTION
The built-up command for the WSL remote connection looks like

```
wsl.exe --distribution Ubuntu --user cole --cd /home/cole -- bash -c SCRIPT
```

Where `SCRIPT` is a command itself. We don't need extra quotes around `SCRIPT` because we already pass it whole as a separate argument to `wsl.exe`.

This isn't yet enough to get ACP servers working in WSL projects (#38332), but it removes one roadblock.

Release Notes:

- windows: Fixed an issue that could prevent running binaries in WSL remote projects.
