### PR TITLE
Improve GPU selection on Windows

### DIFF
--- a/crates/gpui/src/platform/windows/directx_devices.rs
+++ b/crates/gpui/src/platform/windows/directx_devices.rs
@@ -1,4 +1,3 @@
-use windows::core::Interface;
 use anyhow::{Context, Result};
 use util::ResultExt;
 use windows::Win32::{
@@ -15,10 +14,11 @@ use windows::Win32::{
         },
         Dxgi::{
             CreateDXGIFactory2, DXGI_CREATE_FACTORY_DEBUG, DXGI_CREATE_FACTORY_FLAGS,
-            DXGI_GPU_PREFERENCE_MINIMUM_POWER, IDXGIAdapter1, IDXGIFactory6,
+            IDXGIAdapter1, IDXGIFactory6,
         },
     },
 };
+use windows::core::Interface;
 
 pub(crate) fn try_to_recover_from_device_lost<T>(
     mut f: impl FnMut() -> Result<T>,
@@ -122,9 +122,7 @@ fn get_dxgi_factory(debug_layer_available: bool) -> Result<IDXGIFactory6> {
 #[inline]
 fn get_adapter(dxgi_factory: &IDXGIFactory6, debug_layer_available: bool) -> Result<IDXGIAdapter1> {
     for adapter_index in 0.. {
-        let adapter: IDXGIAdapter1 = unsafe {
-            dxgi_factory.EnumAdapters(adapter_index)?.cast()?
-        };
+        let adapter: IDXGIAdapter1 = unsafe { dxgi_factory.EnumAdapters(adapter_index)?.cast()? };
         if let Ok(desc) = unsafe { adapter.GetDesc1() } {
             let gpu_name = String::from_utf16_lossy(&desc.Description)
                 .trim_matches(char::from(0))

--- a/crates/gpui/src/platform/windows/directx_devices.rs
+++ b/crates/gpui/src/platform/windows/directx_devices.rs
@@ -1,3 +1,4 @@
+use windows::core::Interface;
 use anyhow::{Context, Result};
 use util::ResultExt;
 use windows::Win32::{
@@ -122,9 +123,8 @@ fn get_dxgi_factory(debug_layer_available: bool) -> Result<IDXGIFactory6> {
 fn get_adapter(dxgi_factory: &IDXGIFactory6, debug_layer_available: bool) -> Result<IDXGIAdapter1> {
     for adapter_index in 0.. {
         let adapter: IDXGIAdapter1 = unsafe {
-            dxgi_factory
-                .EnumAdapterByGpuPreference(adapter_index, DXGI_GPU_PREFERENCE_MINIMUM_POWER)
-        }?;
+            dxgi_factory.EnumAdapters(adapter_index)?.cast()?
+        };
         if let Ok(desc) = unsafe { adapter.GetDesc1() } {
             let gpu_name = String::from_utf16_lossy(&desc.Description)
                 .trim_matches(char::from(0))


### PR DESCRIPTION
Closes #39263

Release Notes:
- N/A 

from https://github.com/zed-industries/zed/issues/39263#issuecomment-3358220988

> 
> > If you replace that code with
> > 
> > let adapter: IDXGIAdapter1 = unsafe { 
> >    dxgi_factory.EnumAdapters(adapter_index) 
> > }?.cast()?; 
> > 
> > does it not select the right GPU?
>  
> @reflectronic That does seem to select the active gpu for me, meaning whichever GPU is currently connected. This is a much simpler solution than the one I have here (https://github.com/zed-industries/zed/pull/39264 - updated) and while I'm sure I could imagine someone wanting to choose their GPU to render Zed on, that may not be something that the application really needs to support.
> 
> I have a branch with just this as the only change that I can push to that PR if the simpler solution is preferred.
> 
> ```rust
>         let adapter: IDXGIAdapter1 = unsafe {
>             dxgi_factory.EnumAdapters(adapter_index)?.cast()?
>         };
> ```