### PR TITLE
editor: Do not panic on `tab_size > 16`, cap it at 128

### DIFF
--- a/crates/editor/src/display_map/block_map.rs
+++ b/crates/editor/src/display_map/block_map.rs
@@ -26,8 +26,8 @@ use sum_tree::{Bias, ContextLessSummary, Dimensions, SumTree, TreeMap};
 use text::{BufferId, Edit};
 use ui::ElementId;
 
-const NEWLINES: &[u8] = &[b'\n'; u128::BITS as usize];
-const BULLETS: &str = "********************************************************************************************************************************";
+const NEWLINES: &[u8; u128::BITS as usize] = &[b'\n'; _];
+const BULLETS: &[u8; u128::BITS as usize] = &[b'*'; _];
 
 /// Tracks custom blocks such as diagnostics that should be displayed within buffer.
 ///
@@ -1774,7 +1774,7 @@ impl<'a> Iterator for BlockChunks<'a> {
             // need to have the same number of bytes in the input as output.
             let chars_count = prefix.chars().count();
             let bullet_len = chars_count;
-            prefix = &BULLETS[..bullet_len];
+            prefix = unsafe { std::str::from_utf8_unchecked(&BULLETS[..bullet_len]) };
             chars = 1u128.unbounded_shl(bullet_len as u32) - 1;
             tabs = 0;
         }

--- a/crates/language/src/language.rs
+++ b/crates/language/src/language.rs
@@ -760,6 +760,7 @@ pub struct LanguageConfig {
     pub hard_tabs: Option<bool>,
     /// How many columns a tab should occupy.
     #[serde(default)]
+    #[schemars(range(min = 1, max = 128))]
     pub tab_size: Option<NonZeroU32>,
     /// How to soft-wrap long lines of text.
     #[serde(default)]
@@ -856,6 +857,7 @@ pub struct BlockCommentConfig {
     /// A character to add as a prefix when a new line is added to a block comment.
     pub prefix: Arc<str>,
     /// A indent to add for prefix and end line upon new line.
+    #[schemars(range(min = 1, max = 128))]
     pub tab_size: u32,
 }
 

--- a/crates/settings/src/settings_content/language.rs
+++ b/crates/settings/src/settings_content/language.rs
@@ -170,6 +170,7 @@ pub struct LanguageSettingsContent {
     /// How many columns a tab should occupy.
     ///
     /// Default: 4
+    #[schemars(range(min = 1, max = 128))]
     pub tab_size: Option<NonZeroU32>,
     /// Whether to indent lines using tab characters, as opposed to multiple
     /// spaces.


### PR DESCRIPTION
Fixes ZED-1PT
Fixes ZED-1PW
Fixes ZED-1G2

Release Notes:

- Fixed Zed panicking when the `tab_size` is set higher than 16
