### PR TITLE
languages: Update package.json and tsconfig.json schemas

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1514,7 +1514,7 @@
   // }
   //
   "file_types": {
-    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "**/.vscode/**/*.json"],
+    "JSONC": ["**/.zed/**/*.json", "**/zed/**/*.json", "**/Zed/**/*.json", "**/.vscode/**/*.json", "tsconfig*.json"],
     "Shell Script": [".env.*"]
   },
   // Settings for which version of Node.js and NPM to use when installing

--- a/crates/languages/src/json.rs
+++ b/crates/languages/src/json.rs
@@ -181,7 +181,7 @@ impl JsonLspAdapter {
         #[allow(unused_mut)]
         let mut schemas = serde_json::json!([
             {
-                "fileMatch": ["tsconfig.json"],
+                "fileMatch": ["tsconfig*.json"],
                 "schema":tsconfig_schema
             },
             {

--- a/crates/languages/src/json/schemas/package.json
+++ b/crates/languages/src/json/schemas/package.json
@@ -160,6 +160,11 @@
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this specifier is imported as an ECMAScript module using an `import` declaration or the dynamic `import(...)` function."
         },
+        "module-sync": {
+          "$ref": "#/definitions/packageExportsEntryOrFallback",
+          "$comment": "https://nodejs.org/api/packages.html#conditional-exports#:~:text=%22module-sync%22",
+          "description": "The same as `import`, but can be used with require(esm) in Node 20+. This requires the files to not use any top-level awaits."
+        },
         "node": {
           "$ref": "#/definitions/packageExportsEntryOrFallback",
           "description": "The module path that is resolved when this environment is Node.js."
@@ -304,6 +309,33 @@
       "required": [
         "url"
       ]
+    },
+    "devEngineDependency": {
+      "description": "Specifies requirements for development environment components such as operating systems, runtimes, or package managers. Used to ensure consistent development environments across the team.",
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The name of the dependency, with allowed values depending on the parent field"
+        },
+        "version": {
+          "type": "string",
+          "description": "The version range for the dependency"
+        },
+        "onFail": {
+          "type": "string",
+          "enum": [
+            "ignore",
+            "warn",
+            "error",
+            "download"
+          ],
+          "description": "What action to take if validation fails"
+        }
+      }
     }
   },
   "type": "object",
@@ -755,7 +787,7 @@
       ]
     },
     "resolutions": {
-      "description": "Resolutions is used to support selective version resolutions using yarn, which lets you define custom package versions or ranges inside your dependencies. For npm, use overrides instead. See: https://classic.yarnpkg.com/en/docs/selective-version-resolutions",
+      "description": "Resolutions is used to support selective version resolutions using yarn, which lets you define custom package versions or ranges inside your dependencies. For npm, use overrides instead. See: https://yarnpkg.com/configuration/manifest#resolutions",
       "type": "object"
     },
     "overrides": {
@@ -808,6 +840,82 @@
       "type": "array",
       "items": {
         "type": "string"
+      }
+    },
+    "devEngines": {
+      "description": "Define the runtime and package manager for developing the current project.",
+      "type": "object",
+      "properties": {
+        "os": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
+            }
+          ],
+          "description": "Specifies which operating systems are supported for development"
+        },
+        "cpu": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
+            }
+          ],
+          "description": "Specifies which CPU architectures are supported for development"
+        },
+        "libc": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
+            }
+          ],
+          "description": "Specifies which C standard libraries are supported for development"
+        },
+        "runtime": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
+            }
+          ],
+          "description": "Specifies which JavaScript runtimes (like Node.js, Deno, Bun) are supported for development. Values should use WinterCG Runtime Keys (see https://runtime-keys.proposal.wintercg.org/)"
+        },
+        "packageManager": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/devEngineDependency"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/devEngineDependency"
+              }
+            }
+          ],
+          "description": "Specifies which package managers are supported for development"
+        }
       }
     },
     "preferGlobal": {
@@ -973,6 +1081,7 @@
           "additionalProperties": false
         },
         "peerDependencyRules": {
+          "type": "object",
           "properties": {
             "ignoreMissing": {
               "description": "pnpm will not print warnings about missing peer dependencies from this list.",
@@ -1029,6 +1138,10 @@
           "type": "object"
         },
         "allowNonAppliedPatches": {
+          "description": "When true, installation won't fail if some of the patches from the \"patchedDependencies\" field were not applied.",
+          "type": "boolean"
+        },
+        "allowUnusedPatches": {
           "description": "When true, installation won't fail if some of the patches from the \"patchedDependencies\" field were not applied.",
           "type": "boolean"
         },
@@ -1119,6 +1232,41 @@
             }
           },
           "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "stackblitz": {
