### PR TITLE
dap: Add more debug logs for child's stderr

### DIFF
--- a/crates/dap/src/client.rs
+++ b/crates/dap/src/client.rs
@@ -118,6 +118,7 @@ impl DebugAdapterClient {
             R::COMMAND,
             sequence_id
         );
+        log::debug!("  request: {request:?}");
 
         self.send_message(Message::Request(request)).await?;
 
@@ -130,6 +131,8 @@ impl DebugAdapterClient {
             command,
             sequence_id
         );
+        log::debug!("  response: {response:?}");
+
         match response.success {
             true => {
                 if let Some(json) = response.body {

--- a/crates/dap/src/transport.rs
+++ b/crates/dap/src/transport.rs
@@ -262,6 +262,7 @@ impl TransportDelegate {
                     break;
                 }
             }
+            log::debug!("stderr: {line}");
 
             for (kind, handler) in log_handlers.lock().iter_mut() {
                 if matches!(kind, LogKind::Adapter) {


### PR DESCRIPTION
Without this, I would never have converged on @cole-miller's patch https://github.com/zed-industries/zed/pull/38380 when debugging codelldb not spawning in WSL!

Release Notes:

- N/A
