### PR TITLE
python: Install basedpyright if the basedpyright-langserver binary is missing

### DIFF
--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -55,7 +55,7 @@ use std::{
     str,
     sync::{
         Arc, LazyLock,
-        atomic::{AtomicU64, AtomicUsize, Ordering::SeqCst},
+        atomic::{AtomicUsize, Ordering::SeqCst},
     },
 };
 use syntax_map::{QueryCursorHandle, SyntaxSnapshot};
@@ -168,7 +168,6 @@ pub struct CachedLspAdapter {
     pub disk_based_diagnostics_progress_token: Option<String>,
     language_ids: HashMap<LanguageName, String>,
     pub adapter: Arc<dyn LspAdapter>,
-    pub reinstall_attempt_count: AtomicU64,
     cached_binary: ServerBinaryCache,
 }
 
@@ -185,7 +184,6 @@ impl Debug for CachedLspAdapter {
                 &self.disk_based_diagnostics_progress_token,
             )
             .field("language_ids", &self.language_ids)
-            .field("reinstall_attempt_count", &self.reinstall_attempt_count)
             .finish_non_exhaustive()
     }
 }
@@ -204,7 +202,6 @@ impl CachedLspAdapter {
             language_ids,
             adapter,
             cached_binary: Default::default(),
-            reinstall_attempt_count: AtomicU64::new(0),
         })
     }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -611,26 +611,22 @@ where
                 );
                 return Ok(binary);
             }
-            dbg!();
 
             anyhow::ensure!(
                 binary_options.allow_binary_download,
                 "downloading language servers disabled"
             );
-            dbg!();
 
             if let Some((pre_release, cached_binary)) = cached_binary
                 && *pre_release == binary_options.pre_release
             {
                 return Ok(cached_binary.clone());
             }
-            dbg!();
 
             let Some(container_dir) = delegate.language_server_download_dir(&self.name()).await
             else {
                 anyhow::bail!("no language server download dir defined")
             };
-            dbg!();
 
             let mut binary = self
                 .try_fetch_server_binary(
@@ -640,14 +636,12 @@ where
                     cx,
                 )
                 .await;
-            dbg!();
 
             if let Err(error) = binary.as_ref() {
                 if let Some(prev_downloaded_binary) = self
                     .cached_server_binary(container_dir.to_path_buf(), delegate.as_ref())
                     .await
                 {
-                    dbg!();
                     log::info!(
                         "failed to fetch newest version of language server {:?}. \
                         error: {:?}, falling back to using {:?}",
@@ -657,7 +651,6 @@ where
                     );
                     binary = Ok(prev_downloaded_binary);
                 } else {
-                    dbg!();
                     delegate.update_status(
                         self.name(),
                         BinaryStatus::Failed {
@@ -667,10 +660,7 @@ where
                 }
             }
 
-            dbg!();
-
             if let Ok(binary) = &binary {
-                dbg!();
                 *cached_binary = Some((binary_options.pre_release, binary.clone()));
             }
 

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -614,22 +614,26 @@ where
                 );
                 return Ok(binary);
             }
+            dbg!();
 
             anyhow::ensure!(
                 binary_options.allow_binary_download,
                 "downloading language servers disabled"
             );
+            dbg!();
 
             if let Some((pre_release, cached_binary)) = cached_binary
                 && *pre_release == binary_options.pre_release
             {
                 return Ok(cached_binary.clone());
             }
+            dbg!();
 
             let Some(container_dir) = delegate.language_server_download_dir(&self.name()).await
             else {
                 anyhow::bail!("no language server download dir defined")
             };
+            dbg!();
 
             let mut binary = self
                 .try_fetch_server_binary(
@@ -639,12 +643,14 @@ where
                     cx,
                 )
                 .await;
+            dbg!();
 
             if let Err(error) = binary.as_ref() {
                 if let Some(prev_downloaded_binary) = self
                     .cached_server_binary(container_dir.to_path_buf(), delegate.as_ref())
                     .await
                 {
+                    dbg!();
                     log::info!(
                         "failed to fetch newest version of language server {:?}. \
                         error: {:?}, falling back to using {:?}",
@@ -654,6 +660,7 @@ where
                     );
                     binary = Ok(prev_downloaded_binary);
                 } else {
+                    dbg!();
                     delegate.update_status(
                         self.name(),
                         BinaryStatus::Failed {
@@ -663,7 +670,10 @@ where
                 }
             }
 
+            dbg!();
+
             if let Ok(binary) = &binary {
+                dbg!();
                 *cached_binary = Some((binary_options.pre_release, binary.clone()));
             }
 

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1911,7 +1911,6 @@ impl LspInstaller for BasedPyrightLspAdapter {
                 .arg("install")
                 .arg("basedpyright")
                 .arg("--upgrade")
-                .arg("--force-reinstall")
                 .output()
                 .await
                 .context("getting pip install output")?

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1904,7 +1904,6 @@ impl LspInstaller for BasedPyrightLspAdapter {
         _container_dir: PathBuf,
         delegate: &dyn LspAdapterDelegate,
     ) -> Result<LanguageServerBinary> {
-        dbg!();
         let venv = self.base_venv(delegate).await.map_err(|e| anyhow!(e))?;
         let pip_path = venv.join(BINARY_DIR).join("pip3");
         ensure!(
@@ -1925,9 +1924,8 @@ impl LspInstaller for BasedPyrightLspAdapter {
             delegate.which(path.as_os_str()).await.is_some(),
             "basedpyright installation was incomplete"
         );
-        dbg!();
         Ok(LanguageServerBinary {
-            path: dbg!(path),
+            path,
             env: None,
             arguments: vec!["--stdio".into()],
         })

--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1559,7 +1559,7 @@ impl LspInstaller for PyLspAdapter {
             util::command::new_smol_command(pip_path.as_path())
                 .arg("install")
                 .arg("python-lsp-server")
-                .arg("-U")
+                .arg("--upgrade")
                 .output()
                 .await?
                 .status
@@ -1570,7 +1570,7 @@ impl LspInstaller for PyLspAdapter {
             util::command::new_smol_command(pip_path.as_path())
                 .arg("install")
                 .arg("python-lsp-server[all]")
-                .arg("-U")
+                .arg("--upgrade")
                 .output()
                 .await?
                 .status
@@ -1581,7 +1581,7 @@ impl LspInstaller for PyLspAdapter {
             util::command::new_smol_command(pip_path)
                 .arg("install")
                 .arg("pylsp-mypy")
-                .arg("-U")
+                .arg("--upgrade")
                 .output()
                 .await?
                 .status
@@ -1589,6 +1589,10 @@ impl LspInstaller for PyLspAdapter {
             "pylsp-mypy installation failed"
         );
         let pylsp = venv.join(BINARY_DIR).join("pylsp");
+        ensure!(
+            delegate.which(pylsp.as_os_str()).await.is_some(),
+            "pylsp installation was incomplete"
+        );
         Ok(LanguageServerBinary {
             path: pylsp,
             env: None,
@@ -1603,6 +1607,7 @@ impl LspInstaller for PyLspAdapter {
     ) -> Option<LanguageServerBinary> {
         let venv = self.base_venv(delegate).await.ok()?;
         let pylsp = venv.join(BINARY_DIR).join("pylsp");
+        delegate.which(pylsp.as_os_str()).await?;
         Some(LanguageServerBinary {
             path: pylsp,
             env: None,


### PR DESCRIPTION
Potential fix for #38377 

Release Notes:

- N/A