### PR TITLE
Forbid `std::process::Command` spawning, replace with `smol` where appropriate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -861,6 +861,7 @@ todo = "deny"
 declare_interior_mutable_const = "deny"
 
 redundant_clone = "deny"
+disallowed_methods = "deny"
 
 # We currently do not restrict any style rules
 # as it slows down shipping code to Zed.

--- a/clippy.toml
+++ b/clippy.toml
@@ -5,3 +5,12 @@ ignore-interior-mutability = [
     # and Hash impls do not use fields with interior mutability.
     "agent::context::AgentContextKey"
 ]
+disallowed-methods = [
+   { path = "std::process::Command::spawn", reason = "Spawning `std::process::Command` can block the current thread for an unknown duration", replacement = "smol::process::Command::spawn" },
+]
+disallowed-types = [
+    # { path = "std::collections::HashMap", replacement = "collections::HashMap" },
+    # { path = "std::collections::HashSet", replacement = "collections::HashSet" },
+    # { path = "indexmap::IndexSet", replacement = "collections::IndexSet" },
+    # { path = "indexmap::IndexMap", replacement = "collections::IndexMap" },
+]

--- a/clippy.toml
+++ b/clippy.toml
@@ -6,7 +6,9 @@ ignore-interior-mutability = [
     "agent::context::AgentContextKey"
 ]
 disallowed-methods = [
-   { path = "std::process::Command::spawn", reason = "Spawning `std::process::Command` can block the current thread for an unknown duration", replacement = "smol::process::Command::spawn" },
+    { path = "std::process::Command::spawn", reason = "Spawning `std::process::Command` can block the current thread for an unknown duration", replacement = "smol::process::Command::spawn" },
+    { path = "std::process::Command::output", reason = "Spawning `std::process::Command` can block the current thread for an unknown duration", replacement = "smol::process::Command::output" },
+    { path = "std::process::Command::status", reason = "Spawning `std::process::Command` can block the current thread for an unknown duration", replacement = "smol::process::Command::status" },
 ]
 disallowed-types = [
     # { path = "std::collections::HashMap", replacement = "collections::HashMap" },

--- a/crates/auto_update_helper/src/updater.rs
+++ b/crates/auto_update_helper/src/updater.rs
@@ -160,6 +160,7 @@ pub(crate) fn perform_update(app_dir: &Path, hwnd: Option<isize>, launch: bool) 
         }
     }
     if launch {
+        #[allow(clippy::disallowed_methods, reason = "doesn't run in the main binary")]
         let _ = std::process::Command::new(app_dir.join("Zed.exe"))
             .creation_flags(CREATE_NEW_PROCESS_GROUP.0)
             .spawn();

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
 use std::process::Command;
 
 fn main() {

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -970,6 +970,10 @@ mod mac_os {
                         .stdout(subprocess_stdin_file)
                         .arg(url);
 
+                    #[allow(
+                        clippy::disallowed_methods,
+                        reason = "We are starting, no use for async"
+                    )]
                     command
                         .spawn()
                         .with_context(|| format!("Spawning {command:?}"))?;
@@ -1043,6 +1047,10 @@ mod mac_os {
         }
         let app_path = String::from_utf8(app_path_output.stdout)?.trim().to_owned();
         let cli_path = format!("{app_path}/Contents/MacOS/cli");
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "We are starting, no use for async"
+        )]
         Command::new(cli_path).args(leftover_args).spawn()?;
         Ok(())
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,7 @@
+#![allow(
+    clippy::disallowed_methods,
+    reason = "We are not in an async environment, so std::process::Command is fine"
+)]
 #![cfg_attr(
     any(target_os = "linux", target_os = "freebsd", target_os = "windows"),
     allow(dead_code)
@@ -970,10 +974,6 @@ mod mac_os {
                         .stdout(subprocess_stdin_file)
                         .arg(url);
 
-                    #[allow(
-                        clippy::disallowed_methods,
-                        reason = "We are starting, no use for async"
-                    )]
                     command
                         .spawn()
                         .with_context(|| format!("Spawning {command:?}"))?;
