### PR TITLE
editor: Make kill ring cut at EOF a no-op

### DIFF
--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -12338,7 +12338,7 @@ impl Editor {
                 }
             });
         });
-        let item = self.cut_common(true, window, cx);
+        let item = self.cut_common(false, window, cx);
         cx.set_global(KillRing(item))
     }
 

--- a/crates/editor/src/editor_tests.rs
+++ b/crates/editor/src/editor_tests.rs
@@ -6742,6 +6742,14 @@ async fn test_cut_line_ends(cx: &mut TestAppContext) {
 
     let mut cx = EditorTestContext::new(cx).await;
 
+    cx.set_state(indoc! {"The quick brownˇ"});
+    cx.update_editor(|e, window, cx| e.cut_to_end_of_line(&CutToEndOfLine::default(), window, cx));
+    cx.assert_editor_state(indoc! {"The quick brownˇ"});
+
+    cx.set_state(indoc! {"The emacs foxˇ"});
+    cx.update_editor(|e, window, cx| e.kill_ring_cut(&KillRingCut, window, cx));
+    cx.assert_editor_state(indoc! {"The emacs foxˇ"});
+
     cx.set_state(indoc! {"
         The quick« brownˇ»
         fox jumps overˇ


### PR DESCRIPTION
Release Notes:

- Emacs's kill ring cut at the end of the last line of the file will now no-op instead of cutting the entire line