### PR TITLE
Fix up Wild package name and decompression

### DIFF
--- a/script/install-wild
+++ b/script/install-wild
@@ -20,10 +20,10 @@ if [ "$(whoami)" = root ]; then SUDO=; else SUDO="$(command -v sudo || command -
 
 ARCH="$(uname -m)"
 WILD_REPO="${WILD_REPO:-https://github.com/davidlattimore/wild}"
-WILD_PACKAGE="wild-linker-${ARCH}-unknown-linux-gnu"
+WILD_PACKAGE="wild-linker-${WILD_VERSION}-${ARCH}-unknown-linux-gnu"
 WILD_URL="${WILD_URL:-$WILD_REPO}/releases/download/$WILD_VERSION/${WILD_PACKAGE}.tar.gz"
 
 echo "Downloading from $WILD_URL"
 curl -fsSL --output - "$WILD_URL" \
-    | $SUDO tar -C /usr/local/bin --strip-components=1 --no-overwrite-dir -xJf - \
-    "wild-linker-${ARCH}-unknown-linux-gnu/wild"
+    | $SUDO tar -C /usr/local/bin --strip-components=1 --no-overwrite-dir -xzf - \
+    "${WILD_PACKAGE}/wild"


### PR DESCRIPTION
Wild changed in 0.6.0 to using gzip rather than xz, and changed the format of the package name.

Follows on from and fixes https://github.com/zed-industries/zed/pull/37717

cc @dvdsk @mati865 

Release Notes:

- N/A