### PR TITLE
vim: Make `g g` and `shift-g` actions the same behavior of vim

### DIFF
--- a/crates/vim/src/change_list.rs
+++ b/crates/vim/src/change_list.rs
@@ -154,7 +154,7 @@ mod test {
             indoc! {
             "22
              11
-             34ˇ43"
+             4ˇ433"
             },
             Mode::Normal,
         );
@@ -163,7 +163,7 @@ mod test {
             indoc! {
             "2ˇ2
              11
-             3443"
+             4433"
             },
             Mode::Normal,
         );

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2319,13 +2319,9 @@ fn start_of_document(
         return go_to_line(map, display_point, times);
     }
 
-    let point = map.display_point_to_point(display_point, Bias::Left);
-    let mut first_point = Point::zero();
-    first_point.column = point.column;
-
     map.clip_point(
         map.point_to_display_point(
-            map.buffer_snapshot.clip_point(first_point, Bias::Left),
+            map.buffer_snapshot.clip_point(Point::zero(), Bias::Left),
             Bias::Left,
         ),
         Bias::Left,

--- a/crates/vim/src/motion.rs
+++ b/crates/vim/src/motion.rs
@@ -2336,9 +2336,8 @@ fn end_of_document(
     if let Some(times) = maybe_times {
         return go_to_line(map, display_point, times);
     };
-    let point = map.display_point_to_point(display_point, Bias::Left);
     let mut last_point = map.buffer_snapshot.max_point();
-    last_point.column = point.column;
+    last_point.column = 0;
 
     map.clip_point(
         map.point_to_display_point(

--- a/crates/vim/test_data/test_end_of_document.json
+++ b/crates/vim/test_data/test_end_of_document.json
@@ -1,14 +1,15 @@
 {"Put":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrown fox jumps\nover ˇthe lazy dog","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
+{"Put":{"state":"The quick\n\nbrown fox jumps\nover ˇthe lazy dog"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrown fox jumps\nover ˇthe lazy dog","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quick\n\nbrown fox jumps\nover the laˇzy dog"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrown fox jumps\nover the laˇzy dog","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"\n\nbrown fox jumps\nover the laˇzy dog"}}
 {"Key":"shift-g"}
-{"Get":{"state":"\n\nbrown fox jumps\nover the laˇzy dog","mode":"Normal"}}
+{"Get":{"state":"\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"ˇ\n\nbrown fox jumps\nover the lazydog"}}
 {"Key":"2"}
 {"Key":"shift-g"}

--- a/crates/vim/test_data/test_gg.json
+++ b/crates/vim/test_data/test_gg.json
@@ -1,15 +1,15 @@
 {"Put":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog"}}
 {"Key":"g"}
 {"Key":"g"}
-{"Get":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quick\n\nbrown fox jumps\nover ˇthe lazy dog"}}
 {"Key":"g"}
 {"Key":"g"}
-{"Get":{"state":"The qˇuick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quick\n\nbrown fox jumps\nover the laˇzy dog"}}
 {"Key":"g"}
 {"Key":"g"}
-{"Get":{"state":"The quicˇk\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
+{"Get":{"state":"ˇThe quick\n\nbrown fox jumps\nover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"\n\nbrown fox jumps\nover the laˇzy dog"}}
 {"Key":"g"}
 {"Key":"g"}

--- a/crates/vim/test_data/test_jump_to_end.json
+++ b/crates/vim/test_data/test_jump_to_end.json
@@ -1,14 +1,15 @@
 {"Put":{"state":"The ˇquick\n\nbrown fox jumps\nover the lazy dog"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrown fox jumps\noverˇ the lazy dog","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
+{"Put":{"state":"The quick\n\nbrown fox jumps\noverˇ the lazy dog"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrown fox jumps\noverˇ the lazy dog","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quick\n\nbrown fox jumps\nover the lazy doˇg"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrown fox jumps\nover the lazy doˇg","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nbrown fox jumps\nˇover the lazy dog","mode":"Normal"}}
 {"Put":{"state":"The quiˇck\n\nbrown"}}
 {"Key":"shift-g"}
-{"Get":{"state":"The quick\n\nbrowˇn","mode":"Normal"}}
+{"Get":{"state":"The quick\n\nˇbrown","mode":"Normal"}}
 {"Put":{"state":"The quiˇck\n\n"}}
 {"Key":"shift-g"}
 {"Get":{"state":"The quick\n\nˇ","mode":"Normal"}}


### PR DESCRIPTION
Closes #38613

In vim mode, the `g g` keybinding should go to the very begin of the file, and `shift-g` will go to the first column of last line, which is the default behavior in vim whenever the cursor at the middle of content or line.

Release Notes:

- Fixed: In Vim mode, `g g` now jumps to the very beginning of the file, and `shift-g` moves to column 1 of the last line, matching Vim’s default behavior even when the cursor is in the middle of a line or content