### PR TITLE
agent_ui: Fix MCP related buttons overflow

### DIFF
--- a/crates/agent_ui/src/agent_configuration.rs
+++ b/crates/agent_ui/src/agent_configuration.rs
@@ -588,48 +588,41 @@ impl AgentConfiguration {
                 }
             })
             .child(
-                h_flex()
-                    .justify_between()
-                    .gap_1p5()
+                v_flex()
+                    .gap_2()
                     .child(
-                        h_flex().w_full().child(
-                            Button::new("add-context-server", "Add Custom Server")
-                                .style(ButtonStyle::Filled)
-                                .layer(ElevationIndex::ModalSurface)
-                                .full_width()
-                                .icon(IconName::Plus)
-                                .icon_size(IconSize::Small)
-                                .icon_position(IconPosition::Start)
-                                .on_click(|_event, window, cx| {
-                                    window.dispatch_action(AddContextServer.boxed_clone(), cx)
-                                }),
-                        ),
-                    )
-                    .child(
-                        h_flex().w_full().child(
-                            Button::new(
-                                "install-context-server-extensions",
-                                "Install MCP Extensions",
-                            )
+                        Button::new("add-context-server", "Add Custom Server")
                             .style(ButtonStyle::Filled)
                             .layer(ElevationIndex::ModalSurface)
                             .full_width()
-                            .icon(IconName::ToolHammer)
+                            .icon(IconName::Plus)
                             .icon_size(IconSize::Small)
                             .icon_position(IconPosition::Start)
                             .on_click(|_event, window, cx| {
-                                window.dispatch_action(
-                                    zed_actions::Extensions {
-                                        category_filter: Some(
-                                            ExtensionCategoryFilter::ContextServers,
-                                        ),
-                                        id: None,
-                                    }
-                                    .boxed_clone(),
-                                    cx,
-                                )
+                                window.dispatch_action(AddContextServer.boxed_clone(), cx)
                             }),
-                        ),
+                    )
+                    .child(
+                        Button::new(
+                            "install-context-server-extensions",
+                            "Install MCP Extensions",
+                        )
+                        .style(ButtonStyle::Filled)
+                        .layer(ElevationIndex::ModalSurface)
+                        .full_width()
+                        .icon(IconName::ToolHammer)
+                        .icon_size(IconSize::Small)
+                        .icon_position(IconPosition::Start)
+                        .on_click(|_event, window, cx| {
+                            window.dispatch_action(
+                                zed_actions::Extensions {
+                                    category_filter: Some(ExtensionCategoryFilter::ContextServers),
+                                    id: None,
+                                }
+                                .boxed_clone(),
+                                cx,
+                            )
+                        }),
                     ),
             )
     }


### PR DESCRIPTION
Fixed an issue where the “Add Custom MCP” and “Install MCP Extensions” buttons overflowed when the agent settings panel was collapsed.

Before:

<img width="331" height="342" alt="Before" src="https://github.com/user-attachments/assets/97938916-6254-4df1-be7d-e68e68e59065" />

After:

<img width="319" height="369" alt="After" src="https://github.com/user-attachments/assets/a873f170-317f-4fd5-a0eb-b21ae7479b6f" />


Release Notes:

- N/A