### PR TITLE
Move my keybinding fixes to the right platform

### DIFF
--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -550,6 +550,8 @@
       "cmd-ctrl-left": "editor::SelectSmallerSyntaxNode", // Shrink selection
       "cmd-ctrl-right": "editor::SelectLargerSyntaxNode", // Expand selection
       "cmd-ctrl-up": "editor::SelectPreviousSyntaxNode", // Move selection up
+      "ctrl-shift-right": "editor::SelectLargerSyntaxNode", // Expand selection (VSCode version)
+      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink selection (VSCode version)
       "cmd-ctrl-down": "editor::SelectNextSyntaxNode", // Move selection down
       "cmd-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch / find_under_expand
       "cmd-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -497,8 +497,6 @@
       "shift-alt-down": "editor::DuplicateLineDown",
       "shift-alt-right": "editor::SelectLargerSyntaxNode", // Expand selection
       "shift-alt-left": "editor::SelectSmallerSyntaxNode", // Shrink selection
-      "ctrl-shift-right": "editor::SelectLargerSyntaxNode", // Expand selection (VSCode version)
-      "ctrl-shift-left": "editor::SelectSmallerSyntaxNode", // Shrink selection (VSCode version)
       "ctrl-shift-l": "editor::SelectAllMatches", // Select all occurrences of current selection
       "ctrl-f2": "editor::SelectAllMatches", // Select all occurrences of current word
       "ctrl-d": ["editor::SelectNext", { "replace_newest": false }], // editor.action.addSelectionToNextFindMatch  / find_under_expand


### PR DESCRIPTION
In cffb883108ec07ec2f51446cb35eac19b89e625f I put the fixed keybindings on the wrong platform 

Release Notes:

- Fix syntax node shortcuts
