### PR TITLE
agent_ui: Show error tooltip for bypass permissions failures

### DIFF
--- a/crates/agent_ui/src/acp/mode_selector.rs
+++ b/crates/agent_ui/src/acp/mode_selector.rs
@@ -62,20 +62,15 @@ impl ModeSelector {
         self.error_message = None;
         cx.notify();
 
-        let mode_id_clone = mode.clone();
         cx.spawn(async move |this: WeakEntity<ModeSelector>, cx| {
             let result = task.await;
             this.update(cx, |this, cx| {
                 this.setting_mode = false;
                 if let Err(err) = result {
                     let error_string = err.to_string();
-                    log::error!(
-                        "Failed to set session mode '{}': {}",
-                        mode_id_clone.0,
-                        error_string
-                    );
+                    log::error!("Failed to set session mode '{}': {}", mode.0, error_string);
 
-                    if mode_id_clone.0.as_ref() == "bypassPermissions"
+                    if mode.0.as_ref() == "bypassPermissions"
                         && error_string.contains("is not available")
                     {
                         this.error_message =


### PR DESCRIPTION
Closes #39360

Release Notes:

- Fixed: Added error feedback when "Bypass permission" mode fails, showing users that ~/.claude/settings.json configuration is required

### Note for Zed Team

The UI implementation is my suggested approach, and feel free to tell me to adjust the visual design as needed.

**About ~/.claude/settings.json:**
When users try to use "Bypass permission" mode, Claude Code requires a settings file at `~/.claude/settings.json` with specific permissions. Without this file, the mode appears available but fails silently. The fix adds a simple red error tooltip explaining users need to add permission configuration to their Claude settings file to enable bypass mode.