### PR TITLE
Add more selection options to app menus

### DIFF
--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -142,6 +142,13 @@ pub fn app_menus() -> Vec<Menu> {
                         replace_newest: false,
                     },
                 ),
+                MenuItem::action(
+                    "Select Previous Occurrence",
+                    editor::actions::SelectPrevious {
+                        replace_newest: false,
+                    },
+                ),
+                MenuItem::action("Select All Occurrences", editor::actions::SelectAllMatches),
                 MenuItem::separator(),
                 MenuItem::action("Move Line Up", editor::actions::MoveLineUp),
                 MenuItem::action("Move Line Down", editor::actions::MoveLineDown),


### PR DESCRIPTION
## Summary

The purpose of this pull request is to add new menu items for the menu bar as mentioned on this [discussion or feature request](https://github.com/zed-industries/zed/discussions/28153#discussion-8169826).

The actions are already supported by the command palette, but not available on the `MenuBar`.

## Screenshot

<img width="498" height="392" alt="image" src="https://github.com/user-attachments/assets/8ad0e836-8295-4b46-a67a-0edf1408ad59" />

Release Notes:

- Added `SelectPrevious` and `SelectAllMatches` items to the `Selection` app menu.

