### PR TITLE
search: Dismiss modal view when running search action

### DIFF
--- a/crates/search/src/buffer_search/registrar.rs
+++ b/crates/search/src/buffer_search/registrar.rs
@@ -62,7 +62,7 @@ impl<T: 'static> SearchActionsRegistrar for DivRegistrar<'_, '_, T> {
 impl SearchActionsRegistrar for Workspace {
     fn register_handler<A: Action>(&mut self, callback: impl ActionExecutor<A>) {
         self.register_action(move |workspace, action: &A, window, cx| {
-            if workspace.has_active_modal(window, cx) {
+            if workspace.has_active_modal(window, cx) && !workspace.hide_modal(window, cx) {
                 cx.propagate();
                 return;
             }

--- a/crates/workspace/src/workspace.rs
+++ b/crates/workspace/src/workspace.rs
@@ -5864,6 +5864,11 @@ impl Workspace {
         })
     }
 
+    pub fn hide_modal(&mut self, window: &mut Window, cx: &mut App) -> bool {
+        self.modal_layer
+            .update(cx, |modal_layer, cx| modal_layer.hide_modal(window, cx))
+    }
+
     pub fn toggle_status_toast<V: ToastView>(&mut self, entity: Entity<V>, cx: &mut App) {
         self.toast_layer
             .update(cx, |toast_layer, cx| toast_layer.toggle_toast(cx, entity))


### PR DESCRIPTION
Currently, using cmd-f or cmd-shift-f to search while a modal is active (e.g. after cmd-t or cmd-p) doesn't do anything — you need to first close the modal manually before initiating a search. This PR allows these actions to run regardless of whether a modal is active.

Some context: VSCode lets you do this too, and for me it's quite common to do a symbol search with cmd-t immediately followed by a regular search with cmd-shift-f if I don't find what I'm looking for, so having to close the modal first is slightly disruptive. cmd-t followed by cmd-p does dismiss the project symbols modal in order to display the file search modal, so it makes sense to me to also allow search actions to dismiss an active modal.

Maybe this blunt fix has unintended consequences? If some types of modals shouldn't be dismissed when running cmd-f, or some actions shouldn't dismiss a currently active modal, then we'll have to go about it differently.

Release Notes:

- Added the ability to run search actions when a modal is currently active
