### PR TITLE
editor: Improve inlay color border

### DIFF
--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -378,6 +378,14 @@ impl<'a> Iterator for InlayChunks<'a> {
                             renderer = Some(ChunkRenderer {
                                 id: ChunkRendererId::Inlay(inlay.id),
                                 render: Arc::new(move |cx| {
+                                    let is_light = cx.theme().appearance().is_light();
+                                    let border_color = Hsla {
+                                        h: color.h,
+                                        s: color.s,
+                                        l: if is_light { 0.25 } else { 0.75 },
+                                        a: 1.0,
+                                    };
+
                                     div()
                                         .relative()
                                         .size_3p5()
@@ -387,7 +395,7 @@ impl<'a> Iterator for InlayChunks<'a> {
                                                 .right_1()
                                                 .size_3()
                                                 .border_1()
-                                                .border_color(cx.theme().colors().border)
+                                                .border_color(border_color)
                                                 .bg(color),
                                         )
                                         .into_any_element()

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -389,9 +389,9 @@ impl<'a> Iterator for InlayChunks<'a> {
                                                 .border_1()
                                                 .border_color(
                                                     if cx.theme().appearance().is_light() {
-                                                        gpui::black().opacity(0.9)
+                                                        gpui::black().opacity(0.5)
                                                     } else {
-                                                        gpui::white().opacity(0.9)
+                                                        gpui::white().opacity(0.5)
                                                     },
                                                 )
                                                 .bg(color),

--- a/crates/editor/src/display_map/inlay_map.rs
+++ b/crates/editor/src/display_map/inlay_map.rs
@@ -378,14 +378,6 @@ impl<'a> Iterator for InlayChunks<'a> {
                             renderer = Some(ChunkRenderer {
                                 id: ChunkRendererId::Inlay(inlay.id),
                                 render: Arc::new(move |cx| {
-                                    let is_light = cx.theme().appearance().is_light();
-                                    let border_color = Hsla {
-                                        h: color.h,
-                                        s: color.s,
-                                        l: if is_light { 0.25 } else { 0.75 },
-                                        a: 1.0,
-                                    };
-
                                     div()
                                         .relative()
                                         .size_3p5()
@@ -395,7 +387,13 @@ impl<'a> Iterator for InlayChunks<'a> {
                                                 .right_1()
                                                 .size_3()
                                                 .border_1()
-                                                .border_color(border_color)
+                                                .border_color(
+                                                    if cx.theme().appearance().is_light() {
+                                                        gpui::black().opacity(0.9)
+                                                    } else {
+                                                        gpui::white().opacity(0.9)
+                                                    },
+                                                )
                                                 .bg(color),
                                         )
                                         .into_any_element()


### PR DESCRIPTION
Release Notes:

- Improved inlay color border to more clearly.

---

It was used `border_color`, that variable is often gray, which makes the border look blurred when mixed with other inlay color backgrounds.

## Before

<img width="590" height="516" alt="SCR-20251002-qrkt" src="https://github.com/user-attachments/assets/733a9a49-55ac-49aa-83fa-ebcfeece8129" />
<img width="590" height="516" alt="SCR-20251002-qrlt" src="https://github.com/user-attachments/assets/34fa92bb-c754-4587-9e02-f3901dbc2fd6" />
<img width="590" height="516" alt="SCR-20251002-qrmw" src="https://github.com/user-attachments/assets/b7f7abd8-e2c9-415d-9522-0801575b41c7" />
<img width="590" height="516" alt="SCR-20251002-qroa" src="https://github.com/user-attachments/assets/8106d4c5-9bcd-4997-9644-ba680feadbce" />
<img width="590" height="516" alt="SCR-20251002-qrsf" src="https://github.com/user-attachments/assets/6c9f5e58-e3a5-4363-a2d3-d6e5c4f40d17" />
<img width="590" height="516" alt="SCR-20251002-qsaw" src="https://github.com/user-attachments/assets/706171be-af4f-4f19-ba97-ca2dab6ca15e" />

## After

<img width="663" height="541" alt="SCR-20251002-qqci" src="https://github.com/user-attachments/assets/d586b5c3-2a10-4c8d-8403-2707e1e6c8bd" />
<img width="663" height="541" alt="SCR-20251002-qqdl" src="https://github.com/user-attachments/assets/4adbc2a1-3763-4c6f-b1ef-61ef30652079" />
<img width="663" height="541" alt="SCR-20251002-qqev" src="https://github.com/user-attachments/assets/d7d9dcfa-82db-4e3d-ae99-add493b3ebc2" />
<img width="663" height="541" alt="SCR-20251002-qqfs" src="https://github.com/user-attachments/assets/4e910140-9de1-4a10-b2ca-aa0a8b335fad" />
<img width="663" height="541" alt="SCR-20251002-qqhb" src="https://github.com/user-attachments/assets/ea16baee-3015-4899-af99-afed2a5b1dd3" />
