### PR TITLE
git: Fix commit modal tooltip incorrect keybinding shown in amend mode

### DIFF
--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -455,7 +455,11 @@ impl CommitModal {
                                 if can_commit {
                                     Tooltip::with_meta_in(
                                         tooltip,
-                                        Some(if is_amend_pending { &git::Amend } else { &git::Commit }),
+                                        Some(if is_amend_pending {
+                                            &git::Amend
+                                        } else {
+                                            &git::Commit
+                                        }),
                                         format!(
                                             "git commit{}{}",
                                             if is_amend_pending { " --amend" } else { "" },

--- a/crates/git_ui/src/commit_modal.rs
+++ b/crates/git_ui/src/commit_modal.rs
@@ -455,7 +455,7 @@ impl CommitModal {
                                 if can_commit {
                                     Tooltip::with_meta_in(
                                         tooltip,
-                                        Some(&git::Commit),
+                                        Some(if is_amend_pending { &git::Amend } else { &git::Commit }),
                                         format!(
                                             "git commit{}{}",
                                             if is_amend_pending { " --amend" } else { "" },

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3458,7 +3458,7 @@ impl GitPanel {
                         if can_commit {
                             Tooltip::with_meta_in(
                                 tooltip,
-                                Some(&git::Commit),
+                                Some(if amend { &git::Amend } else { &git::Commit }),
                                 format!(
                                     "git commit{}{}",
                                     if amend { " --amend" } else { "" },


### PR DESCRIPTION
Closes #38783

Release Notes:

- Updated commit modal tooltip to show correct shortcut in amend mode; `cmd+enter` -> `shift+cmd+enter`
