### PR TITLE
git: Fix git amend on panel

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1433,7 +1433,6 @@ impl GitPanel {
                         window,
                         cx,
                     );
-                    self.set_amend_pending(false, cx);
                 }
             }
         } else {
@@ -1599,6 +1598,9 @@ impl GitPanel {
         });
 
         self.pending_commit = Some(task);
+        if options.amend {
+            self.set_amend_pending(false, cx);
+        }
     }
 
     pub(crate) fn uncommit(&mut self, window: &mut Window, cx: &mut Context<Self>) {
@@ -3450,7 +3452,6 @@ impl GitPanel {
                                     window,
                                     cx,
                                 );
-                                git_panel.set_amend_pending(false, cx);
                             })
                             .ok();
                     }

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -1425,7 +1425,6 @@ impl GitPanel {
                     self.load_last_commit_message_if_empty(cx);
                 } else {
                     telemetry::event!("Git Amended", source = "Git Panel");
-                    self.set_amend_pending(false, cx);
                     self.commit_changes(
                         CommitOptions {
                             amend: true,
@@ -1434,6 +1433,7 @@ impl GitPanel {
                         window,
                         cx,
                     );
+                    self.set_amend_pending(false, cx);
                 }
             }
         } else {
@@ -3445,12 +3445,12 @@ impl GitPanel {
                         telemetry::event!("Git Committed", source = "Git Panel");
                         git_panel
                             .update(cx, |git_panel, cx| {
-                                git_panel.set_amend_pending(false, cx);
                                 git_panel.commit_changes(
                                     CommitOptions { amend, signoff },
                                     window,
                                     cx,
                                 );
+                                git_panel.set_amend_pending(false, cx);
                             })
                             .ok();
                     }


### PR DESCRIPTION
Closes #38651 

`git_panel.set_amend_pending(false, cx);` was being called before `git_panel.commit_changes(...)` which was causing the commit buffer to be cleared/reset before actually sending the commit request to git. 

Introduced by #35268 which added clear buffer functionality to the `set_amend_pending` function. 

Release Notes:

- Fix git amend on panel sending "Update ..." instead of the original commit message
- FIx git amend button not working
