### PR TITLE
ui: Fix Vim mode detection in keybinding to text helpers

### DIFF
--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -392,6 +392,7 @@ pub fn text_for_action(action: &dyn Action, window: &Window, cx: &App) -> Option
 
 pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {
     let platform_style = PlatformStyle::platform();
+    let vim_enabled = KeyBinding::is_vim_mode(cx);
     keystrokes
         .iter()
         .map(|keystroke| {
@@ -399,7 +400,7 @@ pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {
                 &keystroke.modifiers,
                 &keystroke.key,
                 platform_style,
-                KeyBinding::is_vim_mode(cx),
+                vim_enabled,
             )
         })
         .join(" ")
@@ -407,6 +408,7 @@ pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {
 
 pub fn text_for_keybinding_keystrokes(keystrokes: &[KeybindingKeystroke], cx: &App) -> String {
     let platform_style = PlatformStyle::platform();
+    let vim_enabled = KeyBinding::is_vim_mode(cx);
     keystrokes
         .iter()
         .map(|keystroke| {
@@ -414,7 +416,7 @@ pub fn text_for_keybinding_keystrokes(keystrokes: &[KeybindingKeystroke], cx: &A
                 keystroke.modifiers(),
                 keystroke.key(),
                 platform_style,
-                KeyBinding::is_vim_mode(cx),
+                vim_enabled,
             )
         })
         .join(" ")

--- a/crates/ui/src/components/keybinding.rs
+++ b/crates/ui/src/components/keybinding.rs
@@ -392,7 +392,6 @@ pub fn text_for_action(action: &dyn Action, window: &Window, cx: &App) -> Option
 
 pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {
     let platform_style = PlatformStyle::platform();
-    let vim_enabled = cx.try_global::<VimStyle>().is_some();
     keystrokes
         .iter()
         .map(|keystroke| {
@@ -400,7 +399,7 @@ pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {
                 &keystroke.modifiers,
                 &keystroke.key,
                 platform_style,
-                vim_enabled,
+                KeyBinding::is_vim_mode(cx),
             )
         })
         .join(" ")
@@ -408,7 +407,6 @@ pub fn text_for_keystrokes(keystrokes: &[Keystroke], cx: &App) -> String {
 
 pub fn text_for_keybinding_keystrokes(keystrokes: &[KeybindingKeystroke], cx: &App) -> String {
     let platform_style = PlatformStyle::platform();
-    let vim_enabled = cx.try_global::<VimStyle>().is_some();
     keystrokes
         .iter()
         .map(|keystroke| {
@@ -416,7 +414,7 @@ pub fn text_for_keybinding_keystrokes(keystrokes: &[KeybindingKeystroke], cx: &A
                 keystroke.modifiers(),
                 keystroke.key(),
                 platform_style,
-                vim_enabled,
+                KeyBinding::is_vim_mode(cx),
             )
         })
         .join(" ")
@@ -424,8 +422,7 @@ pub fn text_for_keybinding_keystrokes(keystrokes: &[KeybindingKeystroke], cx: &A
 
 pub fn text_for_keystroke(modifiers: &Modifiers, key: &str, cx: &App) -> String {
     let platform_style = PlatformStyle::platform();
-    let vim_enabled = cx.try_global::<VimStyle>().is_some();
-    keystroke_text(modifiers, key, platform_style, vim_enabled)
+    keystroke_text(modifiers, key, platform_style, KeyBinding::is_vim_mode(cx))
 }
 
 /// Returns a textual representation of the given [`Keystroke`].


### PR DESCRIPTION
# Why

Refs:
* #38969

When working on the PR above I have spotted that keybinding to text helpers incorrectly detects if Vim mode is enabled.

# How

Replace inline check with an existing `KeyBinding::is_vim_mode` method in keybinding text helpers.

Release Notes:

- Fixed incorrect Vim mode detection in UI keybinding to text helpers.

# Test plan

Made sure that when Vim mode is not specified in settings file it resolves to `false`, and correct keybindings are displayed, than I have added the `"vim_mode": true,` line to my settings file and made sure that keybindings text have changed accordingly.

### Before

<img width="712" height="264" alt="Screenshot 2025-09-26 at 16 57 08" src="https://github.com/user-attachments/assets/62bc24bd-c335-420f-9c2e-3690031518c1" />

### After

<img width="712" height="264" alt="Screenshot 2025-09-26 at 17 13 50" src="https://github.com/user-attachments/assets/e0088897-eb6b-4d7b-855a-931adcc15fe8" />

