### PR TITLE
gpui: Respect font smoothing on macOS

### DIFF
--- a/crates/gpui/src/platform/mac/text_system.rs
+++ b/crates/gpui/src/platform/mac/text_system.rs
@@ -396,7 +396,6 @@ impl MacTextSystemState {
             let subpixel_shift = params
                 .subpixel_variant
                 .map(|v| v as f32 / SUBPIXEL_VARIANTS_X as f32);
-            cx.set_allows_font_smoothing(true);
             cx.set_text_drawing_mode(CGTextDrawingMode::CGTextFill);
             cx.set_gray_fill_color(0.0, 1.0);
             cx.set_allows_antialiasing(true);


### PR DESCRIPTION
- Closes #38847
- See also: #37622 and #38467

Release Notes:

- Fonts are now rendered in accordance with the `AppleFontSmoothing` setting.
