### PR TITLE
Only allow single chars for whitespace map

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9324,7 +9324,7 @@ impl Element for EditorElement {
                         .language_settings(cx)
                         .whitespace_map;
 
-                    let tab_char = whitespace_map.tab();
+                    let tab_char = whitespace_map.tab.clone();
                     let tab_len = tab_char.len();
                     let tab_invisible = window.text_system().shape_line(
                         tab_char,
@@ -9340,7 +9340,7 @@ impl Element for EditorElement {
                         None,
                     );
 
-                    let space_char = whitespace_map.space();
+                    let space_char = whitespace_map.space.clone();
                     let space_len = space_char.len();
                     let space_invisible = window.text_system().shape_line(
                         space_char,

--- a/crates/language/src/language_settings.rs
+++ b/crates/language/src/language_settings.rs
@@ -7,7 +7,7 @@ use ec4rs::{
     property::{FinalNewline, IndentSize, IndentStyle, MaxLineLen, TabWidth, TrimTrailingWs},
 };
 use globset::{Glob, GlobMatcher, GlobSet, GlobSetBuilder};
-use gpui::{App, Modifiers};
+use gpui::{App, Modifiers, SharedString};
 use itertools::{Either, Itertools};
 
 pub use settings::{
@@ -57,6 +57,12 @@ pub struct AllLanguageSettings {
     pub defaults: LanguageSettings,
     languages: HashMap<LanguageName, LanguageSettings>,
     pub(crate) file_types: FxHashMap<Arc<str>, GlobSet>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WhitespaceMap {
+    pub space: SharedString,
+    pub tab: SharedString,
 }
 
 /// The settings for a particular language.
@@ -118,7 +124,7 @@ pub struct LanguageSettings {
     /// Whether to show tabs and spaces in the editor.
     pub show_whitespaces: settings::ShowWhitespaceSetting,
     /// Visible characters used to render whitespace when show_whitespaces is enabled.
-    pub whitespace_map: settings::WhitespaceMap,
+    pub whitespace_map: WhitespaceMap,
     /// Whether to start a new line with a comment when a previous line is a comment as well.
     pub extend_comment_on_newline: bool,
     /// Inlay hint related settings.
@@ -503,6 +509,8 @@ impl settings::Settings for AllLanguageSettings {
             let prettier = settings.prettier.unwrap();
             let indent_guides = settings.indent_guides.unwrap();
             let tasks = settings.tasks.unwrap();
+            let whitespace_map = settings.whitespace_map.unwrap();
+
             LanguageSettings {
                 tab_size: settings.tab_size.unwrap(),
                 hard_tabs: settings.hard_tabs.unwrap(),
@@ -536,7 +544,10 @@ impl settings::Settings for AllLanguageSettings {
                 show_edit_predictions: settings.show_edit_predictions.unwrap(),
                 edit_predictions_disabled_in: settings.edit_predictions_disabled_in.unwrap(),
                 show_whitespaces: settings.show_whitespaces.unwrap(),
-                whitespace_map: settings.whitespace_map.unwrap(),
+                whitespace_map: WhitespaceMap {
+                    space: SharedString::new(whitespace_map.space.to_string()),
+                    tab: SharedString::new(whitespace_map.tab.to_string()),
+                },
                 extend_comment_on_newline: settings.extend_comment_on_newline.unwrap(),
                 inlay_hints: InlayHintSettings {
                     enabled: inlay_hints.enabled.unwrap(),

--- a/crates/settings/src/merge_from.rs
+++ b/crates/settings/src/merge_from.rs
@@ -49,6 +49,7 @@ merge_from_overwrites!(
     bool,
     f64,
     f32,
+    char,
     std::num::NonZeroUsize,
     std::num::NonZeroU32,
     String,

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -261,7 +261,7 @@ pub struct LanguageSettingsContent {
     /// Visible characters used to render whitespace when show_whitespaces is enabled.
     ///
     /// Default: "•" for spaces, "→" for tabs.
-    pub whitespace_map: Option<WhitespaceMap>,
+    pub whitespace_map: Option<WhitespaceMapContent>,
     /// Whether to start a new line with a comment when a previous line is a comment as well.
     ///
     /// Default: true
@@ -354,23 +354,9 @@ pub enum ShowWhitespaceSetting {
 
 #[skip_serializing_none]
 #[derive(Clone, Debug, Default, Serialize, Deserialize, JsonSchema, MergeFrom, PartialEq)]
-pub struct WhitespaceMap {
-    pub space: Option<String>,
-    pub tab: Option<String>,
-}
-
-impl WhitespaceMap {
-    pub fn space(&self) -> SharedString {
-        self.space
-            .as_ref()
-            .map_or_else(|| SharedString::from("•"), |s| SharedString::from(s))
-    }
-
-    pub fn tab(&self) -> SharedString {
-        self.tab
-            .as_ref()
-            .map_or_else(|| SharedString::from("→"), |s| SharedString::from(s))
-    }
+pub struct WhitespaceMapContent {
+    pub space: char,
+    pub tab: char,
 }
 
 /// The behavior of `editor::Rewrap`.


### PR DESCRIPTION
Release Notes:

- Only allow single characters in the whitespace map
