### PR TITLE
settings ui: Fix panic that occurred when changing the selected settings file

### DIFF
--- a/crates/settings_ui/src/settings_ui.rs
+++ b/crates/settings_ui/src/settings_ui.rs
@@ -719,6 +719,7 @@ impl SettingsWindow {
             return;
         }
         self.current_file = self.files[ix].clone();
+        self.navbar_entry = 0;
         self.build_ui(cx);
     }
 


### PR DESCRIPTION
The panic happened because navbar index wasn't updated when changing files.

Release Notes:

- N/A
