### PR TITLE
macos: Fix panic when `NSWindow::screen` returns `nil`

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -513,10 +513,11 @@ impl MacWindowState {
 
     fn bounds(&self) -> Bounds<Pixels> {
         let mut window_frame = unsafe { NSWindow::frame(self.native_window) };
-        let screen_frame = unsafe {
-            let screen = NSWindow::screen(self.native_window);
-            NSScreen::frame(screen)
-        };
+        let screen = unsafe { NSWindow::screen(self.native_window) };
+        if screen == nil {
+            return Bounds::new(point(px(0.), px(0.)), crate::DEFAULT_WINDOW_SIZE);
+        }
+        let screen_frame = unsafe { NSScreen::frame(screen) };
 
         // Flip the y coordinate to be top-left origin
         window_frame.origin.y =


### PR DESCRIPTION
Closes #ISSUE

Release Notes:

- mac: Fixed an issue where Zed would panic if the workspace window was previously off screen 
