### PR TITLE
Add Tailwind CSS language server to CSS language settings

### DIFF
--- a/assets/settings/default.json
+++ b/assets/settings/default.json
@@ -1654,6 +1654,7 @@
       }
     },
     "CSS": {
+      "language_servers": ["tailwindcss-language-server"],
       "prettier": {
         "allowed": true
       }


### PR DESCRIPTION
Although **Zed** offers native support for **Tailwind CSS**, users may encounter syntax warnings for custom at-rules and directives (e.g., `@apply`, `@tailwind`) if no language server is explicitly configured, as detailed in the [official guide](https://tailwindcss.com/docs/editor-setup#syntax-support).

This pull request addresses this by **adding the Tailwind CSS Language Server to the default configuration**. This ensures a smooth, warning-free editing experience for Tailwind CSS stylesheets right out of the box, requiring **zero configuration** from the developer.

### Before

<img width="472" height="85" alt="image" src="https://github.com/user-attachments/assets/60f045ff-545c-4c1d-bfce-ee3f722a6e47" />

### After

<img width="272" height="81" alt="image" src="https://github.com/user-attachments/assets/3a377e51-3b9c-4e59-b18b-e539174d9423" />

Release Notes:

- N/A 
