### PR TITLE
Add quick "Edit debug.json" button to debugger control strip

### DIFF
--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -641,6 +641,15 @@ impl DebugPanel {
                 .tooltip(Tooltip::text("Open Debug Adapter Logs"))
         };
 
+        let edit_debug_json_button = || {
+            IconButton::new("debug-edit-debug-json", IconName::Code)
+                .icon_size(IconSize::Small)
+                .on_click(move |_, window, cx| {
+                    window.dispatch_action(zed_actions::OpenProjectDebugTasks.boxed_clone(), cx);
+                })
+                .tooltip(Tooltip::text("Edit debug.json"))
+        };
+
         Some(
             div.w_full()
                 .py_1()
@@ -901,6 +910,7 @@ impl DebugPanel {
                             this.child(new_session_button())
                                 .child(logs_button())
                                 .child(documentation_button())
+                                .child(edit_debug_json_button())
                         }),
                 )
                 .child(
@@ -953,6 +963,7 @@ impl DebugPanel {
                                     this.child(new_session_button())
                                         .child(logs_button())
                                         .child(documentation_button())
+                                        .child(edit_debug_json_button())
                                 }),
                         ),
                 ),

--- a/crates/debugger_ui/src/debugger_panel.rs
+++ b/crates/debugger_ui/src/debugger_panel.rs
@@ -625,6 +625,15 @@ impl DebugPanel {
                 })
         };
 
+        let edit_debug_json_button = || {
+            IconButton::new("debug-edit-debug-json", IconName::Code)
+                .icon_size(IconSize::Small)
+                .on_click(|_, window, cx| {
+                    window.dispatch_action(zed_actions::OpenProjectDebugTasks.boxed_clone(), cx);
+                })
+                .tooltip(Tooltip::text("Edit debug.json"))
+        };
+
         let documentation_button = || {
             IconButton::new("debug-open-documentation", IconName::CircleHelp)
                 .icon_size(IconSize::Small)
@@ -639,15 +648,6 @@ impl DebugPanel {
                     window.dispatch_action(debugger_tools::OpenDebugAdapterLogs.boxed_clone(), cx)
                 })
                 .tooltip(Tooltip::text("Open Debug Adapter Logs"))
-        };
-
-        let edit_debug_json_button = || {
-            IconButton::new("debug-edit-debug-json", IconName::Code)
-                .icon_size(IconSize::Small)
-                .on_click(move |_, window, cx| {
-                    window.dispatch_action(zed_actions::OpenProjectDebugTasks.boxed_clone(), cx);
-                })
-                .tooltip(Tooltip::text("Edit debug.json"))
         };
 
         Some(
@@ -908,9 +908,9 @@ impl DebugPanel {
                         )
                         .when(is_side, |this| {
                             this.child(new_session_button())
-                                .child(logs_button())
-                                .child(documentation_button())
                                 .child(edit_debug_json_button())
+                                .child(documentation_button())
+                                .child(logs_button())
                         }),
                 )
                 .child(
@@ -961,9 +961,9 @@ impl DebugPanel {
                                 ))
                                 .when(!is_side, |this| {
                                     this.child(new_session_button())
-                                        .child(logs_button())
-                                        .child(documentation_button())
                                         .child(edit_debug_json_button())
+                                        .child(documentation_button())
+                                        .child(logs_button())
                                 }),
                         ),
                 ),


### PR DESCRIPTION
This button already exists in the main menu, as well as the "New Session" view in the debugger panel. However, this view disappears after starting the debugging session. This PR adds the same button to the debugger control strip that remains accessible. This is convenient for people editing their debug.json frequently.

Site-node: I feel like the `Cog` icon would be more appropriate, but I picked `Code` to stay consistent with the "New Session" view.

Before:

<img width="194" height="118" alt="image" src="https://github.com/user-attachments/assets/5b42a8a4-f48f-4145-a425-53365dd785ca" />

After:

<img width="194" height="118" alt="image" src="https://github.com/user-attachments/assets/12f56ea1-150b-4564-8e6a-da4671f52079" />

Release Notes:

- Added "Edit debug.json" button to debugger control strip