### PR TITLE
editor: Preserve font features for vim block cursor

### DIFF
--- a/crates/editor/src/element.rs
+++ b/crates/editor/src/element.rs
@@ -1624,12 +1624,13 @@ impl EditorElement {
                             .map(|text| {
                                 let len = text.len();
 
-                                let font = cursor_row_layout
+                                let mut font = cursor_row_layout
                                     .font_id_for_index(cursor_column)
                                     .and_then(|cursor_font_id| {
                                         window.text_system().get_font_for_id(cursor_font_id)
                                     })
                                     .unwrap_or(self.style.text.font());
+                                font.features = self.style.text.font_features.clone();
 
                                 // Invert the text color for the block cursor. Ensure that the text
                                 // color is opaque enough to be visible against the background color.


### PR DESCRIPTION
## Summary

Fixes an issue where font features (like ligatures) were not applied to text under the vim block cursor. The cursor would inherit the font family from the character at the cursor
position, but would use default font features instead of the editor's configured font features.

## Changes

- Make the font mutable when rendering the vim block cursor
- Apply the editor's text style font features to the cursor font

This ensures that text under the block cursor renders with the same visual appearance as the rest of the editor content.

Closes #39471

Release Notes:

- Fixed vim block cursor not respecting font features (like ligatures)