### PR TITLE
worktree: Remove unwrap in BackgroundScanner::update_ignore_status

### DIFF
--- a/crates/worktree/src/worktree.rs
+++ b/crates/worktree/src/worktree.rs
@@ -4547,10 +4547,21 @@ impl BackgroundScanner {
 
         let mut entries_by_id_edits = Vec::new();
         let mut entries_by_path_edits = Vec::new();
-        let path = job
+        let Some(path) = job
             .abs_path
             .strip_prefix(snapshot.abs_path.as_path())
-            .unwrap();
+            .map_err(|_| {
+                anyhow::anyhow!(
+                    "Failed to strip prefix '{}' from path '{}'",
+                    snapshot.abs_path.as_path().display(),
+                    job.abs_path.display()
+                )
+            })
+            .log_err()
+        else {
+            return;
+        };
+
         let Some(path) = RelPath::new(&path, PathStyle::local()).log_err() else {
             return;
         };


### PR DESCRIPTION
We've seen this panic come up in the last two weeks, which might be caused by #33592. However, we are not sure what paths can cause this `unwrap()` to fail. Therefore adding some logging around this, so that the next time someone opens a bug report we can further diagnose the issue.

Fixes ZED-1F6

Release Notes:

- Fixed an issue where Zed could crash when including specific paths in a global `.gitignore` files