### PR TITLE
Revert "gpui: Respect macOS 'Do Nothing' window double-click setting"

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1530,11 +1530,8 @@ impl PlatformWindow for MacWindow {
                             // There is no documented API for "Fill" action, so we'll just zoom the window
                             window.zoom_(nil);
                         }
-                        "None" | "" => {
-                            // Do nothing - respect the "Do Nothing" system setting
-                        }
                         _ => {
-                            // Default to doing nothing for unrecognized settings
+                            window.zoom_(nil);
                         }
                     }
                 }


### PR DESCRIPTION
Reverts zed-industries/zed#39235

This broke double-click to zoom, even though it is configured in settings.