### PR TITLE
vim: Remove duplicate bracket pair

### DIFF
--- a/crates/vim/src/surrounds.rs
+++ b/crates/vim/src/surrounds.rs
@@ -603,13 +603,6 @@ fn all_support_surround_pair() -> Vec<BracketPair> {
             newline: false,
         },
         BracketPair {
-            start: "{".into(),
-            end: "}".into(),
-            close: true,
-            surround: true,
-            newline: false,
-        },
-        BracketPair {
             start: "<".into(),
             end: ">".into(),
             close: true,


### PR DESCRIPTION
remove depulicate code, this same with line: 556-562

Release Notes:

- N/A
