### PR TITLE
agent: Introduce `agent_buffer_font_size` setting

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -76,6 +76,8 @@
   "ui_font_size": 16,
   // The default font size for text in the agent panel. Falls back to the UI font size if unset.
   "agent_font_size": null,
+  // The default font size for user messages in the agent panel. Falls back to the buffer font size if unset.
+  "agent_buffer_font_size": 12,
   // How much to fade out unused code.
   "unnecessary_code_fade": 0.3,
   // Active pane styling settings.

--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -74,8 +74,8 @@
   "ui_font_weight": 400,
   // The default font size for text in the UI
   "ui_font_size": 16,
-  // The default font size for text in the agent panel. Falls back to the UI font size if unset.
-  "agent_font_size": null,
+  // The default font size for agent responses in the agent panel. Falls back to the UI font size if unset.
+  "agent_ui_font_size": null,
   // The default font size for user messages in the agent panel. Falls back to the buffer font size if unset.
   "agent_buffer_font_size": 12,
   // How much to fade out unused code.
@@ -2026,7 +2026,7 @@
   // Examples:
   // "profiles": {
   //   "Presenting": {
-  //     "agent_font_size": 20.0,
+  //     "agent_ui_font_size": 20.0,
   //     "buffer_font_size": 20.0,
   //     "theme": "One Light",
   //     "ui_font_size": 20.0

--- a/crates/agent_ui/src/acp/entry_view_state.rs
+++ b/crates/agent_ui/src/acp/entry_view_state.rs
@@ -203,7 +203,7 @@ impl EntryViewState {
         self.entries.drain(range);
     }
 
