### PR TITLE
git_ui: Allow splitting `commit_view` pane

### DIFF
--- a/crates/git_ui/src/commit_view.rs
+++ b/crates/git_ui/src/commit_view.rs
@@ -522,6 +522,29 @@ impl Item for CommitView {
             editor.added_to_workspace(workspace, window, cx)
         });
     }
+
+    fn clone_on_split(
+        &self,
+        _workspace_id: Option<workspace::WorkspaceId>,
+        window: &mut Window,
+        cx: &mut Context<Self>,
+    ) -> Option<Entity<Self>>
+    where
+        Self: Sized,
+    {
+        Some(cx.new(|cx| {
+            let editor = cx.new(|cx| {
+                self.editor
+                    .update(cx, |editor, cx| editor.clone(window, cx))
+            });
+            let multibuffer = editor.read(cx).buffer().clone();
+            Self {
+                editor,
+                multibuffer,
+                commit: self.commit.clone(),
+            }
+        }))
+    }
 }
 
 impl Render for CommitView {


### PR DESCRIPTION

Release Notes:

- Allow splitting git commit view pane
