### PR TITLE
terminals: Remove (now) incorrect alacritty workaround for task spawning

### DIFF
--- a/crates/project/src/terminals.rs
+++ b/crates/project/src/terminals.rs
@@ -211,12 +211,6 @@ impl Project {
                                 let activation_script = activation_script.join("; ");
                                 let to_run = format_to_run();
 
-                                // todo(lw): Alacritty uses `CreateProcessW` on windows with the entire command and arg sequence merged into a single string,
-                                // without quoting the arguments
-                                #[cfg(windows)]
-                                let arg =
-                                    quote_arg(&format!("{activation_script}; {to_run}"), true);
-                                #[cfg(not(windows))]
                                 let arg = format!("{activation_script}; {to_run}");
 
                                 (
@@ -517,37 +511,6 @@ impl Project {
     pub fn local_terminal_handles(&self) -> &Vec<WeakEntity<terminal::Terminal>> {
         &self.terminals.local_handles
     }
-}
-
-/// We're not using shlex for windows as it is overly eager with escaping some of the special characters (^) we need for nu. Hence, we took
-/// that quote impl straight from Rust stdlib (Command API).
-#[cfg(windows)]
-fn quote_arg(argument: &str, quote: bool) -> String {
-    let mut arg = String::new();
-    if quote {
-        arg.push('"');
-    }
-
-    let mut backslashes: usize = 0;
-    for x in argument.chars() {
-        if x == '\\' {
-            backslashes += 1;
-        } else {
-            if x == '"' {
-                // Add n+1 backslashes to total 2n+1 before internal '"'.
-                arg.extend((0..=backslashes).map(|_| '\\'));
-            }
-            backslashes = 0;
-        }
-        arg.push(x);
-    }
-
-    if quote {
-        // Add n backslashes to total 2n before ending '"'.
-        arg.extend((0..backslashes).map(|_| '\\'));
-        arg.push('"');
-    }
-    arg
 }
 
 fn create_remote_shell(


### PR DESCRIPTION
Alacritty was bumped so this is outdated now
Closes #39228

Release Notes:

- Fixed venv activation failing with powershell