+      "description": "Defines the StackBlitz configuration for the project.",
+      "type": "object",
+      "properties": {
+        "installDependencies": {
+          "description": "StackBlitz automatically installs npm dependencies when opening a project.",
+          "type": "boolean"
+        },
+        "startCommand": {
+          "description": "A terminal command to be executed when opening the project, after installing npm dependencies.",
+          "type": [
+            "string",
+            "boolean"
+          ]
+        },
+        "compileTrigger": {
+          "description": "The compileTrigger option controls how file changes in the editor are written to the WebContainers in-memory filesystem. ",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "auto",
+                "keystroke",
+                "save"
+              ]
+            }
+          ]
+        },
+        "env": {
+          "description": "A map of default environment variables that will be set in each top-level shell process.",
+          "type": "object"
         }
       },
       "additionalProperties": false

--- a/crates/languages/src/json/schemas/tsconfig.json
+++ b/crates/languages/src/json/schemas/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "$comment": "Note that this schema uses 'null' in various places. The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058)",
   "allowTrailingCommas": true,
   "allOf": [
     {
@@ -49,7 +50,6 @@
     "filesDefinition": {
       "properties": {
         "files": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "description": "If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. When a 'files' property is specified, only those files and those specified by 'include' are included.",
           "type": ["array", "null"],
           "uniqueItems": true,
@@ -62,7 +62,6 @@
     "excludeDefinition": {
       "properties": {
         "exclude": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "description": "Specifies a list of files to be excluded from compilation. The 'exclude' property only affects the files included via the 'include' property and not the 'files' property. Glob patterns require TypeScript version 2.0 or later.",
           "type": ["array", "null"],
           "uniqueItems": true,
@@ -75,7 +74,6 @@
     "includeDefinition": {
       "properties": {
         "include": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "description": "Specifies a list of glob patterns that match files to be included in compilation. If no 'files' or 'include' property is present in a tsconfig.json, the compiler defaults to including all files in the containing directory and subdirectories except those specified by 'exclude'. Requires TypeScript version 2.0 or later.",
           "type": ["array", "null"],
           "uniqueItems": true,
@@ -118,41 +116,35 @@
         "buildOptions": {
           "properties": {
             "dry": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "~",
               "type": ["boolean", "null"],
               "default": false
             },
             "force": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Build all projects, including those that appear to be up to date",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Build all projects, including those that appear to be up to date\n\nSee more: https://www.typescriptlang.org/tsconfig#force"
             },
             "verbose": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable verbose logging",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable verbose logging\n\nSee more: https://www.typescriptlang.org/tsconfig#verbose"
             },
             "incremental": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Save .tsbuildinfo files to allow for incremental compilation of projects.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Save .tsbuildinfo files to allow for incremental compilation of projects.\n\nSee more: https://www.typescriptlang.org/tsconfig#incremental"
             },
             "assumeChangesOnlyAffectDirectDependencies": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Have recompiles in projects that use `incremental` and `watch` mode assume that changes within a file will only affect files directly depending on it.\n\nSee more: https://www.typescriptlang.org/tsconfig#assumeChangesOnlyAffectDirectDependencies"
             },
             "traceResolution": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Log paths used during the `moduleResolution` process.",
               "type": ["boolean", "null"],
               "default": false,
@@ -165,7 +157,6 @@
     "watchOptionsDefinition": {
       "properties": {
         "watchOptions": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Settings for the watch mode in TypeScript.",
           "properties": {
@@ -174,31 +165,26 @@
               "type": ["string", "null"]
             },
             "watchFile": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify how the TypeScript watch mode works.",
               "type": ["string", "null"],
               "markdownDescription": "Specify how the TypeScript watch mode works.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchFile"
             },
             "watchDirectory": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify how directories are watched on systems that lack recursive file-watching functionality.",
               "type": ["string", "null"],
               "markdownDescription": "Specify how directories are watched on systems that lack recursive file-watching functionality.\n\nSee more: https://www.typescriptlang.org/tsconfig#watchDirectory"
             },
             "fallbackPolling": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify what approach the watcher should use if the system runs out of native file watchers.",
               "type": ["string", "null"],
               "markdownDescription": "Specify what approach the watcher should use if the system runs out of native file watchers.\n\nSee more: https://www.typescriptlang.org/tsconfig#fallbackPolling"
             },
             "synchronousWatchDirectory": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.",
               "type": ["boolean", "null"],
               "markdownDescription": "Synchronously call callbacks and update the state of directory watchers on platforms that don`t support recursive watching natively.\n\nSee more: https://www.typescriptlang.org/tsconfig#synchronousWatchDirectory"
             },
             "excludeFiles": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Remove a list of files from the watch mode's processing.",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -208,7 +194,6 @@
               "markdownDescription": "Remove a list of files from the watch mode's processing.\n\nSee more: https://www.typescriptlang.org/tsconfig#excludeFiles"
             },
             "excludeDirectories": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Remove a list of directories from the watch process.",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -224,37 +209,31 @@
     "compilerOptionsDefinition": {
       "properties": {
         "compilerOptions": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Instructs the TypeScript compiler how to compile .ts files.",
           "properties": {
             "allowArbitraryExtensions": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable importing files with any extension, provided a declaration file is present.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable importing files with any extension, provided a declaration file is present.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowArbitraryExtensions"
             },
             "allowImportingTsExtensions": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
-              "description": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.",
+              "description": "Allow imports to include TypeScript file extensions. Requires either '--noEmit' or '--emitDeclarationOnly' to be set.",
               "type": ["boolean", "null"],
-              "markdownDescription": "Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
+              "markdownDescription": "Allow imports to include TypeScript file extensions. Requires either '--noEmit' or '--emitDeclarationOnly' to be set.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowImportingTsExtensions"
             },
             "charset": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "No longer supported. In early versions, manually set the text encoding for reading files.",
               "type": ["string", "null"],
               "markdownDescription": "No longer supported. In early versions, manually set the text encoding for reading files.\n\nSee more: https://www.typescriptlang.org/tsconfig#charset"
             },
             "composite": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable constraints that allow a TypeScript project to be used with project references.",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable constraints that allow a TypeScript project to be used with project references.\n\nSee more: https://www.typescriptlang.org/tsconfig#composite"
             },
             "customConditions": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Conditions to set in addition to the resolver-specific defaults when resolving imports.",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -264,52 +243,50 @@
               "markdownDescription": "Conditions to set in addition to the resolver-specific defaults when resolving imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#customConditions"
             },
             "declaration": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Generate .d.ts files from TypeScript and JavaScript files in your project.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Generate .d.ts files from TypeScript and JavaScript files in your project.\n\nSee more: https://www.typescriptlang.org/tsconfig#declaration"
             },
             "declarationDir": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the output directory for generated declaration files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the output directory for generated declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationDir"
             },
             "diagnostics": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Output compiler performance information after building.",
               "type": ["boolean", "null"],
               "markdownDescription": "Output compiler performance information after building.\n\nSee more: https://www.typescriptlang.org/tsconfig#diagnostics"
             },
             "disableReferencedProjectLoad": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Reduce the number of projects loaded automatically by TypeScript.",
               "type": ["boolean", "null"],
               "markdownDescription": "Reduce the number of projects loaded automatically by TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableReferencedProjectLoad"
             },
             "noPropertyAccessFromIndexSignature": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enforces using indexed accessors for keys declared using an indexed type",
               "type": ["boolean", "null"],
               "markdownDescription": "Enforces using indexed accessors for keys declared using an indexed type\n\nSee more: https://www.typescriptlang.org/tsconfig#noPropertyAccessFromIndexSignature"
             },
             "emitBOM": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitBOM"
             },
             "emitDeclarationOnly": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Only output d.ts files and not JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Only output d.ts files and not JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDeclarationOnly"
             },
