### PR TITLE
gpui_macros: Hide inner test function from project symbols

### DIFF
--- a/crates/gpui_macros/src/test.rs
+++ b/crates/gpui_macros/src/test.rs
@@ -100,7 +100,7 @@ pub fn test(args: TokenStream, function: TokenStream) -> TokenStream {
     };
 
     let inner_fn_attributes = mem::take(&mut inner_fn.attrs);
-    let inner_fn_name = format_ident!("_{}", inner_fn.sig.ident);
+    let inner_fn_name = format_ident!("__{}", inner_fn.sig.ident);
     let outer_fn_name = mem::replace(&mut inner_fn.sig.ident, inner_fn_name.clone());
 
     let result = generate_test_function(


### PR DESCRIPTION
This makes rust-analyzer not consider the function for project symbols, meaning searching for tests wont show two entries.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
