### PR TITLE
Fix markdown list in `bump-zed-minor-versions`

### DIFF
--- a/script/bump-zed-minor-versions
+++ b/script/bump-zed-minor-versions
@@ -104,7 +104,7 @@ Prepared new Zed versions locally. You will need to push the branches and open a
       ${prev_minor_branch_name} \\
       ${bump_main_branch_name}
 
-    echo -e "Release Notes:\n\n-N/A" | gh pr create \\
+    echo -e "Release Notes:\n\n- N/A" | gh pr create \\
       --title "Bump Zed to v${major}.${next_minor}" \\
       --body-file "-" \\
       --base main \\


### PR DESCRIPTION
This fixes a small markdown issue in the `bump-zed-minor-versions` script that bugged me for too long 😅 

Release Notes:

- N/A
