### PR TITLE
Fix agent panel terminals to respect user's SHELL environment variable

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -34,7 +34,7 @@ use std::rc::Rc;
 use std::time::{Duration, Instant};
 use std::{fmt::Display, mem, path::PathBuf, sync::Arc};
 use ui::App;
-use util::{ResultExt, get_default_system_shell};
+use util::ResultExt;
 use uuid::Uuid;
 
 #[derive(Debug)]
@@ -1992,7 +1992,7 @@ impl AcpThread {
                                 .and_then(|r| r.read(cx).default_system_shell())
                         })?
                         .as_deref(),
-                    &Shell::Program(get_default_system_shell()),
+                    &Shell::System,
                 )
                 .redirect_stdin_to_dev_null()
                 .build(Some(command.clone()), &args);

--- a/crates/task/src/shell_builder.rs
+++ b/crates/task/src/shell_builder.rs
@@ -369,8 +369,8 @@ mod test {
             let program_lower = program.to_lowercase();
             assert!(
                 program_lower.contains("powershell")
-                || program_lower.contains("pwsh")
-                || program_lower.contains("cmd"),
+                    || program_lower.contains("pwsh")
+                    || program_lower.contains("cmd"),
                 "Expected Windows shell, got: {}",
                 program
             );

--- a/crates/task/src/shell_builder.rs
+++ b/crates/task/src/shell_builder.rs
@@ -363,10 +363,17 @@ mod test {
             assert_eq!(program, expected);
         }
 
-        // On Windows, should use system shell
+        // On Windows, should use system shell (case-insensitive check)
         #[cfg(target_os = "windows")]
         {
-            assert!(program.contains("powershell") || program.contains("cmd"));
+            let program_lower = program.to_lowercase();
+            assert!(
+                program_lower.contains("powershell")
+                || program_lower.contains("pwsh")
+                || program_lower.contains("cmd"),
+                "Expected Windows shell, got: {}",
+                program
+            );
         }
     }
 }


### PR DESCRIPTION
Agent panel terminals were hardcoded to use `/bin/sh` instead of respecting the user's `SHELL` environment variable.

This changes the code to use `Shell::System`, which checks `$SHELL` before falling back to `/bin/sh`, matching the behavior of regular Zed terminals.

Fixes #34530

Release Notes:

- Fixed agent panel terminals to respect the user's `SHELL` environment variable instead of always defaulting to `/bin/sh`