### PR TITLE
Add show_summary & show_command to the initial_tasks.json

### DIFF
--- a/assets/settings/initial_tasks.json
+++ b/assets/settings/initial_tasks.json
@@ -43,7 +43,11 @@
     //           "args": ["--login"]
     //         }
     //     }
-    "shell": "system"
+    "shell": "system",
+    // Whether to show the task line in the output of the spawned task, defaults to `true`.
+    "show_summary": true,
+    // Whether to show the command line in the output of the spawned task, defaults to `true`.
+    "show_command": true
     // Represents the tags for inline runnable indicators, or spawning multiple tasks at once.
     // "tags": []
   }


### PR DESCRIPTION
Release Notes:

- Added "show_summary" & "show_command" settings to the initial tasks.json file.


This makes the initial task template match the docs here: https://zed.dev/docs/tasks