### PR TITLE
remote: Don’t pass `--method=GET` to `wget`

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -548,7 +548,7 @@ impl SshRemoteConnection {
                     .run_command(
                         "wget",
                         &[
-                            "--method=GET",
+                            // "--method=GET", // BusyBox's version of wget does NOT have support for this option
                             "--header=Content-Type: application/json",
                             "--body-data",
                             body,

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -548,7 +548,6 @@ impl SshRemoteConnection {
                     .run_command(
                         "wget",
                         &[
-                            // "--method=GET", // BusyBox's version of wget does NOT have support for this option
                             "--header=Content-Type: application/json",
                             "--body-data",
                             body,


### PR DESCRIPTION
BusyBox's off brand `wget` does not have support for the `--method` argument, which makes `zed` incapable of downloading the remote server unless the _☙authentic❧_ one is installed. Removing this should fix the issue. Couldn't find much about guidelines on how the code is supposed to be formatted, so I opted for commenting the line out with an explanation.

Closes #38712

Release Notes:

- Fixed remote development on BusyBox