### PR TITLE
terminal: Fix terminal split pane opening in wrong directory

### DIFF
--- a/crates/terminal_view/src/terminal_panel.rs
+++ b/crates/terminal_view/src/terminal_panel.rs
@@ -449,12 +449,16 @@ impl TerminalPanel {
             .read(cx)
             .active_item()
             .and_then(|item| item.downcast::<TerminalView>());
-        let working_directory = terminal_view.as_ref().and_then(|terminal_view| {
-            let terminal = terminal_view.read(cx).terminal().read(cx);
-            terminal
-                .working_directory()
-                .or_else(|| default_working_directory(workspace, cx))
-        });
+        let working_directory = terminal_view
+            .as_ref()
+            .and_then(|terminal_view| {
+                terminal_view
+                    .read(cx)
+                    .terminal()
+                    .read(cx)
+                    .working_directory()
+            })
+            .or_else(|| default_working_directory(workspace, cx));
         let is_zoomed = active_pane.read(cx).is_zoomed();
         cx.spawn_in(window, async move |panel, cx| {
             let terminal = project


### PR DESCRIPTION
## Problem
When splitting a terminal pane, the new pane opens in the root directory (`/`) instead of preserving the current working directory of the original terminal.

For example, when working in `/Users/modestnerd/Developer/Projects/zed` (my pc) and splitting the terminal pane, the new pane would open in `/` instead of staying in the current directory.

## Solution
Restructured the fallback logic in `new_pane_with_cloned_active_terminal` (terminal_panel.rs:452-456) to ensure `default_working_directory(workspace, cx)` is called as a fallback even when a terminal view exists but its `working_directory()` returns `None`.

The fix changes the nested `and_then` to use `or_else` for the fallback, ensuring the working directory is always properly resolved before entering the async block.

Release Notes:

- Fixed terminal split pane opening in wrong directory instead of preserving the current working directory
