### PR TITLE
edit_prediction_button: Fix Copilot menu not updating after sign out

### DIFF
--- a/crates/edit_prediction_button/src/edit_prediction_button.rs
+++ b/crates/edit_prediction_button/src/edit_prediction_button.rs
@@ -132,7 +132,8 @@ impl Render for EditPredictionButton {
                 div().child(
                     PopoverMenu::new("copilot")
                         .menu(move |window, cx| {
-                            Some(match status {
+                            let current_status = Copilot::global(cx)?.read(cx).status();
+                            Some(match current_status {
                                 Status::Authorized => this.update(cx, |this, cx| {
                                     this.build_copilot_context_menu(window, cx)
                                 }),


### PR DESCRIPTION
The edit prediction button menu was displaying stale authentication status due to capturing the Copilot status in a closure. After signing out, the menu would still show "Sign Out" instead of "Sign In to Copilot".

This change fixes the issue by reading the current Copilot status each time the menu is displayed, ensuring the menu options are always accurate.

Release Notes:

- Fixed Copilot AI menu not updating after sign out
