### PR TITLE
Only send tools to OpenAI-compatible models that support them

### DIFF
--- a/crates/language_models/src/provider/cloud.rs
+++ b/crates/language_models/src/provider/cloud.rs
@@ -819,6 +819,7 @@ impl LanguageModel for CloudLanguageModel {
                     model.id(),
                     model.supports_parallel_tool_calls(),
                     model.supports_prompt_cache_key(),
+                    model.supports_tools(),
                     None,
                     None,
                 );
@@ -869,6 +870,7 @@ impl LanguageModel for CloudLanguageModel {
                     model.id(),
                     model.supports_parallel_tool_calls(),
                     model.supports_prompt_cache_key(),
+                    model.supports_tool(),
                     None,
                     None,
                 );

--- a/crates/language_models/src/provider/open_ai_compatible.rs
+++ b/crates/language_models/src/provider/open_ai_compatible.rs
@@ -327,6 +327,7 @@ impl LanguageModel for OpenAiCompatibleLanguageModel {
             &self.model.name,
             self.model.capabilities.parallel_tool_calls,
             self.model.capabilities.prompt_cache_key,
+            self.model.capabilities.tools,
             self.max_output_tokens(),
             None,
         );

--- a/crates/language_models/src/provider/vercel.rs
+++ b/crates/language_models/src/provider/vercel.rs
@@ -304,6 +304,7 @@ impl LanguageModel for VercelLanguageModel {
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
+            self.supports_tools(),
             self.max_output_tokens(),
             None,
         );

--- a/crates/language_models/src/provider/x_ai.rs
+++ b/crates/language_models/src/provider/x_ai.rs
@@ -315,6 +315,7 @@ impl LanguageModel for XAiLanguageModel {
             self.model.id(),
             self.model.supports_parallel_tool_calls(),
             self.model.supports_prompt_cache_key(),
+            self.supports_tools(),
             self.max_output_tokens(),
             None,
         );

--- a/crates/open_ai/src/open_ai.rs
+++ b/crates/open_ai/src/open_ai.rs
@@ -244,6 +244,25 @@ impl Model {
     pub fn supports_prompt_cache_key(&self) -> bool {
         true
     }
+
+    /// Returns whether the given model supports tools.
+    pub fn supports_tools(&self) -> bool {
+        match self {
+            Self::ThreePointFiveTurbo
+            | Self::Four
+            | Self::FourTurbo
+            | Self::FourOmni
+            | Self::FourOmniMini
+            | Self::FourPointOne
+            | Self::FourPointOneMini
+            | Self::FourPointOneNano
+            | Self::Five
+            | Self::FiveMini
+            | Self::FiveNano => true,
+            Self::O1 | Self::O3 | Self::O3Mini | Self::O4Mini => false,
+            Self::Custom { .. } => true, // Assume custom models support tools by default
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/discussions/39074#discussioncomment-1453786

This pull request adds support for checking whether a language model supports "tools" functionality across multiple providers. The main change is the introduction and propagation of a `supports_tools` flag, which is used to conditionally include tool-related fields when constructing requests for OpenAI and compatible APIs. This ensures that tool definitions and choices are only sent to models that actually support them, improving compatibility and correctness.

**Support for tools in language models:**

* Added a new method `supports_tools` to the `Model` struct in `crates/open_ai/src/open_ai.rs` to determine if a model supports tools, with logic for various model variants.
* Updated all language model providers (`CloudLanguageModel`, `OpenAiLanguageModel`, `OpenAiCompatibleLanguageModel`, `VercelLanguageModel`, `XAiLanguageModel`) to include the `supports_tools` flag when constructing requests. [[1]](diffhunk://#diff-fb4a2208eb5e8c3a3918f57095850e80ed1396aa91b658409e6fa863921f5d3cR822) [[2]](diffhunk://#diff-fb4a2208eb5e8c3a3918f57095850e80ed1396aa91b658409e6fa863921f5d3cR873) [[3]](diffhunk://#diff-399ea84c2b005160c16f01facc7a3f5657e34a866040cd2c0b83c8cbabc909bdR332) [[4]](diffhunk://#diff-8f6f1a3f49cc971f440eb517ec69d70b9c91bed27544d631f1d53f91950dcc10R330) [[5]](diffhunk://#diff-9269383039735bbb38b98332c6cfa5041ff9cb4fc640ca132e8b343a73424daeR307) [[6]](diffhunk://#diff-06619ce818eb6debd9f53a2eea3863524384a03037bc587f190b1feb748f383aR315)

**Conditional request construction:**

* Modified the `into_open_ai` function in `crates/language_models/src/provider/open_ai.rs` to accept a `supports_tools` parameter and to conditionally include `tools` and `tool_choice` fields only if tools are supported by the model. [[1]](diffhunk://#diff-399ea84c2b005160c16f01facc7a3f5657e34a866040cd2c0b83c8cbabc909bdR350) [[2]](diffhunk://#diff-399ea84c2b005160c16f01facc7a3f5657e34a866040cd2c0b83c8cbabc909bdL445-R448) [[3]](diffhunk://#diff-399ea84c2b005160c16f01facc7a3f5657e34a866040cd2c0b83c8cbabc909bdL455-R470)