### PR TITLE
helix: Streamline mode naming in the UI and in settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -115,6 +115,7 @@
   // Whether to enable vim modes and key bindings.
   "vim_mode": false,
   // Whether to enable helix mode and key bindings.
+  // Enabling this mode will automatically enable vim mode.
   "helix_mode": false,
   // Whether to show the informational hover box when moving the mouse
   // over symbols in the editor.

--- a/crates/settings/src/settings_content.rs
+++ b/crates/settings/src/settings_content.rs
@@ -571,7 +571,6 @@ pub enum ModeContent {
     #[default]
     Normal,
     Insert,
-    HelixNormal,
 }
 
 /// Controls when to use system clipboard.

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -59,8 +59,8 @@ impl Display for Mode {
             Mode::Visual => write!(f, "VISUAL"),
             Mode::VisualLine => write!(f, "VISUAL LINE"),
             Mode::VisualBlock => write!(f, "VISUAL BLOCK"),
-            Mode::HelixNormal => write!(f, "HELIX NORMAL"),
-            Mode::HelixSelect => write!(f, "HELIX SELECT"),
+            Mode::HelixNormal => write!(f, "NORMAL"),
+            Mode::HelixSelect => write!(f, "SELECT"),
         }
     }
 }

--- a/crates/vim/src/vim.rs
+++ b/crates/vim/src/vim.rs
@@ -424,14 +424,23 @@ impl Vim {
     pub fn new(window: &mut Window, cx: &mut Context<Editor>) -> Entity<Self> {
         let editor = cx.entity();
 
-        let mut initial_mode = VimSettings::get_global(cx).default_mode;
-        if initial_mode == Mode::Normal && HelixModeSetting::get_global(cx).0 {
-            initial_mode = Mode::HelixNormal;
-        }
+        let initial_vim_mode = VimSettings::get_global(cx).default_mode;
+        let (mode, last_mode) = if HelixModeSetting::get_global(cx).0 {
+            let initial_helix_mode = match initial_vim_mode {
+                Mode::Normal => Mode::HelixNormal,
+                Mode::Insert => Mode::Insert,
+                // Otherwise, we panic with a note that we should never get there due to the
+                // possible values of VimSettings::get_global(cx).default_mode being either Mode::Normal or Mode::Insert.
+                _ => unreachable!("Invalid default mode"),
+            };
+            (initial_helix_mode, Mode::HelixNormal)
+        } else {
+            (initial_vim_mode, Mode::Normal)
+        };
 
         cx.new(|cx| Vim {
-            mode: initial_mode,
-            last_mode: Mode::Normal,
+            mode,
+            last_mode,
             temp_mode: false,
             exit_temporary_mode: false,
             operator_stack: Vec::new(),
@@ -1843,7 +1852,6 @@ impl From<settings::ModeContent> for Mode {
         match mode {
             ModeContent::Normal => Self::Normal,
             ModeContent::Insert => Self::Insert,
-            ModeContent::HelixNormal => Self::HelixNormal,
         }
     }
 }


### PR DESCRIPTION
Release Notes:

- When `helix_mode = true`, modes are called without the `HELIX_` prefix in the UI:
  `HELIX_NORMAL` becomes `NORMAL`
  `HELIX_SELECT` becomes `SELECT`
- (breaking change) Helix users should remove `"default_mode": "helix_normal"` from their settings. This is now the default when `"helix_mode": true`.
