### PR TITLE
docs: Remove outdated mention about Vulkan on Asahi Linux

### DIFF
--- a/docs/src/linux.md
+++ b/docs/src/linux.md
@@ -137,7 +137,7 @@ vkcube
 
 > **_Note_**: Try running in both X11 and wayland modes by running `vkcube -m [x11|wayland]`. Some versions of `vkcube` use `vkcube` to run in X11 and `vkcube-wayland` to run in wayland.
 
-This should output a line describing your current graphics setup and show a rotating cube. If this does not work, you should be able to fix it by installing Vulkan compatible GPU drivers, however in some cases (for example running Linux on an Arm-based MacBook) there is no Vulkan support yet.
+This should output a line describing your current graphics setup and show a rotating cube. If this does not work, you should be able to fix it by installing Vulkan compatible GPU drivers, however in some cases there is no Vulkan support yet.
 
 You can find out which graphics card Zed is using by looking in the Zed log (`~/.local/share/zed/logs/Zed.log`) for `Using GPU: ...`.
 


### PR DESCRIPTION
Vulkan is now supported running Linux on ARM Macs
https://asahilinux.org/2024/10/aaa-gaming-on-asahi-linux/

Release Notes:

- N/A
