### PR TITLE
Add Cursor Blink Animation Options

### DIFF
--- a/crates/editor/src/blink_manager.rs
+++ b/crates/editor/src/blink_manager.rs
@@ -1,9 +1,45 @@
+//! Cursor blink animation system for the editor.
+
 use crate::EditorSettings;
 use gpui::Context;
 use settings::Settings;
 use settings::SettingsStore;
 use smol::Timer;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+/// Default interval between cursor blink cycles.
+const DEFAULT_BLINK_INTERVAL: Duration = Duration::from_millis(530);
+
+#[derive(Clone, Debug)]
+pub enum BlinkAnimation {
+    Instant,
+    Fade {
+        duration: Duration,
+    },
+    Pulse {
+        fade_in_duration: Duration,
+        hold_duration: Duration,
+        fade_out_duration: Duration,
+    },
+    Zoom {
+        duration: Duration,
+        scale_factor: f32,
+    },
+    Slide {
+        duration: Duration,
+    },
+    Breathe {
+        duration: Duration,
+    },
+}
+
+impl Default for BlinkAnimation {
+    fn default() -> Self {
+        BlinkAnimation::Fade {
+            duration: Duration::from_millis(150),
+        }
+    }
+}
 
 pub struct BlinkManager {
     blink_interval: Duration,
@@ -11,23 +47,45 @@ pub struct BlinkManager {
     blinking_paused: bool,
     visible: bool,
     enabled: bool,
+    animation: BlinkAnimation,
+    animation_progress: f32,
+    animation_scale: f32,
+    animation_start_time: Option<Instant>,
+    target_visible: bool,
+    slide_offset: f32,
 }
 
 impl BlinkManager {
-    pub fn new(blink_interval: Duration, cx: &mut Context<Self>) -> Self {
-        // Make sure we blink the cursors if the setting is re-enabled
+    pub fn new(cx: &mut Context<Self>) -> Self {
         cx.observe_global::<SettingsStore>(move |this, cx| {
+            this.update_from_settings(cx);
             this.blink_cursors(this.blink_epoch, cx)
         })
         .detach();
 
+        let settings = crate::EditorSettings::get_global(cx);
         Self {
-            blink_interval,
+            blink_interval: DEFAULT_BLINK_INTERVAL,
             blink_epoch: 0,
             blinking_paused: false,
             visible: true,
             enabled: false,
+            animation: settings.cursor_blink_animation.clone(),
+            animation_progress: 1.0,
+            animation_scale: 1.0,
+            animation_start_time: None,
+            target_visible: true,
+            slide_offset: 0.0,
         }
+    }
+
+    pub fn set_animation(&mut self, animation: BlinkAnimation) {
+        self.animation = animation;
+    }
+
+    fn update_from_settings(&mut self, cx: &mut Context<Self>) {
+        let settings = crate::EditorSettings::get_global(cx);
+        self.animation = settings.cursor_blink_animation.clone();
     }
 
     fn next_blink_epoch(&mut self) -> usize {
@@ -57,8 +115,8 @@ impl BlinkManager {
     fn blink_cursors(&mut self, epoch: usize, cx: &mut Context<Self>) {
         if EditorSettings::get_global(cx).cursor_blink {
             if epoch == self.blink_epoch && self.enabled && !self.blinking_paused {
-                self.visible = !self.visible;
-                cx.notify();
+                self.target_visible = !self.target_visible;
+                self.start_animation_to_target(cx);
 
                 let epoch = self.next_blink_epoch();
                 let interval = self.blink_interval;
@@ -76,9 +134,294 @@ impl BlinkManager {
         }
     }
 
+    fn start_animation_to_target(&mut self, cx: &mut Context<Self>) {
+        match &self.animation {
+            BlinkAnimation::Instant => {
+                self.visible = self.target_visible;
+                self.animation_progress = if self.target_visible { 1.0 } else { 0.0 };
+                self.animation_scale = 1.0;
+                self.slide_offset = 0.0;
+                cx.notify();
+            }
+            BlinkAnimation::Fade { duration } => {
+                self.animation_start_time = Some(Instant::now());
+                let animation_duration = *duration;
+                self.animate_step_fade(animation_duration, cx);
+            }
+            BlinkAnimation::Pulse {
+                fade_in_duration,
+                hold_duration,
+                fade_out_duration,
+            } => {
+                self.animation_start_time = Some(Instant::now());
+                let _total_duration = *fade_in_duration + *hold_duration + *fade_out_duration;
+                self.animate_step_pulse(*fade_in_duration, *hold_duration, *fade_out_duration, cx);
+            }
+            BlinkAnimation::Zoom {
+                duration,
+                scale_factor,
+            } => {
+                self.animation_start_time = Some(Instant::now());
+                self.animate_step_zoom(*duration, *scale_factor, cx);
+            }
+            BlinkAnimation::Slide { duration } => {
+                self.animation_start_time = Some(Instant::now());
+                self.animate_step_slide(*duration, cx);
+            }
+            BlinkAnimation::Breathe { duration } => {
+                self.animation_start_time = Some(Instant::now());
+                self.animate_step_breathe(*duration, cx);
+            }
+        }
+    }
+
+    fn animate_step_fade(&mut self, animation_duration: Duration, cx: &mut Context<Self>) {
+        if let Some(start_time) = self.animation_start_time {
+            let elapsed = start_time.elapsed();
+            let progress = (elapsed.as_secs_f32() / animation_duration.as_secs_f32()).min(1.0);
+
+            // Calculate the animation progress based on target direction
+            self.animation_progress = if self.target_visible {
+                progress
+            } else {
+                1.0 - progress
+            };
+
+            self.animation_scale = 1.0;
+            self.visible = self.animation_progress > 0.0;
+            cx.notify();
+
+            // Continue animation if not complete
+            if progress < 1.0 {
+                let frame_duration = Duration::from_millis(16); // ~60fps
+                cx.spawn(async move |this, cx| {
+                    Timer::after(frame_duration).await;
+                    if let Some(this) = this.upgrade() {
+                        this.update(cx, |this, cx| {
+                            this.animate_step_fade(animation_duration, cx)
+                        })
+                        .ok();
+                    }
+                })
+                .detach();
+            } else {
+                self.animation_start_time = None;
+                self.visible = self.target_visible;
+                self.animation_progress = if self.target_visible { 1.0 } else { 0.0 };
+                self.animation_scale = 1.0;
+            }
+        }
+    }
+
+    fn animate_step_pulse(
+        &mut self,
+        fade_in_duration: Duration,
+        hold_duration: Duration,
+        fade_out_duration: Duration,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(start_time) = self.animation_start_time {
+            let elapsed = start_time.elapsed();
+            let total_duration = fade_in_duration + hold_duration + fade_out_duration;
+            let total_progress = (elapsed.as_secs_f32() / total_duration.as_secs_f32()).min(1.0);
+
+            let fade_in_end = fade_in_duration.as_secs_f32() / total_duration.as_secs_f32();
+            let hold_end =
+                (fade_in_duration + hold_duration).as_secs_f32() / total_duration.as_secs_f32();
+
+            self.animation_progress = if self.target_visible {
+                if total_progress <= fade_in_end {
+                    total_progress / fade_in_end
+                } else if total_progress <= hold_end {
+                    1.0
+                } else {
+                    1.0 - (total_progress - hold_end) / (1.0 - hold_end)
+                }
+            } else {
+                if total_progress <= fade_in_end {
+                    1.0 - (total_progress / fade_in_end)
+                } else if total_progress <= hold_end {
+                    0.0
+                } else {
+                    (total_progress - hold_end) / (1.0 - hold_end)
+                }
+            };
+
+            self.animation_scale = 1.0;
+            self.visible = self.animation_progress > 0.0;
+            cx.notify();
+
+            if total_progress < 1.0 {
+                let frame_duration = Duration::from_millis(16);
+                cx.spawn(async move |this, cx| {
+                    Timer::after(frame_duration).await;
+                    if let Some(this) = this.upgrade() {
+                        this.update(cx, |this, cx| {
+                            this.animate_step_pulse(
+                                fade_in_duration,
+                                hold_duration,
+                                fade_out_duration,
+                                cx,
+                            )
+                        })
+                        .ok();
+                    }
+                })
+                .detach();
+            } else {
+                self.animation_start_time = None;
+                self.visible = self.target_visible;
+                self.animation_progress = if self.target_visible { 1.0 } else { 0.0 };
+                self.animation_scale = 1.0;
+            }
+        }
+    }
+
+    fn animate_step_zoom(
+        &mut self,
+        animation_duration: Duration,
+        scale_factor: f32,
+        cx: &mut Context<Self>,
+    ) {
+        if let Some(start_time) = self.animation_start_time {
+            let elapsed = start_time.elapsed();
+            let progress = (elapsed.as_secs_f32() / animation_duration.as_secs_f32()).min(1.0);
+
+            let eased_progress = {
+                let t = progress;
+                if t < 0.5 {
+                    2.0 * t * t
+                } else {
+                    1.0 - 2.0 * (1.0 - t) * (1.0 - t)
+                }
+            };
+
+            if self.target_visible {
+                self.animation_progress = eased_progress;
+                self.animation_scale = scale_factor + (1.0 - scale_factor) * eased_progress;
+            } else {
+                self.animation_progress = 1.0 - eased_progress;
+                self.animation_scale = 1.0 - (1.0 - scale_factor) * eased_progress;
+            }
+
+            self.visible = self.animation_progress > 0.0;
+            cx.notify();
+
+            if progress < 1.0 {
+                let frame_duration = Duration::from_millis(16);
+                cx.spawn(async move |this, cx| {
+                    Timer::after(frame_duration).await;
+                    if let Some(this) = this.upgrade() {
+                        this.update(cx, |this, cx| {
+                            this.animate_step_zoom(animation_duration, scale_factor, cx)
+                        })
+                        .ok();
+                    }
+                })
+                .detach();
+            } else {
+                self.animation_start_time = None;
+                self.visible = self.target_visible;
+                self.animation_progress = if self.target_visible { 1.0 } else { 0.0 };
+                self.animation_scale = 1.0;
+                self.slide_offset = 0.0;
+            }
+        }
+    }
+
+    fn animate_step_slide(&mut self, animation_duration: Duration, cx: &mut Context<Self>) {
+        if let Some(start_time) = self.animation_start_time {
+            let elapsed = start_time.elapsed();
+            let progress = (elapsed.as_secs_f32() / animation_duration.as_secs_f32()).min(1.0);
+
+            let eased_progress = progress * progress * (3.0 - 2.0 * progress); // smoothstep
+
+            if self.target_visible {
+                self.animation_progress = eased_progress;
+                self.slide_offset = 4.0 * (1.0 - eased_progress); // slide in from right
+            } else {
+                self.animation_progress = 1.0 - eased_progress;
+                self.slide_offset = 4.0 * eased_progress; // slide out to right
+            }
+
+            self.animation_scale = 1.0;
+            self.visible = self.animation_progress > 0.0;
+            cx.notify();
+
+            if progress < 1.0 {
+                let frame_duration = Duration::from_millis(16);
+                cx.spawn(async move |this, cx| {
+                    Timer::after(frame_duration).await;
+                    if let Some(this) = this.upgrade() {
+                        this.update(cx, |this, cx| {
+                            this.animate_step_slide(animation_duration, cx)
+                        })
+                        .ok();
+                    }
+                })
+                .detach();
+            } else {
+                self.animation_start_time = None;
+                self.visible = self.target_visible;
+                self.animation_progress = if self.target_visible { 1.0 } else { 0.0 };
+                self.animation_scale = 1.0;
+                self.slide_offset = 0.0;
+            }
+        }
+    }
+
+    fn animate_step_breathe(&mut self, animation_duration: Duration, cx: &mut Context<Self>) {
+        if let Some(start_time) = self.animation_start_time {
+            let elapsed = start_time.elapsed();
+            let progress = (elapsed.as_secs_f32() / animation_duration.as_secs_f32()).min(1.0);
+
+            // Sine wave for organic breathing effect
+            let sine_progress = (progress * 2.0 * std::f32::consts::PI).sin() * 0.5 + 0.5;
+
+            if self.target_visible {
+                // Breathe in (scale up slightly while fading in)
+                self.animation_progress = progress;
+                self.animation_scale = 1.0 + sine_progress * 0.1; // subtle scale 1.0 to 1.1
+            } else {
+                // Breathe out (scale down while fading out)
+                self.animation_progress = 1.0 - progress;
+                self.animation_scale = 1.0 + (1.0 - sine_progress) * 0.1;
+            }
+
+            self.slide_offset = 0.0;
+            self.visible = self.animation_progress > 0.0;
+            cx.notify();
+
+            if progress < 1.0 {
+                let frame_duration = Duration::from_millis(16);
+                cx.spawn(async move |this, cx| {
+                    Timer::after(frame_duration).await;
+                    if let Some(this) = this.upgrade() {
+                        this.update(cx, |this, cx| {
+                            this.animate_step_breathe(animation_duration, cx)
+                        })
+                        .ok();
+                    }
+                })
+                .detach();
+            } else {
+                self.animation_start_time = None;
+                self.visible = self.target_visible;
+                self.animation_progress = if self.target_visible { 1.0 } else { 0.0 };
+                self.animation_scale = 1.0;
+                self.slide_offset = 0.0;
+            }
+        }
+    }
+
     pub fn show_cursor(&mut self, cx: &mut Context<BlinkManager>) {
-        if !self.visible {
+        if !self.visible || self.animation_progress < 1.0 {
             self.visible = true;
+            self.target_visible = true;
+            self.animation_progress = 1.0;
+            self.animation_scale = 1.0;
+            self.slide_offset = 0.0;
+            self.animation_start_time = None;
             cx.notify();
         }
     }
@@ -89,18 +432,47 @@ impl BlinkManager {
         }
 
         self.enabled = true;
-        // Set cursors as invisible and start blinking: this causes cursors
-        // to be visible during the next render.
+
         self.visible = false;
+        self.target_visible = false;
+        self.animation_progress = 0.0;
+        self.animation_scale = 1.0;
+        self.slide_offset = 0.0;
+        self.animation_start_time = None;
         self.blink_cursors(self.blink_epoch, cx);
     }
 
     pub fn disable(&mut self, _cx: &mut Context<Self>) {
         self.visible = false;
+        self.target_visible = false;
+        self.animation_progress = 0.0;
+        self.animation_start_time = None;
+        self.animation_scale = 1.0;
+        self.slide_offset = 0.0;
         self.enabled = false;
     }
 
     pub fn visible(&self) -> bool {
         self.visible
+    }
+
+    pub fn opacity(&self) -> f32 {
+        if self.visible {
+            self.animation_progress
+        } else {
+            0.0
+        }
+    }
+
+    pub fn scale(&self) -> f32 {
+        if self.visible {
+            self.animation_scale
+        } else {
+            1.0
+        }
+    }
+
+    pub fn slide_offset(&self) -> f32 {
+        if self.visible { self.slide_offset } else { 0.0 }
     }
 }

--- a/crates/editor/src/editor.rs
+++ b/crates/editor/src/editor.rs
@@ -14,6 +14,7 @@
 //! If you're looking to improve Vim mode, you should check out Vim crate that wraps Editor and overrides its behavior.
 pub mod actions;
 mod blink_manager;
+pub use blink_manager::BlinkAnimation;
 mod clangd_ext;
 pub mod code_context_menus;
 pub mod display_map;
@@ -215,7 +216,7 @@ use crate::{
 
 pub const FILE_HEADER_HEIGHT: u32 = 2;
 pub const MULTI_BUFFER_EXCERPT_HEADER_HEIGHT: u32 = 1;
-const CURSOR_BLINK_INTERVAL: Duration = Duration::from_millis(500);
+
 const MAX_LINE_LEN: usize = 1024;
 const MIN_NAVIGATION_HISTORY_ROW_DELTA: i64 = 10;
 const MAX_SELECTION_HISTORY_LEN: usize = 1024;
@@ -1853,7 +1854,7 @@ impl Editor {
         let selections = SelectionsCollection::new(display_map.clone(), buffer.clone());
 
         let blink_manager = cx.new(|cx| {
-            let mut blink_manager = BlinkManager::new(CURSOR_BLINK_INTERVAL, cx);
+            let mut blink_manager = BlinkManager::new(cx);
             if is_minimap {
                 blink_manager.disable(cx);
             }
@@ -2878,6 +2879,16 @@ impl Editor {
         self.blink_manager.update(cx, BlinkManager::show_cursor);
 
         cx.notify();
+    }
+
+    pub fn set_cursor_blink_animation(
+        &mut self,
+        animation: BlinkAnimation,
+        cx: &mut Context<Self>,
+    ) {
+        self.blink_manager.update(cx, |blink_manager, _| {
+            blink_manager.set_animation(animation);
+        });
     }
 
     pub fn set_current_line_highlight(

--- a/crates/settings/src/settings_content/editor.rs
+++ b/crates/settings/src/settings_content/editor.rs
@@ -8,6 +8,30 @@ use settings_macros::MergeFrom;
 
 use crate::{DiagnosticSeverityContent, ShowScrollbar};
 
+/// Animation settings for cursor blinking
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[serde(rename_all = "snake_case")]
+pub enum BlinkAnimationSetting {
+    /// Instant toggle between visible/invisible (no animation)
+    Instant,
+    /// Fade in/out animation with smooth opacity transition
+    Fade,
+    /// Pulse animation with distinct phases (fade in → hold → fade out)
+    Pulse,
+    /// Zoom animation that scales cursor size with opacity
+    Zoom,
+    /// Slide animation that moves cursor horizontally
+    Slide,
+    /// Breathe animation with organic pulsing
+    Breathe,
+}
+
+impl Default for BlinkAnimationSetting {
+    fn default() -> Self {
+        BlinkAnimationSetting::Fade
+    }
+}
+
 #[skip_serializing_none]
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
 pub struct EditorSettingsContent {
@@ -15,6 +39,31 @@ pub struct EditorSettingsContent {
     ///
     /// Default: true
     pub cursor_blink: Option<bool>,
+    /// The animation type used for cursor blinking.
+    /// Controls how the cursor transitions between visible and invisible states.
+    /// The system automatically uses appropriate timing values for each animation type.
+    ///
+    /// Available animation types:
+    /// - "instant": Binary on/off switching (classic behavior)
+    /// - "fade": Smooth opacity transition
+    /// - "pulse": Three-phase animation with fade in → hold → fade out
+    /// - "zoom": Synchronized fade and scale animation with position-aware anchoring
+    /// - "slide": Horizontal sliding animation
+    /// - "breathe": Organic pulsing animation
+    ///
+    /// Default: "fade"
+    ///
+    /// Examples:
+    /// ```json
+    /// "cursor_blink_animation": "instant"
+    /// ```
+    /// ```json
+    /// "cursor_blink_animation": "fade"
+    /// ```
+    /// ```json
+    /// "cursor_blink_animation": "zoom"
+    /// ```
+    pub cursor_blink_animation: Option<BlinkAnimationSetting>,
     /// Cursor shape for the default editor.
     /// Can be "bar", "block", "underline", or "hollow".
     ///

--- a/crates/settings/src/settings_content/editor.rs
+++ b/crates/settings/src/settings_content/editor.rs
@@ -9,10 +9,11 @@ use settings_macros::MergeFrom;
 use crate::{DiagnosticSeverityContent, ShowScrollbar};
 
 /// Animation settings for cursor blinking
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum BlinkAnimationSetting {
     /// Instant toggle between visible/invisible (no animation)
+    #[default]
     Instant,
     /// Fade in/out animation with smooth opacity transition
     Fade,
@@ -24,12 +25,6 @@ pub enum BlinkAnimationSetting {
     Slide,
     /// Breathe animation with organic pulsing
     Breathe,
-}
-
-impl Default for BlinkAnimationSetting {
-    fn default() -> Self {
-        BlinkAnimationSetting::Fade
-    }
 }
 
 #[skip_serializing_none]


### PR DESCRIPTION
This PR adds configurable cursor blink animations to provide visual variety beyond the standard on/off blinking.

## New Animation Types

Users can now set `cursor_blink_animation` in their settings to one of:

- `"instant"` - Classic binary on/off (default)
- `"fade"` - Smooth opacity transition  
- `"pulse"` - Fade in → hold → fade out pattern
- `"zoom"` - Scale and fade with position-aware anchoring
- `"slide"` - Horizontal slide in/out from left
- `"breathe"` - Gentle organic pulsing

## Usage

```json
{
  "cursor_blink_animation": "fade"
}
```

Each animation uses optimized timing and easing curves. The zoom animation includes smart positioning that anchors bar cursors to the left edge, underline cursors to the bottom, and block cursors to the center for natural-looking scaling effects.

# Release Notes:

- Added animation options for cursor blinking