### PR TITLE
Partially revert "project: Fix terminal activation scripts failing on Windows for new shells (#37986)

### DIFF
--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -1591,7 +1591,7 @@ impl AcpThreadView {
             task.shell = shell;
 
             let terminal = terminal_panel.update_in(cx, |terminal_panel, window, cx| {
-                terminal_panel.spawn_task(login.clone(), window, cx)
+                terminal_panel.spawn_task(&login, window, cx)
             })?;
 
             let terminal = terminal.await?;

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -533,14 +533,10 @@ impl TerminalBuilder {
             child_exited: None,
         };
 
-        if !activation_script.is_empty() && no_task {
+        if cfg!(not(target_os = "windows")) && !activation_script.is_empty() && no_task {
             for activation_script in activation_script {
                 terminal.input(activation_script.into_bytes());
-                terminal.write_to_pty(if cfg!(windows) {
-                    &b"\r\n"[..]
-                } else {
-                    &b"\n"[..]
-                });
+                terminal.write_to_pty(b"\n");
             }
             terminal.clear();
         }

--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -19,7 +19,7 @@ use itertools::Itertools;
 use project::{Fs, Project, ProjectEntryId};
 use search::{BufferSearchBar, buffer_search::DivRegistrar};
 use settings::Settings;
-use task::{RevealStrategy, RevealTarget, SpawnInTerminal, TaskId};
+use task::{RevealStrategy, RevealTarget, ShellBuilder, SpawnInTerminal, TaskId};
 use terminal::{
     Terminal,
     terminal_settings::{TerminalDockPosition, TerminalSettings},
@@ -521,10 +521,42 @@ impl TerminalPanel {
 
     pub fn spawn_task(
         &mut self,
-        task: SpawnInTerminal,
+        task: &SpawnInTerminal,
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> Task<Result<WeakEntity<Terminal>>> {
+        let remote_client = self
+            .workspace
+            .update(cx, |workspace, cx| {
+                let project = workspace.project().read(cx);
+                if project.is_via_collab() {
+                    Err(anyhow!("cannot spawn tasks as a guest"))
+                } else {
+                    Ok(project.remote_client())
+                }
+            })
+            .flatten();
+
+        let remote_client = match remote_client {
+            Ok(remote_client) => remote_client,
+            Err(e) => return Task::ready(Err(e)),
+        };
+
+        let remote_shell = remote_client
+            .as_ref()
+            .and_then(|remote_client| remote_client.read(cx).shell());
+
+        let builder = ShellBuilder::new(remote_shell.as_deref(), &task.shell);
+        let command_label = builder.command_label(&task.command_label);
+        let (command, args) = builder.build(task.command.clone(), &task.args);
+
+        let task = SpawnInTerminal {
+            command_label,
+            command: Some(command),
+            args,
+            ..task.clone()
+        };
+
         if task.allow_concurrent_runs && task.use_new_terminal {
             return self.spawn_in_new_terminal(task, window, cx);
         }
@@ -1558,7 +1590,7 @@ impl workspace::TerminalProvider for TerminalProvider {
         window.spawn(cx, async move |cx| {
             let terminal = terminal_panel
                 .update_in(cx, |terminal_panel, window, cx| {
-                    terminal_panel.spawn_task(task, window, cx)
+                    terminal_panel.spawn_task(&task, window, cx)
                 })
                 .ok()?
                 .await;


### PR DESCRIPTION
This partially reverts commit 4002602a8926b7fe799acf50fcee6bcffb36d376.
Specifically the parts that closes https://github.com/zed-industries/zed/issues/38343 

Release Notes:

- N/A *or* Added/Fixed/Improved ...
