### PR TITLE
Fix caption buttons going off-screen

### DIFF
--- a/crates/title_bar/src/platform_title_bar.rs
+++ b/crates/title_bar/src/platform_title_bar.rs
@@ -109,6 +109,7 @@ impl Render for PlatformTitleBar {
                     .flex_row()
                     .items_center()
                     .justify_between()
+                    .overflow_x_hidden()
                     .w_full()
                     // Note: On Windows the title bar behavior is handled by the platform implementation.
                     .when(self.platform_style == PlatformStyle::Mac, |this| {


### PR DESCRIPTION


https://github.com/user-attachments/assets/27bf58df-b8c4-4730-856b-d62ec639a552

Previously the caption buttons (minimize, maximize, close) would disappear off the right side of the title bar.

Release Notes:

- N/A
