### PR TITLE
Dismiss formatting error notifications from language server on successful format requests

### DIFF
--- a/crates/project/src/lsp_store.rs
+++ b/crates/project/src/lsp_store.rs
@@ -1473,6 +1473,11 @@ impl LocalLspStore {
                         continue;
                     };
 
+                    let lsp_name = language_server.name().clone();
+                    lsp_store.update(cx, |_, cx| {
+                        cx.emit(LspStoreEvent::WillFormatWith(lsp_name));
+                    })?;
+
                     zlog::trace!(
                         logger =>
                         "Formatting buffer '{:?}' using language server '{:?}'",
@@ -3537,12 +3542,20 @@ pub enum LspFetchStrategy {
 pub enum LspStoreEvent {
     LanguageServerAdded(LanguageServerId, LanguageServerName, Option<WorktreeId>),
     LanguageServerRemoved(LanguageServerId),
+    LanguageServerLog(LanguageServerId, LanguageServerLogType, String),
+    WillFormatWith(LanguageServerName),
     LanguageServerUpdate {
         language_server_id: LanguageServerId,
         name: Option<LanguageServerName>,
         message: proto::update_language_server::Variant,
     },
-    LanguageServerLog(LanguageServerId, LanguageServerLogType, String),
+    LanguageServerBufferRegistered {
+        server_id: LanguageServerId,
+        buffer_id: BufferId,
+        buffer_abs_path: PathBuf,
+        name: Option<LanguageServerName>,
+    },
+
     LanguageServerPrompt(LanguageServerPromptRequest),
     LanguageDetected {
         buffer: Entity<Buffer>,

--- a/crates/project/src/project.rs
+++ b/crates/project/src/project.rs
@@ -306,6 +306,7 @@ pub enum Event {
         notification_id: SharedString,
     },
     LanguageServerPrompt(LanguageServerPromptRequest),
+    WillFormatWith(LanguageServerName),
     LanguageNotFound(Entity<Buffer>),
     ActiveEntryChanged(Option<ProjectEntryId>),
     ActivateProjectPanel,
@@ -2983,6 +2984,7 @@ impl Project {
             }
             LspStoreEvent::RefreshInlayHints => cx.emit(Event::RefreshInlayHints),
             LspStoreEvent::RefreshCodeLens => cx.emit(Event::RefreshCodeLens),
+            LspStoreEvent::WillFormatWith(name) => cx.emit(Event::WillFormatWith(name.clone())),
             LspStoreEvent::LanguageServerPrompt(prompt) => {
                 cx.emit(Event::LanguageServerPrompt(prompt.clone()))
             }
@@ -3052,6 +3054,7 @@ impl Project {
                     cx.emit(Event::SnippetEdit(*buffer_id, edits.clone()))
                 }
             }
+            _ => {}
         }
     }
 


### PR DESCRIPTION
This is a partial fix to the issue reported in #38769. I should say that I somewhat accidentally agentically engineered this. I just wanted to ask the agent a couple of questions about how to approach this and he was quick to offer a solution that almost worked. I was then able to actually make it work. I looked at it and it seems good to me, so I went ahead and opened this PR.

There are not tests yet, but if this approach is acceptable to you guys then I would be happy to add them. I did however check it locally and it worked.

The general approach taken is that the `LspStore`, upon receiving a request to format the local buffer, will emit a `WillFormatWith(LanguageServerId)` event, which is propagated through the project to the workspace, where the handler closes any open notifications for the given language server.

If this is something that you would consider merging, I would be happy to make any changes neccessary.

(Partly) Closes #38769

Release Notes:

- Fixed a bug where error notifications for failing formatting requests are not closing even after a successful format has been made.