+            "erasableSyntaxOnly": {
+              "description": "Do not allow runtime constructs that are not part of ECMAScript.",
+              "type": ["boolean", "null"],
+              "default": false,
+              "markdownDescription": "Do not allow runtime constructs that are not part of ECMAScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#erasableSyntaxOnly"
+            },
             "exactOptionalPropertyTypes": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Differentiate between undefined and not present when type checking",
               "type": ["boolean", "null"],
               "default": false,
@@ -320,21 +297,18 @@
               "type": ["boolean", "null"]
             },
             "tsBuildInfoFile": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the folder for .tsbuildinfo incremental compilation files.",
               "default": ".tsbuildinfo",
               "type": ["string", "null"],
               "markdownDescription": "Specify the folder for .tsbuildinfo incremental compilation files.\n\nSee more: https://www.typescriptlang.org/tsconfig#tsBuildInfoFile"
             },
             "inlineSourceMap": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Include sourcemap files inside the emitted JavaScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Include sourcemap files inside the emitted JavaScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#inlineSourceMap"
             },
             "inlineSources": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Include source code in the sourcemaps inside the emitted JavaScript.",
               "type": ["boolean", "null"],
               "default": false,
@@ -351,76 +325,70 @@
               ]
             },
             "reactNamespace": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.",
               "type": ["string", "null"],
               "default": "React",
               "markdownDescription": "Specify the object invoked for `createElement`. This only applies when targeting `react` JSX emit.\n\nSee more: https://www.typescriptlang.org/tsconfig#reactNamespace"
             },
             "jsxFactory": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'",
               "type": ["string", "null"],
               "default": "React.createElement",
               "markdownDescription": "Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFactory"
             },
             "jsxFragmentFactory": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.",
               "type": ["string", "null"],
               "default": "React.Fragment",
               "markdownDescription": "Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxFragmentFactory"
             },
             "jsxImportSource": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.",
               "type": ["string", "null"],
               "default": "react",
               "markdownDescription": "Specify module specifier used to import the JSX factory functions when using `jsx: react-jsx`.\n\nSee more: https://www.typescriptlang.org/tsconfig#jsxImportSource"
             },
             "listFiles": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Print all of the files read during the compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print all of the files read during the compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listFiles"
             },
             "mapRoot": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the location where debugger should locate map files instead of generated locations.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the location where debugger should locate map files instead of generated locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#mapRoot"
             },
             "module": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify what module code is generated.",
               "type": ["string", "null"],
               "anyOf": [
                 {
                   "enum": [
-                    "CommonJS",
-                    "AMD",
-                    "System",
-                    "UMD",
-                    "ES6",
-                    "ES2015",
-                    "ES2020",
-                    "ESNext",
-                    "None",
-                    "ES2022",
-                    "Node16",
-                    "NodeNext",
-                    "Preserve"
+                    "commonjs",
+                    "amd",
+                    "system",
+                    "umd",
+                    "es6",
+                    "es2015",
+                    "es2020",
+                    "esnext",
+                    "none",
+                    "es2022",
+                    "node16",
+                    "node18",
+                    "node20",
+                    "nodenext",
+                    "preserve"
                   ]
                 },
                 {
-                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]16|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee]|[Pp][Rr][Ee][Ss][Ee][Rr][Vv][Ee])$"
+                  "pattern": "^([Cc][Oo][Mm][Mm][Oo][Nn][Jj][Ss]|[AaUu][Mm][Dd]|[Ss][Yy][Ss][Tt][Ee][Mm]|[Ee][Ss]([356]|20(1[567]|2[02])|[Nn][Ee][Xx][Tt])|[Nn][Oo][dD][Ee]1[68]|[Nn][Oo][Dd][Ee][Nn][Ee][Xx][Tt]|[Nn][Oo][Nn][Ee]|[Pp][Rr][Ee][Ss][Ee][Rr][Vv][Ee])$"
                 }
               ],
               "markdownDescription": "Specify what module code is generated.\n\nSee more: https://www.typescriptlang.org/tsconfig#module"
             },
             "moduleResolution": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify how TypeScript looks up a file from a given module specifier.",
               "type": ["string", "null"],
               "anyOf": [
@@ -449,7 +417,6 @@
               "markdownDescription": "Specify how TypeScript looks up a file from a given module specifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#moduleResolution"
             },
             "newLine": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Set the newline character for emitting files.",
               "type": ["string", "null"],
               "default": "lf",
