### PR TITLE
Implement scroll rounding to fix fonts jumping around with grid fitting

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -9096,8 +9096,8 @@ impl Element for EditorElement {
                     });
 
                     let scroll_pixel_position = point(
-                        scroll_position.x * f64::from(em_advance),
-                        scroll_position.y * f64::from(line_height),
+                        (scroll_position.x * f64::from(em_advance)).round(),
+                        (scroll_position.y * f64::from(line_height)).round(),
                     );
                     let indent_guides = self.layout_indent_guides(
                         content_origin,

--- a/crates/gpui/src/elements/div.rs
+++ b/crates/gpui/src/elements/div.rs
@@ -3048,7 +3048,8 @@ impl ScrollHandle {
 
     /// Get the current scroll offset.
     pub fn offset(&self) -> Point<Pixels> {
-        *self.0.borrow().offset.borrow()
+        let offset = *self.0.borrow().offset.borrow();
+        point(offset.x.round(), offset.y.round())
     }
 
     /// Get the maximum scroll offset.
@@ -3136,7 +3137,7 @@ impl ScrollHandle {
     /// As you scroll further down the offset becomes more negative.
     pub fn set_offset(&self, mut position: Point<Pixels>) {
         let state = self.0.borrow();
-        *state.offset.borrow_mut() = position;
+        *state.offset.borrow_mut() = point(position.x.round(), position.y.round());
     }
 
     /// Get the logical scroll top, based on a child index and a pixel offset.

--- a/crates/gpui/src/elements/uniform_list.rs
+++ b/crates/gpui/src/elements/uniform_list.rs
@@ -352,8 +352,8 @@ impl Element for UniformList {
                     let is_scrolled_vertically = !scroll_offset.y.is_zero();
                     let min_vertical_scroll_offset = padded_bounds.size.height - content_height;
                     if is_scrolled_vertically && scroll_offset.y < min_vertical_scroll_offset {
-                        shared_scroll_offset.borrow_mut().y = min_vertical_scroll_offset;
-                        scroll_offset.y = min_vertical_scroll_offset;
+                        shared_scroll_offset.borrow_mut().y = min_vertical_scroll_offset.round();
+                        scroll_offset.y = min_vertical_scroll_offset.round();
                     }
 
                     let content_width = content_size.width + padding.left + padding.right;
@@ -379,10 +379,12 @@ impl Element for UniformList {
 
                         if item_top < scroll_top + padding.top + offset_pixels {
                             scrolled_to_top = true;
-                            updated_scroll_offset.y = -(item_top) + padding.top + offset_pixels;
+                            updated_scroll_offset.y =
+                                (-(item_top) + padding.top + offset_pixels).round();
                         } else if item_bottom > scroll_top + list_height - padding.bottom {
                             scrolled_to_top = true;
-                            updated_scroll_offset.y = -(item_bottom - list_height) - padding.bottom;
+                            updated_scroll_offset.y =
+                                (-(item_bottom - list_height) - padding.bottom).round();
                         }
 
                         if deferred_scroll.scroll_strict
@@ -395,7 +397,8 @@ impl Element for UniformList {
                                     updated_scroll_offset.y = -item_top
                                         .max(Pixels::ZERO)
                                         .min(content_height - list_height)
-                                        .max(Pixels::ZERO);
+                                        .max(Pixels::ZERO)
+                                        .round();
                                 }
                                 ScrollStrategy::Center => {
                                     let item_center = item_top + item_height / 2.0;
@@ -407,13 +410,15 @@ impl Element for UniformList {
                                     updated_scroll_offset.y = -target_scroll_top
                                         .max(Pixels::ZERO)
                                         .min(content_height - list_height)
-                                        .max(Pixels::ZERO);
+                                        .max(Pixels::ZERO)
+                                        .round();
                                 }
                                 ScrollStrategy::Bottom => {
                                     updated_scroll_offset.y = -(item_bottom - list_height)
                                         .max(Pixels::ZERO)
                                         .min(content_height - list_height)
-                                        .max(Pixels::ZERO);
+                                        .max(Pixels::ZERO)
+                                        .round();
                                 }
                             }
                         }

--- a/crates/gpui/src/window.rs
+++ b/crates/gpui/src/window.rs
@@ -2411,7 +2411,7 @@ impl Window {
             return f(self);
         };
 
-        let abs_offset = self.element_offset() + offset;
+        let abs_offset = self.element_offset() + point(offset.x.round(), offset.y.round());
         self.with_absolute_element_offset(abs_offset, f)
     }
 


### PR DESCRIPTION
Ideally this would be fixed by us redoing the layouting library and not allowing subpixel positioning of elements. (Chrome/Firefox don't allow subpixel positioning, in the case of chrome it rounds the position, in the case of firefox it truncates the position). That would be a much larger effort so initially making a smaller patch fix that should make scrolling look better on windows and not worsen other platforms.

Release Notes:

- N/A
