### PR TITLE
zeta2: Compute smaller edits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20587,6 +20587,7 @@ dependencies = [
  "edit_prediction_context",
  "futures 0.3.31",
  "gpui",
+ "indoc",
  "language",
  "language_model",
  "log",

--- a/crates/zeta2/Cargo.toml
+++ b/crates/zeta2/Cargo.toml
@@ -22,6 +22,7 @@ edit_prediction.workspace = true
 edit_prediction_context.workspace = true
 futures.workspace = true
 gpui.workspace = true
+indoc.workspace = true
 language.workspace = true
 language_model.workspace = true
 log.workspace = true

--- a/crates/zeta2/src/zeta2.rs
+++ b/crates/zeta2/src/zeta2.rs
@@ -1287,6 +1287,7 @@ mod tests {
         let buffer = cx.new(|cx| Buffer::local(old, cx));
         let snapshot = buffer.read_with(cx, |buffer, _cx| buffer.snapshot());
 
+        // TODO cover more cases when multi-file is supported
         let big_edits = vec![predict_edits_v3::Edit {
             path: PathBuf::from("test.txt"),
             range: 0..old.len(),


### PR DESCRIPTION
The new cloud endpoint returns structured edits, but they may include more of the input excerpt than what we want to display in the preview, so we compute a smaller diff on the client side against the snapshot.

Release Notes:

- N/A 
