### PR TITLE
agent: Update shell path in system prompt to match the terminal we give it

### DIFF
--- a/crates/prompt_store/src/prompts.rs
+++ b/crates/prompt_store/src/prompts.rs
@@ -14,7 +14,7 @@ use std::{
     time::Duration,
 };
 use text::LineEnding;
-use util::{ResultExt, get_system_shell, rel_path::RelPath};
+use util::{ResultExt, get_default_system_shell, rel_path::RelPath};
 
 use crate::UserPromptId;
 
@@ -43,7 +43,7 @@ impl ProjectContext {
             user_rules: default_user_rules,
             os: std::env::consts::OS.to_string(),
             arch: std::env::consts::ARCH.to_string(),
-            shell: get_system_shell(),
+            shell: get_default_system_shell(),
         }
     }
 }


### PR DESCRIPTION
In the ACP changes, we changed how terminals are created for the agent, and so the system prompt was putting in the system shell instead of the default one, potentially causing confusion for the model.

These are now in sync, so this will hopefully alleviate issues people were seeing, as well as use a more standard shell to increase the likelihood of successful model tool calls.

Release Notes:

- agent: Align default shell path in system prompt with the actual path it is given