@@ -1047,10 +1047,6 @@ mod mac_os {
         }
         let app_path = String::from_utf8(app_path_output.stdout)?.trim().to_owned();
         let cli_path = format!("{app_path}/Contents/MacOS/cli");
-        #[allow(
-            clippy::disallowed_methods,
-            reason = "We are starting, no use for async"
-        )]
         Command::new(cli_path).args(leftover_args).spawn()?;
         Ok(())
     }

--- a/crates/collections/src/collections.rs
+++ b/crates/collections/src/collections.rs
@@ -1,26 +1,7 @@
-#[cfg(feature = "test-support")]
 pub type HashMap<K, V> = FxHashMap<K, V>;
-
-#[cfg(feature = "test-support")]
 pub type HashSet<T> = FxHashSet<T>;
-
-#[cfg(feature = "test-support")]
 pub type IndexMap<K, V> = indexmap::IndexMap<K, V, rustc_hash::FxBuildHasher>;
-
-#[cfg(feature = "test-support")]
 pub type IndexSet<T> = indexmap::IndexSet<T, rustc_hash::FxBuildHasher>;
-
-#[cfg(not(feature = "test-support"))]
-pub type HashMap<K, V> = std::collections::HashMap<K, V>;
-
-#[cfg(not(feature = "test-support"))]
-pub type HashSet<T> = std::collections::HashSet<T>;
-
-#[cfg(not(feature = "test-support"))]
-pub type IndexMap<K, V> = indexmap::IndexMap<K, V>;
-
-#[cfg(not(feature = "test-support"))]
-pub type IndexSet<T> = indexmap::IndexSet<T>;
 
 pub use indexmap::Equivalent;
 pub use rustc_hash::FxHasher;

