### PR TITLE
windows: Make `ctrl-n` open a new terminal when in a terminal

### DIFF
--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -1112,6 +1112,7 @@
       "alt-f": ["terminal::SendText", "\u001bf"],
       "alt-.": ["terminal::SendText", "\u001b."],
       "ctrl-delete": ["terminal::SendText", "\u001bd"],
+      "ctrl-n": "workspace::NewTerminal",
       // Overrides for conflicting keybindings
       "ctrl-b": ["terminal::SendKeystroke", "ctrl-b"],
       "ctrl-c": ["terminal::SendKeystroke", "ctrl-c"],


### PR DESCRIPTION
This is also how `cmd-n` works on macOS. Right now `ctrl-n` from a terminal on Windows with the default keymap usually causes a new buffer to open, which is inconvenient.

Release Notes:

- N/A