### PR TITLE
languages: Add `ignore` keyword for gomod

### DIFF
--- a/crates/languages/src/gomod/highlights.scm
+++ b/crates/languages/src/gomod/highlights.scm
@@ -7,6 +7,7 @@
   "exclude"
   "retract"
   "module"
+  "ignore"
 ] @keyword
 
 "=>" @operator

--- a/crates/languages/src/gomod/structure.scm
+++ b/crates/languages/src/gomod/structure.scm
@@ -27,3 +27,9 @@
   ("(") @structure.open
   (")") @structure.close
 )
+
+(ignore_directive
+  "ignore" @structure.anchor
+  ("(") @structure.open
+  (")") @structure.close
+)


### PR DESCRIPTION
go 1.25 introduce ignore directive in go.mod to specify directories the go command should ignore.

ref:  https://tip.golang.org/doc/go1.25#go-command
Release Notes:

- N/A 