--- a/crates/explorer_command_injector/src/explorer_command_injector.rs
+++ b/crates/explorer_command_injector/src/explorer_command_injector.rs
@@ -77,6 +77,7 @@ impl IExplorerCommand_Impl for ExplorerCommandInjector_Impl {
         for idx in 0..count {
             let item = unsafe { items.GetItemAt(idx)? };
             let item_path = unsafe { item.GetDisplayName(SIGDN_FILESYSPATH)?.to_string()? };
+            #[allow(clippy::disallowed_methods, reason = "no async context in sight..")]
             std::process::Command::new(&zed_exe)
                 .arg(&item_path)
                 .spawn()

--- a/crates/extension/src/extension_builder.rs
+++ b/crates/extension/src/extension_builder.rs
@@ -142,7 +142,7 @@ impl ExtensionBuilder {
         manifest: &mut ExtensionManifest,
         options: CompileExtensionOptions,
     ) -> anyhow::Result<()> {
-        self.install_rust_wasm_target_if_needed()?;
+        self.install_rust_wasm_target_if_needed().await?;
 
         let cargo_toml_content = fs::read_to_string(extension_dir.join("Cargo.toml"))?;
         let cargo_toml: CargoToml = toml::from_str(&cargo_toml_content)?;
@@ -151,7 +151,7 @@ impl ExtensionBuilder {
             "compiling Rust crate for extension {}",
             extension_dir.display()
         );
-        let output = util::command::new_std_command("cargo")
+        let output = util::command::new_smol_command("cargo")
             .args(["build", "--target", RUST_TARGET])
             .args(options.release.then_some("--release"))
             .arg("--target-dir")
@@ -160,6 +160,7 @@ impl ExtensionBuilder {
             .env("RUSTC_WRAPPER", "")
             .current_dir(extension_dir)
             .output()
+            .await
             .context("failed to run `cargo`")?;
         if !output.status.success() {
             bail!(
@@ -235,7 +236,8 @@ impl ExtensionBuilder {
             &grammar_repo_dir,
             &grammar_metadata.repository,
             &grammar_metadata.rev,
-        )?;
+        )
+        .await?;
 
         let base_grammar_path = grammar_metadata
             .path
@@ -248,7 +250,7 @@ impl ExtensionBuilder {
         let scanner_path = src_path.join("scanner.c");
 
         log::info!("compiling {grammar_name} parser");
-        let clang_output = util::command::new_std_command(&clang_path)
+        let clang_output = util::command::new_smol_command(&clang_path)
             .args(["-fPIC", "-shared", "-Os"])
             .arg(format!("-Wl,--export=tree_sitter_{grammar_name}"))
             .arg("-o")
@@ -258,6 +260,7 @@ impl ExtensionBuilder {
             .arg(&parser_path)
             .args(scanner_path.exists().then_some(scanner_path))
             .output()
+            .await
             .context("failed to run clang")?;
 
         if !clang_output.status.success() {
@@ -271,15 +274,16 @@ impl ExtensionBuilder {
         Ok(())
     }
 
-    fn checkout_repo(&self, directory: &Path, url: &str, rev: &str) -> Result<()> {
+    async fn checkout_repo(&self, directory: &Path, url: &str, rev: &str) -> Result<()> {
         let git_dir = directory.join(".git");
 
         if directory.exists() {
-            let remotes_output = util::command::new_std_command("git")
+            let remotes_output = util::command::new_smol_command("git")
                 .arg("--git-dir")
                 .arg(&git_dir)
                 .args(["remote", "-v"])
-                .output()?;
+                .output()
+                .await?;
             let has_remote = remotes_output.status.success()
                 && String::from_utf8_lossy(&remotes_output.stdout)
                     .lines()
@@ -298,10 +302,11 @@ impl ExtensionBuilder {
             fs::create_dir_all(directory).with_context(|| {
                 format!("failed to create grammar directory {}", directory.display(),)
             })?;
-            let init_output = util::command::new_std_command("git")
+            let init_output = util::command::new_smol_command("git")
                 .arg("init")
                 .current_dir(directory)
-                .output()?;
+                .output()
+                .await?;
             if !init_output.status.success() {
                 bail!(
                     "failed to run `git init` in directory '{}'",
@@ -309,11 +314,12 @@ impl ExtensionBuilder {
                 );
             }
 
-            let remote_add_output = util::command::new_std_command("git")
+            let remote_add_output = util::command::new_smol_command("git")
                 .arg("--git-dir")
                 .arg(&git_dir)
                 .args(["remote", "add", "origin", url])
                 .output()
+                .await
                 .context("failed to execute `git remote add`")?;
             if !remote_add_output.status.success() {
                 bail!(
@@ -323,19 +329,21 @@ impl ExtensionBuilder {
             }
         }
 
-        let fetch_output = util::command::new_std_command("git")
+        let fetch_output = util::command::new_smol_command("git")
             .arg("--git-dir")
             .arg(&git_dir)
             .args(["fetch", "--depth", "1", "origin", rev])
             .output()
+            .await
             .context("failed to execute `git fetch`")?;
 
-        let checkout_output = util::command::new_std_command("git")
+        let checkout_output = util::command::new_smol_command("git")
             .arg("--git-dir")
             .arg(&git_dir)
             .args(["checkout", rev])
             .current_dir(directory)
             .output()
+            .await
             .context("failed to execute `git checkout`")?;
         if !checkout_output.status.success() {
             if !fetch_output.status.success() {
@@ -356,11 +364,12 @@ impl ExtensionBuilder {
         Ok(())
     }
 
-    fn install_rust_wasm_target_if_needed(&self) -> Result<()> {
-        let rustc_output = util::command::new_std_command("rustc")
+    async fn install_rust_wasm_target_if_needed(&self) -> Result<()> {
+        let rustc_output = util::command::new_smol_command("rustc")
             .arg("--print")
             .arg("sysroot")
             .output()
+            .await
             .context("failed to run rustc")?;
         if !rustc_output.status.success() {
             bail!(
@@ -374,11 +383,12 @@ impl ExtensionBuilder {
             return Ok(());
         }
 
-        let output = util::command::new_std_command("rustup")
+        let output = util::command::new_smol_command("rustup")
             .args(["target", "add", RUST_TARGET])
             .stderr(Stdio::piped())
             .stdout(Stdio::inherit())
             .output()
+            .await
             .context("failed to run `rustup target add`")?;
         if !output.status.success() {
             bail!(

--- a/crates/extension_cli/src/main.rs
+++ b/crates/extension_cli/src/main.rs
@@ -2,7 +2,6 @@ use std::collections::{BTreeSet, HashMap};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::Arc;
 
 use ::fs::{CopyOptions, Fs, RealFs, copy_recursive};
@@ -13,6 +12,7 @@ use extension::extension_builder::{CompileExtensionOptions, ExtensionBuilder};
 use language::LanguageConfig;
 use reqwest_client::ReqwestClient;
 use rpc::ExtensionProvides;
+use tokio::process::Command;
 use tree_sitter::{Language, Query, WasmStore};
 
 #[derive(Parser, Debug)]
@@ -89,6 +89,7 @@ async fn main() -> Result<()> {
         .current_dir(&output_dir)
         .args(["-czvf", "archive.tar.gz", "-C", "archive", "."])
         .output()
+        .await
         .context("failed to run tar")?;
     if !tar_output.status.success() {
         bail!(

--- a/crates/gpui/build.rs
+++ b/crates/gpui/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
 #![cfg_attr(any(not(target_os = "macos"), feature = "macos-blade"), allow(unused))]
 
 //TODO: consider generating shader code for WGSL

--- a/crates/gpui/src/platform/linux/platform.rs
+++ b/crates/gpui/src/platform/linux/platform.rs
@@ -204,6 +204,10 @@ impl<P: LinuxClient + 'static> Platform for P {
             app_path = app_path.display()
         );
 
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "We are restarting ourselves, using std command thus is fine"
+        )]
         let restart_process = Command::new("/usr/bin/env")
             .arg("bash")
             .arg("-c")
@@ -403,11 +407,15 @@ impl<P: LinuxClient + 'static> Platform for P {
         let path = path.to_owned();
         self.background_executor()
             .spawn(async move {
-                let _ = std::process::Command::new("xdg-open")
+                let _ = smol::process::Command::new("xdg-open")
                     .arg(path)
                     .spawn()
                     .context("invoking xdg-open")
-                    .log_err();
+                    .log_err()?
+                    .status()
+                    .await
+                    .log_err()?;
+                Some(())
             })
             .detach();
     }
@@ -591,10 +599,14 @@ pub(super) fn open_uri_internal(
                     if let Some(token) = activation_token.as_ref() {
                         command.env("XDG_ACTIVATION_TOKEN", token);
                     }
-                    match command.spawn() {
-                        Ok(_) => return,
+                    let program = format!("{:?}", command.get_program());
+                    match smol::process::Command::from(command).spawn() {
+                        Ok(mut cmd) => {
+                            cmd.status().await.log_err();
+                            return;
+                        }
                         Err(e) => {
-                            log::error!("Failed to open with {:?}: {}", command.get_program(), e)
+                            log::error!("Failed to open with {}: {}", program, e)
                         }
                     }
                 }

--- a/crates/gpui/src/platform/windows/platform.rs
+++ b/crates/gpui/src/platform/windows/platform.rs
@@ -349,6 +349,11 @@ impl Platform for WindowsPlatform {
             pid,
             app_path.display(),
         );
+
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "We are restarting ourselves, using std command thus is fine"
+        )]
         let restart_process = util::command::new_std_command("powershell.exe")
             .arg("-command")
             .arg(script)

--- a/crates/media/build.rs
+++ b/crates/media/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
 #[cfg(target_os = "macos")]
 fn main() {
     use std::{env, path::PathBuf, process::Command};

--- a/crates/project/src/environment.rs
+++ b/crates/project/src/environment.rs
@@ -249,7 +249,7 @@ async fn load_shell_environment(
     use util::shell_env;
 
     let dir_ = dir.to_owned();
-    let mut envs = match smol::unblock(move || shell_env::capture(&dir_)).await {
+    let mut envs = match shell_env::capture(&dir_).await {
         Ok(envs) => envs,
         Err(err) => {
             util::log_err(&err);

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1407,7 +1407,7 @@ impl GitStore {
             GitStoreState::Local { fs, .. } => {
                 let fs = fs.clone();
                 cx.background_executor()
-                    .spawn(async move { fs.git_init(&path, fallback_branch_name) })
+                    .spawn(async move { fs.git_init(&path, fallback_branch_name).await })
             }
             GitStoreState::Remote {
                 upstream_client,

--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -470,7 +470,7 @@ impl Project {
         TerminalSettings::get(settings_location, cx)
     }
 
-    pub fn exec_in_shell(&self, command: String, cx: &App) -> Result<std::process::Command> {
+    pub fn exec_in_shell(&self, command: String, cx: &App) -> Result<smol::process::Command> {
         let path = self.first_project_directory(cx);
         let remote_client = self.remote_client.as_ref();
         let settings = self.terminal_settings(&path, cx).clone();
@@ -508,6 +508,10 @@ impl Project {
                 Ok(command)
             }
         }
+        .map(|mut process| {
+            util::set_pre_exec_to_start_new_session(&mut process);
+            smol::process::Command::from(process)
+        })
     }
 
     pub fn local_terminal_handles(&self) -> &Vec<WeakEntity<terminal::Terminal>> {

--- a/crates/remote_server/build.rs
+++ b/crates/remote_server/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
 use std::process::Command;
 
 const ZED_MANIFEST: &str = include_str!("../zed/Cargo.toml");

--- a/crates/system_specs/src/system_specs.rs
+++ b/crates/system_specs/src/system_specs.rs
@@ -146,6 +146,10 @@ impl Display for SystemSpecs {
 fn try_determine_available_gpus() -> Option<String> {
     #[cfg(any(target_os = "linux", target_os = "freebsd"))]
     {
+        #[allow(
+            clippy::disallowed_methods,
+            reason = "we are not running in an executor"
+        )]
         std::process::Command::new("vulkaninfo")
             .args(&["--summary"])
             .output()

--- a/crates/util/src/shell_env.rs
+++ b/crates/util/src/shell_env.rs
@@ -5,7 +5,7 @@ use collections::HashMap;
 
 /// Capture all environment variables from the login shell.
 #[cfg(unix)]
-pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<String, String>> {
+pub async fn capture(directory: &std::path::Path) -> Result<collections::HashMap<String, String>> {
     use std::os::unix::process::CommandExt;
     use std::process::Stdio;
 
@@ -59,7 +59,7 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
 
     super::set_pre_exec_to_start_new_session(&mut command);
 
-    let (env_output, process_output) = spawn_and_read_fd(command, fd_num)?;
+    let (env_output, process_output) = spawn_and_read_fd(command, fd_num).await?;
     let env_output = String::from_utf8_lossy(&env_output);
 
     anyhow::ensure!(
@@ -77,7 +77,7 @@ pub fn capture(directory: &std::path::Path) -> Result<collections::HashMap<Strin
 }
 
 #[cfg(unix)]
-fn spawn_and_read_fd(
+async fn spawn_and_read_fd(
     mut command: std::process::Command,
     child_fd: std::os::fd::RawFd,
 ) -> anyhow::Result<(Vec<u8>, std::process::Output)> {
@@ -91,13 +91,12 @@ fn spawn_and_read_fd(
         child_fd,
     }])?;
 
-    let process = command.spawn()?;
-    drop(command);
+    let process = smol::process::Command::from(command).spawn()?;
 
     let mut buffer = Vec::new();
     reader.read_to_end(&mut buffer)?;
 
-    Ok((buffer, process.wait_with_output()?))
+    Ok((buffer, process.output().await?))
 }
 
 pub fn print_env() {

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -308,7 +308,7 @@ pub fn get_shell_safe_zed_path() -> anyhow::Result<String> {
 }
 
 #[cfg(unix)]
-pub fn load_login_shell_environment() -> Result<()> {
+pub async fn load_login_shell_environment() -> Result<()> {
     load_shell_from_passwd().log_err();
 
     // If possible, we want to `cd` in the user's `$HOME` to trigger programs
@@ -316,7 +316,7 @@ pub fn load_login_shell_environment() -> Result<()> {
     // into shell's `cd` command (and hooks) to manipulate env.
     // We do this so that we get the env a user would have when spawning a shell
     // in home directory.
-    for (name, value) in shell_env::capture(paths::home_dir())? {
+    for (name, value) in shell_env::capture(paths::home_dir()).await? {
         unsafe { env::set_var(&name, &value) };
     }
 

--- a/crates/vim/src/command.rs
+++ b/crates/vim/src/command.rs
@@ -6,6 +6,7 @@ use editor::{
     actions::{SortLinesCaseInsensitive, SortLinesCaseSensitive},
     display_map::ToDisplayPoint,
 };
+use futures::AsyncWriteExt as _;
 use gpui::{Action, App, AppContext as _, Context, Global, Keystroke, Task, Window, actions};
 use itertools::Itertools;
 use language::Point;
@@ -16,7 +17,6 @@ use schemars::JsonSchema;
 use search::{BufferSearchBar, SearchOptions};
 use serde::Deserialize;
 use std::{
-    io::Write,
     iter::Peekable,
     ops::{Deref, Range},
     path::Path,
@@ -1966,7 +1966,6 @@ impl ShellExec {
             process.stdin(Stdio::null());
         };
 
-        util::set_pre_exec_to_start_new_session(&mut process);
         let is_read = self.is_read;
 
         let task = cx.spawn_in(window, async move |vim, cx| {
@@ -1984,18 +1983,16 @@ impl ShellExec {
                 let range = range.clone();
                 cx.background_spawn(async move {
                     for chunk in snapshot.text_for_range(range) {
-                        if stdin.write_all(chunk.as_bytes()).log_err().is_none() {
+                        if stdin.write_all(chunk.as_bytes()).await.log_err().is_none() {
                             return;
                         }
                     }
-                    stdin.flush().log_err();
+                    stdin.flush().await.log_err();
                 })
                 .detach();
             };
 
-            let output = cx
-                .background_spawn(async move { running.wait_with_output() })
-                .await;
+            let output = cx.background_spawn(running.output()).await;
 
             let Some(output) = output.log_err() else {
                 vim.update_in(cx, |vim, window, cx| {

--- a/crates/zed/build.rs
+++ b/crates/zed/build.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods, reason = "build scripts are exempt")]
 use std::process::Command;
 
 fn main() {

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -339,7 +339,7 @@ pub fn main() {
         app.background_executor()
             .spawn(async {
                 #[cfg(unix)]
-                util::load_login_shell_environment().log_err();
+                util::load_login_shell_environment().await.log_err();
                 shell_env_loaded_tx.send(()).ok();
             })
             .detach()

--- a/tooling/perf/Cargo.toml
+++ b/tooling/perf/Cargo.toml
@@ -23,6 +23,7 @@ allow_attributes_without_reason = "deny" # This covers `expect` also, since we d
 let_underscore_must_use = "forbid"
 undocumented_unsafe_blocks = "forbid"
 missing_safety_doc = "forbid"
+disallowed_methods = { level = "allow", priority = 1}
 
 [dependencies]
 collections.workspace = true

--- a/tooling/xtask/src/tasks/clippy.rs
+++ b/tooling/xtask/src/tasks/clippy.rs
@@ -1,3 +1,4 @@
+#![allow(clippy::disallowed_methods, reason = "tooling is exempt")]
 use std::process::Command;
 
 use anyhow::{Context as _, Result, bail};


### PR DESCRIPTION
std commands can block for an arbitrary duration and so runs risk of blocking tasks for too long. This replaces all such uses where sensible with async processes.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
