### PR TITLE
editor: Correct "Toggle Excerpt Fold" tip on macOS

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3838,7 +3838,11 @@ impl EditorElement {
                                                 Tooltip::with_meta_in(
                                                     "Toggle Excerpt Fold",
                                                     Some(&ToggleFold),
-                                                    "Alt+click to toggle all",
+                                                    if cfg!(target_os = "macos") {
+                                                        "Option+click to toggle all"
+                                                    } else {
+                                                        "Alt+click to toggle all"
+                                                    },
                                                     &focus_handle,
                                                     window,
                                                     cx,


### PR DESCRIPTION
Show `"Option+click to toggle all"` instead of `"Alt+click to toggle all"` on macOS.

<img width="546" height="212" alt="Screenshot 2025-09-19 at 10 16 11" src="https://github.com/user-attachments/assets/b1052b7c-349f-4a11-892b-988cfd2ff365" />

Release Notes:

- N/A
