### PR TITLE
acp: Add NO_PROXY if not set otherwise to not proxy localhost urls

### DIFF
--- a/crates/agent_servers/src/agent_servers.rs
+++ b/crates/agent_servers/src/agent_servers.rs
@@ -99,6 +99,9 @@ pub fn load_proxy_env(cx: &mut App) -> HashMap<String, String> {
 
     if let Some(no_proxy) = read_no_proxy_from_env() {
         env.insert("NO_PROXY".to_owned(), no_proxy);
+    } else if proxy_url.is_some() {
+        // We sometimes need local MCP servers that we don't want to proxy
+        env.insert("NO_PROXY".to_owned(), "localhost,127.0.0.1".to_owned());
     }
 
     env


### PR DESCRIPTION
Since we might run MCP servers locally for an agent, we don't want to use the proxy for those.
We set this if the user has set a proxy, but not a custom NO_PROXY env var.

Closes #38839

Release Notes:

- acp: Don't run local mcp servers through proxy, if set
