### PR TITLE
collab: Add `token_spend_in_cents` column to `billing_subscriptions` table

### DIFF
--- a/crates/collab/migrations/20251002214229_add_token_spend_in_cents_to_billing_subscriptions.sql
+++ b/crates/collab/migrations/20251002214229_add_token_spend_in_cents_to_billing_subscriptions.sql
@@ -1,0 +1,3 @@
+alter table billing_subscriptions
+    add column token_spend_in_cents integer,
+    add column token_spend_in_cents_updated_at timestamp without time zone;


### PR DESCRIPTION
This PR adds a `token_spend_in_cents` and associated `token_spend_in_cents_updated_at` column to the `billing_subscriptions` table.

Release Notes:

- N/A
