### PR TITLE
docs: Mention required matching configs when developing language server extensions

### DIFF
--- a/docs/src/extensions/languages.md
+++ b/docs/src/extensions/languages.md
@@ -366,7 +366,7 @@ TBD: `#set! tag`
 
 Zed uses the [Language Server Protocol](https://microsoft.github.io/language-server-protocol/) to provide advanced language support.
 
-An extension may provide any number of language servers. To provide a language server from your extension, add an entry to your `extension.toml` with the name of your language server and the language(s) it applies to:
+An extension may provide any number of language servers. To provide a language server from your extension, add an entry to your `extension.toml` with the name of your language server and the language(s) it applies to. The entry in the list of `languages` has to match the `name` field from the `config.toml` file for that language:
 
 ```toml
 [language_servers.my-language-server]


### PR DESCRIPTION
This took me quite a while to find out when I developed my first language extension. I had non-matching entries in the `languages` array and in the name field of `config.toml`, and it was especially tricky because the zed extension would start up, but not the language server. I sure which this had been in the docs, so I am contributing it now!

Release Notes:

- N/A