### PR TITLE
windows: Fix select previous/next word keybinds

### DIFF
--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -497,8 +497,6 @@
       "shift-alt-down": "editor::DuplicateLineDown",
       "shift-alt-right": "editor::SelectLargerSyntaxNode", // Expand selection
       "shift-alt-left": "editor::SelectSmallerSyntaxNode", // Shrink selection
-      "ctrl-shift-right": "editor::SelectLargerSyntaxNode", // Expand selection (VSCode version)
-      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink selection (VSCode version)
       "ctrl-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "ctrl-f2": "editor::SelectAllMatches", // Select all occurrences of current word
       "ctrl-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch  / find_under_expand


### PR DESCRIPTION
Partialy fixes issue #38394

The changes is #37874 only changed the macOS keybinds, but those changes were reverted in #38208 on the wrong OS (windows instead of macOS). Those changes overwrote the `ctrl-shift-{left/right}` keybinds assigned to `editor::SelectToPreviousWordStart` and `editor::SelectToNextWordEnd` on windows.

On windows there already is a keybind `shift-alt-{left/right}` assigned for syntax node expansion, which is the correct one.

Release Notes:

- Fixed broken `ctrl-shift-{left/right}` keybinds for selecting to the next/previous word