### PR TITLE
Revert "Add setting to show/hide title bar (#37428)"

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -391,8 +391,6 @@
   "use_system_window_tabs": false,
   // Titlebar related settings
   "title_bar": {
-    // When to show the title bar: "always" | "never" | "hide_in_full_screen".
-    "show": "always",
     // Whether to show the branch icon beside branch switcher in the titlebar.
     "show_branch_icon": false,
     // Whether to show the branch name button in the titlebar.

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -237,10 +237,6 @@ pub enum BaseKeymapContent {
 #[skip_serializing_none]
 #[derive(Clone, PartialEq, Default, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
 pub struct TitleBarSettingsContent {
-    /// Controls when the title bar is visible: "always" | "never" | "hide_in_full_screen".
-    ///
-    /// Default: "always"
-    pub show: Option<TitleBarVisibility>,
     /// Whether to show the branch icon beside branch switcher in the title bar.
     ///
     /// Default: false
@@ -269,14 +265,6 @@ pub struct TitleBarSettingsContent {
     ///
     /// Default: false
     pub show_menus: Option<bool>,
-}
-
-#[derive(Copy, Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Debug)]
-#[serde(rename_all = "snake_case")]
-pub enum TitleBarVisibility {
-    Always,
-    Never,
-    HideInFullScreen,
 }
 
 /// Configuration of audio in Zed.

--- a/crates/settings/src/settings_store.rs
+++ b/crates/settings/src/settings_store.rs
@@ -1022,7 +1022,7 @@ mod tests {
     use std::num::NonZeroU32;
 
     use crate::{
-        TitleBarSettingsContent, TitleBarVisibility, VsCodeSettingsSource, default_settings,
+        TitleBarSettingsContent, VsCodeSettingsSource, default_settings,
         settings_content::LanguageSettingsContent, test_settings,
     };
 
@@ -1044,7 +1044,6 @@ mod tests {
 
     #[derive(Debug, PartialEq)]
     struct TitleBarSettings {
-        show: TitleBarVisibility,
         show_branch_name: bool,
     }
 
@@ -1052,21 +1051,7 @@ mod tests {
         fn from_settings(content: &SettingsContent, _: &mut App) -> Self {
             let content = content.title_bar.clone().unwrap();
             TitleBarSettings {
-                show: content.show.unwrap(),
                 show_branch_name: content.show_branch_name.unwrap(),
-            }
-        }
-
-        fn import_from_vscode(vscode: &VsCodeSettings, content: &mut SettingsContent) {
-            let mut show = None;
-
-            vscode.enum_setting("window.titleBarStyle", &mut show, |value| match value {
-                "never" => Some(TitleBarVisibility::Never),
-                "always" => Some(TitleBarVisibility::Always),
-                _ => None,
-            });
-            if let Some(show) = show {
-                content.title_bar.get_or_insert_default().show.replace(show);
             }
         }
     }
@@ -1110,10 +1095,6 @@ mod tests {
             store.get::<AutoUpdateSetting>(None),
             &AutoUpdateSetting { auto_update: true }
         );
-        assert_eq!(
-            store.get::<TitleBarSettings>(None).show,
-            TitleBarVisibility::Always
-        );
 
         store
             .set_user_settings(
@@ -1130,10 +1111,6 @@ mod tests {
         assert_eq!(
             store.get::<AutoUpdateSetting>(None),
             &AutoUpdateSetting { auto_update: false }
-        );
-        assert_eq!(
-            store.get::<TitleBarSettings>(None).show,
-            TitleBarVisibility::Never
         );
 
         store
@@ -1195,16 +1172,10 @@ mod tests {
                 tab_size: 9.try_into().unwrap(),
             }
         );
-        assert_eq!(
-            store.get::<TitleBarSettings>(Some(SettingsLocation {
-                worktree_id: WorktreeId::from_usize(1),
-                path: Path::new("/root2/something")
-            })),
-            &TitleBarSettings {
-                show: TitleBarVisibility::Never,
-                show_branch_name: true,
-            }
-        );
+        assert_eq!(store.get::<TitleBarSettings>(Some(SettingsLocation {
+            worktree_id: WorktreeId::from_usize(1),
+            path: Path::new("/root2/something")
+        })),);
     }
 
     #[gpui::test]
@@ -1219,10 +1190,6 @@ mod tests {
         assert_eq!(
             store.get::<AutoUpdateSetting>(None),
             &AutoUpdateSetting { auto_update: false }
-        );
-        assert_eq!(
-            store.get::<TitleBarSettings>(None).show,
-            TitleBarVisibility::Always,
         );
     }
 
@@ -1568,7 +1535,6 @@ mod tests {
         assert_eq!(
             store.get::<TitleBarSettings>(None),
             &TitleBarSettings {
-                show: TitleBarVisibility::Never,
                 show_branch_name: true,
             }
         );
@@ -1589,7 +1555,6 @@ mod tests {
         assert_eq!(
             store.get::<TitleBarSettings>(None),
             &TitleBarSettings {
-                show: TitleBarVisibility::Always,
                 show_branch_name: true, // Staff from global settings
             }
         );

--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -4,7 +4,7 @@ mod onboarding_banner;
 pub mod platform_title_bar;
 mod platforms;
 mod system_window_tabs;
-pub mod title_bar_settings;
+mod title_bar_settings;
 
 #[cfg(feature = "stories")]
 mod stories;
@@ -35,7 +35,7 @@ use remote::RemoteConnectionOptions;
 use settings::{Settings, SettingsLocation};
 use std::{path::Path, sync::Arc};
 use theme::ActiveTheme;
-use title_bar_settings::{TitleBarSettings, TitleBarVisibility};
+use title_bar_settings::TitleBarSettings;
 use ui::{
     Avatar, Button, ButtonLike, ButtonStyle, Chip, ContextMenu, Icon, IconName, IconSize,
     IconWithIndicator, Indicator, PopoverMenu, PopoverMenuHandle, Tooltip, h_flex, prelude::*,
@@ -73,49 +73,8 @@ pub fn init(cx: &mut App) {
         let Some(window) = window else {
             return;
         };
-        let should_show = match TitleBarSettings::get_global(cx).show {
-            TitleBarVisibility::Always => true,
-            TitleBarVisibility::Never => false,
-            TitleBarVisibility::HideInFullScreen => !window.is_fullscreen(),
-        };
-        if should_show {
-            let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
-            workspace.set_titlebar_item(item.into(), window, cx);
-        }
-
-        cx.observe_global_in::<settings::SettingsStore>(window, |workspace, window, cx| {
-            let should_show = match TitleBarSettings::get_global(cx).show {
-                TitleBarVisibility::Always => true,
-                TitleBarVisibility::Never => false,
-                TitleBarVisibility::HideInFullScreen => !window.is_fullscreen(),
-            };
-            if should_show {
-                if workspace.titlebar_item().is_none() {
-                    let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
-                    workspace.set_titlebar_item(item.into(), window, cx);
-                }
-            } else {
-                workspace.clear_titlebar_item(window, cx);
-            }
-        })
-        .detach();
-
-        cx.observe_window_bounds(window, |workspace, window, cx| {
-            let should_show = match TitleBarSettings::get_global(cx).show {
-                TitleBarVisibility::Always => true,
-                TitleBarVisibility::Never => false,
-                TitleBarVisibility::HideInFullScreen => !window.is_fullscreen(),
-            };
-            if should_show {
-                if workspace.titlebar_item().is_none() {
-                    let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
-                    workspace.set_titlebar_item(item.into(), window, cx);
-                }
-            } else {
-                workspace.clear_titlebar_item(window, cx);
-            }
-        })
-        .detach();
+        let item = cx.new(|cx| TitleBar::new("title-bar", workspace, window, cx));
+        workspace.set_titlebar_item(item.into(), window, cx);
 
         #[cfg(not(target_os = "macos"))]
         workspace.register_action(|workspace, action: &OpenApplicationMenu, window, cx| {

--- a/crates/title_bar/src/title_bar_settings.rs
+++ b/crates/title_bar/src/title_bar_settings.rs
@@ -1,10 +1,8 @@
-pub use settings::TitleBarVisibility;
 use settings::{Settings, SettingsContent};
 use ui::App;
 
 #[derive(Copy, Clone, Debug)]
 pub struct TitleBarSettings {
-    pub show: TitleBarVisibility,
     pub show_branch_icon: bool,
     pub show_onboarding_banner: bool,
     pub show_user_picture: bool,
@@ -18,7 +16,6 @@ impl Settings for TitleBarSettings {
     fn from_settings(s: &SettingsContent, _: &mut App) -> Self {
         let content = s.title_bar.clone().unwrap();
         TitleBarSettings {
-            show: content.show.unwrap(),
             show_branch_icon: content.show_branch_icon.unwrap(),
             show_onboarding_banner: content.show_onboarding_banner.unwrap(),
             show_user_picture: content.show_user_picture.unwrap(),

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -2040,11 +2040,6 @@ impl Workspace {
         cx.notify();
     }
 
-    pub fn clear_titlebar_item(&mut self, _: &mut Window, cx: &mut Context<Self>) {
-        self.titlebar_item = None;
-        cx.notify();
-    }
-
     pub fn set_prompt_for_new_path(&mut self, prompt: PromptForNewPath) {
         self.on_prompt_for_new_path = Some(prompt)
     }

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -4140,7 +4140,6 @@ Run the {#action theme_selector::Toggle} action in the command palette to see a 
 
 ```json
 "title_bar": {
-  "show": "always",
   "show_branch_icon": false,
   "show_branch_name": true,
   "show_project_items": true,

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -108,7 +108,6 @@ To disable this behavior use:
 ```json
   // Control which items are shown/hidden in the title bar
   "title_bar": {
-    "show": "always",               // When to show: always | never | hide_in_full_screen
     "show_branch_icon": false,      // Show/hide branch icon beside branch switcher
     "show_branch_name": true,       // Show/hide branch name
     "show_project_items": true,     // Show/hide project host and name


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/38547

Release Notes:

- Reverted the ability to show/hide the titlebar. This caused rendering bugs on
  macOS, and we're preparing for the redesign which requires the toolbar being present.