### PR TITLE
settings: Fix JSON schema for `ExtensionCapabilityContent`

### DIFF
--- a/crates/extension_host/src/extension_settings.rs
+++ b/crates/extension_host/src/extension_settings.rs
@@ -48,21 +48,15 @@ impl Settings for ExtensionSettings {
                 .unwrap_or_default()
                 .into_iter()
                 .map(|capability| match capability {
-                    settings::ExtensionCapabilityContent::ProcessExec(capability) => {
-                        ExtensionCapability::ProcessExec(ProcessExecCapability {
-                            command: capability.command,
-                            args: capability.args,
-                        })
+                    settings::ExtensionCapabilityContent::ProcessExec { command, args } => {
+                        ExtensionCapability::ProcessExec(ProcessExecCapability { command, args })
                     }
-                    settings::ExtensionCapabilityContent::DownloadFile(capability) => {
-                        ExtensionCapability::DownloadFile(DownloadFileCapability {
-                            host: capability.host,
-                            path: capability.path,
-                        })
+                    settings::ExtensionCapabilityContent::DownloadFile { host, path } => {
+                        ExtensionCapability::DownloadFile(DownloadFileCapability { host, path })
                     }
-                    settings::ExtensionCapabilityContent::NpmInstallPackage(capability) => {
+                    settings::ExtensionCapabilityContent::NpmInstallPackage { package } => {
                         ExtensionCapability::NpmInstallPackage(NpmInstallPackageCapability {
-                            package: capability.package,
+                            package,
                         })
                     }
                 })

--- a/crates/settings/src/settings_content/extension.rs
+++ b/crates/settings/src/settings_content/extension.rs
@@ -29,31 +29,19 @@ pub struct ExtensionSettingsContent {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ExtensionCapabilityContent {
     #[serde(rename = "process:exec")]
-    ProcessExec(ProcessExecCapabilityContent),
-    DownloadFile(DownloadFileCapabilityContent),
+    ProcessExec {
+        /// The command to execute.
+        command: String,
+        /// The arguments to pass to the command. Use `*` for a single wildcard argument.
+        /// If the last element is `**`, then any trailing arguments are allowed.
+        args: Vec<String>,
+    },
+    DownloadFile {
+        host: String,
+        path: Vec<String>,
+    },
     #[serde(rename = "npm:install")]
-    NpmInstallPackage(NpmInstallPackageCapabilityContent),
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct ProcessExecCapabilityContent {
-    /// The command to execute.
-    pub command: String,
-    /// The arguments to pass to the command. Use `*` for a single wildcard argument.
-    /// If the last element is `**`, then any trailing arguments are allowed.
-    pub args: Vec<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct DownloadFileCapabilityContent {
-    pub host: String,
-    pub path: Vec<String>,
-}
-
-#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize, JsonSchema)]
-#[serde(rename_all = "snake_case")]
-pub struct NpmInstallPackageCapabilityContent {
-    pub package: String,
+    NpmInstallPackage {
+        package: String,
+    },
 }


### PR DESCRIPTION
This PR fixes the JSON schema for the `ExtensionCapabilityContent`.

Having the nested structs in the variants caused the `kind` property to not be generated properly. Inlining the fields into the variants fixes this.

Release Notes:

- N/A
