### PR TITLE
agent: Fix terminal tool on Windows

### DIFF
--- a/crates/task/src/shell_builder.rs
+++ b/crates/task/src/shell_builder.rs
@@ -288,7 +288,7 @@ impl ShellBuilder {
                         combined_command.push_str(") </dev/null");
                     }
                     ShellKind::PowerShell => {
-                        combined_command.insert_str(0, "`$null | & {");
+                        combined_command.insert_str(0, "$null | & {");
                         combined_command.push_str("}");
                     }
                     ShellKind::Cmd => {


### PR DESCRIPTION
Seems like we don't want to escape the dollar sign in `$null`.

Release Notes:

- N/A