### PR TITLE
fsevent: Check `CFURLCreateFromFileSystemRepresentation` return value

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6269,6 +6269,7 @@ dependencies = [
  "bitflags 2.9.0",
  "core-foundation 0.10.0",
  "fsevent-sys 3.1.0",
+ "log",
  "parking_lot",
  "tempfile",
  "workspace-hack",

--- a/crates/fsevent/Cargo.toml
+++ b/crates/fsevent/Cargo.toml
@@ -15,6 +15,7 @@ doctest = false
 [dependencies]
 bitflags.workspace = true
 parking_lot.workspace = true
+log.workspace = true
 workspace-hack.workspace = true
 
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/crates/fsevent/src/fsevent.rs
+++ b/crates/fsevent/src/fsevent.rs
@@ -70,10 +70,14 @@ impl EventStream {
                     path_bytes.len() as cf::CFIndex,
                     false,
                 );
-                let cf_path = cf::CFURLCopyFileSystemPath(cf_url, cf::kCFURLPOSIXPathStyle);
-                cf::CFArrayAppendValue(cf_paths, cf_path);
-                cf::CFRelease(cf_path);
-                cf::CFRelease(cf_url);
+                if !cf_url.is_null() {
+                    let cf_path = cf::CFURLCopyFileSystemPath(cf_url, cf::kCFURLPOSIXPathStyle);
+                    cf::CFArrayAppendValue(cf_paths, cf_path);
+                    cf::CFRelease(cf_path);
+                    cf::CFRelease(cf_url);
+                } else {
+                    log::error!("Failed to create CFURL for path: {}", path.display());
+                }
             }
 
             let mut state = Box::new(State {


### PR DESCRIPTION
Fixes ZED-1T

Release Notes:

- Fixed a segmentation fault on macOS fervent stream creation
