### PR TITLE
agent: Fix keybinding to deny running a command

### DIFF
--- a/assets/keymaps/default-linux.json
+++ b/assets/keymaps/default-linux.json
@@ -250,7 +250,7 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "ctrl-y": "agent::AllowOnce",
       "ctrl-alt-y": "agent::AllowAlways",
-      "ctrl-d": "agent::RejectOnce"
+      "ctrl-alt-z": "agent::RejectOnce"
     }
   },
   {

--- a/assets/keymaps/default-macos.json
+++ b/assets/keymaps/default-macos.json
@@ -289,7 +289,7 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "cmd-y": "agent::AllowOnce",
       "cmd-alt-y": "agent::AllowAlways",
-      "cmd-d": "agent::RejectOnce"
+      "cmd-alt-z": "agent::RejectOnce"
     }
   },
   {

--- a/assets/keymaps/default-windows.json
+++ b/assets/keymaps/default-windows.json
@@ -251,7 +251,7 @@
       "alt-enter": "agent::ContinueWithBurnMode",
       "ctrl-y": "agent::AllowOnce",
       "ctrl-alt-y": "agent::AllowAlways",
-      "ctrl-d": "agent::RejectOnce"
+      "ctrl-alt-z": "agent::RejectOnce"
     }
   },
   {


### PR DESCRIPTION
Despite how great `cmd-d` as a keybinding is, that was not working as it was conflicting with an editor keybinding:

https://github.com/user-attachments/assets/2ea8665b-7008-4f0a-9426-8d31d379ee1c

This PR changes it to `cmd-alt-z`, which is the best "remove/fix"-type of keybinding I could find that doesn't conflict with anything else. Ideally, we'd use either the D, N, or R letters for "deny", "no", and "reject", but unfortunately, none of them are nicely available in this context...


Release Notes:

- agent: Fix keybinding to deny running a command
