### PR TITLE
agent: Add "agent: switch profile:" action for all available profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3510,6 +3510,7 @@ dependencies = [
 name = "command_palette"
 version = "0.1.0"
 dependencies = [
+ "agent_settings",
  "anyhow",
  "client",
  "collections",

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -3996,7 +3996,7 @@ impl AcpThreadView {
             settings
                 .agent
                 .get_or_insert_default()
-                .set_profile(settings_profile.0.clone());
+                .set_profile(settings_profile.0);
         });
 
         thread.update(cx, |thread, _| {

--- a/crates/command_palette/Cargo.toml
+++ b/crates/command_palette/Cargo.toml
@@ -33,6 +33,7 @@ telemetry.workspace = true
 workspace.workspace = true
 zed_actions.workspace = true
 workspace-hack.workspace = true
+agent_settings.workspace = true
 
 [dev-dependencies]
 ctor.workspace = true

--- a/crates/zed_actions/src/lib.rs
+++ b/crates/zed_actions/src/lib.rs
@@ -266,7 +266,22 @@ pub mod settings_profile_selector {
 }
 
 pub mod agent {
-    use gpui::actions;
+    use gpui::{Action, actions};
+    use schemars::JsonSchema;
+    use serde::Deserialize;
+
+    /// Switches the active agent profile to the given profile id.
+    #[derive(Clone, PartialEq, Default, Deserialize, JsonSchema, Action)]
+    #[action(namespace = agent)]
+    #[serde(deny_unknown_fields)]
+    pub struct SwitchToProfile {
+        /// The ID of the profile to activate.
+        #[serde(default)]
+        pub profile_id: String,
+        /// Optional display name, used for presenting the action in UI.
+        #[serde(default)]
+        pub profile_name: Option<String>,
+    }
 
     actions!(
         agent,


### PR DESCRIPTION
Split off from https://github.com/zed-industries/zed/pull/39175

Exposes all available profiles with `Switch profile: ` actions

<img width="559" height="189" alt="image" src="https://github.com/user-attachments/assets/c3fba9dd-a136-41ad-886d-34c93147f2fc" />

To allow for adding keybindings to quickly enable a profile: 

<img width="672" height="116" alt="image" src="https://github.com/user-attachments/assets/086702af-4034-4a8f-bf66-2863a939e5c0" />


Release Notes:

- Added "switch profile: " actions for all available agent profiles
