### PR TITLE
acp_thread: Skip git pagination on windows

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -1968,9 +1968,8 @@ impl AcpThread {
 
         let env = cx.spawn(async move |_, _| {
             let mut env = env.await.unwrap_or_default();
-            if cfg!(unix) {
-                env.insert("PAGER".into(), "cat".into());
-            }
+            // Disables paging for `git` and hopefully other commands
+            env.insert("PAGER".into(), "".into());
             for var in extra_env {
                 env.insert(var.name, var.value);
             }


### PR DESCRIPTION

Release Notes:

- Fixed agents running git commands with pagination enabled

Co-authored-by: Cole Miller <cole@zed.dev>