### PR TITLE
Stop using linear color space on Linux Blade renderer

### DIFF
--- a/crates/gpui/src/platform/blade/blade_atlas.rs
+++ b/crates/gpui/src/platform/blade/blade_atlas.rs
@@ -163,7 +163,7 @@ impl BladeAtlasState {
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
             AtlasTextureKind::Polychrome => {
-                format = gpu::TextureFormat::Bgra8UnormSrgb;
+                format = gpu::TextureFormat::Bgra8Unorm;
                 usage = gpu::TextureUsage::COPY | gpu::TextureUsage::RESOURCE;
             }
         }

--- a/crates/gpui/src/platform/blade/blade_renderer.rs
+++ b/crates/gpui/src/platform/blade/blade_renderer.rs
@@ -353,7 +353,7 @@ impl BladeRenderer {
             size: config.size,
             usage: gpu::TextureUsage::TARGET,
             display_sync: gpu::DisplaySync::Recent,
-            color_space: gpu::ColorSpace::Linear,
+            color_space: gpu::ColorSpace::Srgb,
             allow_exclusive_full_screen: false,
             transparent: config.transparent,
         };


### PR DESCRIPTION
Part of https://github.com/zed-industries/zed/issues/7992
Closes https://github.com/zed-industries/zed/issues/22711

Left is main, right is patched.

* default font

<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/c4e3d18a-a0dd-48b8-a1f0-182407655efb" />
<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/6eea07e7-1676-422c-961f-05bc72677fad" />


<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/4d9e30dc-6905-48ad-849d-48eac6ebed03" />
<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/ef20986e-c29c-4fe0-9f20-56da4fb0ac29" />


* font size 7

<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/8b277e92-9ae4-4415-8903-68566b580f5a" />
<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/b9140e73-81af-430b-b07f-af118c7e3dae" />

<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/185f526a-241e-4573-af1d-f27aedeac48e" />
<img width="3862" height="2152" alt="image" src="https://github.com/user-attachments/assets/7a239121-ae13-4db9-99d9-785ec26cd98e" />


Release Notes:

- Improved color rendering on Linux
