### PR TITLE
Disable automation sending release notes to Kit

### DIFF
--- a/.github/workflows/community_release_actions.yml
+++ b/.github/workflows/community_release_actions.yml
@@ -39,7 +39,7 @@ jobs:
           content: ${{ steps.get-content.outputs.string }}
 
   send_release_notes_email:
-    if: github.repository_owner == 'zed-industries' && !github.event.release.prerelease
+    if: false && github.repository_owner == 'zed-industries' && !github.event.release.prerelease
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4


### PR DESCRIPTION
These are now being crafted by hand, using the social media content we do each Wednesday. I'm keeping the action around because we may want to use this to automate publishing the hand-crafted emails in the future.

Release Notes:

- N/A
