### PR TITLE
zed: Show GPUI Inspector item in Dev build menus

### DIFF
--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -667,7 +667,8 @@ pub fn main() {
         watch_themes(fs.clone(), cx);
         watch_languages(fs.clone(), app_state.languages.clone(), cx);
 
-        cx.set_menus(app_menus());
+        let menus = app_menus(cx);
+        cx.set_menus(menus);
         initialize_workspace(app_state.clone(), prompt_builder, cx);
 
         cx.activate(true);

--- a/crates/zed/src/zed.rs
+++ b/crates/zed/src/zed.rs
@@ -1519,7 +1519,8 @@ fn reload_keymaps(cx: &mut App, mut user_key_bindings: Vec<KeyBinding>) {
     }
     cx.bind_keys(user_key_bindings);
 
-    cx.set_menus(app_menus());
+    let menus = app_menus(cx);
+    cx.set_menus(menus);
     // On Windows, this is set in the `update_jump_list` method of the `HistoryManager`.
     #[cfg(not(target_os = "windows"))]
     cx.set_dock_menu(vec![gpui::MenuItem::action(

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -1,10 +1,12 @@
 use collab_ui::collab_panel;
-use gpui::{Menu, MenuItem, OsAction};
+use gpui::{App, Menu, MenuItem, OsAction};
+use release_channel::ReleaseChannel;
 use terminal_view::terminal_panel;
-use zed_actions::ToggleFocus as ToggleDebugPanel;
+use zed_actions::{ToggleFocus as ToggleDebugPanel, dev};
 
-pub fn app_menus() -> Vec<Menu> {
+pub fn app_menus(cx: &mut App) -> Vec<Menu> {
     use zed_actions::Quit;
+    let include_dev_items = ReleaseChannel::global(cx) == ReleaseChannel::Dev;
 
     vec![
         Menu {
@@ -186,6 +188,12 @@ pub fn app_menus() -> Vec<Menu> {
                 MenuItem::separator(),
                 MenuItem::action("Diagnostics", diagnostics::Deploy),
                 MenuItem::separator(),
+                include_dev_items
+                    .then(|| MenuItem::action("GPUI Inspector", dev::ToggleInspector))
+                    .expect("Show only in Dev build"),
+                include_dev_items
+                    .then(|| MenuItem::separator())
+                    .expect("Show only in Dev build"),
             ],
         },
         Menu {

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -7,7 +7,6 @@ use zed_actions::{ToggleFocus as ToggleDebugPanel, dev};
 pub fn app_menus(cx: &mut App) -> Vec<Menu> {
     use zed_actions::Quit;
 
-    let include_dev_items = ReleaseChannel::try_global(cx) == Some(ReleaseChannel::Dev);
     let mut view_items = vec![
         MenuItem::action(
             "Zoom In",
@@ -46,7 +45,7 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
         MenuItem::separator(),
     ];
 
-    if include_dev_items {
+    if ReleaseChannel::try_global(cx) == Some(ReleaseChannel::Dev) {
         view_items.push(MenuItem::action(
             "Toggle GPUI Inspector",
             dev::ToggleInspector,

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -6,7 +6,53 @@ use zed_actions::{ToggleFocus as ToggleDebugPanel, dev};
 
 pub fn app_menus(cx: &mut App) -> Vec<Menu> {
     use zed_actions::Quit;
-    let include_dev_items = ReleaseChannel::global(cx) == ReleaseChannel::Dev;
+
+    let include_dev_items = ReleaseChannel::try_global(cx) == Some(ReleaseChannel::Dev);
+    let mut view_items = vec![
+        MenuItem::action(
+            "Zoom In",
+            zed_actions::IncreaseBufferFontSize { persist: false },
+        ),
+        MenuItem::action(
+            "Zoom Out",
+            zed_actions::DecreaseBufferFontSize { persist: false },
+        ),
+        MenuItem::action(
+            "Reset Zoom",
+            zed_actions::ResetBufferFontSize { persist: false },
+        ),
+        MenuItem::separator(),
+        MenuItem::action("Toggle Left Dock", workspace::ToggleLeftDock),
+        MenuItem::action("Toggle Right Dock", workspace::ToggleRightDock),
+        MenuItem::action("Toggle Bottom Dock", workspace::ToggleBottomDock),
+        MenuItem::action("Close All Docks", workspace::CloseAllDocks),
+        MenuItem::submenu(Menu {
+            name: "Editor Layout".into(),
+            items: vec![
+                MenuItem::action("Split Up", workspace::SplitUp),
+                MenuItem::action("Split Down", workspace::SplitDown),
+                MenuItem::action("Split Left", workspace::SplitLeft),
+                MenuItem::action("Split Right", workspace::SplitRight),
+            ],
+        }),
+        MenuItem::separator(),
+        MenuItem::action("Project Panel", project_panel::ToggleFocus),
+        MenuItem::action("Outline Panel", outline_panel::ToggleFocus),
+        MenuItem::action("Collab Panel", collab_panel::ToggleFocus),
+        MenuItem::action("Terminal Panel", terminal_panel::ToggleFocus),
+        MenuItem::action("Debugger Panel", ToggleDebugPanel),
+        MenuItem::separator(),
+        MenuItem::action("Diagnostics", diagnostics::Deploy),
+        MenuItem::separator(),
+    ];
+
+    if include_dev_items {
+        view_items.push(MenuItem::action(
+            "Toggle GPUI Inspector",
+            dev::ToggleInspector,
+        ));
+        view_items.push(MenuItem::separator());
+    }
 
     vec![
         Menu {
@@ -152,49 +198,7 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
         },
         Menu {
             name: "View".into(),
-            items: vec![
-                MenuItem::action(
-                    "Zoom In",
-                    zed_actions::IncreaseBufferFontSize { persist: false },
-                ),
-                MenuItem::action(
-                    "Zoom Out",
-                    zed_actions::DecreaseBufferFontSize { persist: false },
-                ),
-                MenuItem::action(
-                    "Reset Zoom",
-                    zed_actions::ResetBufferFontSize { persist: false },
-                ),
-                MenuItem::separator(),
-                MenuItem::action("Toggle Left Dock", workspace::ToggleLeftDock),
-                MenuItem::action("Toggle Right Dock", workspace::ToggleRightDock),
-                MenuItem::action("Toggle Bottom Dock", workspace::ToggleBottomDock),
-                MenuItem::action("Close All Docks", workspace::CloseAllDocks),
-                MenuItem::submenu(Menu {
-                    name: "Editor Layout".into(),
-                    items: vec![
-                        MenuItem::action("Split Up", workspace::SplitUp),
-                        MenuItem::action("Split Down", workspace::SplitDown),
-                        MenuItem::action("Split Left", workspace::SplitLeft),
-                        MenuItem::action("Split Right", workspace::SplitRight),
-                    ],
-                }),
-                MenuItem::separator(),
-                MenuItem::action("Project Panel", project_panel::ToggleFocus),
-                MenuItem::action("Outline Panel", outline_panel::ToggleFocus),
-                MenuItem::action("Collab Panel", collab_panel::ToggleFocus),
-                MenuItem::action("Terminal Panel", terminal_panel::ToggleFocus),
-                MenuItem::action("Debugger Panel", ToggleDebugPanel),
-                MenuItem::separator(),
-                MenuItem::action("Diagnostics", diagnostics::Deploy),
-                MenuItem::separator(),
-                include_dev_items
-                    .then(|| MenuItem::action("Toggle GPUI Inspector", dev::ToggleInspector))
-                    .expect("Show only in Dev build"),
-                include_dev_items
-                    .then(|| MenuItem::separator())
-                    .expect("Show only in Dev build"),
-            ],
+            items: view_items,
         },
         Menu {
             name: "Go".into(),

--- a/crates/zed/src/zed/app_menus.rs
+++ b/crates/zed/src/zed/app_menus.rs
@@ -189,7 +189,7 @@ pub fn app_menus(cx: &mut App) -> Vec<Menu> {
                 MenuItem::action("Diagnostics", diagnostics::Deploy),
                 MenuItem::separator(),
                 include_dev_items
-                    .then(|| MenuItem::action("GPUI Inspector", dev::ToggleInspector))
+                    .then(|| MenuItem::action("Toggle GPUI Inspector", dev::ToggleInspector))
                     .expect("Show only in Dev build"),
                 include_dev_items
                     .then(|| MenuItem::separator())


### PR DESCRIPTION
# Why

I have find out that this tool exists by browsing Keymap Editor. I think it would be nice for its discoverability to show it in the app menus in Dev builds.

# How

Add "GPUI Inspector" app menu item conditionally for Dev builds only.

Release Notes:

- N/A

# Preview

<img width="1014" height="948" alt="Screenshot 2025-10-01 at 14 36 48" src="https://github.com/user-attachments/assets/c0409e67-1f4d-44f3-90b3-293ad4fe5c73" />


