### PR TITLE
editor: Update "Changes" view fold button to prevent container overflow

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3829,8 +3829,8 @@ impl EditorElement {
                                 .child(
                                     ButtonLike::new("toggle-buffer-fold")
                                         .style(ui::ButtonStyle::Transparent)
-                                        .height(px(28.).into())
-                                        .width(px(28.))
+                                        .height(px(20.).into())
+                                        .width(px(24.))
                                         .children(toggle_chevron_icon)
                                         .tooltip({
                                             let focus_handle = focus_handle.clone();


### PR DESCRIPTION
# Why

I have spotted that diff fold button in "Uncommitted Changes" view overflows to container, which was most noticable when hovering it.

# How

Reduce the fold button height to fit inside header container with small spacing, also reduce width a bit so button does not feel too stretched.

Release Notes:

- Fix fold button container overflow in "Uncommitted Changes" view 

# Test plan

I have tested the change locally and compared the UI before and after to make sure it feels right.

### Before

<img width="546" height="212" alt="Screenshot 2025-09-19 at 10 28 54" src="https://github.com/user-attachments/assets/b9180e85-cc36-4adf-b119-9652557e363f" />

### After

<img width="546" height="212" alt="Screenshot 2025-09-19 at 10 46 54" src="https://github.com/user-attachments/assets/8a10b88a-ffb2-4560-b84a-5c840addd67b" />

