### PR TITLE
language: Improve completion labels for clangd

### DIFF
--- a/crates/languages/src/c.rs
+++ b/crates/languages/src/c.rs
@@ -166,13 +166,18 @@ impl super::LspAdapter for CLspAdapter {
             None => "",
         };
 
-        let label = completion
+        let mut label = completion
             .label
             .strip_prefix('•')
             .unwrap_or(&completion.label)
             .trim()
-            .to_owned()
-            + label_detail;
+            .to_owned();
+        if !label_detail.is_empty() {
+            if !label.ends_with(' ') && !label_detail.starts_with(' ') {
+                label.push(' ');
+            }
+            label.push_str(label_detail);
+        }
 
         match completion.kind {
             Some(lsp::CompletionItemKind::FIELD) if completion.detail.is_some() => {


### PR DESCRIPTION
Closes #39515 

**Summary**
- Improved the logic for constructing completion labels by ensuring proper spacing between the main label and its detail.
- Now, a space is only inserted if the label does not already end with a space and the detail does not start with one, preventing accidental double spaces or missing spaces.

Screen recording for reference

https://github.com/user-attachments/assets/a2cccc8f-8de1-4a73-b275-1be2effb5ad4

