### PR TITLE
git: Preserve existing whitespace when rewrapping

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -12,7 +12,7 @@ use agent_settings::AgentSettings;
 use anyhow::Context as _;
 use askpass::AskPassDelegate;
 use db::kvp::KEY_VALUE_STORE;
-use editor::{Editor, EditorElement, EditorMode, MultiBuffer};
+use editor::{Editor, EditorElement, EditorMode, MultiBuffer, RewrapOptions};
 use futures::StreamExt as _;
 use git::blame::ParsedCommitMessage;
 use git::repository::{
@@ -1493,7 +1493,13 @@ impl GitPanel {
         let editor = cx.new(|cx| Editor::for_buffer(buffer, None, window, cx));
         let wrapped_message = editor.update(cx, |editor, cx| {
             editor.select_all(&Default::default(), window, cx);
-            editor.rewrap(&Default::default(), window, cx);
+            editor.rewrap_impl(
+                RewrapOptions {
+                    preserve_existing_whitespace: true,
+                    ..Default::default()
+                },
+                cx,
+            );
             editor.text(cx)
         });
         if wrapped_message.trim().is_empty() {


### PR DESCRIPTION
By default, rewrap will merge lines that are separate in the source commit message. This can break Markdown formatting for lists, such as:

- a
- b

... which will get merged into "- a - b" if the commit is amended.

Release Notes:

- git: Preserve whitespace in commit messages when amending or uncommitting