### PR TITLE
git_ui: Expand commit editor hitbox by setting min_lines = max_lines

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -347,7 +347,7 @@ pub(crate) fn commit_message_editor(
     let max_lines = if in_panel { MAX_PANEL_EDITOR_LINES } else { 18 };
     let mut commit_editor = Editor::new(
         EditorMode::AutoHeight {
-            min_lines: 1,
+            min_lines: max_lines,
             max_lines: Some(max_lines),
         },
         buffer,


### PR DESCRIPTION
Closes #26527

The commit editor hitbox was too small since min_lines < max_lines, making it grow only when typing more lines.

Release Notes:

- N/A

https://github.com/user-attachments/assets/e026d688-594f-40b6-a971-6c92e3fdb496