### PR TITLE
Fix typo in `search.rs`

### DIFF
--- a/crates/search/src/search.rs
+++ b/crates/search/src/search.rs
@@ -98,7 +98,7 @@ impl SearchOption {
     pub fn label(&self) -> &'static str {
         match self {
             SearchOption::WholeWord => "Match Whole Words",
-            SearchOption::CaseSensitive => "Match Case Sensitively",
+            SearchOption::CaseSensitive => "Match Case Sensitivity",
             SearchOption::IncludeIgnored => "Also search files ignored by configuration",
             SearchOption::Regex => "Use Regular Expressions",
             SearchOption::OneMatchPerLine => "One Match Per Line",


### PR DESCRIPTION
Fixed confusing word

Release Notes:

- Fixed a typo in the tooltip for search case sensitivity.
