### PR TITLE
macOS: Fix keyboards shortcuts does not work until mouse clicked inside Zed

### DIFF
--- a/crates/gpui/src/platform/mac/window.rs
+++ b/crates/gpui/src/platform/mac/window.rs
@@ -418,6 +418,7 @@ struct MacWindowState {
     select_next_tab_callback: Option<Box<dyn FnMut()>>,
     select_previous_tab_callback: Option<Box<dyn FnMut()>>,
     toggle_tab_bar_callback: Option<Box<dyn FnMut()>>,
+    activated_least_once: bool,
 }
 
 impl MacWindowState {
@@ -723,6 +724,7 @@ impl MacWindow {
                 select_next_tab_callback: None,
                 select_previous_tab_callback: None,
                 toggle_tab_bar_callback: None,
+                activated_least_once: false,
             })));
 
             (*native_window).set_ivar(
@@ -1995,23 +1997,32 @@ extern "C" fn window_did_change_key_status(this: &Object, selector: Sel, _: id) 
     let executor = lock.executor.clone();
     drop(lock);
 
-    // If window is becoming active, trigger immediate synchronous frame request.
+    // When a window becomes active, trigger an immediate synchronous frame request to prevent
+    // tab flicker when switching between windows in native tabs mode.
+    //
+    // This is only done on subsequent activations (not the first) to ensure the initial focus
+    // path is properly established. Without this guard, the focus state would remain unset until
+    // the first mouse click, causing keybindings to be non-functional.
     if selector == sel!(windowDidBecomeKey:) && is_active {
         let window_state = unsafe { get_window_state(this) };
         let mut lock = window_state.lock();
 
-        if let Some(mut callback) = lock.request_frame_callback.take() {
-            #[cfg(not(feature = "macos-blade"))]
-            lock.renderer.set_presents_with_transaction(true);
-            lock.stop_display_link();
-            drop(lock);
-            callback(Default::default());
+        if lock.activated_least_once {
+            if let Some(mut callback) = lock.request_frame_callback.take() {
+                #[cfg(not(feature = "macos-blade"))]
+                lock.renderer.set_presents_with_transaction(true);
+                lock.stop_display_link();
+                drop(lock);
+                callback(Default::default());
 
-            let mut lock = window_state.lock();
-            lock.request_frame_callback = Some(callback);
-            #[cfg(not(feature = "macos-blade"))]
-            lock.renderer.set_presents_with_transaction(false);
-            lock.start_display_link();
+                let mut lock = window_state.lock();
+                lock.request_frame_callback = Some(callback);
+                #[cfg(not(feature = "macos-blade"))]
+                lock.renderer.set_presents_with_transaction(false);
+                lock.start_display_link();
+            }
+        } else {
+            lock.activated_least_once = true;
         }
     }
 


### PR DESCRIPTION
Closes #38258

Regressed in https://github.com/zed-industries/zed/pull/33334
 
Release Notes:

- Fixed an issue on macOS where keyboard shortcuts wouldn’t work until you clicked inside Zed.