### PR TITLE
Fix CRLF handling in display-only terminals

### DIFF
--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -1222,12 +1222,15 @@ impl Terminal {
         // When output comes from piped commands (not a PTY), it only contains LF (\n),
         // which moves the cursor down but not back to the left, creating a diagonal
         // staircase effect. We need to insert CR (\r) before each LF.
+        // Skip insertion if CR is already present (to avoid double CR with CRLF).
         let mut converted = Vec::with_capacity(bytes.len());
+        let mut prev_byte = 0u8;
         for &byte in bytes {
-            if byte == b'\n' {
+            if byte == b'\n' && prev_byte != b'\r' {
                 converted.push(b'\r');
             }
             converted.push(byte);
+            prev_byte = byte;
         }
 
         let mut processor = alacritty_terminal::vte::ansi::Processor::<

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -22,7 +22,8 @@ use alacritty_terminal::{
     tty::{self},
     vi_mode::{ViModeCursor, ViMotion},
     vte::ansi::{
-        ClearMode, CursorStyle as AlacCursorStyle, Handler, NamedPrivateMode, PrivateMode,
+        ClearMode, CursorStyle as AlacCursorStyle, Handler, Mode, NamedMode, NamedPrivateMode,
+        PrivateMode,
     },
 };
 use anyhow::{Context as _, Result, bail};
@@ -370,7 +371,7 @@ impl TerminalBuilder {
         // Enable LineFeedNewLine mode (LNM) for display-only terminals.
         // This automatically converts LF (\n) to CRLF (\r\n) to ensure proper
         // line wrapping when output comes from piped commands (not a PTY).
-        term.mode |= TermMode::LINE_FEED_NEW_LINE;
+        term.set_mode(Mode::Named(NamedMode::LineFeedNewLine));
 
         let term = Arc::new(FairMutex::new(term));
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -22,8 +22,7 @@ use alacritty_terminal::{
     tty::{self},
     vi_mode::{ViModeCursor, ViMotion},
     vte::ansi::{
-        ClearMode, CursorStyle as AlacCursorStyle, Handler, Mode, NamedMode, NamedPrivateMode,
-        PrivateMode,
+        ClearMode, CursorStyle as AlacCursorStyle, Handler, NamedPrivateMode, PrivateMode,
     },
 };
 use anyhow::{Context as _, Result, bail};
@@ -371,7 +370,7 @@ impl TerminalBuilder {
         // Enable LineFeedNewLine mode (LNM) for display-only terminals.
         // This automatically converts LF (\n) to CRLF (\r\n) to ensure proper
         // line wrapping when output comes from piped commands (not a PTY).
-        term.set_mode(Mode::Named(NamedMode::LineFeedNewLine));
+        term.mode |= TermMode::LINE_FEED_NEW_LINE;
 
         let term = Arc::new(FairMutex::new(term));
 

--- a/crates/terminal/src/terminal.rs
+++ b/crates/terminal/src/terminal.rs
@@ -367,11 +367,6 @@ impl TerminalBuilder {
             term.unset_private_mode(PrivateMode::Named(NamedPrivateMode::AlternateScroll));
         }
 
-        // Enable LineFeedNewLine mode (LNM) for display-only terminals.
-        // This automatically converts LF (\n) to CRLF (\r\n) to ensure proper
-        // line wrapping when output comes from piped commands (not a PTY).
-        term.mode |= TermMode::LINE_FEED_NEW_LINE;
-
         let term = Arc::new(FairMutex::new(term));
 
         let terminal = Terminal {
@@ -1222,14 +1217,28 @@ impl Terminal {
     pub fn write_output(&mut self, bytes: &[u8], cx: &mut Context<Self>) {
         // Inject bytes directly into the terminal emulator and refresh the UI.
         // This bypasses the PTY/event loop for display-only terminals.
-        // LineFeedNewLine mode is enabled, so alacritty will automatically
-        // convert LF to CRLF for us.
+
+        // Convert LF to CRLF to ensure proper line wrapping.
+        // When output comes from piped commands (not a PTY), it only contains LF (\n),
+        // which moves the cursor down but not back to the left, creating a diagonal
+        // staircase effect. We need to insert CR (\r) before each LF.
+        // Skip insertion if CR is already present (to avoid double CR with CRLF).
+        let mut converted = Vec::with_capacity(bytes.len());
+        let mut prev_byte = 0u8;
+        for &byte in bytes {
+            if byte == b'\n' && prev_byte != b'\r' {
+                converted.push(b'\r');
+            }
+            converted.push(byte);
+            prev_byte = byte;
+        }
+
         let mut processor = alacritty_terminal::vte::ansi::Processor::<
             alacritty_terminal::vte::ansi::StdSyncHandler,
         >::new();
         {
             let mut term = self.term.lock();
-            processor.advance(&mut *term, bytes);
+            processor.advance(&mut *term, &converted);
         }
         cx.emit(Event::Wakeup);
     }


### PR DESCRIPTION
## Before

<img width="558" height="739" alt="Screenshot 2025-10-03 at 11 08 43 PM" src="https://github.com/user-attachments/assets/5dae7f9d-03b6-48eb-826d-e2be60320546" />

## After

<img width="551" height="843" alt="Screenshot 2025-10-04 at 8 29 51 PM" src="https://github.com/user-attachments/assets/2b06dcec-7758-42ad-acf0-c32a7f50f1b1" />

No release notes because we aren't using display-only terminals anywhere yet (`codex-acp` will be the first to use them, and it's still feature-flagged right now).

Release Notes:

- N/A