@@ -464,208 +431,191 @@
               "markdownDescription": "Set the newline character for emitting files.\n\nSee more: https://www.typescriptlang.org/tsconfig#newLine"
             },
             "noEmit": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable emitting file from a compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting file from a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmit"
             },
             "noEmitHelpers": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable generating custom helper functions like `__extends` in compiled output.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable generating custom helper functions like `__extends` in compiled output.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitHelpers"
             },
             "noEmitOnError": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable emitting files if any type checking errors are reported.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting files if any type checking errors are reported.\n\nSee more: https://www.typescriptlang.org/tsconfig#noEmitOnError"
             },
             "noImplicitAny": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable error reporting for expressions and declarations with an implied `any` type..",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting for expressions and declarations with an implied `any` type..\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitAny"
             },
             "noImplicitThis": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable error reporting when `this` is given the type `any`.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable error reporting when `this` is given the type `any`.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitThis"
             },
             "noUnusedLocals": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable error reporting when a local variable isn't read.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting when a local variable isn't read.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedLocals"
             },
             "noUnusedParameters": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Raise an error when a function parameter isn't read",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Raise an error when a function parameter isn't read\n\nSee more: https://www.typescriptlang.org/tsconfig#noUnusedParameters"
             },
             "noLib": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable including any library files, including the default lib.d.ts.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable including any library files, including the default lib.d.ts.\n\nSee more: https://www.typescriptlang.org/tsconfig#noLib"
             },
             "noResolve": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disallow `import`s, `require`s or `<reference>`s from expanding the number of files TypeScript should add to a project.\n\nSee more: https://www.typescriptlang.org/tsconfig#noResolve"
             },
             "noStrictGenericChecks": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable strict checking of generic signatures in function types.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable strict checking of generic signatures in function types.\n\nSee more: https://www.typescriptlang.org/tsconfig#noStrictGenericChecks"
             },
