### PR TITLE
file_finder: Fix path matching on starting slash

### DIFF
--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -3069,3 +3069,49 @@ async fn test_filename_precedence(cx: &mut TestAppContext) {
         );
     });
 }
+
+#[gpui::test]
+async fn test_paths_with_starting_slash(cx: &mut TestAppContext) {
+    let app_state = init_test(cx);
+    app_state
+        .fs
+        .as_fake()
+        .insert_tree(
+            path!("/root"),
+            json!({
+                "a": {
+                    "file1.txt": "",
+                    "b": {
+                        "file2.txt": "",
+                    },
+                }
+            }),
+        )
+        .await;
+
+    let project = Project::test(app_state.fs.clone(), [path!("/root").as_ref()], cx).await;
+
+    let (picker, workspace, cx) = build_find_picker(project, cx);
+
+    let matching_abs_path = path!("/file1.txt").to_string();
+    picker
+        .update_in(cx, |picker, window, cx| {
+            picker
+                .delegate
+                .update_matches(matching_abs_path, window, cx)
+        })
+        .await;
+    picker.update(cx, |picker, _| {
+        assert_eq!(
+            collect_search_matches(picker).search_paths_only(),
+            vec![rel_path("a/file1.txt").into()],
+            "Relative path starting with slash should match"
+        )
+    });
+    cx.dispatch_action(SelectNext);
+    cx.dispatch_action(Confirm);
+    cx.read(|cx| {
+        let active_editor = workspace.read(cx).active_item_as::<Editor>(cx).unwrap();
+        assert_eq!(active_editor.read(cx).title(cx), "file1.txt");
+    });
+}

--- a/crates/file_finder/src/file_finder_tests.rs
+++ b/crates/file_finder/src/file_finder_tests.rs
@@ -3093,7 +3093,7 @@ async fn test_paths_with_starting_slash(cx: &mut TestAppContext) {
 
     let (picker, workspace, cx) = build_find_picker(project, cx);
 
-    let matching_abs_path = path!("/file1.txt").to_string();
+    let matching_abs_path = "/file1.txt".to_string();
     picker
         .update_in(cx, |picker, window, cx| {
             picker


### PR DESCRIPTION
These changes update the way the file finder decides wether to only look for an absolute path or for a relative path too.

When the provided query started with a slash (`/`) the file finder would assume this to be an absolute path so would always try to find an absolute path and return no matches if none was found. This is meant to support situtations where, for example, a CLI tool might output the absolute path of a file and the user can copy and paste that in the file finder.

However, it's should be possible to use slash (`/`) at the start of the query to specify that only relative files inside a folder should be matched, which would not work in this scenario.

With these changes, the file finder will first check if the path is absolute and, if it is and no absolute matches were found, it'll still try to find relative matches, otherwise it'll simply look for relative matches.

Closes #39350

Release Notes:

- Fixed project files matches when using slash (`/`) at the start in order to consider relative paths
