### PR TITLE
Pass through `cwd` from ACP extension

### DIFF
--- a/crates/acp_thread/src/acp_thread.rs
+++ b/crates/acp_thread/src/acp_thread.rs
@@ -2333,12 +2333,10 @@ mod tests {
         // Create a display-only terminal and then send Created
         let lower = cx.new(|cx| {
             let builder = ::terminal::TerminalBuilder::new_display_only(
-                None,
                 ::terminal::terminal_settings::CursorShape::default(),
                 ::terminal::terminal_settings::AlternateScroll::On,
                 None,
                 0,
-                cx,
             )
             .unwrap();
             builder.subscribe(cx)
@@ -2412,12 +2410,10 @@ mod tests {
         // Now create a display-only lower-level terminal and send Created
         let lower = cx.new(|cx| {
             let builder = ::terminal::TerminalBuilder::new_display_only(
-                None,
                 ::terminal::terminal_settings::CursorShape::default(),
                 ::terminal::terminal_settings::AlternateScroll::On,
                 None,
                 0,
-                cx,
             )
             .unwrap();
             builder.subscribe(cx)

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -719,12 +719,10 @@ impl acp::Client for ClientDelegate {
                         // Create a minimal display-only lower-level terminal and register it.
                         let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
                             let builder = TerminalBuilder::new_display_only(
-                                None,
                                 CursorShape::default(),
                                 AlternateScroll::On,
                                 None,
                                 0,
-                                cx,
                             )?;
                             let lower = cx.new(|cx| builder.subscribe(cx));
                             thread.on_terminal_provider_event(

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -712,6 +712,9 @@ impl acp::Client for ClientDelegate {
                     if let Some(id_str) = terminal_info.get("terminal_id").and_then(|v| v.as_str())
                     {
                         let terminal_id = acp::TerminalId(id_str.into());
+                        let cwd = terminal_info
+                            .get("cwd")
+                            .and_then(|v| v.as_str().map(PathBuf::from));
 
                         // Create a minimal display-only lower-level terminal and register it.
                         let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
@@ -728,7 +731,7 @@ impl acp::Client for ClientDelegate {
                                 TerminalProviderEvent::Created {
                                     terminal_id: terminal_id.clone(),
                                     label: tc.title.clone(),
-                                    cwd: None,
+                                    cwd,
                                     output_byte_limit: None,
                                     terminal: lower,
                                 },

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -712,9 +712,6 @@ impl acp::Client for ClientDelegate {
                     if let Some(id_str) = terminal_info.get("terminal_id").and_then(|v| v.as_str())
                     {
                         let terminal_id = acp::TerminalId(id_str.into());
-                        let cwd = terminal_info
-                            .get("cwd")
-                            .and_then(|v| v.as_str().map(PathBuf::from));
 
                         // Create a minimal display-only lower-level terminal and register it.
                         let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
@@ -729,7 +726,7 @@ impl acp::Client for ClientDelegate {
                                 TerminalProviderEvent::Created {
                                     terminal_id: terminal_id.clone(),
                                     label: tc.title.clone(),
-                                    cwd,
+                                    cwd: None,
                                     output_byte_limit: None,
                                     terminal: lower,
                                 },

--- a/crates/agent_servers/src/acp.rs
+++ b/crates/agent_servers/src/acp.rs
@@ -712,6 +712,9 @@ impl acp::Client for ClientDelegate {
                     if let Some(id_str) = terminal_info.get("terminal_id").and_then(|v| v.as_str())
                     {
                         let terminal_id = acp::TerminalId(id_str.into());
+                        let cwd = terminal_info
+                            .get("cwd")
+                            .and_then(|v| v.as_str().map(PathBuf::from));
 
                         // Create a minimal display-only lower-level terminal and register it.
                         let _ = session.thread.update(&mut self.cx.clone(), |thread, cx| {
@@ -726,7 +729,7 @@ impl acp::Client for ClientDelegate {
                                 TerminalProviderEvent::Created {
                                     terminal_id: terminal_id.clone(),
                                     label: tc.title.clone(),
-                                    cwd: None,
+                                    cwd,
                                     output_byte_limit: None,
                                     terminal: lower,
                                 },

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2716,8 +2716,8 @@ impl AcpThreadView {
 
         let working_dir = working_dir
             .as_ref()
-            .map(|path| format!("{}", path.display()))
-            .unwrap_or_else(|| "current directory".to_string());
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| ".".to_string());
 
         let is_expanded = self.expanded_tool_calls.contains(&tool_call.id);
 

--- a/crates/agent_ui/src/acp/thread_view.rs
+++ b/crates/agent_ui/src/acp/thread_view.rs
@@ -2717,7 +2717,7 @@ impl AcpThreadView {
         let working_dir = working_dir
             .as_ref()
             .map(|path| path.display().to_string())
-            .unwrap_or_else(|| ".".to_string());
+            .unwrap_or_else(|| "current directory".to_string());
 
         let is_expanded = self.expanded_tool_calls.contains(&tool_call.id);
 

--- a/crates/assistant_tools/src/terminal_tool.rs
+++ b/crates/assistant_tools/src/terminal_tool.rs
@@ -479,7 +479,7 @@ impl ToolCard for TerminalToolCard {
             .cloned()
             .or_else(|| env::current_dir().ok())
             .map(|path| path.display().to_string())
-            .unwrap_or_else(|| ".".to_string());
+            .unwrap_or_else(|| "current directory".to_string());
 
         let header = h_flex()
             .flex_none()

--- a/crates/assistant_tools/src/terminal_tool.rs
+++ b/crates/assistant_tools/src/terminal_tool.rs
@@ -478,8 +478,8 @@ impl ToolCard for TerminalToolCard {
             .as_ref()
             .cloned()
             .or_else(|| env::current_dir().ok())
-            .map(|path| format!("{}", path.display()))
-            .unwrap_or_else(|| "current directory".to_string());
+            .map(|path| path.display().to_string())
+            .unwrap_or_else(|| ".".to_string());
 
         let header = h_flex()
             .flex_none()

--- a/crates/debugger_ui/src/session/running.rs
+++ b/crates/debugger_ui/src/session/running.rs
@@ -1228,7 +1228,6 @@ impl RunningState {
 
             terminal.read_with(cx, |terminal, _| {
                 terminal
-                    .pty_info
                     .pid()
                     .map(|pid| pid.as_u32())
                     .context("Terminal was spawned but PID was not available")

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -160,3 +160,34 @@ impl PtyProcessInfo {
         self.pid_getter.pid()
     }
 }
+
+impl Default for PtyProcessInfo {
+    fn default() -> Self {
+        let process_refresh_kind = ProcessRefreshKind::new()
+            .with_cmd(UpdateKind::Always)
+            .with_cwd(UpdateKind::Always)
+            .with_exe(UpdateKind::Always);
+        let refresh_kind = RefreshKind::new().with_processes(process_refresh_kind);
+        let system = System::new_with_specifics(refresh_kind);
+
+        // Create a dummy ProcessIdGetter for display-only terminals
+        #[cfg(unix)]
+        let pid_getter = ProcessIdGetter {
+            handle: -1,
+            fallback_pid: 0,
+        };
+
+        #[cfg(windows)]
+        let pid_getter = ProcessIdGetter {
+            handle: -1,
+            fallback_pid: 0,
+        };
+
+        PtyProcessInfo {
+            system,
+            refresh_kind: process_refresh_kind,
+            pid_getter,
+            current: None,
+        }
+    }
+}

--- a/crates/terminal/src/pty_info.rs
+++ b/crates/terminal/src/pty_info.rs
@@ -160,34 +160,3 @@ impl PtyProcessInfo {
         self.pid_getter.pid()
     }
 }
-
-impl Default for PtyProcessInfo {
-    fn default() -> Self {
-        let process_refresh_kind = ProcessRefreshKind::new()
-            .with_cmd(UpdateKind::Always)
-            .with_cwd(UpdateKind::Always)
-            .with_exe(UpdateKind::Always);
-        let refresh_kind = RefreshKind::new().with_processes(process_refresh_kind);
-        let system = System::new_with_specifics(refresh_kind);
-
-        // Create a dummy ProcessIdGetter for display-only terminals
-        #[cfg(unix)]
-        let pid_getter = ProcessIdGetter {
-            handle: -1,
-            fallback_pid: 0,
-        };
-
-        #[cfg(windows)]
-        let pid_getter = ProcessIdGetter {
-            handle: -1,
-            fallback_pid: 0,
-        };
-
-        PtyProcessInfo {
-            system,
-            refresh_kind: process_refresh_kind,
-            pid_getter,
-            current: None,
-        }
-    }
-}

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -340,12 +340,10 @@ pub struct TerminalBuilder {
 
 impl TerminalBuilder {
     pub fn new_display_only(
-        working_directory: Option<PathBuf>,
         cursor_shape: CursorShape,
         alternate_scroll: AlternateScroll,
         max_scroll_history_lines: Option<usize>,
         window_id: u64,
-        cx: &App,
     ) -> Result<TerminalBuilder> {
         // Create a display-only terminal (no actual PTY).
         let default_cursor_style = AlacCursorStyle::from(cursor_shape);

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -360,7 +360,7 @@ impl TerminalBuilder {
         let mut term = Term::new(
             config.clone(),
             &TerminalBounds::default(),
-            ZedListener(events_tx.clone()),
+            ZedListener(events_tx),
         );
 
         if let AlternateScroll::Off = alternate_scroll {

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -597,7 +597,6 @@ impl TerminalBuilder {
             scroll_px: px(0.),
             next_link_id: 0,
             selection_phase: SelectionPhase::Ended,
-            // hovered_word: false,
             hyperlink_regex_searches: RegexSearches::new(),
             vi_mode_enabled: false,
             is_ssh_terminal,

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -2189,7 +2189,9 @@ unsafe fn append_text_to_term(term: &mut Term<ZedListener>, text_lines: &[&str])
 
 impl Drop for Terminal {
     fn drop(&mut self) {
-        self.pty_tx.0.send(Msg::Shutdown).ok();
+        if let Some(pty_tx) = &self.pty_tx {
+            pty_tx.0.send(Msg::Shutdown).ok();
+        }
     }
 }
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1649,7 +1649,7 @@ impl Terminal {
                 && let Some(bytes) =
                     mouse_moved_report(point, e.pressed_button, e.modifiers, self.last_content.mode)
             {
-                self.pty_tx.notify(bytes);
+                self.write_to_pty(bytes);
             }
         } else if e.modifiers.secondary() {
             self.word_from_position(e.position);
@@ -1756,7 +1756,7 @@ impl Terminal {
             if let Some(bytes) =
                 mouse_button_report(point, e.button, e.modifiers, true, self.last_content.mode)
             {
-                self.pty_tx.notify(bytes);
+                self.write_to_pty(bytes);
             }
         } else {
             match e.button {
@@ -1815,7 +1815,7 @@ impl Terminal {
             if let Some(bytes) =
                 mouse_button_report(point, e.button, e.modifiers, false, self.last_content.mode)
             {
-                self.pty_tx.notify(bytes);
+                self.write_to_pty(bytes);
             }
         } else {
             if e.button == MouseButton::Left && setting.copy_on_select {
@@ -1854,7 +1854,7 @@ impl Terminal {
                 if let Some(scrolls) = scroll_report(point, scroll_lines, e, self.last_content.mode)
                 {
                     for scroll in scrolls {
-                        self.pty_tx.notify(scroll);
+                        self.write_to_pty(scroll);
                     }
                 };
             } else if self
@@ -1863,7 +1863,7 @@ impl Terminal {
                 .contains(TermMode::ALT_SCREEN | TermMode::ALTERNATE_SCROLL)
                 && !e.shift
             {
-                self.pty_tx.notify(alt_scroll(scroll_lines))
+                self.write_to_pty(alt_scroll(scroll_lines));
             } else if scroll_lines != 0 {
                 let scroll = AlacScroll::Delta(scroll_lines);
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1340,7 +1340,8 @@ impl Terminal {
         }
     }
 
-    ///Write the Input payload to the tty.
+    /// Write the Input payload to the PTY, if applicable.
+    /// (This is a no-op for display-only terminals.)
     fn write_to_pty(&self, input: impl Into<Cow<'static, [u8]>>) {
         if let Some(pty_tx) = &self.pty_tx {
             pty_tx.notify(input.into());

--- a/crates/terminal_view/src/terminal_view.rs
+++ b/crates/terminal_view/src/terminal_view.rs
@@ -1142,7 +1142,7 @@ impl Item for TerminalView {
     fn tab_tooltip_content(&self, cx: &App) -> Option<TabTooltipContent> {
         let terminal = self.terminal().read(cx);
         let title = terminal.title(false);
-        let pid = terminal.pty_info.pid_getter().fallback_pid();
+        let pid = terminal.pid_getter()?.fallback_pid();
 
         Some(TabTooltipContent::Custom(Box::new(move |_window, cx| {
             cx.new(|_| TerminalTooltip::new(title.clone(), pid)).into()


### PR DESCRIPTION
If we get a `cwd` from ACP (because e.g. `codex-acp` is driving the terminal rather than our own PTY) then use that to display the `cwd` of the terminal process.

Release Notes:

- N/A
