### PR TITLE
editor: Improve text color in document color highlight

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6276,7 +6276,7 @@ impl EditorElement {
 
                     // paint text above the background color
                     let row_range = &layout.visible_display_row_range;
-                    if range.start.row() >= row_range.start && range.end.row() < row_range.end {
+                    if row_range.start <= range.start.row() && range.end.row() < row_range.end {
                         let row = range.start.row().max(row_range.start).min(row_range.end);
                         let line_height = layout.position_map.line_height;
                         let start_y = layout.content_origin.y + row.as_f32() * line_height

--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -6276,12 +6276,8 @@ impl EditorElement {
 
                     // paint text above the background color
                     let row_range = &layout.visible_display_row_range;
-                    if range.start.row() >= row_range.start && range.end.row() <= row_range.end {
-                        let row = range
-                            .start
-                            .row()
-                            .max(row_range.start)
-                            .min(row_range.end - DisplayRow(1));
+                    if range.start.row() >= row_range.start && range.end.row() < row_range.end {
+                        let row = range.start.row().max(row_range.start).min(row_range.end);
                         let line_height = layout.position_map.line_height;
                         let start_y = layout.content_origin.y + row.as_f32() * line_height
                             - layout.position_map.scroll_pixel_position.y;

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -136,6 +136,7 @@ impl LspColorData {
                     let display_text: SharedString = buffer
                         .text_for_range(range.to_offset(&buffer))
                         .collect::<String>()
+                        .replace("\n", "")
                         .into();
 
                     let display_range = range.clone().to_display_points(snapshot);
@@ -146,10 +147,12 @@ impl LspColorData {
                         a: color.color.alpha,
                     });
 
-                    let font_size = window.text_style().font_size.to_pixels(window.rem_size());
+                    // Blend the color with the background color to avoid alpha.
+                    let soild_color = style.background.blend(color);
+                    let font_size = style.text.font_size.to_pixels(window.rem_size());
                     let text_run = TextRun {
                         len: display_text.len(),
-                        color: if color.l > 0.5 {
+                        color: if soild_color.l >= 0.5 {
                             gpui::black()
                         } else {
                             gpui::white()

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -134,7 +134,6 @@ impl LspColorData {
                         b: color.color.blue,
                         a: color.color.alpha,
                     });
-
                     (display_range, color)
                 })
                 .collect()

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -2,19 +2,19 @@ use std::{cmp, ops::Range};
 
 use collections::HashMap;
 use futures::future::join_all;
-use gpui::{Hsla, Rgba, ShapedLine, TextRun};
+use gpui::{Hsla, Rgba};
 use itertools::Itertools;
 use language::point_from_lsp;
-use multi_buffer::{Anchor, AnchorRangeExt};
+use multi_buffer::Anchor;
 use project::{DocumentColor, lsp_store::LspFetchStrategy};
 use settings::Settings as _;
 use text::{Bias, BufferId, OffsetRangeExt as _};
-use ui::{App, Context, SharedString, Window};
+use ui::{App, Context, Window};
 use util::post_inc;
 
 use crate::{
-    DisplayPoint, Editor, EditorSettings, EditorSnapshot, EditorStyle, InlayId, InlaySplice,
-    RangeToAnchorExt, display_map::Inlay, editor_settings::DocumentColorsRenderMode,
+    DisplayPoint, Editor, EditorSettings, EditorSnapshot, InlayId, InlaySplice, RangeToAnchorExt,
+    display_map::Inlay, editor_settings::DocumentColorsRenderMode,
 };
 
 #[derive(Debug)]
@@ -116,7 +116,6 @@ impl LspColorData {
     pub fn editor_display_highlights(
         &self,
         snapshot: &EditorSnapshot,
-        style: &EditorStyle,
     ) -> (DocumentColorsRenderMode, Vec<(Range<DisplayPoint>, Hsla)>) {
         let render_mode = self.render_mode;
         let highlights = if render_mode == DocumentColorsRenderMode::None

--- a/crates/editor/src/lsp_colors.rs
+++ b/crates/editor/src/lsp_colors.rs
@@ -148,11 +148,11 @@ impl LspColorData {
                     });
 
                     // Blend the color with the background color to avoid alpha.
-                    let soild_color = style.background.blend(color);
+                    let solid_color = style.background.blend(color);
                     let font_size = style.text.font_size.to_pixels(window.rem_size());
                     let text_run = TextRun {
                         len: display_text.len(),
-                        color: if soild_color.l >= 0.5 {
+                        color: if solid_color.l >= 0.5 {
                             gpui::black()
                         } else {
                             gpui::white()


### PR DESCRIPTION
Release Notes:

- Improved text color in LSP document color highlight.

----

Because highlight ranges are implemented using a paint background, there's no way to control the text color.

I've been thinking about this problem for a long time, want to solve it.

~~Today, I come up with a new idea. Re-rendering the document color text at the top should solve this problem.~~

#### Update 10/6: 

> The previous version is not good, when we have soft wrap text, that version will not work correct. 

Now use exists `bg_segments_per_row` feature to fix text color.

## Before

<img width="563" height="540" alt="image" src="https://github.com/user-attachments/assets/99722253-0cab-4d2a-a5d1-7f28393bcaed" />


## After

<img width="544" height="527" alt="image" src="https://github.com/user-attachments/assets/a1bf6cdb-0e9c-435d-b14a-6ee9159a63d9" />


