### PR TITLE
python: Remove a redundant pip install call

### DIFF
--- a/crates/languages/src/python.rs
+++ b/crates/languages/src/python.rs
@@ -1558,17 +1558,6 @@ impl LspInstaller for PyLspAdapter {
         ensure!(
             util::command::new_smol_command(pip_path.as_path())
                 .arg("install")
-                .arg("python-lsp-server")
-                .arg("--upgrade")
-                .output()
-                .await?
-                .status
-                .success(),
-            "python-lsp-server installation failed"
-        );
-        ensure!(
-            util::command::new_smol_command(pip_path.as_path())
-                .arg("install")
                 .arg("python-lsp-server[all]")
                 .arg("--upgrade")
                 .output()


### PR DESCRIPTION
I confirmed that the pip packages match for:
```sh
pip install python-lsp-server && pip install 'python-lsp-server[all]'
pip install 'python-lsp-server[all]'
```

Originally introduced here:
- https://github.com/zed-industries/zed/pull/20358 

Release Notes:

- N/A