### PR TITLE
ui: Display `option` in lowercase in Vim mode keybindings

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -473,6 +473,7 @@ fn keystroke_text(
     if modifiers.alt {
         match (platform_style, vim_mode) {
             (PlatformStyle::Mac, false) => text.push_str("Option"),
+            (PlatformStyle::Mac, true) => text.push_str("option"),
             (PlatformStyle::Linux | PlatformStyle::Windows, false) => text.push_str("Alt"),
             (_, true) => text.push_str("alt"),
         }


### PR DESCRIPTION
# Why

Spotted that some tooltips include `alt` keystroke combination on macOS.

# How

Add missing `vim_mode` version definition of `Option` key to the `keystroke_text` helper.

Release Notes:

- Fixed keystroke to text helper output for macOS `Option` key in Vim mode

# Preview

### Before

<img width="712" height="264" alt="Screenshot 2025-09-26 at 16 57 08" src="https://github.com/user-attachments/assets/d5daa37f-0da7-4430-91ea-4a750c025472" />

### After

<img width="712" height="264" alt="Screenshot 2025-09-26 at 16 56 21" src="https://github.com/user-attachments/assets/5804ed39-9b1b-4028-a9c9-32c066042f4a" />
