### PR TITLE
Update a Help menu item in app_menus.rs with "Locally"

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -252,7 +252,7 @@ pub fn app_menus() -> Vec<Menu> {
             name: "Help".into(),
             items: vec![
                 MenuItem::action(
-                    "View Release Notes",
+                    "View Release Notes Locally",
                     auto_update_ui::ViewReleaseNotesLocally,
                 ),
                 MenuItem::action("View Telemetry", zed_actions::OpenTelemetryLog),


### PR DESCRIPTION
Add the single word "Locally" to clarify where the info is coming from, (and that you don't need to be online.)

Closes #ISSUE

Release Notes:

- N/A *or* Added/Fixed/Improved ...
