### PR TITLE
editor: Replace hardcoded keystroke in Excerpt Fold Toggle tooltip

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -43,7 +43,7 @@ use gpui::{
     Bounds, ClickEvent, ClipboardItem, ContentMask, Context, Corner, Corners, CursorStyle,
     DispatchPhase, Edges, Element, ElementInputHandler, Entity, Focusable as _, FontId,
     GlobalElementId, Hitbox, HitboxBehavior, Hsla, InteractiveElement, IntoElement, IsZero,
-    KeybindingKeystroke, Length, ModifiersChangedEvent, MouseButton, MouseClickEvent,
+    KeybindingKeystroke, Length, Modifiers, ModifiersChangedEvent, MouseButton, MouseClickEvent,
     MouseDownEvent, MouseMoveEvent, MouseUpEvent, PaintQuad, ParentElement, Pixels, ScrollDelta,
     ScrollHandle, ScrollWheelEvent, ShapedLine, SharedString, Size, StatefulInteractiveElement,
     Style, Styled, TextRun, TextStyleRefinement, WeakEntity, Window, anchored, deferred, div, fill,
@@ -86,7 +86,7 @@ use theme::{ActiveTheme, Appearance, BufferLineHeight, PlayerColor};
 use ui::utils::ensure_minimum_contrast;
 use ui::{
     ButtonLike, ContextMenu, Indicator, KeyBinding, POPOVER_Y_PADDING, Tooltip, h_flex, prelude::*,
-    right_click_menu, scrollbars::ShowScrollbar,
+    right_click_menu, scrollbars::ShowScrollbar, text_for_keystroke,
 };
 use unicode_segmentation::UnicodeSegmentation;
 use util::post_inc;
@@ -3844,11 +3844,14 @@ impl EditorElement {
                                                 Tooltip::with_meta_in(
                                                     "Toggle Excerpt Fold",
                                                     Some(&ToggleFold),
-                                                    if cfg!(target_os = "macos") {
-                                                        "Option+click to toggle all"
-                                                    } else {
-                                                        "Alt+click to toggle all"
-                                                    },
+                                                    format!(
+                                                        "{} to toggle all",
+                                                        text_for_keystroke(
+                                                            &Modifiers::alt(),
+                                                            "click",
+                                                            cx
+                                                        )
+                                                    ),
                                                     &focus_handle,
                                                     window,
                                                     cx,


### PR DESCRIPTION
# Why

I have recently corrected this tooltip content for macOS, but recently have learnt that keystroke to text helpers already exist in the codebase.

# How

Replace hardcoded keystroke for Excerpt Fold Toggle in Uncommitted Changes tab.

> [!important]
> Should be merged after #38969 and #38971, otherwise it would be a regression on macOS.

Release Notes:

- N/A

# Preview (stacked on mentioned above PRs)

<img width="618" height="248" alt="Screenshot 2025-09-26 at 17 43 53" src="https://github.com/user-attachments/assets/cdc7fb74-e1d8-4a59-b847-8a8d2edd4641" />

