### PR TITLE
docs: fix Python language server config example

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -81,11 +81,11 @@ These are disabled by default, but can be enabled in your settings. For example:
 {
   "languages": {
     "Python": {
-      "language_servers": {
+      "language_servers": [
         // Disable basedpyright and enable Ty, and otherwise
         // use the default configuration.
-        "ty", "!basedpyright", ".."
-      }
+        "ty", "!basedpyright", "..."
+      ]
     }
   }
 }


### PR DESCRIPTION
I just noticed an error in Python configuration document.

Current:

```json
{
  "languages": {
    "Python": {
      "language_servers": {
        // Disable basedpyright and enable Ty, and otherwise
        // use the default configuration.
        "ty", "!basedpyright", ".."
      }
    }
  }
}

```

Two issues:

1. Array of language servers should use `[]` instead of `{}`
2. Placeholder should use `"..."` instead of `".."`

Ref: https://zed.dev/docs/configuring-languages#choosing-language-servers

Release Notes:

- Fixed Python Language Server config example
