### PR TITLE
audio: Replace inferred array lengths with `BUFFER_SIZE`

### DIFF
--- a/crates/audio/src/audio.rs
+++ b/crates/audio/src/audio.rs
@@ -128,7 +128,7 @@ impl Audio {
                     target_os = "freebsd"
                 )))]
                 let source = source.inspect_buffer::<BUFFER_SIZE, _>(move |buffer| {
-                    let mut buf: [i16; _] = buffer.map(|s| s.to_sample());
+                    let mut buf: [i16; BUFFER_SIZE] = buffer.map(|s| s.to_sample());
                     echo_canceller
                         .lock()
                         .process_reverse_stream(
@@ -169,7 +169,7 @@ impl Audio {
         let (replay, stream) = UniformSourceIterator::new(stream, CHANNEL_COUNT, SAMPLE_RATE)
             .limit(LimitSettings::live_performance())
             .process_buffer::<BUFFER_SIZE, _>(move |buffer| {
-                let mut int_buffer: [i16; _] = buffer.map(|s| s.to_sample());
+                let mut int_buffer: [i16; BUFFER_SIZE] = buffer.map(|s| s.to_sample());
                 if voip_parts
                     .echo_canceller
                     .lock()


### PR DESCRIPTION
### Summary
Fix stable Rust builds (E0658) by replacing `_`-inferred array lengths with explicit `BUFFER_SIZE` in `crates/audio/src/audio.rs`. No behavior changes.

### Context
Stable Rust doesn’t allow `_` as an array length in type position (E0658; see rust-lang/rust#85077), causing two compile errors in `audio.rs`.

I got these two compilation errors : 

```
error[E0658]: using `_` for array lengths is unstable
   --> crates/audio/src/audio.rs:131:40
    |
131 |                     let mut buf: [i16; _] = buffer.map(|s| s.to_sample());
    |                                        ^
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information

error[E0658]: using `_` for array lengths is unstable
   --> crates/audio/src/audio.rs:172:43
    |
172 |                 let mut int_buffer: [i16; _] = buffer.map(|s| s.to_sample());
    |                                           ^
    |
    = note: see issue #85077 <https://github.com/rust-lang/rust/issues/85077> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `audio` (lib) due to 2 previous errors
warning: build failed, waiting for other jobs to finish...
```

`BUFFER_SIZE` matches the surrounding const generics:
- `inspect_buffer::<BUFFER_SIZE, _>(...)`
- `process_buffer::<BUFFER_SIZE, _>(...)`

### Testing
Built successfully on stable:
- rustc 1.88.0 (6b00bc388 2025-06-23), LLVM 19.1.4
- target: x86_64-unknown-linux-gnu (Void Linux)

### Impact
Build-only fix; no functional changes.

### Release notes
Fix: Restore stable Rust build by replacing `_` array lengths with `BUFFER_SIZE` in `crates/audio/src/audio.rs` (E0658).