### PR TITLE
Fix background on rules library panel

### DIFF
--- a/crates/rules_library/src/rules_library.rs
+++ b/crates/rules_library/src/rules_library.rs
@@ -1354,6 +1354,7 @@ impl Render for RulesLibrary {
 
         client_side_decorations(
             v_flex()
+                .bg(theme.colors().background)
                 .id("rules-library")
                 .key_context("PromptLibrary")
                 .on_action(cx.listener(|this, &NewRule, window, cx| this.new_rule(window, cx)))


### PR DESCRIPTION
Closes #39318 

The rules panel on the rules library window was rendering a black background when the `panel.background` property on the active theme had some level of transparency (for example `1917264D` on `nightfox` theme).

<img width="1650" height="889" alt="image" src="https://github.com/user-attachments/assets/6a8d124a-38da-4d01-817a-c289926bd39c" />

Left is before, right is after. The bug can be replicated by using `theme_overrides` on settings:

```json
  "experimental.theme_overrides": {
    "panel.background": "#00000000",
    "background": "#ffffff"
  },
```

Release Notes:

- Fix "secondary" background on rules panel
