### PR TITLE
sum_tree: Reduce stack size of `Cursor`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15335,6 +15335,7 @@ dependencies = [
  "log",
  "rand 0.9.1",
  "rayon",
+ "smallvec",
  "workspace-hack",
  "zlog",
 ]

--- a/crates/sum_tree/Cargo.toml
+++ b/crates/sum_tree/Cargo.toml
@@ -14,6 +14,7 @@ doctest = false
 
 [dependencies]
 arrayvec = "0.7.1"
+smallvec.workspace = true
 rayon.workspace = true
 log.workspace = true
 workspace-hack.workspace = true


### PR DESCRIPTION
`Cursor` can be massive and frequently constructed which causes the compiler to emit a lot of memmove's on hot paths. This shrinks it (depending on generics) in various cases from ~500 bytes to ~150 while potentially allocating.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
