### PR TITLE
Implement regex_select action for Helix

### DIFF
--- a/assets/keymaps/vim.json
+++ b/assets/keymaps/vim.json
@@ -426,6 +426,7 @@
       ";": "vim::HelixCollapseSelection",
       ":": "command_palette::Toggle",
       "m": "vim::PushHelixMatch",
+      "s": "vim::HelixSelectRegex",
       "]": ["vim::PushHelixNext", { "around": true }],
       "[": ["vim::PushHelixPrevious", { "around": true }],
       "left": "vim::WrappingLeft",

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -1525,17 +1525,12 @@ impl SearchableItem for Editor {
         if let Some(range) = enabled {
             let ranges = self.selections.disjoint_anchor_ranges().collect::<Vec<_>>();
 
-            match range {
-                FilteredSearchRange::Selection => {
-                    if ranges.iter().any(|s| s.start != s.end) {
-                        self.set_search_within_ranges(&ranges, cx);
-                    }
-                }
-                FilteredSearchRange::Default => {
-                    if let Some(previous_search_ranges) = self.previous_search_ranges.take() {
-                        self.set_search_within_ranges(&previous_search_ranges, cx);
-                    }
-                }
+            if ranges.iter().any(|s| s.start != s.end) {
+                self.set_search_within_ranges(&ranges, cx);
+            } else if let Some(previous_search_ranges) = self.previous_search_ranges.take()
+                && range != FilteredSearchRange::Selection
+            {
+                self.set_search_within_ranges(&previous_search_ranges, cx);
             }
         }
     }

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -44,7 +44,9 @@ use workspace::{
     CollaboratorId, ItemId, ItemNavHistory, ToolbarItemLocation, ViewId, Workspace, WorkspaceId,
     invalid_buffer_view::InvalidBufferView,
     item::{FollowableItem, Item, ItemEvent, ProjectItem, SaveOptions},
-    searchable::{Direction, SearchEvent, SearchableItem, SearchableItemHandle},
+    searchable::{
+        Direction, FilteredSearchRange, SearchEvent, SearchableItem, SearchableItemHandle,
+    },
 };
 use workspace::{
     OpenOptions,
@@ -1510,7 +1512,7 @@ impl SearchableItem for Editor {
 
     fn toggle_filtered_search_ranges(
         &mut self,
-        enabled: bool,
+        enabled: Option<FilteredSearchRange>,
         _: &mut Window,
         cx: &mut Context<Self>,
     ) {
@@ -1520,15 +1522,21 @@ impl SearchableItem for Editor {
                 .map(|(_, ranges)| ranges)
         }
 
-        if !enabled {
-            return;
-        }
+        if let Some(range) = enabled {
+            let ranges = self.selections.disjoint_anchor_ranges().collect::<Vec<_>>();
 
-        let ranges = self.selections.disjoint_anchor_ranges().collect::<Vec<_>>();
-        if ranges.iter().any(|s| s.start != s.end) {
-            self.set_search_within_ranges(&ranges, cx);
-        } else if let Some(previous_search_ranges) = self.previous_search_ranges.take() {
-            self.set_search_within_ranges(&previous_search_ranges, cx)
+            match range {
+                FilteredSearchRange::Selection => {
+                    if ranges.iter().any(|s| s.start != s.end) {
+                        self.set_search_within_ranges(&ranges, cx);
+                    }
+                }
+                FilteredSearchRange::Default => {
+                    if let Some(previous_search_ranges) = self.previous_search_ranges.take() {
+                        self.set_search_within_ranges(&previous_search_ranges, cx);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -720,6 +720,7 @@ impl BufferSearchBar {
         };
         if self.show(window, cx) {
             if let Some(active_item) = self.active_searchable_item.as_mut() {
+                dbg!("Here {}", filtered_search_range);
                 active_item.toggle_filtered_search_ranges(filtered_search_range, window, cx);
             }
             self.search_suggested(window, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -720,7 +720,6 @@ impl BufferSearchBar {
         };
         if self.show(window, cx) {
             if let Some(active_item) = self.active_searchable_item.as_mut() {
-                dbg!("Here {}", filtered_search_range);
                 active_item.toggle_filtered_search_ranges(filtered_search_range, window, cx);
             }
             self.search_suggested(window, cx);

--- a/crates/search/src/buffer_search.rs
+++ b/crates/search/src/buffer_search.rs
@@ -38,7 +38,9 @@ use util::ResultExt;
 use workspace::{
     ToolbarItemEvent, ToolbarItemLocation, ToolbarItemView, Workspace,
     item::ItemHandle,
-    searchable::{Direction, SearchEvent, SearchableItemHandle, WeakSearchableItemHandle},
+    searchable::{
+        Direction, FilteredSearchRange, SearchEvent, SearchableItemHandle, WeakSearchableItemHandle,
+    },
 };
 
 pub use registrar::DivRegistrar;
@@ -117,7 +119,7 @@ pub struct BufferSearchBar {
     search_history: SearchHistory,
     search_history_cursor: SearchHistoryCursor,
     replace_enabled: bool,
-    selection_search_enabled: bool,
+    selection_search_enabled: Option<FilteredSearchRange>,
     scroll_handle: ScrollHandle,
     editor_scroll_handle: ScrollHandle,
     editor_needed_width: Pixels,
@@ -255,13 +257,13 @@ impl Render for BufferSearchBar {
                     )
                     .style(ButtonStyle::Subtle)
                     .shape(IconButtonShape::Square)
-                    .when(self.selection_search_enabled, |button| {
+                    .when(self.selection_search_enabled.is_some(), |button| {
                         button.style(ButtonStyle::Filled)
                     })
                     .on_click(cx.listener(|this, _: &ClickEvent, window, cx| {
                         this.toggle_selection(&ToggleSelection, window, cx);
                     }))
-                    .toggle_state(self.selection_search_enabled)
+                    .toggle_state(self.selection_search_enabled.is_some())
                     .tooltip({
                         let focus_handle = focus_handle.clone();
                         move |window, cx| {
@@ -673,7 +675,7 @@ impl BufferSearchBar {
             search_history_cursor: Default::default(),
             active_search: None,
             replace_enabled: false,
-            selection_search_enabled: false,
+            selection_search_enabled: None,
             scroll_handle: ScrollHandle::new(),
             editor_scroll_handle: ScrollHandle::new(),
             editor_needed_width: px(0.),
@@ -696,10 +698,10 @@ impl BufferSearchBar {
             }
         }
         if let Some(active_editor) = self.active_searchable_item.as_mut() {
-            self.selection_search_enabled = false;
+            self.selection_search_enabled = None;
             self.replace_enabled = false;
             active_editor.search_bar_visibility_changed(false, window, cx);
-            active_editor.toggle_filtered_search_ranges(false, window, cx);
+            active_editor.toggle_filtered_search_ranges(None, window, cx);
             let handle = active_editor.item_focus_handle(cx);
             self.focus(&handle, window);
         }
@@ -711,18 +713,23 @@ impl BufferSearchBar {
     }
 
     pub fn deploy(&mut self, deploy: &Deploy, window: &mut Window, cx: &mut Context<Self>) -> bool {
+        let filtered_search_range = if deploy.selection_search_enabled {
+            Some(FilteredSearchRange::Default)
+        } else {
+            None
+        };
         if self.show(window, cx) {
             if let Some(active_item) = self.active_searchable_item.as_mut() {
-                active_item.toggle_filtered_search_ranges(
-                    deploy.selection_search_enabled,
-                    window,
-                    cx,
-                );
+                active_item.toggle_filtered_search_ranges(filtered_search_range, window, cx);
             }
             self.search_suggested(window, cx);
             self.smartcase(window, cx);
             self.replace_enabled = deploy.replace_enabled;
-            self.selection_search_enabled = deploy.selection_search_enabled;
+            self.selection_search_enabled = if deploy.selection_search_enabled {
+                Some(FilteredSearchRange::Default)
+            } else {
+                None
+            };
             if deploy.focus {
                 let mut handle = self.query_editor.focus_handle(cx);
                 let mut select_query = true;
@@ -923,6 +930,19 @@ impl BufferSearchBar {
         }
     }
 
+    pub fn set_search_within_selection(
+        &mut self,
+        search_within_selection: Option<FilteredSearchRange>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<oneshot::Receiver<()>> {
+        let active_item = self.active_searchable_item.as_mut()?;
+        self.selection_search_enabled = search_within_selection;
+        active_item.toggle_filtered_search_ranges(self.selection_search_enabled, window, cx);
+        cx.notify();
+        Some(self.update_matches(false, false, window, cx))
+    }
+
     pub fn set_search_options(&mut self, search_options: SearchOptions, cx: &mut Context<Self>) {
         self.search_options = search_options;
         self.adjust_query_regex_language(cx);
@@ -957,7 +977,7 @@ impl BufferSearchBar {
         self.select_match(Direction::Prev, 1, window, cx);
     }
 
-    fn select_all_matches(
+    pub fn select_all_matches(
         &mut self,
         _: &SelectAllMatches,
         window: &mut Window,
@@ -1125,12 +1145,15 @@ impl BufferSearchBar {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) {
-        if let Some(active_item) = self.active_searchable_item.as_mut() {
-            self.selection_search_enabled = !self.selection_search_enabled;
-            active_item.toggle_filtered_search_ranges(self.selection_search_enabled, window, cx);
-            drop(self.update_matches(false, false, window, cx));
-            cx.notify();
-        }
+        self.set_search_within_selection(
+            if let Some(_) = self.selection_search_enabled {
+                None
+            } else {
+                Some(FilteredSearchRange::Default)
+            },
+            window,
+            cx,
+        );
     }
 
     fn toggle_regex(&mut self, _: &ToggleRegex, window: &mut Window, cx: &mut Context<Self>) {

--- a/crates/vim/src/normal/search.rs
+++ b/crates/vim/src/normal/search.rs
@@ -149,13 +149,6 @@ impl Vim {
         self.move_to_match_internal(self.search.direction.opposite(), window, cx)
     }
 
-    // Option 1: Modify this action to have a toggle for selection search
-    // How does SearchOptions work?
-    // Option 2: `"s": ["buffer_search::Deploy", { "selection_search_enabled": true }]` as per dgmulf on github
-    // however he reports inconsistent behavior
-    // Option 3: Implement a new action that toggles selection search, probably in the Helix crate titled 'select_regex'
-    //
-    // Look into disabling search results when nothing is selected
     fn search(&mut self, action: &Search, window: &mut Window, cx: &mut Context<Self>) {
         let Some(pane) = self.pane(window, cx) else {
             return;

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -988,6 +988,7 @@ pub struct SearchState {
     pub prior_selections: Vec<Range<Anchor>>,
     pub prior_operator: Option<Operator>,
     pub prior_mode: Mode,
+    pub helix_select: bool,
 }
 
 impl Operator {

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -48,7 +48,7 @@ pub struct SearchOptions {
 // Whether to always select the current selection (even if empty)
 // or to use the default (restoring the previous search ranges if some,
 // otherwise using the whole file).
-#[derive(Clone, Copy, Debug, Default)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub enum FilteredSearchRange {
     Selection,
     #[default]

--- a/crates/workspace/src/searchable.rs
+++ b/crates/workspace/src/searchable.rs
@@ -45,6 +45,16 @@ pub struct SearchOptions {
     pub find_in_results: bool,
 }
 
+// Whether to always select the current selection (even if empty)
+// or to use the default (restoring the previous search ranges if some,
+// otherwise using the whole file).
+#[derive(Clone, Copy, Debug, Default)]
+pub enum FilteredSearchRange {
+    Selection,
+    #[default]
+    Default,
+}
+
 pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
     type Match: Any + Sync + Send + Clone;
 
@@ -73,7 +83,7 @@ pub trait SearchableItem: Item + EventEmitter<SearchEvent> {
 
     fn toggle_filtered_search_ranges(
         &mut self,
-        _enabled: bool,
+        _enabled: Option<FilteredSearchRange>,
         _window: &mut Window,
         _cx: &mut Context<Self>,
     ) {
@@ -216,7 +226,12 @@ pub trait SearchableItemHandle: ItemHandle {
     ) -> Option<usize>;
     fn search_bar_visibility_changed(&self, visible: bool, window: &mut Window, cx: &mut App);
 
-    fn toggle_filtered_search_ranges(&mut self, enabled: bool, window: &mut Window, cx: &mut App);
+    fn toggle_filtered_search_ranges(
+        &mut self,
+        enabled: Option<FilteredSearchRange>,
+        window: &mut Window,
+        cx: &mut App,
+    );
 }
 
 impl<T: SearchableItem> SearchableItemHandle for Entity<T> {
@@ -362,7 +377,12 @@ impl<T: SearchableItem> SearchableItemHandle for Entity<T> {
         });
     }
 
-    fn toggle_filtered_search_ranges(&mut self, enabled: bool, window: &mut Window, cx: &mut App) {
+    fn toggle_filtered_search_ranges(
+        &mut self,
+        enabled: Option<FilteredSearchRange>,
+        window: &mut Window,
+        cx: &mut App,
+    ) {
         self.update(cx, |this, cx| {
             this.toggle_filtered_search_ranges(enabled, window, cx)
         });


### PR DESCRIPTION
Closes #31561

Release Notes:

- Implemented the select_regex Helix keymap

Prior: The keymap `s` defaulted to `vim::Substitute`

After:
<img width="1387" height="376" alt="image" src="https://github.com/user-attachments/assets/4d3181d9-9d3f-40d2-890f-022655c77577" />

Thank you to @ConradIrwin for pairing to work on this
