### PR TITLE
zeta_cli: Add `--output-format both` and `--prompt-format only-snippets`

### DIFF
--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -48,6 +48,7 @@ pub enum PromptFormat {
     #[default]
     MarkedExcerpt,
     LabeledSections,
+    OnlySnippets,
 }
 
 impl PromptFormat {
@@ -61,6 +62,7 @@ impl std::fmt::Display for PromptFormat {
         match self {
             PromptFormat::MarkedExcerpt => write!(f, "Marked Excerpt"),
             PromptFormat::LabeledSections => write!(f, "Labeled Sections"),
+            PromptFormat::OnlySnippets => write!(f, "Only Snippets"),
         }
     }
 }

--- a/crates/cloud_llm_client/src/predict_edits_v3.rs
+++ b/crates/cloud_llm_client/src/predict_edits_v3.rs
@@ -48,6 +48,7 @@ pub enum PromptFormat {
     #[default]
     MarkedExcerpt,
     LabeledSections,
+    /// Prompt format intended for use via zeta_cli
     OnlySnippets,
 }
 

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -54,6 +54,7 @@ pub fn system_prompt(format: PromptFormat) -> &'static str {
     match format {
         PromptFormat::MarkedExcerpt => MARKED_EXCERPT_SYSTEM_PROMPT,
         PromptFormat::LabeledSections => LABELED_SECTIONS_SYSTEM_PROMPT,
+        PromptFormat::OnlySnippets => "todo!",
     }
 }
 
@@ -317,7 +318,9 @@ impl<'a> PlannedPrompt<'a> {
             text: &self.request.excerpt,
             text_is_truncated: false,
         };
-        excerpt_file_snippets.push(&excerpt_snippet);
+        if !matches!(self.request.prompt_format, PromptFormat::OnlySnippets) {
+            excerpt_file_snippets.push(&excerpt_snippet);
+        }
         file_snippets.push((&self.request.excerpt_path, excerpt_file_snippets, true));
 
         let mut excerpt_file_insertions = match self.request.prompt_format {
@@ -343,6 +346,7 @@ impl<'a> PlannedPrompt<'a> {
                 self.request.excerpt_range.start + self.request.cursor_offset,
                 CURSOR_MARKER,
             )],
+            PromptFormat::OnlySnippets => vec![],
         };
 
         let mut prompt = String::new();
@@ -436,7 +440,7 @@ impl<'a> PlannedPrompt<'a> {
                 let section_index = section_ranges.len();
 
                 match self.request.prompt_format {
-                    PromptFormat::MarkedExcerpt => {
+                    PromptFormat::MarkedExcerpt | PromptFormat::OnlySnippets => {
                         if range.start > 0 {
                             output.push_str("…\n");
                         }

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -54,7 +54,8 @@ pub fn system_prompt(format: PromptFormat) -> &'static str {
     match format {
         PromptFormat::MarkedExcerpt => MARKED_EXCERPT_SYSTEM_PROMPT,
         PromptFormat::LabeledSections => LABELED_SECTIONS_SYSTEM_PROMPT,
-        PromptFormat::OnlySnippets => "todo!",
+        // only intended for use via zeta_cli
+        PromptFormat::OnlySnippets => "",
     }
 }
 

--- a/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
+++ b/crates/cloud_zeta2_prompt/src/cloud_zeta2_prompt.rs
@@ -487,7 +487,11 @@ impl<'a> PlannedPrompt<'a> {
         }
 
         Ok(SectionLabels {
-            excerpt_index: excerpt_index.context("bug: no snippet found for excerpt")?,
+            // TODO: Clean this up
+            excerpt_index: match self.request.prompt_format {
+                PromptFormat::OnlySnippets => 0,
+                _ => excerpt_index.context("bug: no snippet found for excerpt")?,
+            },
             section_ranges,
         })
     }

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -15,6 +15,7 @@ use language_model::LlmApiToken;
 use project::{Project, ProjectPath, Worktree};
 use release_channel::AppVersion;
 use reqwest_client::ReqwestClient;
+use serde_json::json;
 use std::path::{Path, PathBuf};
 use std::process::exit;
 use std::str::FromStr;
@@ -102,6 +103,7 @@ enum OutputFormat {
     #[default]
     Prompt,
     Request,
+    Both,
 }
 
 #[derive(Debug, Clone)]
@@ -269,16 +271,19 @@ async fn get_context(
                             zeta.cloud_request_for_zeta_cli(&project, &buffer, cursor, cx)
                         })?
                         .await?;
+
+                    let planned_prompt = cloud_zeta2_prompt::PlannedPrompt::populate(&request)?;
+                    // TODO: Output the section label ranges
+                    let prompt_string = planned_prompt.to_prompt_string()?.0;
                     match zeta2_args.output_format {
-                        OutputFormat::Prompt => {
-                            let planned_prompt =
-                                cloud_zeta2_prompt::PlannedPrompt::populate(&request)?;
-                            // TODO: Output the section label ranges
-                            anyhow::Ok(planned_prompt.to_prompt_string()?.0)
-                        }
+                        OutputFormat::Prompt => anyhow::Ok(prompt_string),
                         OutputFormat::Request => {
                             anyhow::Ok(serde_json::to_string_pretty(&request)?)
                         }
+                        OutputFormat::Both => anyhow::Ok(serde_json::to_string_pretty(&json!({
+                            "request": request,
+                            "prompt": prompt_string,
+                        }))?),
                     }
                 })
             })?

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -275,7 +275,6 @@ async fn get_context(
                         .await?;
 
                     let planned_prompt = cloud_zeta2_prompt::PlannedPrompt::populate(&request)?;
-                    // TODO: Output the section label ranges
                     let prompt_string = planned_prompt.to_prompt_string()?.0;
                     match zeta2_args.output_format {
                         OutputFormat::Prompt => anyhow::Ok(prompt_string),

--- a/crates/zeta_cli/src/main.rs
+++ b/crates/zeta_cli/src/main.rs
@@ -87,6 +87,7 @@ enum PromptFormat {
     #[default]
     MarkedExcerpt,
     LabeledSections,
+    OnlySnippets,
 }
 
 impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
@@ -94,6 +95,7 @@ impl Into<predict_edits_v3::PromptFormat> for PromptFormat {
         match self {
             Self::MarkedExcerpt => predict_edits_v3::PromptFormat::MarkedExcerpt,
             Self::LabeledSections => predict_edits_v3::PromptFormat::LabeledSections,
+            Self::OnlySnippets => predict_edits_v3::PromptFormat::OnlySnippets,
         }
     }
 }


### PR DESCRIPTION
These are options are probably temporary, added for use in some experimental code 

Release Notes:

- N/A