### PR TITLE
windows: Fix inconsistent separators in buffer headers and breadcrumbs

### DIFF
--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -159,7 +159,7 @@ pub struct FileContextHandle {
 #[derive(Debug, Clone)]
 pub struct FileContext {
     pub handle: FileContextHandle,
-    pub full_path: Arc<Path>,
+    pub full_path: String,
     pub text: SharedString,
     pub is_outline: bool,
 }
@@ -187,7 +187,7 @@ impl FileContextHandle {
             log::error!("file context missing path");
             return Task::ready(None);
         };
-        let full_path: Arc<Path> = file.full_path(cx).into();
+        let full_path = file.full_path(cx).to_string_lossy().to_string();
         let rope = buffer_ref.as_rope().clone();
         let buffer = self.buffer.clone();
 
@@ -236,7 +236,7 @@ pub struct DirectoryContextHandle {
 #[derive(Debug, Clone)]
 pub struct DirectoryContext {
     pub handle: DirectoryContextHandle,
-    pub full_path: Arc<Path>,
+    pub full_path: String,
     pub descendants: Vec<DirectoryContextDescendant>,
 }
 
@@ -274,13 +274,16 @@ impl DirectoryContextHandle {
         }
 
         let directory_path = entry.path.clone();
-        let directory_full_path = worktree_ref.full_path(&directory_path).into();
+        let directory_full_path = worktree_ref
+            .full_path(&directory_path)
+            .to_string_lossy()
+            .to_string();
 
         let file_paths = collect_files_in_path(worktree_ref, &directory_path);
         let descendants_future = future::join_all(file_paths.into_iter().map(|path| {
             let worktree_ref = worktree.read(cx);
             let worktree_id = worktree_ref.id();
-            let full_path = worktree_ref.full_path(&path);
+            let full_path = worktree_ref.full_path(&path).to_string_lossy().to_string();
 
             let rel_path = path
                 .strip_prefix(&directory_path)
@@ -361,7 +364,7 @@ pub struct SymbolContextHandle {
 #[derive(Debug, Clone)]
 pub struct SymbolContext {
     pub handle: SymbolContextHandle,
-    pub full_path: Arc<Path>,
+    pub full_path: String,
     pub line_range: Range<Point>,
     pub text: SharedString,
 }
@@ -400,7 +403,7 @@ impl SymbolContextHandle {
             log::error!("symbol context's file has no path");
             return Task::ready(None);
         };
-        let full_path = file.full_path(cx).into();
+        let full_path = file.full_path(cx).to_string_lossy().to_string();
         let line_range = self.enclosing_range.to_point(&buffer_ref.snapshot());
         let text = self.text(cx);
         let buffer = self.buffer.clone();
@@ -434,7 +437,7 @@ pub struct SelectionContextHandle {
 #[derive(Debug, Clone)]
 pub struct SelectionContext {
     pub handle: SelectionContextHandle,
-    pub full_path: Arc<Path>,
+    pub full_path: String,
     pub line_range: Range<Point>,
     pub text: SharedString,
 }
@@ -473,7 +476,7 @@ impl SelectionContextHandle {
         let text = self.text(cx);
         let buffer = self.buffer.clone();
         let context = AgentContext::Selection(SelectionContext {
-            full_path: full_path.into(),
+            full_path: full_path.to_string_lossy().to_string(),
             line_range: self.line_range(cx),
             text,
             handle: self,
@@ -703,7 +706,7 @@ impl Display for RulesContext {
 #[derive(Debug, Clone)]
 pub struct ImageContext {
     pub project_path: Option<ProjectPath>,
-    pub full_path: Option<Arc<Path>>,
+    pub full_path: Option<String>,
     pub original_image: Arc<gpui::Image>,
     // TODO: handle this elsewhere and remove `ignore-interior-mutability` opt-out in clippy.toml
     // needed due to a false positive of `clippy::mutable_key_type`.
@@ -983,14 +986,17 @@ fn collect_files_in_path(worktree: &Worktree, path: &RelPath) -> Vec<Arc<RelPath
     files
 }
 
-fn codeblock_tag(full_path: &Path, line_range: Option<Range<Point>>) -> String {
+fn codeblock_tag(full_path: &str, line_range: Option<Range<Point>>) -> String {
     let mut result = String::new();
 
-    if let Some(extension) = full_path.extension().and_then(|ext| ext.to_str()) {
+    if let Some(extension) = Path::new(full_path)
+        .extension()
+        .and_then(|ext| ext.to_str())
+    {
         let _ = write!(result, "{} ", extension);
     }
 
-    let _ = write!(result, "{}", full_path.display());
+    let _ = write!(result, "{}", full_path);
 
     if let Some(range) = line_range {
         if range.start.row == range.end.row {

--- a/crates/agent/src/context_store.rs
+++ b/crates/agent/src/context_store.rs
@@ -312,7 +312,7 @@ impl ContextStore {
                 let item = image_item.read(cx);
                 this.insert_image(
                     Some(item.project_path(cx)),
-                    Some(item.file.full_path(cx).into()),
+                    Some(item.file.full_path(cx).to_string_lossy().to_string()),
                     item.image.clone(),
                     remove_if_exists,
                     cx,
@@ -328,7 +328,7 @@ impl ContextStore {
     fn insert_image(
         &mut self,
         project_path: Option<ProjectPath>,
-        full_path: Option<Arc<Path>>,
+        full_path: Option<String>,
         image: Arc<Image>,
         remove_if_exists: bool,
         cx: &mut Context<ContextStore>,

--- a/crates/agent2/src/tools/read_file_tool.rs
+++ b/crates/agent2/src/tools/read_file_tool.rs
@@ -225,9 +225,12 @@ impl AgentTool for ReadFileTool {
                 Ok(result.into())
             } else {
                 // No line ranges specified, so check file size to see if it's too big.
-                let buffer_content =
-                    outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), cx)
-                        .await?;
+                let buffer_content = outline::get_buffer_content_or_outline(
+                    buffer.clone(),
+                    Some(&abs_path.to_string_lossy()),
+                    cx,
+                )
+                .await?;
 
                 action_log.update(cx, |log, cx| {
                     log.buffer_read(buffer.clone(), cx);

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -459,9 +459,12 @@ impl MessageEditor {
             .update(cx, |project, cx| project.open_buffer(project_path, cx));
         cx.spawn(async move |_, cx| {
             let buffer = buffer.await?;
-            let buffer_content =
-                outline::get_buffer_content_or_outline(buffer.clone(), Some(&abs_path), &cx)
-                    .await?;
+            let buffer_content = outline::get_buffer_content_or_outline(
+                buffer.clone(),
+                Some(&abs_path.to_string_lossy()),
+                &cx,
+            )
+            .await?;
 
             Ok(Mention::Text {
                 content: buffer_content.text,
@@ -1181,14 +1184,20 @@ fn full_mention_for_directory(
     abs_path: &Path,
     cx: &mut App,
 ) -> Task<Result<Mention>> {
-    fn collect_files_in_path(worktree: &Worktree, path: &RelPath) -> Vec<(Arc<RelPath>, PathBuf)> {
+    fn collect_files_in_path(worktree: &Worktree, path: &RelPath) -> Vec<(Arc<RelPath>, String)> {
         let mut files = Vec::new();
 
         for entry in worktree.child_entries(path) {
             if entry.is_dir() {
                 files.extend(collect_files_in_path(worktree, &entry.path));
             } else if entry.is_file() {
-                files.push((entry.path.clone(), worktree.full_path(&entry.path)));
+                files.push((
+                    entry.path.clone(),
+                    worktree
+                        .full_path(&entry.path)
+                        .to_string_lossy()
+                        .to_string(),
+                ));
             }
         }
 
@@ -1266,7 +1275,7 @@ fn full_mention_for_directory(
     })
 }
 
-fn render_directory_contents(entries: Vec<(Arc<RelPath>, PathBuf, String)>) -> String {
+fn render_directory_contents(entries: Vec<(Arc<RelPath>, String, String)>) -> String {
     let mut output = String::new();
     for (_relative_path, full_path, content) in entries {
         let fence = codeblock_fence_for_path(Some(&full_path), None);

--- a/crates/assistant_slash_commands/src/file_command.rs
+++ b/crates/assistant_slash_commands/src/file_command.rs
@@ -355,9 +355,7 @@ fn collect_files(
                         let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
                         append_buffer_to_output(
                             &snapshot,
-                            Some(Path::new(
-                                path_including_worktree_name.display(path_style).as_ref(),
-                            )),
+                            Some(path_including_worktree_name.display(path_style).as_ref()),
                             &mut output,
                         )
                         .log_err();
@@ -382,18 +380,18 @@ fn collect_files(
 }
 
 pub fn codeblock_fence_for_path(
-    path: Option<&Path>,
+    path: Option<&str>,
     row_range: Option<RangeInclusive<u32>>,
 ) -> String {
     let mut text = String::new();
     write!(text, "```").unwrap();
 
     if let Some(path) = path {
-        if let Some(extension) = path.extension().and_then(|ext| ext.to_str()) {
+        if let Some(extension) = Path::new(path).extension().and_then(|ext| ext.to_str()) {
             write!(text, "{} ", extension).unwrap();
         }
 
-        write!(text, "{}", path.display()).unwrap();
+        write!(text, "{path}").unwrap();
     } else {
         write!(text, "untitled").unwrap();
     }
@@ -413,12 +411,12 @@ pub struct FileCommandMetadata {
 
 pub fn build_entry_output_section(
     range: Range<usize>,
-    path: Option<&Path>,
+    path: Option<&str>,
     is_directory: bool,
     line_range: Option<Range<u32>>,
 ) -> SlashCommandOutputSection<usize> {
     let mut label = if let Some(path) = path {
-        path.to_string_lossy().to_string()
+        path.to_string()
     } else {
         "untitled".to_string()
     };
@@ -441,7 +439,7 @@ pub fn build_entry_output_section(
         } else {
             path.and_then(|path| {
                 serde_json::to_value(FileCommandMetadata {
-                    path: path.to_string_lossy().to_string(),
+                    path: path.to_string(),
                 })
                 .ok()
             })
@@ -532,7 +530,7 @@ mod custom_path_matcher {
 
 pub fn append_buffer_to_output(
     buffer: &BufferSnapshot,
-    path: Option<&Path>,
+    path: Option<&str>,
     output: &mut SlashCommandOutput,
 ) -> Result<()> {
     let prev_len = output.text.len();

--- a/crates/assistant_slash_commands/src/selection_command.rs
+++ b/crates/assistant_slash_commands/src/selection_command.rs
@@ -137,7 +137,9 @@ pub fn selections_creases(
             None
         };
         let language_name = language_name.as_deref().unwrap_or("");
-        let filename = snapshot.file_at(range.start).map(|file| file.full_path(cx));
+        let filename = snapshot
+            .file_at(range.start)
+            .map(|file| file.full_path(cx).to_string_lossy().to_string());
         let text = if language_name == "markdown" {
             selected_text
                 .lines()
@@ -187,9 +189,9 @@ pub fn selections_creases(
             let start_line = range.start.row + 1;
             let end_line = range.end.row + 1;
             if start_line == end_line {
-                format!("{}, Line {}", path.display(), start_line)
+                format!("{path}, Line {start_line}")
             } else {
-                format!("{}, Lines {} to {}", path.display(), start_line, end_line)
+                format!("{path}, Lines {start_line} to {end_line}")
             }
         } else {
             "Quoted selection".to_string()

--- a/crates/assistant_slash_commands/src/symbols_command.rs
+++ b/crates/assistant_slash_commands/src/symbols_command.rs
@@ -7,8 +7,8 @@ use editor::Editor;
 use gpui::{AppContext as _, Task, WeakEntity};
 use language::{BufferSnapshot, LspAdapterDelegate};
 use std::sync::Arc;
-use std::{path::Path, sync::atomic::AtomicBool};
-use ui::{App, IconName, Window};
+use std::sync::atomic::AtomicBool;
+use ui::{App, IconName, SharedString, Window};
 use workspace::Workspace;
 
 pub struct OutlineSlashCommand;
@@ -67,13 +67,13 @@ impl SlashCommand for OutlineSlashCommand {
             };
 
             let snapshot = buffer.read(cx).snapshot();
-            let path = snapshot.resolve_file_path(cx, true);
+            let path = snapshot.resolve_file_path(true, cx);
 
             cx.background_spawn(async move {
                 let outline = snapshot.outline(None);
 
-                let path = path.as_deref().unwrap_or(Path::new("untitled"));
-                let mut outline_text = format!("Symbols for {}:\n", path.display());
+                let path = path.as_deref().unwrap_or("untitled");
+                let mut outline_text = format!("Symbols for {path}:\n");
                 for item in &outline.path_candidates {
                     outline_text.push_str("- ");
                     outline_text.push_str(&item.string);
@@ -84,7 +84,7 @@ impl SlashCommand for OutlineSlashCommand {
                     sections: vec![SlashCommandOutputSection {
                         range: 0..outline_text.len(),
                         icon: IconName::ListTree,
-                        label: path.to_string_lossy().to_string().into(),
+                        label: SharedString::new(path),
                         metadata: None,
                     }],
                     text: outline_text,

--- a/crates/assistant_tool/src/outline.rs
+++ b/crates/assistant_tool/src/outline.rs
@@ -5,7 +5,6 @@ use language::{Buffer, OutlineItem, ParseStatus};
 use project::Project;
 use regex::Regex;
 use std::fmt::Write;
-use std::path::Path;
 use text::Point;
 
 /// For files over this size, instead of reading them (or including them in context),
@@ -143,7 +142,7 @@ pub struct BufferContent {
 /// For smaller files, returns the full content.
 pub async fn get_buffer_content_or_outline(
     buffer: Entity<Buffer>,
-    path: Option<&Path>,
+    path: Option<&str>,
     cx: &AsyncApp,
 ) -> Result<BufferContent> {
     let file_size = buffer.read_with(cx, |buffer, _| buffer.text().len())?;
@@ -170,15 +169,10 @@ pub async fn get_buffer_content_or_outline(
 
         let text = if let Some(path) = path {
             format!(
-                "# File outline for {} (file too large to show full content)\n\n{}",
-                path.display(),
-                outline_text
+                "# File outline for {path} (file too large to show full content)\n\n{outline_text}",
             )
         } else {
-            format!(
-                "# File outline (file too large to show full content)\n\n{}",
-                outline_text
-            )
+            format!("# File outline (file too large to show full content)\n\n{outline_text}",)
         };
         Ok(BufferContent {
             text,

--- a/crates/assistant_tools/src/edit_agent.rs
+++ b/crates/assistant_tools/src/edit_agent.rs
@@ -26,13 +26,13 @@ use language_model::{
 use project::{AgentLocation, Project};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use std::{cmp, iter, mem, ops::Range, path::PathBuf, pin::Pin, sync::Arc, task::Poll};
+use std::{cmp, iter, mem, ops::Range, pin::Pin, sync::Arc, task::Poll};
 use streaming_diff::{CharOperation, StreamingDiff};
 use streaming_fuzzy_matcher::StreamingFuzzyMatcher;
 
 #[derive(Serialize)]
 struct CreateFilePromptTemplate {
-    path: Option<PathBuf>,
+    path: Option<String>,
     edit_description: String,
 }
 
@@ -42,7 +42,7 @@ impl Template for CreateFilePromptTemplate {
 
 #[derive(Serialize)]
 struct EditFileXmlPromptTemplate {
-    path: Option<PathBuf>,
+    path: Option<String>,
     edit_description: String,
 }
 
@@ -52,7 +52,7 @@ impl Template for EditFileXmlPromptTemplate {
 
 #[derive(Serialize)]
 struct EditFileDiffFencedPromptTemplate {
-    path: Option<PathBuf>,
+    path: Option<String>,
     edit_description: String,
 }
 
@@ -115,7 +115,7 @@ impl EditAgent {
         let conversation = conversation.clone();
         let output = cx.spawn(async move |cx| {
             let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
-            let path = cx.update(|cx| snapshot.resolve_file_path(cx, true))?;
+            let path = cx.update(|cx| snapshot.resolve_file_path(true, cx))?;
             let prompt = CreateFilePromptTemplate {
                 path,
                 edit_description,
@@ -229,7 +229,7 @@ impl EditAgent {
         let edit_format = self.edit_format;
         let output = cx.spawn(async move |cx| {
             let snapshot = buffer.read_with(cx, |buffer, _| buffer.snapshot())?;
-            let path = cx.update(|cx| snapshot.resolve_file_path(cx, true))?;
+            let path = cx.update(|cx| snapshot.resolve_file_path(true, cx))?;
             let prompt = match edit_format {
                 EditFormat::XmlTags => EditFileXmlPromptTemplate {
                     path,

--- a/crates/assistant_tools/src/read_file_tool.rs
+++ b/crates/assistant_tools/src/read_file_tool.rs
@@ -261,9 +261,8 @@ impl Tool for ReadFileTool {
                 Ok(result)
             } else {
                 // No line ranges specified, so check file size to see if it's too big.
-                let path_buf = std::path::PathBuf::from(&file_path);
                 let buffer_content =
-                    outline::get_buffer_content_or_outline(buffer.clone(), Some(&path_buf), cx)
+                    outline::get_buffer_content_or_outline(buffer.clone(), Some(&file_path), cx)
                         .await?;
 
                 action_log.update(cx, |log, cx| {

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -3782,13 +3782,17 @@ impl EditorElement {
         let file = for_excerpt.buffer.file();
         let can_open_excerpts = Editor::can_open_excerpts_in_file(file);
         let path_style = file.map(|file| file.path_style(cx));
-        let relative_path = for_excerpt.buffer.resolve_file_path(cx, include_root);
-        let filename = relative_path
-            .as_ref()
-            .and_then(|path| Some(path.file_name()?.to_string_lossy().to_string()));
-        let parent_path = relative_path.as_ref().and_then(|path| {
-            Some(path.parent()?.to_string_lossy().to_string() + path_style?.separator())
-        });
+        let relative_path = for_excerpt.buffer.resolve_file_path(include_root, cx);
+        let (parent_path, filename) = if let Some(path) = &relative_path {
+            if let Some(path_style) = path_style {
+                let (dir, file_name) = path_style.split(path);
+                (dir.map(|dir| dir.to_owned()), Some(file_name.to_owned()))
+            } else {
+                (None, Some(path.clone()))
+            }
+        } else {
+            (None, None)
+        };
         let focus_handle = editor.focus_handle(cx);
         let colors = cx.theme().colors();
 

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -963,13 +963,12 @@ impl Item for Editor {
             buffer
                 .snapshot()
                 .resolve_file_path(
-                    cx,
                     self.project
                         .as_ref()
                         .map(|project| project.read(cx).visible_worktrees(cx).count() > 1)
                         .unwrap_or_default(),
+                    cx,
                 )
-                .map(|path| path.to_string_lossy().to_string())
                 .unwrap_or_else(|| {
                     if multibuffer.is_singleton() {
                         multibuffer.title(cx).to_string()

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4628,12 +4628,12 @@ impl BufferSnapshot {
         self.file.as_ref()
     }
 
-    pub fn resolve_file_path(&self, cx: &App, include_root: bool) -> Option<PathBuf> {
+    pub fn resolve_file_path(&self, include_root: bool, cx: &App) -> Option<String> {
         if let Some(file) = self.file() {
             if file.path().file_name().is_none() || include_root {
-                Some(file.full_path(cx))
+                Some(file.full_path(cx).to_string_lossy().to_string())
             } else {
-                Some(file.path().as_std_path().to_owned())
+                Some(file.path().display(file.path_style(cx)).to_string())
             }
         } else {
             None

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -280,6 +280,17 @@ impl PathStyle {
             ))
         }
     }
+
+    pub fn split(self, path_like: &str) -> (Option<&str>, &str) {
+        let Some(pos) = path_like.rfind(self.separator()) else {
+            return (None, path_like);
+        };
+        let filename_start = pos + self.separator().len();
+        (
+            Some(&path_like[..filename_start]),
+            &path_like[filename_start..],
+        )
+    }
 }
 
 #[derive(Debug, Clone)]


### PR DESCRIPTION
Make `resolve_full_path` use the appropriate separators, and return a `String`.

As part of fixing the fallout from that type change, this also fixes a bunch of places in the agent code that were using `std::path::Path` operations on paths that could be non-local, by changing them to operate instead on strings and use the project's `PathStyle`.

This clears the way a bit for making `full_path` also return a string instead of a `PathBuf`, but I've left that for a follow-up.

Release Notes:

- N/A