### PR TITLE
snippets: Fix `configure snippets` not opening on remote workspaces

### DIFF
--- a/crates/snippets_ui/src/snippets_ui.rs
+++ b/crates/snippets_ui/src/snippets_ui.rs
@@ -221,15 +221,19 @@ impl PickerDelegate for ScopeSelectorDelegate {
 
                     workspace.update_in(cx, |workspace, window, cx| {
                         workspace
-                            .open_abs_path(
-                                snippets_dir().join(scope_file_name.with_extension()),
-                                OpenOptions {
-                                    visible: Some(OpenVisible::None),
-                                    ..Default::default()
-                                },
-                                window,
-                                cx,
-                            )
+                            .with_local_workspace(window, cx, |workspace, window, cx| {
+                                workspace
+                                    .open_abs_path(
+                                        snippets_dir().join(scope_file_name.with_extension()),
+                                        OpenOptions {
+                                            visible: Some(OpenVisible::None),
+                                            ..Default::default()
+                                        },
+                                        window,
+                                        cx,
+                                    )
+                                    .detach();
+                            })
                             .detach();
                     })
                 })


### PR DESCRIPTION
Release Notes:

- Fixed `snippets: configure snippets` action not working on remote workspaces
