### PR TITLE
Remove the duplicated Global LSP Settings section

### DIFF
--- a/docs/src/configuring-zed.md
+++ b/docs/src/configuring-zed.md
@@ -1571,22 +1571,6 @@ While other options may be changed at a runtime and should be placed under `sett
 - Setting: `lsp_highlight_debounce`
 - Default: `75`
 
-## Global LSP Settings
-
-- Description: Common language server settings.
-- Setting: `global_lsp_settings`
-- Default:
-
-```json
-"global_lsp_settings": {
-  "button": true
-}
-```
-
-**Options**
-
-`integer` values representing milliseconds
-
 ## Features
 
 - Description: Features that can be globally enabled or disabled


### PR DESCRIPTION
This section [shows up twice](https://zed.dev/docs/configuring-zed#global-lsp-settings) in the documentation.

<img width="701" height="1269" alt="image" src="https://github.com/user-attachments/assets/4d930676-5cae-43c8-83d4-6406c27d149c" />

Release Notes:

- N/A