### PR TITLE
Improve recent projects search result ordering

### DIFF
--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -328,7 +328,11 @@ impl PickerDelegate for RecentProjectsDelegate {
             &Default::default(),
             cx.background_executor().clone(),
         ));
-        self.matches.sort_unstable_by_key(|m| m.candidate_id);
+        self.matches.sort_unstable_by(|a, b| {
+            b.score.partial_cmp(&a.score) // Descending score
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.candidate_id.cmp(&b.candidate_id)) // Ascending candidate_id for ties
+        });
 
         if self.reset_selected_match_index {
             self.selected_match_index = self

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -329,7 +329,8 @@ impl PickerDelegate for RecentProjectsDelegate {
             cx.background_executor().clone(),
         ));
         self.matches.sort_unstable_by(|a, b| {
-            b.score.partial_cmp(&a.score) // Descending score
+            b.score
+                .partial_cmp(&a.score) // Descending score
                 .unwrap_or(std::cmp::Ordering::Equal)
                 .then_with(|| a.candidate_id.cmp(&b.candidate_id)) // Ascending candidate_id for ties
         });


### PR DESCRIPTION
Previously, search results were sorted solely by candidate_id (preserving original order from the database), which could result in less relevant matches appearing before better ones.

This change sorts results primarily by fuzzy match score (descending), with candidate_id as a tiebreaker for equal scores. This ensures that better matches appear first while preserving recency order among items with identical scores.

Example improvement:
- Searching for 'pica' will now rank 'picabo' higher than scattered matches like 'project-api, project-chat'
- Consecutive character matches are prioritized over scattered matches across multiple path segments

Release Notes:
- Improved project search relevance by ranking results using match score instead of insertion order.