### PR TITLE
markdown: Use the faster hasher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10418,6 +10418,7 @@ version = "0.1.0"
 dependencies = [
  "assets",
  "base64 0.22.1",
+ "collections",
  "env_logger 0.11.8",
  "fs",
  "futures 0.3.31",

--- a/crates/markdown/Cargo.toml
+++ b/crates/markdown/Cargo.toml
@@ -20,6 +20,7 @@ test-support = [
 
 [dependencies]
 base64.workspace = true
+collections.workspace = true
 futures.workspace = true
 gpui.workspace = true
 language.workspace = true

--- a/crates/markdown/src/markdown.rs
+++ b/crates/markdown/src/markdown.rs
@@ -9,8 +9,6 @@ use log::Level;
 pub use path_range::{LineCol, PathWithRange};
 
 use std::borrow::Cow;
-use std::collections::HashMap;
-use std::collections::HashSet;
 use std::iter;
 use std::mem;
 use std::ops::Range;
@@ -19,6 +17,7 @@ use std::rc::Rc;
 use std::sync::Arc;
 use std::time::Duration;
 
+use collections::{HashMap, HashSet};
 use gpui::{
     AnyElement, App, BorderStyle, Bounds, ClipboardItem, CursorStyle, DispatchPhase, Edges, Entity,
     FocusHandle, Focusable, FontStyle, FontWeight, GlobalElementId, Hitbox, Hsla, Image,
@@ -176,7 +175,7 @@ impl Markdown {
             options: Options {
                 parse_links_only: false,
             },
-            copied_code_blocks: HashSet::new(),
+            copied_code_blocks: HashSet::default(),
         };
         this.parse(cx);
         this
@@ -199,7 +198,7 @@ impl Markdown {
             options: Options {
                 parse_links_only: true,
             },
-            copied_code_blocks: HashSet::new(),
+            copied_code_blocks: HashSet::default(),
         };
         this.parse(cx);
         this

--- a/crates/markdown/src/parser.rs
+++ b/crates/markdown/src/parser.rs
@@ -4,7 +4,9 @@ pub use pulldown_cmark::TagEnd as MarkdownTagEnd;
 use pulldown_cmark::{
     Alignment, CowStr, HeadingLevel, LinkType, MetadataBlockKind, Options, Parser,
 };
-use std::{collections::HashSet, ops::Range, path::Path, sync::Arc};
+use std::{ops::Range, path::Path, sync::Arc};
+
+use collections::HashSet;
 
 use crate::path_range::PathWithRange;
 
@@ -26,8 +28,8 @@ pub fn parse_markdown(
     HashSet<Arc<Path>>,
 ) {
     let mut events = Vec::new();
-    let mut language_names = HashSet::new();
-    let mut language_paths = HashSet::new();
+    let mut language_names = HashSet::default();
+    let mut language_paths = HashSet::default();
     let mut within_link = false;
     let mut within_metadata = false;
     let mut parser = Parser::new_ext(text, PARSE_OPTIONS)
@@ -579,8 +581,8 @@ mod tests {
                     (30..37, Text),
                     (30..37, End(MarkdownTagEnd::Paragraph))
                 ],
-                HashSet::new(),
-                HashSet::new()
+                HashSet::default(),
+                HashSet::default()
             )
         )
     }
@@ -613,8 +615,8 @@ mod tests {
                     (46..51, Text),
                     (0..51, End(MarkdownTagEnd::Paragraph))
                 ],
-                HashSet::new(),
-                HashSet::new()
+                HashSet::default(),
+                HashSet::default()
             )
         );
     }
@@ -670,8 +672,8 @@ mod tests {
                     (43..53, SubstitutedText("–––––".into())),
                     (0..53, End(MarkdownTagEnd::Paragraph))
                 ],
-                HashSet::new(),
-                HashSet::new()
+                HashSet::default(),
+                HashSet::default()
             )
         )
     }
@@ -695,8 +697,12 @@ mod tests {
                     (8..34, Text),
                     (0..37, End(MarkdownTagEnd::CodeBlock)),
                 ],
-                HashSet::from(["rust".into()]),
-                HashSet::new()
+                {
+                    let mut h = HashSet::default();
+                    h.insert("rust".into());
+                    h
+                },
+                HashSet::default()
             )
         );
         assert_eq!(
@@ -716,8 +722,8 @@ mod tests {
                     (4..16, Text),
                     (4..16, End(MarkdownTagEnd::CodeBlock))
                 ],
-                HashSet::new(),
-                HashSet::new()
+                HashSet::default(),
+                HashSet::default()
             )
         );
     }

--- a/crates/zed/src/zed/component_preview.rs
+++ b/crates/zed/src/zed/component_preview.rs
@@ -216,7 +216,7 @@ impl ComponentPreview {
     }
 
     fn scope_ordered_entries(&self) -> Vec<PreviewEntry> {
-        use std::collections::HashMap;
+        use collections::HashMap;
 
         let mut scope_groups: HashMap<
             ComponentScope,


### PR DESCRIPTION
Micro-optimisation in the markdown crate to use the faster hasher.

Release Notes:

- N/A