### PR TITLE
title_bar: Show app menu even when signed out

### DIFF
--- a/crates/title_bar/src/title_bar.rs
+++ b/crates/title_bar/src/title_bar.rs
@@ -197,9 +197,7 @@ impl Render for TitleBar {
                     user.is_none() && TitleBarSettings::get_global(cx).show_sign_in,
                     |el| el.child(self.render_sign_in_button(cx)),
                 )
-                .when(user.is_some(), |parent| {
-                    parent.child(self.render_user_menu_button(cx))
-                })
+                .child(self.render_app_menu_button(cx))
                 .into_any_element(),
         );
 
@@ -636,7 +634,7 @@ impl TitleBar {
             })
     }
 
-    pub fn render_user_menu_button(&mut self, cx: &mut Context<Self>) -> impl Element {
+    pub fn render_app_menu_button(&mut self, cx: &mut Context<Self>) -> impl Element {
         let user_store = self.user_store.read(cx);
         if let Some(user) = user_store.current_user() {
             let has_subscription_period = user_store.subscription_period().is_some();


### PR DESCRIPTION
Partially closes #39271

Regressed in https://github.com/zed-industries/zed/pull/35375

<img width="282" height="188" alt="image" src="https://github.com/user-attachments/assets/7e39d819-458a-47a1-96ca-e29797602e73" />

Release Notes:

- Fixed the top-right dropdown not showing when you're not signed in.
