### PR TITLE
gpui: Respect macOS 'Do Nothing' window double-click setting

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1530,8 +1530,11 @@ impl PlatformWindow for MacWindow {
                             // There is no documented API for "Fill" action, so we'll just zoom the window
                             window.zoom_(nil);
                         }
+                        "None" | "" => {
+                            // Do nothing - respect the "Do Nothing" system setting
+                        }
                         _ => {
-                            window.zoom_(nil);
+                            // Default to doing nothing for unrecognized settings
                         }
                     }
                 }


### PR DESCRIPTION
Fixes titlebar double-click behavior to properly handle the macOS system setting when "Do Nothing" is selected in System Settings > Desktop & Dock > "Double-click a window's title bar to".

Closes #39102

Release Notes:

- Fixed macOS `Do Nothing` window double click setting not be respected