### PR TITLE
windows: Do not attempt to encrypt empty encrypted strings

### DIFF
--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -354,6 +354,7 @@ impl SshRemoteConnection {
             &temp_dir,
             askpass
                 .get_password()
+                .or_else(|| askpass::EncryptedPassword::try_from("").ok())
                 .context("Failed to fetch askpass password")?,
         )?;
         drop(askpass);


### PR DESCRIPTION
Related to #38427

Release Notes:

* N/A
