### PR TITLE
agent: Only show profile manage list item selection keybinding on the focused item

### DIFF
--- a/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
+++ b/crates/agent_ui/src/agent_configuration/manage_profiles_modal.rs
@@ -317,6 +317,8 @@ impl ManageProfilesModal {
         window: &mut Window,
         cx: &mut Context<Self>,
     ) -> impl IntoElement + use<> {
+        let is_focused = profile.navigation.focus_handle.contains_focused(window, cx);
+
         div()
             .id(SharedString::from(format!("profile-{}", profile.id)))
             .track_focus(&profile.navigation.focus_handle)
@@ -328,25 +330,27 @@ impl ManageProfilesModal {
             })
             .child(
                 ListItem::new(SharedString::from(format!("profile-{}", profile.id)))
-                    .toggle_state(profile.navigation.focus_handle.contains_focused(window, cx))
+                    .toggle_state(is_focused)
                     .inset(true)
                     .spacing(ListItemSpacing::Sparse)
                     .child(Label::new(profile.name.clone()))
-                    .end_slot(
-                        h_flex()
-                            .gap_1()
-                            .child(
-                                Label::new("Customize")
-                                    .size(LabelSize::Small)
-                                    .color(Color::Muted),
-                            )
-                            .children(KeyBinding::for_action_in(
-                                &menu::Confirm,
-                                &self.focus_handle,
-                                window,
-                                cx,
-                            )),
-                    )
+                    .when(is_focused, |this| {
+                        this.end_slot(
+                            h_flex()
+                                .gap_1()
+                                .child(
+                                    Label::new("Customize")
+                                        .size(LabelSize::Small)
+                                        .color(Color::Muted),
+                                )
+                                .children(KeyBinding::for_action_in(
+                                    &menu::Confirm,
+                                    &self.focus_handle,
+                                    window,
+                                    cx,
+                                )),
+                        )
+                    })
                     .on_click({
                         let profile_id = profile.id.clone();
                         cx.listener(move |this, _, window, cx| {


### PR DESCRIPTION
Small update here that makes the UI simpler; there's no need to see the keybinding in all the items you're not focused in.

| Before | After |
|--------|--------|
| <img width="1112" height="720" alt="Screenshot 2025-09-30 at 5  25@2x" src="https://github.com/user-attachments/assets/e0362f98-889a-4007-a50d-8006dfb91787" /> | <img width="1112" height="732" alt="Screenshot 2025-09-30 at 5  25 2@2x" src="https://github.com/user-attachments/assets/b536b6ba-ef61-4891-8b2f-c27c40c70e4e" /> | 

Release Notes:

- N/A
