### PR TITLE
Show config messages from install-wild, install-mold

### DIFF
--- a/script/install-mold
+++ b/script/install-mold
@@ -35,3 +35,13 @@ curl -fsSL --output - "$MOLD_URL" \
 
 # Note this binary depends on the system libatomic.so.1 which is usually
 # provided as a dependency of gcc so it should be available on most systems.
+
+cat <<EOF
+Mold is installed to /usr/local/bin/mold
+
+To make it your default, add or merge these lines into your ~/.cargo/config.toml:
+
+[target.'cfg(target_os = "linux")']
+linker = "clang"
+rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+EOF

--- a/script/install-wild
+++ b/script/install-wild
@@ -22,8 +22,23 @@ ARCH="$(uname -m)"
 WILD_REPO="${WILD_REPO:-https://github.com/davidlattimore/wild}"
 WILD_PACKAGE="wild-linker-${WILD_VERSION}-${ARCH}-unknown-linux-gnu"
 WILD_URL="${WILD_URL:-$WILD_REPO}/releases/download/$WILD_VERSION/${WILD_PACKAGE}.tar.gz"
+DEST_DIR=/usr/local/bin
 
 echo "Downloading from $WILD_URL"
 curl -fsSL --output - "$WILD_URL" \
-    | $SUDO tar -C /usr/local/bin --strip-components=1 --no-overwrite-dir -xzf - \
+    | $SUDO tar -C ${DEST_DIR} --strip-components=1 --no-overwrite-dir -xzf - \
     "${WILD_PACKAGE}/wild"
+
+cat <<EOF
+Wild is installed to ${DEST_DIR}/wild
+
+To make it your default, add or merge these lines into your ~/.cargo/config.toml:
+
+[target.x86_64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=--ld-path=wild"]
+
+[target.aarch64-unknown-linux-gnu]
+linker = "clang"
+rustflags = ["-C", "link-arg=--ld-path=wild"]
+EOF

--- a/script/linux
+++ b/script/linux
@@ -14,17 +14,6 @@ function finalize {
   cat <<EOF
 Note: It's recommended to install and configure Wild or Mold for faster builds.
       Run script/install-wild or script/install-mold.
-      Then add these lines to your ~/.cargo/config.toml:
-
-[target.x86_64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=--ld-path=wild"]
-
-[target.aarch64-unknown-linux-gnu]
-linker = "clang"
-rustflags = ["-C", "link-arg=--ld-path=wild"]
-
-
 
 Finished installing Linux dependencies with script/linux
 EOF


### PR DESCRIPTION
Follows on from https://github.com/zed-industries/zed/pull/37717#discussion_r2376739687

@dvdsk suggested this but I didn't get to it in the previous PR.

# Tested

```
; sudo rm /usr/local/bin/wild
; ./script/install-wild
Downloading from https://github.com/davidlattimore/wild/releases/download/0.6.0/wild-linker-0.6.0-x86_64-unknown-linux-gnu.tar.gz
Wild is installed to /usr/local/bin/wild

To make it your default, add or merge these lines into your ~/.cargo/config.toml:

[target.x86_64-unknown-linux-gnu]
linker = "clang"
rustflags = ["-C", "link-arg=--ld-path=wild"]

[target.aarch64-unknown-linux-gnu]
linker = "clang"
rustflags = ["-C", "link-arg=--ld-path=wild"]

```

```
; sudo rm /usr/local/bin/mold
; ./script/install-mold 2.34.0
Downloading from https://github.com/rui314/mold/releases/download/v2.34.0/mold-2.34.0-x86_64-linux.tar.gz
Mold is installed to /usr/local/bin/mold

To make it your default, add or merge these lines into your ~/.cargo/config.toml:

[target.'cfg(target_os = "linux")']
linker = "clang"
rustflags = ["-C", "link-arg=-fuse-ld=mold"]
```

Release Notes:

- N/A