### PR TITLE
assistant_context: Fix `thread_summary_model` not getting used in Text Threads

### DIFF
--- a/crates/assistant_context/src/assistant_context.rs
+++ b/crates/assistant_context/src/assistant_context.rs
@@ -2669,7 +2669,7 @@ impl AssistantContext {
     }
 
     pub fn summarize(&mut self, mut replace_old: bool, cx: &mut Context<Self>) {
-        let Some(model) = LanguageModelRegistry::read_global(cx).default_model() else {
+        let Some(model) = LanguageModelRegistry::read_global(cx).thread_summary_model() else {
             return;
         };
 

--- a/crates/assistant_context/src/assistant_context_tests.rs
+++ b/crates/assistant_context/src/assistant_context_tests.rs
@@ -1329,13 +1329,12 @@ fn setup_context_editor_with_fake_model(
     cx.update(|cx| {
         init_test(cx);
         LanguageModelRegistry::global(cx).update(cx, |registry, cx| {
-            registry.set_default_model(
-                Some(ConfiguredModel {
-                    provider: fake_provider.clone(),
-                    model: fake_model.clone(),
-                }),
-                cx,
-            )
+            let configured_model = ConfiguredModel {
+                provider: fake_provider.clone(),
+                model: fake_model.clone(),
+            };
+            registry.set_default_model(Some(configured_model.clone()), cx);
+            registry.set_thread_summary_model(Some(configured_model), cx);
         })
     });
 


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/37472

Release Notes:

- Fixed an issue in Text Threads where it was using `default_model` even in case `thread_summary_model` was set.