+            "out": {
+              "description": "DEPRECATED. Specify an output for the build. It is recommended to use `outFile` instead.",
+              "type": ["string", "null"],
+              "markdownDescription": "Specify an output for the build. It is recommended to use `outFile` instead.\n\nSee more: https://www.typescriptlang.org/tsconfig/#out"
+            },
             "skipDefaultLibCheck": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Skip type checking .d.ts files that are included with TypeScript.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking .d.ts files that are included with TypeScript.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipDefaultLibCheck"
             },
             "skipLibCheck": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Skip type checking all .d.ts files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Skip type checking all .d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#skipLibCheck"
             },
             "outFile": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.",
               "type": ["string", "null"],
               "markdownDescription": "Specify a file that bundles all outputs into one JavaScript file. If `declaration` is true, also designates a file that bundles all .d.ts output.\n\nSee more: https://www.typescriptlang.org/tsconfig#outFile"
             },
             "outDir": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify an output folder for all emitted files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify an output folder for all emitted files.\n\nSee more: https://www.typescriptlang.org/tsconfig#outDir"
             },
             "preserveConstEnums": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable erasing `const enum` declarations in generated code.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable erasing `const enum` declarations in generated code.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveConstEnums"
             },
             "preserveSymlinks": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable resolving symlinks to their realpath. This correlates to the same flag in node.\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveSymlinks"
             },
             "preserveValueImports": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Preserve unused imported values in the JavaScript output that would otherwise be removed",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Preserve unused imported values in the JavaScript output that would otherwise be removed\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveValueImports"
             },
             "preserveWatchOutput": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable wiping the console in watch mode",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable wiping the console in watch mode\n\nSee more: https://www.typescriptlang.org/tsconfig#preserveWatchOutput"
             },
             "pretty": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable color and formatting in output to make compiler errors easier to read",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Enable color and formatting in output to make compiler errors easier to read\n\nSee more: https://www.typescriptlang.org/tsconfig#pretty"
             },
             "removeComments": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable emitting comments.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable emitting comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#removeComments"
             },
+            "rewriteRelativeImportExtensions": {
+              "description": "Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files.",
+              "type": ["boolean", "null"],
+              "default": false,
+              "markdownDescription": "Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rewriteRelativeImportExtensions"
+            },
             "rootDir": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the root folder within your source files.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root folder within your source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDir"
             },
             "isolatedModules": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Ensure that each file can be safely transpiled without relying on other imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure that each file can be safely transpiled without relying on other imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedModules"
             },
             "sourceMap": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Create source map files for emitted JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create source map files for emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceMap"
             },
             "sourceRoot": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the root path for debuggers to find the reference source code.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the root path for debuggers to find the reference source code.\n\nSee more: https://www.typescriptlang.org/tsconfig#sourceRoot"
             },
             "suppressExcessPropertyErrors": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable reporting of excess property errors during the creation of object literals.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable reporting of excess property errors during the creation of object literals.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressExcessPropertyErrors"
             },
             "suppressImplicitAnyIndexErrors": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Suppress `noImplicitAny` errors when indexing objects that lack index signatures.\n\nSee more: https://www.typescriptlang.org/tsconfig#suppressImplicitAnyIndexErrors"
             },
             "stripInternal": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable emitting declarations that have `@internal` in their JSDoc comments.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable emitting declarations that have `@internal` in their JSDoc comments.\n\nSee more: https://www.typescriptlang.org/tsconfig#stripInternal"
             },
             "target": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.",
               "type": ["string", "null"],
