### PR TITLE
Focus project panel when clicking empty space

### DIFF
--- a/crates/project_panel/src/project_panel.rs
+++ b/crates/project_panel/src/project_panel.rs
@@ -5771,13 +5771,14 @@ impl Render for ProjectPanel {
                                         cx.stop_propagation();
                                     },
                                 ))
-                                .on_click(cx.listener(|this, event, _, cx| {
+                                .on_click(cx.listener(|this, event, window, cx| {
                                     if matches!(event, gpui::ClickEvent::Keyboard(_)) {
                                         return;
                                     }
                                     cx.stop_propagation();
                                     this.state.selection = None;
                                     this.marked_entries.clear();
+                                    this.focus_handle(cx).focus(window);
                                 }))
                                 .on_mouse_down(
                                     MouseButton::Right,


### PR DESCRIPTION
Closes #39486

Release Notes:

- Fixed: Project Panel now properly focuses when clicking empty space, allowing keyboard shortcuts to work as expected