### PR TITLE
debugger: Fix debug scenario picker showing history in reverse order

### DIFF
--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -258,7 +258,7 @@ impl Inventory {
     ) {
         self.last_scheduled_scenarios
             .retain(|(s, _)| s.label != scenario.label);
-        self.last_scheduled_scenarios.push_back((
+        self.last_scheduled_scenarios.push_front((
             scenario,
             DebugScenarioContext {
                 task_context,


### PR DESCRIPTION
Closes #37859

Release Notes:

- debugger: Fix sort order of pasted launched debug sessions in debugger launch modal
