### PR TITLE
Docs: change format_on_save value from false to "off"

### DIFF
--- a/docs/src/languages/python.md
+++ b/docs/src/languages/python.md
@@ -198,7 +198,7 @@ You can disable format-on-save for Python files in your `settings.json`:
 {
   "languages": {
     "Python": {
-      "format_on_save": false
+      "format_on_save": "off"
     }
   }
 }


### PR DESCRIPTION
Found this outdated piece of information in the docs while trying to disable it myself, this PR simply changes `false` to `"off"`.

Release Notes:

- N/A