### PR TITLE
Don't run MCP servers in wrong directory for remote projects

### DIFF
--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -166,11 +166,10 @@ impl ContextServerStore {
     pub fn new(
         worktree_store: Entity<WorktreeStore>,
         weak_project: WeakEntity<Project>,
-        run_servers: bool,
         cx: &mut Context<Self>,
     ) -> Self {
         Self::new_internal(
-            run_servers,
+            true,
             None,
             ContextServerDescriptorRegistry::default_global(cx),
             worktree_store,

--- a/crates/project/src/context_server_store.rs
+++ b/crates/project/src/context_server_store.rs
@@ -166,10 +166,11 @@ impl ContextServerStore {
     pub fn new(
         worktree_store: Entity<WorktreeStore>,
         weak_project: WeakEntity<Project>,
+        run_servers: bool,
         cx: &mut Context<Self>,
     ) -> Self {
         Self::new_internal(
-            true,
+            run_servers,
             None,
             ContextServerDescriptorRegistry::default_global(cx),
             worktree_store,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1052,7 +1052,7 @@ impl Project {
 
             let weak_self = cx.weak_entity();
             let context_server_store =
-                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, cx));
+                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, true, cx));
 
             let environment = cx.new(|_| ProjectEnvironment::new(env));
             let manifest_tree = ManifestTree::new(worktree_store.clone(), cx);
@@ -1235,7 +1235,7 @@ impl Project {
 
             let weak_self = cx.weak_entity();
             let context_server_store =
-                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, cx));
+                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, false, cx));
 
             let buffer_store = cx.new(|cx| {
                 BufferStore::remote(
@@ -1560,7 +1560,7 @@ impl Project {
 
             let weak_self = cx.weak_entity();
             let context_server_store =
-                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, cx));
+                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, false, cx));
 
             let mut worktrees = Vec::new();
             for worktree in response.payload.worktrees {

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -1052,7 +1052,7 @@ impl Project {
 
             let weak_self = cx.weak_entity();
             let context_server_store =
-                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, true, cx));
+                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, cx));
 
             let environment = cx.new(|_| ProjectEnvironment::new(env));
             let manifest_tree = ManifestTree::new(worktree_store.clone(), cx);
@@ -1235,7 +1235,7 @@ impl Project {
 
             let weak_self = cx.weak_entity();
             let context_server_store =
-                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, false, cx));
+                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, cx));
 
             let buffer_store = cx.new(|cx| {
                 BufferStore::remote(
@@ -1560,7 +1560,7 @@ impl Project {
 
             let weak_self = cx.weak_entity();
             let context_server_store =
-                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, false, cx));
+                cx.new(|cx| ContextServerStore::new(worktree_store.clone(), weak_self, cx));
 
             let mut worktrees = Vec::new();
             for worktree in response.payload.worktrees {


### PR DESCRIPTION
Closes #39213

Release Notes:

- Fixed a bug where we tried to run MCP servers in the remote project's working directory on the local machine
