### PR TITLE
agent: Add support for Z.ai and models like GLM 4.6

### DIFF
--- a/assets/icons/ai_z_ai.svg
+++ b/assets/icons/ai_z_ai.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg" fill-rule="evenodd" clip-rule="evenodd" stroke-miterlimit="10">
+    <g fill="#000" fill-rule="nonzero">
+        <path d="M8.269 3.433l-.751 1.070c-.116.168-.312.272-.520.272H2.893V3.088c-.006.006 5.376.006 5.376.006zM13.373 3.433L6.922 12.573H2.621l6.451-9.140h4.301zM7.726 12.573l.758-1.075c.115-.168.312-.272.520-.272h4.101v1.347H7.726z"/>
+    </g>
+</svg>

--- a/crates/icons/src/icons.rs
+++ b/crates/icons/src/icons.rs
@@ -15,6 +15,7 @@ pub enum IconName {
     AiDeepSeek,
     AiEdit,
     AiGemini,
+    AiZAi,
     AiGoogle,
     AiLmStudio,
     AiMistral,

--- a/crates/language_model/src/language_model.rs
+++ b/crates/language_model/src/language_model.rs
@@ -46,6 +46,9 @@ pub const GOOGLE_PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId:
 pub const GOOGLE_PROVIDER_NAME: LanguageModelProviderName =
     LanguageModelProviderName::new("Google AI");
 
+pub const ZAI_PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("zai");
+pub const ZAI_PROVIDER_NAME: LanguageModelProviderName = LanguageModelProviderName::new("Z.ai");
+
 pub const OPEN_AI_PROVIDER_ID: LanguageModelProviderId = LanguageModelProviderId::new("openai");
 pub const OPEN_AI_PROVIDER_NAME: LanguageModelProviderName =
     LanguageModelProviderName::new("OpenAI");

--- a/crates/language_models/src/language_models.rs
+++ b/crates/language_models/src/language_models.rs
@@ -16,6 +16,7 @@ use crate::provider::anthropic::AnthropicLanguageModelProvider;
 use crate::provider::bedrock::BedrockLanguageModelProvider;
 use crate::provider::cloud::CloudLanguageModelProvider;
 use crate::provider::copilot_chat::CopilotChatLanguageModelProvider;
+use crate::provider::zai::ZaiLanguageModelProvider;
 use crate::provider::google::GoogleLanguageModelProvider;
 use crate::provider::lmstudio::LmStudioLanguageModelProvider;
 use crate::provider::mistral::MistralLanguageModelProvider;
@@ -131,6 +132,10 @@ fn register_language_model_providers(
     );
     registry.register_provider(
         GoogleLanguageModelProvider::new(client.http_client(), cx),
+        cx,
+    );
+    registry.register_provider(
+        ZaiLanguageModelProvider::new(client.http_client(), cx),
         cx,
     );
     registry.register_provider(

--- a/crates/language_models/src/provider.rs
+++ b/crates/language_models/src/provider.rs
@@ -3,6 +3,7 @@ pub mod bedrock;
 pub mod cloud;
 pub mod copilot_chat;
 pub mod deepseek;
+pub mod zai;
 pub mod google;
 pub mod lmstudio;
 pub mod mistral;

--- a/crates/language_models/src/provider/zai.rs
+++ b/crates/language_models/src/provider/zai.rs
@@ -1,0 +1,830 @@
+use anyhow::{Result, anyhow};
+use collections::{BTreeMap, HashMap};
+use futures::Stream;
+use futures::{FutureExt, StreamExt, future, future::BoxFuture};
+use gpui::{AnyView, App, AsyncApp, Context, Entity, SharedString, Task, Window};
+use http_client::HttpClient;
+use language_model::{
+    AuthenticateError, LanguageModel, LanguageModelCompletionError, LanguageModelCompletionEvent,
+    LanguageModelId, LanguageModelName, LanguageModelProvider, LanguageModelProviderId,
+    LanguageModelProviderName, LanguageModelProviderState, LanguageModelRequest,
+    LanguageModelToolChoice, LanguageModelToolResultContent, LanguageModelToolUse, MessageContent,
+    RateLimiter, Role, StopReason, TokenUsage,
+};
+use menu;
+use open_ai::{ImageUrl, ResponseStreamEvent, stream_completion};
+use settings::{Settings, SettingsStore};
+use std::pin::Pin;
+use std::str::FromStr as _;
+use std::sync::{Arc, LazyLock};
+use ui::{ElevationIndex, List, Tooltip, prelude::*};
+use ui_input::SingleLineInput;
+use util::{ResultExt, truncate_and_trailoff};
+use zed_env_vars::{EnvVar, env_var};
+
+use crate::{api_key::ApiKeyState, ui::InstructionListItem};
+
+const PROVIDER_ID: LanguageModelProviderId = language_model::ZAI_PROVIDER_ID;
+const PROVIDER_NAME: LanguageModelProviderName = language_model::ZAI_PROVIDER_NAME;
+const API_KEY_ENV_VAR_NAME: &str = "ZAI_API_KEY";
+static API_KEY_ENV_VAR: LazyLock<EnvVar> = env_var!(API_KEY_ENV_VAR_NAME);
+
+const ZAI_API_URL: &str = "https://api.z.ai/api/coding/paas/v4/";
+
+#[derive(Default, Clone, Debug, PartialEq)]
+pub struct ZaiSettings {
+    pub api_url: String,
+    pub available_models: Vec<AvailableModel>,
+}
+
+pub use settings::ZaiAvailableModel as AvailableModel;
+
+pub struct ZaiLanguageModelProvider {
+    http_client: Arc<dyn HttpClient>,
+    state: Entity<State>,
+}
+
+pub struct State {
+    api_key_state: ApiKeyState,
+}
+
+impl State {
+    fn is_authenticated(&self) -> bool {
+        self.api_key_state.has_key()
+    }
+
+    fn set_api_key(&mut self, api_key: Option<String>, cx: &mut Context<Self>) -> Task<Result<()>> {
+        let api_url = ZaiLanguageModelProvider::api_url(cx);
+        self.api_key_state
+            .store(api_url, api_key, |this| &mut this.api_key_state, cx)
+    }
+
+    fn authenticate(&mut self, cx: &mut Context<Self>) -> Task<Result<(), AuthenticateError>> {
+        let api_url = ZaiLanguageModelProvider::api_url(cx);
+        self.api_key_state.load_if_needed(
+            api_url,
+            &API_KEY_ENV_VAR,
+            |this| &mut this.api_key_state,
+            cx,
+        )
+    }
+}
+
+impl ZaiLanguageModelProvider {
+    pub fn new(http_client: Arc<dyn HttpClient>, cx: &mut App) -> Self {
+        let state = cx.new(|cx| {
+            cx.observe_global::<SettingsStore>(|this: &mut State, cx| {
+                let api_url = Self::api_url(cx);
+                this.api_key_state.handle_url_change(
+                    api_url,
+                    &API_KEY_ENV_VAR,
+                    |this| &mut this.api_key_state,
+                    cx,
+                );
+                cx.notify();
+            })
+            .detach();
+            State {
+                api_key_state: ApiKeyState::new(Self::api_url(cx)),
+            }
+        });
+
+        Self { http_client, state }
+    }
+    pub fn create_language_model(&self, model: ZaiModel) -> Arc<dyn LanguageModel> {
+        Arc::new(ZaiLanguageModel {
+            id: LanguageModelId::from(model.id().to_string()),
+            model,
+            state: self.state.clone(),
+            http_client: self.http_client.clone(),
+            request_limiter: RateLimiter::new(4),
+        })
+    }
+    fn settings(cx: &App) -> &ZaiSettings {
+        &crate::AllLanguageModelSettings::get_global(cx).zai
+    }
+
+    pub fn api_url(cx: &App) -> SharedString {
+        let api_url = &Self::settings(cx).api_url;
+        if api_url.is_empty() {
+            ZAI_API_URL.into()
+        } else {
+            SharedString::new(api_url.as_str())
+        }
+    }
+}
+
+impl LanguageModelProviderState for ZaiLanguageModelProvider {
+    type ObservableEntity = State;
+
+    fn observable_entity(&self) -> Option<Entity<Self::ObservableEntity>> {
+        Some(self.state.clone())
+    }
+}
+
+impl LanguageModelProvider for ZaiLanguageModelProvider {
+    fn id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn icon(&self) -> IconName {
+        IconName::AiZAi
+    }
+
+    fn default_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(ZaiModel::default()))
+    }
+
+    fn default_fast_model(&self, _cx: &App) -> Option<Arc<dyn LanguageModel>> {
+        Some(self.create_language_model(ZaiModel::default_fast()))
+    }
+
+    fn provided_models(&self, cx: &App) -> Vec<Arc<dyn LanguageModel>> {
+        let mut models = BTreeMap::default();
+
+        for model in ZaiModel::iter() {
+            if !matches!(model, ZaiModel::Custom { .. }) {
+                models.insert(model.id().to_string(), model);
+            }
+        }
+
+        for model in &ZaiLanguageModelProvider::settings(cx).available_models {
+            models.insert(
+                model.name.clone(),
+                ZaiModel::Custom {
+                    name: model.name.clone(),
+                    display_name: model
+                        .display_name
+                        .clone()
+                        .unwrap_or_else(|| model.name.clone()),
+                    max_tokens: model.max_tokens,
+                    max_output_tokens: model.max_output_tokens,
+                },
+            );
+        }
+
+        models
+            .into_values()
+            .map(|model| self.create_language_model(model))
+            .collect()
+    }
+
+    fn is_authenticated(&self, cx: &App) -> bool {
+        self.state.read(cx).is_authenticated()
+    }
+
+    fn authenticate(&self, cx: &mut App) -> Task<Result<(), AuthenticateError>> {
+        self.state.update(cx, |state, cx| state.authenticate(cx))
+    }
+
+    fn configuration_view(
+        &self,
+        _target_agent: language_model::ConfigurationViewTargetAgent,
+        window: &mut Window,
+        cx: &mut App,
+    ) -> AnyView {
+        cx.new(|cx| ConfigurationView::new(self.state.clone(), window, cx))
+            .into()
+    }
+
+    fn reset_credentials(&self, cx: &mut App) -> Task<Result<()>> {
+        self.state
+            .update(cx, |state, cx| state.set_api_key(None, cx))
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ZaiModel {
+    Zai46,
+    Zai45,
+    Zai45Air,
+    Zai45Flash,
+    Custom {
+        name: String,
+        display_name: String,
+        max_tokens: Option<u32>,
+        max_output_tokens: Option<u32>,
+    },
+}
+
+impl ZaiModel {
+    pub fn iter() -> impl Iterator<Item = Self> {
+        [Self::Zai46, Self::Zai45, Self::Zai45Air, Self::Zai45Flash].into_iter()
+    }
+
+    pub fn default() -> Self {
+        Self::Zai46
+    }
+
+    pub fn default_fast() -> Self {
+        Self::Zai45
+    }
+
+    pub fn id(&self) -> &str {
+        match self {
+            Self::Zai46 => "glm-4.6",
+            Self::Zai45 => "glm-4.5",
+            Self::Zai45Air => "glm-4.5-air",
+            Self::Zai45Flash => "glm-4.5-flash",
+            Self::Custom { name, .. } => name,
+        }
+    }
+
+    pub fn display_name(&self) -> &str {
+        match self {
+            Self::Zai46 => "GLM-4.6",
+            Self::Zai45 => "GLM-4.5",
+            Self::Zai45Air => "GLM-4.5 Air",
+            Self::Zai45Flash => "GLM-4.5 Flash",
+            Self::Custom { display_name, .. } => display_name,
+        }
+    }
+
+    pub fn max_token_count(&self) -> u64 {
+        match self {
+            Self::Zai46 => 128000,
+            Self::Zai45 => 128000,
+            Self::Zai45Air => 128000,
+            Self::Zai45Flash => 128000,
+            Self::Custom { max_tokens, .. } => max_tokens.map(|t| t as u64).unwrap_or(128000),
+        }
+    }
+
+    pub fn max_output_tokens(&self) -> Option<u64> {
+        match self {
+            Self::Zai46 => Some(8192),
+            Self::Zai45 => Some(8192),
+            Self::Zai45Air => Some(8192),
+            Self::Zai45Flash => Some(8192),
+            Self::Custom {
+                max_output_tokens, ..
+            } => max_output_tokens.map(|t| t as u64),
+        }
+    }
+
+    pub fn supports_tools(&self) -> bool {
+        true
+    }
+
+    pub fn supports_images(&self) -> bool {
+        match self {
+            Self::Zai46 => true,
+            Self::Zai45 => false,
+            Self::Zai45Air => false,
+            Self::Zai45Flash => false,
+            Self::Custom { .. } => true, // Assume custom models support images
+        }
+    }
+}
+
+pub struct ZaiLanguageModel {
+    id: LanguageModelId,
+    model: ZaiModel,
+    state: Entity<State>,
+    http_client: Arc<dyn HttpClient>,
+    request_limiter: RateLimiter,
+}
+
+impl ZaiLanguageModel {
+    fn stream_completion(
+        &self,
+        request: open_ai::Request,
+        cx: &AsyncApp,
+    ) -> BoxFuture<'static, Result<futures::stream::BoxStream<'static, Result<ResponseStreamEvent>>>>
+    {
+        let http_client = self.http_client.clone();
+
+        let Ok((api_key, api_url)) = self.state.read_with(cx, |state, cx| {
+            let api_url = ZaiLanguageModelProvider::api_url(cx);
+            (state.api_key_state.key(&api_url), api_url)
+        }) else {
+            return future::ready(Err(anyhow!("App state dropped"))).boxed();
+        };
+
+        let future = self.request_limiter.stream(async move {
+            let Some(api_key) = api_key else {
+                return Err(LanguageModelCompletionError::NoApiKey {
+                    provider: PROVIDER_NAME,
+                });
+            };
+
+            // GLM uses the same streaming API format as OpenAI
+            let request = stream_completion(http_client.as_ref(), &api_url, &api_key, request);
+            let response = request.await?;
+            Ok(response)
+        });
+
+        async move { Ok(future.await?.boxed()) }.boxed()
+    }
+}
+
+impl LanguageModel for ZaiLanguageModel {
+    fn id(&self) -> LanguageModelId {
+        self.id.clone()
+    }
+
+    fn name(&self) -> LanguageModelName {
+        LanguageModelName::from(self.model.display_name().to_string())
+    }
+
+    fn provider_id(&self) -> LanguageModelProviderId {
+        PROVIDER_ID
+    }
+
+    fn provider_name(&self) -> LanguageModelProviderName {
+        PROVIDER_NAME
+    }
+
+    fn supports_tools(&self) -> bool {
+        self.model.supports_tools()
+    }
+
+    fn supports_images(&self) -> bool {
+        self.model.supports_images()
+    }
+
+    fn supports_tool_choice(&self, choice: LanguageModelToolChoice) -> bool {
+        match choice {
+            LanguageModelToolChoice::Auto => true,
+            LanguageModelToolChoice::Any => true,
+            LanguageModelToolChoice::None => true,
+        }
+    }
+
+    fn telemetry_id(&self) -> String {
+        format!("glm/{}", self.model.id())
+    }
+
+    fn max_token_count(&self) -> u64 {
+        self.model.max_token_count()
+    }
+
+    fn max_output_tokens(&self) -> Option<u64> {
+        self.model.max_output_tokens()
+    }
+
+    fn count_tokens(
+        &self,
+        request: LanguageModelRequest,
+        cx: &App,
+    ) -> BoxFuture<'static, Result<u64>> {
+        // For GLM, we'll use a rough estimation based on character count
+        // In a real implementation, you'd want to use GLM's tokenizer
+        cx.background_spawn(async move {
+            let total_chars: usize = request
+                .messages
+                .iter()
+                .map(|m| m.string_contents().len())
+                .sum();
+            // Rough approximation: ~1.3 characters per token for Chinese/English mixed content
+            Ok((total_chars as f64 / 1.3) as u64)
+        })
+        .boxed()
+    }
+
+    fn stream_completion(
+        &self,
+        request: LanguageModelRequest,
+        cx: &AsyncApp,
+    ) -> BoxFuture<
+        'static,
+        Result<
+            futures::stream::BoxStream<
+                'static,
+                Result<LanguageModelCompletionEvent, LanguageModelCompletionError>,
+            >,
+            LanguageModelCompletionError,
+        >,
+    > {
+        let request = into_open_ai(
+            request,
+            self.model.id(),
+            self.model.supports_tools(),
+            self.max_output_tokens(),
+        );
+        let completions = self.stream_completion(request, cx);
+        async move {
+            let mapper = ZaiEventMapper::new();
+            Ok(mapper.map_stream(completions.await?).boxed())
+        }
+        .boxed()
+    }
+}
+
+pub fn into_open_ai(
+    request: LanguageModelRequest,
+    model_id: &str,
+    supports_tools: bool,
+    max_output_tokens: Option<u64>,
+) -> open_ai::Request {
+    let mut messages = Vec::new();
+    for message in request.messages {
+        for content in message.content {
+            match content {
+                MessageContent::Text(text) | MessageContent::Thinking { text, .. } => {
+                    add_message_content_part(
+                        open_ai::MessagePart::Text { text },
+                        message.role,
+                        &mut messages,
+                    )
+                }
+                MessageContent::RedactedThinking(_) => {}
+                MessageContent::Image(image) => {
+                    add_message_content_part(
+                        open_ai::MessagePart::Image {
+                            image_url: ImageUrl {
+                                url: image.to_base64_url(),
+                                detail: None,
+                            },
+                        },
+                        message.role,
+                        &mut messages,
+                    );
+                }
+                MessageContent::ToolUse(tool_use) => {
+                    let tool_call = open_ai::ToolCall {
+                        id: tool_use.id.to_string(),
+                        content: open_ai::ToolCallContent::Function {
+                            function: open_ai::FunctionContent {
+                                name: tool_use.name.to_string(),
+                                arguments: serde_json::to_string(&tool_use.input)
+                                    .unwrap_or_default(),
+                            },
+                        },
+                    };
+
+                    if let Some(open_ai::RequestMessage::Assistant { tool_calls, .. }) =
+                        messages.last_mut()
+                    {
+                        tool_calls.push(tool_call);
+                    } else {
+                        messages.push(open_ai::RequestMessage::Assistant {
+                            content: None,
+                            tool_calls: vec![tool_call],
+                        });
+                    }
+                }
+                MessageContent::ToolResult(tool_result) => {
+                    let content = match &tool_result.content {
+                        LanguageModelToolResultContent::Text(text) => {
+                            vec![open_ai::MessagePart::Text {
+                                text: text.to_string(),
+                            }]
+                        }
+                        LanguageModelToolResultContent::Image(image) => {
+                            vec![open_ai::MessagePart::Image {
+                                image_url: ImageUrl {
+                                    url: image.to_base64_url(),
+                                    detail: None,
+                                },
+                            }]
+                        }
+                    };
+
+                    messages.push(open_ai::RequestMessage::Tool {
+                        content: content.into(),
+                        tool_call_id: tool_result.tool_use_id.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    open_ai::Request {
+        model: model_id.into(),
+        messages,
+        stream: true,
+        stop: request.stop,
+        temperature: request.temperature.unwrap_or(0.7),
+        max_completion_tokens: max_output_tokens,
+        parallel_tool_calls: if supports_tools && !request.tools.is_empty() {
+            // Disable parallel tool calls, as the Agent currently expects a maximum of one per turn.
+            Some(false)
+        } else {
+            None
+        },
+        prompt_cache_key: None,
+        tools: request
+            .tools
+            .into_iter()
+            .map(|tool| open_ai::ToolDefinition::Function {
+                function: open_ai::FunctionDefinition {
+                    name: tool.name,
+                    description: Some(tool.description),
+                    parameters: Some(tool.input_schema),
+                },
+            })
+            .collect(),
+        tool_choice: request.tool_choice.map(|choice| match choice {
+            LanguageModelToolChoice::Auto => open_ai::ToolChoice::Auto,
+            LanguageModelToolChoice::Any => open_ai::ToolChoice::Required,
+            LanguageModelToolChoice::None => open_ai::ToolChoice::None,
+        }),
+        reasoning_effort: None,
+    }
+}
+
+fn add_message_content_part(
+    new_part: open_ai::MessagePart,
+    role: Role,
+    messages: &mut Vec<open_ai::RequestMessage>,
+) {
+    match (role, messages.last_mut()) {
+        (Role::User, Some(open_ai::RequestMessage::User { content }))
+        | (
+            Role::Assistant,
+            Some(open_ai::RequestMessage::Assistant {
+                content: Some(content),
+                ..
+            }),
+        )
+        | (Role::System, Some(open_ai::RequestMessage::System { content, .. })) => {
+            content.push_part(new_part);
+        }
+        _ => {
+            messages.push(match role {
+                Role::User => open_ai::RequestMessage::User {
+                    content: open_ai::MessageContent::from(vec![new_part]),
+                },
+                Role::Assistant => open_ai::RequestMessage::Assistant {
+                    content: Some(open_ai::MessageContent::from(vec![new_part])),
+                    tool_calls: Vec::new(),
+                },
+                Role::System => open_ai::RequestMessage::System {
+                    content: open_ai::MessageContent::from(vec![new_part]),
+                },
+            });
+        }
+    }
+}
+
+pub struct ZaiEventMapper {
+    tool_calls_by_index: HashMap<usize, RawToolCall>,
+}
+
+impl ZaiEventMapper {
+    pub fn new() -> Self {
+        Self {
+            tool_calls_by_index: HashMap::default(),
+        }
+    }
+
+    pub fn map_stream(
+        mut self,
+        events: Pin<Box<dyn Send + Stream<Item = Result<ResponseStreamEvent>>>>,
+    ) -> impl Stream<Item = Result<LanguageModelCompletionEvent, LanguageModelCompletionError>>
+    {
+        events.flat_map(move |event| {
+            futures::stream::iter(match event {
+                Ok(event) => self.map_event(event),
+                Err(error) => vec![Err(LanguageModelCompletionError::from(anyhow!(error)))],
+            })
+        })
+    }
+
+    pub fn map_event(
+        &mut self,
+        event: ResponseStreamEvent,
+    ) -> Vec<Result<LanguageModelCompletionEvent, LanguageModelCompletionError>> {
+        let mut events = Vec::new();
+        if let Some(usage) = event.usage {
+            events.push(Ok(LanguageModelCompletionEvent::UsageUpdate(TokenUsage {
+                input_tokens: usage.prompt_tokens,
+                output_tokens: usage.completion_tokens,
+                cache_creation_input_tokens: 0,
+                cache_read_input_tokens: 0,
+            })));
+        }
+
+        let Some(choice) = event.choices.first() else {
+            return events;
+        };
+
+        if let Some(content) = choice.delta.content.clone() {
+            if !content.is_empty() {
+                events.push(Ok(LanguageModelCompletionEvent::Text(content)));
+            }
+        }
+
+        if let Some(tool_calls) = choice.delta.tool_calls.as_ref() {
+            for tool_call in tool_calls {
+                let entry = self.tool_calls_by_index.entry(tool_call.index).or_default();
+
+                if let Some(tool_id) = tool_call.id.clone() {
+                    entry.id = tool_id;
+                }
+
+                if let Some(function) = tool_call.function.as_ref() {
+                    if let Some(name) = function.name.clone() {
+                        entry.name = name;
+                    }
+
+                    if let Some(arguments) = function.arguments.clone() {
+                        entry.arguments.push_str(&arguments);
+                    }
+                }
+            }
+        }
+
+        match choice.finish_reason.as_deref() {
+            Some("stop") => {
+                events.push(Ok(LanguageModelCompletionEvent::Stop(StopReason::EndTurn)));
+            }
+            Some("tool_calls") => {
+                events.extend(self.tool_calls_by_index.drain().map(|(_, tool_call)| {
+                    match serde_json::Value::from_str(&tool_call.arguments) {
+                        Ok(input) => Ok(LanguageModelCompletionEvent::ToolUse(
+                            LanguageModelToolUse {
+                                id: tool_call.id.clone().into(),
+                                name: tool_call.name.as_str().into(),
+                                is_input_complete: true,
+                                input,
+                                raw_input: tool_call.arguments.clone(),
+                            },
+                        )),
+                        Err(error) => Ok(LanguageModelCompletionEvent::ToolUseJsonParseError {
+                            id: tool_call.id.into(),
+                            tool_name: tool_call.name.into(),
+                            raw_input: tool_call.arguments.clone().into(),
+                            json_parse_error: error.to_string(),
+                        }),
+                    }
+                }));
+
+                events.push(Ok(LanguageModelCompletionEvent::Stop(StopReason::ToolUse)));
+            }
+            Some(stop_reason) => {
+                log::error!("Unexpected GLM stop_reason: {stop_reason:?}",);
+                events.push(Ok(LanguageModelCompletionEvent::Stop(StopReason::EndTurn)));
+            }
+            None => {}
+        }
+
+        events
+    }
+}
+
+#[derive(Default)]
+struct RawToolCall {
+    id: String,
+    name: String,
+    arguments: String,
+}
+
+struct ConfigurationView {
+    api_key_editor: Entity<SingleLineInput>,
+    state: Entity<State>,
+    load_credentials_task: Option<Task<()>>,
+}
+
+impl ConfigurationView {
+    fn new(state: Entity<State>, window: &mut Window, cx: &mut Context<Self>) -> Self {
+        let api_key_editor = cx.new(|cx| SingleLineInput::new(window, cx, "your_glm_api_key_here"));
+
+        cx.observe(&state, |_, _, cx| {
+            cx.notify();
+        })
+        .detach();
+
+        let load_credentials_task = Some(cx.spawn_in(window, {
+            let state = state.clone();
+            async move |this, cx| {
+                if let Some(task) = state
+                    .update(cx, |state, cx| state.authenticate(cx))
+                    .log_err()
+                {
+                    // We don't log an error, because "not signed in" is also an error.
+                    let _ = task.await;
+                }
+                this.update(cx, |this, cx| {
+                    this.load_credentials_task = None;
+                    cx.notify();
+                })
+                .log_err();
+            }
+        }));
+
+        Self {
+            api_key_editor,
+            state,
+            load_credentials_task,
+        }
+    }
+
+    fn save_api_key(&mut self, _: &menu::Confirm, window: &mut Window, cx: &mut Context<Self>) {
+        let api_key = self.api_key_editor.read(cx).text(cx).trim().to_string();
+        if api_key.is_empty() {
+            return;
+        }
+
+        self.api_key_editor
+            .update(cx, |editor, cx| editor.set_text("", window, cx));
+
+        let state = self.state.clone();
+        cx.spawn_in(window, async move |_, cx| {
+            state
+                .update(cx, |state, cx| state.set_api_key(Some(api_key), cx))?
+                .await
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn reset_api_key(&mut self, window: &mut Window, cx: &mut Context<Self>) {
+        self.api_key_editor
+            .update(cx, |input, cx| input.set_text("", window, cx));
+
+        let state = self.state.clone();
+        cx.spawn_in(window, async move |_, cx| {
+            state
+                .update(cx, |state, cx| state.set_api_key(None, cx))?
+                .await
+        })
+        .detach_and_log_err(cx);
+    }
+
+    fn should_render_editor(&self, cx: &mut Context<Self>) -> bool {
+        !self.state.read(cx).is_authenticated()
+    }
+}
+
+impl Render for ConfigurationView {
+    fn render(&mut self, _: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
+        let env_var_set = self.state.read(cx).api_key_state.is_from_env_var();
+
+        let api_key_section = if self.should_render_editor(cx) {
+            v_flex()
+                .on_action(cx.listener(Self::save_api_key))
+                .child(Label::new("To use Zed's agent with GLM, you need to add an API key. Follow these steps:"))
+                .child(
+                    List::new()
+                        .child(InstructionListItem::new(
+                            "Create one by visiting",
+                            Some("GLM's console"),
+                            Some("https://z.ai/manage-apikey/apikey-list"),
+                        ))
+                        .child(InstructionListItem::text_only(
+                            "Ensure your GLM account has sufficient quota",
+                        ))
+                        .child(InstructionListItem::text_only(
+                            "Paste your API key below and hit enter to start using the assistant",
+                        )),
+                )
+                .child(self.api_key_editor.clone())
+                .child(
+                    Label::new(format!(
+                        "You can also assign the {API_KEY_ENV_VAR_NAME} environment variable and restart Zed."
+                    ))
+                    .size(LabelSize::Small)
+                    .color(Color::Muted),
+                )
+                .into_any()
+        } else {
+            h_flex()
+                .mt_1()
+                .p_1()
+                .justify_between()
+                .rounded_md()
+                .border_1()
+                .border_color(cx.theme().colors().border)
+                .bg(cx.theme().colors().background)
+                .child(
+                    h_flex()
+                        .gap_1()
+                        .child(Icon::new(IconName::Check).color(Color::Success))
+                        .child(Label::new(if env_var_set {
+                            format!("API key set in {API_KEY_ENV_VAR_NAME} environment variable")
+                        } else {
+                            let api_url = ZaiLanguageModelProvider::api_url(cx);
+                            if api_url == ZAI_API_URL {
+                                "API key configured".to_string()
+                            } else {
+                                format!("API key configured for {}", truncate_and_trailoff(&api_url, 32))
+                            }
+                        })),
+                )
+                .child(
+                    Button::new("reset-api-key", "Reset API Key")
+                        .label_size(LabelSize::Small)
+                        .icon(IconName::Undo)
+                        .icon_size(IconSize::Small)
+                        .icon_position(IconPosition::Start)
+                        .layer(ElevationIndex::ModalSurface)
+                        .when(env_var_set, |this| {
+                            this.tooltip(Tooltip::text(format!("To reset your API key, unset the {API_KEY_ENV_VAR_NAME} environment variable.")))
+                        })
+                        .on_click(cx.listener(|this, _, window, cx| this.reset_api_key(window, cx))),
+                )
+                .into_any()
+        };
+
+        if self.load_credentials_task.is_some() {
+            div().child(Label::new("Loading credentials…")).into_any()
+        } else {
+            v_flex().size_full().child(api_key_section).into_any()
+        }
+    }
+}

--- a/crates/language_models/src/settings.rs
+++ b/crates/language_models/src/settings.rs
@@ -6,7 +6,7 @@ use settings::Settings;
 
 use crate::provider::{
     anthropic::AnthropicSettings, bedrock::AmazonBedrockSettings, cloud::ZedDotDevSettings,
-    deepseek::DeepSeekSettings, google::GoogleSettings, lmstudio::LmStudioSettings,
+    deepseek::DeepSeekSettings, zai::ZaiSettings, google::GoogleSettings, lmstudio::LmStudioSettings,
     mistral::MistralSettings, ollama::OllamaSettings, open_ai::OpenAiSettings,
     open_ai_compatible::OpenAiCompatibleSettings, open_router::OpenRouterSettings,
     vercel::VercelSettings, x_ai::XAiSettings,
@@ -21,6 +21,7 @@ pub struct AllLanguageModelSettings {
     pub anthropic: AnthropicSettings,
     pub bedrock: AmazonBedrockSettings,
     pub deepseek: DeepSeekSettings,
+    pub zai: ZaiSettings,
     pub google: GoogleSettings,
     pub lmstudio: LmStudioSettings,
     pub mistral: MistralSettings,
@@ -67,6 +68,10 @@ impl settings::Settings for AllLanguageModelSettings {
             deepseek: DeepSeekSettings {
                 api_url: deepseek.api_url.unwrap(),
                 available_models: deepseek.available_models.unwrap_or_default(),
+            },
+            zai: ZaiSettings {
+                api_url: zai.api_url.unwrap(),
+                available_models: zai.available_models.unwrap_or_default(),
             },
             google: GoogleSettings {
                 api_url: google.api_url.unwrap(),

--- a/crates/settings/src/settings_content/language_model.rs
+++ b/crates/settings/src/settings_content/language_model.rs
@@ -12,6 +12,7 @@ pub struct AllLanguageModelSettingsContent {
     pub anthropic: Option<AnthropicSettingsContent>,
     pub bedrock: Option<AmazonBedrockSettingsContent>,
     pub deepseek: Option<DeepseekSettingsContent>,
+    pub zai: Option<ZaiSettingsContent>,
     pub google: Option<GoogleSettingsContent>,
     pub lmstudio: Option<LmStudioSettingsContent>,
     pub mistral: Option<MistralSettingsContent>,
@@ -284,6 +285,22 @@ pub struct GoogleAvailableModel {
     pub display_name: Option<String>,
     pub max_tokens: u64,
     pub mode: Option<ModelMode>,
+}
+
+#[skip_serializing_none]
+#[derive(Default, Clone, Debug, Serialize, Deserialize, PartialEq, JsonSchema, MergeFrom)]
+pub struct ZaiSettingsContent {
+    pub api_url: Option<String>,
+    pub available_models: Option<Vec<ZaiAvailableModel>>,
+}
+
+#[skip_serializing_none]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, MergeFrom)]
+pub struct ZaiAvailableModel {
+    pub name: String,
+    pub display_name: Option<String>,
+    pub max_tokens: Option<u32>,
+    pub max_output_tokens: Option<u32>,
 }
 
 #[skip_serializing_none]

--- a/crates/zai/Cargo.toml
+++ b/crates/zai/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "zai"
+version = "0.1.0"
+edition.workspace = true
+publish.workspace = true
+license = "GPL-3.0-or-later"
+
+[lints]
+workspace = true
+
+[lib]
+path = "src/zai.rs"
+
+[features]
+default = []
+schemars = ["dep:schemars"]
+
+[dependencies]
+anyhow.workspace = true
+futures.workspace = true
+http_client.workspace = true
+schemars = { workspace = true, optional = true }
+log.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+settings.workspace = true
+strum.workspace = true
+workspace-hack.workspace = true


### PR DESCRIPTION
Release Notes:

- Added support for provider Z.ai and models like GLM 4.6

Reason:

I just had to, after reading:

> GLM-4.6 [just shipped](https://substack.com/redirect/a78f314d-2280-409f-b5e5-fbab6b661f3e?j=eyJ1IjoiMXI3bmM0In0.Q9Whrs_PMxJFJeit9EoiFygtmE-3Pm2xvtzDLlL69O8) with a 48.6% win rate against Claude Sonnet 4 in real-world coding tasks. That’s near-parity performance at one-fifth the cost—[$0.60/$2.20](https://substack.com/redirect/53dcd0d1-cb03-4be7-8166-a9e1c7197616?j=eyJ1IjoiMXI3bmM0In0.Q9Whrs_PMxJFJeit9EoiFygtmE-3Pm2xvtzDLlL69O8) per million tokens versus $3/$15.

<img width="924" height="1105" alt="CleanShot 2025-10-01 at 07 46 44" src="https://github.com/user-attachments/assets/87cb5d66-fd3b-4c64-a425-426fc64b9bd8" />

<img width="644" height="771" alt="CleanShot 2025-10-01 at 07 47 08" src="https://github.com/user-attachments/assets/1898bcc1-38e7-49de-a970-b42fbf1ead7c" />

<img width="649" height="309" alt="CleanShot 2025-10-01 at 07 47 21" src="https://github.com/user-attachments/assets/afc921e6-364e-4c2d-908b-a2c8508b0b2f" />
