### PR TITLE
askpass: Fix cli path when executed in a remote server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -806,6 +806,7 @@ dependencies = [
  "anyhow",
  "futures 0.3.31",
  "gpui",
+ "log",
  "net",
  "proto",
  "smol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20216,6 +20216,7 @@ dependencies = [
  "agent_ui",
  "anyhow",
  "ashpd 0.11.0",
+ "askpass",
  "assets",
  "assistant_tools",
  "audio",

--- a/crates/askpass/Cargo.toml
+++ b/crates/askpass/Cargo.toml
@@ -18,6 +18,7 @@ gpui.workspace = true
 net.workspace = true
 proto.workspace = true
 smol.workspace = true
+log.workspace = true
 tempfile.workspace = true
 util.workspace = true
 workspace-hack.workspace = true

--- a/crates/askpass/Cargo.toml
+++ b/crates/askpass/Cargo.toml
@@ -26,3 +26,6 @@ zeroize.workspace = true
 
 [target.'cfg(target_os = "windows")'.dependencies]
 windows.workspace = true
+
+[package.metadata.cargo-machete]
+ignored = ["log"]

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -14,7 +14,7 @@ use futures::{
 };
 use gpui::{AsyncApp, BackgroundExecutor, Task};
 use smol::fs;
-use util::ResultExt as _;
+use util::{ResultExt as _, debug_panic};
 
 use crate::encrypted_password::decrypt;
 
@@ -264,7 +264,7 @@ pub fn main(socket: &str) {
 
 pub fn set_askpass_program(path: std::path::PathBuf) {
     if ASKPASS_PROGRAM.set(path).is_err() {
-        panic!("askpass program has already been set");
+        debug_panic!("askpass program has already been set");
     }
 }
 
@@ -273,7 +273,6 @@ pub fn set_askpass_program(path: std::path::PathBuf) {
 fn generate_askpass_script(askpass_program: &str, askpass_socket: &std::path::Path) -> String {
     format!(
         "{shebang}\n{print_args} | {askpass_program} --askpass={askpass_socket} 2> /dev/null \n",
-        askpass_program = askpass_program,
         askpass_socket = askpass_socket.display(),
         print_args = "printf '%s\\0' \"$@\"",
         shebang = "#!/bin/sh",
@@ -288,7 +287,6 @@ fn generate_askpass_script(askpass_program: &str, askpass_socket: &std::path::Pa
         $ErrorActionPreference = 'Stop';
         ($args -join [char]0) | & "{askpass_program}" --askpass={askpass_socket} 2> $null
         "#,
-        askpass_program = askpass_program,
         askpass_socket = askpass_socket.display(),
     )
 }

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -3,7 +3,6 @@ mod encrypted_password;
 pub use encrypted_password::{EncryptedPassword, ProcessExt};
 use util::paths::PathExt;
 
-#[cfg(target_os = "windows")]
 use std::sync::OnceLock;
 use std::{ffi::OsStr, time::Duration};
 
@@ -15,11 +14,14 @@ use futures::{
 };
 use gpui::{AsyncApp, BackgroundExecutor, Task};
 use smol::fs;
-use std::sync::OnceLock;
 use util::ResultExt as _;
 
 use crate::encrypted_password::decrypt;
 
+/// Path to the program used for askpass
+///
+/// On Unix and remote servers, this defaults to the current executable
+/// On Windows, this is set to the CLI variant of zed
 static ASKPASS_PROGRAM: OnceLock<std::path::PathBuf> = OnceLock::new();
 
 #[derive(PartialEq, Eq)]
@@ -95,7 +97,7 @@ impl AskPassSession {
         let askpass_program = ASKPASS_PROGRAM
             .get_or_init(|| current_exec)
             .try_shell_safe()
-            .context("Failed to shell-escape Zed executable path.")?
+            .context("Failed to shell-escape Askpass program path.")?
             .trim_end_matches(" (deleted)") // See https://github.com/rust-lang/rust/issues/69343
             .to_string();
 

--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -94,11 +94,11 @@ impl AskPassSession {
 
         let current_exec =
             std::env::current_exe().context("Failed to determine current zed executable path.")?;
+
         let askpass_program = ASKPASS_PROGRAM
             .get_or_init(|| current_exec)
             .try_shell_safe()
             .context("Failed to shell-escape Askpass program path.")?
-            .trim_end_matches(" (deleted)") // See https://github.com/rust-lang/rust/issues/69343
             .to_string();
 
         let (askpass_kill_master_tx, askpass_kill_master_rx) = oneshot::channel::<()>();

--- a/crates/util/src/paths.rs
+++ b/crates/util/src/paths.rs
@@ -1,3 +1,4 @@
+use anyhow::Context;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use itertools::Itertools;
 use regex::Regex;
@@ -48,7 +49,6 @@ pub trait PathExt {
         }
         #[cfg(windows)]
         {
-            use anyhow::Context as _;
             use tendril::fmt::{Format, WTF8};
             WTF8::validate(bytes)
                 .then(|| {
@@ -169,12 +169,12 @@ impl<T: AsRef<Path>> PathExt for T {
             let path_str = self
                 .as_ref()
                 .to_str()
-                .ok_or_else(|| anyhow::anyhow!("Path contains invalid UTF-8"))?;
+                .with_context(|| "Path contains invalid UTF-8")?;
 
             // As of writing, this can only be fail if the path contains a null byte, which shouldn't be possible
             // but shlex has annotated the error as #[non_exhaustive] so we can't make it a compile error if other
             // errors are introduced in the future :(
-            Ok(shlex::try_quote(path_str)?.to_string())
+            Ok(shlex::try_quote(path_str)?.into())
         }
     }
 }

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -295,10 +295,9 @@ pub fn get_shell_safe_zed_path() -> anyhow::Result<String> {
     let zed_path =
         std::env::current_exe().context("Failed to determine current zed executable path.")?;
 
-    Ok(zed_path
+    zed_path
         .try_shell_safe()
-        .context("Failed to shell-escape Zed executable path.")?
-        .to_string())
+        .context("Failed to shell-escape Zed executable path.")
 }
 
 /// Returns a path for the zed cli executable, this function

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -302,7 +302,7 @@ pub fn get_shell_safe_zed_path() -> anyhow::Result<String> {
         .to_string())
 }
 
-/// Returns a shell escaped path for the zed cli executable, this function
+/// Returns a path for the zed cli executable, this function
 /// should be called from the zed executable, not zed-cli.
 pub fn get_zed_cli_path() -> Result<PathBuf> {
     let zed_path =

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -288,7 +288,6 @@ fn load_shell_from_passwd() -> Result<()> {
     Ok(())
 }
 
-#[cfg(unix)]
 /// Returns a shell escaped path for the current zed executable
 pub fn get_shell_safe_zed_path() -> anyhow::Result<String> {
     let zed_path = std::env::current_exe()

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -298,7 +298,6 @@ pub fn get_shell_safe_zed_path() -> anyhow::Result<String> {
     Ok(zed_path
         .try_shell_safe()
         .context("Failed to shell-escape Zed executable path.")?
-        .trim_end_matches(" (deleted)") // See https://github.com/rust-lang/rust/issues/69343
         .to_string())
 }
 

--- a/crates/util/src/util.rs
+++ b/crates/util/src/util.rs
@@ -296,13 +296,20 @@ pub fn get_shell_safe_zed_path() -> anyhow::Result<String> {
         .trim_end_matches(" (deleted)") // see https://github.com/rust-lang/rust/issues/69343
         .to_string();
 
+    #[cfg(target_os = "windows")]
+    {
+        Ok(zed_path)
+    }
+
     // As of writing, this can only be fail if the path contains a null byte, which shouldn't be possible
     // but shlex has annotated the error as #[non_exhaustive] so we can't make it a compile error if other
     // errors are introduced in the future :(
-    let zed_path_escaped =
-        shlex::try_quote(&zed_path).context("Failed to shell-escape Zed executable path.")?;
-
-    Ok(zed_path_escaped.to_string())
+    #[cfg(not(target_os = "windows"))]
+    {
+        Ok(shlex::try_quote(&zed_path)
+            .context("Failed to shell-escape Zed executable path.")?
+            .to_string())
+    }
 }
 
 /// Returns a shell escaped path for the zed cli executable, this function

--- a/crates/zed/Cargo.toml
+++ b/crates/zed/Cargo.toml
@@ -25,6 +25,7 @@ agent.workspace = true
 agent_settings.workspace = true
 agent_ui.workspace = true
 anyhow.workspace = true
+askpass.workspace = true
 assets.workspace = true
 assistant_tools.workspace = true
 audio.workspace = true

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -168,9 +168,6 @@ pub fn main() {
     #[cfg(unix)]
     util::prevent_root_execution();
 
-    #[cfg(target_os = "windows")]
-    askpass::set_askpass_program(util::get_shell_safe_zed_cli_path());
-
     let args = Args::parse();
 
     // `zed --askpass` Makes zed operate in nc/netcat mode for use with askpass
@@ -219,6 +216,15 @@ pub fn main() {
 
         if args.foreground {
             let _ = AttachConsole(ATTACH_PARENT_PROCESS);
+        }
+    }
+
+    #[cfg(target_os = "windows")]
+    match util::get_zed_cli_path() {
+        Ok(path) => askpass::set_askpass_program(path),
+        Err(err) => {
+            eprintln!("Error: {}", err);
+            process::exit(1);
         }
     }
 

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -170,6 +170,13 @@ pub fn main() {
 
     let args = Args::parse();
 
+    // `zed --askpass` Makes zed operate in nc/netcat mode for use with askpass
+    #[cfg(not(target_os = "windows"))]
+    if let Some(socket) = &args.askpass {
+        askpass::main(socket);
+        return;
+    }
+
     // `zed --crash-handler` Makes zed operate in minidump crash handler mode
     if let Some(socket) = &args.crash_handler {
         crashes::crash_server(socket.as_path());
@@ -1264,6 +1271,13 @@ struct Args {
     #[cfg(target_os = "windows")]
     #[arg(hide = true)]
     dock_action: Option<usize>,
+
+    /// Used for SSH/Git password authentication, to remove the need for netcat as a dependency,
+    /// by having Zed act like netcat communicating over a Unix socket.
+    #[arg(long)]
+    #[cfg(not(target_os = "windows"))]
+    #[arg(hide = true)]
+    askpass: Option<String>,
 
     #[arg(long, hide = true)]
     dump_all_actions: bool,

--- a/crates/zed/src/main.rs
+++ b/crates/zed/src/main.rs
@@ -168,6 +168,9 @@ pub fn main() {
     #[cfg(unix)]
     util::prevent_root_execution();
 
+    #[cfg(target_os = "windows")]
+    askpass::set_askpass_program(util::get_shell_safe_zed_cli_path());
+
     let args = Args::parse();
 
     // `zed --askpass` Makes zed operate in nc/netcat mode for use with askpass


### PR DESCRIPTION
Closes #39469
Closes #39438
Closes #39458

I'm not able to test it, i would appreciate if somebody could do it. I think this bug was present also for SSH remote projects

Release Notes:

- Fixed an issue where zed bin was not found in remote servers for askpass
