### PR TITLE
Revert "remote: Remove excess quoting in WSL `build_command` (#38380)"

### DIFF
--- a/crates/remote/src/transport/wsl.rs
+++ b/crates/remote/src/transport/wsl.rs
@@ -409,7 +409,7 @@ impl RemoteConnection for WslRemoteConnection {
                 "--".to_string(),
                 self.shell.clone(),
                 "-c".to_string(),
-                script,
+                shlex::try_quote(&script)?.to_string(),
             ]
         } else {
             vec![
@@ -420,7 +420,7 @@ impl RemoteConnection for WslRemoteConnection {
                 "--".to_string(),
                 self.shell.clone(),
                 "-c".to_string(),
-                script,
+                shlex::try_quote(&script)?.to_string(),
             ]
         };
 


### PR DESCRIPTION
This reverts commit 202dcb122f719036590f05430b2bac73cdfa5b07 as that broke opening the terminal on wsl remotes.

Scripts can also have spaces because they set env/etc so in theory escaping should always occur..?

Release Notes:

- N/A
