### PR TITLE
Add a helix-specific substitute method

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -497,7 +497,8 @@
       "shift-u": "editor::Redo",
       "ctrl-c": "editor::ToggleComments",
       "d": "vim::HelixDelete",
-      "c": "vim::Substitute",
+      "c": "vim::HelixSubstitute",
+      "alt-c": "vim::HelixSubstituteNoYank",
       "shift-c": "vim::HelixDuplicateBelow",
       "alt-shift-c": "vim::HelixDuplicateAbove",
       ",": "vim::HelixKeepNewestSelection"


### PR DESCRIPTION
`vim::Substitute` is a little different from the helix behavior, so this PR adds helix versions. The most important difference (for my usage, at least) is that if you're selecting whole lines then helix drops the `\n` from the selection (much like vim's lines mode, except that helix bases this behavior on the selection instead of having a different mode).

Release Notes:

- Added vim::HelixSubstitute and vim::HelixSubstituteNoYank with better imitations of helix's behavior
