### PR TITLE
editor: Fix predict edit at cursor action when show_edit_predictions is false

### DIFF
--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -211,6 +211,8 @@ impl EditPredictionProvider for CopilotCompletionProvider {
                 copilot.discard_completions(&self.completions, cx)
             })
             .detach_and_log_err(cx);
+        
+        self.completions.clear();
     }
 
     fn suggest(

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -211,7 +211,7 @@ impl EditPredictionProvider for CopilotCompletionProvider {
                 copilot.discard_completions(&self.completions, cx)
             })
             .detach_and_log_err(cx);
-        
+
         self.completions.clear();
     }
 

--- a/crates/copilot/src/copilot_completion_provider.rs
+++ b/crates/copilot/src/copilot_completion_provider.rs
@@ -211,8 +211,6 @@ impl EditPredictionProvider for CopilotCompletionProvider {
                 copilot.discard_completions(&self.completions, cx)
             })
             .detach_and_log_err(cx);
-
-        self.completions.clear();
     }
 
     fn suggest(

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -7,9 +7,7 @@ use std::ops::Range;
 use text::{Point, ToOffset};
 
 use crate::{
-    EditPrediction,
-    editor_tests::{init_test, update_test_language_settings},
-    test::editor_test_context::EditorTestContext,
+    EditPrediction, editor_tests::init_test, test::editor_test_context::EditorTestContext,
 };
 
 #[gpui::test]

--- a/crates/editor/src/edit_prediction_tests.rs
+++ b/crates/editor/src/edit_prediction_tests.rs
@@ -273,44 +273,6 @@ async fn test_edit_prediction_jump_disabled_for_non_zed_providers(cx: &mut gpui:
     });
 }
 
-#[gpui::test]
-async fn test_edit_predictions_disabled_in_scope(cx: &mut gpui::TestAppContext) {
-    init_test(cx, |_| {});
-
-    update_test_language_settings(cx, |settings| {
-        settings.defaults.edit_predictions_disabled_in = Some(vec!["string".to_string()]);
-    });
-
-    let mut cx = EditorTestContext::new(cx).await;
-    let provider = cx.new(|_| FakeEditPredictionProvider::default());
-    assign_editor_completion_provider(provider.clone(), &mut cx);
-
-    let language = languages::language("javascript", tree_sitter_typescript::LANGUAGE_TSX.into());
-    cx.update_buffer(|buffer, cx| buffer.set_language(Some(language), cx));
-
-    // Test disabled inside of string
-    cx.set_state("const x = \"hello ˇworld\";");
-    propose_edits(&provider, vec![(17..17, "beautiful ")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-    cx.editor(|editor, _, _| {
-        assert!(
-            editor.active_edit_prediction.is_none(),
-            "Edit predictions should be disabled in string scopes when configured in edit_predictions_disabled_in"
-        );
-    });
-
-    // Test enabled outside of string
-    cx.set_state("const x = \"hello world\"; ˇ");
-    propose_edits(&provider, vec![(24..24, "// comment")], &mut cx);
-    cx.update_editor(|editor, window, cx| editor.update_visible_edit_prediction(window, cx));
-    cx.editor(|editor, _, _| {
-        assert!(
-            editor.active_edit_prediction.is_some(),
-            "Edit predictions should work outside of disabled scopes"
-        );
-    });
-}
-
 fn assert_editor_active_edit_completion(
     cx: &mut EditorTestContext,
     assert: impl FnOnce(MultiBufferSnapshot, &Vec<(Range<Anchor>, String)>),

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -7152,6 +7152,8 @@ impl Editor {
             return None;
         }
 
+        self.update_visible_edit_prediction(window, cx);
+
         if !user_requested
             && (!self.should_show_edit_predictions()
                 || !self.is_focused(window)
@@ -7161,7 +7163,6 @@ impl Editor {
             return None;
         }
 
-        self.update_visible_edit_prediction(window, cx);
         provider.refresh(
             self.project.clone(),
             buffer,
@@ -7853,11 +7854,6 @@ impl Editor {
 
         self.edit_prediction_settings =
             self.edit_prediction_settings_at_position(&buffer, cursor_buffer_position, cx);
-
-        if let EditPredictionSettings::Disabled = self.edit_prediction_settings {
-            self.discard_edit_prediction(false, cx);
-            return None;
-        };
 
         self.edit_prediction_indent_conflict = multibuffer.is_line_whitespace_upto(cursor);
 


### PR DESCRIPTION
Closes #37601 

Regressed in https://github.com/zed-industries/zed/pull/36469. 

Edit: Original issue https://github.com/zed-industries/zed/issues/25744 is fixed for Zeta in this PR. For Copilot, it will be covered in a follow-up. In the case of Copilot, even after discarding, we still get a prediction on suggest, which is a bug.

Release Notes:

- Fixed issue where predict edit at cursor didn't work when `show_edit_predictions` is `false`.
