### PR TITLE
Add support for macOS' "Do Nothing" window setting

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -1520,6 +1520,9 @@ impl PlatformWindow for MacWindow {
                     };
 
                     match action_str.as_ref() {
+                        "None" => {
+                            // "Do Nothing" selected, so do no action
+                        }
                         "Minimize" => {
                             window.miniaturize_(nil);
                         }


### PR DESCRIPTION
Fixes titlebar double-click behavior to properly handle the macOS system setting when "Do Nothing" is selected in System Settings > Desktop & Dock > "Double-click a window's title bar to".

Closes https://github.com/zed-industries/zed/issues/39102

Release Notes:

- Fixed macOS Do Nothing window double click setting not being respected.