### PR TITLE
agent: Make settings view more consistent across different sections

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -1141,6 +1141,13 @@
     }
   },
   {
+    "context": "ContextServerToolsModal",
+    "use_key_equivalents": true,
+    "bindings": {
+      "escape": "menu::Cancel"
+    }
+  },
+  {
     "context": "OnboardingAiConfigurationModal",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -1245,6 +1245,13 @@
     }
   },
   {
+    "context": "ContextServerToolsModal",
+    "use_key_equivalents": true,
+    "bindings": {
+      "escape": "menu::Cancel"
+    }
+  },
+  {
     "context": "OnboardingAiConfigurationModal",
     "use_key_equivalents": true,
     "bindings": {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1161,6 +1161,13 @@
     }
   },
   {
+    "context": "ContextServerToolsModal",
+    "use_key_equivalents": true,
+    "bindings": {
+      "escape": "menu::Cancel"
+    }
+  },
+  {
     "context": "OnboardingAiConfigurationModal",
     "use_key_equivalents": true,
     "bindings": {

--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -950,7 +950,6 @@ impl AgentConfiguration {
                                         let context_server_manager =
                                             self.context_server_store.clone();
                                         let fs = self.fs.clone();
-                                        let context_server_id = context_server_id.clone();
 
                                         move |state, _window, cx| {
                                             let is_enabled = match state {
@@ -1057,7 +1056,7 @@ impl AgentConfiguration {
         let user_defined_agents = user_defined_agents
             .into_iter()
             .map(|name| {
-                self.render_agent_server(IconName::Ai, name.clone())
+                self.render_agent_server(IconName::Ai, name)
                     .into_any_element()
             })
             .collect::<Vec<_>>();

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
@@ -107,8 +107,6 @@ impl ConfigureContextServerToolsModal {
                                                 .color(Color::Muted),
                                         )
                                         .on_click(cx.listener({
-                                            let tool_name = tool_name.clone();
-
                                             move |this, _event, _window, _cx| {
                                                 let current = this
                                                     .expanded_tools

--- a/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/configure_context_server_tools_modal.rs
@@ -1,0 +1,178 @@
+use assistant_tool::{ToolSource, ToolWorkingSet};
+use context_server::ContextServerId;
+use gpui::{
+    DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, ScrollHandle, Window, prelude::*,
+};
+use ui::{Divider, DividerColor, Modal, ModalHeader, WithScrollbar, prelude::*};
+use workspace::{ModalView, Workspace};
+
+pub struct ConfigureContextServerToolsModal {
+    context_server_id: ContextServerId,
+    tools: Entity<ToolWorkingSet>,
+    focus_handle: FocusHandle,
+    expanded_tools: std::collections::HashMap<String, bool>,
+    scroll_handle: ScrollHandle,
+}
+
+impl ConfigureContextServerToolsModal {
+    fn new(
+        context_server_id: ContextServerId,
+        tools: Entity<ToolWorkingSet>,
+        _window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Self {
+        Self {
+            context_server_id,
+            tools,
+            focus_handle: cx.focus_handle(),
+            expanded_tools: std::collections::HashMap::new(),
+            scroll_handle: ScrollHandle::new(),
+        }
+    }
+
+    pub fn toggle(
+        context_server_id: ContextServerId,
+        tools: Entity<ToolWorkingSet>,
+        workspace: &mut Workspace,
+        window: &mut Window,
+        cx: &mut Context<Workspace>,
+    ) {
+        workspace.toggle_modal(window, cx, |window, cx| {
+            Self::new(context_server_id, tools, window, cx)
+        });
+    }
+
+    fn cancel(&mut self, _: &menu::Cancel, _: &mut Window, cx: &mut Context<Self>) {
+        cx.emit(DismissEvent)
+    }
+
+    fn render_modal_content(
+        &self,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> impl IntoElement {
+        let tools_by_source = self.tools.read(cx).tools_by_source(cx);
+        let server_tools = tools_by_source
+            .get(&ToolSource::ContextServer {
+                id: self.context_server_id.0.clone().into(),
+            })
+            .map(|tools| tools.as_slice())
+            .unwrap_or(&[]);
+
+        div()
+            .size_full()
+            .pb_2()
+            .child(
+                v_flex()
+                    .id("modal_content")
+                    .px_2()
+                    .gap_1()
+                    .max_h_128()
+                    .overflow_y_scroll()
+                    .track_scroll(&self.scroll_handle)
+                    .children(server_tools.iter().enumerate().flat_map(|(index, tool)| {
+                        let tool_name = tool.name();
+                        let is_expanded = self
+                            .expanded_tools
+                            .get(&tool_name)
+                            .copied()
+                            .unwrap_or(false);
+
+                        let icon = if is_expanded {
+                            IconName::ChevronUp
+                        } else {
+                            IconName::ChevronDown
+                        };
+
+                        let mut items = vec![
+                            v_flex()
+                                .child(
+                                    h_flex()
+                                        .id(SharedString::from(format!("tool-header-{}", index)))
+                                        .py_1()
+                                        .pl_1()
+                                        .pr_2()
+                                        .w_full()
+                                        .justify_between()
+                                        .rounded_sm()
+                                        .hover(|s| s.bg(cx.theme().colors().element_hover))
+                                        .child(
+                                            Label::new(tool_name.clone())
+                                                .buffer_font(cx)
+                                                .size(LabelSize::Small),
+                                        )
+                                        .child(
+                                            Icon::new(icon)
+                                                .size(IconSize::Small)
+                                                .color(Color::Muted),
+                                        )
+                                        .on_click(cx.listener({
+                                            let tool_name = tool_name.clone();
+
+                                            move |this, _event, _window, _cx| {
+                                                let current = this
+                                                    .expanded_tools
+                                                    .get(&tool_name)
+                                                    .copied()
+                                                    .unwrap_or(false);
+                                                this.expanded_tools
+                                                    .insert(tool_name.clone(), !current);
+                                                _cx.notify();
+                                            }
+                                        })),
+                                )
+                                .when(is_expanded, |this| {
+                                    this.child(
+                                        Label::new(tool.description()).color(Color::Muted).mx_1(),
+                                    )
+                                })
+                                .into_any_element(),
+                        ];
+
+                        if index < server_tools.len() - 1 {
+                            items.push(
+                                h_flex()
+                                    .w_full()
+                                    .child(Divider::horizontal().color(DividerColor::BorderVariant))
+                                    .into_any_element(),
+                            );
+                        }
+
+                        items
+                    })),
+            )
+            .vertical_scrollbar_for(self.scroll_handle.clone(), window, cx)
+            .into_any_element()
+    }
+}
+
+impl ModalView for ConfigureContextServerToolsModal {}
+
+impl Focusable for ConfigureContextServerToolsModal {
+    fn focus_handle(&self, _cx: &App) -> FocusHandle {
+        self.focus_handle.clone()
+    }
+}
+
+impl EventEmitter<DismissEvent> for ConfigureContextServerToolsModal {}
+
+impl Render for ConfigureContextServerToolsModal {
+    fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        div()
+            .key_context("ContextServerToolsModal")
+            .occlude()
+            .elevation_3(cx)
+            .w(rems(34.))
+            .on_action(cx.listener(Self::cancel))
+            .track_focus(&self.focus_handle)
+            .child(
+                Modal::new("configure-context-server-tools", None::<ScrollHandle>)
+                    .header(
+                        ModalHeader::new()
+                            .headline(format!("Tools from {}", self.context_server_id.0))
+                            .show_dismiss_button(true),
+                    )
+                    .child(self.render_modal_content(window, cx)),
+            )
+    }
+}

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -286,6 +286,15 @@ impl ContextServerStore {
         self.servers.keys().cloned().collect()
     }
 
+    pub fn all_registry_descriptor_ids(&self, cx: &App) -> Vec<ContextServerId> {
+        self.registry
+            .read(cx)
+            .context_server_descriptors()
+            .into_iter()
+            .map(|(id, _)| ContextServerId(id))
+            .collect()
+    }
+
     pub fn running_servers(&self) -> Vec<Arc<ContextServer>> {
         self.servers
             .values()

--- a/crates/ui/src/components/divider.rs
+++ b/crates/ui/src/components/divider.rs
@@ -36,6 +36,7 @@ enum DividerDirection {
 #[derive(Default)]
 pub enum DividerColor {
     Border,
+    BorderFaded,
     #[default]
     BorderVariant,
 }
@@ -44,6 +45,7 @@ impl DividerColor {
     pub fn hsla(self, cx: &mut App) -> Hsla {
         match self {
             DividerColor::Border => cx.theme().colors().border,
+            DividerColor::BorderFaded => cx.theme().colors().border.opacity(0.6),
             DividerColor::BorderVariant => cx.theme().colors().border_variant,
         }
     }


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/37660

This PR makes sections in the AI settings UI more consistent with each other and also just overall simpler. One of the main changes here is adding the tools from a given MCP server in a modal (as opposed to in a disclosure within the settings view). That's mostly an artifact of wanting to make all of the items within sections look more of the same. Then, in the process of doing so, also changed the logic that we were using to display MCP servers; previously, in the case of extension-based servers, we were only showing those that were _configured_, which felt wrong because you should be able to see everything you have _installed_, despite of its status (configured or not).

However, there's still a bit of a bug (to be solved in a follow-up PR), which already existed but it was just not visible given we'd only display configured servers: an MCP server installed through an extension stays as a "custom server" until it is configured. If you don't configure it, you can't also uninstall it from the settings view (though it is possible to do so via the extensions UI).

Release Notes:

- agent: Improve settings view UI and solve issue where MCP servers would get unsorted upon turning them on and off (they're all alphabetically sorted now).
