### PR TITLE
editor: Fix rare panic in wrap map

### DIFF
--- a/crates/editor/src/display_map/wrap_map.rs
+++ b/crates/editor/src/display_map/wrap_map.rs
@@ -965,7 +965,7 @@ impl<'a> Iterator for WrapChunks<'a> {
         }
 
         if self.input_chunk.text.is_empty() {
-            self.input_chunk = self.input_chunks.next().unwrap();
+            self.input_chunk = self.input_chunks.next()?;
         }
 
         let mut input_len = 0;


### PR DESCRIPTION
Closes ZED-1SV
Closes ZED-TG
Closes ZED-22G
Closes ZED-22J

This seems to fix the reported error there, but ultimately, this might benefit from a test to reproduce. Hence, marking as draft for now.

Release Notes:

- Fixed a rare panic whilst wrapping lines.