### PR TITLE
themes: Fix Ayu theme comment colors

### DIFF
--- a/assets/themes/ayu/ayu.json
+++ b/assets/themes/ayu/ayu.json
@@ -192,7 +192,7 @@
             "font_weight": null
           },
           "comment": {
-            "color": "#abb5be8c",
+            "color": "#5c6773ff",
             "font_style": null,
             "font_weight": null
           },
@@ -583,7 +583,7 @@
             "font_weight": null
           },
           "comment": {
-            "color": "#787b8099",
+            "color": "#abb0b6ff",
             "font_style": null,
             "font_weight": null
           },
@@ -974,7 +974,7 @@
             "font_weight": null
           },
           "comment": {
-            "color": "#b8cfe680",
+            "color": "#5c6773ff",
             "font_style": null,
             "font_weight": null
           },


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/39122

Currently comment colors in Ayu theme do not work as expected and hard to differentiate. In my understanding something is really wrong how zed interprets rgba hex color codes, for example:

|  #5c677300 | #5c6773ff |
| ------------- | ---------- |
| <img width="134" height="38" alt="image" src="https://github.com/user-attachments/assets/c9f1f618-958e-4fe9-a44a-636681d2f418" /> | <img width="117" height="32" alt="image" src="https://github.com/user-attachments/assets/78eac6b3-aecd-4be1-83d4-42590604c3a6" /> |

This PR works around this by using comment color codes from [ayu-vim](https://github.com/ayu-theme/ayu-vim). Maybe I am not understanding how RGBA works, but in my opinion underlying issue should be solved.

Release Notes:

- N/A
