### PR TITLE
acp: Fix behavior of read_text_file for ACP agents

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -3313,15 +3313,4 @@ mod tests {
             }
         });
     }
-
-    #[test]
-    fn grab_lines_from_file() {
-        fn grab_lines_from_file(text: &str) -> String {
-            text.lines().collect::<String>()
-        }
-
-        let text = "Hello\nWorld\nHow\nAre\nYou";
-        let lines = grab_lines_from_file(text);
-        assert_eq!(lines, text);
-    }
 }

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1812,7 +1812,11 @@ impl AcpThread {
                     action_log.buffer_read(buffer.clone(), cx);
                 })?;
 
-                buffer.update(cx, |buffer, _| buffer.snapshot())?
+                let snapshot = buffer.update(cx, |buffer, _| buffer.snapshot())?;
+                this.update(cx, |this, _| {
+                    this.shared_buffers.insert(buffer.clone(), snapshot.clone());
+                })?;
+                snapshot
             };
 
             let max_point = snapshot.max_point();

--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1811,22 +1811,20 @@ impl AcpThread {
                 action_log.update(cx, |action_log, cx| {
                     action_log.buffer_read(buffer.clone(), cx);
                 })?;
-                project.update(cx, |project, cx| {
-                    let position = buffer
-                        .read(cx)
-                        .snapshot()
-                        .anchor_before(Point::new(line, 0));
-                    project.set_agent_location(
-                        Some(AgentLocation {
-                            buffer: buffer.downgrade(),
-                            position,
-                        }),
-                        cx,
-                    );
-                })?;
 
                 buffer.update(cx, |buffer, _| buffer.snapshot())?
             };
+
+            let position = snapshot.anchor_before(Point::new(line, 0));
+            project.update(cx, |project, cx| {
+                project.set_agent_location(
+                    Some(AgentLocation {
+                        buffer: buffer.downgrade(),
+                        position,
+                    }),
+                    cx,
+                );
+            })?;
 
             this.update(cx, |this, _| {
                 let text = snapshot.text();


### PR DESCRIPTION
We were incorrectly handling the line number as well as stripping out line breaks when returning portions of files.

It also makes sure following is updated even when we load a snapshot from cache, which wasn't the case before.

We also are able to load the text via a range in the snapshot, rather than allocating a string for the entire file and then another after iterating over lines in the file.

Release Notes:

- acp: Fix incorrect behavior when ACP agents requested to read portions of files.
