### PR TITLE
Account for LLM provider returning a negative tool call index

### DIFF
--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -531,7 +531,11 @@ impl LmStudioEventMapper {
 
         if let Some(tool_calls) = choice.delta.tool_calls {
             for tool_call in tool_calls {
-                let entry = self.tool_calls_by_index.entry(tool_call.index).or_default();
+                let mut index = tool_call.index.unwrap_or_default();
+                if index < 0 {
+                    index = 0;
+                }
+                let entry = self.tool_calls_by_index.entry(index as usize).or_default();
 
                 if let Some(tool_id) = tool_call.id {
                     entry.id = tool_id;

--- a/crates/language_models/src/provider/lmstudio.rs
+++ b/crates/language_models/src/provider/lmstudio.rs
@@ -484,7 +484,7 @@ impl LanguageModel for LmStudioLanguageModel {
 }
 
 struct LmStudioEventMapper {
-    tool_calls_by_index: HashMap<usize, RawToolCall>,
+    tool_calls_by_index: HashMap<isize, RawToolCall>,
 }
 
 impl LmStudioEventMapper {
@@ -531,14 +531,14 @@ impl LmStudioEventMapper {
 
         if let Some(tool_calls) = choice.delta.tool_calls {
             for tool_call in tool_calls {
-                let mut index = tool_call.index.unwrap_or_default();
-                if index < 0 {
-                    index = 0;
-                }
-                let entry = self.tool_calls_by_index.entry(index as usize).or_default();
+                let index = tool_call.index.unwrap_or_default();
+                let entry = self.tool_calls_by_index.entry(index).or_default();
 
+                // Only update id when it's not empty (avoid overwriting existing id)
                 if let Some(tool_id) = tool_call.id {
-                    entry.id = tool_id;
+                    if !tool_id.is_empty() {
+                        entry.id = tool_id;
+                    }
                 }
 
                 if let Some(function) = tool_call.function {

--- a/crates/language_models/src/provider/open_ai.rs
+++ b/crates/language_models/src/provider/open_ai.rs
@@ -558,7 +558,11 @@ impl OpenAiEventMapper {
 
         if let Some(tool_calls) = choice.delta.tool_calls.as_ref() {
             for tool_call in tool_calls {
-                let entry = self.tool_calls_by_index.entry(tool_call.index).or_default();
+                let mut index = tool_call.index.unwrap_or_default();
+                if index < 0 {
+                    index = 0;
+                }
+                let entry = self.tool_calls_by_index.entry(index as usize).or_default();
 
                 if let Some(tool_id) = tool_call.id.clone() {
                     entry.id = tool_id;

--- a/crates/lmstudio/src/lmstudio.rs
+++ b/crates/lmstudio/src/lmstudio.rs
@@ -240,7 +240,7 @@ pub struct ChoiceDelta {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct ToolCallChunk {
-    pub index: usize,
+    pub index: Option<isize>,
     pub id: Option<String>,
 
     // There is also an optional `type` field that would determine if a

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -404,7 +404,7 @@ pub struct ResponseMessageDelta {
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct ToolCallChunk {
-    pub index: usize,
+    pub index: Option<isize>,
     pub id: Option<String>,
 
     // There is also an optional `type` field that would determine if a


### PR DESCRIPTION
some inference framework may return `-1` `index` when returning tool call response, and some other one will not return the `index` field. make the index type as `Option<isize>` can handle these problems