-              "default": "ES3",
+              "default": "es3",
               "anyOf": [
                 {
                   "enum": [
-                    "ES3",
-                    "ES5",
-                    "ES6",
-                    "ES2015",
-                    "ES2016",
-                    "ES2017",
-                    "ES2018",
-                    "ES2019",
-                    "ES2020",
-                    "ES2021",
-                    "ES2022",
-                    "ES2023",
-                    "ES2024",
-                    "ESNext"
+                    "es3",
+                    "es5",
+                    "es6",
+                    "es2015",
+                    "es2016",
+                    "es2017",
+                    "es2018",
+                    "es2019",
+                    "es2020",
+                    "es2021",
+                    "es2022",
+                    "es2023",
+                    "es2024",
+                    "esnext"
                   ]
                 },
                 {
@@ -675,7 +625,6 @@
               "markdownDescription": "Set the JavaScript language version for emitted JavaScript and include compatible library declarations.\n\nSee more: https://www.typescriptlang.org/tsconfig#target"
             },
             "useUnknownInCatchVariables": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Default catch clause variables as `unknown` instead of `any`.",
               "type": ["boolean", "null"],
               "default": false,
@@ -720,86 +669,72 @@
               "default": "useFsEvents"
             },
             "experimentalDecorators": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable experimental support for TC39 stage 2 draft decorators.",
               "type": ["boolean", "null"],
               "markdownDescription": "Enable experimental support for TC39 stage 2 draft decorators.\n\nSee more: https://www.typescriptlang.org/tsconfig#experimentalDecorators"
             },
             "emitDecoratorMetadata": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Emit design-type metadata for decorated declarations in source files.",
               "type": ["boolean", "null"],
               "markdownDescription": "Emit design-type metadata for decorated declarations in source files.\n\nSee more: https://www.typescriptlang.org/tsconfig#emitDecoratorMetadata"
             },
             "allowUnusedLabels": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable error reporting for unused labels.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unused labels.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnusedLabels"
             },
             "noImplicitReturns": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable error reporting for codepaths that do not explicitly return in a function.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for codepaths that do not explicitly return in a function.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitReturns"
             },
             "noUncheckedIndexedAccess": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Add `undefined` to a type when accessed using an index.",
               "type": ["boolean", "null"],
               "markdownDescription": "Add `undefined` to a type when accessed using an index.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedIndexedAccess"
             },
             "noFallthroughCasesInSwitch": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable error reporting for fallthrough cases in switch statements.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting for fallthrough cases in switch statements.\n\nSee more: https://www.typescriptlang.org/tsconfig#noFallthroughCasesInSwitch"
             },
             "noImplicitOverride": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Ensure overriding members in derived classes are marked with an override modifier.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Ensure overriding members in derived classes are marked with an override modifier.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitOverride"
             },
             "allowUnreachableCode": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable error reporting for unreachable code.",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable error reporting for unreachable code.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUnreachableCode"
             },
             "forceConsistentCasingInFileNames": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Ensure that casing is correct in imports.",
               "type": ["boolean", "null"],
               "default": true,
               "markdownDescription": "Ensure that casing is correct in imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#forceConsistentCasingInFileNames"
             },
             "generateCpuProfile": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Emit a v8 CPU profile of the compiler run for debugging.",
               "type": ["string", "null"],
               "default": "profile.cpuprofile",
               "markdownDescription": "Emit a v8 CPU profile of the compiler run for debugging.\n\nSee more: https://www.typescriptlang.org/tsconfig#generateCpuProfile"
             },
             "baseUrl": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the base directory to resolve non-relative module names.",
               "type": ["string", "null"],
               "markdownDescription": "Specify the base directory to resolve non-relative module names.\n\nSee more: https://www.typescriptlang.org/tsconfig#baseUrl"
             },
             "paths": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify a set of entries that re-map imports to additional lookup locations.",
               "type": ["object", "null"],
               "additionalProperties": {
-                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["array", "null"],
                 "uniqueItems": true,
                 "items": {
-                  "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                   "type": ["string", "null"],
                   "description": "Path mapping to be computed relative to baseUrl option."
                 }
@@ -807,11 +742,9 @@
               "markdownDescription": "Specify a set of entries that re-map imports to additional lookup locations.\n\nSee more: https://www.typescriptlang.org/tsconfig#paths"
             },
             "plugins": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify a list of language service plugins to include.",
               "type": ["array", "null"],
               "items": {
-                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["object", "null"],
                 "properties": {
                   "name": {
@@ -823,7 +756,6 @@
               "markdownDescription": "Specify a list of language service plugins to include.\n\nSee more: https://www.typescriptlang.org/tsconfig#plugins"
             },
             "rootDirs": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Allow multiple folders to be treated as one when resolving modules.",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -833,7 +765,6 @@
               "markdownDescription": "Allow multiple folders to be treated as one when resolving modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#rootDirs"
             },
             "typeRoots": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify multiple folders that act like `./node_modules/@types`.",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -843,7 +774,6 @@
               "markdownDescription": "Specify multiple folders that act like `./node_modules/@types`.\n\nSee more: https://www.typescriptlang.org/tsconfig#typeRoots"
             },
             "types": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify type package names to be included without being referenced in a source file.",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -853,59 +783,50 @@
               "markdownDescription": "Specify type package names to be included without being referenced in a source file.\n\nSee more: https://www.typescriptlang.org/tsconfig#types"
             },
             "traceResolution": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable tracing of the name resolution process. Requires TypeScript version 2.0 or later.",
               "type": ["boolean", "null"],
               "default": false
             },
             "allowJs": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow JavaScript files to be a part of your program. Use the `checkJS` option to get errors from these files.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowJs"
             },
             "noErrorTruncation": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable truncating types in error messages.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable truncating types in error messages.\n\nSee more: https://www.typescriptlang.org/tsconfig#noErrorTruncation"
             },
             "allowSyntheticDefaultImports": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Allow 'import x from y' when a module doesn't have a default export.",
               "type": ["boolean", "null"],
               "markdownDescription": "Allow 'import x from y' when a module doesn't have a default export.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowSyntheticDefaultImports"
             },
             "noImplicitUseStrict": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable adding 'use strict' directives in emitted JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable adding 'use strict' directives in emitted JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#noImplicitUseStrict"
             },
             "listEmittedFiles": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Print the names of emitted files after a compilation.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Print the names of emitted files after a compilation.\n\nSee more: https://www.typescriptlang.org/tsconfig#listEmittedFiles"
             },
             "disableSizeLimit": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Remove the 20mb cap on total source code size for JavaScript files in the TypeScript language server.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSizeLimit"
             },
             "lib": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify a set of bundled library declaration files that describe the target runtime environment.",
               "type": ["array", "null"],
               "uniqueItems": true,
               "items": {
-                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["string", "null"],
                 "anyOf": [
                   {
@@ -954,6 +875,7 @@
                       "ESNext.BigInt",
                       "ESNext.Collection",
                       "ESNext.Intl",
+                      "ESNext.Iterator",
                       "ESNext.Object",
                       "ESNext.Promise",
                       "ESNext.Regexp",
@@ -1001,7 +923,9 @@
                       "ES2017.Date",
                       "ES2023.Collection",
                       "ESNext.Decorators",
-                      "ESNext.Disposable"
+                      "ESNext.Disposable",
+                      "ESNext.Error",
+                      "ESNext.Sharedmemory"
                     ]
                   },
                   {
@@ -1056,26 +980,29 @@
               },
               "markdownDescription": "Specify a set of bundled library declaration files that describe the target runtime environment.\n\nSee more: https://www.typescriptlang.org/tsconfig#lib"
             },
