### PR TITLE
Add an action for that runs a sequence of actions

### DIFF
--- a/crates/settings/src/settings.rs
+++ b/crates/settings/src/settings.rs
@@ -30,6 +30,8 @@ pub use settings_store::{
 
 pub use vscode_import::{VsCodeSettings, VsCodeSettingsSource};
 
+pub use keymap_file::ActionSequence;
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct ActiveSettingsProfileName(pub String);
 

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5553,6 +5553,13 @@ impl Workspace {
 
     fn actions(&self, div: Div, window: &mut Window, cx: &mut Context<Self>) -> Div {
         self.add_workspace_actions_listeners(div, window, cx)
+            .on_action(cx.listener(
+                |_workspace, action_sequence: &settings::ActionSequence, window, cx| {
+                    for action in &action_sequence.0 {
+                        window.dispatch_action(action.boxed_clone(), cx);
+                    }
+                },
+            ))
             .on_action(cx.listener(Self::close_inactive_items_and_panes))
             .on_action(cx.listener(Self::close_all_items_and_panes))
             .on_action(cx.listener(Self::save_all))

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -4393,6 +4393,7 @@ mod tests {
                     | "workspace::OpenTerminal"
                     | "workspace::SendKeystrokes"
                     | "agent::NewNativeAgentThreadFromSummary"
+                    | "action::Sequence"
                     | "zed::OpenBrowser"
                     | "zed::OpenZedUrl" => {}
                     _ => {
@@ -4454,6 +4455,7 @@ mod tests {
             assert_eq!(actions_without_namespace, Vec::<&str>::new());
 
             let expected_namespaces = vec![
+                "action",
                 "activity_indicator",
                 "agent",
                 #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
Thanks to @Zertsov for #37932 which caused me to consider this implementation approach.

One known issue with this is that it will not wait for actions that do async work to complete.  Supporting this would require quite a lot of code change.  It also doesn't affect the main usecase of sequencing editor actions, since few are async.

Another caveat is that this is implemented as an action handler on workspace and so won't work in other types of windows.  This seems fine for now, since action sequences don't seem useful in other window types.  The command palette isn't accessible in non-workspace windows.

Alternatives considered:

* Add `cx: &App` to `Action::build`.  This would allow removal of the special case in keymap parsing.  Decided not to do this, since ideally `build` is a pure function of the input json.

* Build it more directly into GPUI.  The main advantage of this would be the potential to handle non-workspace windows.  Since it's possible to do outside of GPUI, seems better to do so.  While some aspects of the GPUI action system are pretty directly informed by the specifics of Zed's keymap files, it seems to avoid this as much as possible.

* Bake it more directly into keymap syntax like in #37932.  While I think it would be good for this to be a primitive in the JSON syntax, it seems like it would better fit in a more comprehensive change to provide better JSON structure.  So in the meantime it seems better to keep the structure the same and just add a new action.

    - Another reason to not bake it in yet is that this provides a place to document the caveat about async actions.

Closes #17710

Release Notes:

- Added support for action sequences in keymaps. Example: `["action::Sequence", [        ["editor::SelectLargerSyntaxNode", "editor::Copy", "editor::UndoSelection"]`