### PR TITLE
Switch to "standard" as a default line height in the terminal

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1412,7 +1412,7 @@
     //         "line_height": {
     //           "custom": 2
     //         },
-    "line_height": "comfortable",
+    "line_height": "standard",
     // Activate the python virtual environment, if one is found, in the
     // terminal's working directory (as resolved by the working_directory
     // setting). Set this to "off" to disable this behavior.

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3791,11 +3791,11 @@ See Buffer Font Features
 
 - Description: Set the terminal's line height.
 - Setting: `line_height`
-- Default: `comfortable`
+- Default: `standard`
 
 **Options**
 
-1. Use a line height that's `comfortable` for reading, 1.618. (default)
+1. Use a line height that's `comfortable` for reading, 1.618.
 
 ```json
 {
@@ -3805,7 +3805,7 @@ See Buffer Font Features
 }
 ```
 
-2. Use a `standard` line height, 1.3. This option is useful for TUIs, particularly if they use box characters
+2. Use a `standard` line height, 1.3. This option is useful for TUIs, particularly if they use box characters. (default)
 
 ```json
 {

--- a/docs/src/visual-customization.md
+++ b/docs/src/visual-customization.md
@@ -58,7 +58,7 @@ If you would like to use distinct themes for light mode/dark mode that can be se
     "font_family": "",
     "font_size": 15,
     // Terminal line height: comfortable (1.618), standard(1.3) or `{ "custom": 2 }`
-    "line_height": "comfortable",
+    "line_height": "standard",
   },
 
   // Agent Panel Font Settings


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/38686

Release Notes:

- Switched to "standard" as a default line height in the terminal