### PR TITLE
task: Fix `ShellBuilder::redirect_stdin_to_dev_null` constructing invalid commands on windows

### DIFF
--- a/crates/task/src/shell_builder.rs
+++ b/crates/task/src/shell_builder.rs
@@ -288,7 +288,7 @@ impl ShellBuilder {
                         combined_command.push_str(") </dev/null");
                     }
                     ShellKind::PowerShell => {
-                        combined_command.insert_str(0, "$null | {");
+                        combined_command.insert_str(0, "`$null | & {");
                         combined_command.push_str("}");
                     }
                     ShellKind::Cmd => {


### PR DESCRIPTION

Release Notes:

- Fixed agents not being able to use the terminal tool with powershell