### PR TITLE
Allow `zed filename.rs:`

### DIFF
--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -379,6 +379,8 @@ const ROW_COL_CAPTURE_REGEX: &str = r"(?xs)
         \:+(\d+)\:(\d+)\:*$  # filename:row:column
         |
         \:+(\d+)\:*()$       # filename:row
+        |
+        \:+()()$
     )";
 
 /// A representation of a path-like string with optional row and column numbers.
@@ -455,8 +457,8 @@ impl PathWithPosition {
     ///     row: None,
     ///     column: None,
     /// });
-    /// assert_eq!(PathWithPosition::parse_str("test_file.rs::"), PathWithPosition {
-    ///     path: PathBuf::from("test_file.rs::"),
+    /// assert_eq!(PathWithPosition::parse_str("test_file.rs"), PathWithPosition {
+    ///     path: PathBuf::from("test_file.rs"),
     ///     row: None,
     ///     column: None,
     /// });
@@ -998,7 +1000,7 @@ mod tests {
         assert_eq!(
             PathWithPosition::parse_str("test_file.rs:"),
             PathWithPosition {
-                path: PathBuf::from("test_file.rs:"),
+                path: PathBuf::from("test_file.rs"),
                 row: None,
                 column: None
             }


### PR DESCRIPTION
iTerm's editor configuration dialog allows you to set your editor to
`zed \1:\2`, but not (as far as I know) to leave off the : when there's
no line number

This fixes clicking on bare filenames in iTerm for me.

Release Notes:

- Fixed line number parsing so that `zed filename.rs:` will now act as though you did `zed filename.rs`
