### PR TITLE
windows: Automatically find Windows SDK when building gpui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7355,7 +7355,6 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-numerics",
  "windows-registry 0.5.3",
- "winreg 0.55.0",
  "x11-clipboard",
  "x11rb",
  "xkbcommon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7355,6 +7355,7 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-numerics",
  "windows-registry 0.5.3",
+ "winreg 0.55.0",
  "x11-clipboard",
  "x11rb",
  "xkbcommon",

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -253,7 +253,7 @@ util = { workspace = true, features = ["test-support"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 embed-resource = "3.0"
-winreg = "0.55"
+windows-registry = "0.5"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 bindgen = "0.71"

--- a/crates/gpui/Cargo.toml
+++ b/crates/gpui/Cargo.toml
@@ -253,6 +253,7 @@ util = { workspace = true, features = ["test-support"] }
 
 [target.'cfg(target_os = "windows")'.build-dependencies]
 embed-resource = "3.0"
+winreg = "0.55"
 
 [target.'cfg(target_os = "macos")'.build-dependencies]
 bindgen = "0.71"

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -257,7 +257,7 @@ mod windows {
 
     pub(super) fn build() {
         // Compile HLSL shaders
-        // #[cfg(not(debug_assertions))]
+        #[cfg(not(debug_assertions))]
         compile_shaders();
 
         // Embed the Windows manifest and resource file

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -358,14 +358,12 @@ mod windows {
         };
 
         if let Some(highest_version) = versions.last() {
-            let res = Ok(Some(
+            return Ok(Some(
                 install_folder_bin
                     .join(highest_version)
                     .join(arch)
                     .join(binary),
             ));
-            dbg!("{:?}", &res);
-            return res;
         }
 
         Ok(None)


### PR DESCRIPTION
### Summary

This PR changes `gpui/build.rs` to look up the Windows SDK directory in the registry instead of falling back to a hard-coded path.

---

### Problem

Currently, building `gpui` on Windows requires `fxc.exe` to be in `PATH` or at a predefined location (unless `GPUI_FXC_PATH` is set). This requires to maintain a certain build environment with proper paths/vars or to install the specific SDK version.

It is possible to find the SDK automatically using the registry keys it creates upon installation. Specifically in
`SOFTWARE\\WOW6432Node\\Microsoft\\Microsoft SDKs\\Windows\\v10.0` branch there are:
* `InstallationFolder` telling the SDK installation location;
* `ProductVersion` telling the SDK version in use.

These keys provide enough information to locate the SDK binaries, with added robustness:
* handles non-standard SDK installation path;
* deterministically selects the latest SDK when multiple versions are present.

---

### Changes Made

* **Updated `crates/gpui/build.rs`**:

  * added dependency on `winreg`
  * introduced `find_latest_windows_sdk_binary()` helper
  * updated fallback logic to use registry lookup

This PR only changes the fallback location, and does not touch the established environment-based workflow.

Release Notes:

- N/A

---

### Impact

Reduces manual configuration needed to build GPUI on Windows.
