### PR TITLE
Respect user's font-smoothing setting

### DIFF
--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -397,7 +397,6 @@ impl MacTextSystemState {
                 .subpixel_variant
                 .map(|v| v as f32 / SUBPIXEL_VARIANTS as f32);
             cx.set_allows_font_smoothing(true);
-            cx.set_should_smooth_fonts(true);
             cx.set_text_drawing_mode(CGTextDrawingMode::CGTextFill);
             cx.set_gray_fill_color(0.0, 1.0);
             cx.set_allows_antialiasing(true);


### PR DESCRIPTION
#37622 was incorrectly forcing font smoothing to be enabled on macos even when the user had disabled that setting at the OS level. See [this comment](https://github.com/zed-industries/zed/pull/37622#issuecomment-3310030659) for an example of the difference that font smoothing makes.

Release Notes:

- N/A