-    pub fn agent_font_size_changed(&mut self, cx: &mut App) {
+    pub fn agent_ui_font_size_changed(&mut self, cx: &mut App) {
         for entry in self.entries.iter() {
             match entry {
                 Entry::UserMessage { .. } | Entry::AssistantMessage { .. } => {}
@@ -387,7 +387,7 @@ fn diff_editor_text_style_refinement(cx: &mut App) -> TextStyleRefinement {
         font_size: Some(
             TextSize::Small
                 .rems(cx)
-                .to_pixels(ThemeSettings::get_global(cx).agent_font_size(cx))
+                .to_pixels(ThemeSettings::get_global(cx).agent_ui_font_size(cx))
                 .into(),
         ),
         ..Default::default()

--- a/crates/agent_ui/src/acp/message_editor.rs
+++ b/crates/agent_ui/src/acp/message_editor.rs
@@ -1299,7 +1299,7 @@ impl Render for MessageEditor {
                     font_family: settings.buffer_font.family.clone(),
                     font_fallbacks: settings.buffer_font.fallbacks.clone(),
                     font_features: settings.buffer_font.features.clone(),
-                    font_size: settings.buffer_font_size(cx).into(),
+                    font_size: settings.agent_buffer_font_size(cx).into(),
                     line_height: relative(settings.buffer_line_height.value()),
                     ..Default::default()
                 };

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -381,8 +381,8 @@ impl AcpThreadView {
         });
 
         let subscriptions = [
-            cx.observe_global_in::<SettingsStore>(window, Self::agent_font_size_changed),
-            cx.observe_global_in::<AgentFontSize>(window, Self::agent_font_size_changed),
+            cx.observe_global_in::<SettingsStore>(window, Self::agent_ui_font_size_changed),
+            cx.observe_global_in::<AgentFontSize>(window, Self::agent_ui_font_size_changed),
             cx.subscribe_in(&message_editor, window, Self::handle_message_editor_event),
             cx.subscribe_in(&entry_view_state, window, Self::handle_entry_view_event),
         ];
@@ -4902,9 +4902,9 @@ impl AcpThreadView {
         )
     }
 
-    fn agent_font_size_changed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
+    fn agent_ui_font_size_changed(&mut self, _window: &mut Window, cx: &mut Context<Self>) {
         self.entry_view_state.update(cx, |entry_view_state, cx| {
-            entry_view_state.agent_font_size_changed(cx);
+            entry_view_state.agent_ui_font_size_changed(cx);
         });
     }
 

--- a/crates/agent_ui/src/agent_panel.rs
+++ b/crates/agent_ui/src/agent_panel.rs
@@ -1108,15 +1108,15 @@ impl AgentPanel {
             WhichFontSize::AgentFont => {
                 if persist {
                     update_settings_file(self.fs.clone(), cx, move |settings, cx| {
-                        let agent_font_size =
-                            ThemeSettings::get_global(cx).agent_font_size(cx) + delta;
+                        let agent_ui_font_size =
+                            ThemeSettings::get_global(cx).agent_ui_font_size(cx) + delta;
                         let _ = settings
                             .theme
-                            .agent_font_size
-                            .insert(theme::clamp_font_size(agent_font_size).into());
+                            .agent_ui_font_size
+                            .insert(theme::clamp_font_size(agent_ui_font_size).into());
                     });
                 } else {
-                    theme::adjust_agent_font_size(cx, |size| size + delta);
+                    theme::adjust_agent_ui_font_size(cx, |size| size + delta);
                 }
             }
             WhichFontSize::BufferFont => {
@@ -1136,10 +1136,10 @@ impl AgentPanel {
     ) {
         if action.persist {
             update_settings_file(self.fs.clone(), cx, move |settings, _| {
-                settings.theme.agent_font_size = None;
+                settings.theme.agent_ui_font_size = None;
             });
         } else {
-            theme::reset_agent_font_size(cx);
+            theme::reset_agent_ui_font_size(cx);
         }
     }
 
@@ -2570,7 +2570,7 @@ impl Render for AgentPanel {
 
         match self.active_view.which_font_size_used() {
             WhichFontSize::AgentFont => {
-                WithRemSize::new(ThemeSettings::get_global(cx).agent_font_size(cx))
+                WithRemSize::new(ThemeSettings::get_global(cx).agent_ui_font_size(cx))
                     .size_full()
                     .child(content)
                     .into_any()

--- a/crates/assistant_tools/src/edit_file_tool.rs
+++ b/crates/assistant_tools/src/edit_file_tool.rs
@@ -1003,7 +1003,7 @@ impl ToolCard for EditFileToolCard {
                 font_size: Some(
                     TextSize::Small
                         .rems(cx)
-                        .to_pixels(ThemeSettings::get_global(cx).agent_font_size(cx))
+                        .to_pixels(ThemeSettings::get_global(cx).agent_ui_font_size(cx))
                         .into(),
                 ),
                 ..TextStyleRefinement::default()

--- a/crates/migrator/src/migrations.rs
+++ b/crates/migrator/src/migrations.rs
@@ -111,3 +111,9 @@ pub(crate) mod m_2025_10_02 {
 
     pub(crate) use settings::remove_formatters_on_save;
 }
+
+pub(crate) mod m_2025_10_03 {
+    mod settings;
+
+    pub(crate) use settings::SETTINGS_PATTERNS;
+}

--- a/crates/migrator/src/migrations/m_2025_10_03/settings.rs
+++ b/crates/migrator/src/migrations/m_2025_10_03/settings.rs
@@ -1,0 +1,30 @@
+use std::ops::Range;
+use tree_sitter::{Query, QueryMatch};
+
+use crate::MigrationPatterns;
+use crate::patterns::SETTINGS_ROOT_KEY_VALUE_PATTERN;
+
+pub const SETTINGS_PATTERNS: MigrationPatterns =
+    &[(SETTINGS_ROOT_KEY_VALUE_PATTERN, rename_agent_font_size)];
+
+/// Renames the setting `agent_font_size` to `agent_ui_font_size`
+fn rename_agent_font_size(
+    contents: &str,
+    mat: &QueryMatch,
+    query: &Query,
+) -> Option<(Range<usize>, String)> {
+    let setting_capture_ix = query.capture_index_for_name("name")?;
+
+    let setting_name_range = mat
+        .nodes_for_capture_index(setting_capture_ix)
+        .next()?
+        .byte_range();
+
+    let setting_name = contents.get(setting_name_range.clone())?;
+
+    if setting_name != "agent_font_size" {
+        return None;
+    }
+
+    Some((setting_name_range, "agent_ui_font_size".to_string()))
+}

--- a/crates/migrator/src/migrator.rs
+++ b/crates/migrator/src/migrator.rs
@@ -200,6 +200,10 @@ pub fn migrate_settings(text: &str) -> Result<Option<String>> {
             &SETTINGS_QUERY_2025_10_01,
         ),
         MigrationType::Json(migrations::m_2025_10_02::remove_formatters_on_save),
+        MigrationType::TreeSitter(
+            migrations::m_2025_10_03::SETTINGS_PATTERNS,
+            &SETTINGS_QUERY_2025_10_03,
+        ),
     ];
     run_migrations(text, migrations)
 }
@@ -317,6 +321,10 @@ define_query!(
 define_query!(
     SETTINGS_QUERY_2025_10_01,
     migrations::m_2025_10_01::SETTINGS_PATTERNS
+);
+define_query!(
+    SETTINGS_QUERY_2025_10_03,
+    migrations::m_2025_10_03::SETTINGS_PATTERNS
 );
 
 // custom query

--- a/crates/settings/src/settings_content/theme.rs
+++ b/crates/settings/src/settings_content/theme.rs
@@ -52,9 +52,9 @@ pub struct ThemeSettingsContent {
     #[serde(default)]
     #[schemars(default = "default_font_features")]
     pub buffer_font_features: Option<FontFeatures>,
-    /// The font size for the agent panel. Falls back to the UI font size if unset.
+    /// The font size for agent responses in the agent panel. Falls back to the UI font size if unset.
     #[serde(default)]
-    pub agent_font_size: Option<f32>,
+    pub agent_ui_font_size: Option<f32>,
     /// The font size for user messages in the agent panel. Falls back to the buffer font size if unset.
     #[serde(default)]
     pub agent_buffer_font_size: Option<f32>,

--- a/crates/settings/src/settings_content/theme.rs
+++ b/crates/settings/src/settings_content/theme.rs
@@ -55,6 +55,9 @@ pub struct ThemeSettingsContent {
     /// The font size for the agent panel. Falls back to the UI font size if unset.
     #[serde(default)]
     pub agent_font_size: Option<f32>,
+    /// The font size for user messages in the agent panel. Falls back to the buffer font size if unset.
+    #[serde(default)]
+    pub agent_buffer_font_size: Option<f32>,
     /// The name of the Zed theme to use.
     #[serde(default)]
     pub theme: Option<ThemeSelection>,

--- a/crates/theme/src/settings.rs
+++ b/crates/theme/src/settings.rs
@@ -115,7 +115,9 @@ pub struct ThemeSettings {
     /// The terminal font family can be overridden using it's own setting.
     pub buffer_font: Font,
     /// The agent font size. Determines the size of text in the agent panel. Falls back to the UI font size if unset.
-    agent_font_size: Option<Pixels>,
+    agent_ui_font_size: Option<Pixels>,
+    /// The agent buffer font size. Determines the size of user messages in the agent panel. Falls back to the buffer font size if unset.
+    agent_buffer_font_size: Option<Pixels>,
     /// The line height for buffers, and the terminal.
     ///
     /// Changing this may affect the spacing of some UI elements.
@@ -539,10 +541,10 @@ impl ThemeSettings {
     }
 
     /// Returns the agent panel font size. Falls back to the UI font size if unset.
-    pub fn agent_font_size(&self, cx: &App) -> Pixels {
+    pub fn agent_ui_font_size(&self, cx: &App) -> Pixels {
         cx.try_global::<AgentFontSize>()
             .map(|size| size.0)
-            .or(self.agent_font_size)
+            .or(self.agent_ui_font_size)
             .map(clamp_font_size)
             .unwrap_or_else(|| self.ui_font_size(cx))
     }
@@ -575,9 +577,17 @@ impl ThemeSettings {
     /// Returns the agent font size, read from the settings.
     ///
     /// The real agent font size is stored in-memory, to support temporary font size changes.
-    /// Use [`Self::agent_font_size`] to get the real font size.
-    pub fn agent_font_size_settings(&self) -> Option<Pixels> {
-        self.agent_font_size
+    /// Use [`Self::agent_ui_font_size`] to get the real font size.
+    pub fn agent_ui_font_size_settings(&self) -> Option<Pixels> {
+        self.agent_ui_font_size
+    }
+
+    /// Returns the agent buffer font size, read from the settings.
+    ///
+    /// The real agent buffer font size is stored in-memory, to support temporary font size changes.
+    /// Use [`Self::agent_buffer_font_size`] to get the real font size.
+    pub fn agent_buffer_font_size_settings(&self) -> Option<Pixels> {
+        self.agent_buffer_font_size
     }
 
     // TODO: Rename: `line_height` -> `buffer_line_height`
@@ -734,9 +744,24 @@ pub fn reset_ui_font_size(cx: &mut App) {
     }
 }
 
-/// Sets the adjusted agent panel font size.
-pub fn adjust_agent_font_size(cx: &mut App, f: impl FnOnce(Pixels) -> Pixels) {
-    let agent_font_size = ThemeSettings::get_global(cx).agent_font_size(cx);
+/// Sets the adjusted font size of agent responses in the agent panel.
+pub fn adjust_agent_ui_font_size(cx: &mut App, f: impl FnOnce(Pixels) -> Pixels) {
+    let agent_ui_font_size = ThemeSettings::get_global(cx).agent_ui_font_size(cx);
+    let adjusted_size = cx
+        .try_global::<AgentFontSize>()
+        .map_or(agent_ui_font_size, |adjusted_size| adjusted_size.0);
+    cx.set_global(AgentFontSize(clamp_font_size(f(adjusted_size))));
+    cx.refresh_windows();
+}
+
+/// Resets the agent response font size in the agent panel to the default value.
+pub fn reset_agent_ui_font_size(cx: &mut App) {
+    if cx.has_global::<AgentFontSize>() {
+        cx.remove_global::<AgentFontSize>();
+        cx.refresh_windows();
+    }
+}
+
 /// Sets the adjusted font size of user messages in the agent panel.
 pub fn adjust_agent_buffer_font_size(cx: &mut App, f: impl FnOnce(Pixels) -> Pixels) {
     let agent_buffer_font_size = ThemeSettings::get_global(cx).agent_buffer_font_size(cx);

--- a/crates/theme/src/theme.rs
+++ b/crates/theme/src/theme.rs
@@ -111,8 +111,11 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut App) {
     let mut prev_buffer_font_size_settings =
         ThemeSettings::get_global(cx).buffer_font_size_settings();
     let mut prev_ui_font_size_settings = ThemeSettings::get_global(cx).ui_font_size_settings();
-    let mut prev_agent_font_size_settings =
-        ThemeSettings::get_global(cx).agent_font_size_settings();
+    let mut prev_agent_ui_font_size_settings =
+        ThemeSettings::get_global(cx).agent_ui_font_size_settings();
+    let mut prev_agent_buffer_font_size_settings =
+        ThemeSettings::get_global(cx).agent_buffer_font_size_settings();
+
     cx.observe_global::<SettingsStore>(move |cx| {
         let buffer_font_size_settings = ThemeSettings::get_global(cx).buffer_font_size_settings();
         if buffer_font_size_settings != prev_buffer_font_size_settings {
@@ -126,10 +129,18 @@ pub fn init(themes_to_load: LoadThemes, cx: &mut App) {
             reset_ui_font_size(cx);
         }
 
-        let agent_font_size_settings = ThemeSettings::get_global(cx).agent_font_size_settings();
-        if agent_font_size_settings != prev_agent_font_size_settings {
-            prev_agent_font_size_settings = agent_font_size_settings;
-            reset_agent_font_size(cx);
+        let agent_ui_font_size_settings =
+            ThemeSettings::get_global(cx).agent_ui_font_size_settings();
+        if agent_ui_font_size_settings != prev_agent_ui_font_size_settings {
+            prev_agent_ui_font_size_settings = agent_ui_font_size_settings;
+            reset_agent_ui_font_size(cx);
+        }
+
+        let agent_buffer_font_size_settings =
+            ThemeSettings::get_global(cx).agent_buffer_font_size_settings();
+        if agent_buffer_font_size_settings != prev_agent_buffer_font_size_settings {
+            prev_agent_buffer_font_size_settings = agent_buffer_font_size_settings;
+            reset_agent_buffer_font_size(cx);
         }
     })
     .detach();


### PR DESCRIPTION
Closes https://github.com/zed-industries/zed/issues/39406
Follow up to https://github.com/zed-industries/zed/pull/38726

This PR introduces the `agent_buffer_font_size` setting and renames `agent_font_size` to `agent_ui_font_size`. This allows whoever wants `buffer_font_size` and `agent_buffer_font_size` to match, as well as folks who want a slightly smaller size only in the agent panel (which... also looks just better by default!).

Release Notes:

- agent: Introduced the `agent_buffer_font_size` setting and renamed `agent_font_size` to `agent_ui_font_size`, allowing for granular buffer font size control in the agent panel vs. regular editors.
