### PR TITLE
themes: Set `font_weight` to `null` for `syntax.hint`

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -239,7 +239,7 @@
           "hint": {
             "color": "#628b80ff",
             "font_style": null,
-            "font_weight": 700
+            "font_weight": null
           },
           "keyword": {
             "color": "#ff8f3fff",

--- a/assets/themes/gruvbox/gruvbox.json
+++ b/assets/themes/gruvbox/gruvbox.json
@@ -248,7 +248,7 @@
           "hint": {
             "color": "#8c957dff",
             "font_style": null,
-            "font_weight": 700
+            "font_weight": null
           },
           "keyword": {
             "color": "#fb4833ff",

--- a/assets/themes/one/one.json
+++ b/assets/themes/one/one.json
@@ -244,7 +244,7 @@
           "hint": {
             "color": "#788ca6ff",
             "font_style": null,
-            "font_weight": 700
+            "font_weight": null
           },
           "keyword": {
             "color": "#b477cfff",


### PR DESCRIPTION
Since https://github.com/zed-industries/zed/pull/36219 we now render inlay hints as bold due to this.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
