### PR TITLE
remote: expand tilde in SSH project paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12828,6 +12828,7 @@ dependencies = [
  "serde",
  "serde_json",
  "settings",
+ "shellexpand 2.1.2",
  "smol",
  "task",
  "telemetry",

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1973,7 +1973,10 @@
   //     // "port": 22, "username": "test", "args": ["-i", "/home/user/.ssh/id_rsa"]
   //     "projects": [
   //       {
-  //         "paths": ["/home/user/code/zed"]
+  //         "paths": [
+  //           "/home/user/code/zed",
+  //           "~/code/zed"
+  //         ]
   //       }
   //     ]
   //   }

--- a/crates/recent_projects/Cargo.toml
+++ b/crates/recent_projects/Cargo.toml
@@ -44,6 +44,7 @@ workspace.workspace = true
 zed_actions.workspace = true
 workspace-hack.workspace = true
 indoc.workspace = true
+shellexpand.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows-registry = "0.6.0"

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -238,7 +238,10 @@ impl ProjectPicker {
                         update_settings_file(fs, cx, {
                             let paths = paths
                                 .iter()
-                                .map(|path| path.to_string_lossy().to_string())
+                                .map(|path| {
+                                    let path_str = path.to_string_lossy();
+                                    shellexpand::tilde(&path_str).to_string()
+                                })
                                 .collect();
                             move |settings, _| match index {
                                 ServerIndex::Ssh(index) => {


### PR DESCRIPTION
Release Notes:

- N/A


Ensure `~/path` entries are expanded to absolute paths.
