### PR TITLE
Disable subpixel shifting for y axis on Linux

### DIFF
--- a/crates/gpui/src/platform/linux/text_system.rs
+++ b/crates/gpui/src/platform/linux/text_system.rs
@@ -1,7 +1,7 @@
 use crate::{
     Bounds, DevicePixels, Font, FontFeatures, FontId, FontMetrics, FontRun, FontStyle, FontWeight,
     GlyphId, LineLayout, Pixels, PlatformTextSystem, Point, RenderGlyphParams, SUBPIXEL_VARIANTS_X,
-    ShapedGlyph, ShapedRun, SharedString, Size, point, size,
+    SUBPIXEL_VARIANTS_Y, ShapedGlyph, ShapedRun, SharedString, Size, point, size,
 };
 use anyhow::{Context as _, Ok, Result};
 use collections::HashMap;
@@ -274,9 +274,10 @@ impl CosmicTextSystemState {
 
     fn raster_bounds(&mut self, params: &RenderGlyphParams) -> Result<Bounds<DevicePixels>> {
         let font = &self.loaded_fonts[params.font_id.0].font;
-        let subpixel_shift = params
-            .subpixel_variant
-            .map(|v| v as f32 / (SUBPIXEL_VARIANTS_X as f32 * params.scale_factor));
+        let subpixel_shift = point(
+            params.subpixel_variant.x as f32 / SUBPIXEL_VARIANTS_X as f32 / params.scale_factor,
+            params.subpixel_variant.y as f32 / SUBPIXEL_VARIANTS_Y as f32 / params.scale_factor,
+        );
         let image = self
             .swash_cache
             .get_image(
@@ -309,9 +310,10 @@ impl CosmicTextSystemState {
         } else {
             let bitmap_size = glyph_bounds.size;
             let font = &self.loaded_fonts[params.font_id.0].font;
-            let subpixel_shift = params
-                .subpixel_variant
-                .map(|v| v as f32 / (SUBPIXEL_VARIANTS_X as f32 * params.scale_factor));
+            let subpixel_shift = point(
+                params.subpixel_variant.x as f32 / SUBPIXEL_VARIANTS_X as f32 / params.scale_factor,
+                params.subpixel_variant.y as f32 / SUBPIXEL_VARIANTS_Y as f32 / params.scale_factor,
+            );
             let mut image = self
                 .swash_cache
                 .get_image(

--- a/crates/gpui/src/text_system.rs
+++ b/crates/gpui/src/text_system.rs
@@ -43,11 +43,12 @@ pub struct FontFamilyId(pub usize);
 
 pub(crate) const SUBPIXEL_VARIANTS_X: u8 = 4;
 
-pub(crate) const SUBPIXEL_VARIANTS_Y: u8 = if cfg!(target_os = "windows") {
-    1
-} else {
-    SUBPIXEL_VARIANTS_X
-};
+pub(crate) const SUBPIXEL_VARIANTS_Y: u8 =
+    if cfg!(target_os = "windows") || cfg!(target_os = "linux") {
+        1
+    } else {
+        SUBPIXEL_VARIANTS_X
+    };
 
 /// The GPUI text rendering sub system.
 pub struct TextSystem {


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/7992
Port of #38440

<img width="3836" height="2142" alt="zed_nightly_vs_zed_dev_2" src="https://github.com/user-attachments/assets/66bcbb9a-2159-4790-8a9a-d4814058d966" />

Does not change the rendering on Linux, but prepares us for the times without cosmic-text where this will be needed.

Release Notes:

- N/A 
