### PR TITLE
gpui: Fix incorrect handling of Function key modifier on macOS

### DIFF
--- a/crates/gpui/src/platform/keystroke.rs
+++ b/crates/gpui/src/platform/keystroke.rs
@@ -572,6 +572,14 @@ impl Modifiers {
         }
     }
 
+    /// Returns [`Modifiers`] with just function.
+    pub fn function() -> Modifiers {
+        Modifiers {
+            function: true,
+            ..Default::default()
+        }
+    }
+
     /// Returns [`Modifiers`] with command + shift.
     pub fn command_shift() -> Modifiers {
         Modifiers {

--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1753,9 +1753,9 @@ extern "C" fn handle_key_event(this: &Object, native_event: id, key_equivalent: 
                 }
             }
 
-            // Don't send key equivalents to the input handler,
-            // or macOS shortcuts like cmd-` will stop working.
-            if key_equivalent {
+            // Don't send key equivalents to the input handler if there are key modifiers other
+            // than Function key, or macOS shortcuts like cmd-` will stop working.
+            if key_equivalent && key_down_event.keystroke.modifiers != Modifiers::function() {
                 return NO;
             }
 


### PR DESCRIPTION
On macOS, the Function key is reserved for system use and should not be used in application code.

This commit updated keystroke matching and key event handling to ignore the Function key modifier while users are typing or pressing keybindings.

For some keyboards with compact layout (like my 65% keyboard), there is no separated backtick key. Esc and it shares the same physical key. To input backtick, users may press `Fn-Esc`. However, macOS will still deliver events with Fn key modifier to applications. Cocoa framework can handle this correctly, which typically ignore the Fn directly. GPUI should also follow the same rule, otherwise, the backtick key on those keyboards won't work.

Release Notes:

- Fixed a bug where typing fn-\` on macOS would not insert a `.