+            "libReplacement": {
+              "description": "Enable lib replacement.",
+              "type": ["boolean", "null"],
+              "default": true,
+              "markdownDescription": "Enable lib replacement.\n\nSee more: https://www.typescriptlang.org/tsconfig#libReplacement"
+            },
             "moduleDetection": {
               "description": "Specify how TypeScript determine a file as module.",
               "enum": ["auto", "legacy", "force"]
             },
             "strictNullChecks": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "When type checking, take into account `null` and `undefined`.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When type checking, take into account `null` and `undefined`.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictNullChecks"
             },
             "maxNodeModuleJsDepth": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.",
               "type": ["number", "null"],
               "default": 0,
               "markdownDescription": "Specify the maximum folder depth used for checking JavaScript files from `node_modules`. Only applicable with `allowJs`.\n\nSee more: https://www.typescriptlang.org/tsconfig#maxNodeModuleJsDepth"
             },
             "importHelpers": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Allow importing helper functions from tslib once per project, instead of including them per-file.",
               "type": ["boolean", "null"],
               "default": false,
@@ -1087,104 +1014,89 @@
               "enum": ["remove", "preserve", "error"]
             },
             "alwaysStrict": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Ensure 'use strict' is always emitted.",
               "type": ["boolean", "null"],
               "markdownDescription": "Ensure 'use strict' is always emitted.\n\nSee more: https://www.typescriptlang.org/tsconfig#alwaysStrict"
             },
             "strict": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable all strict type checking options.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable all strict type checking options.\n\nSee more: https://www.typescriptlang.org/tsconfig#strict"
             },
             "strictBindCallApply": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check that the arguments for `bind`, `call`, and `apply` methods match the original function.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictBindCallApply"
             },
             "downlevelIteration": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Emit more compliant, but verbose and less performant JavaScript for iteration.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit more compliant, but verbose and less performant JavaScript for iteration.\n\nSee more: https://www.typescriptlang.org/tsconfig#downlevelIteration"
             },
             "checkJs": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable error reporting in type-checked JavaScript files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable error reporting in type-checked JavaScript files.\n\nSee more: https://www.typescriptlang.org/tsconfig#checkJs"
             },
             "strictFunctionTypes": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "When assigning functions, check to ensure parameters and the return values are subtype-compatible.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictFunctionTypes"
             },
             "strictPropertyInitialization": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Check for class properties that are declared but not set in the constructor.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check for class properties that are declared but not set in the constructor.\n\nSee more: https://www.typescriptlang.org/tsconfig#strictPropertyInitialization"
             },
             "esModuleInterop": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit additional JavaScript to ease support for importing CommonJS modules. This enables `allowSyntheticDefaultImports` for type compatibility.\n\nSee more: https://www.typescriptlang.org/tsconfig#esModuleInterop"
             },
             "allowUmdGlobalAccess": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Allow accessing UMD globals from modules.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Allow accessing UMD globals from modules.\n\nSee more: https://www.typescriptlang.org/tsconfig#allowUmdGlobalAccess"
             },
             "keyofStringsOnly": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Make keyof only return strings instead of string, numbers or symbols. Legacy option.\n\nSee more: https://www.typescriptlang.org/tsconfig#keyofStringsOnly"
             },
             "useDefineForClassFields": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Emit ECMAScript-standard-compliant class fields.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Emit ECMAScript-standard-compliant class fields.\n\nSee more: https://www.typescriptlang.org/tsconfig#useDefineForClassFields"
             },
             "declarationMap": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Create sourcemaps for d.ts files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Create sourcemaps for d.ts files.\n\nSee more: https://www.typescriptlang.org/tsconfig#declarationMap"
             },
             "resolveJsonModule": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable importing .json files",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Enable importing .json files\n\nSee more: https://www.typescriptlang.org/tsconfig#resolveJsonModule"
             },
             "resolvePackageJsonExports": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Use the package.json 'exports' field when resolving package imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Use the package.json 'exports' field when resolving package imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#resolvePackageJsonExports"
             },
             "resolvePackageJsonImports": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Use the package.json 'imports' field when resolving imports.",
               "type": ["boolean", "null"],
               "default": false,
