### PR TITLE
remote: Fix `build_command` not setting `ZED_SSH_ASKPASS`

### DIFF
--- a/crates/askpass/src/askpass.rs
+++ b/crates/askpass/src/askpass.rs
@@ -16,8 +16,6 @@ use gpui::{AsyncApp, BackgroundExecutor, Task};
 use smol::fs;
 use util::ResultExt as _;
 
-use crate::encrypted_password::decrypt;
-
 #[derive(PartialEq, Eq)]
 pub enum AskPassResult {
     CancelledByUser,
@@ -116,7 +114,7 @@ impl AskPassSession {
                     {
                         askpass_secret.get_or_init(|| password.clone());
                     }
-                    if let Ok(decrypted) = decrypt(password) {
+                    if let Ok(decrypted) = password.decrypt() {
                         stream.write_all(decrypted.as_bytes()).await.log_err();
                     }
                 } else {

--- a/crates/remote/src/transport/ssh.rs
+++ b/crates/remote/src/transport/ssh.rs
@@ -134,7 +134,10 @@ impl RemoteConnection for SshRemoteConnection {
             ssh_shell,
             ..
         } = self;
-        let env = socket.envs.clone();
+        let mut env = socket.envs.clone();
+        if let Ok(password) = socket.password.clone().decrypt() {
+            env.insert("ZED_SSH_ASKPASS".to_owned(), password);
+        }
         build_command(
             input_program,
             input_args,


### PR DESCRIPTION
Release Notes:

- Fixed `build_command` not setting `ZED_SSH_ASKPASS`

Co-authored-by: Max Brunsfeld <max@zed.dev>
Co-authored-by: Cole Miller <cole@zed.dev>
