### PR TITLE
Disable terminal breadcrumbs by default

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1432,7 +1432,7 @@
       //
       // The shell running in the terminal needs to be configured to emit the title.
       // Example: `echo -e "\e]2;New Title\007";`
-      "breadcrumbs": true
+      "breadcrumbs": false
     },
     // Scrollbar-related settings
     "scrollbar": {

--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -3536,7 +3536,7 @@ List of `integer` column numbers
     "button": true,
     "shell": "system",
     "toolbar": {
-      "breadcrumbs": true
+      "breadcrumbs": false
     },
     "working_directory": "current_project_directory",
     "scrollbar": {
@@ -3957,7 +3957,7 @@ Disable with:
 {
   "terminal": {
     "toolbar": {
-      "breadcrumbs": true
+      "breadcrumbs": false
     }
   }
 }


### PR DESCRIPTION
<img width="1211" height="238" alt="image" src="https://github.com/user-attachments/assets/d847fabe-0e00-474c-ad79-cb4da221b319" />

At least on Windows, "git terminal" and PowerShell set the header, which is not very useful but occupies space and sometimes confuses users:

![telegram-cloud-photo-size-2-5377720447174575846-x](https://github.com/user-attachments/assets/a889fa44-e879-4b3d-956b-0af959113e1e)

Release Notes:

- Disable terminal breadcrumbs by default. Set `terminal.toolbar.breadcrumbs` to `true` to re-enable.
