### PR TITLE
Add comment language injection for supported languages

### DIFF
--- a/crates/languages/src/c/injections.scm
+++ b/crates/languages/src/c/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (preproc_def
     value: (preproc_arg) @injection.content
     (#set! injection.language "c"))

--- a/crates/languages/src/cpp/injections.scm
+++ b/crates/languages/src/cpp/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (preproc_def
     value: (preproc_arg) @injection.content
     (#set! injection.language "c++"))

--- a/crates/languages/src/gitcommit/injections.scm
+++ b/crates/languages/src/gitcommit/injections.scm
@@ -1,3 +1,7 @@
+((comment) @content
+ (#set! injection.language "comment")
+)
+
 ((scissors) @content
  (#set! "language" "diff"))
 

--- a/crates/languages/src/go/injections.scm
+++ b/crates/languages/src/go/injections.scm
@@ -1,4 +1,8 @@
 ; Refer to https://github.com/nvim-treesitter/nvim-treesitter/blob/master/queries/go/injections.scm#L4C1-L16C41
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (call_expression
   (selector_expression) @_function
   (#any-of? @_function

--- a/crates/languages/src/javascript/injections.scm
+++ b/crates/languages/src/javascript/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (((comment) @_jsdoc_comment
   (#match? @_jsdoc_comment "(?s)^/[*][*][^*].*[*]/$")) @injection.content
   (#set! injection.language "jsdoc"))

--- a/crates/languages/src/markdown/injections.scm
+++ b/crates/languages/src/markdown/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (fenced_code_block
   (info_string
     (language) @injection.language)

--- a/crates/languages/src/rust/injections.scm
+++ b/crates/languages/src/rust/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (macro_invocation
     macro: (identifier) @_macro_name
     (#not-any-of? @_macro_name "view" "html")

--- a/crates/languages/src/tsx/injections.scm
+++ b/crates/languages/src/tsx/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (((comment) @_jsdoc_comment
   (#match? @_jsdoc_comment "(?s)^/[*][*][^*].*[*]/$")) @injection.content
   (#set! injection.language "jsdoc"))

--- a/crates/languages/src/typescript/injections.scm
+++ b/crates/languages/src/typescript/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (((comment) @_jsdoc_comment
   (#match? @_jsdoc_comment "(?s)^/[*][*][^*].*[*]/$")) @injection.content
   (#set! injection.language "jsdoc"))

--- a/extensions/html/languages/html/injections.scm
+++ b/extensions/html/languages/html/injections.scm
@@ -1,3 +1,7 @@
+((comment) @injection.content
+ (#set! injection.language "comment")
+)
+
 (script_element
   (raw_text) @injection.content
   (#set! injection.language "javascript"))


### PR DESCRIPTION
Release Notes:

- Added support for comment highlighting for packaged languages via [comment extension](https://github.com/thedadams/zed-comment).
