### PR TITLE
Use `into_owned` over `to_string` for `Cow<str>`

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -573,7 +573,7 @@ impl ToolCallContent {
             ))),
             acp::ToolCallContent::Diff { diff } => Ok(Self::Diff(cx.new(|cx| {
                 Diff::finalized(
-                    diff.path.to_string_lossy().to_string(),
+                    diff.path.to_string_lossy().into_owned(),
                     diff.old_text,
                     diff.new_text,
                     language_registry,

--- a/crates/agent/src/context.rs
+++ b/crates/agent/src/context.rs
@@ -187,7 +187,7 @@ impl FileContextHandle {
             log::error!("file context missing path");
             return Task::ready(None);
         };
-        let full_path = file.full_path(cx).to_string_lossy().to_string();
+        let full_path = file.full_path(cx).to_string_lossy().into_owned();
         let rope = buffer_ref.as_rope().clone();
         let buffer = self.buffer.clone();
 
@@ -283,7 +283,7 @@ impl DirectoryContextHandle {
         let descendants_future = future::join_all(file_paths.into_iter().map(|path| {
             let worktree_ref = worktree.read(cx);
             let worktree_id = worktree_ref.id();
-            let full_path = worktree_ref.full_path(&path).to_string_lossy().to_string();
+            let full_path = worktree_ref.full_path(&path).to_string_lossy().into_owned();
 
             let rel_path = path
                 .strip_prefix(&directory_path)
@@ -403,7 +403,7 @@ impl SymbolContextHandle {
             log::error!("symbol context's file has no path");
             return Task::ready(None);
         };
-        let full_path = file.full_path(cx).to_string_lossy().to_string();
+        let full_path = file.full_path(cx).to_string_lossy().into_owned();
         let line_range = self.enclosing_range.to_point(&buffer_ref.snapshot());
         let text = self.text(cx);
         let buffer = self.buffer.clone();
@@ -476,7 +476,7 @@ impl SelectionContextHandle {
         let text = self.text(cx);
         let buffer = self.buffer.clone();
         let context = AgentContext::Selection(SelectionContext {
-            full_path: full_path.to_string_lossy().to_string(),
+            full_path: full_path.to_string_lossy().into_owned(),
             line_range: self.line_range(cx),
             text,
             handle: self,

--- a/crates/agent/src/context_store.rs
+++ b/crates/agent/src/context_store.rs
@@ -312,7 +312,7 @@ impl ContextStore {
                 let item = image_item.read(cx);
                 this.insert_image(
                     Some(item.project_path(cx)),
-                    Some(item.file.full_path(cx).to_string_lossy().to_string()),
+                    Some(item.file.full_path(cx).to_string_lossy().into_owned()),
                     item.image.clone(),
                     remove_if_exists,
                     cx,

--- a/crates/agent/src/history_store.rs
+++ b/crates/agent/src/history_store.rs
@@ -155,7 +155,7 @@ impl HistoryStore {
             .iter()
             .filter_map(|entry| match entry {
                 HistoryEntryId::Context(path) => path.file_name().map(|file| {
-                    SerializedRecentOpen::ContextName(file.to_string_lossy().to_string())
+                    SerializedRecentOpen::ContextName(file.to_string_lossy().into_owned())
                 }),
                 HistoryEntryId::Thread(id) => Some(SerializedRecentOpen::Thread(id.to_string())),
             })

--- a/crates/agent/src/thread.rs
+++ b/crates/agent/src/thread.rs
@@ -2875,7 +2875,7 @@ impl Thread {
             // Get worktree path and snapshot
             let worktree_info = cx.update(|app_cx| {
                 let worktree = worktree.read(app_cx);
-                let path = worktree.abs_path().to_string_lossy().to_string();
+                let path = worktree.abs_path().to_string_lossy().into_owned();
                 let snapshot = worktree.snapshot();
                 (path, snapshot)
             });

--- a/crates/agent2/src/history_store.rs
+++ b/crates/agent2/src/history_store.rs
@@ -262,7 +262,7 @@ impl HistoryStore {
             .iter()
             .filter_map(|entry| match entry {
                 HistoryEntryId::TextThread(path) => path.file_name().map(|file| {
-                    SerializedRecentOpen::TextThread(file.to_string_lossy().to_string())
+                    SerializedRecentOpen::TextThread(file.to_string_lossy().into_owned())
                 }),
                 HistoryEntryId::AcpThread(id) => {
                     Some(SerializedRecentOpen::AcpThread(id.to_string()))

--- a/crates/agent2/src/thread.rs
+++ b/crates/agent2/src/thread.rs
@@ -898,7 +898,7 @@ impl Thread {
             // Get worktree path and snapshot
             let worktree_info = cx.update(|app_cx| {
                 let worktree = worktree.read(app_cx);
-                let path = worktree.abs_path().to_string_lossy().to_string();
+                let path = worktree.abs_path().to_string_lossy().into_owned();
                 let snapshot = worktree.snapshot();
                 (path, snapshot)
             });

--- a/crates/agent2/src/tools/edit_file_tool.rs
+++ b/crates/agent2/src/tools/edit_file_tool.rs
@@ -218,7 +218,7 @@ impl AgentTool for EditFileTool {
                         .read(cx)
                         .short_full_path_for_project_path(&project_path, cx)
                 })
-                .unwrap_or(input.path.to_string_lossy().to_string())
+                .unwrap_or(input.path.to_string_lossy().into_owned())
                 .into(),
             Err(raw_input) => {
                 if let Some(input) =
@@ -476,7 +476,7 @@ impl AgentTool for EditFileTool {
     ) -> Result<()> {
         event_stream.update_diff(cx.new(|cx| {
             Diff::finalized(
-                output.input_path.to_string_lossy().to_string(),
+                output.input_path.to_string_lossy().into_owned(),
                 Some(output.old_text.to_string()),
                 output.new_text,
                 self.language_registry.clone(),

--- a/crates/agent2/src/tools/open_tool.rs
+++ b/crates/agent2/src/tools/open_tool.rs
@@ -104,7 +104,7 @@ mod tests {
     async fn test_to_absolute_path(cx: &mut TestAppContext) {
         init_test(cx);
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let temp_path = temp_dir.path().to_string_lossy().to_string();
+        let temp_path = temp_dir.path().to_string_lossy().into_owned();
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(

--- a/crates/agent_servers/src/claude.rs
+++ b/crates/agent_servers/src/claude.rs
@@ -62,7 +62,7 @@ impl AgentServer for ClaudeCode {
         cx: &mut App,
     ) -> Task<Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>> {
         let name = self.name();
-        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().to_string());
+        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().into_owned());
         let is_remote = delegate.project.read(cx).is_via_remote_server();
         let store = delegate.store.downgrade();
         let extra_env = load_proxy_env(cx);

--- a/crates/agent_servers/src/custom.rs
+++ b/crates/agent_servers/src/custom.rs
@@ -67,7 +67,7 @@ impl crate::AgentServer for CustomAgentServer {
         cx: &mut App,
     ) -> Task<Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>> {
         let name = self.name();
-        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().to_string());
+        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().into_owned());
         let is_remote = delegate.project.read(cx).is_via_remote_server();
         let default_mode = self.default_mode(cx);
         let store = delegate.store.downgrade();

--- a/crates/agent_servers/src/gemini.rs
+++ b/crates/agent_servers/src/gemini.rs
@@ -31,7 +31,7 @@ impl AgentServer for Gemini {
         cx: &mut App,
     ) -> Task<Result<(Rc<dyn AgentConnection>, Option<task::SpawnInTerminal>)>> {
         let name = self.name();
-        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().to_string());
+        let root_dir = root_dir.map(|root_dir| root_dir.to_string_lossy().into_owned());
         let is_remote = delegate.project.read(cx).is_via_remote_server();
         let store = delegate.store.downgrade();
         let mut extra_env = load_proxy_env(cx);

--- a/crates/agent_ui/src/terminal_inline_assistant.rs
+++ b/crates/agent_ui/src/terminal_inline_assistant.rs
@@ -238,7 +238,7 @@ impl TerminalInlineAssistant {
                 let latest_output = terminal.last_n_non_empty_lines(DEFAULT_CONTEXT_LINES);
                 let working_directory = terminal
                     .working_directory()
-                    .map(|path| path.to_string_lossy().to_string());
+                    .map(|path| path.to_string_lossy().into_owned());
                 (latest_output, working_directory)
             })
             .ok()

--- a/crates/assistant_slash_command/src/extension_slash_command.rs
+++ b/crates/assistant_slash_command/src/extension_slash_command.rs
@@ -50,7 +50,7 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
     }
 
     fn root_path(&self) -> String {
-        self.0.worktree_root_path().to_string_lossy().to_string()
+        self.0.worktree_root_path().to_string_lossy().into_owned()
     }
 
     async fn read_text_file(&self, path: &RelPath) -> Result<String> {
@@ -61,7 +61,7 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
         self.0
             .which(binary_name.as_ref())
             .await
-            .map(|path| path.to_string_lossy().to_string())
+            .map(|path| path.to_string_lossy().into_owned())
     }
 
     async fn shell_env(&self) -> Vec<(String, String)> {

--- a/crates/assistant_slash_commands/src/selection_command.rs
+++ b/crates/assistant_slash_commands/src/selection_command.rs
@@ -139,7 +139,7 @@ pub fn selections_creases(
         let language_name = language_name.as_deref().unwrap_or("");
         let filename = snapshot
             .file_at(range.start)
-            .map(|file| file.full_path(cx).to_string_lossy().to_string());
+            .map(|file| file.full_path(cx).to_string_lossy().into_owned());
         let text = if language_name == "markdown" {
             selected_text
                 .lines()

--- a/crates/assistant_tools/src/find_path_tool.rs
+++ b/crates/assistant_tools/src/find_path_tool.rs
@@ -262,7 +262,7 @@ impl ToolCard for FindPathToolCard {
                     .children(self.paths.iter().enumerate().map(|(index, path)| {
                         let path_clone = path.clone();
                         let workspace_clone = workspace.clone();
-                        let button_label = path.to_string_lossy().to_string();
+                        let button_label = path.to_string_lossy().into_owned();
 
                         Button::new(("path", index), button_label)
                             .icon(IconName::ArrowUpRight)

--- a/crates/assistant_tools/src/open_tool.rs
+++ b/crates/assistant_tools/src/open_tool.rs
@@ -104,7 +104,7 @@ mod tests {
     async fn test_to_absolute_path(cx: &mut TestAppContext) {
         init_test(cx);
         let temp_dir = TempDir::new().expect("Failed to create temp directory");
-        let temp_path = temp_dir.path().to_string_lossy().to_string();
+        let temp_path = temp_dir.path().to_string_lossy().into_owned();
 
         let fs = FakeFs::new(cx.executor());
         fs.insert_tree(

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -143,7 +143,7 @@ fn parse_path_with_position(argument_str: &str) -> anyhow::Result<String> {
         }
         .with_context(|| format!("parsing as path with position {argument_str}"))?,
     };
-    Ok(canonicalized.to_string(|path| path.to_string_lossy().to_string()))
+    Ok(canonicalized.to_string(|path| path.to_string_lossy().into_owned()))
 }
 
 fn parse_path_in_wsl(source: &str, wsl: &str) -> Result<String> {
@@ -320,12 +320,12 @@ fn main() -> Result<()> {
             urls.push(path.to_string());
         } else if path == "-" && args.paths_with_position.len() == 1 {
             let file = NamedTempFile::new()?;
-            paths.push(file.path().to_string_lossy().to_string());
+            paths.push(file.path().to_string_lossy().into_owned());
             let (file, _) = file.keep()?;
             stdin_tmp_file = Some(file);
         } else if let Some(file) = anonymous_fd(path) {
             let tmp_file = NamedTempFile::new()?;
-            paths.push(tmp_file.path().to_string_lossy().to_string());
+            paths.push(tmp_file.path().to_string_lossy().into_owned());
             let (tmp_file, _) = tmp_file.keep()?;
             anonymous_fd_tmp_files.push((file, tmp_file));
         } else if let Some(wsl) = wsl {

--- a/crates/context_server/src/client.rs
+++ b/crates/context_server/src/client.rs
@@ -172,7 +172,7 @@ impl Client {
         let server_name = binary
             .executable
             .file_name()
-            .map(|name| name.to_string_lossy().to_string())
+            .map(|name| name.to_string_lossy().into_owned())
             .unwrap_or_else(String::new);
 
         let timeout = binary.timeout.map(Duration::from_millis);

--- a/crates/dap/src/adapters.rs
+++ b/crates/dap/src/adapters.rs
@@ -238,7 +238,7 @@ impl DebugAdapterBinary {
             cwd: self
                 .cwd
                 .as_ref()
-                .map(|cwd| cwd.to_string_lossy().to_string()),
+                .map(|cwd| cwd.to_string_lossy().into_owned()),
             connection: self.connection.as_ref().map(|c| c.to_proto()),
             launch_type: match self.request_args.request {
                 StartDebuggingRequestArgumentsRequest::Launch => {

--- a/crates/dap_adapters/src/codelldb.rs
+++ b/crates/dap_adapters/src/codelldb.rs
@@ -332,7 +332,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
         _: &mut AsyncApp,
     ) -> Result<DebugAdapterBinary> {
         let mut command = user_installed_path
-            .map(|p| p.to_string_lossy().to_string())
+            .map(|p| p.to_string_lossy().into_owned())
             .or(self.path_to_codelldb.get().cloned());
 
         if command.is_none() {
@@ -372,7 +372,7 @@ impl DebugAdapter for CodeLldbDebugAdapter {
                 }
             };
             let adapter_dir = version_path.join("extension").join("adapter");
-            let path = adapter_dir.join("codelldb").to_string_lossy().to_string();
+            let path = adapter_dir.join("codelldb").to_string_lossy().into_owned();
             self.path_to_codelldb.set(path.clone()).ok();
             command = Some(path);
         };

--- a/crates/dap_adapters/src/go.rs
+++ b/crates/dap_adapters/src/go.rs
@@ -415,11 +415,11 @@ impl DebugAdapter for GoDebugAdapter {
         let dlv_path = adapter_path.join("dlv");
 
         let delve_path = if let Some(path) = user_installed_path {
-            path.to_string_lossy().to_string()
+            path.to_string_lossy().into_owned()
         } else if let Some(path) = delegate.which(OsStr::new("dlv")).await {
-            path.to_string_lossy().to_string()
+            path.to_string_lossy().into_owned()
         } else if delegate.fs().is_file(&dlv_path).await {
-            dlv_path.to_string_lossy().to_string()
+            dlv_path.to_string_lossy().into_owned()
         } else {
             let go = delegate
                 .which(OsStr::new("go"))
@@ -443,7 +443,7 @@ impl DebugAdapter for GoDebugAdapter {
                 );
             }
 
-            adapter_path.join("dlv").to_string_lossy().to_string()
+            adapter_path.join("dlv").to_string_lossy().into_owned()
         };
 
         let cwd = Some(

--- a/crates/dap_adapters/src/javascript.rs
+++ b/crates/dap_adapters/src/javascript.rs
@@ -138,11 +138,11 @@ impl JsDebugAdapter {
         };
 
         let arguments = if let Some(mut args) = user_args {
-            args.insert(0, adapter_path.to_string_lossy().to_string());
+            args.insert(0, adapter_path.to_string_lossy().into_owned());
             args
         } else {
             vec![
-                adapter_path.to_string_lossy().to_string(),
+                adapter_path.to_string_lossy().into_owned(),
                 port.to_string(),
                 host.to_string(),
             ]

--- a/crates/dap_adapters/src/python.rs
+++ b/crates/dap_adapters/src/python.rs
@@ -46,7 +46,7 @@ impl PythonDebugAdapter {
                 "Using user-installed debugpy adapter from: {}",
                 user_installed_path.display()
             );
-            vec![user_installed_path.to_string_lossy().to_string()]
+            vec![user_installed_path.to_string_lossy().into_owned()]
         } else {
             let adapter_path = paths::debug_adapters_dir().join(Self::DEBUG_ADAPTER_NAME.as_ref());
             let path = adapter_path
@@ -264,7 +264,7 @@ impl PythonDebugAdapter {
             name = delegate
                 .which(OsStr::new(cmd))
                 .await
-                .map(|path| path.to_string_lossy().to_string());
+                .map(|path| path.to_string_lossy().into_owned());
             if name.is_some() {
                 break;
             }

--- a/crates/debug_adapter_extension/src/extension_dap_adapter.rs
+++ b/crates/debug_adapter_extension/src/extension_dap_adapter.rs
@@ -55,7 +55,7 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
     }
 
     fn root_path(&self) -> String {
-        self.0.worktree_root_path().to_string_lossy().to_string()
+        self.0.worktree_root_path().to_string_lossy().into_owned()
     }
 
     async fn read_text_file(&self, path: &RelPath) -> Result<String> {
@@ -66,7 +66,7 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
         self.0
             .which(binary_name.as_ref())
             .await
-            .map(|path| path.to_string_lossy().to_string())
+            .map(|path| path.to_string_lossy().into_owned())
     }
 
     async fn shell_env(&self) -> Vec<(String, String)> {

--- a/crates/debugger_ui/src/attach_modal.rs
+++ b/crates/debugger_ui/src/attach_modal.rs
@@ -373,7 +373,7 @@ fn get_processes_for_project(project: &Entity<Project>, cx: &mut App) -> Task<Ar
                     command: process
                         .cmd()
                         .iter()
-                        .map(|s| s.to_string_lossy().to_string())
+                        .map(|s| s.to_string_lossy().into_owned())
                         .collect::<Vec<_>>(),
                 }
             })

--- a/crates/debugger_ui/src/new_process_modal.rs
+++ b/crates/debugger_ui/src/new_process_modal.rs
@@ -1578,7 +1578,7 @@ impl PickerDelegate for DebugDelegate {
 
 pub(crate) fn resolve_path(path: &mut String) {
     if path.starts_with('~') {
-        let home = paths::home_dir().to_string_lossy().to_string();
+        let home = paths::home_dir().to_string_lossy().into_owned();
         let trimmed_path = path.trim().to_owned();
         *path = trimmed_path.replacen('~', &home, 1);
     } else if let Some(strip_path) = path.strip_prefix(&format!(".{}", std::path::MAIN_SEPARATOR)) {

--- a/crates/debugger_ui/src/tests/debugger_panel.rs
+++ b/crates/debugger_ui/src/tests/debugger_panel.rs
@@ -351,7 +351,7 @@ async fn test_handle_successful_run_in_terminal_reverse_request(
         .fake_reverse_request::<RunInTerminal>(RunInTerminalRequestArguments {
             kind: None,
             title: None,
-            cwd: std::env::temp_dir().to_string_lossy().to_string(),
+            cwd: std::env::temp_dir().to_string_lossy().into_owned(),
             args: vec![],
             env: None,
             args_can_be_interpreted_by_shell: None,

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -4030,7 +4030,7 @@ impl EditorElement {
                                     Some(Box::new(zed_actions::workspace::CopyPath)),
                                     window.handler_for(&editor, move |_, _, cx| {
                                         cx.write_to_clipboard(ClipboardItem::new_string(
-                                            abs_path.to_string_lossy().to_string(),
+                                            abs_path.to_string_lossy().into_owned(),
                                         ));
                                     }),
                                 )

--- a/crates/editor/src/items.rs
+++ b/crates/editor/src/items.rs
@@ -640,7 +640,7 @@ impl Item for Editor {
             .and_then(|f| f.as_local())?
             .abs_path(cx);
 
-        let file_path = file_path.compact().to_string_lossy().to_string();
+        let file_path = file_path.compact().to_string_lossy().into_owned();
 
         Some(file_path.into())
     }
@@ -1909,7 +1909,7 @@ fn path_for_file<'a>(
                 return None;
             }
         }
-        Some(full_path.to_string_lossy().to_string().into())
+        Some(full_path.to_string_lossy().into_owned().into())
     } else {
         let mut path = file.path().strip_prefix(prefix).ok()?;
         if !include_filename {

--- a/crates/editor/src/persistence.rs
+++ b/crates/editor/src/persistence.rs
@@ -35,7 +35,7 @@ impl Bind for SerializedEditor {
             &self
                 .abs_path
                 .as_ref()
-                .map(|p| p.to_string_lossy().to_string()),
+                .map(|p| p.to_string_lossy().into_owned()),
             start_index,
         )?;
         let start_index = statement.bind(&self.contents, start_index)?;

--- a/crates/eval/src/examples/mod.rs
+++ b/crates/eval/src/examples/mod.rs
@@ -106,7 +106,7 @@ impl DeclarativeExample {
     }
 
     pub fn name_from_path(path: &Path) -> String {
-        path.file_stem().unwrap().to_string_lossy().to_string()
+        path.file_stem().unwrap().to_string_lossy().into_owned()
     }
 }
 

--- a/crates/eval/src/instance.rs
+++ b/crates/eval/src/instance.rs
@@ -164,7 +164,7 @@ impl ExampleInstance {
         } else {
             println!("{}Creating worktree", self.log_prefix);
 
-            let worktree_path_string = worktree_path.to_string_lossy().to_string();
+            let worktree_path_string = worktree_path.to_string_lossy().into_owned();
 
             run_git(
                 &self.repo_path,

--- a/crates/explorer_command_injector/src/explorer_command_injector.rs
+++ b/crates/explorer_command_injector/src/explorer_command_injector.rs
@@ -181,7 +181,7 @@ fn get_zed_install_folder() -> Option<PathBuf> {
 
 #[inline]
 fn get_zed_exe_path() -> Option<String> {
-    get_zed_install_folder().map(|path| path.join("Zed.exe").to_string_lossy().to_string())
+    get_zed_install_folder().map(|path| path.join("Zed.exe").to_string_lossy().into_owned())
 }
 
 #[inline]

--- a/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
+++ b/crates/extension_host/src/wasm_host/wit/since_v0_6_0.rs
@@ -724,7 +724,7 @@ impl nodejs::Host for WasmState {
             .node_runtime
             .binary_path()
             .await
-            .map(|path| path.to_string_lossy().to_string())
+            .map(|path| path.to_string_lossy().into_owned())
             .to_wasmtime_result()
     }
 

--- a/crates/fs/src/fs.rs
+++ b/crates/fs/src/fs.rs
@@ -2642,8 +2642,8 @@ fn atomic_replace<P: AsRef<Path>>(
 
     unsafe {
         ReplaceFileW(
-            &HSTRING::from(replaced_file.as_ref().to_string_lossy().to_string()),
-            &HSTRING::from(replacement_file.as_ref().to_string_lossy().to_string()),
+            &HSTRING::from(replaced_file.as_ref().to_string_lossy().into_owned()),
+            &HSTRING::from(replacement_file.as_ref().to_string_lossy().into_owned()),
             None,
             REPLACE_FILE_FLAGS::default(),
             None,

--- a/crates/git/src/repository.rs
+++ b/crates/git/src/repository.rs
@@ -1869,7 +1869,7 @@ async fn exclude_files(git: &GitBinary) -> Result<GitExcludeOverride> {
     if !excluded_paths.is_empty() {
         let exclude_patterns = excluded_paths
             .into_iter()
-            .map(|path| path.to_string_lossy().to_string())
+            .map(|path| path.to_string_lossy().into_owned())
             .collect::<Vec<_>>()
             .join("\n");
         excludes.add_excludes(&exclude_patterns).await?;

--- a/crates/git_ui/src/file_diff_view.rs
+++ b/crates/git_ui/src/file_diff_view.rs
@@ -241,7 +241,7 @@ impl Item for FileDiffView {
             buffer
                 .read(cx)
                 .file()
-                .map(|file| file.full_path(cx).compact().to_string_lossy().to_string())
+                .map(|file| file.full_path(cx).compact().to_string_lossy().into_owned())
                 .unwrap_or_else(|| "untitled".into())
         };
         let old_path = path(&self.old_buffer);

--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -2085,7 +2085,7 @@ impl GitPanel {
                             .to_string()
                             .into()
                     } else {
-                        worktree_abs_path.to_string_lossy().to_string().into()
+                        worktree_abs_path.to_string_lossy().into_owned().into()
                     }
                 })
                 .collect_vec();

--- a/crates/git_ui/src/text_diff_view.rs
+++ b/crates/git_ui/src/text_diff_view.rs
@@ -193,7 +193,7 @@ impl TextDiffView {
             .and_then(|b| {
                 b.read(cx)
                     .file()
-                    .map(|f| f.full_path(cx).compact().to_string_lossy().to_string())
+                    .map(|f| f.full_path(cx).compact().to_string_lossy().into_owned())
             })
             .unwrap_or("untitled".into());
 

--- a/crates/gpui/examples/animation.rs
+++ b/crates/gpui/examples/animation.rs
@@ -21,7 +21,7 @@ impl AssetSource for Assets {
         Ok(std::fs::read_dir(path)?
             .filter_map(|entry| {
                 Some(SharedString::from(
-                    entry.ok()?.path().to_string_lossy().to_string(),
+                    entry.ok()?.path().to_string_lossy().into_owned(),
                 ))
             })
             .collect::<Vec<_>>())

--- a/crates/gpui/examples/image_loading.rs
+++ b/crates/gpui/examples/image_loading.rs
@@ -21,7 +21,7 @@ impl AssetSource for Assets {
         Ok(std::fs::read_dir(path)?
             .filter_map(|entry| {
                 Some(SharedString::from(
-                    entry.ok()?.path().to_string_lossy().to_string(),
+                    entry.ok()?.path().to_string_lossy().into_owned(),
                 ))
             })
             .collect::<Vec<_>>())

--- a/crates/image_viewer/src/image_viewer.rs
+++ b/crates/image_viewer/src/image_viewer.rs
@@ -104,7 +104,7 @@ impl Item for ImageView {
 
     fn tab_tooltip_text(&self, cx: &App) -> Option<SharedString> {
         let abs_path = self.image_item.read(cx).abs_path(cx)?;
-        let file_path = abs_path.compact().to_string_lossy().to_string();
+        let file_path = abs_path.compact().to_string_lossy().into_owned();
         Some(file_path.into())
     }
 

--- a/crates/language/src/buffer.rs
+++ b/crates/language/src/buffer.rs
@@ -4631,7 +4631,7 @@ impl BufferSnapshot {
     pub fn resolve_file_path(&self, include_root: bool, cx: &App) -> Option<String> {
         if let Some(file) = self.file() {
             if file.path().file_name().is_none() || include_root {
-                Some(file.full_path(cx).to_string_lossy().to_string())
+                Some(file.full_path(cx).to_string_lossy().into_owned())
             } else {
                 Some(file.path().display(file.path_style(cx)).to_string())
             }

--- a/crates/language_extension/src/extension_lsp_adapter.rs
+++ b/crates/language_extension/src/extension_lsp_adapter.rs
@@ -33,7 +33,7 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
     }
 
     fn root_path(&self) -> String {
-        self.0.worktree_root_path().to_string_lossy().to_string()
+        self.0.worktree_root_path().to_string_lossy().into_owned()
     }
 
     async fn read_text_file(&self, path: &RelPath) -> Result<String> {
@@ -44,7 +44,7 @@ impl WorktreeDelegate for WorktreeDelegateAdapter {
         self.0
             .which(binary_name.as_ref())
             .await
-            .map(|path| path.to_string_lossy().to_string())
+            .map(|path| path.to_string_lossy().into_owned())
     }
 
     async fn shell_env(&self) -> Vec<(String, String)> {

--- a/crates/languages/src/go.rs
+++ b/crates/languages/src/go.rs
@@ -528,7 +528,7 @@ impl ContextProvider for GoContextProvider {
                 let module_dir = buffer_dir
                     .ancestors()
                     .find(|dir| dir.join("go.mod").is_file())
-                    .map(|dir| dir.to_string_lossy().to_string())
+                    .map(|dir| dir.to_string_lossy().into_owned())
                     .unwrap_or_else(|| ".".to_string());
 
                 (GO_MODULE_ROOT_TASK_VARIABLE.clone(), module_dir)

--- a/crates/languages/src/rust.rs
+++ b/crates/languages/src/rust.rs
@@ -1029,7 +1029,7 @@ fn test_fragment(variables: &TaskVariables, path: &Path, stem: &str) -> String {
         // filter out just that module.
         Some("--lib".to_owned())
     } else if stem == "mod" {
-        maybe!({ Some(path.parent()?.file_name()?.to_string_lossy().to_string()) })
+        maybe!({ Some(path.parent()?.file_name()?.to_string_lossy().into_owned()) })
     } else if stem == "main" {
         if let (Some(bin_name), Some(bin_kind)) = (
             variables.get(&RUST_BIN_NAME_TASK_VARIABLE),

--- a/crates/multi_buffer/src/multi_buffer.rs
+++ b/crates/multi_buffer/src/multi_buffer.rs
@@ -178,7 +178,7 @@ impl PathKey {
 
     pub fn for_buffer(buffer: &Entity<Buffer>, cx: &App) -> Self {
         if let Some(file) = buffer.read(cx).file() {
-            Self::namespaced(1, file.full_path(cx).to_string_lossy().to_string().into())
+            Self::namespaced(1, file.full_path(cx).to_string_lossy().into_owned().into())
         } else {
             Self::namespaced(0, buffer.entity_id().to_string().into())
         }

--- a/crates/outline_panel/src/outline_panel.rs
+++ b/crates/outline_panel/src/outline_panel.rs
@@ -1893,7 +1893,7 @@ impl OutlinePanel {
         if let Some(clipboard_text) = self
             .selected_entry()
             .and_then(|entry| self.abs_path(entry, cx))
-            .map(|p| p.to_string_lossy().to_string())
+            .map(|p| p.to_string_lossy().into_owned())
         {
             cx.write_to_clipboard(ClipboardItem::new_string(clipboard_text));
         }
@@ -4077,7 +4077,7 @@ impl OutlinePanel {
             .iter()
             .map(|entry| self.entry_name(&worktree_id, entry, cx))
             .collect::<PathBuf>();
-        dir_names_segment.to_string_lossy().to_string()
+        dir_names_segment.to_string_lossy().into_owned()
     }
 
     fn query(&self, cx: &App) -> Option<String> {

--- a/crates/project/src/agent_server_store.rs
+++ b/crates/project/src/agent_server_store.rs
@@ -415,7 +415,7 @@ impl AgentServerStore {
             })??
             .await?;
         Ok(proto::AgentServerCommand {
-            path: command.path.to_string_lossy().to_string(),
+            path: command.path.to_string_lossy().into_owned(),
             args: command.args,
             env: command
                 .env
@@ -650,7 +650,7 @@ fn get_or_npm_install_builtin_agent(
 
         anyhow::Ok(AgentServerCommand {
             path: node_path,
-            args: vec![agent_server_path.to_string_lossy().to_string()],
+            args: vec![agent_server_path.to_string_lossy().into_owned()],
             env: None,
         })
     })
@@ -842,7 +842,7 @@ impl ExternalAgentServer for LocalGemini {
 
             // Gemini CLI doesn't seem to have a dedicated invocation for logging in--we just run it normally without any arguments.
             let login = task::SpawnInTerminal {
-                command: Some(command.path.to_string_lossy().to_string()),
+                command: Some(command.path.to_string_lossy().into_owned()),
                 args: command.args.clone(),
                 env: command.env.clone().unwrap_or_default(),
                 label: "gemini /auth".into(),
@@ -851,7 +851,11 @@ impl ExternalAgentServer for LocalGemini {
 
             command.env.get_or_insert_default().extend(extra_env);
             command.args.push("--experimental-acp".into());
-            Ok((command, root_dir.to_string_lossy().to_string(), Some(login)))
+            Ok((
+                command,
+                root_dir.to_string_lossy().into_owned(),
+                Some(login),
+            ))
         })
     }
 
@@ -919,7 +923,7 @@ impl ExternalAgentServer for LocalClaudeCode {
                         path.strip_suffix("/@zed-industries/claude-code-acp/dist/index.js")
                     })
                     .map(|path_prefix| task::SpawnInTerminal {
-                        command: Some(command.path.to_string_lossy().to_string()),
+                        command: Some(command.path.to_string_lossy().into_owned()),
                         args: vec![
                             Path::new(path_prefix)
                                 .join("@anthropic-ai/claude-code/cli.js")
@@ -935,7 +939,7 @@ impl ExternalAgentServer for LocalClaudeCode {
             };
 
             command.env.get_or_insert_default().extend(extra_env);
-            Ok((command, root_dir.to_string_lossy().to_string(), login))
+            Ok((command, root_dir.to_string_lossy().into_owned(), login))
         })
     }
 
@@ -974,7 +978,7 @@ impl ExternalAgentServer for LocalCustomAgent {
             env.extend(command.env.unwrap_or_default());
             env.extend(extra_env);
             command.env = Some(env);
-            Ok((command, root_dir.to_string_lossy().to_string(), None))
+            Ok((command, root_dir.to_string_lossy().into_owned(), None))
         })
     }
 

--- a/crates/project/src/debugger/session.rs
+++ b/crates/project/src/debugger/session.rs
@@ -170,8 +170,8 @@ fn client_source(abs_path: &Path) -> dap::Source {
     dap::Source {
         name: abs_path
             .file_name()
-            .map(|filename| filename.to_string_lossy().to_string()),
-        path: Some(abs_path.to_string_lossy().to_string()),
+            .map(|filename| filename.to_string_lossy().into_owned()),
+        path: Some(abs_path.to_string_lossy().into_owned()),
         source_reference: None,
         presentation_hint: None,
         origin: None,

--- a/crates/project/src/git_store.rs
+++ b/crates/project/src/git_store.rs
@@ -1420,7 +1420,7 @@ impl GitStore {
                     client
                         .request(proto::GitInit {
                             project_id: project_id,
-                            abs_path: path.to_string_lossy().to_string(),
+                            abs_path: path.to_string_lossy().into_owned(),
                             fallback_branch_name,
                         })
                         .await?;
@@ -1455,7 +1455,7 @@ impl GitStore {
                 }
                 let request = upstream_client.request(proto::GitClone {
                     project_id: *upstream_project_id,
-                    abs_path: path.to_string_lossy().to_string(),
+                    abs_path: path.to_string_lossy().into_owned(),
                     remote_repo: repo,
                 });
 
@@ -2802,7 +2802,7 @@ impl RepositorySnapshot {
             merge_message: self.merge.message.as_ref().map(|msg| msg.to_string()),
             project_id,
             id: self.id.to_proto(),
-            abs_path: self.work_directory_abs_path.to_string_lossy().to_string(),
+            abs_path: self.work_directory_abs_path.to_string_lossy().into_owned(),
             entry_ids: vec![self.id.to_proto()],
             scan_id: self.scan_id,
             is_last_update: true,
@@ -2871,7 +2871,7 @@ impl RepositorySnapshot {
             merge_message: self.merge.message.as_ref().map(|msg| msg.to_string()),
             project_id,
             id: self.id.to_proto(),
-            abs_path: self.work_directory_abs_path.to_string_lossy().to_string(),
+            abs_path: self.work_directory_abs_path.to_string_lossy().into_owned(),
             entry_ids: vec![],
             scan_id: self.scan_id,
             is_last_update: true,

--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -2485,7 +2485,7 @@ impl LocalLspStore {
                     name: None,
                     message: proto::update_language_server::Variant::RegisteredForBuffer(
                         proto::RegisteredForBuffer {
-                            buffer_abs_path: abs_path.to_string_lossy().to_string(),
+                            buffer_abs_path: abs_path.to_string_lossy().into_owned(),
                             buffer_id: buffer_id.to_proto(),
                         },
                     ),
@@ -3188,7 +3188,7 @@ impl LocalLspStore {
                         let pattern = watcher_path
                             .as_path()
                             .strip_prefix(&path)
-                            .map(|p| p.to_string_lossy().to_string())
+                            .map(|p| p.to_string_lossy().into_owned())
                             .unwrap_or_else(|e| {
                                 debug_panic!(
                                     "Failed to strip prefix for string pattern: {}, with prefix: {}, with error: {}",
@@ -3196,7 +3196,7 @@ impl LocalLspStore {
                                     path.display(),
                                     e
                                 );
-                                watcher_path.as_path().to_string_lossy().to_string()
+                                watcher_path.as_path().to_string_lossy().into_owned()
                             });
                         (path, pattern)
                     }
@@ -3212,7 +3212,7 @@ impl LocalLspStore {
                         let path = glob_literal_prefix(Path::new(&rp.pattern));
                         let pattern = Path::new(&rp.pattern)
                             .strip_prefix(&path)
-                            .map(|p| p.to_string_lossy().to_string())
+                            .map(|p| p.to_string_lossy().into_owned())
                             .unwrap_or_else(|e| {
                                 debug_panic!(
                                     "Failed to strip prefix for relative pattern: {}, with prefix: {}, with error: {}",
@@ -3285,7 +3285,7 @@ impl LocalLspStore {
                     Some((
                         worktree.clone(),
                         RelPath::new(&literal_prefix, path_style).ok()?.into_arc(),
-                        relative.to_string_lossy().to_string(),
+                        relative.to_string_lossy().into_owned(),
                     ))
                 }
                 lsp::GlobPattern::Relative(rp) => {
@@ -4622,7 +4622,9 @@ impl LspStore {
                                 message:
                                     proto::update_language_server::Variant::RegisteredForBuffer(
                                         proto::RegisteredForBuffer {
-                                            buffer_abs_path: abs_path.to_string_lossy().to_string(),
+                                            buffer_abs_path: abs_path
+                                                .to_string_lossy()
+                                                .into_owned(),
                                             buffer_id: buffer_id.to_proto(),
                                         },
                                     ),
@@ -10582,7 +10584,7 @@ impl LspStore {
                 name: Some(adapter.name()),
                 message: proto::update_language_server::Variant::RegisteredForBuffer(
                     proto::RegisteredForBuffer {
-                        buffer_abs_path: abs_path.to_string_lossy().to_string(),
+                        buffer_abs_path: abs_path.to_string_lossy().into_owned(),
                         buffer_id: buffer_id.to_proto(),
                     },
                 ),
@@ -10843,7 +10845,7 @@ impl LspStore {
                 abs_path,
                 signature,
             } => {
-                result.path = abs_path.to_string_lossy().to_string();
+                result.path = abs_path.to_string_lossy().into_owned();
                 result.signature = signature.to_vec();
             }
         }

--- a/crates/project/src/lsp_store/lsp_ext_command.rs
+++ b/crates/project/src/lsp_store/lsp_ext_command.rs
@@ -691,7 +691,7 @@ impl LspCommand for GetLspRunnables {
                     task_template.command = shell.program;
                     task_template.args = shell.args;
                     task_template.env = shell.environment;
-                    task_template.cwd = Some(shell.cwd.to_string_lossy().to_string());
+                    task_template.cwd = Some(shell.cwd.to_string_lossy().into_owned());
                 }
             }
 

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -891,8 +891,8 @@ impl DirectoryLister {
         project
             .visible_worktrees(cx)
             .next()
-            .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().to_string())
-            .or_else(|| std::env::home_dir().map(|dir| dir.to_string_lossy().to_string()))
+            .map(|worktree| worktree.read(cx).abs_path().to_string_lossy().into_owned())
+            .or_else(|| std::env::home_dir().map(|dir| dir.to_string_lossy().into_owned()))
             .map(|mut s| {
                 s.push_str(path_style.separator());
                 s
@@ -4207,7 +4207,7 @@ impl Project {
                 let metadata = fs.metadata(&expanded).await.ok().flatten();
 
                 metadata.map(|metadata| ResolvedPath::AbsPath {
-                    path: expanded.to_string_lossy().to_string(),
+                    path: expanded.to_string_lossy().into_owned(),
                     is_dir: metadata.is_dir,
                 })
             })

--- a/crates/project/src/task_inventory.rs
+++ b/crates/project/src/task_inventory.rs
@@ -1027,7 +1027,7 @@ impl ContextProvider for BasicContextProvider {
             let path_style = worktree.path_style();
             task_variables.insert(
                 VariableName::WorktreeRoot,
-                worktree.abs_path().to_string_lossy().to_string(),
+                worktree.abs_path().to_string_lossy().into_owned(),
             );
             if let Some(current_file) = current_file.as_ref() {
                 let relative_path = current_file.path();
@@ -1062,7 +1062,7 @@ impl ContextProvider for BasicContextProvider {
                 task_variables.insert(VariableName::Dirname, dirname.into());
             }
 
-            task_variables.insert(VariableName::File, path.to_string_lossy().to_string());
+            task_variables.insert(VariableName::File, path.to_string_lossy().into_owned());
         }
 
         Task::ready(Ok(task_variables))

--- a/crates/project/src/task_store.rs
+++ b/crates/project/src/task_store.rs
@@ -149,7 +149,7 @@ impl TaskStore {
             project_env: task_context.project_env.into_iter().collect(),
             cwd: task_context
                 .cwd
-                .map(|cwd| cwd.to_string_lossy().to_string()),
+                .map(|cwd| cwd.to_string_lossy().into_owned()),
             task_variables: task_context
                 .task_variables
                 .into_iter()

--- a/crates/project/src/toolchain_store.rs
+++ b/crates/project/src/toolchain_store.rs
@@ -278,7 +278,7 @@ impl ToolchainStore {
                 let path = PathBuf::from(toolchain.path.to_string());
                 proto::Toolchain {
                     name: toolchain.name.into(),
-                    path: path.to_string_lossy().to_string(),
+                    path: path.to_string_lossy().into_owned(),
                     raw_json: toolchain.as_json.to_string(),
                 }
             }),
@@ -330,7 +330,7 @@ impl ToolchainStore {
                     let path = PathBuf::from(toolchain.path.to_string());
                     proto::Toolchain {
                         name: toolchain.name.to_string(),
-                        path: path.to_string_lossy().to_string(),
+                        path: path.to_string_lossy().into_owned(),
                         raw_json: toolchain.as_json.to_string(),
                     }
                 })
@@ -609,7 +609,7 @@ impl RemoteToolchainStore {
                             language_name: toolchain.language_name.into(),
                             toolchain: Some(proto::Toolchain {
                                 name: toolchain.name.into(),
-                                path: path.to_string_lossy().to_string(),
+                                path: path.to_string_lossy().into_owned(),
                                 raw_json: toolchain.as_json.to_string(),
                             }),
                             path: Some(project_path.path.to_proto()),

--- a/crates/project/src/worktree_store.rs
+++ b/crates/project/src/worktree_store.rs
@@ -536,8 +536,8 @@ impl WorktreeStore {
             let root_path_buf = PathBuf::from(response.canonicalized_path.clone());
             let root_name = root_path_buf
                 .file_name()
-                .map(|n| n.to_string_lossy().to_string())
-                .unwrap_or(root_path_buf.to_string_lossy().to_string());
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or(root_path_buf.to_string_lossy().into_owned());
 
             let worktree = cx.update(|cx| {
                 Worktree::remote(
@@ -860,7 +860,7 @@ impl WorktreeStore {
                     id: worktree.id().to_proto(),
                     root_name: worktree.root_name_str().to_owned(),
                     visible: worktree.is_visible(),
-                    abs_path: worktree.abs_path().to_string_lossy().to_string(),
+                    abs_path: worktree.abs_path().to_string_lossy().into_owned(),
                 }
             })
             .collect()

--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -4081,7 +4081,7 @@ impl ProjectPanel {
         let canonical_path = details
             .canonical_path
             .as_ref()
-            .map(|f| f.to_string_lossy().to_string());
+            .map(|f| f.to_string_lossy().into_owned());
         let path_style = self.project.read(cx).path_style(cx);
         let path = details.path.clone();
         let path_for_external_paths = path.clone();

--- a/crates/recent_projects/src/recent_projects.rs
+++ b/crates/recent_projects/src/recent_projects.rs
@@ -604,7 +604,7 @@ fn highlights_for_path(
     // Again subset the highlight positions to just those that line up with the file_name
     // again adjusted to the start of the file_name
     let file_name_text_and_positions = path.file_name().map(|file_name| {
-        let file_name_text = file_name.to_string_lossy().to_string();
+        let file_name_text = file_name.to_string_lossy().into_owned();
         let file_name_start_byte = path_byte_len - file_name_text.len();
         let highlight_positions = path_positions
             .iter()

--- a/crates/recent_projects/src/remote_connections.rs
+++ b/crates/recent_projects/src/remote_connections.rs
@@ -369,7 +369,7 @@ impl RenderOnce for SshConnectionHeader {
                     )
                     .child(div().overflow_x_hidden().text_ellipsis().children(
                         self.paths.into_iter().map(|path| {
-                            Label::new(path.to_string_lossy().to_string())
+                            Label::new(path.to_string_lossy().into_owned())
                                 .size(LabelSize::Small)
                                 .color(Color::Muted)
                         }),

--- a/crates/recent_projects/src/remote_servers.rs
+++ b/crates/recent_projects/src/remote_servers.rs
@@ -238,7 +238,7 @@ impl ProjectPicker {
                         update_settings_file(fs, cx, {
                             let paths = paths
                                 .iter()
-                                .map(|path| path.to_string_lossy().to_string())
+                                .map(|path| path.to_string_lossy().into_owned())
                                 .collect();
                             move |settings, _| match index {
                                 ServerIndex::Ssh(index) => {

--- a/crates/remote_server/src/headless_project.rs
+++ b/crates/remote_server/src/headless_project.rs
@@ -442,7 +442,7 @@ impl HeadlessProject {
             let worktree = worktree.read(cx);
             proto::AddWorktreeResponse {
                 worktree_id: worktree.id().to_proto(),
-                canonicalized_path: canonicalized.to_string_lossy().to_string(),
+                canonicalized_path: canonicalized.to_string_lossy().into_owned(),
             }
         })?;
 
@@ -672,7 +672,7 @@ impl HeadlessProject {
         while let Some(path) = response.next().await {
             let path = path?;
             if let Some(file_name) = path.file_name() {
-                entries.push(file_name.to_string_lossy().to_string());
+                entries.push(file_name.to_string_lossy().into_owned());
                 if check_info {
                     let is_dir = fs.is_dir(&path).await;
                     entry_info.push(proto::EntryInfo { is_dir });
@@ -699,7 +699,7 @@ impl HeadlessProject {
         Ok(proto::GetPathMetadataResponse {
             exists: metadata.is_some(),
             is_dir,
-            path: expanded.to_string_lossy().to_string(),
+            path: expanded.to_string_lossy().into_owned(),
         })
     }
 
@@ -743,7 +743,7 @@ impl HeadlessProject {
             let command = process
                 .cmd()
                 .iter()
-                .map(|s| s.to_string_lossy().to_string())
+                .map(|s| s.to_string_lossy().into_owned())
                 .collect::<Vec<_>>();
 
             processes.push(proto::ProcessInfo {

--- a/crates/repl/src/kernels/mod.rs
+++ b/crates/repl/src/kernels/mod.rs
@@ -48,8 +48,8 @@ impl KernelSpecification {
 
     pub fn path(&self) -> SharedString {
         SharedString::from(match self {
-            Self::Jupyter(spec) => spec.path.to_string_lossy().to_string(),
-            Self::PythonEnv(spec) => spec.path.to_string_lossy().to_string(),
+            Self::Jupyter(spec) => spec.path.to_string_lossy().into_owned(),
+            Self::PythonEnv(spec) => spec.path.to_string_lossy().into_owned(),
             Self::Remote(spec) => spec.url.to_string(),
         })
     }

--- a/crates/repl/src/kernels/native_kernel.rs
+++ b/crates/repl/src/kernels/native_kernel.rs
@@ -371,7 +371,7 @@ async fn read_kernelspec_at(
 ) -> Result<LocalKernelSpecification> {
     let path = kernel_dir;
     let kernel_name = if let Some(kernel_name) = path.file_name() {
-        kernel_name.to_string_lossy().to_string()
+        kernel_name.to_string_lossy().into_owned()
     } else {
         anyhow::bail!("Invalid kernelspec directory: {path:?}");
     };

--- a/crates/settings/src/vscode_import.rs
+++ b/crates/settings/src/vscode_import.rs
@@ -51,7 +51,7 @@ impl VsCodeSettings {
                 "No settings file found, expected to find it in one of the following paths:\n{}",
                 candidate_paths
                     .into_iter()
-                    .map(|path| path.to_string_lossy().to_string())
+                    .map(|path| path.to_string_lossy().into_owned())
                     .collect::<Vec<_>>()
                     .join("\n")
             ));

--- a/crates/tasks_ui/src/tasks_ui.rs
+++ b/crates/tasks_ui/src/tasks_ui.rs
@@ -379,7 +379,7 @@ fn worktree_context(worktree_abs_path: &Path) -> TaskContext {
     let mut task_variables = TaskVariables::default();
     task_variables.insert(
         VariableName::WorktreeRoot,
-        worktree_abs_path.to_string_lossy().to_string(),
+        worktree_abs_path.to_string_lossy().into_owned(),
     );
     TaskContext {
         cwd: Some(worktree_abs_path.to_path_buf()),

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1862,7 +1862,7 @@ impl Terminal {
                             let process_file = fpi
                                 .cwd
                                 .file_name()
-                                .map(|name| name.to_string_lossy().to_string())
+                                .map(|name| name.to_string_lossy().into_owned())
                                 .unwrap_or_default();
 
                             let argv = fpi.argv.as_slice();

--- a/crates/terminal/src/terminal_hyperlinks.rs
+++ b/crates/terminal/src/terminal_hyperlinks.rs
@@ -1127,7 +1127,7 @@ mod tests {
             let Ok(path) = url.to_file_path() else {
                 panic!("Failed to interpret file IRI `{iri_or_path}` as a path");
             };
-            iri_or_path = path.to_string_lossy().to_string();
+            iri_or_path = path.to_string_lossy().into_owned();
         }
 
         if cfg!(windows) {

--- a/crates/terminal_view/src/persistence.rs
+++ b/crates/terminal_view/src/persistence.rs
@@ -458,7 +458,10 @@ impl TerminalDb {
             let mut next_index = statement.bind(&item_id, 1)?;
             next_index = statement.bind(&workspace_id, next_index)?;
             next_index = statement.bind(&working_directory, next_index)?;
-            statement.bind(&working_directory.to_string_lossy().to_string(), next_index)?;
+            statement.bind(
+                &working_directory.to_string_lossy().into_owned(),
+                next_index,
+            )?;
             statement.exec()
         })
         .await

--- a/crates/terminal_view/src/terminal_path_like_target.rs
+++ b/crates/terminal_view/src/terminal_path_like_target.rs
@@ -109,7 +109,7 @@ fn possible_hover_target(
             .update(cx, |terminal_view, _| match file_to_open {
                 Some(OpenTarget::File(path, _) | OpenTarget::Worktree(path, ..)) => {
                     terminal_view.hover = Some(HoverTarget {
-                        tooltip: path.to_string(|path| path.to_string_lossy().to_string()),
+                        tooltip: path.to_string(|path| path.to_string_lossy().into_owned()),
                         hovered_word,
                     });
                 }

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1233,7 +1233,7 @@ mod tests {
     #[perf]
     fn test_path_compact() {
         let path: PathBuf = [
-            home_dir().to_string_lossy().to_string(),
+            home_dir().to_string_lossy().into_owned(),
             "some_file.txt".to_string(),
         ]
         .iter()

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -599,7 +599,7 @@ pub fn get_windows_system_shell() -> String {
             .or_else(|| find_pwsh_in_msix(true))
             .or_else(|| find_pwsh_in_programfiles(true, true))
             .or_else(find_pwsh_in_scoop)
-            .map(|p| p.to_string_lossy().to_string())
+            .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or("powershell.exe".to_string())
     });
 

--- a/crates/vim/src/normal.rs
+++ b/crates/vim/src/normal.rs
@@ -858,9 +858,9 @@ impl Vim {
             let filename = if let Some(file) = buffer.read(cx).file() {
                 if count.is_some() {
                     if let Some(local) = file.as_local() {
-                        local.abs_path(cx).to_string_lossy().to_string()
+                        local.abs_path(cx).to_string_lossy().into_owned()
                     } else {
-                        file.full_path(cx).to_string_lossy().to_string()
+                        file.full_path(cx).to_string_lossy().into_owned()
                     }
                 } else {
                     file.path().display(file.path_style(cx)).into_owned()

--- a/crates/vim/src/state.rs
+++ b/crates/vim/src/state.rs
@@ -1610,7 +1610,7 @@ impl PickerDelegate for MarksViewDelegate {
 
         let (right_output, right_runs): (String, Vec<_>) = match &mark_match.info {
             MarksMatchInfo::Path(path) => {
-                let s = path.to_string_lossy().to_string();
+                let s = path.to_string_lossy().into_owned();
                 (
                     s.clone(),
                     vec![(0..s.len(), HighlightStyle::color(cx.theme().colors().text))],

--- a/crates/workspace/src/pane.rs
+++ b/crates/workspace/src/pane.rs
@@ -2865,7 +2865,7 @@ impl Pane {
                                         Some(Box::new(zed_actions::workspace::CopyPath)),
                                         window.handler_for(&pane, move |_, _, cx| {
                                             cx.write_to_clipboard(ClipboardItem::new_string(
-                                                abs_path.to_string_lossy().to_string(),
+                                                abs_path.to_string_lossy().into_owned(),
                                             ));
                                         }),
                                     )

--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -622,7 +622,7 @@ impl Worktree {
             id: self.id().to_proto(),
             root_name: self.root_name().to_proto(),
             visible: self.is_visible(),
-            abs_path: self.abs_path().to_string_lossy().to_string(),
+            abs_path: self.abs_path().to_string_lossy().into_owned(),
         }
     }
 
@@ -982,7 +982,7 @@ impl Worktree {
                     .join("~", &*stripped.to_string_lossy())
                     .unwrap()
             } else {
-                full_path.to_string_lossy().to_string()
+                full_path.to_string_lossy().into_owned()
             };
 
             if worktree_relative_path.components().next().is_some() {
@@ -2072,7 +2072,7 @@ impl Snapshot {
         proto::UpdateWorktree {
             project_id,
             worktree_id,
-            abs_path: self.abs_path().to_string_lossy().to_string(),
+            abs_path: self.abs_path().to_string_lossy().into_owned(),
             root_name: self.root_name().to_proto(),
             updated_entries,
             removed_entries: Vec::new(),
@@ -2415,7 +2415,7 @@ impl LocalSnapshot {
         proto::UpdateWorktree {
             project_id,
             worktree_id,
-            abs_path: self.abs_path().to_string_lossy().to_string(),
+            abs_path: self.abs_path().to_string_lossy().into_owned(),
             root_name: self.root_name().to_proto(),
             updated_entries,
             removed_entries,
@@ -5354,7 +5354,7 @@ impl<'a> From<&'a Entry> for proto::Entry {
             canonical_path: entry
                 .canonical_path
                 .as_ref()
-                .map(|path| path.to_string_lossy().to_string()),
+                .map(|path| path.to_string_lossy().into_owned()),
         }
     }
 }

--- a/crates/zed/src/zed/open_listener.rs
+++ b/crates/zed/src/zed/open_listener.rs
@@ -434,7 +434,7 @@ async fn open_workspaces(
                     let workspace_paths = workspace_paths
                         .paths()
                         .iter()
-                        .map(|path| path.to_string_lossy().to_string())
+                        .map(|path| path.to_string_lossy().into_owned())
                         .collect();
 
                     let workspace_failed_to_open = open_local_workspace(

--- a/crates/zed/src/zed/windows_only_instance.rs
+++ b/crates/zed/src/zed/windows_only_instance.rs
@@ -104,7 +104,7 @@ fn retrieve_message_from_pipe_inner(pipe: HANDLE) -> anyhow::Result<String> {
         ReadFile(pipe, Some(&mut buffer), None, None)?;
     }
     let message = std::ffi::CStr::from_bytes_until_nul(&buffer)?;
-    Ok(message.to_string_lossy().to_string())
+    Ok(message.to_string_lossy().into_owned())
 }
 
 // This part of code is mostly from crates/cli/src/main.rs
@@ -124,7 +124,7 @@ fn send_args_to_instance(args: &Args) -> anyhow::Result<()> {
         let mut diff_paths = vec![];
         for path in args.paths_or_urls.iter() {
             match std::fs::canonicalize(&path) {
-                Ok(path) => paths.push(path.to_string_lossy().to_string()),
+                Ok(path) => paths.push(path.to_string_lossy().into_owned()),
                 Err(error) => {
                     if path.starts_with("zed://")
                         || path.starts_with("http://")
@@ -145,8 +145,8 @@ fn send_args_to_instance(args: &Args) -> anyhow::Result<()> {
             let new = std::fs::canonicalize(&path[1]).log_err();
             if let Some((old, new)) = old.zip(new) {
                 diff_paths.push([
-                    old.to_string_lossy().to_string(),
-                    new.to_string_lossy().to_string(),
+                    old.to_string_lossy().into_owned(),
+                    new.to_string_lossy().into_owned(),
                 ]);
             }
         }

--- a/crates/zeta/src/license_detection.rs
+++ b/crates/zeta/src/license_detection.rs
@@ -435,7 +435,7 @@ mod tests {
             let Ok(contents) = std::fs::read_to_string(entry.path()) else {
                 continue;
             };
-            let path_string = entry.path().to_string_lossy().to_string();
+            let path_string = entry.path().to_string_lossy().into_owned();
             let license = detect_license(&contents);
             match license {
                 Some(license) => detected.push((license, path_string)),

--- a/crates/zeta/src/rate_completion_modal.rs
+++ b/crates/zeta/src/rate_completion_modal.rs
@@ -619,8 +619,8 @@ impl Render for RateCompletionModal {
                                                 (false, false) => (IconName::FileDiff, Color::Accent, "Edits Available"),
                                             };
 
-                                            let file_name = completion.path.file_name().map(|f| f.to_string_lossy().to_string()).unwrap_or("untitled".to_string());
-                                            let file_path = completion.path.parent().map(|p| p.to_string_lossy().to_string());
+                                            let file_name = completion.path.file_name().map(|f| f.to_string_lossy().into_owned()).unwrap_or("untitled".to_string());
+                                            let file_path = completion.path.parent().map(|p| p.to_string_lossy().into_owned());
 
                                             ListItem::new(completion.id)
                                                 .inset(true)

--- a/crates/zeta/src/zeta.rs
+++ b/crates/zeta/src/zeta.rs
@@ -443,7 +443,7 @@ impl Zeta {
             .file()
             .map(|f| Arc::from(f.full_path(cx).as_path()))
             .unwrap_or_else(|| Arc::from(Path::new("untitled")));
-        let full_path_str = full_path.to_string_lossy().to_string();
+        let full_path_str = full_path.to_string_lossy().into_owned();
         let cursor_point = cursor.to_point(&snapshot);
         let cursor_offset = cursor_point.to_offset(&snapshot);
         let prompt_for_events = {


### PR DESCRIPTION
This removes unnecessary allocations when the `Cow` is already owned


Release Notes:

- N/A *or* Added/Fixed/Improved ...
