### PR TITLE
keymap_editor: Fix filter input element alignment

### DIFF
--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1569,14 +1569,12 @@ impl Render for KeymapEditor {
                         h_flex()
                             .gap_2()
                             .child(
-                                div()
+                                h_flex()
                                     .key_context({
                                         let mut context = KeyContext::new_with_defaults();
                                         context.add("BufferSearchBar");
                                         context
                                     })
-                                    .flex()
-                                    .items_center()
                                     .size_full()
                                     .h_8()
                                     .pl_2()

--- a/crates/keymap_editor/src/keymap_editor.rs
+++ b/crates/keymap_editor/src/keymap_editor.rs
@@ -1575,6 +1575,8 @@ impl Render for KeymapEditor {
                                         context.add("BufferSearchBar");
                                         context
                                     })
+                                    .flex()
+                                    .items_center()
                                     .size_full()
                                     .h_8()
                                     .pl_2()


### PR DESCRIPTION
# Why

I have spotted that Keymap Editor filter input (editor) is misaligned vertically.

# How

Switch the input wrapper to flex layout, use `items_center` to align editor vertically in center of the wrapper.

Release Notes:

- Fixed Keymap Editor filter input alignment

# Test plan

I have tested the change locally and compared the UI before and after, to make sure that change does not affect the size of the wrapper element.

### Before

<img width="1622" height="428" alt="Screenshot 2025-09-25 at 18 18 59" src="https://github.com/user-attachments/assets/7d09be5c-6caf-4873-8ecf-2542851cb40a" />

### After

<img width="1622" height="428" alt="Screenshot 2025-09-25 at 18 07 18" src="https://github.com/user-attachments/assets/540fcb3e-691d-4fb7-8130-2ed45ddc0adc" />
