### PR TITLE
When searching outline, select nearest match to cursor if multiple are found

### DIFF
--- a/crates/editor/src/actions.rs
+++ b/crates/editor/src/actions.rs
@@ -165,7 +165,7 @@ pub struct MoveUpByLines {
 #[serde(deny_unknown_fields)]
 pub struct MoveDownByLines {
     #[serde(default)]
-    pub(super) lines: u32,
+    pub lines: u32,
 }
 
 /// Extends selection up by a specified number of lines.

--- a/crates/language/src/outline.rs
+++ b/crates/language/src/outline.rs
@@ -4,7 +4,7 @@ use gpui::{BackgroundExecutor, HighlightStyle};
 use std::ops::Range;
 
 /// An outline of all the symbols contained in a buffer.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Outline<T> {
     pub items: Vec<OutlineItem<T>>,
     candidates: Vec<StringMatchCandidate>,

--- a/crates/outline/src/outline.rs
+++ b/crates/outline/src/outline.rs
@@ -217,7 +217,6 @@ impl PickerDelegate for OutlineViewDelegate {
         _: &mut Window,
         cx: &mut Context<Picker<OutlineViewDelegate>>,
     ) {
-        println!("Selected index: {}", ix);
         self.set_selected_index(ix, true, cx);
     }
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/29774

**Background**
There was a bug when multiple matches were found when searching an outline. If multiple matches were found, it would simply compare by match score, which is calculated using longest subsequence. If there were multiple matches with the same score, it would always return the last match (see [max_by_key docs)](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.max_by_key)).

**Solution**
Now, the match closest to the cursor when the search takes place is selected. This is based on a distance calculation.

Release Notes:
- Fixed bug when searching outline, if multiple matches were found with the same match score, it would always select the last match. Now it selects the match closest to the cursor in this when multiple matches with the same match score are found.