### PR TITLE
Fix diff highlights

### DIFF
--- a/crates/languages/src/diff/highlights.scm
+++ b/crates/languages/src/diff/highlights.scm
@@ -3,12 +3,12 @@
 [
   (addition)
   (new_file)
-] @diff.plus
+] @string
 
 [
   (deletion)
   (old_file)
-] @diff.minus
+] @keyword
 
 (commit) @constant
 
@@ -17,8 +17,6 @@
 (command
   "diff" @function
   (argument) @variable.parameter)
-
-(filename) @string.special.path
 
 (mode) @number
 

--- a/crates/languages/src/diff/highlights.scm
+++ b/crates/languages/src/diff/highlights.scm
@@ -4,11 +4,13 @@
   (addition)
   (new_file)
 ] @string
+;; TODO: This should eventually be `@diff.plus` with a fallback of `@string`
 
 [
   (deletion)
   (old_file)
 ] @keyword
+;; TODO: This should eventually be `@diff.minus` with a fallback of `@keyword`
 
 (commit) @constant
 


### PR DESCRIPTION
Per https://github.com/zed-industries/zed/discussions/23371#discussioncomment-13533635, the issue is not new and I don't know how to solve the problem more holistically yet.

All of the native themes don't have spec for `@diff.plus` and `@diff.minus` leaving addition and deletion not being highlighted. For diff file, the most valuable highlighting comes from exactly what we're missing. Hence, I think this is worth fixing.

Perhaps, the ideal fix would be standardizing and documenting captures such as `@diff.plus` and `@diff.minus` on https://zed.dev/docs/extensions/languages#syntax-highlighting for theme writers to adopt. But the existing list of captures seems to be language-agnostic so I'm not sure if that's the best way forward.

Per https://github.com/the-mikedavis/tree-sitter-diff/pull/18#issuecomment-2569785346, `tree-sitter-diff`'s author prefers using `@keyword` and `@string` so that `tree-sitter highlight` can work out of the box. So it seems to be an ok choice for Zed.

Another approach is just adding `@diff.plus` and `@diff.minus` to the native themes. Let me know if I should pursue this instead.

Before
<img width="668" height="328" alt="Screenshot 2025-09-18 at 11 16 14 AM" src="https://github.com/user-attachments/assets/d9a5b3b5-b9ef-4e74-883f-831630fb431e" />

After
<img width="1011" height="404" alt="Screenshot 2025-09-18 at 12 11 15 PM" src="https://github.com/user-attachments/assets/9cf453c0-30df-4d17-99e9-f2297865f12a" />
<img width="915" height="448" alt="Screenshot 2025-09-18 at 12 12 14 PM" src="https://github.com/user-attachments/assets/9e7438a6-9009-4136-b841-1f8e1356bc9b" />



Closes https://github.com/zed-industries/extensions/issues/490


Release Notes:
- Fixed highlighting for addition and deletion for diff language
