### PR TITLE
Add more unit tests for Rope

### DIFF
--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -641,19 +641,10 @@ mod tests {
 
     #[gpui::test(iterations = 100)]
     fn test_random_chunks(mut rng: StdRng) {
-        let chunk_len = rng.random_range(0..=MAX_BASE);
-        let text = RandomCharIter::new(&mut rng)
-            .take(chunk_len)
-            .collect::<String>();
-        let mut ix = chunk_len;
-        while !text.is_char_boundary(ix) {
-            ix -= 1;
-        }
-        let text = &text[..ix];
-
+        let text = random_string_with_utf8_len(&mut rng, MAX_BASE);
         log::info!("Chunk: {:?}", text);
-        let chunk = Chunk::new(text);
-        verify_chunk(chunk.as_slice(), text);
+        let chunk = Chunk::new(&text);
+        verify_chunk(chunk.as_slice(), &text);
 
         for _ in 0..10 {
             let mut start = rng.random_range(0..=chunk.text.len());

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -10,9 +10,19 @@ pub(crate) const MAX_BASE: usize = MIN_BASE * 2;
 
 #[derive(Clone, Debug, Default)]
 pub struct Chunk {
+    /// If bit[i] is set, then the character at index i is the start of a UTF-8 character in the
+    /// text.
     chars: u128,
+    /// The number of set bits is the number of UTF-16 code units it would take to represent the
+    /// text.
+    ///
+    /// Bit[i] is set if text[i] is the start of a UTF-8 character. If the character would
+    /// take two UTF-16 code units, then bit[i+1] is also set. (Rust chars never take more
+    /// than two UTF-16 code units.)
     chars_utf16: u128,
+    /// If bit[i] is set, then the character at index i is an ascii newline.
     newlines: u128,
+    /// If bit[i] is set, then the character at index i is an ascii tab.
     pub tabs: u128,
     pub text: ArrayString<MAX_BASE>,
 }

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -154,6 +154,12 @@ impl<'a> ChunkSlice<'a> {
         let mask = if range.end == MAX_BASE {
             u128::MAX
         } else {
+            debug_assert!(
+                self.is_char_boundary(range.end),
+                "Invalid range end {} in {:?}",
+                range.end,
+                self
+            );
             (1u128 << range.end) - 1
         };
         if range.start == MAX_BASE {
@@ -165,6 +171,12 @@ impl<'a> ChunkSlice<'a> {
                 text: "",
             }
         } else {
+            debug_assert!(
+                self.is_char_boundary(range.start),
+                "Invalid range start {} in {:?}",
+                range.start,
+                self
+            );
             Self {
                 chars: (self.chars & mask) >> range.start,
                 chars_utf16: (self.chars_utf16 & mask) >> range.start,
@@ -703,7 +715,6 @@ mod tests {
         let mut chunk1 = Chunk::new(&str1);
         let chunk2 = Chunk::new(&str2);
         chunk1.append(chunk2.as_slice());
-
         verify_chunk(chunk1.as_slice(), &(str1 + &str2));
     }
 

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -646,6 +646,14 @@ mod tests {
         let chunk = Chunk::new(&text);
         verify_chunk(chunk.as_slice(), &text);
 
+        // Verify Chunk::chars() bitmap
+        let expected_chars = text
+            .char_indices()
+            .map(|(i, _c)| i)
+            .inspect(|i| assert!(*i < 128))
+            .fold(0u128, |acc, i| acc | (1 << i));
+        assert_eq!(chunk.chars(), expected_chars);
+
         for _ in 0..10 {
             let mut start = rng.random_range(0..=chunk.text.len());
             let mut end = rng.random_range(start..=chunk.text.len());

--- a/crates/rope/src/chunk.rs
+++ b/crates/rope/src/chunk.rs
@@ -668,6 +668,20 @@ mod tests {
         }
     }
 
+    #[gpui::test(iterations = 100)]
+    fn test_split_chunk_slice(mut rng: StdRng) {
+        let text = &random_string_with_utf8_len(&mut rng, MAX_BASE);
+        let chunk = Chunk::new(text);
+        let offset = char_offsets_with_end(text)
+            .into_iter()
+            .choose(&mut rng)
+            .unwrap();
+        let (a, b) = chunk.as_slice().split_at(offset);
+        let (a_str, b_str) = text.split_at(offset);
+        verify_chunk(a, a_str);
+        verify_chunk(b, b_str);
+    }
+
     #[gpui::test(iterations = 1000)]
     fn test_nth_set_bit_random(mut rng: StdRng) {
         let set_count = rng.random_range(0..=128);


### PR DESCRIPTION
I was looking at the rope implementation and some of the existing bugs that crash in there, and I ran cargo-mutants to inspect test coverage. I was motivated by bugs like https://github.com/zed-industries/zed/issues/38556 but this doesn't fix it and the bug may well be at a higher layer.

This PR adds coverage for a few functions that aren't tested today. I didn't find any actual bugs yet. 

I can see this tree is pretty sparse on docstrings so if you think these are too verbose I can take them out  or drop the whole PR. 

Release Notes:

- N/A
