### PR TITLE
zed: Add binary type to sentry crash tags

### DIFF
--- a/crates/crashes/src/crashes.rs
+++ b/crates/crashes/src/crashes.rs
@@ -154,6 +154,7 @@ pub struct CrashInfo {
 pub struct InitCrashHandler {
     pub session_id: String,
     pub zed_version: String,
+    pub binary: String,
     pub release_channel: String,
     pub commit_sha: String,
 }

--- a/crates/remote_server/src/unix.rs
+++ b/crates/remote_server/src/unix.rs
@@ -349,6 +349,7 @@ pub fn execute_run(
         .spawn(crashes::init(crashes::InitCrashHandler {
             session_id: id,
             zed_version: VERSION.to_owned(),
+            binary: "zed-remote-server".to_string(),
             release_channel: release_channel::RELEASE_CHANNEL_NAME.clone(),
             commit_sha: option_env!("ZED_COMMIT_SHA").unwrap_or("no_sha").to_owned(),
         }))
@@ -543,6 +544,7 @@ pub(crate) fn execute_proxy(
     smol::spawn(crashes::init(crashes::InitCrashHandler {
         session_id: id,
         zed_version: VERSION.to_owned(),
+        binary: "zed-remote-server".to_string(),
         release_channel: release_channel::RELEASE_CHANNEL_NAME.clone(),
         commit_sha: option_env!("ZED_COMMIT_SHA").unwrap_or("no_sha").to_owned(),
     }))

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -270,6 +270,7 @@ pub fn main() {
         .spawn(crashes::init(InitCrashHandler {
             session_id: session_id.clone(),
             zed_version: app_version.to_string(),
+            binary: "zed".to_string(),
             release_channel: release_channel::RELEASE_CHANNEL_NAME.clone(),
             commit_sha: app_commit_sha
                 .as_ref()

--- a/crates/zed/src/reliability.rs
+++ b/crates/zed/src/reliability.rs
@@ -330,6 +330,7 @@ async fn upload_minidump(
             metadata.init.release_channel.clone(),
         )
         .text("sentry[tags][version]", metadata.init.zed_version.clone())
+        .text("sentry[tags][binary]", metadata.init.binary.clone())
         .text("sentry[release]", metadata.init.commit_sha.clone())
         .text("platform", "rust");
     let mut panic_message = "".to_owned();


### PR DESCRIPTION
This allows to filter by main zed binary or remote server crashes, as well as easily tell whether a crash happened in a remote-server binary or not.

Release Notes:

- N/A *or* Added/Fixed/Improved ...
