### PR TITLE
Add note about `inode/directory` to Zed desktop entry

### DIFF
--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -10,7 +10,10 @@ Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
-MimeType=text/plain;inode/directory;application/x-zerosize;x-scheme-handler/zed;
+# To add Zed to "Open Folder With..." context menu, add `inode/directory` to the MimeType field (semicolon separated)
+# Arch linux users have reported this setting Zed as default file browser. See https://github.com/zed-industries/zed/pull/39076 and related issues.
+# If this happens to you, an unconfirmed fix may be to install Arch's `gnome-defaults-list` package.
+MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;
 Actions=NewWorkspace;
 
 [Desktop Action NewWorkspace]

--- a/crates/zed/resources/zed.desktop.in
+++ b/crates/zed/resources/zed.desktop.in
@@ -10,7 +10,7 @@ Exec=$APP_CLI $APP_ARGS
 Icon=$APP_ICON
 Categories=Utility;TextEditor;Development;IDE;
 Keywords=zed;
-MimeType=text/plain;application/x-zerosize;x-scheme-handler/zed;
+MimeType=text/plain;inode/directory;application/x-zerosize;x-scheme-handler/zed;
 Actions=NewWorkspace;
 
 [Desktop Action NewWorkspace]


### PR DESCRIPTION
Release Notes:

- N/A
