### PR TITLE
search: Remove noisy buffer search logs

### DIFF
--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -794,10 +794,13 @@ impl BufferSearchBar {
 
         if let Some(search) = search {
             cx.spawn_in(window, async move |this, cx| {
-                search.await?;
-                this.update_in(cx, |this, window, cx| {
-                    this.activate_current_match(window, cx)
-                })
+                if search.await.is_ok() {
+                    this.update_in(cx, |this, window, cx| {
+                        this.activate_current_match(window, cx)
+                    })
+                } else {
+                    Ok(())
+                }
             })
             .detach_and_log_err(cx);
         }
@@ -1057,10 +1060,13 @@ impl BufferSearchBar {
                 cx.notify();
 
                 cx.spawn_in(window, async move |this, cx| {
-                    search.await?;
-                    this.update_in(cx, |this, window, cx| {
-                        this.activate_current_match(window, cx)
-                    })
+                    if search.await.is_ok() {
+                        this.update_in(cx, |this, window, cx| {
+                            this.activate_current_match(window, cx)
+                        })
+                    } else {
+                        Ok(())
+                    }
                 })
                 .detach_and_log_err(cx);
             }


### PR DESCRIPTION
Buffer search initiates a new search every time a key is pressed in the buffer search bar. This would cancel the task associated with any pending searches. Whenever one of these searches was canceled Zed would log `[search]: oneshot canceled`. This log would trigger almost on every keypress when typing moderately fast. This PR silences these logs by not treating canceled searches as errors.

Release Notes:

- N/A
