### PR TITLE
editor: Stop clipping at line ends when hollow cursor is used

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -9947,8 +9947,10 @@ impl Editor {
         }
         self.hide_mouse_cursor(HideMouseCursorOrigin::TypingAction, cx);
 
-        // If hollow, allow deletion on the right side.
-        if self.cursor_shape == CursorShape::Hollow {
+        let vim_mode = vim_enabled(cx);
+
+        // Allow clipping as in vim mode the cursor selects the character do we need to not have it clip the end.
+        if self.cursor_shape == CursorShape::Hollow && vim_mode {
             self.set_clip_at_line_ends(false, cx);
         }
 
@@ -9967,8 +9969,8 @@ impl Editor {
             this.refresh_edit_prediction(true, false, window, cx);
         });
 
-        // Fixup cursor position after the deletion
-        if self.cursor_shape == CursorShape::Hollow {
+        // Move cursor to the left to ensure the position is correct
+        if self.cursor_shape == CursorShape::Hollow && vim_mode {
             self.set_clip_at_line_ends(true, cx);
             self.change_selections(Default::default(), window, cx, |s| {
                 s.move_with(|map, selection| {


### PR DESCRIPTION
Closes #35217 

Release Notes: 
 - **Fixed:** editor::delete doesn't work on the last character of a line
 - **How:** If a hollow cursor is used, (the cursor used by vim), then change clip_at_line_ends to false, and then move the cursor left to ensure cursor position is correct.
 - **Caution Note:** I wasn't sure if I should add a test to this or not, if so, I am not completely sure how to do that, I could copy the existing test and then change the cursor and see if the test works for that? What do you suggest?


