### PR TITLE
git_ui: Reduce spacing between action icon and label

### DIFF
--- a/crates/git_ui/src/git_ui.rs
+++ b/crates/git_ui/src/git_ui.rs
@@ -518,7 +518,6 @@ mod remote_button {
             this.child(
                 h_flex()
                     .ml_neg_0p5()
-                    .mr_1()
                     .when(behind_count > 0, |this| {
                         this.child(Icon::new(IconName::ArrowDown).size(IconSize::XSmall))
                             .child(count(behind_count))
@@ -533,7 +532,6 @@ mod remote_button {
             this.child(
                 h_flex()
                     .ml_neg_0p5()
-                    .mr_1()
                     .child(Icon::new(left_icon).size(IconSize::XSmall)),
             )
         })


### PR DESCRIPTION
# Why

Opinionated change: A bit uneven spacing between Git action icon and label, in comparison to the border on the right in the segmented action button was triggering my UI OCD a bit. 😅 

# How

Remove the right margin from icon and icon + counter children of the segmented Git action button in Git Panel. The default spacing from the button layout seems to be enough to separate them from the left-side label.

# Release Notes

- Reduced spacing between Git action icon and label in Git Panel

# Test plan

I have tested few cases, and made sure that the spacing is still present, but icon (or icon and counter) does not feel too separated/detached from the label.

### Before

<img width="384" height="186" alt="Screenshot 2025-09-18 at 20 11 16" src="https://github.com/user-attachments/assets/8f353b8f-8e43-466d-88a9-567a82100b5f" />
<img width="384" height="186" alt="Screenshot 2025-09-18 at 20 13 19" src="https://github.com/user-attachments/assets/1ecb4e1a-8a60-45b6-988e-966fb2b27ff5" />


### After

<img width="392" height="168" alt="Screenshot 2025-09-18 at 19 53 14" src="https://github.com/user-attachments/assets/388d9b83-9906-4eac-82ed-13d2ae78c990" />
<img width="392" height="168" alt="Screenshot 2025-09-18 at 19 53 34" src="https://github.com/user-attachments/assets/a179239b-ac09-479e-b688-f895ba75ca33" />
<img width="392" height="168" alt="Screenshot 2025-09-18 at 19 56 23" src="https://github.com/user-attachments/assets/6ca10cf1-d46d-43b7-b847-832555823b8a" />

Release Notes: 

- N/A