### PR TITLE
extension_host: Expand supported extension API range to include v0.7.0

### DIFF
--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -35,7 +35,7 @@ use util::{archive::extract_zip, fs::make_file_executable, maybe};
 use wasmtime::component::{Linker, Resource};
 
 pub const MIN_VERSION: SemanticVersion = SemanticVersion::new(0, 6, 0);
-pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 6, 0);
+pub const MAX_VERSION: SemanticVersion = SemanticVersion::new(0, 7, 0);
 
 wasmtime::component::bindgen!({
     async: true,


### PR DESCRIPTION
This PR updates the version range for v0.6.0 of the extension API to include v0.7.0.

Since we bumped the `zed_extension_api` crate's version to v0.7.0, we need to expand this range in order for Zed clients to be able to install extensions built against v0.7.0 of `zed_extension_api`.

Currently no extensions that target `zed_extension_api@0.7.0` can be installed.

Release Notes:

- N/A
