### PR TITLE
Fix name truncation for the highlighted branch in the branch picker

### DIFF
--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -504,15 +504,10 @@ impl PickerDelegate for BranchListDelegate {
                         .size(IconSize::Small)
                         .color(Color::Muted),
                 )
-                .child(
-                    Label::new(format!("Create branch \"{}\"…", entry.branch.name()))
-                        .single_line()
-                        .truncate(),
-                )
+                .child(Label::new(format!("Create branch \"{}\"…", entry.branch.name())).truncate())
                 .into_any_element()
         } else {
             HighlightedLabel::new(entry.branch.name().to_owned(), entry.positions.clone())
-                .single_line()
                 .truncate()
                 .into_any_element()
         };

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -499,6 +499,7 @@ impl PickerDelegate for BranchListDelegate {
         let branch_name = if entry.is_new {
             h_flex()
                 .gap_1()
+                .w_full()
                 .child(
                     Icon::new(IconName::Plus)
                         .size(IconSize::Small)

--- a/crates/git_ui/src/branch_picker.rs
+++ b/crates/git_ui/src/branch_picker.rs
@@ -512,6 +512,7 @@ impl PickerDelegate for BranchListDelegate {
                 .into_any_element()
         } else {
             HighlightedLabel::new(entry.branch.name().to_owned(), entry.positions.clone())
+                .single_line()
                 .truncate()
                 .into_any_element()
         };


### PR DESCRIPTION
**Before**

If Zed is configured to use a custom UI font (Berkeley Mono, in my case), the highlighted branch with a name of 49 characters is rendered on two lines:

https://github.com/user-attachments/assets/f5efc12c-8053-4230-ac7d-73812166789d

new branch:

https://github.com/user-attachments/assets/3bcdb9ff-7e1b-4e64-9421-5c6c59868844

**After**

Highlighted label always rendered in a single line with truncation:

https://github.com/user-attachments/assets/d550ce11-ae40-43bb-a7e4-51017bc1b359

new branch:

https://github.com/user-attachments/assets/5afc354c-3e67-4f06-938f-8dcdec1a5a1b

Release Notes:

- Fixed: Fix name truncation for the highlighted branch in the branch picker
