### PR TITLE
terminal: Escape args in alacritty on Windows

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -428,7 +428,7 @@ impl TerminalBuilder {
                 drain_on_exit: true,
                 env: env.clone().into_iter().collect(),
                 #[cfg(windows)]
-                escape_args: false,
+                escape_args: true,
             }
         };
 


### PR DESCRIPTION
Release Notes:

- N/A
