### PR TITLE
Incremental Project Search

### DIFF
--- a/crates/search/src/project_search.rs
+++ b/crates/search/src/project_search.rs
@@ -1411,7 +1411,8 @@ impl ProjectSearchView {
                     if search_view.auto_search_generation == generation {
                         search_view.run_auto_search(cx);
                     }
-                }).ok();
+                })
+                .ok();
             }
         })
         .detach();


### PR DESCRIPTION
Closes #ISSUE
https://github.com/zed-industries/zed/discussions/17837#discussioncomment-14361067

Release Notes:
- This PR implemented the incremental project search.
- Introduced a 200 ms PROJECT_SEARCH_AUTO_SEARCH_DEBOUNCE_MS constant and added debounce logic that launches a timer on each query edit. It increments an auto_search_generation counter so only the latest timer run actually triggers run_auto_search, preventing stale tasks from firing.
- Extended ProjectSearchView with two new fields, auto_search_generation for the debounce, and focus_results_on_search to record whether the next search should steal focus.
- Thank you for any reviews and suggestions!

https://github.com/user-attachments/assets/24be2c88-49e7-4e78-93f7-9eb0502dd4ef


