### PR TITLE
git_ui: Remove duplicated/unused tooltips

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -368,10 +368,6 @@ impl CommitModal {
             .icon_color(Color::Placeholder)
             .color(Color::Muted)
             .icon_position(IconPosition::Start)
-            .tooltip(Tooltip::for_action_title(
-                "Switch Branch",
-                &zed_actions::git::Branch,
-            ))
             .on_click(cx.listener(|_, _, window, cx| {
                 window.dispatch_action(zed_actions::git::Branch.boxed_clone(), cx);
             }))

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -4585,10 +4585,6 @@ impl RenderOnce for PanelRepoFooter {
             .size(ButtonSize::None)
             .label_size(LabelSize::Small)
             .truncate(true)
-            .tooltip(Tooltip::for_action_title(
-                "Switch Branch",
-                &zed_actions::git::Switch,
-            ))
             .on_click(|_, window, cx| {
                 window.dispatch_action(zed_actions::git::Switch.boxed_clone(), cx);
             });


### PR DESCRIPTION
# Why

While exploring Git UI code I have spotted that switch branch buttons have defined tooltips, which are not used. 

Both buttons are passed to `PopoverMenu` component, which then uses them inside `trigger_with_tooltip`, where the same tooltips are re-defined, and take the precedent over ones defined directly on buttons.

# How

Remove duplicated/unused tooltips from "Switch Branch" buttons in panel and modal UIs.

Release Notes:

- N/A

# Test plan

I have made sure that after the removals both tooltips are still displayed like before the code changes.

<img width="750" height="238" alt="Screenshot 2025-09-18 at 19 12 04" src="https://github.com/user-attachments/assets/819c928c-8079-4f54-a2a0-882db3b652de" />

<img width="750" height="238" alt="Screenshot 2025-09-18 at 19 17 23" src="https://github.com/user-attachments/assets/9e49e4cd-ff9f-4d62-b808-f39693b128f8" />
