### PR TITLE
docs: Update note about agent message editor setting

### DIFF
--- a/docs/src/ai/agent-settings.md
+++ b/docs/src/ai/agent-settings.md
@@ -196,8 +196,6 @@ It is set to `4` by default, and the max number of lines is always double of the
 }
 ```
 
-> This setting is currently available only in Preview.
-
 ### Modifier to Send
 
 Make a modifier (`cmd` on macOS, `ctrl` on Linux) required to send messages.


### PR DESCRIPTION
As of stable 206.0, the `agent.message_editor_min_lines` setting is fully available, so removing the docs note that said it was only for Preview.

Release Notes:

- N/A
