### PR TITLE
git: Docs-based workaround for GitHub/git auth confusion

### DIFF
--- a/crates/git_ui/src/askpass_modal.rs
+++ b/crates/git_ui/src/askpass_modal.rs
@@ -2,9 +2,7 @@ use editor::Editor;
 use futures::channel::oneshot;
 use gpui::{AppContext, DismissEvent, Entity, EventEmitter, Focusable, Styled};
 use ui::{
-    ActiveTheme, App, Context, DynamicSpacing, Headline, HeadlineSize, Icon, IconName, IconSize,
-    InteractiveElement, IntoElement, ParentElement, Render, SharedString, StyledExt,
-    StyledTypography, Window, div, h_flex, v_flex,
+    div, h_flex, v_flex, ActiveTheme, AnyElement, App, Context, DynamicSpacing, Headline, HeadlineSize, Icon, IconName, IconSize, InteractiveElement, IntoElement, ParentElement, Render, SharedString, StyledExt, StyledTypography, Window
 };
 use workspace::ModalView;
 
@@ -33,7 +31,7 @@ impl AskPassModal {
     ) -> Self {
         let editor = cx.new(|cx| {
             let mut editor = Editor::single_line(window, cx);
-            if prompt.contains("yes/no") {
+            if prompt.contains("yes/no") || prompt.contains("Username") {
                 editor.set_masked(false, cx);
             } else {
                 editor.set_masked(true, cx);
@@ -57,6 +55,17 @@ impl AskPassModal {
             tx.send(self.editor.read(cx).text(cx)).ok();
         }
         cx.emit(DismissEvent);
+    }
+
+    fn render_hint(&mut self, &mut Context<Self>) -> Option<AnyElement> {
+        // if (self.prompt.contains("Password") || self.prompt.contains("Username")) && self.prompt.contains("github.com") {
+            return Some(
+                div().p_2().child("OOPS!").into()
+            )
+
+        // }
+
+        // None
     }
 }
 
@@ -97,5 +106,6 @@ impl Render for AskPassModal {
                     .child(self.prompt.clone())
                     .child(self.editor.clone()),
             )
+                .children(self.render_hint(cx))
     }
 }

--- a/crates/git_ui/src/askpass_modal.rs
+++ b/crates/git_ui/src/askpass_modal.rs
@@ -2,10 +2,10 @@ use editor::Editor;
 use futures::channel::oneshot;
 use gpui::{AppContext, DismissEvent, Entity, EventEmitter, Focusable, Styled};
 use ui::{
-    ActiveTheme, AnyElement, App, Button, ButtonCommon, ButtonSize, Clickable, Color, Context,
-    DynamicSpacing, Headline, HeadlineSize, Icon, IconName, IconSize, InteractiveElement,
-    IntoElement, Label, LabelCommon, LabelSize, ParentElement, Render, SharedString, StyledExt,
-    StyledTypography, Window, div, h_flex, v_flex,
+    ActiveTheme, AnyElement, App, Button, Clickable, Color, Context, DynamicSpacing, Headline,
+    HeadlineSize, Icon, IconName, IconSize, InteractiveElement, IntoElement, Label, LabelCommon,
+    LabelSize, ParentElement, Render, SharedString, StyledExt, StyledTypography, Window, div,
+    h_flex, v_flex,
 };
 use workspace::ModalView;
 

--- a/crates/git_ui/src/askpass_modal.rs
+++ b/crates/git_ui/src/askpass_modal.rs
@@ -2,7 +2,10 @@ use editor::Editor;
 use futures::channel::oneshot;
 use gpui::{AppContext, DismissEvent, Entity, EventEmitter, Focusable, Styled};
 use ui::{
-    div, h_flex, v_flex, ActiveTheme, AnyElement, App, Context, DynamicSpacing, Headline, HeadlineSize, Icon, IconName, IconSize, InteractiveElement, IntoElement, ParentElement, Render, SharedString, StyledExt, StyledTypography, Window
+    ActiveTheme, AnyElement, App, Button, ButtonCommon, ButtonSize, Clickable, Color, Context,
+    DynamicSpacing, Headline, HeadlineSize, Icon, IconName, IconSize, InteractiveElement,
+    IntoElement, Label, LabelCommon, LabelSize, ParentElement, Render, SharedString, StyledExt,
+    StyledTypography, Window, div, h_flex, v_flex,
 };
 use workspace::ModalView;
 
@@ -57,15 +60,34 @@ impl AskPassModal {
         cx.emit(DismissEvent);
     }
 
-    fn render_hint(&mut self, &mut Context<Self>) -> Option<AnyElement> {
-        // if (self.prompt.contains("Password") || self.prompt.contains("Username")) && self.prompt.contains("github.com") {
+    fn render_hint(&mut self, cx: &mut Context<Self>) -> Option<AnyElement> {
+        let color = cx.theme().status().info_background;
+        if (self.prompt.contains("Password") || self.prompt.contains("Username"))
+            && self.prompt.contains("github.com")
+        {
             return Some(
-                div().p_2().child("OOPS!").into()
-            )
-
-        // }
-
-        // None
+            div()
+                .p_2()
+                .bg(color)
+                .border_t_1()
+                .border_color(cx.theme().status().info_border)
+                .child(
+                    h_flex().gap_2()
+                        .child(
+                            Icon::new(IconName::Github).size(IconSize::Small)
+                        )
+                        .child(
+                            Label::new("You may need to configure git for Github.")
+                                .size(LabelSize::Small),
+                        )
+                        .child(Button::new("learn-more", "Learn more").color(Color::Accent).label_size(LabelSize::Small).on_click(|_, _, cx| {
+                            cx.open_url("https://docs.github.com/en/get-started/git-basics/set-up-git#authenticating-with-github-from-git")
+                        })),
+                )
+                .into_any_element(),
+        );
+        }
+        None
     }
 }
 
@@ -77,9 +99,9 @@ impl Render for AskPassModal {
             .on_action(cx.listener(Self::confirm))
             .elevation_2(cx)
             .size_full()
-            .font_buffer(cx)
             .child(
                 h_flex()
+                    .font_buffer(cx)
                     .px(DynamicSpacing::Base12.rems(cx))
                     .pt(DynamicSpacing::Base08.rems(cx))
                     .pb(DynamicSpacing::Base04.rems(cx))
@@ -95,6 +117,7 @@ impl Render for AskPassModal {
             )
             .child(
                 div()
+                    .font_buffer(cx)
                     .text_buffer(cx)
                     .py_2()
                     .px_3()
@@ -106,6 +129,6 @@ impl Render for AskPassModal {
                     .child(self.prompt.clone())
                     .child(self.editor.clone()),
             )
-                .children(self.render_hint(cx))
+            .children(self.render_hint(cx))
     }
 }


### PR DESCRIPTION

Closes #ISSUE

Release Notes:

- git: Added a link to Github's authentication help if you end up in Zed trying to type a password in for https auth
