### PR TITLE
git_ui: Fix last commit UI glitching on panel resize

### DIFF
--- a/crates/git_ui/src/git_panel.rs
+++ b/crates/git_ui/src/git_panel.rs
@@ -3527,7 +3527,7 @@ impl GitPanel {
                     div()
                         .flex_grow()
                         .overflow_hidden()
-                        .max_w(relative(0.85))
+                        .line_clamp(1)
                         .child(
                             Label::new(commit.subject.clone())
                                 .size(LabelSize::Small)


### PR DESCRIPTION
# Why

Spotted that on Git Panel resize last commit UI part could glitch due to commit message being wrapped into second line in certain situations.

# How

Force only one line for the last commit message in Git Panel via `line_clamp`.

I have also remove manual `max-width` setting since it is controlled by flex layout and gap setting no matter if there is an additional element on the right or not.

Release Notes:

- Fixed last commit UI glitching on panel resize

# Preview

### Before

https://github.com/user-attachments/assets/9ce74f6f-d33c-4787-b7e4-010de8f0ffff

<img width="852" height="502" alt="Screenshot 2025-09-28 at 18 16 35" src="https://github.com/user-attachments/assets/1131c73f-fe06-4d8e-adbb-5ce84ecf31e0" />

### After

https://github.com/user-attachments/assets/279b8c37-7ec9-4038-8761-197cba26aa83