### PR TITLE
Fix arrow function detection in TypeScript/JavaScript outline

### DIFF
--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -116,4 +116,26 @@
     )
 ) @item
 
+; Arrow functions in variable declarations (anywhere in the tree, including nested in functions)
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (arrow_function)) @item)
+
+; Async arrow functions in variable declarations
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (arrow_function
+            "async" @context)) @item)
+
+; Named function expressions in variable declarations
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (function_expression)) @item)
+
 (comment) @annotation

--- a/crates/languages/src/tsx/outline.scm
+++ b/crates/languages/src/tsx/outline.scm
@@ -124,4 +124,26 @@
     )
 ) @item
 
+; Arrow functions in variable declarations (anywhere in the tree, including nested in functions)
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (arrow_function)) @item)
+
+; Async arrow functions in variable declarations
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (arrow_function
+            "async" @context)) @item)
+
+; Named function expressions in variable declarations
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (function_expression)) @item)
+
 (comment) @annotation

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -124,4 +124,26 @@
     )
 ) @item
 
+; Arrow functions in variable declarations (anywhere in the tree, including nested in functions)
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (arrow_function)) @item)
+
+; Async arrow functions in variable declarations
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (arrow_function
+            "async" @context)) @item)
+
+; Named function expressions in variable declarations
+(lexical_declaration
+    ["let" "const"] @context
+    (variable_declarator
+        name: (_) @name
+        value: (function_expression)) @item)
+
 (comment) @annotation


### PR DESCRIPTION
Closes #35102 


https://github.com/user-attachments/assets/3c946d6c-0acd-4cfe-8cb3-61eb6d20f808


Release Notes:

- TypeScript/JavaScript: symbol outline now includes closures nested within functions.