@@ -1195,7 +1107,6 @@
               "type": ["boolean", "null"]
             },
             "extendedDiagnostics": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Output more detailed compiler performance information after building.",
               "type": ["boolean", "null"],
               "default": false,
@@ -1206,46 +1117,39 @@
               "type": ["boolean", "null"]
             },
             "disableSourceOfProjectReferenceRedirect": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable preferring source files instead of declaration files when referencing composite projects",
               "type": ["boolean", "null"],
               "markdownDescription": "Disable preferring source files instead of declaration files when referencing composite projects\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSourceOfProjectReferenceRedirect"
             },
             "disableSolutionSearching": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Opt a project out of multi-project reference checking when editing.",
               "type": ["boolean", "null"],
               "markdownDescription": "Opt a project out of multi-project reference checking when editing.\n\nSee more: https://www.typescriptlang.org/tsconfig#disableSolutionSearching"
             },
             "verbatimModuleSyntax": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.",
               "type": ["boolean", "null"],
               "markdownDescription": "Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting.\n\nSee more: https://www.typescriptlang.org/tsconfig#verbatimModuleSyntax"
             },
             "noCheck": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Disable full type checking (only critical parse and emit errors will be reported)",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Disable full type checking (only critical parse and emit errors will be reported)\n\nSee more: https://www.typescriptlang.org/tsconfig#noCheck"
             },
             "isolatedDeclarations": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Require sufficient annotation on exports so other tools can trivially generate declaration files.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Require sufficient annotation on exports so other tools can trivially generate declaration files.\n\nSee more: https://www.typescriptlang.org/tsconfig#isolatedDeclarations"
             },
             "noUncheckedSideEffectImports": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Check side effect imports.",
               "type": ["boolean", "null"],
               "default": false,
               "markdownDescription": "Check side effect imports.\n\nSee more: https://www.typescriptlang.org/tsconfig#noUncheckedSideEffectImports"
             },
             "strictBuiltinIteratorReturn": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'.",
               "type": ["boolean", "null"],
               "default": false,
@@ -1258,18 +1162,15 @@
     "typeAcquisitionDefinition": {
       "properties": {
         "typeAcquisition": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["object", "null"],
           "description": "Auto type (.d.ts) acquisition options for this project. Requires TypeScript version 2.1 or later.",
           "properties": {
             "enable": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Enable auto type acquisition",
               "type": ["boolean", "null"],
               "default": false
             },
             "include": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specifies a list of type declarations to be included in auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -1278,7 +1179,6 @@
               }
             },
             "exclude": {
-              "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
               "description": "Specifies a list of type declarations to be excluded from auto type acquisition. Ex. [\"jquery\", \"lodash\"]",
               "type": ["array", "null"],
               "uniqueItems": true,
@@ -1293,17 +1193,14 @@
     "referencesDefinition": {
       "properties": {
         "references": {
-          "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
           "type": ["array", "null"],
           "uniqueItems": true,
           "description": "Referenced projects. Requires TypeScript version 3.0 or later.",
           "items": {
-            "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
             "type": ["object", "null"],
             "description": "Project reference.",
             "properties": {
               "path": {
-                "$comment": "The value of 'null' is UNDOCUMENTED (https://github.com/microsoft/TypeScript/pull/18058).",
                 "type": ["string", "null"],
                 "description": "Path to referenced tsconfig or to folder containing tsconfig."
               }


### PR DESCRIPTION
Closes: https://github.com/zed-industries/zed/issues/34382

- Add support for `tsconfig.*.json` not just `tsconfig.json`. 
- Updated JSON schemas to [SchemaStore/schemastore@281aa4a](https://github.com/SchemaStore/schemastore/tree/281aa4aa4ac21385814423f86a54d1b8ccfc17a1) (2025-09-21)
  - [tsconfig.json](https://github.com/SchemaStore/schemastore/commits/master/src/schemas/json/tsconfig.json) @ [281aa4a](https://raw.githubusercontent.com/SchemaStore/schemastore/281aa4aa4ac21385814423f86a54d1b8ccfc17a1/src/schemas/json/tsconfig.json)
  - [package.json](https://github.com/SchemaStore/schemastore/commits/master/src/schemas/json/package.json) @ [281aa4a](https://raw.githubusercontent.com/SchemaStore/schemastore/281aa4aa4ac21385814423f86a54d1b8ccfc17a1/src/schemas/json/package.json)

See also: 
- [discord thread](https://discord.com/channels/869392257814519848/1419298937290096760)
- https://github.com/zed-industries/zed/issues/21994#issuecomment-3319321308

Release Notes:

- Updated package.json and tsconfig.json schemas to newest release (2025-09-21). Match `tsconfig.*.json` too.