### PR TITLE
Revert "Fix arrow function detection in TypeScript/JavaScript outline (#38411)"

### DIFF
--- a/crates/languages/src/javascript/outline.scm
+++ b/crates/languages/src/javascript/outline.scm
@@ -116,26 +116,4 @@
     )
 ) @item
 
-; Arrow functions in variable declarations (anywhere in the tree, including nested in functions)
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (arrow_function)) @item)
-
-; Async arrow functions in variable declarations
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (arrow_function
-            "async" @context)) @item)
-
-; Named function expressions in variable declarations
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (function_expression)) @item)
-
 (comment) @annotation

--- a/crates/languages/src/tsx/outline.scm
+++ b/crates/languages/src/tsx/outline.scm
@@ -124,26 +124,4 @@
     )
 ) @item
 
-; Arrow functions in variable declarations (anywhere in the tree, including nested in functions)
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (arrow_function)) @item)
-
-; Async arrow functions in variable declarations
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (arrow_function
-            "async" @context)) @item)
-
-; Named function expressions in variable declarations
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (function_expression)) @item)
-
 (comment) @annotation

--- a/crates/languages/src/typescript/outline.scm
+++ b/crates/languages/src/typescript/outline.scm
@@ -124,26 +124,4 @@
     )
 ) @item
 
-; Arrow functions in variable declarations (anywhere in the tree, including nested in functions)
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (arrow_function)) @item)
-
-; Async arrow functions in variable declarations
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (arrow_function
-            "async" @context)) @item)
-
-; Named function expressions in variable declarations
-(lexical_declaration
-    ["let" "const"] @context
-    (variable_declarator
-        name: (_) @name
-        value: (function_expression)) @item)
-
 (comment) @annotation


### PR DESCRIPTION
This reverts commit 1bbf98aea6f335e791f19d8f76ba8a5f0510937f.

We found that #38411 caused problems where anonymous functions are included too many times in the outline. We'd like to figure out a better fix before shipping this to stable.

Fixes #38956

Release Notes:

- (preview only) revert changes to outline view