### PR TITLE
x_ai: Fix `Model::from_id` for Grok 4

### DIFF
--- a/crates/x_ai/src/x_ai.rs
+++ b/crates/x_ai/src/x_ai.rs
@@ -18,7 +18,7 @@ pub enum Model {
     Grok3Fast,
     #[serde(rename = "grok-3-mini-fast-latest")]
     Grok3MiniFast,
-    #[serde(rename = "grok-4-latest")]
+    #[serde(rename = "grok-4", alias = "grok-4-latest")]
     Grok4,
     #[serde(rename = "grok-code-fast-1")]
     GrokCodeFast1,
@@ -40,6 +40,7 @@ impl Model {
 
     pub fn from_id(id: &str) -> Result<Self> {
         match id {
+            "grok-4" => Ok(Self::Grok4),
             "grok-2-vision" => Ok(Self::Grok2Vision),
             "grok-3" => Ok(Self::Grok3),
             "grok-3-mini" => Ok(Self::Grok3Mini),


### PR DESCRIPTION
This PR fixes `x_ai::Model::from_id`, which was not properly handling `grok-4`.

Release Notes:

- N/A
