### PR TITLE
Fix selecting and deleting user toolchains

### DIFF
--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -1045,9 +1045,10 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                     let toolchain = toolchain.clone();
                     let scope = scope.clone();
 
-                    this.end_slot(IconButton::new(id, IconName::Trash))
-                        .on_click(cx.listener(move |this, _, _, cx| {
+                    this.end_slot(IconButton::new(id, IconName::Trash).on_click(cx.listener(
+                        move |this, _, _, cx| {
                             this.delegate.project.update(cx, |this, cx| {
+                                println!("Clicked Trash can!");
                                 this.remove_toolchain(toolchain.clone(), scope.clone(), cx)
                             });
 
@@ -1074,7 +1075,8 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                             }
                             cx.stop_propagation();
                             cx.notify();
-                        }))
+                        },
+                    )))
                 }),
         )
     }

--- a/crates/toolchain_selector/src/toolchain_selector.rs
+++ b/crates/toolchain_selector/src/toolchain_selector.rs
@@ -1048,7 +1048,6 @@ impl PickerDelegate for ToolchainSelectorDelegate {
                     this.end_slot(IconButton::new(id, IconName::Trash).on_click(cx.listener(
                         move |this, _, _, cx| {
                             this.delegate.project.update(cx, |this, cx| {
-                                println!("Clicked Trash can!");
                                 this.remove_toolchain(toolchain.clone(), scope.clone(), cx)
                             });
 

--- a/crates/workspace/src/persistence.rs
+++ b/crates/workspace/src/persistence.rs
@@ -994,6 +994,13 @@ impl WorkspaceDb {
                         }
                     }
                 }
+
+                conn.exec_bound(
+                    sql!(
+                        DELETE FROM user_toolchains WHERE workspace_id = ?1;
+                    )
+                )?(workspace.id).context("Clearing old user toolchains")?;
+
                 for (scope, toolchains) in workspace.user_toolchains {
                     for toolchain in toolchains {
                         let query = sql!(INSERT OR REPLACE INTO user_toolchains(remote_connection_id, workspace_id, worktree_id, relative_worktree_path, language_name, name, path, raw_json) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8));


### PR DESCRIPTION
I was trying to use the new user toolchains but every time I clicked on one I had added, it would delete it from the picker. Ironically, it wouldn't delete it permanently when I tried to by clicking on the trash can icon. Every time I reopened the workspace all user toolchains were there.

Release Notes:

- Fixed selecting and deleting user toolchains.
