### PR TITLE
Agent profiles improvements - add search bar, "Switch profile: " actions, default_model

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,6 +3510,7 @@ dependencies = [
 name = "command_palette"
 version = "0.1.0"
 dependencies = [
+ "agent_settings",
  "anyhow",
  "client",
  "collections",

--- a/crates/agent2/src/tests/mod.rs
+++ b/crates/agent2/src/tests/mod.rs
@@ -897,7 +897,7 @@ async fn test_profiles(cx: &mut TestAppContext) {
     // Test that test-1 profile (default) has echo and delay tools
     thread
         .update(cx, |thread, cx| {
-            thread.set_profile(AgentProfileId("test-1".into()));
+            thread.set_profile(AgentProfileId("test-1".into()), cx);
             thread.send(UserMessageId::new(), ["test"], cx)
         })
         .unwrap();
@@ -917,7 +917,7 @@ async fn test_profiles(cx: &mut TestAppContext) {
     // Switch to test-2 profile, and verify that it has only the infinite tool.
     thread
         .update(cx, |thread, cx| {
-            thread.set_profile(AgentProfileId("test-2".into()));
+            thread.set_profile(AgentProfileId("test-2".into()), cx);
             thread.send(UserMessageId::new(), ["test2"], cx)
         })
         .unwrap();
@@ -966,8 +966,8 @@ async fn test_mcp_tools(cx: &mut TestAppContext) {
     )
     .await;
     cx.run_until_parked();
-    thread.update(cx, |thread, _| {
-        thread.set_profile(AgentProfileId("test".into()))
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx)
     });
 
     let mut mcp_tool_calls = setup_context_server(
@@ -1133,8 +1133,8 @@ async fn test_mcp_tool_truncation(cx: &mut TestAppContext) {
     .await;
     cx.run_until_parked();
 
-    thread.update(cx, |thread, _| {
-        thread.set_profile(AgentProfileId("test".into()));
+    thread.update(cx, |thread, cx| {
+        thread.set_profile(AgentProfileId("test".into()), cx);
         thread.add_tool(EchoTool);
         thread.add_tool(DelayTool);
         thread.add_tool(WordListTool);

--- a/crates/agent_ui/src/agent_configuration/tool_picker.rs
+++ b/crates/agent_ui/src/agent_configuration/tool_picker.rs
@@ -294,6 +294,7 @@ impl PickerDelegate for ToolPickerDelegate {
                                 )
                             })
                             .collect(),
+                        default_model: default_profile.default_model.clone(),
                     });
 
                 if let Some(server_id) = server_id {

--- a/crates/agent_ui/src/profile_selector.rs
+++ b/crates/agent_ui/src/profile_selector.rs
@@ -10,7 +10,11 @@ use gpui::{
 };
 use picker::{Picker, PickerDelegate, popover_menu::PickerPopoverMenu};
 use settings::{DockPosition, Settings as _, SettingsStore, update_settings_file};
-use std::{rc::Rc, sync::atomic::Ordering, sync::{Arc, atomic::AtomicBool}};
+use std::{
+    rc::Rc,
+    sync::atomic::Ordering,
+    sync::{Arc, atomic::AtomicBool},
+};
 use ui::{
     Button, ButtonStyle, DocumentationSide, HighlightedLabel, Icon, IconName, Label, LabelSize,
     ListItem, ListItemSpacing, PopoverMenuHandle, TintColor, Tooltip, prelude::*,

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -33,6 +33,7 @@ telemetry.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 workspace-hack.workspace = true
+agent_settings.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -4,9 +4,9 @@ pub mod popover_menu;
 
 use anyhow::Result;
 use editor::{
+    Editor, SelectionEffects,
     actions::{MoveDown, MoveUp, SelectAll},
     scroll::Autoscroll,
-    Editor, SelectionEffects,
 };
 use gpui::{
     Action, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EventEmitter, FocusHandle,

--- a/crates/picker/src/picker.rs
+++ b/crates/picker/src/picker.rs
@@ -4,9 +4,9 @@ pub mod popover_menu;
 
 use anyhow::Result;
 use editor::{
-    Editor, SelectionEffects,
-    actions::{MoveDown, MoveUp},
+    actions::{MoveDown, MoveUp, SelectAll},
     scroll::Autoscroll,
+    Editor, SelectionEffects,
 };
 use gpui::{
     Action, AnyElement, App, ClickEvent, Context, DismissEvent, Entity, EventEmitter, FocusHandle,
@@ -354,6 +354,14 @@ impl<D: PickerDelegate> Picker<D> {
 
     pub fn focus(&self, window: &mut Window, cx: &mut App) {
         self.focus_handle(cx).focus(window);
+    }
+
+    pub fn select_all(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        if let Head::Editor(editor) = &self.head {
+            editor.update(cx, |editor, cx| {
+                editor.select_all(&SelectAll, window, cx);
+            });
+        }
     }
 
     /// Handles the selecting an index, and passing the change to the delegate.

--- a/crates/picker/src/popover_menu.rs
+++ b/crates/picker/src/popover_menu.rs
@@ -1,3 +1,5 @@
+use std::rc::Rc;
+
 use gpui::{
     AnyView, Corner, DismissEvent, Entity, EventEmitter, FocusHandle, Focusable, Subscription,
 };
@@ -19,6 +21,7 @@ where
     tooltip: TT,
     handle: Option<PopoverMenuHandle<Picker<P>>>,
     anchor: Corner,
+    on_open: Option<Rc<dyn Fn(&mut Window, &mut App)>>,
     _subscriptions: Vec<Subscription>,
 }
 
@@ -44,11 +47,17 @@ where
             tooltip,
             handle: None,
             anchor,
+            on_open: None,
         }
     }
 
     pub fn with_handle(mut self, handle: PopoverMenuHandle<Picker<P>>) -> Self {
         self.handle = Some(handle);
+        self
+    }
+
+    pub fn on_open(mut self, on_open: Rc<dyn Fn(&mut Window, &mut App)>) -> Self {
+        self.on_open = Some(on_open);
         self
     }
 }
@@ -86,6 +95,7 @@ where
             .trigger_with_tooltip(self.trigger, self.tooltip)
             .anchor(self.anchor)
             .when_some(self.handle, |menu, handle| menu.with_handle(handle))
+            .when_some(self.on_open, |menu, on_open| menu.on_open(on_open))
             .offset(gpui::Point {
                 x: px(0.0),
                 y: px(-2.0),

--- a/crates/settings/src/settings_content/agent.rs
+++ b/crates/settings/src/settings_content/agent.rs
@@ -178,6 +178,8 @@ pub struct AgentProfileContent {
     pub enable_all_context_servers: Option<bool>,
     #[serde(default)]
     pub context_servers: IndexMap<Arc<str>, ContextServerPresetContent>,
+    /// Default language model selection to apply when activating this profile.
+    pub default_model: Option<LanguageModelSelection>,
 }
 
 #[skip_serializing_none]

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -266,7 +266,22 @@ pub mod settings_profile_selector {
 }
 
 pub mod agent {
-    use gpui::actions;
+    use gpui::{Action, actions};
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    /// Switches the active agent profile to the given profile id.
+    #[derive(Clone, PartialEq, Default, Deserialize, JsonSchema, Action)]
+    #[action(namespace = agent)]
+    #[serde(deny_unknown_fields)]
+    pub struct SwitchToProfile {
+        /// The ID of the profile to activate.
+        #[serde(default)]
+        pub profile_id: String,
+        /// Optional display name, used for presenting the action in UI.
+        #[serde(default)]
+        pub profile_name: Option<String>,
+    }
 
     actions!(
         agent,


### PR DESCRIPTION
Adds 3 things to make profiles more useful. I can also split them up into 3 PRs if that's easier 

1. Adds a search bar to the 'profile' panel, so that we can switch profiles without having to use the mouse or `tab` a few times

![2025-09-30 13 32 55](https://github.com/user-attachments/assets/2fc1f32b-9e25-4059-aae1-d195334a5fdb)

2. Exposes all available profiles with `Switch profile: ` actions

<img width="559" height="189" alt="image" src="https://github.com/user-attachments/assets/c3fba9dd-a136-41ad-886d-34c93147f2fc" />

To allow for adding keybindings to quickly enable a profile: 

<img width="672" height="116" alt="image" src="https://github.com/user-attachments/assets/086702af-4034-4a8f-bf66-2863a939e5c0" />

3. Adds support for `default_model` for profiles: 

```
      "my-profile": {
        "name": "Coding Agent",
        "tools": {},
        "enable_all_context_servers": false,
        "context_servers": {},
        "default_model": {
          "provider": "copilot_chat",
          "model": "grok-code-fast-1"
        }
      }
```

Which will then switch to the default model whenever the profile is activated

![2025-09-30 17 09 06](https://github.com/user-attachments/assets/43f07b7b-85d9-4aff-82ce-25d6f5050d50)


Release Notes: 

- Added search bar to profile switcher
- Added action to switch profiles
- Added `default_model` support to profile config 

